### PR TITLE
Add zero TotalPortfolioValue check in BrokerageSetupHandler

### DIFF
--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -284,8 +284,7 @@ namespace QuantConnect.Lean.Engine.Setup
                     {
                         Log.Trace("BrokerageSetupHandler.Setup(): Setting " + cash.Currency + " cash to " + cash.Amount);
 
-                        var conversionRate = cash.Currency == algorithm.AccountCurrency ? 1 : 0;
-                        algorithm.Portfolio.SetCash(cash.Currency, cash.Amount, conversionRate);
+                        algorithm.Portfolio.SetCash(cash.Currency, cash.Amount, 0);
                     }
                 }
                 catch (Exception err)

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -348,7 +348,9 @@ namespace QuantConnect.Tests.Engine.Setup
 
             var isSuccess = hasCashBalance || hasHoldings;
 
-            Assert.AreEqual(isSuccess, setupHandler.Setup(new SetupHandlerParameters(_dataManager.UniverseSelection, algorithm, brokerage.Object, job, resultHandler.Object,
+            var dataManager = new DataManagerStub(algorithm, new MockDataFeed(), true);
+
+            Assert.AreEqual(isSuccess, setupHandler.Setup(new SetupHandlerParameters(dataManager.UniverseSelection, algorithm, brokerage.Object, job, resultHandler.Object,
                 transactionHandler.Object, realTimeHandler.Object, objectStore.Object)));
 
             if (isSuccess)


### PR DESCRIPTION

#### Description
- Added a check for zero `TotalPortfolioValue` in `BrokerageSetupHandler` (resubmit of #4639) 

#### Related Issue
Closes #4638 

#### Motivation and Context
- Better live trading experience

#### Requires Documentation Change
No

#### How Has This Been Tested?
- New unit tests
- Local and cloud live testing

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`