### PR TITLE
Bug 4686 Fix yahoodatadownloader failing download split and dividend

### DIFF
--- a/ToolBox/YahooDownloader/YahooDataDownloader.cs
+++ b/ToolBox/YahooDownloader/YahooDataDownloader.cs
@@ -113,7 +113,7 @@ namespace QuantConnect.ToolBox.YahooDownloader
                         parsed.Add(new Dividend
                         {
                             Time = Parse.DateTimeExact(values[0].Replace("-", string.Empty), DateFormat.EightCharacter),
-                            Value = Parse.Decimal(values[1])
+                            Value = Parse.Decimal(values[1], System.Globalization.NumberStyles.Float)
                         });
                     }
                 }


### PR DESCRIPTION

#### Description

The decimal parsing in the method YahooDataDownloader.DownloadSplitAndDividendData was throwing and exception when the number was in the exponential format (9.8E-4)

#### Related Issue

related issue : https://github.com/QuantConnect/Lean/issues/4686

#### Motivation and Context

Was not working


#### Requires Documentation Change

No

#### How Has This Been Tested?

Unit test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [x ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
