### PR TITLE
Fix LiveTradingRealTimeHandler pack-up creating the potential for a N…

### DIFF
--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -204,10 +204,12 @@ namespace QuantConnect.Lean.Engine.RealTime
         /// </summary>
         public void Exit()
         {
-            _timeMonitor.DisposeSafely();
-            _timeMonitor = null;
             _realTimeThread.StopSafely(TimeSpan.FromMinutes(5), _cancellationTokenSource);
             _realTimeThread = null;
+            _timeMonitor.DisposeSafely();
+            _timeMonitor = null;
+            _cancellationTokenSource.DisposeSafely();
+            _cancellationTokenSource = null;
         }
 
         /// <summary>


### PR DESCRIPTION
…ullReferenceException


<!--- Provide a general summary of your changes in the Title above -->

#### Description
Changes the order of pack-up in `LiveTradingRealTimeHandler.Exit()` to avoid a potential `NullReferenceException`.

#### Related Issue
Closes https://github.com/QuantConnect/Lean/issues/4532

#### Motivation and Context
The exception was thrown in one of our environments and meant QC didn't pack-up cleanly.  Functionality wasn't impacted, as QC was packing down anyway.  However it still shouldn't be thrown.

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
Test code was provided in the issue, showing how to reproduce the exception.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. _**Reason:** Unable to cover in a unit test._
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
