### PR TITLE
Refactors SecurityCache to Support Access to Tick of Different Type

### DIFF
--- a/Common/Securities/SecurityCache.cs
+++ b/Common/Securities/SecurityCache.cs
@@ -142,26 +142,10 @@ namespace QuantConnect.Securities
         private void AddDataImpl(BaseData data, bool cacheByType)
         {
             var tick = data as Tick;
-            if (tick != null)
+            if (tick?.TickType == TickType.OpenInterest)
             {
-                switch (tick.TickType)
-                {
-                    case TickType.Trade:
-                        if (tick.Quantity != 0) Volume = tick.Quantity;
-                        break;
-
-                    case TickType.Quote:
-                        if (tick.BidPrice != 0) BidPrice = tick.BidPrice;
-                        if (tick.BidSize != 0) BidSize = tick.BidSize;
-
-                        if (tick.AskPrice != 0) AskPrice = tick.AskPrice;
-                        if (tick.AskSize != 0) AskSize = tick.AskSize;
-                        break;
-
-                    case TickType.OpenInterest:
-                        OpenInterest = (long)tick.Value;
-                        return;
-                }
+                OpenInterest = (long)tick.Value;
+                return;
             }
 
             // Only cache non fill-forward data.
@@ -213,6 +197,27 @@ namespace QuantConnect.Securities
                 _lastData = data;
             }
 
+            if (tick != null)
+            {
+                if (tick.Value != 0) Price = tick.Value;
+
+                switch (tick.TickType)
+                {
+                    case TickType.Trade:
+                        if (tick.Quantity != 0) Volume = tick.Quantity;
+                        break;
+
+                    case TickType.Quote:
+                        if (tick.BidPrice != 0) BidPrice = tick.BidPrice;
+                        if (tick.BidSize != 0) BidSize = tick.BidSize;
+
+                        if (tick.AskPrice != 0) AskPrice = tick.AskPrice;
+                        if (tick.AskSize != 0) AskSize = tick.AskSize;
+                        break;
+                }
+                return;
+            }
+
             var bar = data as IBar;
             if (bar != null)
             {
@@ -247,7 +252,7 @@ namespace QuantConnect.Securities
                     if (quoteBar.LastAskSize != 0) AskSize = quoteBar.LastAskSize;
                 }
             }
-            else if (data.DataType != MarketDataType.Auxiliary && data.Price != 0)
+            else if (data.DataType != MarketDataType.Auxiliary)
             {
                 Price = data.Price;
             }

--- a/Tests/Common/Securities/SecurityCacheTests.cs
+++ b/Tests/Common/Securities/SecurityCacheTests.cs
@@ -103,6 +103,56 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
+        public void AddData_SecurityCacheHasTradeAndQuoteTick()
+        {
+            // Arrange
+            var securityCache = new SecurityCache();
+            var time = DateTime.Now;
+
+            var quote = new Tick(time, Symbol.Empty, 100, 102) { TickType = TickType.Quote };
+            securityCache.AddData(quote);
+
+            var trade = new Tick(time, Symbol.Empty, 100, 100, 102) {TickType = TickType.Trade};
+            securityCache.AddData(trade);
+
+            var openInterest = new OpenInterest(time, Symbol.Empty, 1000);
+            securityCache.AddData(openInterest);
+
+            // Assert
+            Assert.True(securityCache.GetData().Equals(trade));
+            Assert.True(securityCache.GetData<Tick>().Equals(trade));
+
+            Assert.True(securityCache.GetAll<Tick>().LastOrDefault(x => x.TickType == TickType.Quote).Equals(quote));
+            Assert.True(securityCache.GetAll<Tick>().LastOrDefault(x => x.TickType == TickType.Trade).Equals(trade));
+        }
+
+
+        [Test]
+        public void StoreData_SecurityCacheHasTradeAndQuoteTick()
+        {
+            // Arrange
+            var securityCache = new SecurityCache();
+            var time = DateTime.Now;
+
+            var quote = new Tick(time, Symbol.Empty, 100, 102) { TickType = TickType.Quote };
+            securityCache.StoreData(new[] {quote}, typeof(Tick));
+
+            var trade = new Tick(time, Symbol.Empty, 100, 100, 102) { TickType = TickType.Trade };
+            securityCache.StoreData(new[] { trade }, typeof(Tick));
+
+            // Adding OpenInterest as Tick or OpenInterest should not matter
+            var openInterest = new OpenInterest(time, Symbol.Empty, 1000);
+            securityCache.StoreData(new[] { openInterest }, typeof(Tick));           // Add as Tick
+            securityCache.StoreData(new[] { openInterest }, typeof(OpenInterest));   // Add as OI
+
+            // Assert
+            Assert.True(securityCache.GetData<Tick>().Equals(trade));
+
+            Assert.True(securityCache.GetAll<Tick>().LastOrDefault(x => x.TickType == TickType.Quote).Equals(quote));
+            Assert.True(securityCache.GetAll<Tick>().LastOrDefault(x => x.TickType == TickType.Trade).Equals(trade));
+        }
+
+        [Test]
         [TestCaseSource(nameof(GetSecurityCacheInitialStates))]
         public void AddDataWithSameEndTime_SetsOpenInterestValues(SecurityCache cache, SecuritySeedData seedType)
         {

--- a/Tests/Common/Securities/SecurityCacheTests.cs
+++ b/Tests/Common/Securities/SecurityCacheTests.cs
@@ -126,7 +126,6 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.True(securityCache.GetAll<Tick>().LastOrDefault(x => x.TickType == TickType.Trade).Equals(trade));
         }
 
-
         [Test]
         public void StoreData_SecurityCacheHasTradeAndQuoteTick()
         {
@@ -137,7 +136,7 @@ namespace QuantConnect.Tests.Common.Securities
             var quote = new Tick(time, Symbol.Empty, 100, 102) { TickType = TickType.Quote };
             securityCache.StoreData(new[] {quote}, typeof(Tick));
 
-            var trade = new Tick(time, Symbol.Empty, 100, 100, 102) { TickType = TickType.Trade };
+            var trade = new Tick(time.AddMilliseconds(1), Symbol.Empty, 100, 100, 102) { TickType = TickType.Trade };
             securityCache.StoreData(new[] { trade }, typeof(Tick));
 
             // Adding OpenInterest as Tick or OpenInterest should not matter
@@ -146,10 +145,73 @@ namespace QuantConnect.Tests.Common.Securities
             securityCache.StoreData(new[] { openInterest }, typeof(OpenInterest));   // Add as OI
 
             // Assert
+            Assert.IsTrue(securityCache.HasData(typeof(Tick)));
             Assert.True(securityCache.GetData<Tick>().Equals(trade));
+            Assert.True(securityCache.GetData<OpenInterest>().Equals(openInterest));
 
             Assert.True(securityCache.GetAll<Tick>().LastOrDefault(x => x.TickType == TickType.Quote).Equals(quote));
             Assert.True(securityCache.GetAll<Tick>().LastOrDefault(x => x.TickType == TickType.Trade).Equals(trade));
+        }
+
+        [Test]
+        public void StoreData_TargetToModify_SecurityCacheHasTradeAndQuoteTick()
+        {
+            // Arrange
+            var sourceToShare = new SecurityCache();
+            var time = DateTime.Now;
+
+            var quote = new Tick(time, Symbol.Empty, 100, 102) { TickType = TickType.Quote };
+            sourceToShare.StoreData(new[] { quote }, typeof(Tick));
+
+            var trade = new Tick(time, Symbol.Empty, 100, 100, 102) { TickType = TickType.Trade };
+            sourceToShare.StoreData(new[] { trade }, typeof(Tick));
+
+            // Adding OpenInterest as Tick or OpenInterest should not matter
+            var openInterest = new OpenInterest(time, Symbol.Empty, 1000);
+            sourceToShare.StoreData(new[] { openInterest }, typeof(Tick));           // Add as Tick
+            sourceToShare.StoreData(new[] { openInterest }, typeof(OpenInterest));   // Add as OI
+
+            var targetToModify = new SecurityCache();
+            SecurityCache.ShareTypeCacheInstance(sourceToShare, targetToModify);
+
+            // Assert
+            Assert.IsTrue(targetToModify.HasData(typeof(Tick)));
+            Assert.True(targetToModify.GetData<Tick>().Equals(trade));
+            Assert.True(targetToModify.GetData<OpenInterest>().Equals(openInterest));
+
+            Assert.True(targetToModify.GetAll<Tick>().LastOrDefault(x => x.TickType == TickType.Quote).Equals(quote));
+            Assert.True(targetToModify.GetAll<Tick>().LastOrDefault(x => x.TickType == TickType.Trade).Equals(trade));
+        }
+
+        [Test]
+        [TestCaseSource(nameof(GetSecurityCacheInitialStates))]
+        public void ResetTests(SecurityCache cache, SecuritySeedData seedType)
+        {
+            switch (seedType)
+            {
+                case SecuritySeedData.None:
+                case SecuritySeedData.OpenInterest:
+                case SecuritySeedData.OpenInterestTick:
+                    break;
+                case SecuritySeedData.QuoteTick:
+                    Assert.IsNotNull(cache.GetData());
+                    Assert.Greater(cache.GetAll<Tick>().Count(x => x.TickType == TickType.Quote), 0);
+                    cache.Reset();
+                    Assert.IsFalse(cache.HasData(typeof(Tick)));
+                    Assert.AreEqual(cache.GetAll<Tick>().Count(x => x.TickType == TickType.Quote), 0);
+                    break;
+                case SecuritySeedData.TradeTick:
+                    Assert.IsNotNull(cache.GetData());
+                    Assert.Greater(cache.GetAll<Tick>().Count(x => x.TickType == TickType.Trade), 0);
+                    cache.Reset();
+                    Assert.IsFalse(cache.HasData(typeof(Tick)));
+                    Assert.AreEqual(cache.GetAll<Tick>().Count(x => x.TickType == TickType.Trade), 0);
+                    break;
+                default:
+                    Assert.IsNotNull(cache.GetData());
+                    cache.Reset();
+                    break;
+            }
         }
 
         [Test]
@@ -356,6 +418,25 @@ namespace QuantConnect.Tests.Common.Securities
             }, typeof(CustomDataBitcoinAlgorithm.Bitcoin));
 
             var data = cache.GetAll<CustomDataBitcoinAlgorithm.Bitcoin>().ToList();
+            Assert.AreEqual(2, data.Count);
+            Assert.AreEqual(1m, data[0].Ask);
+            Assert.AreEqual(2m, data[1].Ask);
+        }
+
+        [Test]
+        public void GetAllData_ReturnsListOfDataOnTargetCache()
+        {
+            var cache = new SecurityCache();
+            cache.StoreData(new[]
+            {
+                new CustomDataBitcoinAlgorithm.Bitcoin{Ask = 1m},
+                new CustomDataBitcoinAlgorithm.Bitcoin{Ask = 2m}
+            }, typeof(CustomDataBitcoinAlgorithm.Bitcoin));
+
+            var targetToModify = new SecurityCache();
+            SecurityCache.ShareTypeCacheInstance(cache, targetToModify);
+
+            var data = targetToModify.GetAll<CustomDataBitcoinAlgorithm.Bitcoin>().ToList();
             Assert.AreEqual(2, data.Count);
             Assert.AreEqual(1m, data[0].Ask);
             Assert.AreEqual(2m, data[1].Ask);


### PR DESCRIPTION
#### Description
Adds two read-only lists of `BaseData` to save the last list of `Tick` of `TickType.Trade` and `TickType.Quote`. Changes methods accordingly to get and set these lists.

#### Related Issue
Closes #4617

#### Motivation and Context
It's important to be able to access the last tick of each type since fill models take different actions on a different kind of `Tick`.

#### How Has This Been Tested?
Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`