### PR TITLE
Bug 4722: Prevent Repetitive Factor File Numerical Precision Warnings

### DIFF
--- a/Common/DataProviderEvents.cs
+++ b/Common/DataProviderEvents.cs
@@ -21,9 +21,29 @@ using QuantConnect.Securities;
 namespace QuantConnect
 {
     /// <summary>
+    /// Defines a base class for <see cref="IDataProviderEvents"/>
+    /// </summary>
+    public abstract class DataProviderEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the symbol being processed that generated the event
+        /// </summary>
+        public Symbol Symbol { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataProviderEventArgs"/> class
+        /// </summary>
+        /// <param name="symbol">Symbol being processed that generated the event</param>
+        protected DataProviderEventArgs(Symbol symbol)
+        {
+            Symbol = symbol;
+        }
+    }
+
+    /// <summary>
     /// Event arguments for the <see cref="IDataProviderEvents.InvalidConfigurationDetected"/> event
     /// </summary>
-    public sealed class InvalidConfigurationDetectedEventArgs : EventArgs
+    public sealed class InvalidConfigurationDetectedEventArgs : DataProviderEventArgs
     {
         /// <summary>
         /// Gets the error message
@@ -33,8 +53,10 @@ namespace QuantConnect
         /// <summary>
         /// Initializes a new instance of the <see cref="InvalidConfigurationDetectedEventArgs"/> class
         /// </summary>
+        /// <param name="symbol">Symbol being processed that generated the event</param>
         /// <param name="message">The error message</param>
-        public InvalidConfigurationDetectedEventArgs(string message)
+        public InvalidConfigurationDetectedEventArgs(Symbol symbol, string message)
+            : base(symbol)
         {
             Message = message;
         }
@@ -43,7 +65,7 @@ namespace QuantConnect
     /// <summary>
     /// Event arguments for the <see cref="IDataProviderEvents.NumericalPrecisionLimited"/> event
     /// </summary>
-    public sealed class NumericalPrecisionLimitedEventArgs : EventArgs
+    public sealed class NumericalPrecisionLimitedEventArgs : DataProviderEventArgs
     {
         /// <summary>
         /// Gets the error message
@@ -53,8 +75,10 @@ namespace QuantConnect
         /// <summary>
         /// Initializes a new instance of the <see cref="NumericalPrecisionLimitedEventArgs"/> class
         /// </summary>
+        /// <param name="symbol">Symbol being processed that generated the event</param>
         /// <param name="message">The error message</param>
-        public NumericalPrecisionLimitedEventArgs(string message)
+        public NumericalPrecisionLimitedEventArgs(Symbol symbol, string message)
+            : base(symbol)
         {
             Message = message;
         }
@@ -63,7 +87,7 @@ namespace QuantConnect
     /// <summary>
     /// Event arguments for the <see cref="IDataProviderEvents.DownloadFailed"/> event
     /// </summary>
-    public sealed class DownloadFailedEventArgs : EventArgs
+    public sealed class DownloadFailedEventArgs : DataProviderEventArgs
     {
         /// <summary>
         /// Gets the error message
@@ -78,9 +102,11 @@ namespace QuantConnect
         /// <summary>
         /// Initializes a new instance of the <see cref="DownloadFailedEventArgs"/> class
         /// </summary>
+        /// <param name="symbol">Symbol being processed that generated the event</param>
         /// <param name="message">The error message</param>
         /// <param name="stackTrace">The error stack trace</param>
-        public DownloadFailedEventArgs(string message, string stackTrace = "")
+        public DownloadFailedEventArgs(Symbol symbol, string message, string stackTrace = "")
+            : base(symbol)
         {
             Message = message;
             StackTrace = stackTrace;
@@ -90,7 +116,7 @@ namespace QuantConnect
     /// <summary>
     /// Event arguments for the <see cref="IDataProviderEvents.ReaderErrorDetected"/> event
     /// </summary>
-    public sealed class ReaderErrorDetectedEventArgs : EventArgs
+    public sealed class ReaderErrorDetectedEventArgs : DataProviderEventArgs
     {
         /// <summary>
         /// Gets the error message
@@ -105,9 +131,11 @@ namespace QuantConnect
         /// <summary>
         /// Initializes a new instance of the <see cref="ReaderErrorDetectedEventArgs"/> class
         /// </summary>
+        /// <param name="symbol">Symbol being processed that generated the event</param>
         /// <param name="message">The error message</param>
         /// <param name="stackTrace">The error stack trace</param>
-        public ReaderErrorDetectedEventArgs(string message, string stackTrace = "")
+        public ReaderErrorDetectedEventArgs(Symbol symbol, string message, string stackTrace = "")
+            : base(symbol)
         {
             Message = message;
             StackTrace = stackTrace;
@@ -117,7 +145,7 @@ namespace QuantConnect
     /// <summary>
     /// Event arguments for the <see cref="IDataProviderEvents.StartDateLimited"/> event
     /// </summary>
-    public sealed class StartDateLimitedEventArgs : EventArgs
+    public sealed class StartDateLimitedEventArgs : DataProviderEventArgs
     {
         /// <summary>
         /// Gets the error message
@@ -127,8 +155,10 @@ namespace QuantConnect
         /// <summary>
         /// Initializes a new instance of the <see cref="StartDateLimitedEventArgs"/> class
         /// </summary>
+        /// <param name="symbol">Symbol being processed that generated the event</param>
         /// <param name="message">The error message</param>
-        public StartDateLimitedEventArgs(string message)
+        public StartDateLimitedEventArgs(Symbol symbol, string message)
+            : base(symbol)
         {
             Message = message;
         }
@@ -137,13 +167,8 @@ namespace QuantConnect
     /// <summary>
     /// Event arguments for the NewTradableDate event
     /// </summary>
-    public sealed class NewTradableDateEventArgs : EventArgs
+    public sealed class NewTradableDateEventArgs : DataProviderEventArgs
     {
-        /// <summary>
-        /// The <see cref="Symbol"/> of the new tradable date
-        /// </summary>
-        public Symbol Symbol { get; }
-
         /// <summary>
         /// The new tradable date
         /// </summary>
@@ -163,10 +188,10 @@ namespace QuantConnect
         /// <see cref="Security"/> for which we are enumerating</param>
         /// <param name="symbol">The <see cref="Symbol"/> of the new tradable date</param>
         public NewTradableDateEventArgs(DateTime date, BaseData lastBaseData, Symbol symbol)
+            : base(symbol)
         {
             Date = date;
             LastBaseData = lastBaseData;
-            Symbol = symbol;
         }
     }
 }

--- a/Common/Util/ConcurrentSet.cs
+++ b/Common/Util/ConcurrentSet.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Util
         /// <summary>Adds an item to the <see cref="T:System.Collections.Generic.ICollection`1" />.</summary>
         /// <param name="item">The object to add to the <see cref="T:System.Collections.Generic.ICollection`1" />.</param>
         /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only.</exception>
-        public void Add(T item)
+        void ICollection<T>.Add(T item)
         {
             if (item == null)
             {
@@ -292,7 +292,7 @@ namespace QuantConnect.Util
         /// <summary>Adds an element to the current set and returns a value to indicate if the element was successfully added. </summary>
         /// <returns>true if the element is added to the set; false if the element is already in the set.</returns>
         /// <param name="item">The element to add to the set.</param>
-        bool ISet<T>.Add(T item)
+        public bool Add(T item)
         {
             lock (_set)
             {

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -180,7 +180,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
             catch (ArgumentException exception)
             {
-                OnInvalidConfigurationDetected(new InvalidConfigurationDetectedEventArgs(exception.Message));
+                OnInvalidConfigurationDetected(new InvalidConfigurationDetectedEventArgs(_config.Symbol, exception.Message));
                 _endOfStream = true;
                 return;
             }
@@ -255,7 +255,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                                     _periodStart = _factorFile.FactorFileMinimumDate.Value;
 
                                     OnNumericalPrecisionLimited(
-                                        new NumericalPrecisionLimitedEventArgs(
+                                        new NumericalPrecisionLimitedEventArgs(_config.Symbol,
                                             $"Data for symbol {_config.Symbol.Value} has been limited due to numerical precision issues in the factor file. " +
                                             $"The starting date has been set to {_factorFile.FactorFileMinimumDate.Value.ToShortDateString()}."));
                                 }
@@ -268,7 +268,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             _periodStart = mapFile.FirstDate;
 
                             OnStartDateLimited(
-                                new StartDateLimitedEventArgs(
+                                new StartDateLimitedEventArgs(_config.Symbol,
                                     $"The starting date for symbol {_config.Symbol.Value}," +
                                     $" {originalStart.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}, has been adjusted to match map file first date" +
                                     $" {mapFile.FirstDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}."));
@@ -512,7 +512,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                     case SubscriptionTransportMedium.RemoteFile:
                         OnDownloadFailed(
-                            new DownloadFailedEventArgs(
+                            new DownloadFailedEventArgs(_config.Symbol,
                                 $"Error downloading custom data source file, skipped: {source} " +
                                 $"Error: {args.Exception.Message}", args.Exception.StackTrace));
                         break;
@@ -534,7 +534,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     if (_config.IsCustomData && !_config.Type.GetBaseDataInstance().IsSparseData())
                     {
                         OnDownloadFailed(
-                            new DownloadFailedEventArgs(
+                            new DownloadFailedEventArgs(_config.Symbol,
                                 "We could not fetch the requested data. " +
                                 "This may not be valid data, or a failed download of custom data. " +
                                 $"Skipping source ({args.Source.Source})."));
@@ -545,7 +545,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 textSubscriptionFactory.ReaderError += (sender, args) =>
                 {
                     OnReaderErrorDetected(
-                        new ReaderErrorDetectedEventArgs(
+                        new ReaderErrorDetectedEventArgs(_config.Symbol,
                             $"Error invoking {_config.Symbol} data reader. " +
                             $"Line: {args.Line} Error: {args.Exception.Message}",
                             args.Exception.StackTrace));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This change aims to remove some debug message spam observed when a security is added/removed multiple times with a factor file with INF entries forcing the 'starting date' to be in the future. We accomplish this by tracking which symbols have raised the numerical precision warning event and only passing the message through to the result handler the first time for each symbol.

#### Description

* Add DataProviderEventArgs base class for IDataProviderEvents event args

> This base class includes a Symbol property. This will empower event listeners
to make decisions based on which security (symbol) raised the event. The immediate
use case is preventing multiple numerical precision messages for the same security.
This pattern can equally be applied to other error messages that are raised each
time a security is added to a universe.

* Update ConcurrentSet.Add to use ISet<T>.Add returning bool

> It's a very common pattern to use if (set.Add(item)) which is enabled
via bool ISet<T>.Add(item) but not enabled via void ICollectiont<T>.Add(item).
This change simples changes the default Add implementation to use the ISet<T>
overload and relegates the ICollection<T>.Add implementation to be explicit.

* Prevent multiple numerical precision messages for same symbol

> If a security is continually added/removed from a universe, then the user will
see this message each time the security is added. This results in some spam.
This change simply remembers for which symbols we've notified the user about the
numerical precision issue.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #4722

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Limit debug message spam in console

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested using DRYS over a period of 2016-03-01 to 2017-03-01 w/ a manual universe that adds/removes DRYS each month. This was run against current `origin/master` where the message spam was observed and again against `bug-4722-prevent-repetitive-factor-file-warning` where the message was only emitted once.

RE: Unit tests:
The `SubscriptionDataReaderSubscriptionEnumeratorFactory` class is a beast to unit test due to multiple varying dependencies. It additionally uses the `new` operator directly and even invokes a static function, `CorporateEventEnumeratorFactory.CreateEnumerators`. In order to create unit tests without needing to mock the entire world (likely making the tests incredibly fragile), this type would need to be decomposed. For one, a factory could be provided for creating the `SubscriptionDataReader`, thereby removing some of the dependencies. Additionally, the result of the `CorporateEventEnumeratorFactory.CreateEnumerators` could be composed externally to this factory type and encapsulated in yet another factory type. In theory, factory types exist as an abstraction over the `new` operator and it looks like this factory has been overloaded, 'newing up' multiple objects (in this case enumerator stacks), making unit testing very involved.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
