### PR TITLE
Fixes Fill Model Logic to Get Prices to Fill Different Order Types

### DIFF
--- a/Common/Python/FillModelPythonWrapper.cs
+++ b/Common/Python/FillModelPythonWrapper.cs
@@ -150,5 +150,18 @@ namespace QuantConnect.Python
                 return (_model.GetPrices(asset, direction) as PyObject).GetAndDispose<Prices>();
             }
         }
+
+        /// <summary>
+        /// Get the minimum and maximum price for this security in the last bar for market fill orders
+        /// </summary>
+        /// <param name="asset">Security asset we're checking</param>
+        /// <param name="direction">The order direction, decides whether to pick bid or ask</param>
+        protected override Prices GetPricesForMarketFill(Security asset, OrderDirection direction)
+        {
+            using (Py.GIL())
+            {
+                return (_model.GetPricesForMarketFill(asset, direction) as PyObject).GetAndDispose<Prices>();
+            }
+        }
     }
 }

--- a/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
+++ b/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
@@ -288,18 +288,19 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
-                    "from clr import AddReference\n" +
-                    "AddReference(\"QuantConnect.Common\")\n" +
-                    "from QuantConnect.Orders.Fills import ImmediateFillModel\n" +
-                    "class CustomFillModel(ImmediateFillModel):\n" +
-                    "   def __init__(self):\n" +
-                    "       self.MarketFillWasCalled = False\n" +
-                    "   def MarketFill(self, asset, order):\n" +
-                    "       self.MarketFillWasCalled = True\n" +
-                    "       return super().MarketFill(asset, order)");
+                var customFillModel = PythonEngine.ModuleFromString(
+                    Guid.NewGuid().ToString(),
+                    @"from clr import AddReference
+AddReference('QuantConnect.Common')
+from QuantConnect.Orders.Fills import ImmediateFillModel
+class CustomFillModel(ImmediateFillModel):
+    def __init__(self):
+        self.MarketFillWasCalled = False
+    def MarketFill(self, asset, order):
+        self.MarketFillWasCalled = True
+        return super().MarketFill(asset, order)"
+                ).GetAttr("CustomFillModel").Invoke();
 
-                var customFillModel = module.GetAttr("CustomFillModel").Invoke();
                 var wrapper = new FillModelPythonWrapper(customFillModel);
 
                 var result = wrapper.Fill(new FillModelParameters(
@@ -322,18 +323,19 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
-                    "from clr import AddReference\n" +
-                    "AddReference(\"QuantConnect.Common\")\n" +
-                    "from QuantConnect.Orders.Fills import FillModel\n" +
-                    "class CustomFillModel(FillModel):\n" +
-                    "   def __init__(self):\n" +
-                    "       self.MarketFillWasCalled = False\n" +
-                    "   def MarketFill(self, asset, order):\n" +
-                    "       self.MarketFillWasCalled = True\n" +
-                    "       return super().MarketFill(asset, order)");
+                var customFillModel = PythonEngine.ModuleFromString(
+                    Guid.NewGuid().ToString(),
+                    @"from clr import AddReference
+AddReference('QuantConnect.Common')
+from QuantConnect.Orders.Fills import FillModel
+class CustomFillModel(FillModel):
+    def __init__(self):
+        self.MarketFillWasCalled = False
+    def MarketFill(self, asset, order):
+        self.MarketFillWasCalled = True
+        return super().MarketFill(asset, order)"
+                ).GetAttr("CustomFillModel").Invoke();
 
-                var customFillModel = module.GetAttr("CustomFillModel").Invoke();
                 var wrapper = new FillModelPythonWrapper(customFillModel);
 
                 var result = wrapper.Fill(new FillModelParameters(
@@ -356,18 +358,19 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
-                    "from clr import AddReference\n" +
-                    "AddReference(\"QuantConnect.Common\")\n" +
-                    "from QuantConnect.Orders.Fills import FillModel\n" +
-                    "class CustomFillModel(FillModel):\n" +
-                    "   def __init__(self):\n" +
-                    "       self.FillWasCalled = False\n" +
-                    "   def Fill(self, parameters):\n" +
-                    "       self.FillWasCalled = True\n" +
-                    "       return super().Fill(parameters)");
+                var customFillModel = PythonEngine.ModuleFromString(
+                    Guid.NewGuid().ToString(),
+                    @"from clr import AddReference
+AddReference('QuantConnect.Common')
+from QuantConnect.Orders.Fills import FillModel
+class CustomFillModel(FillModel):
+    def __init__(self):
+        self.FillWasCalled = False
+    def Fill(self, parameters):
+        self.FillWasCalled = True
+        return super().Fill(parameters)"
+                ).GetAttr("CustomFillModel").Invoke();
 
-                var customFillModel = module.GetAttr("CustomFillModel").Invoke();
                 var wrapper = new FillModelPythonWrapper(customFillModel);
 
                 var result = wrapper.Fill(new FillModelParameters(
@@ -390,23 +393,24 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
-                    "from clr import AddReference\n" +
-                    "AddReference(\"QuantConnect.Common\")\n" +
-                    "from QuantConnect.Orders.Fills import FillModel, Fill\n" +
-                    "class CustomFillModel(FillModel):\n" +
-                    "   def __init__(self):\n" +
-                    "       self.FillWasCalled = False\n" +
-                    "       self.MarketFillWasCalled = False\n" +
-                    "   def Fill(self, parameters):\n" +
-                    "       self.FillWasCalled = True\n" +
-                    "       self.Parameters = parameters\n" +
-                    "       return Fill(self.MarketFill(parameters.Security, parameters.Order))\n" +
-                    "   def MarketFill(self, asset, order):\n" +
-                    "       self.MarketFillWasCalled = True\n" +
-                    "       return super().MarketFill(asset, order)");
+                var customFillModel = PythonEngine.ModuleFromString(
+                    Guid.NewGuid().ToString(),
+                    @"from clr import AddReference
+AddReference('QuantConnect.Common')
+from QuantConnect.Orders.Fills import FillModel, Fill
+class CustomFillModel(FillModel):
+    def __init__(self):
+        self.FillWasCalled = False
+        self.MarketFillWasCalled = False
+    def Fill(self, parameters):
+        self.FillWasCalled = True
+        self.Parameters = parameters
+        return Fill(self.MarketFill(parameters.Security, parameters.Order))
+    def MarketFill(self, asset, order):
+        self.MarketFillWasCalled = True
+        return super().MarketFill(asset, order)"
+                ).GetAttr("CustomFillModel").Invoke();
 
-                var customFillModel = module.GetAttr("CustomFillModel").Invoke();
                 var wrapper = new FillModelPythonWrapper(customFillModel);
 
                 var result = wrapper.Fill(new FillModelParameters(
@@ -431,24 +435,28 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
-                    "from clr import AddReference\n" +
-                    "AddReference(\"QuantConnect.Common\")\n" +
-                    "from QuantConnect.Orders.Fills import FillModel, Fill\n" +
-                    "from QuantConnect.Orders import OrderEvent\n" +
-                    "class CustomFillModel(FillModel):\n" +
-                    "   def __init__(self):\n" +
-                    "       self.FillWasCalled = False\n" +
-                    "       self.GetPricesWasCalled = False\n" +
-                    "   def Fill(self, parameters):\n" +
-                    "       self.FillWasCalled = True\n" +
-                    "       self.Parameters = parameters\n" +
-                    "       return Fill(super().MarketFill(parameters.Security, parameters.Order))\n" +
-                    "   def GetPrices(self, asset, direction):\n" +
-                    "       self.GetPricesWasCalled = True\n" +
-                    "       return super().GetPrices(asset, direction)");
+                var customFillModel = PythonEngine.ModuleFromString(
+                    Guid.NewGuid().ToString(),
+                    @"from clr import AddReference
+AddReference('QuantConnect.Common') 
+from QuantConnect.Orders.Fills import FillModel, Fill
+from QuantConnect.Orders import OrderEvent
+class CustomFillModel(FillModel):
+    def __init__(self):
+        self.FillWasCalled = False
+        self.GetPricesWasCalled = False
+    def Fill(self, parameters):
+        self.FillWasCalled = True
+        self.Parameters = parameters
+        return Fill(super().MarketFill(parameters.Security, parameters.Order))
+    def GetPrices(self, asset, direction):
+        self.GetPricesWasCalled = True
+        return super().GetPrices(asset, direction)
+    def GetPricesForMarketFill(self, asset, direction):
+        self.GetPricesWasCalled = True
+        return self.GetPrices(asset, direction)"
+                ).GetAttr("CustomFillModel").Invoke();
 
-                var customFillModel = module.GetAttr("CustomFillModel").Invoke();
                 var wrapper = new FillModelPythonWrapper(customFillModel);
 
                 var result = wrapper.Fill(new FillModelParameters(
@@ -473,18 +481,20 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
-                    "from clr import AddReference\n" +
-                    "AddReference(\"QuantConnect.Common\")\n" +
-                    "from QuantConnect.Orders.Fills import ImmediateFillModel\n" +
-                    "class CustomFillModel(ImmediateFillModel):\n" +
-                    "   def __init__(self):\n" +
-                    "       self.MarketFillWasCalled = False\n" +
-                    "   def MarketFill(self, asset, order):\n" +
-                    "       self.MarketFillWasCalled = True\n" +
-                    "       return super().MarketFill(asset, order)");
+                var customFillModel = PythonEngine.ModuleFromString(
+                    Guid.NewGuid().ToString(),
+                    @"
+from clr import AddReference
+AddReference('QuantConnect.Common')
+from QuantConnect.Orders.Fills import ImmediateFillModel
+class CustomFillModel(ImmediateFillModel):
+    def __init__(self):
+        self.MarketFillWasCalled = False
+    def MarketFill(self, asset, order):
+        self.MarketFillWasCalled = True
+        return super().MarketFill(asset, order)"
+                ).GetAttr("CustomFillModel").Invoke();
 
-                var customFillModel = module.GetAttr("CustomFillModel").Invoke();
                 var wrapper = new FillModelPythonWrapper(customFillModel);
 
                 var result = wrapper.Fill(new FillModelParameters(
@@ -637,6 +647,11 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 GetPricesWasCalled = true;
                 return new Prices(orderDateTime, 12345, 12345, 12345, 12345, 12345);
             }
+
+            protected override Prices GetPricesForMarketFill(Security asset, OrderDirection direction)
+            {
+                return GetPrices(asset, direction);
+            }
         }
 
         private class TestFillModelInheritBaseClassDoesNotOverride : FillModel
@@ -649,6 +664,11 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 // call base.GetPrices() just to test it show its possible
                 base.GetPrices(asset, direction);
                 return new Prices(orderDateTime, 12345, 12345, 12345, 12345, 12345);
+            }
+
+            protected override Prices GetPricesForMarketFill(Security asset, OrderDirection direction)
+            {
+                return GetPrices(asset, direction);
             }
         }
 


### PR DESCRIPTION
#### Description
Break FillModel.GetPrices into two methods: one is specific for market orders and the other for the other types. This is required because only market order doesn't depend on OHLC information.

Fixes unit tests that didn't consider multiple data types and add unit test to verify whether limit and stop orders could be filled by open interest data (bug).

#### Related Issue
Closes #4457 

#### Motivation and Context
Bur fix and improve modeling.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New and improved unit tests. In QC Cloud, we ran the algorithm from issue #4457.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`