### PR TITLE
Adds Overload to AddSecurity with Symbol Parameter

### DIFF
--- a/Tests/Algorithm/AlgorithmAddSecurityTests.cs
+++ b/Tests/Algorithm/AlgorithmAddSecurityTests.cs
@@ -1,0 +1,109 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Securities.Cfd;
+using QuantConnect.Securities.Crypto;
+using QuantConnect.Securities.Equity;
+using QuantConnect.Securities.Forex;
+using QuantConnect.Securities.Future;
+using QuantConnect.Securities.Option;
+using QuantConnect.Tests.Engine.DataFeeds;
+using System;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    [TestFixture]
+    public class AlgorithmAddSecurityTests
+    {
+        private QCAlgorithm _algo;
+
+        /// <summary>
+        /// Instatiate a new algorithm before each test.
+        /// Clear the <see cref="SymbolCache"/> so that no symbols and associated brokerage models are cached between test
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            _algo = new QCAlgorithm();
+            _algo.SubscriptionManager.SetDataManager(new DataManagerStub(_algo));
+        }
+
+        [Test, TestCaseSource(nameof(TestAddSecurityWithSymbol))]
+        public void AddSecurityWithSymbol(Symbol symbol)
+        {
+            var security = _algo.AddSecurity(symbol);
+            Assert.AreEqual(security.Symbol, symbol);
+            Assert.IsTrue(_algo.Securities.ContainsKey(symbol));
+
+            Assert.DoesNotThrow(() =>
+            {
+                switch (symbol.SecurityType)
+                {
+                    case SecurityType.Equity:
+                        var equity = (Equity)security;
+                        break;
+                    case SecurityType.Option:
+                        var option = (Option)security;
+                        break;
+                    case SecurityType.Forex:
+                        var forex = (Forex)security;
+                        break;
+                    case SecurityType.Future:
+                        var future = (Future)security;
+                        break;
+                    case SecurityType.Cfd:
+                        var cfd = (Cfd)security;
+                        break;
+                    case SecurityType.Crypto:
+                        var crypto = (Crypto)security;
+                        break;
+                    default:
+                        throw new Exception($"Invalid Security Type: {symbol.SecurityType}");
+                }
+            });
+
+            if (symbol.IsCanonical())
+            {
+                // Throws NotImplementedException because we are using NullDataFeed
+                // We need to call this to add the pending universe additions
+                Assert.Throws<NotImplementedException>(() => _algo.OnEndOfTimeStep());
+
+                Assert.IsTrue(_algo.UniverseManager.ContainsKey(symbol));
+            }
+        }
+
+        private static TestCaseData[] TestAddSecurityWithSymbol
+        {
+            get
+            {
+                return new[]
+                {
+                    new TestCaseData(Symbols.SPY),
+                    new TestCaseData(Symbols.EURUSD),
+                    new TestCaseData(Symbols.DE30EUR),
+                    new TestCaseData(Symbols.BTCUSD),
+                    new TestCaseData(Symbols.ES_Future_Chain),
+                    new TestCaseData(Symbols.Future_ESZ18_Dec2018),
+                    new TestCaseData(Symbols.SPY_Option_Chain),
+                    new TestCaseData(Symbols.SPY_C_192_Feb19_2016),
+                    new TestCaseData(Symbols.SPY_P_192_Feb19_2016),
+                };
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -293,6 +293,7 @@
     <Compile Include="Algorithm\AlgorithmPlottingTests.cs" />
     <Compile Include="Algorithm\AlgorithmRegisterIndicatorTests.cs" />
     <Compile Include="Algorithm\AlgorithmResolveConsolidatorTests.cs" />
+    <Compile Include="Algorithm\AlgorithmAddSecurityTests.cs" />
     <Compile Include="Algorithm\AlgorithmSetBrokerageTests.cs" />
     <Compile Include="Algorithm\AlgorithmSetHoldingsTests.cs" />
     <Compile Include="Algorithm\AlgorithmSettingsTest.cs" />

--- a/Tests/Symbols.cs
+++ b/Tests/Symbols.cs
@@ -50,12 +50,14 @@ namespace QuantConnect.Tests
         public static readonly Symbol XAGUSD = CreateCfdSymbol("XAGUSD", Market.FXCM);
         public static readonly Symbol XAUUSD = CreateCfdSymbol("XAUUSD", Market.FXCM);
 
+        public static readonly Symbol SPY_Option_Chain = CreateOptionsCanonicalSymbol("SPY");
         public static readonly Symbol SPY_C_192_Feb19_2016 = CreateOptionSymbol("SPY", OptionRight.Call, 192m, new DateTime(2016, 02, 19));
         public static readonly Symbol SPY_P_192_Feb19_2016 = CreateOptionSymbol("SPY", OptionRight.Put, 192m, new DateTime(2016, 02, 19));
 
         public static readonly Symbol Fut_SPY_Feb19_2016 = CreateFutureSymbol(Futures.Indices.SP500EMini, new DateTime(2016, 02, 19));
         public static readonly Symbol Fut_SPY_Mar19_2016 = CreateFutureSymbol(Futures.Indices.SP500EMini, new DateTime(2016, 03, 19));
 
+        public static readonly Symbol ES_Future_Chain = CreateFuturesCanonicalSymbol(Futures.Indices.SP500EMini);
         public static readonly Symbol Future_ESZ18_Dec2018 = CreateFutureSymbol(Futures.Indices.SP500EMini, new DateTime(2018, 12, 21));
         public static readonly Symbol Future_CLF19_Jan2019 = CreateFutureSymbol("CL", new DateTime(2018, 12, 19));
 
@@ -126,5 +128,19 @@ namespace QuantConnect.Tests
             return Symbol.Create(symbol, SecurityType.Crypto, Market.GDAX);
         }
 
+        private static Symbol CreateOptionsCanonicalSymbol(string underlying)
+        {
+            return Symbol.Create(underlying, SecurityType.Option, Market.USA, "?" + underlying);
+        }
+
+        private static Symbol CreateFuturesCanonicalSymbol(string ticker)
+        {
+            string market;
+            if (!SymbolPropertiesDatabase.FromDataFolder().TryGetMarket(ticker, SecurityType.Future, out market))
+            {
+                market = DefaultBrokerageModel.DefaultMarketMap[SecurityType.Future];
+            }
+            return Symbol.Create(ticker, SecurityType.Future, market, "/" + ticker);
+        }
     }
 }


### PR DESCRIPTION
#### Description
Adds overload to `AddSecurity` method that accepts a `Symbol` parameter.
Refactors some methods of the AddSecurity-family to avoid code duplication. 

#### Related Issue
Closes #4366 

#### Motivation and Context
When the `Symbol` object is known but not the ticker at the time, allow adding the symbol object directly with the `AddSecurity` call.

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
New unit tests and existing regression tests. 

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`