### PR TITLE
Upgrade NLog from 4.4.11 to 4.4.13

### DIFF
--- a/Logging/QuantConnect.Logging.csproj
+++ b/Logging/QuantConnect.Logging.csproj
@@ -91,7 +91,7 @@
       <HintPath>..\packages\MathNet.Numerics.3.19.0\lib\net40\MathNet.Numerics.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.11\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.4.13\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/Logging/packages.config
+++ b/Logging/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.CodeQuality.Analyzers" version="2.9.3" targetFramework="net452" />
   <package id="Microsoft.NetCore.Analyzers" version="2.9.3" targetFramework="net452" />
   <package id="Microsoft.NetFramework.Analyzers" version="2.9.3" targetFramework="net452" />
-  <package id="NLog" version="4.4.11" targetFramework="net452" />
-  <package id="NLog.Config" version="4.4.11" targetFramework="net452" />
-  <package id="NLog.Schema" version="4.4.11" targetFramework="net452" />
+  <package id="NLog" version="4.4.13" targetFramework="net452" />
+  <package id="NLog.Config" version="4.4.13" targetFramework="net452" />
+  <package id="NLog.Schema" version="4.4.13" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
#### Description
Due to a bug in NLog < 4.4.13, it's possible for NLog to not initialize properly on Mono.
This PR just upgrades the version of NLog to include the fix.


#### Related Issue
Fixes #4771

#### Motivation and Context
(Fix the above issue)

#### Requires Documentation Change
No

#### How Has This Been Tested?
Just locally, with a customized NLog.config.
All details of the bug are in the link on the linked issue.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. _Not required - dependency upgrade._
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
