### PR TITLE
Removes Delisted ETFs from LiquidEETFUniverse

### DIFF
--- a/Algorithm.Framework/Selection/LiquidETFUniverse.cs
+++ b/Algorithm.Framework/Selection/LiquidETFUniverse.cs
@@ -30,16 +30,16 @@ namespace QuantConnect.Algorithm.Framework.Selection
             new[]
             {
                 "VDE", "USO", "XES", "XOP", "UNG", "ICLN", "ERX",
-                "UCO", "AMJ", "BNO", "AMLP", "UGAZ", "TAN"
+                "UCO", "AMJ", "BNO", "AMLP", "TAN"
             },
-            new[] {"ERY", "SCO", "DGAZ" }
+            new[] {"ERY", "SCO" }
         );
 
         /// <summary>
         /// Represents the Metals ETF Category which can be used to access the list of Long and Inverse symbols
         /// </summary>
         public static Grouping Metals = new Grouping(
-            new[] {"GLD", "IAU", "SLV", "GDX", "AGQ", "PPLT", "NUGT", "USLV", "UGLD", "JNUG"},
+            new[] {"GLD", "IAU", "SLV", "GDX", "AGQ", "PPLT", "NUGT", "JNUG"},
             new[] {"DUST", "JDST"}
         );
 
@@ -67,7 +67,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// Represents the Volatility ETF Category which can be used to access the list of Long and Inverse symbols
         /// </summary>
         public static Grouping Volatility = new Grouping(
-            new[] {"TVIX", "VIXY", "SPLV", "UVXY", "EEMV", "EFAV", "USMV"},
+            new[] {"VIXY", "SPLV", "UVXY", "EEMV", "EFAV", "USMV"},
             new[] {"SVXY"}
         );
 


### PR DESCRIPTION
#### Description
According to [Bloomberg](https://www.bloomberg.com/news/articles/2020-06-22/credit-suisse-delists-3-billion-worth-of-etns-in-lineup-revamp), TVIX, UGLD, USLV, DGLD, DSLV, UGAZ, DGAZ, ZIV, and VIIX were delisted and, in fact, we don't have data from them after 20200702.

#### Motivation and Context
This Universe is used by Alpha Streams algorithms that cannot include delisted securities in their backtest.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`