### PR TITLE
Fixes Decimal Parse of MinimumPriceVariation

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -710,6 +710,16 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Extension method for string to decimal conversion where string can represent a number with exponent xe-y
+        /// </summary>
+        /// <param name="str">String to be converted to decimal value</param>
+        /// <returns>Decimal value of the string</returns>
+        public static decimal ToDecimalAllowExponent(this string str)
+        {
+            return decimal.Parse(str, NumberStyles.AllowExponent | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
         /// Extension method for faster string to Int32 conversion.
         /// </summary>
         /// <param name="str">String to be converted to positive Int32 value</param>

--- a/Common/Securities/SymbolPropertiesDatabase.cs
+++ b/Common/Securities/SymbolPropertiesDatabase.cs
@@ -206,7 +206,7 @@ namespace QuantConnect.Securities
                 description: csv[3],
                 quoteCurrency: csv[4],
                 contractMultiplier: csv[5].ToDecimal(),
-                minimumPriceVariation: csv[6].ToDecimal(),
+                minimumPriceVariation: csv[6].ToDecimalAllowExponent(),
                 lotSize: csv[7].ToDecimal());
         }
 

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -1105,9 +1105,9 @@ actualDictionary.update({'IBM': 5})
         public void DecimalAllowExponentTests()
         {
             const string strWithExponent = "5e-5";
-            Assert.Equals(strWithExponent.ToDecimalAllowExponent(), 0.00005);
+            Assert.AreEqual(strWithExponent.ToDecimalAllowExponent(), 0.00005);
             Assert.AreNotEqual(strWithExponent.ToDecimal(), 0.00005);
-            Assert.Equals(strWithExponent.ToDecimal(), 10275);
+            Assert.AreEqual(strWithExponent.ToDecimal(), 10275);
         }
 
         [Test]

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -1102,6 +1102,15 @@ actualDictionary.update({'IBM': 5})
         }
 
         [Test]
+        public void DecimalAllowExponentTests()
+        {
+            const string strWithExponent = "5e-5";
+            Assert.Equals(strWithExponent.ToDecimalAllowExponent(), 0.00005);
+            Assert.AreNotEqual(strWithExponent.ToDecimal(), 0.00005);
+            Assert.Equals(strWithExponent.ToDecimal(), 10275);
+        }
+
+        [Test]
         public void DateRulesToFunc()
         {
             var dateRules = new DateRules(new SecurityManager(


### PR DESCRIPTION
#### Description
`MinimumPriceVariation` values in `SymbolPropertiesDatabase` can be represented as a exponent number. `ToDecimal` method fails to parse it correctly. A new method, `ToDecimalAllowExponent` is used instead.

#### Motivation and Context
Bug fix.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`