### PR TITLE
Update fill price modeling for stop market orders in FillModel

### DIFF
--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -155,6 +155,10 @@ namespace QuantConnect.Orders.Fills
         /// <param name="asset">Security asset we're filling</param>
         /// <param name="order">Order packet to model</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
+        /// <remarks>
+        /// There's no way to know if the price has "gapped" past the stop price within a single OHLC bar. 
+        /// So we have to assume a fluid, high volume market, where every price between the high and low has been touched.
+        /// </remarks>
         /// <seealso cref="MarketFill(Security, MarketOrder)"/>
         public virtual OrderEvent StopMarketFill(Security asset, StopMarketOrder order)
         {
@@ -186,10 +190,19 @@ namespace QuantConnect.Orders.Fills
                     if (prices.Low < order.StopPrice)
                     {
                         fill.Status = OrderStatus.Filled;
-                        // Assuming worse case scenario fill - fill at lowest of the stop & asset price.
-                        fill.FillPrice = Math.Min(order.StopPrice, prices.Current - slip);
                         // assume the order completely filled
                         fill.FillQuantity = order.Quantity;
+
+                        // if bar opens below stop price, fill at open price
+                        if (prices.Open < order.StopPrice)
+                        {
+                            fill.FillPrice = prices.Open - slip;
+                        }
+                        // otherwise, assume price moved through the stop price
+                        else
+                        {
+                            fill.FillPrice = order.StopPrice - slip;
+                        }
                     }
                     break;
 
@@ -198,10 +211,19 @@ namespace QuantConnect.Orders.Fills
                     if (prices.High > order.StopPrice)
                     {
                         fill.Status = OrderStatus.Filled;
-                        // Assuming worse case scenario fill - fill at highest of the stop & asset price.
-                        fill.FillPrice = Math.Max(order.StopPrice, prices.Current + slip);
                         // assume the order completely filled
                         fill.FillQuantity = order.Quantity;
+
+                        // if bar opens above stop price, fill at open price
+                        if (prices.Open > order.StopPrice)
+                        {
+                            fill.FillPrice = prices.Open + slip;
+                        }
+                        // otherwise, assume price moved through the stop price
+                        else
+                        {
+                            fill.FillPrice = order.StopPrice + slip;
+                        }                        
                     }
                     break;
             }

--- a/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
@@ -284,7 +284,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             var slippageModel = new ConstantSlippageModel(.01m);
-            security.SetSlippageModel(new ConstantSlippageModel(.01m));
+            security.SetSlippageModel(slippageModel);
 
             // scenario 1: price doesn't trigger stop market fill
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
@@ -338,7 +338,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             var slippageModel = new ConstantSlippageModel(.01m);
-            security.SetSlippageModel(new ConstantSlippageModel(.01m));
+            security.SetSlippageModel(slippageModel);
 
             // scenario 1: price doesn't trigger stop market fill
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));

--- a/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
@@ -21,6 +21,7 @@ using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fills;
+using QuantConnect.Orders.Slippage;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Forex;
 using QuantConnect.Tests.Common.Data;
@@ -282,29 +283,41 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 new SecurityCache()
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
-            security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
+            var slippageModel = new ConstantSlippageModel(.01m);
+            security.SetSlippageModel(new ConstantSlippageModel(.01m));
 
+            // scenario 1: price doesn't trigger stop market fill
+            security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
                 new MockSubscriptionDataConfigProvider(config),
                 Time.OneHour)).OrderEvent;
-
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
             Assert.AreEqual(OrderStatus.None, fill.Status);
 
-            security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102.5m));
-
+            // scenario 2: price moves through stop price; should fill at stop price plus slippage
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 101m, 110m, 100m, 110m, 100));
             fill = model.Fill(new FillModelParameters(
                 security,
                 order,
                 new MockSubscriptionDataConfigProvider(config),
                 Time.OneHour)).OrderEvent;
-
-            // this fills worst case scenario, so it's min of asset/stop price
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
-            Assert.AreEqual(Math.Max(security.Price, order.StopPrice), fill.FillPrice);
+            Assert.AreEqual(order.StopPrice + slippageModel.GetSlippageApproximation(security, order), fill.FillPrice);
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+
+            // scenario 3: bar opens above the stop price; should fill at open price plus slippage
+            var tradeBar = new TradeBar(Noon, Symbols.SPY, 105m, 110m, 99m, 100m, 100);
+            security.SetMarketPrice(tradeBar);
+            fill = model.Fill(new FillModelParameters(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
+            Assert.AreEqual(order.Quantity, fill.FillQuantity);
+            Assert.AreEqual(tradeBar.Open + slippageModel.GetSlippageApproximation(security, order), fill.FillPrice);
             Assert.AreEqual(OrderStatus.Filled, fill.Status);
         }
 
@@ -324,29 +337,41 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 new SecurityCache()
             );
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
-            security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
+            var slippageModel = new ConstantSlippageModel(.01m);
+            security.SetSlippageModel(new ConstantSlippageModel(.01m));
 
+            // scenario 1: price doesn't trigger stop market fill
+            security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
                 new MockSubscriptionDataConfigProvider(config),
                 Time.OneHour)).OrderEvent;
-
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
             Assert.AreEqual(OrderStatus.None, fill.Status);
 
-            security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
-
+            // scenario 2: price moves through stop price; should fill at stop price minus slippage
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 102m, 103m, 90m, 90m, 100));
             fill = model.Fill(new FillModelParameters(
                 security,
                 order,
                 new MockSubscriptionDataConfigProvider(config),
                 Time.OneHour)).OrderEvent;
-
-            // this fills worst case scenario, so it's min of asset/stop price
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
-            Assert.AreEqual(Math.Min(security.Price, order.StopPrice), fill.FillPrice);
+            Assert.AreEqual(order.StopPrice - slippageModel.GetSlippageApproximation(security, order), fill.FillPrice);
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+
+            // scenario 3: bar opens below the stop price; should fill at open price minus slippage
+            var tradeBar = new TradeBar(Noon, Symbols.SPY, 100m, 105m, 95m, 103m, 100);
+            security.SetMarketPrice(tradeBar);
+            fill = model.Fill(new FillModelParameters(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour)).OrderEvent;
+            Assert.AreEqual(order.Quantity, fill.FillQuantity);
+            Assert.AreEqual(tradeBar.Open - slippageModel.GetSlippageApproximation(security, order), fill.FillPrice);
             Assert.AreEqual(OrderStatus.Filled, fill.Status);
         }
 
@@ -619,7 +644,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         }
 
         [TestCase(100, 291.50)]
-        [TestCase(-100, 290.50)]
+        [TestCase(-100, 291.50)]
         public void StopMarketOrderDoesNotFillUsingDataBeforeSubmitTime(decimal orderQuantity, decimal stopPrice)
         {
             var time = new DateTime(2018, 9, 24, 9, 30, 0);
@@ -663,7 +688,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             time += TimeSpan.FromMinutes(1);
             timeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
 
-            tradeBar = new TradeBar(time, symbol, 290m, 292m, 289m, 291m, 12345);
+            tradeBar = new TradeBar(time, symbol, 291.5m, 292m, 289m, 291m, 12345);
             security.SetMarketPrice(tradeBar);
 
             fill = fillModel.StopMarketFill(security, order);


### PR DESCRIPTION
#### Description
- Updated fill price modeling for stop market orders in FillModel.cs
- Updated relevant unit tests to highlight expected behavior

#### Related Issue
Closes #4545

#### Motivation and Context
Generate more realistic fill prices for stop market orders when backtesting.

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
Updated the relevant unit tests for ImmediateFillModel. I debated breaking the scenarios out into separate tests but I ended up leaving them together to keep it consistent with the rest of the order type tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`