### PR TITLE
Allow use of the MarketHoursDatabase class without requiring the Data folder

### DIFF
--- a/Common/Securities/MarketHoursDatabase.cs
+++ b/Common/Securities/MarketHoursDatabase.cs
@@ -32,6 +32,7 @@ namespace QuantConnect.Securities
     public class MarketHoursDatabase
     {
         private static MarketHoursDatabase _dataFolderMarketHoursDatabase;
+        private static MarketHoursDatabase _alwaysOpenMarketHoursDatabase;
         private static readonly object DataFolderMarketHoursDatabaseLock = new object();
 
         private readonly Dictionary<SecurityDatabaseKey, Entry> _entries;
@@ -44,7 +45,18 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Gets a <see cref="MarketHoursDatabase"/> that always returns <see cref="SecurityExchangeHours.AlwaysOpen"/>
         /// </summary>
-        public static MarketHoursDatabase AlwaysOpen { get; } = new AlwaysOpenMarketHoursDatabaseImpl();
+        public static MarketHoursDatabase AlwaysOpen
+        {
+            get
+            {
+                if (_alwaysOpenMarketHoursDatabase == null)
+                {
+                    _alwaysOpenMarketHoursDatabase = new AlwaysOpenMarketHoursDatabaseImpl();
+                }
+
+                return _alwaysOpenMarketHoursDatabase;
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MarketHoursDatabase"/> class


### PR DESCRIPTION
#### Description
Changes the way that `MarketHoursDatabase` works, such that the static property `AlwaysOpen` isn't assigned when the class is first accessed.

#### Related Issue
Closes https://github.com/QuantConnect/Lean/issues/4597

#### Motivation and Context
Allows unit testing of code requiring an instance of `MarketHoursDatabase`. 

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Provided unit test in the issue is able to pass with the attached change.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. _Not required, as any code accessing the property changed will behave in exactly the same way.  Code not dependent on this property will no longer have to deal with the code executed via that code branch._ 
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`