### PR TITLE
Add zero TotalPortfolioValue check in BrokerageSetupHandler

### DIFF
--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -293,6 +293,12 @@ namespace QuantConnect.Lean.Engine.Setup
                     return false;
                 }
 
+                if (algorithm.Portfolio.CashBook.TotalValueInAccountCurrency == 0)
+                {
+                    AddInitializationError("No cash balances were found in the brokerage account.");
+                    return false;
+                }
+
                 var supportedSecurityTypes = new HashSet<SecurityType>
                 {
                     SecurityType.Equity, SecurityType.Forex, SecurityType.Cfd, SecurityType.Option, SecurityType.Future, SecurityType.Crypto

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -293,12 +293,6 @@ namespace QuantConnect.Lean.Engine.Setup
                     return false;
                 }
 
-                if (algorithm.Portfolio.CashBook.TotalValueInAccountCurrency == 0)
-                {
-                    AddInitializationError("No cash balances were found in the brokerage account.");
-                    return false;
-                }
-
                 var supportedSecurityTypes = new HashSet<SecurityType>
                 {
                     SecurityType.Equity, SecurityType.Forex, SecurityType.Cfd, SecurityType.Option, SecurityType.Future, SecurityType.Crypto
@@ -364,6 +358,12 @@ namespace QuantConnect.Lean.Engine.Setup
                 {
                     Log.Error(err);
                     AddInitializationError("Error getting account holdings from brokerage: " + err.Message, err);
+                    return false;
+                }
+
+                if (algorithm.Portfolio.TotalPortfolioValue == 0)
+                {
+                    AddInitializationError("No cash balances or holdings were found in the brokerage account.");
                     return false;
                 }
 

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -299,7 +299,7 @@ namespace QuantConnect.Tests.Engine.Setup
         }
 
         [Test]
-        public void HasErrorWithNoCashBalances()
+        public void HasErrorWithZeroTotalPortfolioValue()
         {
             var algorithm = new TestAlgorithm();
 
@@ -335,7 +335,7 @@ namespace QuantConnect.Tests.Engine.Setup
 
             Assert.AreEqual(1, setupHandler.Errors.Count);
 
-            Assert.That(setupHandler.Errors[0].Message.Contains("No cash balances were found in the brokerage account."));
+            Assert.That(setupHandler.Errors[0].Message.Contains("No cash balances or holdings were found in the brokerage account."));
         }
 
         private static TestCaseData[] GetExistingHoldingsAndOrdersTestCaseData()

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -298,6 +298,46 @@ namespace QuantConnect.Tests.Engine.Setup
             Assert.Greater(algorithm.UtcTime, time);
         }
 
+        [Test]
+        public void HasErrorWithNoCashBalances()
+        {
+            var algorithm = new TestAlgorithm();
+
+            algorithm.SetHistoryProvider(new BrokerageTransactionHandlerTests.BrokerageTransactionHandlerTests.EmptyHistoryProvider());
+            var job = new LiveNodePacket
+            {
+                UserId = 1,
+                ProjectId = 1,
+                DeployId = "1",
+                Brokerage = "TestBrokerage",
+                DataQueueHandler = "none",
+                Controls = new Controls { RamAllocation = 4096 } // no real limit
+            };
+
+            var resultHandler = new Mock<IResultHandler>();
+            var transactionHandler = new Mock<ITransactionHandler>();
+            var realTimeHandler = new Mock<IRealTimeHandler>();
+            var brokerage = new Mock<IBrokerage>();
+            var objectStore = new Mock<IObjectStore>();
+
+            brokerage.Setup(x => x.IsConnected).Returns(true);
+            brokerage.Setup(x => x.GetCashBalance()).Returns(new List<CashAmount>());
+            brokerage.Setup(x => x.GetAccountHoldings()).Returns(new List<Holding>());
+            brokerage.Setup(x => x.GetOpenOrders()).Returns(new List<Order>());
+
+            var setupHandler = new BrokerageSetupHandler();
+
+            IBrokerageFactory factory;
+            setupHandler.CreateBrokerage(job, algorithm, out factory);
+
+            Assert.IsFalse(setupHandler.Setup(new SetupHandlerParameters(_dataManager.UniverseSelection, algorithm, brokerage.Object, job, resultHandler.Object,
+                transactionHandler.Object, realTimeHandler.Object, objectStore.Object)));
+
+            Assert.AreEqual(1, setupHandler.Errors.Count);
+
+            Assert.That(setupHandler.Errors[0].Message.Contains("No cash balances were found in the brokerage account."));
+        }
+
         private static TestCaseData[] GetExistingHoldingsAndOrdersTestCaseData()
         {
             return new[]
@@ -476,6 +516,18 @@ namespace QuantConnect.Tests.Engine.Setup
                 GetOpenOrders(algorithm, resultHandler, transactionHandler, brokerage, _supportedSecurityTypes, Resolution.Second);
             }
         }
+    }
+
+    internal class TestBrokerageFactory : BrokerageFactory
+    {
+        public TestBrokerageFactory() : base(typeof(TestBrokerage))
+        {
+        }
+
+        public override Dictionary<string, string> BrokerageData => new Dictionary<string, string>();
+        public override IBrokerageModel GetBrokerageModel(IOrderProvider orderProvider) => new BrokerageTransactionHandlerTests.BrokerageTransactionHandlerTests.TestBrokerageModel();
+        public override IBrokerage CreateBrokerage(LiveNodePacket job, IAlgorithm algorithm) => new TestBrokerage();
+        public override void Dispose() { }
     }
 
     internal class TestBrokerage : Brokerage


### PR DESCRIPTION
#### Description
- Added a check for zero `TotalPortfolioValue` in `BrokerageSetupHandler`

#### Related Issue
Closes #4638 

#### Motivation and Context
- Better live trading experience

#### Requires Documentation Change
n/a

#### How Has This Been Tested?
- New unit test
- Local live test

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`