### PR TITLE
Fix duplicated history entries when contains daylight saving time change

### DIFF
--- a/Algorithm.CSharp/DaylightSavingTimeHistoryRegressionTest.cs
+++ b/Algorithm.CSharp/DaylightSavingTimeHistoryRegressionTest.cs
@@ -24,12 +24,8 @@ using QuantConnect.Interfaces;
 namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
-    /// Basic template algorithm simply initializes the date range and cash. This is a skeleton
-    /// framework you can use for designing an algorithm.
+    /// Regression test algorithm simply fetch history on boarder of Daylight Saving Time shift
     /// </summary>
-    /// <meta name="tag" content="using data" />
-    /// <meta name="tag" content="using quantconnect" />
-    /// <meta name="tag" content="trading and orders" />
     public class DaylightSavingTimeHistoryRegressionTest : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private Symbol[] _symbols = new[]
@@ -45,11 +41,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2011, 11, 10);  //Set Start Date
             SetEndDate(2011, 11, 11);    //Set End Date
             SetCash(100000);             //Set Strategy Cash
-            
-            // Find more symbols here: http://quantconnect.com/data
-            // Forex, CFD, Equities Resolutions: Tick, Second, Minute, Hour, Daily.
-            // Futures Resolution: Tick, Second, Minute
-            // Options Resolution: Minute Only.
+
             for (int i = 0; i < _symbols.Length; i++)
             {
                 var symbol = _symbols[i];
@@ -64,9 +56,6 @@ namespace QuantConnect.Algorithm.CSharp
                     throw new Exception($"Duplicated bars were issued for time {time}");
                 }
             }
-
-            // There are other assets with similar methods. See "Selecting Options" etc for more details.
-            // AddFuture, AddForex, AddCfd, AddOption
         }
 
         /// <summary>
@@ -77,7 +66,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+        public Language[] Languages { get; } = { Language.CSharp };
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/DaylightSavingTimeHistoryRegressionTest.cs
+++ b/Algorithm.CSharp/DaylightSavingTimeHistoryRegressionTest.cs
@@ -1,0 +1,129 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NodaTime;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Basic template algorithm simply initializes the date range and cash. This is a skeleton
+    /// framework you can use for designing an algorithm.
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="using quantconnect" />
+    /// <meta name="tag" content="trading and orders" />
+    public class DaylightSavingTimeHistoryRegressionTest : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol[] _symbols = new[]
+        {
+            QuantConnect.Symbol.Create("EURUSD", SecurityType.Forex, Market.FXCM),
+            QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA)
+        };
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2011, 11, 10);  //Set Start Date
+            SetEndDate(2011, 11, 11);    //Set End Date
+            SetCash(100000);             //Set Strategy Cash
+            
+            // Find more symbols here: http://quantconnect.com/data
+            // Forex, CFD, Equities Resolutions: Tick, Second, Minute, Hour, Daily.
+            // Futures Resolution: Tick, Second, Minute
+            // Options Resolution: Minute Only.
+            for (int i = 0; i < _symbols.Length; i++)
+            {
+                var symbol = _symbols[i];
+                var history = History<QuoteBar>(symbol, 10, Resolution.Daily);
+
+                var duplications = history
+                    .GroupBy(k => k.Time)
+                    .Where(g => g.Count() > 1);
+                if (duplications.Any())
+                {
+                    var time = duplications.First().Key;
+                    throw new Exception($"Duplicated bars were issued for time {time}");
+                }
+            }
+
+            // There are other assets with similar methods. See "Selecting Options" etc for more details.
+            // AddFuture, AddForex, AddCfd, AddOption
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "371857150"}
+        };
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -427,6 +427,9 @@
     <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.3\analyzers\dotnet\cs\Microsoft.NetFramework.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.3\analyzers\dotnet\cs\Microsoft.NetFramework.CSharp.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DaylightSavingTimeHistoryRegressionTest.cs" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/Engine/DataFeeds/Enumerators/FillForwardEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/FillForwardEnumerator.cs
@@ -290,6 +290,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                 var potentialUtc = _offsetProvider.ConvertToUtc(item.ReferenceDateTime) + item.Interval;
                 var potentialInTimeZone = _offsetProvider.ConvertFromUtc(potentialUtc);
                 var potentialBarEndTime = RoundDown(potentialInTimeZone, item.Interval);
+                // apply the same timezone to next and potential bars
+                // calculate next endTime by adding duration to the previous data time because incoming next.EndTime is swallowing one hour
                 var nextEndTime = _offsetProvider.ConvertFromUtc(previousTimeUtc) + nextPreviousTimeDelta + _dataResolution;
                 if (potentialBarEndTime < nextEndTime)
                 {

--- a/Engine/DataFeeds/Enumerators/FillForwardEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/FillForwardEnumerator.cs
@@ -273,6 +273,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                 return false;
             }
 
+            // define how many hours we swallowed when assigned next.EndTime
+            var daylightMovement = nextEndTimeUtc - (previousTimeUtc + nextPreviousTimeDelta + _dataResolution);
+
             // every bar emitted MUST be of the data resolution.
 
             // compute end times of the four potential fill forward scenarios
@@ -292,7 +295,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                 var potentialBarEndTime = RoundDown(potentialInTimeZone, item.Interval);
                 // apply the same timezone to next and potential bars
                 // calculate next endTime by adding duration to the previous data time because incoming next.EndTime is swallowing one hour
-                var nextEndTime = _offsetProvider.ConvertFromUtc(previousTimeUtc) + nextPreviousTimeDelta + _dataResolution;
+                var nextEndTime = next.EndTime - daylightMovement;
                 if (potentialBarEndTime < nextEndTime)
                 {
                     var nextFillForwardBarStartTime = potentialBarEndTime - item.Interval;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Correct next.EndTime value according to daylight saving time shift.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4630 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Duplicated history items are return on the board of daylight saving time interval

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created regression test that fetch history for EURUSD, SPY for daily resolution. No duplicated items should be returned

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
