### PR TITLE
Fix path bug in StoreOrderEvents

### DIFF
--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -231,7 +231,9 @@ namespace QuantConnect.Lean.Engine.Results
                 return;
             }
 
-            var path = $"{AlgorithmId}-order-events.json";
+            var filename = $"{AlgorithmId}-order-events.json";
+            var path = GetResultsPath(filename);
+
             var data = JsonConvert.SerializeObject(orderEvents, Formatting.None, OrderEventJsonConverter);
 
             File.WriteAllText(path, data);
@@ -309,7 +311,7 @@ namespace QuantConnect.Lean.Engine.Results
         {
             return Path.Combine(ResultsDestinationFolder, filename);
         }
-        
+
         /// <summary>
         /// Returns the location of the logs
         /// </summary>

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -363,7 +363,9 @@ namespace QuantConnect.Lean.Engine.Results
                 return;
             }
 
-            var path = $"{AlgorithmId}-{utcTime:yyyy-MM-dd}-order-events.json";
+            var filename = $"{AlgorithmId}-{utcTime:yyyy-MM-dd}-order-events.json";
+            var path = GetResultsPath(filename);
+
             var data = JsonConvert.SerializeObject(orderEvents, Formatting.None);
 
             File.WriteAllText(path, data);


### PR DESCRIPTION

#### Description
- The `StoreOrderEvents` methods in `BaseResultsHandler` and `LiveTradingResultHandler` have been updated to use the configured file path. 

#### Related Issue
Closes #4534 

#### Motivation and Context
- Config setting not respected

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`