### PR TITLE
Fix Resolution.Tick TradeBar history request

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -250,8 +250,8 @@ namespace QuantConnect.Algorithm
 
                 var exchange = GetExchangeHours(x);
                 var res = GetResolution(x, resolution);
-                var start = _historyRequestFactory.GetStartTimeAlgoTz(x, periods, res.Value, exchange);
-                return _historyRequestFactory.CreateHistoryRequest(config, start, Time.RoundDown(res.Value.ToTimeSpan()), exchange, res);
+                var start = _historyRequestFactory.GetStartTimeAlgoTz(x, periods, res, exchange);
+                return _historyRequestFactory.CreateHistoryRequest(config, start, Time.RoundDown(res.ToTimeSpan()), exchange, res);
             });
 
             return History(requests.Where(x => x != null)).Get<T>().Memoize();
@@ -306,16 +306,10 @@ namespace QuantConnect.Algorithm
         {
             if (symbol == null) throw new ArgumentException(_symbolEmptyErrorMessage);
 
-            var securityType = symbol.ID.SecurityType;
-            if (securityType == SecurityType.Forex || securityType == SecurityType.Cfd)
-            {
-                Error("Calling History<TradeBar> method on a Forex or CFD security will return an empty result. Please use the generic version with QuoteBar type parameter.");
-            }
-
             resolution = GetResolution(symbol, resolution);
             var start = _historyRequestFactory.GetStartTimeAlgoTz(symbol, periods, resolution.Value, GetExchangeHours(symbol));
 
-            return History(new[] { symbol }, start, Time.RoundDown(resolution.Value.ToTimeSpan()), resolution).Get(symbol).Memoize();
+            return History(symbol, start, Time.RoundDown(resolution.Value.ToTimeSpan()), resolution);
         }
 
         /// <summary>
@@ -400,13 +394,14 @@ namespace QuantConnect.Algorithm
                 Error("Calling History<TradeBar> method on a Forex or CFD security will return an empty result. Please use the generic version with QuoteBar type parameter.");
             }
 
-            if (resolution.HasValue && resolution == Resolution.Tick)
+            var resolutionToUse = resolution ?? GetResolution(symbol, resolution);
+            if (resolutionToUse == Resolution.Tick)
             {
                 throw new InvalidOperationException("Calling History<TradeBar> method with Resolution.Tick will return an empty result." +
                                                     " Please use the generic version with Tick type parameter or provide an enumerable of Symbols to use the Slice history request API.");
             }
 
-            return History(new[] { symbol }, start, end, resolution).Get(symbol).Memoize();
+            return History(new[] { symbol }, start, end, resolutionToUse).Get(symbol).Memoize();
         }
 
         /// <summary>
@@ -615,7 +610,7 @@ namespace QuantConnect.Algorithm
 
                     // apply overrides
                     var res = GetResolution(x, resolution);
-                    if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? res : null;
+                    if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? res : (Resolution?) null;
                     if (extendedMarket.HasValue) request.IncludeExtendedMarketHours = extendedMarket.Value;
 
                     requests.Add(request);
@@ -634,8 +629,8 @@ namespace QuantConnect.Algorithm
             {
                 var res = GetResolution(x, resolution);
                 var exchange = GetExchangeHours(x);
-                var start = _historyRequestFactory.GetStartTimeAlgoTz(x, periods, res.Value, exchange);
-                var end = Time.RoundDown(res.Value.ToTimeSpan());
+                var start = _historyRequestFactory.GetStartTimeAlgoTz(x, periods, res, exchange);
+                var end = Time.RoundDown(res.ToTimeSpan());
 
                 return GetMatchingSubscriptions(x, typeof(BaseData), resolution)
                     .Select(config => _historyRequestFactory.CreateHistoryRequest(config, start, end, exchange, res));
@@ -704,7 +699,7 @@ namespace QuantConnect.Algorithm
             return MarketHoursDatabase.GetEntry(symbol.ID.Market, symbol, symbol.ID.SecurityType).ExchangeHours;
         }
 
-        private Resolution? GetResolution(Symbol symbol, Resolution? resolution)
+        private Resolution GetResolution(Symbol symbol, Resolution? resolution)
         {
             Security security;
             if (Securities.TryGetValue(symbol, out security))

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -398,7 +398,7 @@ namespace QuantConnect.Algorithm
             if (resolutionToUse == Resolution.Tick)
             {
                 throw new InvalidOperationException("Calling History<TradeBar> method with Resolution.Tick will return an empty result." +
-                                                    " Please use the generic version with Tick type parameter or provide an enumerable of Symbols to use the Slice history request API.");
+                                                    " Please use the generic version with Tick type parameter or provide a list of Symbols to use the Slice history request API.");
             }
 
             return History(new[] { symbol }, start, end, resolutionToUse).Get(symbol).Memoize();

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -381,13 +381,7 @@ namespace QuantConnect.Algorithm
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         public IEnumerable<TradeBar> History(Symbol symbol, TimeSpan span, Resolution? resolution = null)
         {
-            var securityType = symbol.ID.SecurityType;
-            if (securityType == SecurityType.Forex || securityType == SecurityType.Cfd)
-            {
-                Error("Calling History<TradeBar> method on a Forex or CFD security will return an empty result. Please use the generic version with QuoteBar type parameter.");
-            }
-
-            return History(new[] { symbol }, span, resolution).Get(symbol).Memoize();
+            return History(symbol, Time - span, Time, resolution);
         }
 
         /// <summary>
@@ -404,6 +398,12 @@ namespace QuantConnect.Algorithm
             if (securityType == SecurityType.Forex || securityType == SecurityType.Cfd)
             {
                 Error("Calling History<TradeBar> method on a Forex or CFD security will return an empty result. Please use the generic version with QuoteBar type parameter.");
+            }
+
+            if (resolution.HasValue && resolution == Resolution.Tick)
+            {
+                throw new InvalidOperationException("Calling History<TradeBar> method with Resolution.Tick will return an empty result." +
+                                                    " Please use the generic version with Tick type parameter or provide an enumerable of Symbols to use the Slice history request API.");
             }
 
             return History(new[] { symbol }, start, end, resolution).Get(symbol).Memoize();

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -734,8 +734,8 @@ namespace QuantConnect.Algorithm
 
                 var res = GetResolution(x, resolution);
                 var exchange = GetExchangeHours(x);
-                var start = _historyRequestFactory.GetStartTimeAlgoTz(x, periods, res.Value, exchange);
-                return _historyRequestFactory.CreateHistoryRequest(config, start, Time.RoundDown(res.Value.ToTimeSpan()), exchange, res);
+                var start = _historyRequestFactory.GetStartTimeAlgoTz(x, periods, res, exchange);
+                return _historyRequestFactory.CreateHistoryRequest(config, start, Time.RoundDown(res.ToTimeSpan()), exchange, res);
             });
 
             return PandasConverter.GetDataFrame(History(requests.Where(x => x != null)).Memoize());
@@ -796,8 +796,8 @@ namespace QuantConnect.Algorithm
             if (resolution == Resolution.Tick) throw new ArgumentException("History functions that accept a 'periods' parameter can not be used with Resolution.Tick");
 
             var res = GetResolution(symbol, resolution);
-            var start = _historyRequestFactory.GetStartTimeAlgoTz(symbol, periods, res.Value, GetExchangeHours(symbol));
-            var end = Time.RoundDown(res.Value.ToTimeSpan());
+            var start = _historyRequestFactory.GetStartTimeAlgoTz(symbol, periods, res, GetExchangeHours(symbol));
+            var end = Time.RoundDown(res.ToTimeSpan());
             return History(type, symbol, start, end, resolution);
         }
 

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -45,7 +45,51 @@ namespace QuantConnect.Tests.Algorithm
         }
 
         [Test]
-        [TestCase(Resolution.Tick)]
+        public void TickResolutionHistoryRequest()
+        {
+            _algorithm = new QCAlgorithm();
+            _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(_algorithm));
+            _algorithm.HistoryProvider = new SubscriptionDataReaderHistoryProvider();
+            var dataProvider = new DefaultDataProvider();
+            var zipCacheProvider = new ZipDataCacheProvider(dataProvider);
+            _algorithm.HistoryProvider.Initialize(new HistoryProviderInitializeParameters(
+                null,
+                null,
+                dataProvider,
+                zipCacheProvider,
+                new LocalDiskMapFileProvider(),
+                new LocalDiskFactorFileProvider(),
+                null,
+                false));
+            _algorithm.SetStartDate(2013, 10, 08);
+            var start = new DateTime(2013, 10, 07);
+
+            // Trades and quotes
+            var result = _algorithm.History(new [] { Symbols.SPY }, start.AddHours(9.8), start.AddHours(10), Resolution.Tick).ToList();
+
+            // Just Trades
+            var result2 = _algorithm.History<Tick>(Symbols.SPY, start.AddHours(9.8), start.AddHours(10), Resolution.Tick).ToList();
+
+            zipCacheProvider.DisposeSafely();
+            Assert.IsNotEmpty(result);
+            Assert.IsNotEmpty(result2);
+
+            Assert.IsTrue(result2.All(tick => tick.TickType == TickType.Trade));
+
+            // (Trades and quotes).Count > Trades * 2
+            Assert.Greater(result.Count, result2.Count * 2);
+        }
+
+        [Test]
+        public void TickResolutionHistoryRequestTradeBarApiThrowsException()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => _algorithm.History(Symbols.SPY, TimeSpan.FromSeconds(2), Resolution.Tick).ToList());
+
+            Assert.Throws<InvalidOperationException>(
+                () => _algorithm.History(Symbols.SPY, DateTime.UtcNow.AddDays(-1), DateTime.UtcNow, Resolution.Tick).ToList());
+        }
+
         [TestCase(Resolution.Second)]
         [TestCase(Resolution.Minute)]
         [TestCase(Resolution.Hour)]

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -84,6 +84,9 @@ namespace QuantConnect.Tests.Algorithm
         public void TickResolutionHistoryRequestTradeBarApiThrowsException()
         {
             Assert.Throws<InvalidOperationException>(
+                () => _algorithm.History(Symbols.SPY, 1, Resolution.Tick).ToList());
+
+            Assert.Throws<InvalidOperationException>(
                 () => _algorithm.History(Symbols.SPY, TimeSpan.FromSeconds(2), Resolution.Tick).ToList());
 
             Assert.Throws<InvalidOperationException>(
@@ -115,8 +118,6 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(TickType.Trade, _testHistoryProvider.HistryRequests.First().TickType);
         }
 
-        [Test]
-        [TestCase(Resolution.Tick)]
         [TestCase(Resolution.Second)]
         [TestCase(Resolution.Minute)]
         [TestCase(Resolution.Hour)]

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -81,6 +81,13 @@ namespace QuantConnect.Tests.Algorithm
         }
 
         [Test]
+        public void ImplicitTickResolutionHistoryRequestTradeBarApiThrowsException()
+        {
+            var spy = _algorithm.AddEquity("SPY", Resolution.Tick).Symbol;
+            Assert.Throws<InvalidOperationException>(() => _algorithm.History(spy, 1).ToList());
+        }
+
+        [Test]
         public void TickResolutionHistoryRequestTradeBarApiThrowsException()
         {
             Assert.Throws<InvalidOperationException>(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Based on @gsalaz98 findings exposed on issue https://github.com/QuantConnect/Lean/issues/4435:
- Throw exception if requesting `Resolution.Tick` using the TradeBar
  history request API
- Adding unit tests, asserting current behavior

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Partially resolution for https://github.com/QuantConnect/Lean/issues/4435
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve API user experience
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
