### PR TITLE
Check both late open and early closes when looking up the next market open/close time

### DIFF
--- a/Common/Securities/SecurityExchangeHours.cs
+++ b/Common/Securities/SecurityExchangeHours.cs
@@ -240,6 +240,17 @@ namespace QuantConnect.Securities
                         continue;
                     }
 
+                    TimeSpan earlyCloseTime;
+                    if (_earlyCloses.TryGetValue(time.Date, out earlyCloseTime))
+                    {
+                        var earlyCloseDateTime = time.Date.Add(earlyCloseTime);
+                        if (time > earlyCloseDateTime)
+                        {
+                            time = time.Date + Time.OneDay;
+                            continue;
+                        }
+                    }
+
                     var marketOpenTimeOfDay = marketHours.GetMarketOpen(time.TimeOfDay, extendedMarket);
                     if (marketOpenTimeOfDay.HasValue)
                     {
@@ -282,6 +293,17 @@ namespace QuantConnect.Securities
 
                         time = time.Date + Time.OneDay;
                         continue;
+                    }
+
+                    TimeSpan lateOpenTime;
+                    if (_lateOpens.TryGetValue(time.Date, out lateOpenTime))
+                    {
+                        var lateOpenDateTime = time.Date.Add(lateOpenTime);
+                        if (time < lateOpenDateTime)
+                        {
+                            time = lateOpenDateTime;
+                            continue;
+                        }
                     }
 
                     var marketCloseTimeOfDay = marketHours.GetMarketClose(time.TimeOfDay, extendedMarket);


### PR DESCRIPTION
#### Description
Changes the way the next market open / close is determined to check both the early closes and late opens for the security.

#### Related Issue
Fixes #4754

#### Motivation and Context
Look-up is broken when multiple market hours are defined in a single day.

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
Unit tests included.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`