### PR TITLE
Add missing Gdax Brokerage user channel subscription for local LEAN usage

### DIFF
--- a/Brokerages/GDAX/GDAXDataQueueHandler.cs
+++ b/Brokerages/GDAX/GDAXDataQueueHandler.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Brokerages.GDAX
         /// <summary>
         /// The list of websocket channels to subscribe
         /// </summary>
-        protected override string[] ChannelNames { get; } = { "heartbeat", "level2", "matches" };
+        protected override string[] ChannelNames { get; } = { "heartbeat", "level2", "matches", "user" };
 
         /// <summary>
         /// Get the next ticks from the live trading data queue


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
- Order fill events were not emitted (only local LEAN users were affected), this bug was caused by the changes in #4317

#### Related Issue
#4317 

#### Motivation and Context
- Missing order fill events for local LEAN users

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Tested order fills both locally and in cloud

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.