### PR TITLE
Allow LeanDataWriter to create zip files for futures data

### DIFF
--- a/Compression/Compression.cs
+++ b/Compression/Compression.cs
@@ -155,26 +155,16 @@ namespace QuantConnect
         /// <summary>
         /// Append the zip data to the file-entry specified.
         /// </summary>
-        /// <param name="path"></param>
-        /// <param name="entry"></param>
-        /// <param name="data"></param>
-        /// <param name="overrideEntry"></param>
-        /// <returns></returns>
+        /// <param name="path">The zip file path</param>
+        /// <param name="entry">The entry name</param>
+        /// <param name="data">The entry data</param>
+        /// <param name="overrideEntry">True if should override entry if it already exists</param>
+        /// <returns>True on success</returns>
         public static bool ZipCreateAppendData(string path, string entry, string data, bool overrideEntry = false)
         {
             try
             {
-                ZipFile zip;
-                if (File.Exists(path) && !overrideEntry)
-                {
-                    zip = ZipFile.Read(path);
-                }
-                else
-                {
-                    zip = new ZipFile(path);
-                }
-
-                using (zip)
+                using (var zip = File.Exists(path) ? ZipFile.Read(path) : new ZipFile(path))
                 {
                     if (zip.ContainsEntry(entry) && overrideEntry)
                     {

--- a/Compression/Compression.cs
+++ b/Compression/Compression.cs
@@ -158,26 +158,31 @@ namespace QuantConnect
         /// <param name="path"></param>
         /// <param name="entry"></param>
         /// <param name="data"></param>
+        /// <param name="overrideEntry"></param>
         /// <returns></returns>
-        public static bool ZipCreateAppendData(string path, string entry, string data)
+        public static bool ZipCreateAppendData(string path, string entry, string data, bool overrideEntry = false)
         {
             try
             {
-                if (File.Exists(path))
+                ZipFile zip;
+                if (File.Exists(path) && !overrideEntry)
                 {
-                    using (var zip = ZipFile.Read(path))
-                    {
-                        zip.AddEntry(entry, data);
-                        zip.Save();
-                    }
+                    zip = ZipFile.Read(path);
                 }
                 else
                 {
-                    using (var zip = new ZipFile(path))
+                    zip = new ZipFile(path);
+                }
+
+                using (zip)
+                {
+                    if (zip.ContainsEntry(entry) && overrideEntry)
                     {
-                        zip.AddEntry(entry, data);
-                        zip.Save();
+                        zip.RemoveEntry(entry);
                     }
+
+                    zip.AddEntry(entry, data);
+                    zip.Save();
                 }
             }
             catch (Exception err)

--- a/Tests/Compression/CompressionTests.cs
+++ b/Tests/Compression/CompressionTests.cs
@@ -176,5 +176,29 @@ namespace QuantConnect.Tests.Compression
             Assert.AreEqual(expected.Key, actual.Key);
             Assert.AreEqual(expected.Value, actual.Value);
         }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ZipCreateAppendData(bool overrideEntry)
+        {
+            var name = $"PepeGrillo{overrideEntry}.zip";
+            if (File.Exists(name))
+            {
+                File.Delete(name);
+            }
+            QuantConnect.Compression.Zip("Pinocho", name, "cow");
+
+            Assert.AreEqual(overrideEntry, QuantConnect.Compression.ZipCreateAppendData(name, "cow", "jiji", overrideEntry));
+
+            var result = QuantConnect.Compression.Unzip(name).ToList();
+            Assert.AreEqual(1, result.Count);
+
+            var kvp = result.Single();
+            Assert.AreEqual("cow", kvp.Key);
+
+            var data = kvp.Value.ToList();
+            Assert.AreEqual(1, data.Count);
+            Assert.AreEqual((overrideEntry ? "jiji" : "Pinocho"), data[0]);
+        }
     }
 }

--- a/ToolBox/LeanDataWriter.cs
+++ b/ToolBox/LeanDataWriter.cs
@@ -206,7 +206,7 @@ namespace QuantConnect.ToolBox
             IReadOnlyDictionary<Symbol, List<BaseData>> historyBySymbol)
         {
             var zipFileName = Path.Combine(
-                Globals.DataFolder,
+                _dataDirectory,
                 LeanData.GenerateRelativeZipFilePath(canonicalSymbol, DateTime.MinValue, _resolution, _tickType));
 
             var folder = Path.GetDirectoryName(zipFileName);
@@ -295,7 +295,7 @@ namespace QuantConnect.ToolBox
             while (date <= endTimeUtc)
             {
                 var zipFileName = Path.Combine(
-                    Globals.DataFolder,
+                    _dataDirectory,
                     LeanData.GenerateRelativeZipFilePath(canonicalSymbol, date, _resolution, _tickType));
 
                 var folder = Path.GetDirectoryName(zipFileName);

--- a/ToolBox/LeanDataWriter.cs
+++ b/ToolBox/LeanDataWriter.cs
@@ -484,7 +484,7 @@ namespace QuantConnect.ToolBox
             if (_appendToZips)
             {
                 var entryName = LeanData.GenerateZipEntryName(_symbol, date, _resolution, _tickType);
-                Compression.ZipCreateAppendData(filePath, entryName, data);
+                Compression.ZipCreateAppendData(filePath, entryName, data, true);
                 Log.Trace("LeanDataWriter.Write(): Appended: " + filePath);
             }
             else

--- a/ToolBox/LeanDataWriter.cs
+++ b/ToolBox/LeanDataWriter.cs
@@ -35,6 +35,7 @@ namespace QuantConnect.ToolBox
         private readonly Symbol _symbol;
         private readonly string _dataDirectory;
         private readonly TickType _tickType;
+        private readonly bool _appendToZips;
         private readonly Resolution _resolution;
         private readonly SecurityType _securityType;
 
@@ -45,13 +46,14 @@ namespace QuantConnect.ToolBox
         /// <param name="dataDirectory">Base data directory</param>
         /// <param name="resolution">Resolution of the desired output data</param>
         /// <param name="tickType">The tick type</param>
-        public LeanDataWriter(Resolution resolution, Symbol symbol, string dataDirectory, TickType tickType = TickType.Trade)
+        public LeanDataWriter(Resolution resolution, Symbol symbol, string dataDirectory, TickType tickType = TickType.Trade) : this(
+            dataDirectory,
+            resolution,
+            symbol.ID.SecurityType,
+            tickType
+        )
         {
-            _securityType = symbol.ID.SecurityType;
-            _dataDirectory = dataDirectory;
-            _resolution = resolution;
             _symbol = symbol;
-            _tickType = tickType;
             // All fx data is quote data.
             if (_securityType == SecurityType.Forex || _securityType == SecurityType.Cfd)
             {
@@ -77,6 +79,7 @@ namespace QuantConnect.ToolBox
             _resolution = resolution;
             _securityType = securityType;
             _tickType = tickType;
+            _appendToZips = securityType == SecurityType.Future;
         }
 
         /// <summary>
@@ -301,7 +304,7 @@ namespace QuantConnect.ToolBox
                     Directory.CreateDirectory(folder);
                 }
 
-                if (File.Exists(zipFileName))
+                if (File.Exists(zipFileName) && !_appendToZips)
                 {
                     File.Delete(zipFileName);
                 }
@@ -322,6 +325,12 @@ namespace QuantConnect.ToolBox
                                     var line = LeanData.GenerateLine(row, _securityType, _resolution);
                                     sb.AppendLine(line);
                                 }
+
+                                if (_appendToZips && zip.ContainsEntry(zipEntryName))
+                                {
+                                    zip.RemoveEntry(zipEntryName);
+                                }
+
                                 zip.AddEntry(zipEntryName, sb.ToString());
                                 break;
                             }
@@ -463,7 +472,7 @@ namespace QuantConnect.ToolBox
             var tempFilePath = filePath + ".tmp";
 
             data = data.TrimEnd();
-            if (File.Exists(filePath))
+            if (File.Exists(filePath) && !_appendToZips)
             {
                 File.Delete(filePath);
                 Log.Trace("LeanDataWriter.Write(): Existing deleted: " + filePath);
@@ -472,13 +481,21 @@ namespace QuantConnect.ToolBox
             // Create the directory if it doesnt exist
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));
 
-            // Write out this data string to a zip file
-            Compression.Zip(data, tempFilePath, LeanData.GenerateZipEntryName(_symbol, date, _resolution, _tickType));
+            if (_appendToZips)
+            {
+                var entryName = LeanData.GenerateZipEntryName(_symbol, date, _resolution, _tickType);
+                Compression.ZipCreateAppendData(filePath, entryName, data);
+                Log.Trace("LeanDataWriter.Write(): Appended: " + filePath);
+            }
+            else
+            {
+                // Write out this data string to a zip file
+                Compression.Zip(data, tempFilePath, LeanData.GenerateZipEntryName(_symbol, date, _resolution, _tickType));
 
-            // Move temp file to the final destination with the appropriate name
-            File.Move(tempFilePath, filePath);
-
-            Log.Trace("LeanDataWriter.Write(): Created: " + filePath);
+                // Move temp file to the final destination with the appropriate name
+                File.Move(tempFilePath, filePath);
+                Log.Trace("LeanDataWriter.Write(): Created: " + filePath);
+            }
         }
 
         /// <summary>

--- a/ToolBox/LeanDataWriter.cs
+++ b/ToolBox/LeanDataWriter.cs
@@ -317,7 +317,7 @@ namespace QuantConnect.ToolBox
 
                         foreach (var group in historyBySymbol[symbol])
                         {
-                            if (group.Key == date)
+                            if (group.Key == date.Date)
                             {
                                 var sb = new StringBuilder();
                                 foreach (var row in group)


### PR DESCRIPTION
`LeanDataWriter` is able to create data files in the expected QC format for all symbols, except futures where multiple contracts exist in the file.  This is a format supported by the `LeanDataReader`, but there isn't a writer equivalent.

#### Description
The approach I took was to add a `boolean` value that controls whether a file should be appended to or not.
If the ZIP entry exists, it will be replaced in its entirity.
However, any existing entries will be maintained.

This may not be the best approach, and there are potential issues - such as retention of stale data.
I'd be happy to hear suggestions on how it can be improved / a better approach.

I've also included 2 fixes that I found while trying to use this class.
* I couldn't override the output location when using the end-to-end retrieve & write function.  It always wrote to the global data directory.
* Data wasn't grouped if the input had a time portion attached.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
Unable to generate futures data zips without any custom code, as the file was always overridden.

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
I have included unit tests for the futures change.
I also have tested it locally, generating ~5 years of data across a set of futures, with each output file containing multiple contracts.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`