### PR TITLE
Performance Issue #3622 Log handling via a dedicated thread

### DIFF
--- a/Launcher/Program.cs
+++ b/Launcher/Program.cs
@@ -66,85 +66,92 @@ namespace QuantConnect.Lean.Launcher
             Log.FilePath = Path.Combine(Config.Get("results-destination-folder"), "log.txt");
             Log.LogHandler = Composer.Instance.GetExportedValueByTypeName<ILogHandler>(Config.Get("log-handler", "CompositeLogHandler"));
 
-            //Name thread for the profiler:
-            Thread.CurrentThread.Name = "Algorithm Analysis Thread";
-            Log.Trace("Engine.Main(): LEAN ALGORITHMIC TRADING ENGINE v" + Globals.Version + " Mode: " + mode + " (" + (Environment.Is64BitProcess ? "64" : "32") + "bit)");
-            Log.Trace("Engine.Main(): Started " + DateTime.Now.ToShortTimeString());
-
-            //Import external libraries specific to physical server location (cloud/local)
-            LeanEngineSystemHandlers leanEngineSystemHandlers;
             try
             {
-                leanEngineSystemHandlers = LeanEngineSystemHandlers.FromConfiguration(Composer.Instance);
-            }
-            catch (CompositionException compositionException)
-            {
-                Log.Error("Engine.Main(): Failed to load library: " + compositionException);
-                throw;
-            }
+                //Name thread for the profiler:
+                Thread.CurrentThread.Name = "Algorithm Analysis Thread";
+                Log.Trace("Engine.Main(): LEAN ALGORITHMIC TRADING ENGINE v" + Globals.Version + " Mode: " + mode + " (" + (Environment.Is64BitProcess ? "64" : "32") + "bit)");
+                Log.Trace("Engine.Main(): Started " + DateTime.Now.ToShortTimeString());
 
-            //Setup packeting, queue and controls system: These don't do much locally.
-            leanEngineSystemHandlers.Initialize();
+                //Import external libraries specific to physical server location (cloud/local)
+                LeanEngineSystemHandlers leanEngineSystemHandlers;
+                try
+                {
+                    leanEngineSystemHandlers = LeanEngineSystemHandlers.FromConfiguration(Composer.Instance);
+                }
+                catch (CompositionException compositionException)
+                {
+                    Log.Error("Engine.Main(): Failed to load library: " + compositionException);
+                    throw;
+                }
 
-            //-> Pull job from QuantConnect job queue, or, pull local build:
-            string assemblyPath;
-            var job = leanEngineSystemHandlers.JobQueue.NextJob(out assemblyPath);
+                //Setup packeting, queue and controls system: These don't do much locally.
+                leanEngineSystemHandlers.Initialize();
 
-            if (job == null)
-            {
-                const string jobNullMessage = "Engine.Main(): Sorry we could not process this algorithm request.";
-                Log.Error(jobNullMessage);
-                throw new ArgumentException(jobNullMessage);
-            }
+                //-> Pull job from QuantConnect job queue, or, pull local build:
+                string assemblyPath;
+                var job = leanEngineSystemHandlers.JobQueue.NextJob(out assemblyPath);
 
-            LeanEngineAlgorithmHandlers leanEngineAlgorithmHandlers;
-            try
-            {
-                leanEngineAlgorithmHandlers = LeanEngineAlgorithmHandlers.FromConfiguration(Composer.Instance);
-            }
-            catch (CompositionException compositionException)
-            {
-                Log.Error("Engine.Main(): Failed to load library: " + compositionException);
-                throw;
-            }
+                if (job == null)
+                {
+                    const string jobNullMessage = "Engine.Main(): Sorry we could not process this algorithm request.";
+                    Log.Error(jobNullMessage);
+                    throw new ArgumentException(jobNullMessage);
+                }
 
-            // if the job version doesn't match this instance version then we can't process it
-            // we also don't want to reprocess redelivered jobs
-            if (VersionHelper.IsNotEqualVersion(job.Version) || job.Redelivered)
-            {
-                Log.Error("Engine.Run(): Job Version: " + job.Version + "  Deployed Version: " + Globals.Version + " Redelivered: " + job.Redelivered);
-                //Tiny chance there was an uncontrolled collapse of a server, resulting in an old user task circulating.
-                //In this event kill the old algorithm and leave a message so the user can later review.
-                leanEngineSystemHandlers.Api.SetAlgorithmStatus(job.AlgorithmId, AlgorithmStatus.RuntimeError, _collapseMessage);
-                leanEngineSystemHandlers.Notify.SetAuthentication(job);
-                leanEngineSystemHandlers.Notify.Send(new RuntimeErrorPacket(job.UserId, job.AlgorithmId, _collapseMessage));
-                leanEngineSystemHandlers.JobQueue.AcknowledgeJob(job);
-                return;
-            }
+                LeanEngineAlgorithmHandlers leanEngineAlgorithmHandlers;
+                try
+                {
+                    leanEngineAlgorithmHandlers = LeanEngineAlgorithmHandlers.FromConfiguration(Composer.Instance);
+                }
+                catch (CompositionException compositionException)
+                {
+                    Log.Error("Engine.Main(): Failed to load library: " + compositionException);
+                    throw;
+                }
 
-            try
-            {
-                var algorithmManager = new AlgorithmManager(liveMode, job);
+                // if the job version doesn't match this instance version then we can't process it
+                // we also don't want to reprocess redelivered jobs
+                if (VersionHelper.IsNotEqualVersion(job.Version) || job.Redelivered)
+                {
+                    Log.Error("Engine.Run(): Job Version: " + job.Version + "  Deployed Version: " + Globals.Version + " Redelivered: " + job.Redelivered);
+                    //Tiny chance there was an uncontrolled collapse of a server, resulting in an old user task circulating.
+                    //In this event kill the old algorithm and leave a message so the user can later review.
+                    leanEngineSystemHandlers.Api.SetAlgorithmStatus(job.AlgorithmId, AlgorithmStatus.RuntimeError, _collapseMessage);
+                    leanEngineSystemHandlers.Notify.SetAuthentication(job);
+                    leanEngineSystemHandlers.Notify.Send(new RuntimeErrorPacket(job.UserId, job.AlgorithmId, _collapseMessage));
+                    leanEngineSystemHandlers.JobQueue.AcknowledgeJob(job);
+                    return;
+                }
 
-                leanEngineSystemHandlers.LeanManager.Initialize(leanEngineSystemHandlers, leanEngineAlgorithmHandlers, job, algorithmManager);
+                try
+                {
+                    var algorithmManager = new AlgorithmManager(liveMode, job);
 
-                var engine = new Engine.Engine(leanEngineSystemHandlers, leanEngineAlgorithmHandlers, liveMode);
-                engine.Run(job, algorithmManager, assemblyPath, WorkerThread.Instance);
-            }
+                    leanEngineSystemHandlers.LeanManager.Initialize(leanEngineSystemHandlers, leanEngineAlgorithmHandlers, job, algorithmManager);
+
+                    var engine = new Engine.Engine(leanEngineSystemHandlers, leanEngineAlgorithmHandlers, liveMode);
+                    engine.Run(job, algorithmManager, assemblyPath, WorkerThread.Instance);
+                }
+                finally
+                {
+                    //Delete the message from the job queue:
+                    leanEngineSystemHandlers.JobQueue.AcknowledgeJob(job);
+                    Log.Trace("Engine.Main(): Packet removed from queue: " + job.AlgorithmId);
+
+                    // clean up resources
+                    leanEngineSystemHandlers.Dispose();
+                    leanEngineAlgorithmHandlers.Dispose();
+                    Log.Trace("Program.Main(): Exiting Lean...");
+                
+                    Log.LogHandler.Dispose();
+                    Environment.Exit(0);
+                }
+            } 
             finally
             {
-                //Delete the message from the job queue:
-                leanEngineSystemHandlers.JobQueue.AcknowledgeJob(job);
-                Log.Trace("Engine.Main(): Packet removed from queue: " + job.AlgorithmId);
-
-                // clean up resources
-                leanEngineSystemHandlers.Dispose();
-                leanEngineAlgorithmHandlers.Dispose();
+                // If anything breaks we still need to flush our logging thread
                 Log.LogHandler.Dispose();
-
-                Log.Trace("Program.Main(): Exiting Lean...");
-
-                Environment.Exit(0);
             }
         }
     }

--- a/Logging/BaseLogHandler.cs
+++ b/Logging/BaseLogHandler.cs
@@ -21,7 +21,7 @@ using System.Threading;
 namespace QuantConnect.Logging
 {
     /// <summary>
-    /// BaseLogHandler that collect messages to later write to the result handler
+    /// BaseLogHandler that collect messages in a queue and then writes them with a dedicated thread
     /// </summary>
     public abstract class BaseLogHandler : ILogHandler
     {

--- a/Logging/BaseLogHandler.cs
+++ b/Logging/BaseLogHandler.cs
@@ -1,0 +1,137 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Threading;
+
+namespace QuantConnect.Logging
+{
+    /// <summary>
+    /// BaseLogHandler that collect messages to later write to the result handler
+    /// </summary>
+    public abstract class BaseLogHandler : ILogHandler
+    {
+        private ConcurrentQueue<LogEntry> LogsQueue;
+        private const string DateFormat = "yyyyMMdd HH:mm:ss";
+        private Thread LogThread;
+
+        /// <summary>
+        /// Logging event delegate
+        /// </summary>
+        private static AutoResetEvent MessageEvent;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuantConnect.Logging.BaseLogHandler"/> class.
+        /// </summary>
+        public BaseLogHandler()
+        {
+            LogsQueue = new ConcurrentQueue<LogEntry>();
+            MessageEvent = new AutoResetEvent(false);
+            LogThread = new Thread(WriteThread) { IsBackground = true, Name = "Logging Thread" };
+            LogThread.Start();
+        }
+
+        /// <summary>
+        /// Write error message to log
+        /// </summary>
+        /// <param name="text">The error text to log</param>
+        public void Error(string text)
+        {
+            var log = new LogEntry(text, DateTime.UtcNow, LogType.Error);
+            LogsQueue.Enqueue(log);
+            MessageEvent.Set();
+        }
+
+        /// <summary>
+        /// Write debug message to log
+        /// </summary>
+        /// <param name="text">The debug text to log</param>
+        public void Debug(string text)
+        {
+            var log = new LogEntry(text, DateTime.UtcNow, LogType.Debug);
+            LogsQueue.Enqueue(log);
+            MessageEvent.Set();
+        }
+
+        /// <summary>
+        /// Write debug message to log
+        /// </summary>
+        /// <param name="text">The trace text to log</param>
+        public void Trace(string text)
+        {
+            var log = new LogEntry(text, DateTime.UtcNow, LogType.Trace);
+            LogsQueue.Enqueue(log);
+            MessageEvent.Set();
+        }
+
+        /// <summary>
+        /// Thread function in charge of dispersing log messages
+        /// </summary>
+        public void WriteThread()
+        {
+            try{
+                while(true){
+                    while (!LogsQueue.IsEmpty){
+                        LogEntry entry;
+                        bool success = LogsQueue.TryDequeue(out entry);
+
+                        switch(entry.MessageType){
+                            case LogType.Trace:
+                                WriteTrace(entry.Message);
+                                break;
+                            case LogType.Debug:
+                                WriteDebug(entry.Message);
+                                break;
+                            case LogType.Error:
+                                WriteError(entry.Message);
+                                break;
+                        }
+                    }
+
+                    MessageEvent.Reset();
+                }
+            } catch {
+                Console.WriteLine("Dead Thread me Boi");
+            }
+        }
+
+        /// <summary>
+        /// Function to write a trace statement
+        /// </summary>
+        public abstract void WriteTrace(string message);
+
+        /// <summary>
+        /// Function to write a debug statement
+        /// </summary>
+        public abstract void WriteDebug(string message);
+
+        /// <summary>
+        /// Function to write a error statement
+        /// </summary>
+        public abstract void WriteError(string message);
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <filterpriority>2</filterpriority>
+        public virtual void Dispose()
+        {
+            LogThread.Join(50);
+        }
+
+    }
+}

--- a/Logging/ConsoleLogHandler.cs
+++ b/Logging/ConsoleLogHandler.cs
@@ -22,7 +22,7 @@ namespace QuantConnect.Logging
     /// <summary>
     /// ILogHandler implementation that writes log output to console.
     /// </summary>
-    public class ConsoleLogHandler : ILogHandler
+    public class ConsoleLogHandler : BaseLogHandler
     {
         private const string DefaultDateFormat = "yyyyMMdd HH:mm:ss.fff";
         private readonly TextWriter _trace;
@@ -54,7 +54,7 @@ namespace QuantConnect.Logging
         /// Write error message to log
         /// </summary>
         /// <param name="text">The error text to log</param>
-        public void Error(string text)
+        public override void WriteError(string text)
         {
 #if DEBUG
             Console.ForegroundColor = ConsoleColor.Red;
@@ -69,7 +69,7 @@ namespace QuantConnect.Logging
         /// Write debug message to log
         /// </summary>
         /// <param name="text">The debug text to log</param>
-        public void Debug(string text)
+        public override void WriteDebug(string text)
         {
             _trace.WriteLine(DateTime.Now.ToString(_dateFormat, CultureInfo.InvariantCulture) + " DEBUG:: " + text);
         }
@@ -78,17 +78,9 @@ namespace QuantConnect.Logging
         /// Write debug message to log
         /// </summary>
         /// <param name="text">The trace text to log</param>
-        public void Trace(string text)
+        public override void WriteTrace(string text)
         {
             _trace.WriteLine(DateTime.Now.ToString(_dateFormat, CultureInfo.InvariantCulture) + " Trace:: " + text);
-        }
-
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        /// <filterpriority>2</filterpriority>
-        public void Dispose()
-        {
         }
     }
 }

--- a/Logging/ConsoleLogHandler.cs
+++ b/Logging/ConsoleLogHandler.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Logging
         /// Write error message to log
         /// </summary>
         /// <param name="text">The error text to log</param>
-        public override void WriteError(string text)
+        protected override void WriteError(string text)
         {
 #if DEBUG
             Console.ForegroundColor = ConsoleColor.Red;
@@ -69,7 +69,7 @@ namespace QuantConnect.Logging
         /// Write debug message to log
         /// </summary>
         /// <param name="text">The debug text to log</param>
-        public override void WriteDebug(string text)
+        protected override void WriteDebug(string text)
         {
             _trace.WriteLine(DateTime.Now.ToString(_dateFormat, CultureInfo.InvariantCulture) + " DEBUG:: " + text);
         }
@@ -78,7 +78,7 @@ namespace QuantConnect.Logging
         /// Write debug message to log
         /// </summary>
         /// <param name="text">The trace text to log</param>
-        public override void WriteTrace(string text)
+        protected override void WriteTrace(string text)
         {
             _trace.WriteLine(DateTime.Now.ToString(_dateFormat, CultureInfo.InvariantCulture) + " Trace:: " + text);
         }

--- a/Logging/FileLogHandler.cs
+++ b/Logging/FileLogHandler.cs
@@ -20,7 +20,7 @@ using System.IO;
 namespace QuantConnect.Logging
 {
     /// <summary>
-    /// Provides an implementation of <see cref="ILogHandler"/> that writes all log messages to a file on disk.
+    /// Provides an implementation of <see cref="BaseLogHandler"/> that writes all log messages to a file on disk.
     /// </summary>
     public class FileLogHandler : BaseLogHandler
     {

--- a/Logging/FileLogHandler.cs
+++ b/Logging/FileLogHandler.cs
@@ -22,7 +22,7 @@ namespace QuantConnect.Logging
     /// <summary>
     /// Provides an implementation of <see cref="ILogHandler"/> that writes all log messages to a file on disk.
     /// </summary>
-    public class FileLogHandler : ILogHandler
+    public class FileLogHandler : BaseLogHandler
     {
         private bool _disposed;
 
@@ -57,7 +57,7 @@ namespace QuantConnect.Logging
         /// Write error message to log
         /// </summary>
         /// <param name="text">The error text to log</param>
-        public void Error(string text)
+        public override void WriteError(string text)
         {
             WriteMessage(text, "ERROR");
         }
@@ -66,7 +66,7 @@ namespace QuantConnect.Logging
         /// Write debug message to log
         /// </summary>
         /// <param name="text">The debug text to log</param>
-        public void Debug(string text)
+        public override void WriteDebug(string text)
         {
             WriteMessage(text, "DEBUG");
         }
@@ -75,7 +75,7 @@ namespace QuantConnect.Logging
         /// Write debug message to log
         /// </summary>
         /// <param name="text">The trace text to log</param>
-        public void Trace(string text)
+        public override void WriteTrace(string text)
         {
             WriteMessage(text, "TRACE");
         }
@@ -84,8 +84,8 @@ namespace QuantConnect.Logging
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         /// <filterpriority>2</filterpriority>
-        public void Dispose()
-        {
+        public override void Dispose()
+        {   
             lock (_lock)
             {
                 if (_writer.IsValueCreated)
@@ -94,6 +94,8 @@ namespace QuantConnect.Logging
                     _writer.Value.Dispose();
                 }
             }
+
+            base.Dispose();
         }
 
         /// <summary>

--- a/Logging/FileLogHandler.cs
+++ b/Logging/FileLogHandler.cs
@@ -27,7 +27,6 @@ namespace QuantConnect.Logging
         private bool _disposed;
 
         // we need to control synchronization to our stream writer since it's not inherently thread-safe
-        private readonly object _lock = new object();
         private readonly Lazy<TextWriter> _writer;
         private readonly bool _useTimestampPrefix;
 
@@ -85,17 +84,14 @@ namespace QuantConnect.Logging
         /// </summary>
         /// <filterpriority>2</filterpriority>
         public override void Dispose()
-        {   
-            lock (_lock)
-            {
-                if (_writer.IsValueCreated)
-                {
-                    _disposed = true;
-                    _writer.Value.Dispose();
-                }
-            }
-
+        {
             base.Dispose();
+
+            if (_writer.IsValueCreated)
+            {
+                _disposed = true;
+                _writer.Value.Dispose();
+            }
         }
 
         /// <summary>
@@ -118,12 +114,9 @@ namespace QuantConnect.Logging
         /// </summary>
         private void WriteMessage(string text, string level)
         {
-            lock (_lock)
-            {
-                if (_disposed) return;
-                _writer.Value.WriteLine(CreateMessage(text, level));
-                _writer.Value.Flush();
-            }
+            if (_disposed) return;
+            _writer.Value.WriteLine(CreateMessage(text, level));
+            _writer.Value.Flush();
         }
     }
 }

--- a/Logging/FileLogHandler.cs
+++ b/Logging/FileLogHandler.cs
@@ -56,7 +56,7 @@ namespace QuantConnect.Logging
         /// Write error message to log
         /// </summary>
         /// <param name="text">The error text to log</param>
-        public override void WriteError(string text)
+        protected override void WriteError(string text)
         {
             WriteMessage(text, "ERROR");
         }
@@ -65,7 +65,7 @@ namespace QuantConnect.Logging
         /// Write debug message to log
         /// </summary>
         /// <param name="text">The debug text to log</param>
-        public override void WriteDebug(string text)
+        protected override void WriteDebug(string text)
         {
             WriteMessage(text, "DEBUG");
         }
@@ -74,7 +74,7 @@ namespace QuantConnect.Logging
         /// Write debug message to log
         /// </summary>
         /// <param name="text">The trace text to log</param>
-        public override void WriteTrace(string text)
+        protected override void WriteTrace(string text)
         {
             WriteMessage(text, "TRACE");
         }

--- a/Logging/QuantConnect.Logging.csproj
+++ b/Logging/QuantConnect.Logging.csproj
@@ -107,6 +107,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="BaseLogHandler.cs" />
     <Compile Include="CompositeLogHandler.cs" />
     <Compile Include="CompositeNLogHandler.cs" />
     <Compile Include="NLogHandler.cs" />

--- a/Tests/Logging/FileLogHandlerTests.cs
+++ b/Tests/Logging/FileLogHandlerTests.cs
@@ -64,5 +64,39 @@ namespace QuantConnect.Tests.Logging
 
             File.Delete(Log.FilePath);
         }
+
+        [Test]
+        public void TestLoggingSpeeds()
+        {
+            var start = DateTime.Now;
+            const string file = "log2.txt";
+
+            //Delete it first, just to make sure it is not there.
+            File.Delete(file);
+            int math = 1;
+
+            using (var log = new FileLogHandler(file))
+            {
+                //Log messages but also do other things in the meantime to test log threading.
+                for (int i = 0; i < 1000000; i++)
+                {
+                    var debugMessage = "debug message " + i;
+                    log.Debug(debugMessage);
+
+                    for (int j = 0; j < 10000; j++)
+                    {
+                        math = math * j;
+                    }
+
+                    log.Debug(math.ToStringInvariant());
+                }
+            }
+
+
+            var end = DateTime.Now;
+            var time = start - end;
+
+            Console.WriteLine(time);
+        }
     }
 }

--- a/Tests/Logging/FileLogHandlerTests.cs
+++ b/Tests/Logging/FileLogHandlerTests.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Tests.Logging
 
         [TestCase(10)]
         [TestCase(100)]
-        [TestCase(1000)]
+        [Ignore("Long logging speed performance test.")]
         public void TestLoggingSpeeds(int x)
         {
             var start = DateTime.Now;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The current implementation of log handling has thread contention over which thread is using the logger. The new baseloghandler class implements a queue log system that allows the rest of the engine to post log messages to a logging queue and then alert the logging thread that there is new messages that need to be processed. Then the logging thread can process each message in the queue through the implementing classes log methods. 

This PR does change the functionality of the console and file log handlers to implement the new abstract BaseLogHandler class; now the console and file log handlers contain a set of methods for writing to their respective outs (WriteDebug, WriteTrace, WriteError) which is called on by the Logger Thread.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #3622 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Performance improvement since it removes thread contention for logger
- Separates i/o functions from the rest of the worker and engine threads which is a safer approach.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
None

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test included TestLoggingSpeeds(int x); these are ignored by default.
x = number of threads writing to the log. Each thread writes 1000 messages concurrently to the log. 

Comparing the current implementation vs this new one shows pretty significant differences, cuts the time to about half.

### Current Setup
> Test Name:	TestLoggingSpeeds(10)
> Test Outcome:	Passed
> Result1 StandardOutput:	-00:00:00.1349963
> 
> Test Name:	TestLoggingSpeeds(100)
> Test Outcome:	Passed
> Result2 StandardOutput:	-00:00:01.3751058
> 
> Test Name:	TestLoggingSpeeds(1000)
> Test Outcome:	Passed
> Result3 StandardOutput:	-00:00:11.2671876



### New BaseLogHandler
> Test Name:	TestLoggingSpeeds(10)
> Test Outcome:	Passed
> Result1 StandardOutput:	-00:00:00.0760017
> 
> Test Name:	TestLoggingSpeeds(100)
> Test Outcome:	Passed
> Result2 StandardOutput:	-00:00:00.6815223
> 
> Test Name:	TestLoggingSpeeds(1000)
> Test Outcome:	Passed
> Result3 StandardOutput:	-00:00:05.9647384


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
