### PR TITLE
Adds Support to List of Symbol and String (Ticker)

### DIFF
--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -87,6 +87,8 @@ def mapper(key):
         kvp = SymbolCache.TryGetSymbol(key, None)
         if kvp[0]:
             return str(kvp[1].ID)
+    if keyType is list:
+        return [mapper(x) for x in key]
     if keyType is tuple:
         return tuple([mapper(x) for x in key])
     if keyType is dict:


### PR DESCRIPTION
#### Description
Adds case in the `mapper` method to handled list type.

#### Related Issue
Closes #4547 

#### Motivation and Context
Pandas DataFrame/Series created in Lean support `Symbol` object as implicit index. 

#### How Has This Been Tested?
New unit test. Notebook in #4547. Code snippet in [QC forum thread](https://www.quantconnect.com/forum/discussion/8161/pandas-symbol-remapper-easier-access-to-data-frames/p1).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. 
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`