### PR TITLE
Bug 4680 sync portfolio, add configuration for more frequent synchronization

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2222,6 +2222,7 @@ namespace QuantConnect.Algorithm
         /// <summary>
         /// Set brokerage synchronization frequency to hourly instead of daily
         /// </summary>
+        /// <param name="syncHourly">set true to sync brokerage hourly instead of daily</param>
         public void SetSyncBrokerageHourly(bool syncHourly = true)
         {
             if (_locked)

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -91,6 +91,9 @@ namespace QuantConnect.Algorithm
 
         // flips to true when the user
         private bool _userSetSecurityInitializer = false;
+        
+        // brokerage synchronization run per hour
+        private bool _syncBrokerageHourly = false;
 
         // warmup resolution variables
         private TimeSpan? _warmupTimeSpan;
@@ -502,6 +505,17 @@ namespace QuantConnect.Algorithm
         /// Gets the object store, used for persistence
         /// </summary>
         public ObjectStore ObjectStore { get; private set; }
+
+        /// <summary>
+        /// Synchronization run hourly instead of daily when its true
+        /// </summary>
+        public bool SyncBrokerageHourly
+        {
+            get
+            {
+                return _syncBrokerageHourly;
+            }
+        }
 
         /// <summary>
         /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
@@ -2203,6 +2217,19 @@ namespace QuantConnect.Algorithm
         public void SetObjectStore(IObjectStore objectStore)
         {
             ObjectStore = new ObjectStore(objectStore);
+        }
+
+        /// <summary>
+        /// Set brokerage synchronization frequency to hourly instead of daily
+        /// </summary>
+        public void SetSyncBrokerageHourly(bool syncHourly = true)
+        {
+            if (_locked)
+            {
+                throw new InvalidOperationException("Algorithm.SetSyncBrokerageHourly(): Cannot set synchronization frequency after algorithm initialized.");
+            }
+
+            _syncBrokerageHourly = syncHourly;
         }
     }
 }

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -296,6 +296,11 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         public Slice CurrentSlice => _baseAlgorithm.CurrentSlice;
 
         /// <summary>
+        /// Synchronization run hourly instead of daily when its true
+        /// </summary>
+        public bool SyncBrokerageHourly => _baseAlgorithm.SyncBrokerageHourly;
+
+        /// <summary>
         /// Algorithm start date for backtesting, set by the SetStartDate methods.
         /// </summary>
         public DateTime StartDate => _baseAlgorithm.StartDate;
@@ -930,5 +935,11 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// </summary>
         /// <param name="objectStore">The object store</param>
         public void SetObjectStore(IObjectStore objectStore) => _baseAlgorithm.SetObjectStore(objectStore);
+
+        /// <summary>
+        /// Set brokerage synchronization frequency to hourly instead of daily
+        /// </summary>
+        /// <param name="syncHourly">set true to sync brokerage hourly instead of daily</param>
+        public void SetSyncBrokerageHourly(bool syncHourly) => _baseAlgorithm.SetSyncBrokerageHourly(syncHourly);
     }
 }

--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -366,7 +366,7 @@ namespace QuantConnect.Brokerages
                     {
                         // this will cause us to come back in and reset cash again until we
                         // haven't processed a fill for +- 10 seconds of the set cash time
-                        _syncedLiveBrokerageCash = true;
+                        _syncedLiveBrokerageCash = false;
                         //_failedCashSyncAttempts = 0;
                         Log.Trace("Brokerage.PerformCashSync(): Unverified cash sync - resync required.");
                     }

--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -250,7 +250,7 @@ namespace QuantConnect.Brokerages
         /// <returns>True if the cash sync should be performed</returns>
         public virtual bool ShouldPerformCashSync(DateTime currentTimeUtc)
         {
-            // every morning flip this switch back
+            // every hour flip this switch back
             var currentTimeNewYork = currentTimeUtc.ConvertFromUtc(TimeZones.NewYork);
             if (_syncedLiveBrokerageCash && currentTimeNewYork.Hour != LastSyncHour)
             {
@@ -306,7 +306,7 @@ namespace QuantConnect.Brokerages
                     }
                 }
 
-                // if we were returned our balances, update everything and flip our flag as having performed sync today
+                // if we were returned our balances, update everything and flip our flag as having performed sync in this hour
                 foreach (var kvp in algorithm.Portfolio.CashBook)
                 {
                     var cash = kvp.Value;

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2974,10 +2974,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// Returns whether the brokerage should perform the cash synchronization
         /// </summary>
         /// <param name="currentTimeUtc">The current time (UTC)</param>
+        /// <param name="syncHourly">set true to sync brokerage hourly instead of daily</param>
         /// <returns>True if the cash sync should be performed</returns>
-        public override bool ShouldPerformCashSync(DateTime currentTimeUtc)
+        public override bool ShouldPerformCashSync(DateTime currentTimeUtc, bool syncHourly)
         {
-            return base.ShouldPerformCashSync(currentTimeUtc) &&
+            return base.ShouldPerformCashSync(currentTimeUtc, syncHourly) &&
                    !_ibAutomater.IsWithinScheduledServerResetTimes();
         }
 

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -330,6 +330,11 @@ namespace QuantConnect.Interfaces
         /// Returns the current Slice object
         /// </summary>
         Slice CurrentSlice { get; }
+        
+        /// <summary>
+        /// Synchronization run hourly instead of daily when its true
+        /// </summary>
+        bool SyncBrokerageHourly { get; }
 
         /// <summary>
         /// Initialise the Algorithm and Prepare Required Data:
@@ -696,5 +701,10 @@ namespace QuantConnect.Interfaces
         /// </summary>
         /// <param name="objectStore">The object store</param>
         void SetObjectStore(IObjectStore objectStore);
+
+        /// <summary>
+        /// Set brokerage synchronization frequency to hourly instead of daily
+        /// </summary>
+        void SetSyncBrokerageHourly(bool syncHourly);
     }
 }

--- a/Common/Interfaces/IBrokerageCashSynchronizer.cs
+++ b/Common/Interfaces/IBrokerageCashSynchronizer.cs
@@ -31,8 +31,9 @@ namespace QuantConnect.Interfaces
         /// Returns whether the brokerage should perform the cash synchronization
         /// </summary>
         /// <param name="currentTimeUtc">The current time (UTC)</param>
+        /// <param name="syncHourly">set true to sync brokerage hourly instead of daily</param>
         /// <returns>True if the cash sync should be performed</returns>
-        bool ShouldPerformCashSync(DateTime currentTimeUtc);
+        bool ShouldPerformCashSync(DateTime currentTimeUtc, bool syncHourly);
 
         /// <summary>
         /// Synchronizes the cashbook with the brokerage account

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -549,7 +549,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             Log.Debug("BrokerageTransactionHandler.ProcessSynchronousEvents(): Enter");
 
             // check if the brokerage should perform cash sync now
-            if (_brokerage.ShouldPerformCashSync(CurrentTimeUtc))
+            if (_brokerage.ShouldPerformCashSync(CurrentTimeUtc, _algorithm.SyncBrokerageHourly))
             {
                 // only perform cash syncs if we haven't had a fill for at least 10 seconds
                 if (TimeSinceLastFill > TimeSpan.FromSeconds(10))

--- a/Tests/Algorithm/AlgorithmLiveTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmLiveTradingTests.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Tests.Algorithm
             public bool AccountInstantlyUpdated { get; } = true;
             public IEnumerable<BaseData> GetHistory(HistoryRequest request) { return Enumerable.Empty<BaseData>(); }
             public DateTime LastSyncDateTimeUtc { get; } = DateTime.UtcNow;
-            public bool ShouldPerformCashSync(DateTime currentTimeUtc) { return false; }
+            public bool ShouldPerformCashSync(DateTime currentTimeUtc, bool syncHourly) { return false; }
             public bool PerformCashSync(IAlgorithm algorithm, DateTime currentTimeUtc, Func<TimeSpan> getTimeSinceLastFill) { return true; }
         }
     }

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -905,7 +905,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             Assert.AreNotEqual(lastSyncDateAfter, lastSyncDateBefore);
 
             var count = 0;
-            while (!brokerage.ShouldPerformCashSync(transactionHandler.TestCurrentTimeUtc, _algorithm.SyncBrokerageHourly))
+            while (!brokerage.ShouldPerformCashSync(transactionHandler.TestCurrentTimeUtc, false))
             {
                 count++;
                 if (count > 40)

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -954,7 +954,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var ib = new Mock<IBrokerage>();
             ib.Setup(m => m.GetCashBalance()).Callback(() => { throw new Exception("Connection error in CashBalance"); });
             ib.Setup(m => m.IsConnected).Returns(false);
-            ib.Setup(m => m.ShouldPerformCashSync(It.IsAny<DateTime>()), false).Returns(true);
+            ib.Setup(m => m.ShouldPerformCashSync(It.IsAny<DateTime>(), false)).Returns(true);
             ib.Setup(m => m.PerformCashSync(It.IsAny<IAlgorithm>(), It.IsAny<DateTime>(), It.IsAny<Func<TimeSpan>>()))
                 .Returns(
                     () =>

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -944,7 +944,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             // cash sync happened
             Assert.AreNotEqual(lastSyncDateAfter, lastSyncDateBefore);
 
-            Assert.AreEqual(0, brokerage.GetCashBalanceCallCount);
+            Assert.AreEqual(1, brokerage.GetCashBalanceCallCount);
         }
 
         [Test]

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -936,12 +936,13 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var lastSyncDateBefore = transactionHandler.GetLastSyncDate();
 
             // Advance current time UTC
-            transactionHandler.TestCurrentTimeUtc = transactionHandler.TestCurrentTimeUtc.AddDays(2);
+            transactionHandler.TestCurrentTimeUtc = transactionHandler.TestCurrentTimeUtc.AddHours(2);
 
             transactionHandler.ProcessSynchronousEvents();
             var lastSyncDateAfter = transactionHandler.GetLastSyncDate();
 
-            Assert.AreEqual(lastSyncDateAfter, lastSyncDateBefore);
+            // cash sync happened
+            Assert.AreNotEqual(lastSyncDateAfter, lastSyncDateBefore);
 
             Assert.AreEqual(0, brokerage.GetCashBalanceCallCount);
         }

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -905,7 +905,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             Assert.AreNotEqual(lastSyncDateAfter, lastSyncDateBefore);
 
             var count = 0;
-            while (!brokerage.ShouldPerformCashSync(transactionHandler.TestCurrentTimeUtc))
+            while (!brokerage.ShouldPerformCashSync(transactionHandler.TestCurrentTimeUtc, _algorithm.SyncBrokerageHourly))
             {
                 count++;
                 if (count > 40)
@@ -936,15 +936,15 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var lastSyncDateBefore = transactionHandler.GetLastSyncDate();
 
             // Advance current time UTC
-            transactionHandler.TestCurrentTimeUtc = transactionHandler.TestCurrentTimeUtc.AddHours(2);
+            transactionHandler.TestCurrentTimeUtc = transactionHandler.TestCurrentTimeUtc.AddDays(2);
 
             transactionHandler.ProcessSynchronousEvents();
             var lastSyncDateAfter = transactionHandler.GetLastSyncDate();
 
             // cash sync happened
-            Assert.AreNotEqual(lastSyncDateAfter, lastSyncDateBefore);
+            Assert.AreEqual(lastSyncDateAfter, lastSyncDateBefore);
 
-            Assert.AreEqual(1, brokerage.GetCashBalanceCallCount);
+            Assert.AreEqual(0, brokerage.GetCashBalanceCallCount);
         }
 
         [Test]
@@ -954,7 +954,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var ib = new Mock<IBrokerage>();
             ib.Setup(m => m.GetCashBalance()).Callback(() => { throw new Exception("Connection error in CashBalance"); });
             ib.Setup(m => m.IsConnected).Returns(false);
-            ib.Setup(m => m.ShouldPerformCashSync(It.IsAny<DateTime>())).Returns(true);
+            ib.Setup(m => m.ShouldPerformCashSync(It.IsAny<DateTime>()), false).Returns(true);
             ib.Setup(m => m.PerformCashSync(It.IsAny<IAlgorithm>(), It.IsAny<DateTime>(), It.IsAny<Func<TimeSpan>>()))
                 .Returns(
                     () =>


### PR DESCRIPTION
#### Description
I checked Brokerage.cs, the synchronization with brokerage only run once per day, can it run much more frequent such as once per hour instead of once per day ?

#### Related Issue
#4680 
#4681 

#### Motivation and Context
I'm using Bitfinex as my algorithm brokerage. The algorithm run once per hours for crypto day trading.
The Portfolio.CashBook and its total value are always asynchronous with actual Bitfinex holding after SetHoldings,
so my algorithm sometimes run with outdated Portfolio value during live trading, this situation won't happen in backtest.
It will resume normal after redeployment or one day after.

For example, my strategy always maintein 90% of Portfolio value on ETH, I assume that someday ETH value raised, then my strategy will sell some of my ETH to maintein 90% ratio. but the amount in CashBook can't update on time, so the program keep sell out my ETH on brokerage until nothing left.

#### Requires Documentation Change
I guess no documentation need to be updated, please advice.

#### How Has This Been Tested?
Don't know how to test it, I'm not familiar with this infrastructure, please advice.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
