### PR TITLE
Syncronize with brokerage once per hour instead of once per day (#4680)

### DIFF
--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -250,7 +250,7 @@ namespace QuantConnect.Brokerages
         /// <returns>True if the cash sync should be performed</returns>
         public virtual bool ShouldPerformCashSync(DateTime currentTimeUtc)
         {
-            // every morning flip this switch back
+            // every hour flip this switch back
             var currentTimeNewYork = currentTimeUtc.ConvertFromUtc(TimeZones.NewYork);
             if (_syncedLiveBrokerageCash && currentTimeNewYork.Hour != LastSyncHour)
             {
@@ -306,7 +306,7 @@ namespace QuantConnect.Brokerages
                     }
                 }
 
-                // if we were returned our balances, update everything and flip our flag as having performed sync today
+                // if we were returned our balances, update everything and flip our flag as having performed sync in this hour
                 foreach (var kvp in algorithm.Portfolio.CashBook)
                 {
                     var cash = kvp.Value;

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -944,7 +944,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             // cash sync happened
             Assert.AreNotEqual(lastSyncDateAfter, lastSyncDateBefore);
 
-            Assert.AreEqual(0, brokerage.GetCashBalanceCallCount);
+            Assert.AreEqual(1, brokerage.GetCashBalanceCallCount);
         }
 
         [Test]

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -936,12 +936,13 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var lastSyncDateBefore = transactionHandler.GetLastSyncDate();
 
             // Advance current time UTC
-            transactionHandler.TestCurrentTimeUtc = transactionHandler.TestCurrentTimeUtc.AddDays(2);
+            transactionHandler.TestCurrentTimeUtc = transactionHandler.TestCurrentTimeUtc.AddHours(2);
 
             transactionHandler.ProcessSynchronousEvents();
             var lastSyncDateAfter = transactionHandler.GetLastSyncDate();
 
-            Assert.AreEqual(lastSyncDateAfter, lastSyncDateBefore);
+            // cash sync happened
+            Assert.AreNotEqual(lastSyncDateAfter, lastSyncDateBefore);
 
             Assert.AreEqual(0, brokerage.GetCashBalanceCallCount);
         }


### PR DESCRIPTION
#### Description
I checked Brokerage.cs, the synchronization with brokerage only run once per day, can it run much more frequent such as once per hour instead of once per day ?

#### Related Issue
https://github.com/QuantConnect/Lean/issues/4680

#### Motivation and Context
I'm using Bitfinex as my algorithm brokerage. The algorithm run once per hours for crypto day trading.
The Portfolio.CashBook and its total value are always asynchronous with actual Bitfinex holding after SetHoldings,
so my algorithm sometimes run with outdated Portfolio value during live trading, this situation won't happen in backtest.
It will resume normal after redeployment or one day after.

For example, my strategy always maintein 90% of Portfolio value on ETH, I assume that someday ETH value raised, then my strategy will sell some of my ETH to maintein 90% ratio. but the amount in CashBook can't update on time, so the program keep sell out my ETH on brokerage until nothing left.

#### Requires Documentation Change
I guess no documentation need to be updated, please advice.

#### How Has This Been Tested?
Don't know how to test it, I'm not familiar with this infrastructure, please advice.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
