### PR TITLE
Add GDAX symbol mapper for GDAX brokerage

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
@@ -26,7 +26,6 @@ using System.Net;
 using System.Threading.Tasks;
 using System.Threading;
 using RestSharp;
-using System.Text.RegularExpressions;
 using QuantConnect.Configuration;
 using QuantConnect.Logging;
 using QuantConnect.Orders.Fees;
@@ -45,12 +44,13 @@ namespace QuantConnect.Brokerages.GDAX
         /// </summary>
         public ConcurrentDictionary<long, GDAXFill> FillSplit { get; set; }
         private readonly string _passPhrase;
-        private const string SymbolMatching = "ETH|LTC|BTC|BCH|XRP|EOS|XLM|ETC|ZRX";
         private readonly IAlgorithm _algorithm;
         private readonly CancellationTokenSource _canceller = new CancellationTokenSource();
         private readonly ConcurrentDictionary<Symbol, DefaultOrderBook> _orderBooks = new ConcurrentDictionary<Symbol, DefaultOrderBook>();
         private readonly bool _isDataQueueHandler;
         protected readonly IDataAggregator _aggregator;
+
+        private readonly GDAXSymbolMapper _symbolMapper = new GDAXSymbolMapper();
 
         // GDAX has different rate limits for public and private endpoints
         // https://docs.gdax.com/#rate-limits
@@ -167,7 +167,7 @@ namespace QuantConnect.Brokerages.GDAX
             {
                 var message = JsonConvert.DeserializeObject<Messages.Snapshot>(data);
 
-                var symbol = ConvertProductId(message.ProductId);
+                var symbol = _symbolMapper.GetLeanSymbol(message.ProductId, SecurityType.Crypto, Market.GDAX);
 
                 DefaultOrderBook orderBook;
                 if (!_orderBooks.TryGetValue(symbol, out orderBook))
@@ -222,7 +222,7 @@ namespace QuantConnect.Brokerages.GDAX
             {
                 var message = JsonConvert.DeserializeObject<Messages.L2Update>(data);
 
-                var symbol = ConvertProductId(message.ProductId);
+                var symbol = _symbolMapper.GetLeanSymbol(message.ProductId, SecurityType.Crypto, Market.GDAX);
 
                 var orderBook = _orderBooks[symbol];
 
@@ -277,7 +277,7 @@ namespace QuantConnect.Brokerages.GDAX
 
         private void EmitFillOrderEvent(Messages.Fill fill, Order order)
         {
-            var symbol = ConvertProductId(fill.ProductId);
+            var symbol = _symbolMapper.GetLeanSymbol(fill.ProductId, SecurityType.Crypto, Market.GDAX);
 
             if (!FillSplit.ContainsKey(order.Id))
             {
@@ -329,7 +329,9 @@ namespace QuantConnect.Brokerages.GDAX
         /// <returns></returns>
         public Tick GetTick(Symbol symbol)
         {
-            var req = new RestRequest($"/products/{ConvertSymbol(symbol)}/ticker", Method.GET);
+            var brokerageSymbol = _symbolMapper.GetBrokerageSymbol(symbol);
+
+            var req = new RestRequest($"/products/{brokerageSymbol}/ticker", Method.GET);
             var response = ExecuteRestRequest(req, GdaxEndpointType.Public);
             if (response.StatusCode != System.Net.HttpStatusCode.OK)
             {
@@ -368,7 +370,7 @@ namespace QuantConnect.Brokerages.GDAX
         /// </summary>
         private void EmitTradeTick(Messages.Matched message)
         {
-            var symbol = ConvertProductId(message.ProductId);
+            var symbol = _symbolMapper.GetLeanSymbol(message.ProductId, SecurityType.Crypto, Market.GDAX);
 
             _aggregator.Update(new Tick
             {
@@ -389,20 +391,25 @@ namespace QuantConnect.Brokerages.GDAX
             var pendingSymbols = new List<Symbol>();
             foreach (var item in fullList)
             {
-                if (!IsSubscribeAvailable(item))
+                if (_symbolMapper.IsKnownLeanSymbol(item))
+                {
+                    pendingSymbols.Add(item);
+                }
+                else if (item.SecurityType == SecurityType.Crypto)
+                {
+                    Log.Error($"Unknown GDAX symbol: {item.Value}");
+                }
+                else
                 {
                     //todo: refactor this outside brokerage
                     //alternative service: http://openexchangerates.org/latest.json
                     PollTick(item);
                 }
-                else
-                {
-                    pendingSymbols.Add(item);
-                }
             }
 
             var products = pendingSymbols
-                .Select(s => s.Value.Substring(0, 3) + "-" + s.Value.Substring(3)).ToArray();
+                .Select(s => _symbolMapper.GetBrokerageSymbol(s))
+                .ToArray();
 
             var payload = new
             {
@@ -486,11 +493,6 @@ namespace QuantConnect.Brokerages.GDAX
             }
         }
 
-        private bool IsSubscribeAvailable(Symbol symbol)
-        {
-            return Regex.IsMatch(symbol.Value, SymbolMatching);
-        }
-
         /// <summary>
         /// Ends current subscriptions
         /// </summary>
@@ -499,7 +501,7 @@ namespace QuantConnect.Brokerages.GDAX
             if (WebSocket.IsOpen)
             {
                 var products = symbols
-                    .Select(s => s.Value.Substring(0, 3) + "-" + s.Value.Substring(3))
+                    .Select(s => _symbolMapper.GetBrokerageSymbol(s))
                     .ToArray();
 
                 var payload = new

--- a/Brokerages/GDAX/GDAXBrokerage.Utility.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Utility.cs
@@ -129,26 +129,6 @@ namespace QuantConnect.Brokerages.GDAX
             throw new NotSupportedException($"GDAXBrokerage.ConvertOrderType: Unsupported order type:{orderType.ToStringInvariant()}");
         }
 
-        /// <summary>
-        /// Converts a product id to a symbol
-        /// </summary>
-        /// <param name="productId">gdax format product id</param>
-        /// <returns>Symbol</returns>
-        public static Symbol ConvertProductId(string productId)
-        {
-            return Symbol.Create(productId.Replace("-", ""), SecurityType.Crypto, Market.GDAX);
-        }
-
-        /// <summary>
-        /// Converts a symbol to a product id
-        /// </summary>
-        /// <param name="symbol">Th symbol</param>
-        /// <returns>gdax product id</returns>
-        protected static string ConvertSymbol(Symbol symbol)
-        {
-            return $"{symbol.Value.Substring(0, 3).ToUpperInvariant()}-{symbol.Value.Substring(3, 3).ToUpperInvariant()}";
-        }
-
         private static Orders.OrderStatus ConvertOrderStatus(Messages.Order order)
         {
             if (order.FilledSize != 0 && order.FilledSize != order.Size)

--- a/Brokerages/GDAX/GDAXBrokerage.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.cs
@@ -64,7 +64,7 @@ namespace QuantConnect.Brokerages.GDAX
                     (order as StopMarketOrder)?.StopPrice ?? 0;
             }
 
-            payload.product_id = ConvertSymbol(order.Symbol);
+            payload.product_id = _symbolMapper.GetBrokerageSymbol(order.Symbol);
 
             if (_algorithm.BrokerageModel.AccountType == AccountType.Margin)
             {
@@ -246,7 +246,7 @@ namespace QuantConnect.Brokerages.GDAX
 
                 order.Quantity = item.Side == "sell" ? -item.Size : item.Size;
                 order.BrokerId = new List<string> { item.Id };
-                order.Symbol = ConvertProductId(item.ProductId);
+                order.Symbol = _symbolMapper.GetLeanSymbol(item.ProductId, SecurityType.Crypto, Market.GDAX);
                 order.Time = DateTime.UtcNow;
                 order.Status = ConvertOrderStatus(item);
                 order.Price = item.Price;
@@ -323,6 +323,13 @@ namespace QuantConnect.Brokerages.GDAX
                 yield break;
             }
 
+            if (!_symbolMapper.IsKnownLeanSymbol(request.Symbol))
+            {
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidSymbol",
+                    $"Unknown symbol: {request.Symbol.Value}, no history returned"));
+                yield break;
+            }
+
             if (request.EndTimeUtc < request.StartTimeUtc)
             {
                 OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidDateRange",
@@ -351,7 +358,7 @@ namespace QuantConnect.Brokerages.GDAX
         /// <param name="request">The history request instance</param>
         private IEnumerable<TradeBar> GetHistoryFromCandles(HistoryRequest request)
         {
-            var productId = ConvertSymbol(request.Symbol);
+            var productId = _symbolMapper.GetBrokerageSymbol(request.Symbol);
             var granularity = Convert.ToInt32(request.Resolution.ToTimeSpan().TotalSeconds);
 
             var startTime = request.StartTimeUtc;

--- a/Brokerages/GDAX/GDAXSymbolMapper.cs
+++ b/Brokerages/GDAX/GDAXSymbolMapper.cs
@@ -1,0 +1,213 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Crypto;
+
+namespace QuantConnect.Brokerages.GDAX
+{
+    /// <summary>
+    /// Provides the mapping between Lean symbols and GDAX symbols.
+    /// </summary>
+    public class GDAXSymbolMapper : ISymbolMapper
+    {
+        /// <summary>
+        /// The list of known GDAX symbols.
+        /// </summary>
+        public static readonly HashSet<string> KnownTickers =
+            new HashSet<string>(SymbolPropertiesDatabase
+                .FromDataFolder()
+                .GetSymbolPropertiesList(Market.GDAX, SecurityType.Crypto)
+                .Select(x => x.Key.Symbol));
+
+        /// <summary>
+        /// Converts a Lean symbol instance to a GDAX symbol
+        /// </summary>
+        /// <param name="symbol">A Lean symbol instance</param>
+        /// <returns>The GDAX symbol</returns>
+        public string GetBrokerageSymbol(Symbol symbol)
+        {
+            if (symbol == null || string.IsNullOrWhiteSpace(symbol.Value))
+            {
+                throw new ArgumentException("Invalid symbol: " + (symbol == null ? "null" : symbol.ToString()));
+            }
+
+            if (symbol.ID.SecurityType != SecurityType.Crypto)
+            {
+                throw new ArgumentException("Invalid security type: " + symbol.ID.SecurityType);
+            }
+
+            if (symbol.ID.Market != Market.GDAX)
+            {
+                throw new ArgumentException($"Invalid market: {symbol.ID.Market}");
+            }
+
+            var brokerageSymbol = ConvertLeanSymbolToGdaxSymbol(symbol.Value);
+
+            if (!IsKnownBrokerageSymbol(brokerageSymbol))
+            {
+                throw new ArgumentException("Unknown GDAX symbol: " + symbol.Value);
+            }
+
+            return brokerageSymbol;
+        }
+
+        /// <summary>
+        /// Converts a GDAX symbol to a Lean symbol instance
+        /// </summary>
+        /// <param name="brokerageSymbol">The GDAX symbol</param>
+        /// <param name="securityType">The security type</param>
+        /// <param name="market">The market</param>
+        /// <param name="expirationDate">Expiration date of the security(if applicable)</param>
+        /// <param name="strike">The strike of the security (if applicable)</param>
+        /// <param name="optionRight">The option right of the security (if applicable)</param>
+        /// <returns>A new Lean Symbol instance</returns>
+        public Symbol GetLeanSymbol(string brokerageSymbol, SecurityType securityType, string market, DateTime expirationDate = default(DateTime), decimal strike = 0, OptionRight optionRight = 0)
+        {
+            if (string.IsNullOrWhiteSpace(brokerageSymbol))
+            {
+                throw new ArgumentException($"Invalid GDAX symbol: {brokerageSymbol}");
+            }
+
+            if (!IsKnownBrokerageSymbol(brokerageSymbol))
+            {
+                throw new ArgumentException($"Unknown GDAX symbol: {brokerageSymbol}");
+            }
+
+            if (securityType != SecurityType.Crypto)
+            {
+                throw new ArgumentException($"Invalid security type: {securityType}");
+            }
+
+            if (market != Market.GDAX)
+            {
+                throw new ArgumentException($"Invalid market: {market}");
+            }
+
+            return Symbol.Create(ConvertGdaxSymbolToLeanSymbol(brokerageSymbol), GetBrokerageSecurityType(brokerageSymbol), Market.GDAX);
+        }
+
+        /// <summary>
+        /// Converts a GDAX symbol to a Lean symbol instance
+        /// </summary>
+        /// <param name="brokerageSymbol">The GDAX symbol</param>
+        /// <returns>A new Lean Symbol instance</returns>
+        public Symbol GetLeanSymbol(string brokerageSymbol)
+        {
+            var securityType = GetBrokerageSecurityType(brokerageSymbol);
+            return GetLeanSymbol(brokerageSymbol, securityType, Market.GDAX);
+        }
+
+        /// <summary>
+        /// Returns the security type for a GDAX symbol
+        /// </summary>
+        /// <param name="brokerageSymbol">The GDAX symbol</param>
+        /// <returns>The security type</returns>
+        public SecurityType GetBrokerageSecurityType(string brokerageSymbol)
+        {
+            if (string.IsNullOrWhiteSpace(brokerageSymbol))
+            {
+                throw new ArgumentException($"Invalid GDAX symbol: {brokerageSymbol}");
+            }
+
+            if (!IsKnownBrokerageSymbol(brokerageSymbol))
+            {
+                throw new ArgumentException($"Unknown GDAX symbol: {brokerageSymbol}");
+            }
+
+            return SecurityType.Crypto;
+        }
+
+        /// <summary>
+        /// Returns the security type for a Lean symbol
+        /// </summary>
+        /// <param name="leanSymbol">The Lean symbol</param>
+        /// <returns>The security type</returns>
+        public SecurityType GetLeanSecurityType(string leanSymbol)
+        {
+            return GetBrokerageSecurityType(ConvertLeanSymbolToGdaxSymbol(leanSymbol));
+        }
+
+        /// <summary>
+        /// Checks if the symbol is supported by GDAX
+        /// </summary>
+        /// <param name="brokerageSymbol">The GDAX symbol</param>
+        /// <returns>True if GDAX supports the symbol</returns>
+        public bool IsKnownBrokerageSymbol(string brokerageSymbol)
+        {
+            if (string.IsNullOrWhiteSpace(brokerageSymbol) || !brokerageSymbol.Contains("-"))
+            {
+                return false;
+            }
+
+            var leanSymbol = ConvertGdaxSymbolToLeanSymbol(brokerageSymbol);
+
+            return KnownTickers.Contains(leanSymbol);
+        }
+
+        /// <summary>
+        /// Checks if the symbol is supported by GDAX
+        /// </summary>
+        /// <param name="symbol">The Lean symbol</param>
+        /// <returns>True if GDAX supports the symbol</returns>
+        public static bool IsKnownLeanSymbol(Symbol symbol)
+        {
+            if (string.IsNullOrWhiteSpace(symbol?.Value))
+            {
+                return false;
+            }
+
+            return KnownTickers.Contains(symbol.Value);
+        }
+
+        /// <summary>
+        /// Converts a GDAX symbol to a Lean symbol string
+        /// </summary>
+        private static string ConvertGdaxSymbolToLeanSymbol(string brokerageSymbol)
+        {
+            if (string.IsNullOrWhiteSpace(brokerageSymbol) || !brokerageSymbol.Contains("-"))
+            {
+                throw new ArgumentException($"Invalid GDAX symbol: {brokerageSymbol}");
+            }
+
+            return brokerageSymbol.Replace("-", "");
+        }
+
+        /// <summary>
+        /// Converts a Lean symbol to a GDAX symbol
+        /// </summary>
+        private static string ConvertLeanSymbolToGdaxSymbol(string leanSymbol)
+        {
+            var symbol = Symbol.Create(leanSymbol, SecurityType.Crypto, Market.GDAX);
+
+            if (!IsKnownLeanSymbol(symbol))
+            {
+                throw new ArgumentException($"Invalid Lean symbol: {leanSymbol}");
+            }
+
+            var symbolProperties = SymbolPropertiesDatabase
+                .FromDataFolder()
+                .GetSymbolProperties(Market.GDAX, leanSymbol, SecurityType.Crypto, Currencies.USD);
+
+            string baseCurrency, quoteCurrency;
+            Crypto.DecomposeCurrencyPair(symbol, symbolProperties, out baseCurrency, out quoteCurrency);
+
+            return $"{baseCurrency}-{quoteCurrency}";
+        }
+    }
+}

--- a/Brokerages/GDAX/GDAXSymbolMapper.cs
+++ b/Brokerages/GDAX/GDAXSymbolMapper.cs
@@ -165,7 +165,7 @@ namespace QuantConnect.Brokerages.GDAX
         /// </summary>
         /// <param name="symbol">The Lean symbol</param>
         /// <returns>True if GDAX supports the symbol</returns>
-        public static bool IsKnownLeanSymbol(Symbol symbol)
+        public bool IsKnownLeanSymbol(Symbol symbol)
         {
             if (string.IsNullOrWhiteSpace(symbol?.Value))
             {
@@ -191,7 +191,7 @@ namespace QuantConnect.Brokerages.GDAX
         /// <summary>
         /// Converts a Lean symbol to a GDAX symbol
         /// </summary>
-        private static string ConvertLeanSymbolToGdaxSymbol(string leanSymbol)
+        private string ConvertLeanSymbolToGdaxSymbol(string leanSymbol)
         {
             var symbol = Symbol.Create(leanSymbol, SecurityType.Crypto, Market.GDAX);
 

--- a/Brokerages/QuantConnect.Brokerages.csproj
+++ b/Brokerages/QuantConnect.Brokerages.csproj
@@ -356,6 +356,7 @@
     <Compile Include="Bitfinex\Converters\TickerConverter.cs" />
     <Compile Include="Bitfinex\Converters\PositionConverter.cs" />
     <Compile Include="Bitfinex\Converters\WalletConverter.cs" />
+    <Compile Include="GDAX\GDAXSymbolMapper.cs" />
     <Compile Include="InteractiveBrokers\InteractiveBrokersStateManager.cs" />
     <Compile Include="IOrderBookUpdater.cs" />
     <Compile Include="DefaultOrderBook.cs" />

--- a/Tests/Brokerages/BrokerageTests.cs
+++ b/Tests/Brokerages/BrokerageTests.cs
@@ -108,12 +108,6 @@ namespace QuantConnect.Tests.Brokerages
                 Assert.Fail("Failed to connect to brokerage");
             }
 
-            //gdax does not have a user data stream. Instead, we need to symbol subscribe and monitor for our orders.
-            if (brokerage.Name == "GDAX")
-            {
-                ((QuantConnect.Brokerages.GDAX.GDAXBrokerage)brokerage).Subscribe(new[] { Symbol });
-            }
-
             Log.Trace("");
             Log.Trace("GET OPEN ORDERS");
             Log.Trace("");

--- a/Tests/Brokerages/GDAX/GDAXBrokerageTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageTests.cs
@@ -160,7 +160,7 @@ namespace QuantConnect.Tests.Brokerages.GDAX
         {
             const decimal orderQuantity = 6.1m;
 
-            _unit.PlaceOrder(new MarketOrder("BTCUSD", orderQuantity, DateTime.UtcNow)
+            _unit.PlaceOrder(new MarketOrder(Symbols.BTCUSD, orderQuantity, DateTime.UtcNow)
             {
                 // set the quote currency here to prevent the test from accessing algorithm.Securities
                 PriceCurrency = "USD"
@@ -354,18 +354,18 @@ namespace QuantConnect.Tests.Brokerages.GDAX
 
             var gotBTCUSD = false;
             var gotGBPUSD = false;
-            var gotBTCETH = false;
+            var gotETHBTC = false;
 
             _unit.Subscribe(GetSubscriptionDataConfig<Tick>(Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX), Resolution.Tick), (s, e) => { gotBTCUSD = true; });
             StringAssert.Contains("[\"BTC-USD\"]", actual);
             _unit.Subscribe(GetSubscriptionDataConfig<Tick>(Symbol.Create("GBPUSD", SecurityType.Forex, Market.FXCM), Resolution.Tick), (s, e) => { gotGBPUSD = true; });
-            _unit.Subscribe(GetSubscriptionDataConfig<Tick>(Symbol.Create("BTCETH", SecurityType.Crypto, Market.GDAX), Resolution.Tick), (s, e) => { gotBTCETH = true; });
-            StringAssert.Contains("[\"BTC-USD\",\"BTC-ETH\"]", actual);
+            _unit.Subscribe(GetSubscriptionDataConfig<Tick>(Symbol.Create("ETHBTC", SecurityType.Crypto, Market.GDAX), Resolution.Tick), (s, e) => { gotETHBTC = true; });
+            StringAssert.Contains("[\"BTC-USD\",\"ETH-BTC\"]", actual);
             Thread.Sleep(1000);
 
             Assert.IsFalse(gotBTCUSD);
             Assert.IsTrue(gotGBPUSD);
-            Assert.IsFalse(gotBTCETH);
+            Assert.IsFalse(gotETHBTC);
         }
 
         [Test]
@@ -394,24 +394,16 @@ namespace QuantConnect.Tests.Brokerages.GDAX
         }
 
         [Test]
-        public void ErrorTest()
+        public void InvalidSymbolSubscribeTest()
         {
             string actual = null;
-
-            // subscribe to invalid symbol
-            const string expected = "[\"BTC-LTC\"]";
             _wss.Setup(w => w.Send(It.IsAny<string>())).Callback<string>(c => actual = c);
 
+            // subscribe to invalid symbol
             _unit.Subscribe(new[] { Symbol.Create("BTCLTC", SecurityType.Crypto, Market.GDAX) });
 
-            StringAssert.Contains(expected, actual);
-
-            BrokerageMessageType messageType = 0;
-            _unit.Message += (sender, e) => { messageType = e.Type; };
-            const string json = "{\"type\":\"error\",\"message\":\"Failed to subscribe\",\"reason\":\"Invalid product ID provided\"}";
-            _unit.OnMessage(_unit, GDAXTestsHelpers.GetArgs(json));
-
-            Assert.AreEqual(BrokerageMessageType.Error, messageType);
+            // subscribe is not called for invalid symbols
+            Assert.IsNull(actual);
         }
 
         private SubscriptionDataConfig GetSubscriptionDataConfig<T>(Symbol symbol, Resolution resolution)

--- a/Tests/Brokerages/GDAX/GDAXSymbolMapperTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXSymbolMapperTests.cs
@@ -1,0 +1,162 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using QuantConnect.Brokerages.GDAX;
+using System;
+
+namespace QuantConnect.Tests.Brokerages.GDAX
+{
+    [TestFixture]
+    public class GDAXSymbolMapperTests
+    {
+        #region Data
+
+        private static TestCaseData[] BrokerageSymbols => new[]
+        {
+            new TestCaseData("ETH-USD", "ETHUSD"),
+            new TestCaseData("ETH-BTC", "ETHBTC"),
+            new TestCaseData("BTC-USD", "BTCUSD"),
+            new TestCaseData("BTC-USDC", "BTCUSDC"),
+            new TestCaseData("ATOM-USD", "ATOMUSD")
+        };
+
+        private static TestCaseData[] CryptoSymbols => new[]
+        {
+            new TestCaseData(Symbol.Create("ETHUSD", SecurityType.Crypto, Market.GDAX), "ETH-USD"),
+            new TestCaseData(Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX), "BTC-USD"),
+            new TestCaseData(Symbol.Create("ETHBTC", SecurityType.Crypto, Market.GDAX), "ETH-BTC"),
+            new TestCaseData(Symbol.Create("BTCUSDC", SecurityType.Crypto, Market.GDAX), "BTC-USDC"),
+            new TestCaseData(Symbol.Create("ATOMUSD", SecurityType.Crypto, Market.GDAX), "ATOM-USD")
+        };
+
+        private static TestCaseData[] CurrencyPairs => new[]
+        {
+            new TestCaseData(""),
+            new TestCaseData("EURUSD"),
+            new TestCaseData("GBP-USD"),
+            new TestCaseData("USD-JPY")
+        };
+
+        private static TestCaseData[] UnknownSymbols => new[]
+        {
+            new TestCaseData("AAA-BBB", SecurityType.Crypto, Market.GDAX),
+            new TestCaseData("USD-BTC", SecurityType.Crypto, Market.GDAX),
+            new TestCaseData("EUR-USD", SecurityType.Crypto, Market.GDAX),
+            new TestCaseData("GBP-USD", SecurityType.Crypto, Market.GDAX),
+            new TestCaseData("USD-JPY", SecurityType.Crypto, Market.GDAX),
+            new TestCaseData("BTC-ETH", SecurityType.Crypto, Market.GDAX),
+            new TestCaseData("USDC-BTC", SecurityType.Crypto, Market.GDAX)
+        };
+
+        private static TestCaseData[] UnknownSecurityType => new[]
+        {
+            new TestCaseData("BTC-USD", SecurityType.Forex, Market.GDAX)
+        };
+
+        private static TestCaseData[] UnknownMarket => new[]
+        {
+            new TestCaseData("ETH-USD", SecurityType.Crypto, Market.Bitfinex)
+        };
+
+        #endregion
+
+        [TestCaseSource(nameof(BrokerageSymbols))]
+        public void ReturnsCryptoSecurityType(string brokerageSymbol, string leanSymbol)
+        {
+            var mapper = new GDAXSymbolMapper();
+
+            Assert.AreEqual(SecurityType.Crypto, mapper.GetBrokerageSecurityType(brokerageSymbol));
+            var symbol = mapper.GetLeanSymbol(brokerageSymbol);
+            Assert.AreEqual(leanSymbol, symbol.Value);
+            Assert.AreEqual(SecurityType.Crypto, mapper.GetLeanSecurityType(symbol.Value));
+            Assert.AreEqual(Market.GDAX, symbol.ID.Market);
+        }
+
+        [TestCaseSource(nameof(BrokerageSymbols))]
+        public void ReturnsCorrectLeanSymbol(string brokerageSymbol, string leanSymbol)
+        {
+            var mapper = new GDAXSymbolMapper();
+
+            var symbol = mapper.GetLeanSymbol(brokerageSymbol);
+            Assert.AreEqual(leanSymbol, symbol.Value);
+            Assert.AreEqual(SecurityType.Crypto, symbol.ID.SecurityType);
+            Assert.AreEqual(Market.GDAX, symbol.ID.Market);
+        }
+
+        [TestCaseSource(nameof(CryptoSymbols))]
+        public void ReturnsCorrectBrokerageSymbol(Symbol symbol, string brokerageSymbol)
+        {
+            var mapper = new GDAXSymbolMapper();
+
+            Assert.AreEqual(brokerageSymbol, mapper.GetBrokerageSymbol(symbol));
+        }
+
+        [TestCaseSource(nameof(CurrencyPairs))]
+        public void ThrowsOnCurrencyPairs(string brokerageSymbol)
+        {
+            var mapper = new GDAXSymbolMapper();
+
+            Assert.Throws<ArgumentException>(() => mapper.GetBrokerageSecurityType(brokerageSymbol));
+        }
+
+        [Test]
+        public void ThrowsOnNullOrEmptySymbols()
+        {
+            var mapper = new GDAXSymbolMapper();
+
+            string ticker = null;
+            Assert.IsFalse(mapper.IsKnownBrokerageSymbol(ticker));
+            Assert.Throws<ArgumentException>(() => mapper.GetLeanSymbol(ticker, SecurityType.Crypto, Market.GDAX));
+            Assert.Throws<ArgumentException>(() => mapper.GetBrokerageSecurityType(ticker));
+
+            ticker = "";
+            Assert.IsFalse(mapper.IsKnownBrokerageSymbol(ticker));
+            Assert.Throws<ArgumentException>(() => mapper.GetLeanSymbol(ticker, SecurityType.Crypto, Market.GDAX));
+            Assert.Throws<ArgumentException>(() => mapper.GetBrokerageSecurityType(ticker));
+            Assert.Throws<ArgumentException>(() => mapper.GetBrokerageSymbol(Symbol.Create(ticker, SecurityType.Crypto, Market.GDAX)));
+        }
+
+        [TestCaseSource(nameof(UnknownSymbols))]
+        public void ThrowsOnUnknownSymbols(string brokerageSymbol, SecurityType type, string market)
+        {
+            var mapper = new GDAXSymbolMapper();
+
+            Assert.IsFalse(mapper.IsKnownBrokerageSymbol(brokerageSymbol));
+            Assert.Throws<ArgumentException>(() => mapper.GetLeanSymbol(brokerageSymbol, type, market));
+            Assert.Throws<ArgumentException>(() => mapper.GetBrokerageSymbol(Symbol.Create(brokerageSymbol.Replace("-", ""), type, market)));
+        }
+
+        [TestCaseSource(nameof(UnknownSecurityType))]
+        public void ThrowsOnUnknownSecurityType(string brokerageSymbol, SecurityType type, string market)
+        {
+            var mapper = new GDAXSymbolMapper();
+
+            Assert.IsTrue(mapper.IsKnownBrokerageSymbol(brokerageSymbol));
+            Assert.Throws<ArgumentException>(() => mapper.GetLeanSymbol(brokerageSymbol, type, market));
+            Assert.Throws<ArgumentException>(() => mapper.GetBrokerageSymbol(Symbol.Create(brokerageSymbol.Replace("-", ""), type, market)));
+        }
+
+        [TestCaseSource(nameof(UnknownMarket))]
+        public void ThrowsOnUnknownMarket(string brokerageSymbol, SecurityType type, string market)
+        {
+            var mapper = new GDAXSymbolMapper();
+
+            Assert.IsTrue(mapper.IsKnownBrokerageSymbol(brokerageSymbol));
+            Assert.Throws<ArgumentException>(() => mapper.GetLeanSymbol(brokerageSymbol, type, market));
+            Assert.Throws<ArgumentException>(() => mapper.GetBrokerageSymbol(Symbol.Create(brokerageSymbol.Replace("-", ""), type, market)));
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -367,6 +367,7 @@
     <Compile Include="Brokerages\Bitfinex\BitfinexSymbolMapperTests.cs" />
     <Compile Include="Brokerages\Bitfinex\BitfinexBrokerageHistoryProviderTests.cs" />
     <Compile Include="Brokerages\DowngradeErrorCodeToWarningBrokerageMessageHandlerTests.cs" />
+    <Compile Include="Brokerages\GDAX\GDAXSymbolMapperTests.cs" />
     <Compile Include="Brokerages\InteractiveBrokers\InteractiveBrokersFuturesTests.cs" />
     <Compile Include="Brokerages\Paper\PaperBrokerageTests.cs" />
     <Compile Include="AlgorithmRunnerResults.cs" />


### PR DESCRIPTION

#### Description
- Added new `GDAXSymbolMapper`
- Updated `GDAXBrokerage` to use `GDAXSymbolMapper`
- Fixed `GDAXBrokerage` unit tests

#### Related Issue
Closes #4723 

#### Motivation and Context
- Support all available GDAX pairs -- to be added in symbol properties database: #4708 

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Brokerage unit tests

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`