### PR TITLE
Fix KeyNotFoundException in Cash.EnsureCurrencyDataFeed

### DIFF
--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -584,6 +584,26 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.DoesNotThrow(() => JsonConvert.SerializeObject(book, Formatting.Indented));
         }
 
+        [Test]
+        public void EnsureCurrencyDataFeedThrowsWithUnsupportedCurrency()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var book = new CashBook
+                {
+                    {Currencies.USD, new Cash(Currencies.USD, 100, 1) },
+                    {"ILS", new Cash("ILS", 0, 0.3m) }
+                };
+                var subscriptions = new SubscriptionManager();
+                var dataManager = new DataManagerStub(TimeKeeper);
+                subscriptions.SetDataManager(dataManager);
+                var securities = new SecurityManager(TimeKeeper);
+
+                // System.ArgumentException: In order to maintain cash in ILS you are required to add a subscription for Forex pair ILSUSD or USDILS
+                book.EnsureCurrencyDataFeeds(securities, subscriptions, MarketMap, SecurityChanges.None, dataManager.SecurityService);
+            });
+        }
+
         private static TimeKeeper TimeKeeper
         {
             get { return new TimeKeeper(DateTime.Now, new[] { TimeZone }); }


### PR DESCRIPTION

#### Description
- Added a missing dictionary check in `Cash.EnsureCurrencyDataFeed`

#### Related Issue
Closes #4609 

#### Motivation and Context
- Better error message for unsupported currencies

#### Requires Documentation Change
No

#### How Has This Been Tested?
- Live algorithm deployed to IB
- New unit test

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`