### PR TITLE
Bug 4668 python register indicator

### DIFF
--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -474,49 +474,43 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">The symbol to register against</param>
         /// <param name="indicator">The indicator to receive data from the consolidator</param>
-        /// <param name="consolidator">The python consolidator to receive subscription data</param>
+        /// <param name="pyObject">The python object that it is trying to register with, could be consolidator or a timespan</param>
         /// <param name="selector">Selects a value from the BaseData send into the indicator, if null defaults to a cast (x => (T)x)</param>
-        public void RegisterIndicator(Symbol symbol, PyObject indicator, PyObject consolidator, PyObject selector = null)
+        public void RegisterIndicator(Symbol symbol, PyObject indicator, PyObject pyObject, PyObject selector = null)
         {
-
-            // First check if this is just a regular IDataConsolidator
-            IDataConsolidator dataConsolidator;
-            if (consolidator.TryConvert(out dataConsolidator))
-            {
-                RegisterIndicator(symbol, indicator, dataConsolidator, selector);
-                return;
-            } 
-
-            // Then try and wrap it as a custom Python consolidator and register it
             try
             {
-                IDataConsolidator pyConsolidator = new DataConsolidatorPythonWrapper(consolidator);
-                RegisterIndicator(symbol, indicator, pyConsolidator, selector);
+                // First check if this is just a regular IDataConsolidator
+                IDataConsolidator dataConsolidator;
+                if (!pyObject.TryConvert(out dataConsolidator))
+                {
+                    // If not then try and wrap it as a custom Python consolidator
+                    dataConsolidator = new DataConsolidatorPythonWrapper(pyObject);
+                }
+                RegisterIndicator(symbol, indicator, dataConsolidator, selector);
                 return;
             }
-            catch 
+            catch
             {
 
-            }
+            }     
 
-            // Finally just try it as a timespan
-            // Issue #4668 Fix, need to try it as a timespan
-            TimeSpan? timeSpan;
+            // Finally, since above didn't work, just try it as a timespan
+            // Issue #4668 Fix
             using (Py.GIL())
             {
                 try
                 {
                     // tryConvert does not work for timespan
-                    timeSpan = consolidator.As<TimeSpan>();
+                    TimeSpan? timeSpan = pyObject.As<TimeSpan>();
                     if (timeSpan != default(TimeSpan))
                     {
                         RegisterIndicator(symbol, indicator, timeSpan, selector);
-                        return;
                     }
                 }
                 catch 
                 {
-                    throw new ArgumentException("Invalid Argument");
+                    throw new ArgumentException("Invalid third argument, should be either a valid consolidator or timedelta object");
                 }
             }
         }

--- a/Common/Python/DataConsolidatorPythonWrapper.cs
+++ b/Common/Python/DataConsolidatorPythonWrapper.cs
@@ -75,6 +75,16 @@ namespace QuantConnect.Python
         /// <param name="consolidator">Represents a custom python consolidator</param>
         public DataConsolidatorPythonWrapper(PyObject consolidator)
         {
+            using (Py.GIL())
+            {
+                foreach (var attributeName in new[] { "InputType", "OutputType", "WorkingData", "Consolidated" })
+                {
+                    if (!consolidator.HasAttr(attributeName))
+                    {
+                        throw new NotImplementedException($"IDataConsolidator.{attributeName} must be implemented. Please implement this missing method on {consolidator.GetPythonType()}");
+                    }
+                }
+            }
             _consolidator = consolidator;
         }
         

--- a/Tests/Python/DataConsolidatorPythonWrapperTests.cs
+++ b/Tests/Python/DataConsolidatorPythonWrapperTests.cs
@@ -31,9 +31,17 @@ namespace QuantConnect.Tests.Python
             using (Py.GIL())
             {
                 var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                    "from clr import AddReference\n" +
+                    "AddReference(\"QuantConnect.Common\")\n" +
+                    "from QuantConnect import *\n" +
+                    "from QuantConnect.Data.Market import *\n" +
                     "class CustomConsolidator():\n" +
                     "   def __init__(self):\n" +
                     "       self.UpdateWasCalled = False\n" +
+                    "       self.InputType = QuoteBar\n" +
+                    "       self.OutputType = QuoteBar\n" +
+                    "       self.Consolidated = None\n" +
+                    "       self.WorkingData = None\n" +
                     "   def Update(self, data):\n" +
                     "       self.UpdateWasCalled = True\n");
 
@@ -68,9 +76,17 @@ namespace QuantConnect.Tests.Python
             using (Py.GIL())
             {
                 var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                    "from clr import AddReference\n" +
+                    "AddReference(\"QuantConnect.Common\")\n" +
+                    "from QuantConnect import *\n" +
+                    "from QuantConnect.Data.Market import *\n" +
                     "class CustomConsolidator():\n" +
                     "   def __init__(self):\n" +
-                    "       self.ScanWasCalled = False\n" +    
+                    "       self.ScanWasCalled = False\n" +
+                    "       self.InputType = QuoteBar\n" +
+                    "       self.OutputType = QuoteBar\n" +
+                    "       self.Consolidated = None\n" +
+                    "       self.WorkingData = None\n" +
                     "   def Scan(self,time):\n" +
                     "       self.ScanWasCalled = True\n");
 
@@ -100,7 +116,10 @@ namespace QuantConnect.Tests.Python
                     "from QuantConnect.Data.Market import *\n" +
                     "class CustomConsolidator():\n" +
                     "   def __init__(self):\n" +
-                    "       self.InputType = QuoteBar\n");
+                    "       self.InputType = QuoteBar\n" +
+                    "       self.OutputType = QuoteBar\n" +
+                    "       self.Consolidated = None\n" +
+                    "       self.WorkingData = None\n");
 
                 var customConsolidator = module.GetAttr("CustomConsolidator").Invoke();
                 var wrapper = new DataConsolidatorPythonWrapper(customConsolidator);
@@ -125,7 +144,10 @@ namespace QuantConnect.Tests.Python
                     "from QuantConnect.Data.Market import *\n" +
                     "class CustomConsolidator():\n" +
                     "   def __init__(self):\n" +
-                    "       self.OutputType = QuoteBar\n");
+                    "       self.InputType = QuoteBar\n" +
+                    "       self.OutputType = QuoteBar\n" +
+                    "       self.Consolidated = None\n" +
+                    "       self.WorkingData = None\n");
 
                 var customConsolidator = module.GetAttr("CustomConsolidator").Invoke();
                 var wrapper = new DataConsolidatorPythonWrapper(customConsolidator);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Fix for `RegisterIndicator` bug that would break our `RegisterIndicatorRegressionAlgorithm`. Now the Register Indicator function attempts to try three different types of possible `PyObjects` that would enter through this method.
1. Just a regular `IDataConsolidator` -> Convert it to a `IDataConsolidator` Obj
2. A Custom Python Consolidator -> Wrap it with our `DataConsolidatorPythonWrapper`
3. A `TimeDelta` obj -> convert it to a `TimeSpan`

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #4668 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When Python calls RegisterIndicator it was associating all types of objects as PyObjects, so it would attempt to wrap them with our DataConsolidatorPythonWrapper. This would break if an Algo was attempting to use a timedelta object which originally would have been routed to the RegisterIndicator with a timespan variable.


#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
None.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All regression tests have been run and are passing

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
