### PR TITLE
Adds Validation for barSize Parameter of RenkoConsolidator Constructor

### DIFF
--- a/Common/Data/Consolidators/RenkoConsolidator.cs
+++ b/Common/Data/Consolidators/RenkoConsolidator.cs
@@ -85,18 +85,9 @@ namespace QuantConnect.Data.Consolidators
         /// <param name="barSize">The constant value size of each bar</param>
         /// <param name="evenBars">When true bar open/close will be a multiple of the barSize</param>
         public RenkoConsolidator(decimal barSize, bool evenBars = true)
+            : this(barSize, x => x.Value, x => 0, evenBars)
         {
-            if (barSize < Extensions.GetDecimalEpsilon())
-            {
-                throw new ArgumentOutOfRangeException(nameof(barSize), "RenkoConsolidator bar size must be positve and greater than 1e-28");
-            }
 
-            _barSize = barSize;
-            _selector = x => x.Value;
-            _volumeSelector = x => 0;
-            _evenBars = evenBars;
-
-            Type = RenkoType.Classic;
         }
 
         /// <summary>
@@ -135,21 +126,12 @@ namespace QuantConnect.Data.Consolidators
         public RenkoConsolidator(decimal barSize, PyObject selector, PyObject volumeSelector = null, bool evenBars = true)
             : this(barSize, evenBars)
         {
-            if (barSize < Extensions.GetDecimalEpsilon())
-            {
-                throw new ArgumentOutOfRangeException(nameof(barSize), "RenkoConsolidator bar size must be positve and greater than 1e-28");
-            }
-
             if (selector != null)
             {
                 if (!selector.TryConvertToDelegate(out _selector))
                 {
                     throw new ArgumentException("Unable to convert parameter 'selector' to delegate type Func<IBaseData, decimal>");
                 }
-            }
-            else
-            {
-                _selector = (x => x.Value);
             }
 
             if (volumeSelector != null)
@@ -158,10 +140,6 @@ namespace QuantConnect.Data.Consolidators
                 {
                     throw new ArgumentException("Unable to convert parameter 'volumeSelector' to delegate type Func<IBaseData, decimal>");
                 }
-            }
-            else
-            {
-                _volumeSelector = (x => 0);
             }
         }
 

--- a/Common/Data/Consolidators/RenkoConsolidator.cs
+++ b/Common/Data/Consolidators/RenkoConsolidator.cs
@@ -68,6 +68,11 @@ namespace QuantConnect.Data.Consolidators
                 throw new ArgumentException($"RenkoConsolidator can only be initialized with RenkoType.Wicked. For RenkoType.Classic, please use the other constructor overloads.");
             }
 
+            if (barSize < Extensions.GetDecimalEpsilon())
+            {
+                throw new ArgumentOutOfRangeException(nameof(barSize), "RenkoConsolidator bar size must be positve and greater than 1e-28");
+            }
+
             _barSize = barSize;
             Type = type;
         }
@@ -81,6 +86,11 @@ namespace QuantConnect.Data.Consolidators
         /// <param name="evenBars">When true bar open/close will be a multiple of the barSize</param>
         public RenkoConsolidator(decimal barSize, bool evenBars = true)
         {
+            if (barSize < Extensions.GetDecimalEpsilon())
+            {
+                throw new ArgumentOutOfRangeException(nameof(barSize), "RenkoConsolidator bar size must be positve and greater than 1e-28");
+            }
+
             _barSize = barSize;
             _selector = x => x.Value;
             _volumeSelector = x => 0;

--- a/Tests/Common/Data/RenkoConsolidatorTests.cs
+++ b/Tests/Common/Data/RenkoConsolidatorTests.cs
@@ -737,5 +737,24 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(openRenko.Low, 7.9);
             Assert.AreEqual(openRenko.Close, 7.9);
         }
+
+        [Test]
+        public void WickedArgumentExceptionRenkoTypeClassicTest()
+        {
+            Assert.Throws<ArgumentException>(() => new RenkoConsolidator(2.5m, RenkoType.Classic));
+        }
+
+        [Test]
+        public void ClassicArgumentOutOfRangeExceptionZeroBarSizeTests()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new RenkoConsolidator(0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new RenkoConsolidator(0, x => x.Value, x => 0));
+        }
+
+        [Test]
+        public void WickedArgumentOutOfRangeExceptionZeroBarSizeTests()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new RenkoConsolidator(0, RenkoType.Wicked));
+        }
     }
 }


### PR DESCRIPTION
#### Description
Adds validation for `barSize` parameter of `RenkoConsolidator` constructor since `RenkoConsolidator.BarSize` cannot be negative or zero.

#### Related Issue
Closes #4553 

#### Motivation and Context
Without this validation, available in some constructor overloads, the consolidator throws an unhandled exception `DivideByZeroException`. 

#### How Has This Been Tested?
New unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. 
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`