### PR TITLE
Quote bar previous close and current open should be same

### DIFF
--- a/Common/Data/Consolidators/TickQuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/TickQuoteBarConsolidator.cs
@@ -25,6 +25,7 @@ namespace QuantConnect.Data.Consolidators
     /// </summary>
     public class TickQuoteBarConsolidator : PeriodCountConsolidatorBase<Tick, QuoteBar>
     {
+        private Tick _previousTick;
         /// <summary>
         /// Initializes a new instance of the <see cref="TickQuoteBarConsolidator"/> class
         /// </summary>
@@ -99,12 +100,19 @@ namespace QuantConnect.Data.Consolidators
                     Ask = null
                 };
 
+                // sync last tick  close price with this tick open price
+                if (_previousTick != null)
+                {
+                    workingBar.Update(0, _previousTick.BidPrice, _previousTick.AskPrice, 0, _previousTick.BidSize, _previousTick.AskSize);
+                }
+
                 if (Period.HasValue) workingBar.Period = Period.Value;
             }
 
             // update the bid and ask
             workingBar.Update(0, data.BidPrice, data.AskPrice, 0, data.BidSize, data.AskSize);
             if (!Period.HasValue) workingBar.EndTime = GetRoundedBarTime(data.EndTime);
+            _previousTick = (Tick) data.Clone();
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
For quote bar previous close should equal to current bar open when using TickQuoteBarConsolidator

#### Description
<!--- Describe your changes in detail -->
Store the previous tick. when ever a new working bar is created, initialise it with previous tick

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 https://github.com/QuantConnect/Lean/issues/4522

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required so that correct return series could be constructed when using Future Rolling contracts data.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Yes. Added unit tests for the same

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
