### PR TITLE
Previous QuoteBar Close is not equal to Current QuoteBar Open

### DIFF
--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -212,7 +212,6 @@ namespace QuantConnect.Data.Consolidators
 
                 OnDataConsolidated(_workingBar);
                 _lastEmit = IsTimeBased && _workingBar != null ? _workingBar.Time.Add(Period ?? TimeSpan.Zero) : data.Time;
-                _workingBar = null;
             }
 
             if (!aggregateBeforeFire)
@@ -238,7 +237,6 @@ namespace QuantConnect.Data.Consolidators
                 {
                     OnDataConsolidated(_workingBar);
                     _lastEmit = currentLocalTime;
-                    _workingBar = null;
                 }
             }
         }
@@ -294,6 +292,8 @@ namespace QuantConnect.Data.Consolidators
         {
             base.OnDataConsolidated(e);
             DataConsolidated?.Invoke(this, e);
+
+            _workingBar = null;
         }
 
         /// <summary>

--- a/Common/Data/Consolidators/QuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/QuoteBarConsolidator.cs
@@ -88,10 +88,17 @@ namespace QuantConnect.Data.Consolidators
                 {
                     Symbol = data.Symbol,
                     Time = GetRoundedBarTime(data.Time),
-                    Bid = bid == null ? null : bid.Clone(),
-                    Ask = ask == null ? null : ask.Clone(),
+                    Bid = null,
+                    Ask = null,
                     Period = IsTimeBased && Period.HasValue ? (TimeSpan)Period : data.Period
                 };
+
+                // open ask and bid should match previous close ask and bid
+                if (Consolidated != null)
+                {
+                    var previous = Consolidated as QuoteBar;
+                    workingBar.Update(0, previous.Bid?.Close ?? 0, previous.Ask?.Close ?? 0, 0, previous.LastBidSize, previous.LastAskSize);
+                }
             }
 
             // update the bid and ask

--- a/Common/Data/Consolidators/QuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/QuoteBarConsolidator.cs
@@ -96,6 +96,7 @@ namespace QuantConnect.Data.Consolidators
                 // open ask and bid should match previous close ask and bid
                 if (Consolidated != null)
                 {
+                    // note that we will only fill forward previous close ask and bid when a new data point comes in and we generate a new working bar which is not a fill forward bar
                     var previous = Consolidated as QuoteBar;
                     workingBar.Update(0, previous.Bid?.Close ?? 0, previous.Ask?.Close ?? 0, 0, previous.LastBidSize, previous.LastAskSize);
                 }

--- a/Common/Data/Consolidators/TickQuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/TickQuoteBarConsolidator.cs
@@ -25,7 +25,6 @@ namespace QuantConnect.Data.Consolidators
     /// </summary>
     public class TickQuoteBarConsolidator : PeriodCountConsolidatorBase<Tick, QuoteBar>
     {
-        private Tick _previousTick;
         /// <summary>
         /// Initializes a new instance of the <see cref="TickQuoteBarConsolidator"/> class
         /// </summary>
@@ -100,10 +99,11 @@ namespace QuantConnect.Data.Consolidators
                     Ask = null
                 };
 
-                // sync last tick  close price with this tick open price
-                if (_previousTick != null)
+                // open ask and bid should match previous close ask and bid
+                if (Consolidated != null)
                 {
-                    workingBar.Update(0, _previousTick.BidPrice, _previousTick.AskPrice, 0, _previousTick.BidSize, _previousTick.AskSize);
+                    var previous = Consolidated as QuoteBar;
+                    workingBar.Update(0, previous.Bid?.Close ?? 0, previous.Ask?.Close ?? 0, 0, previous.LastBidSize, previous.LastAskSize);
                 }
 
                 if (Period.HasValue) workingBar.Period = Period.Value;
@@ -112,7 +112,6 @@ namespace QuantConnect.Data.Consolidators
             // update the bid and ask
             workingBar.Update(0, data.BidPrice, data.AskPrice, 0, data.BidSize, data.AskSize);
             if (!Period.HasValue) workingBar.EndTime = GetRoundedBarTime(data.EndTime);
-            _previousTick = (Tick) data.Clone();
         }
     }
 }

--- a/Common/Data/Consolidators/TickQuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/TickQuoteBarConsolidator.cs
@@ -102,6 +102,7 @@ namespace QuantConnect.Data.Consolidators
                 // open ask and bid should match previous close ask and bid
                 if (Consolidated != null)
                 {
+                    // note that we will only fill forward previous close ask and bid when a new data point comes in and we generate a new working bar which is not a fill forward bar
                     var previous = Consolidated as QuoteBar;
                     workingBar.Update(0, previous.Bid?.Close ?? 0, previous.Ask?.Close ?? 0, 0, previous.LastBidSize, previous.LastAskSize);
                 }

--- a/Common/Data/Consolidators/TickQuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/TickQuoteBarConsolidator.cs
@@ -25,6 +25,7 @@ namespace QuantConnect.Data.Consolidators
     /// </summary>
     public class TickQuoteBarConsolidator : PeriodCountConsolidatorBase<Tick, QuoteBar>
     {
+        private Tick _previousTick;
         /// <summary>
         /// Initializes a new instance of the <see cref="TickQuoteBarConsolidator"/> class
         /// </summary>
@@ -99,12 +100,19 @@ namespace QuantConnect.Data.Consolidators
                     Ask = null
                 };
 
+                // sync last tick  close price with this tick open price
+                if (_previousTick != null)
+                {
+                    workingBar.Update(0, _previousTick.BidPrice, _previousTick.AskPrice, 0, _previousTick.BidSize, _previousTick.AskSize);
+                }
+
                 if (Period.HasValue) workingBar.Period = Period.Value;
             }
 
             // update the bid and ask
             workingBar.Update(0, data.BidPrice, data.AskPrice, 0, data.BidSize, data.AskSize);
             if (!Period.HasValue) workingBar.EndTime = GetRoundedBarTime(data.EndTime);
+            _previousTick = (Tick) data.Clone();
         }
     }
 }

--- a/Common/Data/Market/Tick.cs
+++ b/Common/Data/Market/Tick.cs
@@ -55,13 +55,11 @@ namespace QuantConnect.Data.Market
         /// <summary>
         /// Bid Price for Tick
         /// </summary>
-        /// <remarks>QuantConnect does not currently have quote data but was designed to handle ticks and quotes</remarks>
         public decimal BidPrice = 0;
 
         /// <summary>
         /// Asking price for the Tick quote.
         /// </summary>
-        /// <remarks>QuantConnect does not currently have quote data but was designed to handle ticks and quotes</remarks>
         public decimal AskPrice = 0;
 
         /// <summary>

--- a/Engine/DataFeeds/Enumerators/QuoteBarBuilderEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/QuoteBarBuilderEnumerator.cs
@@ -85,6 +85,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                 var currentLocalTime = utcNow.ConvertFromUtc(_timeZone);
                 var barStartTime = currentLocalTime.RoundDown(_barSize);
                 working = new QuoteBar();
+
+                // open ask and bid should match previous close ask and bid
+                if (Current != null)
+                {
+                    var previous = Current as QuoteBar;
+                    working.Update(0, previous.Bid?.Close ?? 0, previous.Ask?.Close ?? 0, 0, previous.LastBidSize, previous.LastAskSize);
+                }
+
                 working.Update(data.Value, bidPrice, askPrice, qty, bidSize, askSize);
                 working.Period = _barSize;
                 working.Time = barStartTime;

--- a/Engine/DataFeeds/Enumerators/QuoteBarBuilderEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/QuoteBarBuilderEnumerator.cs
@@ -89,6 +89,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                 // open ask and bid should match previous close ask and bid
                 if (Current != null)
                 {
+                    // note that we will only fill forward previous close ask and bid when a new data point comes in and we generate a new working bar which is not a fill forward bar
                     var previous = Current as QuoteBar;
                     working.Update(0, previous.Bid?.Close ?? 0, previous.Ask?.Close ?? 0, 0, previous.LastBidSize, previous.LastAskSize);
                 }

--- a/Tests/Engine/DataFeeds/Enumerators/QuoteBarBuilderEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/QuoteBarBuilderEnumeratorTests.cs
@@ -1,0 +1,147 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Data.Market;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
+
+namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
+{
+    [TestFixture]
+    public class QuoteBarBuilderEnumeratorTests
+    {
+        [Test]
+        public void AggregatesTicksIntoSecondBars()
+        {
+            var timeProvider = new ManualTimeProvider(TimeZones.NewYork);
+            var enumerator = new QuoteBarBuilderEnumerator(Time.OneSecond, TimeZones.NewYork, timeProvider, false);
+
+            // noon new york time
+            var currentTime = new DateTime(2015, 10, 08, 12, 0, 0);
+            timeProvider.SetCurrentTime(currentTime);
+
+            // add some ticks
+            var ticks = new List<Tick>
+            {
+                new Tick(currentTime, Symbols.SPY, 199, 200) {Quantity = 10},
+                new Tick(currentTime, Symbols.SPY, 199.21m, 200.02m) {Quantity = 5},
+                new Tick(currentTime, Symbols.SPY, 198.77m, 199.75m) {Quantity = 20},
+                new Tick(currentTime, Symbols.SPY, 198.77m, 199.75m) {Quantity = 0},
+                new Tick(currentTime, Symbols.SPY, 198.77m, 199.75m) {Quantity = 20},
+                new Tick(currentTime, Symbols.SPY, 198.77m, 199.75m) {Quantity = 0},
+            };
+
+            foreach (var tick in ticks)
+            {
+                enumerator.ProcessData(tick);
+            }
+
+            // even though no data is here, it will still return true
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNull(enumerator.Current);
+
+            // advance a second
+            currentTime = currentTime.AddSeconds(1);
+            timeProvider.SetCurrentTime(currentTime);
+
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNotNull(enumerator.Current);
+
+            var bar = (QuoteBar)enumerator.Current;
+            Assert.AreEqual(currentTime.AddSeconds(-1), bar.Time);
+            Assert.AreEqual(currentTime, bar.EndTime);
+            Assert.AreEqual(Symbols.SPY, bar.Symbol);
+            Assert.AreEqual(ticks.First().LastPrice, bar.Open);
+            Assert.AreEqual(ticks.Max(x => x.LastPrice), bar.High);
+            Assert.AreEqual(ticks.Min(x => x.LastPrice), bar.Low);
+            Assert.AreEqual(ticks.Last().LastPrice, bar.Close);
+
+            enumerator.Dispose();
+        }
+
+        [Test]
+        public void LastCloseAndCurrentOpenPriceShouldBeSameConsolidated()
+        {
+            var timeProvider = new ManualTimeProvider(TimeZones.NewYork);
+            var enumerator = new QuoteBarBuilderEnumerator(Time.OneSecond, TimeZones.NewYork, timeProvider, false);
+
+            // noon new york time
+            var currentTime = new DateTime(2015, 10, 08, 12, 0, 0);
+            timeProvider.SetCurrentTime(currentTime);
+
+            var reference = DateTime.Today;
+            var tick1 = new Tick
+            {
+                Symbol = Symbols.SPY,
+                Time = reference,
+                TickType = TickType.Quote,
+                AskPrice = 0,
+                BidPrice = 24,
+
+            };
+            enumerator.ProcessData(tick1);
+
+            var tick2 = new Tick
+            {
+                Symbol = Symbols.SPY,
+                Time = reference.AddSeconds(1),
+                TickType = TickType.Quote,
+                AskPrice = 25,
+                BidPrice = 0,
+
+            };
+            enumerator.ProcessData(tick2);
+            currentTime = currentTime.AddSeconds(1);
+            timeProvider.SetCurrentTime(currentTime);
+
+            Assert.IsTrue(enumerator.MoveNext());
+
+            var quoteBar = enumerator.Current as QuoteBar;
+
+            // bar 1 emitted
+            Assert.AreEqual(tick2.AskPrice, quoteBar.Ask.Open);
+            Assert.AreEqual(tick1.BidPrice, quoteBar.Bid.Open);
+            Assert.AreEqual(tick2.AskPrice, quoteBar.Ask.Close);
+            Assert.AreEqual(tick1.BidPrice, quoteBar.Bid.Close);
+
+            var tick3 = new Tick
+            {
+                Symbol = Symbols.SPY,
+                Time = reference.AddSeconds(1),
+                TickType = TickType.Quote,
+                AskPrice = 36,
+                BidPrice = 35,
+            };
+            enumerator.ProcessData(tick3);
+
+            currentTime = currentTime.AddSeconds(1);
+            timeProvider.SetCurrentTime(currentTime);
+            Assert.IsTrue(enumerator.MoveNext());
+            quoteBar = enumerator.Current as QuoteBar;
+
+            // bar 2 emitted
+            Assert.AreEqual(tick2.AskPrice, quoteBar.Ask.Open, "Ask Open not equal to Previous Close");
+            Assert.AreEqual(tick1.BidPrice, quoteBar.Bid.Open, "Bid Open not equal to Previous Close");
+            Assert.AreEqual(tick3.AskPrice, quoteBar.Ask.Close, "Ask Close incorrect");
+            Assert.AreEqual(tick3.BidPrice, quoteBar.Bid.Close, "Bid Close incorrect");
+
+            enumerator.Dispose();
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -429,6 +429,7 @@
     <Compile Include="Engine\BrokerageTransactionHandlerTests\BacktestingTransactionHandlerTests.cs" />
     <Compile Include="Engine\DataFeeds\BacktestingFutureChainProviderTests.cs" />
     <Compile Include="Engine\DataFeeds\DataPermissionManagerTests.cs" />
+    <Compile Include="Engine\DataFeeds\Enumerators\QuoteBarBuilderEnumeratorTests.cs" />
     <Compile Include="Engine\DataFeeds\SubscriptionDataTests.cs" />
     <Compile Include="Engine\DataFeeds\DataManagerStub.cs" />
     <Compile Include="Engine\DataFeeds\DataManagerTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- On top of PR https://github.com/QuantConnect/Lean/pull/4523, thank you @AnandVishnu: Refactor to use `Consolidated` as source of the previous close. This is because using previous Tick might not be enough because ticks could only be a bid or ask update, with the other side being 0 for that tick (no update). Updating unit tests
- Applying fix for `QuoteBarConsolidator` and `QuoteBarBuilderEnumerator` as well. Adding unit tests
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/4522
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Quotes are valid until a new quote arrives
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
