### PR TITLE
Bug Backtesting Brokerage Clones

### DIFF
--- a/Algorithm.CSharp/BacktestingBrokerageRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/BacktestingBrokerageRegressionAlgorithm.cs
@@ -1,0 +1,263 @@
+﻿using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+using QuantConnect.Orders.Fees;
+using QuantConnect.Orders.Fills;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Option;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+
+    /// <summary>
+    /// This regression algorithm tests the order processing of the backtesting brokerage.
+    /// We open an equity position that should fill in two parts, on two different bars.
+    /// We open a long option position and let it expire so we can exercise the position.
+    /// To check the orders we use OnOrderEvent and throw exceptions if verification fails.
+    /// </summary>
+    /// <meta name="tag" content="backtesting brokerage" />
+    /// <meta name="tag" content="regression test" />
+    /// <meta name="tag" content="options" />
+    class BacktestingBrokerageRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Security _security;
+        public Symbol Spy;
+        private Option _option;
+        public Symbol OptionSymbol;
+        private bool _optionBought = false;
+        private bool _equityBought = false;
+
+        private decimal _optionStrikePrice;
+
+        /// <summary>
+        /// Initialize the algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            SetCash(1000000);
+            SetStartDate(2015, 12, 24);
+            SetEndDate(2015, 12, 28);
+
+            _security = AddEquity("SPY", Resolution.Hour);
+            Spy = _security.Symbol;
+
+            _security.SetFillModel(new PartialMarketFillModel(2));
+
+
+            _option = AddOption("GOOG");
+            OptionSymbol = _option.Symbol;
+
+            // Set our strike/expiry filter for this option chain
+            _option.SetFilter(u => u.IncludeWeeklys()
+                                   .Strikes(-2, +2)
+                                   .Expiration(TimeSpan.Zero, TimeSpan.FromDays(10)));
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {   
+            if (!_equityBought && data.ContainsKey(Spy)) {
+                //Buy our Equity
+                var quantity = CalculateOrderQuantity(Spy, .1m);
+                MarketOrder(Spy, quantity, asynchronous: true);
+                _equityBought = true;
+            }
+
+            if (!_optionBought)
+            {
+                // Buy our option
+                OptionChain chain;
+                if (data.OptionChains.TryGetValue(OptionSymbol, out chain))
+                {
+                    // Find the second call strike under market price expiring today
+                    var contracts = (
+                        from optionContract in chain.OrderByDescending(x => x.Strike)
+                        where optionContract.Right == OptionRight.Call
+                        where optionContract.Expiry == Time.Date
+                        where optionContract.Strike < chain.Underlying.Price
+                        select optionContract
+                        ).Take(2);
+
+                    if (contracts.Any())
+                    {
+                        var optionToBuy = contracts.FirstOrDefault();
+                        _optionStrikePrice = optionToBuy.Strike;
+                        MarketOrder(optionToBuy.Symbol, 2);
+                        _optionBought = true;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// All order events get pushed through this function
+        /// </summary>
+        /// <param name="orderEvent">OrderEvent object that contains all the information about the event</param>
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {   
+            // Get the order from our transactions
+            var order = Transactions.GetOrderById(orderEvent.OrderId);
+
+            // Based on the type verify the order
+            switch(order.Type)
+            {
+                case OrderType.Market:
+                    VerifyMarketOrder(order);
+                    break;
+
+                case OrderType.OptionExercise:
+                    VerifyOptionExercise(order);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// To verify Market orders is process correctly
+        /// </summary>
+        /// <param name="order">Order object to analyze</param>
+        public void VerifyMarketOrder(Order order)
+        {
+            switch(order.Status)
+            {
+                case OrderStatus.Submitted:
+                    break;
+
+                // All PartiallyFilled orders should have a LastFillTime
+                case OrderStatus.PartiallyFilled:
+                    if (order.LastFillTime == null) 
+                    {
+                        throw new Exception("LastFillTime should not be null");
+                    }
+                    break;
+
+                // All filled equity orders should have filled after creation because of our fill model!
+                case OrderStatus.Filled:
+                    if (order.SecurityType == SecurityType.Equity && order.CreatedTime == order.LastFillTime)
+                    {
+                        throw new Exception("Order should not finish during the CreatedTime bar");
+                    }
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        /// <summary>
+        /// To verify OptionExercise orders is process correctly
+        /// </summary>
+        /// <param name="order">Order object to analyze</param>
+        public void VerifyOptionExercise(Order order)
+        {
+            // If the option price isn't the same as the strike price, its incorrect
+            if (order.Price != _optionStrikePrice)
+            {
+                throw new Exception("OptionExercise order price should be strike price!!");
+            }
+        }
+
+        /// <summary>
+        /// PartialMarketFillModel that allows the user to set the number of fills and restricts
+        /// the fill to only one per bar.
+        /// </summary>
+        public class PartialMarketFillModel : ImmediateFillModel
+        {
+            private readonly decimal _percent;
+            private readonly Dictionary<long, decimal> _absoluteRemainingByOrderId = new Dictionary<long, decimal>();
+
+            /// <param name="numberOfFills"></param>
+            public PartialMarketFillModel(int numberOfFills = 1)
+            {
+                _percent = 1m / numberOfFills;
+            }
+
+            /// <summary>
+            /// Performs partial market fills once per time step
+            /// </summary>
+            /// <param name="asset">The security being ordered</param>
+            /// <param name="order">The order</param>
+            /// <returns>The order fill</returns>
+            public override OrderEvent MarketFill(Security asset, MarketOrder order)
+            {
+                var currentUtcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
+
+                // Only fill once a time slice
+                if (order.LastFillTime != null && currentUtcTime <= order.LastFillTime)
+                {
+                    return new OrderEvent(order, currentUtcTime, OrderFee.Zero);
+                }
+
+                decimal absoluteRemaining;
+                if (!_absoluteRemainingByOrderId.TryGetValue(order.Id, out absoluteRemaining))
+                {
+                    absoluteRemaining = order.AbsoluteQuantity;
+                    _absoluteRemainingByOrderId.Add(order.Id, order.AbsoluteQuantity);
+                }
+
+                var fill = base.MarketFill(asset, order);
+                var absoluteFillQuantity = (int)(Math.Min(absoluteRemaining, (int)(_percent * order.Quantity)));
+                fill.FillQuantity = Math.Sign(order.Quantity) * absoluteFillQuantity;
+
+                if (absoluteRemaining == absoluteFillQuantity)
+                {
+                    fill.Status = OrderStatus.Filled;
+                    _absoluteRemainingByOrderId.Remove(order.Id);
+                }
+                else
+                {
+                    absoluteRemaining = absoluteRemaining - absoluteFillQuantity;
+                    _absoluteRemainingByOrderId[order.Id] = absoluteRemaining;
+                    fill.Status = OrderStatus.PartiallyFilled;
+                }
+
+                return fill;
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "3"},
+            {"Average Win", "0%"},
+            {"Average Loss", "-0.08%"},
+            {"Compounding Annual Return", "-6.043%"},
+            {"Drawdown", "0.100%"},
+            {"Expectancy", "-1"},
+            {"Net Profit", "-0.080%"},
+            {"Sharpe Ratio", "-7.915"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "100%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0.005"},
+            {"Beta", "0.116"},
+            {"Annual Standard Deviation", "0.002"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "10.295"},
+            {"Tracking Error", "0.018"},
+            {"Treynor Ratio", "-0.164"},
+            {"Total Fees", "$3.54"},
+            {"Fitness Score", "0.062"},
+            {"OrderListHash", "1399223394"}
+        };
+    }
+}

--- a/Algorithm.CSharp/BacktestingBrokerageRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/BacktestingBrokerageRegressionAlgorithm.cs
@@ -1,4 +1,19 @@
-﻿using QuantConnect.Data;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;
@@ -12,7 +27,6 @@ using System.Linq;
 
 namespace QuantConnect.Algorithm.CSharp
 {
-
     /// <summary>
     /// This regression algorithm tests the order processing of the backtesting brokerage.
     /// We open an equity position that should fill in two parts, on two different bars.
@@ -30,7 +44,6 @@ namespace QuantConnect.Algorithm.CSharp
         public Symbol OptionSymbol;
         private bool _optionBought = false;
         private bool _equityBought = false;
-
         private decimal _optionStrikePrice;
 
         /// <summary>
@@ -42,19 +55,17 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2015, 12, 24);
             SetEndDate(2015, 12, 28);
 
+            // Get our equity
             _security = AddEquity("SPY", Resolution.Hour);
+            _security.SetFillModel(new PartialMarketFillModel(2));
             Spy = _security.Symbol;
 
-            _security.SetFillModel(new PartialMarketFillModel(2));
-
-
+            // Get our option
             _option = AddOption("GOOG");
-            OptionSymbol = _option.Symbol;
-
-            // Set our strike/expiry filter for this option chain
             _option.SetFilter(u => u.IncludeWeeklys()
                                    .Strikes(-2, +2)
                                    .Expiration(TimeSpan.Zero, TimeSpan.FromDays(10)));
+            OptionSymbol = _option.Symbol;
         }
 
         /// <summary>

--- a/Algorithm.CSharp/BasicTemplateOptionsFilterUniverseAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFilterUniverseAlgorithm.cs
@@ -141,7 +141,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-1214175458"}
+            {"OrderListHash", "1935621950"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionExerciseAssignRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExerciseAssignRegressionAlgorithm.cs
@@ -161,7 +161,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-1018168907"}
+            {"OrderListHash", "1038273097"}
         };
     }
 }

--- a/Algorithm.CSharp/OrderImmutabilityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OrderImmutabilityRegressionAlgorithm.cs
@@ -1,0 +1,148 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This regression algorithm tests that orders are unchangeable from the QCAlgorithm Layer
+    /// Orders should only be modifiable via their ticket and only in permitted ways
+    /// </summary>
+    /// <meta name="tag" content="backtesting brokerage" />
+    /// <meta name="tag" content="regression test" />
+    /// <meta name="tag" content="options" />
+    public class OrderImmutabilityRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private readonly Symbol _spy = QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA);
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 08);  //Set Start Date
+            SetEndDate(2013, 10, 17);    //Set End Date
+            SetCash(100000);             //Set Strategy Cash
+            AddEquity("SPY", Resolution.Daily);
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (!Portfolio.Invested)
+            {
+                SetHoldings(_spy, 1);
+                Debug("Purchased Stock");
+            }
+        }
+
+        /// <summary>
+        /// All order events get pushed through this function
+        /// </summary>
+        /// <param name="orderEvent">OrderEvent object that contains all the information about the event</param>
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            // Get the order twice, since they are clones they should NOT be the same
+            var orderV1 = Transactions.GetOrderById(orderEvent.OrderId);
+            var orderV2 = Transactions.GetOrderById(orderEvent.OrderId);
+
+            if (orderV1 == orderV2)
+            {
+                Error("Orders should be clones, hence not equal!");
+                throw new Exception("Orders should be clones, hence not equal!");
+            }
+
+            //Try and manipulate the orderV1 using UpdateOrderRequest
+            //NOTICE: Orders should only be updated through their tickets!
+            var updateFields = new UpdateOrderFields { Quantity = 99, Tag = "Pepe" };
+            var updateRequest = new UpdateOrderRequest(DateTime.Now, orderEvent.OrderId, updateFields);
+            orderV1.ApplyUpdateOrderRequest(updateRequest);
+
+            //Get another copy of the order and compare
+            var orderV3 = Transactions.GetOrderById(orderEvent.OrderId);
+
+            if (orderV1.Quantity == orderV3.Quantity)
+            {
+                Error("Quantities should not be changed!");
+                throw new Exception("Quantities should not be changed!");
+            }
+            
+            if (orderV1.Tag == orderV3.Tag)
+            {
+                Error("Tag should not be changed!");
+                throw new Exception("Tag should not be changed!");
+            }
+
+            //Try and manipulate orderV2 using the only external accessor BrokerID
+            orderV2.BrokerId.Add("FAKE BROKER ID");
+
+            //Get another copy of the order and compare
+            var orderV4 = Transactions.GetOrderById(orderEvent.OrderId);
+
+            if (orderV2.BrokerId == orderV4.BrokerId)
+            {
+                Error("BrokerIDs should not be the same!");
+                throw new Exception("BrokerIDs should not be the same!");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "246.000%"},
+            {"Drawdown", "1.100%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "3.459%"},
+            {"Sharpe Ratio", "10.11"},
+            {"Probabilistic Sharpe Ratio", "83.150%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "1.935"},
+            {"Beta", "-0.119"},
+            {"Annual Standard Deviation", "0.16"},
+            {"Annual Variance", "0.026"},
+            {"Information Ratio", "-4.556"},
+            {"Tracking Error", "0.221"},
+            {"Treynor Ratio", "-13.568"},
+            {"Total Fees", "$3.26"},
+            {"Fitness Score", "0.111"},
+            {"OrderListHash", "1268340653"}
+        };
+    }
+}

--- a/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
+++ b/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
@@ -527,7 +527,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "1237222672"}
+            {"OrderListHash", "-1594146186"}
         };
     }
 }

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -167,6 +167,7 @@
     <Compile Include="AltData\TiingoNewsAlgorithm.cs" />
     <Compile Include="AutomaticIndicatorWarmupDataTypeRegressionAlgorithm.cs" />
     <Compile Include="AutomaticIndicatorWarmupRegressionAlgorithm.cs" />
+    <Compile Include="BacktestingBrokerageRegressionAlgorithm.cs" />
     <Compile Include="ExtendedMarketTradingRegressionAlgorithm.cs" />
     <Compile Include="CoarseTiingoNewsUniverseSelectionAlgorithm.cs" />
     <Compile Include="DelistedFutureLiquidateRegressionAlgorithm.cs" />

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -200,6 +200,7 @@
     <Compile Include="MarginRemainingRegressionAlgorithm.cs" />
     <Compile Include="NoMarginCallExpectedRegressionAlgorithm.cs" />
     <Compile Include="ObjectStoreExampleAlgorithm.cs" />
+    <Compile Include="OrderImmutabilityRegressionAlgorithm.cs" />
     <Compile Include="OrderSubmissionDataRegressionAlgorithm.cs" />
     <Compile Include="RegisterIndicatorRegressionAlgorithm.cs" />
     <Compile Include="ScheduledEventsOrderRegressionAlgorithm.cs" />

--- a/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
@@ -233,7 +233,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "124750474"}
+            {"OrderListHash", "1536869386"}
         };
     }
 }

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -517,8 +517,7 @@ namespace QuantConnect.Brokerages.Backtesting
         /// <returns></returns>
         private void SetPendingOrder(Order order)
         {
-            // only save off clones!
-            _pending[order.Id] = order.Clone();
+            _pending[order.Id] = order;
         }
     }
 }

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1027,15 +1027,8 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                     }
                 }
 
-                // update the ticket and order after we've processed the fill, but before the event, this way everything is ready for user code
+                // update the ticket after we've processed the fill, but before the event, this way everything is ready for user code
                 ticket.AddOrderEvent(orderEvent);
-
-                //Option exercise order prices are already set when the order is created
-                //If this is able to change it, it will change the fill price of the security
-                if (order.Type != OrderType.OptionExercise)
-                {
-                    order.Price = ticket.AverageFillPrice;
-                }
             }
             
             //We have an event! :) Order filled, send it in to be handled by algorithm portfolio.

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1029,8 +1029,15 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
                 // update the ticket and order after we've processed the fill, but before the event, this way everything is ready for user code
                 ticket.AddOrderEvent(orderEvent);
-                order.Price = ticket.AverageFillPrice;
+
+                //Option exercise order prices are already set when the order is created
+                //If this is able to change it, it will change the fill price of the security
+                if (order.Type != OrderType.OptionExercise)
+                {
+                    order.Price = ticket.AverageFillPrice;
+                }
             }
+            
             //We have an event! :) Order filled, send it in to be handled by algorithm portfolio.
             if (orderEvent.Status != OrderStatus.None) //order.Status != OrderStatus.Submitted
             {

--- a/Tests/Algorithm/Framework/Execution/ImmediateExecutionModelTests.cs
+++ b/Tests/Algorithm/Framework/Execution/ImmediateExecutionModelTests.cs
@@ -157,7 +157,11 @@ namespace QuantConnect.Tests.Algorithm.Framework.Execution
 
             var openOrderRequest = new SubmitOrderRequest(OrderType.Market, SecurityType.Equity, Symbols.AAPL, 100, 0, 0, DateTime.MinValue, "");
             openOrderRequest.SetOrderId(1);
+
+            var order = Order.CreateOrder(openOrderRequest);
             var openOrderTicket = new OrderTicket(algorithm.Transactions, openOrderRequest);
+            openOrderTicket.SetOrder(order);
+
             openOrderTicket.AddOrderEvent(new OrderEvent(1, Symbols.AAPL, DateTime.MinValue, OrderStatus.PartiallyFilled, OrderDirection.Buy, 250, 70, OrderFee.Zero));
 
             var orderProcessor = new Mock<IOrderProcessor>();

--- a/Tests/Common/Orders/OrderSizingTests.cs
+++ b/Tests/Common/Orders/OrderSizingTests.cs
@@ -105,9 +105,7 @@ namespace QuantConnect.Tests.Common.Orders
         {
             var algo = new AlgorithmStub();
             var orderProcessor = new FakeOrderProcessor();
-            var ticket = new OrderTicket(
-                algo.Transactions,
-                new SubmitOrderRequest(
+            var orderRequest = new SubmitOrderRequest(
                     OrderType.Market,
                     SecurityType.Future,
                     Symbols.Future_CLF19_Jan2019,
@@ -116,8 +114,12 @@ namespace QuantConnect.Tests.Common.Orders
                     250,
                     new DateTime(2020, 1, 1),
                     "Pepe"
-                )
-            );
+                );
+
+            var order = Order.CreateOrder(orderRequest);
+            var ticket = new OrderTicket(algo.Transactions, orderRequest);
+            ticket.SetOrder(order);
+           
             ticket.AddOrderEvent(new OrderEvent(1,
                 Symbols.Future_CLF19_Jan2019,
                 new DateTime(2020, 1, 1),

--- a/Tests/Python/PythonOptionTests.cs
+++ b/Tests/Python/PythonOptionTests.cs
@@ -96,7 +96,7 @@ namespace QuantConnect.Tests.Python
                     {"Tracking Error", "0"},
                     {"Treynor Ratio", "0"},
                     {"Total Fees", "$1.00"},
-                    {"OrderListHash", "529919541"}
+                    {"OrderListHash", "-379511851"}
                     },
                     Language.Python,
                     AlgorithmStatus.Completed);
@@ -152,7 +152,7 @@ namespace QuantConnect.Tests.Python
                     {"Mean Population Magnitude", "0%"},
                     {"Rolling Averaged Population Direction", "0%"},
                     {"Rolling Averaged Population Magnitude", "0%"},
-                    {"OrderListHash", "-1214175458"}
+                    {"OrderListHash", "1935621950"}
                 },
                 Language.Python,
                 AlgorithmStatus.Completed);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
In the current implementation the `BacktestingBrokerage` passes around a clone of an order for processing. As a result when trying to make use of order variables such as `LastFillTime`, or `StopTriggered` that would be updated by the Backtesting Brokerage, it won't work since the Algorithms order is not updated.

In correcting this issue, I uncovered other issues related to the processing of `OptionExercised` orders. Without a clone the `OptionExercised` order takes on the value assigned by the ticket in `HandleOrderEvent()`, The initial tickets `AverageFillPrice` = 0 since the first event is removing the expired option. If I did not correct this problem after removing the `BackTestingBrokerage` clone, it would have allowed the option exercised price to be changed permanently to 0, therefore exercising a option to buy 100 shares of X at $0.

To fix this, I placed a conditional that if the `OrderType` is `OptionExercised`, the price is fixed and should not be changed.

Furthermore I had to make changes to some of our regression algorithms `OrderListsHash` to match the output. These changes have been analyzed and tested to be sure they reflects what the values should be.

Attached is a report on the Regression Algorithms that had to be changed and why.

[Regression Algorithm Changes Report.docx](https://github.com/QuantConnect/Lean/files/5119444/Regression.Algorithm.Changes.Report.docx)


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4445 - With the clone removed the order will now have the `LastFillTime` updated
Closes #2846 - The `OptionExercised` order `price` will now not be skewed by the removal of the option. It is handled in the processing of the ticket.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Read above!


#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
None


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All regression tests have been run and are successful. The changed regression algorithms are described in the attached document above.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
