### PR TITLE
Add handler for Alpaca rejected order events

### DIFF
--- a/Brokerages/Alpaca/AlpacaBrokerage.Utility.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerage.Utility.cs
@@ -146,6 +146,13 @@ namespace QuantConnect.Brokerages.Alpaca
                         FillQuantity = fillQuantity * (order.Direction == OrderDirection.Buy ? 1 : -1)
                     });
                 }
+                else if (trade.Event == TradeEvent.Rejected)
+                {
+                    OnOrderEvent(new OrderEvent(order,
+                            DateTime.UtcNow,
+                            OrderFee.Zero,
+                            "Alpaca Rejected Order Event") { Status = OrderStatus.Invalid });
+                }
                 else if (trade.Event == TradeEvent.Canceled)
                 {
                     OnOrderEvent(new OrderEvent(order,

--- a/Brokerages/Alpaca/AlpacaBrokerage.Utility.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerage.Utility.cs
@@ -153,12 +153,12 @@ namespace QuantConnect.Brokerages.Alpaca
                             OrderFee.Zero,
                             "Alpaca Rejected Order Event") { Status = OrderStatus.Invalid });
                 }
-                else if (trade.Event == TradeEvent.Canceled)
+                else if (trade.Event == TradeEvent.Canceled || trade.Event == TradeEvent.Expired)
                 {
                     OnOrderEvent(new OrderEvent(order,
                         DateTime.UtcNow,
                         OrderFee.Zero,
-                        "Alpaca Cancel Order Event") { Status = OrderStatus.Canceled });
+                        $"Alpaca {trade.Event} Order Event") { Status = OrderStatus.Canceled });
                 }
                 else if (trade.Event == TradeEvent.OrderCancelRejected)
                 {


### PR DESCRIPTION

#### Description
-  Added missing handler for `TradeEvent.Rejected` in `AlpacaBrokerage.OnTradeUpdate` 

#### Related Issue
Closes #4550 

#### Motivation and Context
- Unexpected behavior in `Liquidate` caused by "pending" (rejected) market orders not flagged with `OrderStatus.Invalid`

#### Requires Documentation Change
No.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`