### PR TITLE
Improve Error Message For Arithmetic Overflow In Decimal Cast of Double

### DIFF
--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Algorithm
         /// <seealso cref="Buy(Symbol, decimal)"/>
         public OrderTicket Buy(Symbol symbol, double quantity)
         {
-            return Order(symbol, (decimal)Math.Abs(quantity));
+            return Order(symbol, Math.Abs(quantity).SafeDecimalCast());
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace QuantConnect.Algorithm
         /// <returns>int Order Id.</returns>
         public OrderTicket Sell(Symbol symbol, double quantity)
         {
-            return Order(symbol, (decimal)Math.Abs(quantity) * -1);
+            return Order(symbol, Math.Abs(quantity).SafeDecimalCast() * -1m);
         }
 
         /// <summary>
@@ -130,7 +130,7 @@ namespace QuantConnect.Algorithm
         /// <seealso cref="Order(Symbol, decimal)"/>
         public OrderTicket Order(Symbol symbol, double quantity)
         {
-            return Order(symbol, (decimal)quantity);
+            return Order(symbol, quantity.SafeDecimalCast());
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">Symbol of the MarketType Required.</param>
         /// <param name="quantity">Number of shares to request.</param>
-        /// <param name="asynchronous">Send the order asynchrously (false). Otherwise we'll block until it fills</param>
+        /// <param name="asynchronous">Send the order asynchronously (false). Otherwise we'll block until it fills</param>
         /// <param name="tag">Place a custom order property or tag (e.g. indicator data).</param>
         /// <seealso cref="MarketOrder(Symbol, decimal, bool, string)"/>
         public OrderTicket Order(Symbol symbol, decimal quantity, bool asynchronous = false, string tag = "")
@@ -169,7 +169,7 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">Symbol of the MarketType Required.</param>
         /// <param name="quantity">Number of shares to request.</param>
-        /// <param name="asynchronous">Send the order asynchrously (false). Otherwise we'll block until it fills</param>
+        /// <param name="asynchronous">Send the order asynchronously (false). Otherwise we'll block until it fills</param>
         /// <param name="tag">Place a custom order property or tag (e.g. indicator data).</param>
         /// <returns>int Order id</returns>
         public OrderTicket MarketOrder(Symbol symbol, int quantity, bool asynchronous = false, string tag = "")
@@ -182,12 +182,12 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">Symbol of the MarketType Required.</param>
         /// <param name="quantity">Number of shares to request.</param>
-        /// <param name="asynchronous">Send the order asynchrously (false). Otherwise we'll block until it fills</param>
+        /// <param name="asynchronous">Send the order asynchronously (false). Otherwise we'll block until it fills</param>
         /// <param name="tag">Place a custom order property or tag (e.g. indicator data).</param>
         /// <returns>int Order id</returns>
         public OrderTicket MarketOrder(Symbol symbol, double quantity, bool asynchronous = false, string tag = "")
         {
-            return MarketOrder(symbol, (decimal)quantity, asynchronous, tag);
+            return MarketOrder(symbol, quantity.SafeDecimalCast(), asynchronous, tag);
         }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">Symbol of the MarketType Required.</param>
         /// <param name="quantity">Number of shares to request.</param>
-        /// <param name="asynchronous">Send the order asynchrously (false). Otherwise we'll block until it fills</param>
+        /// <param name="asynchronous">Send the order asynchronously (false). Otherwise we'll block until it fills</param>
         /// <param name="tag">Place a custom order property or tag (e.g. indicator data).</param>
         /// <returns>int Order id</returns>
         public OrderTicket MarketOrder(Symbol symbol, decimal quantity, bool asynchronous = false, string tag = "")
@@ -255,7 +255,7 @@ namespace QuantConnect.Algorithm
         /// <returns>The order ID</returns>
         public OrderTicket MarketOnOpenOrder(Symbol symbol, double quantity, string tag = "")
         {
-            return MarketOnOpenOrder(symbol, (decimal)quantity, tag);
+            return MarketOnOpenOrder(symbol, quantity.SafeDecimalCast(), tag);
         }
 
         /// <summary>
@@ -311,7 +311,7 @@ namespace QuantConnect.Algorithm
         /// <returns>The order ID</returns>
         public OrderTicket MarketOnCloseOrder(Symbol symbol, double quantity, string tag = "")
         {
-            return MarketOnCloseOrder(symbol, (decimal)quantity, tag);
+            return MarketOnCloseOrder(symbol, quantity.SafeDecimalCast(), tag);
         }
 
         /// <summary>
@@ -357,7 +357,7 @@ namespace QuantConnect.Algorithm
         /// <returns>Order id</returns>
         public OrderTicket LimitOrder(Symbol symbol, double quantity, decimal limitPrice, string tag = "")
         {
-            return LimitOrder(symbol, (decimal)quantity, limitPrice, tag);
+            return LimitOrder(symbol, quantity.SafeDecimalCast(), limitPrice, tag);
         }
 
         /// <summary>
@@ -404,7 +404,7 @@ namespace QuantConnect.Algorithm
         /// <returns>Int orderId for the new order.</returns>
         public OrderTicket StopMarketOrder(Symbol symbol, double quantity, decimal stopPrice, string tag = "")
         {
-            return StopMarketOrder(symbol, (decimal)quantity, stopPrice, tag);
+            return StopMarketOrder(symbol, quantity.SafeDecimalCast(), stopPrice, tag);
         }
 
         /// <summary>
@@ -453,7 +453,7 @@ namespace QuantConnect.Algorithm
         /// <returns>Order id</returns>
         public OrderTicket StopLimitOrder(Symbol symbol, double quantity, decimal stopPrice, decimal limitPrice, string tag = "")
         {
-            return StopLimitOrder(symbol, (decimal)quantity, stopPrice, limitPrice, tag);
+            return StopLimitOrder(symbol, quantity.SafeDecimalCast(), stopPrice, limitPrice, tag);
         }
 
         /// <summary>
@@ -484,7 +484,7 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="optionSymbol">String symbol for the option position</param>
         /// <param name="quantity">Quantity of options contracts</param>
-        /// <param name="asynchronous">Send the order asynchrously (false). Otherwise we'll block until it fills</param>
+        /// <param name="asynchronous">Send the order asynchronously (false). Otherwise we'll block until it fills</param>
         /// <param name="tag">String tag for the order (optional)</param>
         public OrderTicket ExerciseOption(Symbol optionSymbol, int quantity, bool asynchronous = false, string tag = "")
         {
@@ -626,7 +626,7 @@ namespace QuantConnect.Algorithm
 
 
         /// <summary>
-        /// Perform preorder checks to ensure we have sufficient capital,
+        /// Perform pre-order checks to ensure we have sufficient capital,
         /// the market is open, and we haven't exceeded maximum realistic orders per day.
         /// </summary>
         /// <returns>OrderResponse. If no error, order request is submitted.</returns>
@@ -641,7 +641,7 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Perform preorder checks to ensure we have sufficient capital,
+        /// Perform pre-order checks to ensure we have sufficient capital,
         /// the market is open, and we haven't exceeded maximum realistic orders per day.
         /// </summary>
         /// <returns>OrderResponse. If no error, order request is submitted.</returns>
@@ -889,7 +889,7 @@ namespace QuantConnect.Algorithm
         /// <seealso cref="MarketOrder(QuantConnect.Symbol,decimal,bool,string)"/>
         public void SetHoldings(Symbol symbol, double percentage, bool liquidateExistingHoldings = false)
         {
-            SetHoldings(symbol, (decimal)percentage, liquidateExistingHoldings);
+            SetHoldings(symbol, percentage.SafeDecimalCast(), liquidateExistingHoldings);
         }
 
         /// <summary>
@@ -989,18 +989,18 @@ namespace QuantConnect.Algorithm
         /// Calculate the order quantity to achieve target-percent holdings.
         /// </summary>
         /// <param name="symbol">Security object we're asking for</param>
-        /// <param name="target">Target percentag holdings</param>
+        /// <param name="target">Target percentage holdings</param>
         /// <returns>Order quantity to achieve this percentage</returns>
         public decimal CalculateOrderQuantity(Symbol symbol, double target)
         {
-            return CalculateOrderQuantity(symbol, (decimal)target);
+            return CalculateOrderQuantity(symbol, target.SafeDecimalCast());
         }
 
         /// <summary>
         /// Calculate the order quantity to achieve target-percent holdings.
         /// </summary>
         /// <param name="symbol">Security object we're asking for</param>
-        /// <param name="target">Target percentage holdings, this is an unlevered value, so
+        /// <param name="target">Target percentage holdings, this is an unleveraged value, so
         /// if you have 2x leverage and request 100% holdings, it will utilize half of the
         /// available margin</param>
         /// <returns>Order quantity to achieve this percentage</returns>

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -672,7 +672,15 @@ namespace QuantConnect
         /// as a decimal, then the closest decimal value will be returned</returns>
         public static decimal SafeDecimalCast(this double input)
         {
-            if (input.IsNaNOrZero()) return 0;
+            if (double.IsNaN(input) || double.IsInfinity(input))
+            {
+                throw new ArgumentException(
+                    $"It is not possible to cast a non-finite floating-point value ({input}) as decimal. Please review math operations and verify the result is valid.",
+                    nameof(input),
+                    new NotFiniteNumberException(input)
+                );
+            }
+
             if (input <= (double) decimal.MinValue) return decimal.MinValue;
             if (input >= (double) decimal.MaxValue) return decimal.MaxValue;
             return (decimal) input;

--- a/Common/Statistics/KellyCriterionManager.cs
+++ b/Common/Statistics/KellyCriterionManager.cs
@@ -108,7 +108,7 @@ namespace QuantConnect.Statistics
                         (1 / variance + 2 * averagePowered / variancePowered)
                         / _insightValues.Count - 1);
 
-                    KellyCriterionProbabilityValue =
+                    KellyCriterionProbabilityValue = kellyCriterionStandardDeviation.IsNaNOrZero() ? 1 :
                         1 - _normalDistribution.CumulativeDistribution(kellyCriterionEstimate / kellyCriterionStandardDeviation)
                             .SafeDecimalCast();
                 }

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -666,6 +666,28 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual(decimal.MinValue, output);
         }
 
+        [TestCase(Language.CSharp, double.NaN)]
+        [TestCase(Language.Python, double.NaN)]
+        [TestCase(Language.CSharp, double.NegativeInfinity)]
+        [TestCase(Language.Python, double.NegativeInfinity)]
+        [TestCase(Language.CSharp, double.PositiveInfinity)]
+        [TestCase(Language.Python, double.PositiveInfinity)]
+        public void SafeDecimalCastThrowsArgumentException(Language language, double number)
+        {
+            if (language == Language.CSharp)
+            {
+                Assert.Throws<ArgumentException>(() => number.SafeDecimalCast());
+                return;
+            }
+
+            using (Py.GIL())
+            {
+                var pyNumber = number.ToPython();
+                var csNumber = pyNumber.As<double>();
+                Assert.Throws<ArgumentException>(() => csNumber.SafeDecimalCast());
+            }
+        }
+
         [Test]
         [TestCase(1.200, "1.2")]
         [TestCase(1200, "1200")]


### PR DESCRIPTION
#### Description
- SafeDecimalCast Throws Exception For Non-Finite Numbers
- Fixes Arithmetic Overflow Exception in QCAlgorithm.Trading Methods
    - Replace decimal cast for `SafeDecimalCast()`.
    - If the algorithm uses a non-finite number in QCAlgorithm trading methods, it will throw with an user-frieldly exception message.
- Fixes KellyCriterionProbabilityValue Calculation

#### Related Issue
Closes #4726

#### Motivation and Context
Improves exception message.

#### How Has This Been Tested?
Unit and regression tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`