### PR TITLE
IEX DataQueueHandler updates

### DIFF
--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -124,6 +124,9 @@
   // To get your access token go to https://www.eia.gov/opendata
   "us-energy-information-auth-token": "",
 
+  // Required for IEX history requests
+  "iex-cloud-api-key": "",
+
   // alpaca configuration
   // available trading mode: 'paper', 'live'
   "alpaca-key-id": "",

--- a/ToolBox/IEX/IEXDataDownloader.cs
+++ b/ToolBox/IEX/IEXDataDownloader.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,27 +14,23 @@
 */
 
 using NodaTime;
-using QuantConnect.Brokerages.InteractiveBrokers;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
-using QuantConnect.Logging;
 using QuantConnect.Securities;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace QuantConnect.ToolBox.IEX
 {
     public class IEXDataDownloader : IDataDownloader, IDisposable
     {
-        private IEXDataQueueHandler _handler;
-        private readonly string _apiKey;
+        private readonly IEXDataQueueHandler _handler;
 
-        public IEXDataDownloader(string apiKey)
+        public IEXDataDownloader()
         {
-            _handler = new IEXDataQueueHandler(false, apiKey);
-            _apiKey = apiKey;
+            _handler = new IEXDataQueueHandler(false);
         }
+
         public void Dispose()
         {
             _handler.Dispose();

--- a/ToolBox/IEX/IEXDataQueueHandler.cs
+++ b/ToolBox/IEX/IEXDataQueueHandler.cs
@@ -69,6 +69,11 @@ namespace QuantConnect.ToolBox.IEX
         {
             Endpoint = "https://ws-api.iextrading.com/1.0/tops";
 
+            if (string.IsNullOrWhiteSpace(_apiKey))
+            {
+                Log.Trace("IEXDataQueueHandler(): The IEX API key was not provided, history calls will return no data.");
+            }
+
             if (live)
             {
                 Reconnect();
@@ -204,7 +209,6 @@ namespace QuantConnect.ToolBox.IEX
             }
         }
 
-
         /// <summary>
         /// Unsubscribe from symbols
         /// </summary>
@@ -332,6 +336,12 @@ namespace QuantConnect.ToolBox.IEX
         /// <returns>An enumerable of the slices of data covering the span specified in each request</returns>
         public override IEnumerable<Slice> GetHistory(IEnumerable<Data.HistoryRequest> requests, DateTimeZone sliceTimeZone)
         {
+            if (string.IsNullOrWhiteSpace(_apiKey))
+            {
+                Log.Error("IEXDataQueueHandler.GetHistory(): History calls for IEX require an API key.");
+                yield break;
+            }
+
             foreach (var request in requests)
             {
                 foreach (var slice in ProcessHistoryRequests(request))

--- a/ToolBox/IEX/IEXDownloaderProgram.cs
+++ b/ToolBox/IEX/IEXDownloaderProgram.cs
@@ -15,12 +15,9 @@
 
 using System;
 using System.Collections.Generic;
-using QuantConnect.Brokerages.InteractiveBrokers;
 using QuantConnect.Logging;
 using QuantConnect.Util;
 using QuantConnect.Configuration;
-using QuantConnect.Data.Market;
-using System.Linq;
 
 namespace QuantConnect.ToolBox.IEX
 {
@@ -29,18 +26,13 @@ namespace QuantConnect.ToolBox.IEX
         /// <summary>
         /// Primary entry point to the program. This program only supports FOREX for now.
         /// </summary>
-        public static void IEXDownloader(IList<string> tickers, string resolution, DateTime fromDate, DateTime toDate, string apiKey)
+        public static void IEXDownloader(IList<string> tickers, string resolution, DateTime fromDate, DateTime toDate)
         {
             if (resolution.IsNullOrEmpty() || tickers.IsNullOrEmpty())
             {
                 Console.WriteLine("IEXDownloader ERROR: '--tickers=' or '--resolution=' parameter is missing");
                 Console.WriteLine("--tickers=eg SPY,AAPL");
                 Console.WriteLine("--resolution=Minute/Daily");
-                Environment.Exit(1);
-            }
-            if (apiKey.IsNullOrEmpty())
-            {
-                Console.WriteLine("QuandlBitfinexDownloader ERROR: '--api-key=' parameter is missing");
                 Environment.Exit(1);
             }
 
@@ -53,12 +45,12 @@ namespace QuantConnect.ToolBox.IEX
                 var dataDirectory = Config.Get("data-directory", "../../../Data");
                 var startDate = fromDate.ConvertToUtc(TimeZones.NewYork);
                 var endDate = toDate.ConvertToUtc(TimeZones.NewYork);
-                
+
                 // Create an instance of the downloader
                 const string market = Market.USA;
                 SecurityType securityType = SecurityType.Equity;
 
-                using (var downloader = new IEXDataDownloader(apiKey = apiKey))
+                using (var downloader = new IEXDataDownloader())
                 {
                     foreach (var ticker in tickers)
                     {
@@ -74,7 +66,7 @@ namespace QuantConnect.ToolBox.IEX
             }
             catch (Exception err)
             {
-                Log.Error(err);       
+                Log.Error(err);
             }
             Console.ReadLine();
         }

--- a/ToolBox/Program.cs
+++ b/ToolBox/Program.cs
@@ -99,7 +99,7 @@ namespace QuantConnect.ToolBox
                         break;
                     case "iexdl":
                     case "iexdownloader":
-                        IEXDownloaderProgram.IEXDownloader(tickers, resolution, fromDate, toDate, GetParameterOrExit(optionsObject, "api-key"));
+                        IEXDownloaderProgram.IEXDownloader(tickers, resolution, fromDate, toDate);
                         break;
                     case "iqfdl":
                     case "iqfeeddownloader":


### PR DESCRIPTION

#### Description
- Added parameterless constructor (for usage in LEAN config)
- Added config setting for IEX Cloud API key (required for history requests)
- Fixed history provider unit tests

#### Related Issue
Closes #4568 

#### Motivation and Context
- Exception is thrown when trying to use the IEXDataQueueHandler in the LEAN config.json

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Tested locally with Alpaca brokerage
- Unit tests passing

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`