### PR TITLE
HistoryRequestFactory Resolution.Hour ExtendedMarketHours

### DIFF
--- a/Algorithm.CSharp/ExtendedMarketHoursHistoryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ExtendedMarketHoursHistoryRegressionAlgorithm.cs
@@ -1,0 +1,172 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm testing doing some history requests outside market hours, reproducing GH issue #4783
+    /// </summary>
+    public class ExtendedMarketHoursHistoryRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private int _minuteHistoryCount;
+        private int _hourHistoryCount;
+        private int _dailyHistoryCount;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 09);
+            SetCash(100000);
+
+            AddEquity("SPY", Resolution.Minute, extendedMarketHours:true, fillDataForward:false);
+
+            Schedule.On("RunHistoryCall", DateRules.EveryDay(), TimeRules.Every(TimeSpan.FromHours(1)), RunHistoryCall);
+        }
+
+        private void RunHistoryCall()
+        {
+            var spy = Securities["SPY"];
+            var regularHours = spy.Exchange.Hours.IsOpen(Time, false);
+            var extendedHours = !regularHours && spy.Exchange.Hours.IsOpen(Time, true);
+
+            if (regularHours)
+            {
+                _minuteHistoryCount++;
+                var history = History(spy.Symbol, 5, Resolution.Minute).Count();
+                if (history != 5)
+                {
+                    throw new Exception($"Unexpected Minute data count: {history}");
+                }
+            }
+            else
+            {
+                if (extendedHours)
+                {
+                    _hourHistoryCount++;
+                    var history = History(spy.Symbol, 5, Resolution.Hour).Count();
+                    if (history != 5)
+                    {
+                        throw new Exception($"Unexpected Hour data count {history}");
+                    }
+                }
+                else
+                {
+                    _dailyHistoryCount++;
+                    var history = History(spy.Symbol, 5, Resolution.Daily).Count();
+                    if (history != 5)
+                    {
+                        throw new Exception($"Unexpected Daily data count {history}");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (!Portfolio.Invested)
+            {
+                SetHoldings("SPY", 1);
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_minuteHistoryCount != 3 * 6)
+            {
+                throw new Exception($"Unexpected minute history requests count {_minuteHistoryCount}");
+            }
+            // 6 pre market from 4am to 9am + 4 post market 4pm to 7pm
+            if (_hourHistoryCount != 3 * 10)
+            {
+                throw new Exception($"Unexpected hour history requests count {_hourHistoryCount}");
+            }
+            // 0am to 3am + 8pm to 11pm, last day ends at 8pm
+            if (_dailyHistoryCount != (2 * 8 + 5))
+            {
+                throw new Exception($"Unexpected Daily history requests count: {_dailyHistoryCount}");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "20"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0.00%"},
+            {"Compounding Annual Return", "-74.182%"},
+            {"Drawdown", "2.200%"},
+            {"Expectancy", "-1"},
+            {"Net Profit", "-1.046%"},
+            {"Sharpe Ratio", "-8.269"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "100%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "-0.19"},
+            {"Beta", "0.579"},
+            {"Annual Standard Deviation", "0.065"},
+            {"Annual Variance", "0.004"},
+            {"Information Ratio", "1.326"},
+            {"Tracking Error", "0.049"},
+            {"Treynor Ratio", "-0.934"},
+            {"Total Fees", "$22.26"},
+            {"Fitness Score", "0.002"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "-11.855"},
+            {"Return Over Maximum Drawdown", "-70.945"},
+            {"Portfolio Turnover", "0.342"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "-1961710414"}
+        };
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -144,6 +144,7 @@
     <Compile Include="AddAlphaModelAlgorithm.cs" />
     <Compile Include="DailyHistoryForDailyResolutionRegressionAlgorithm.cs" />
     <Compile Include="DailyHistoryForMinuteResolutionRegressionAlgorithm.cs" />
+    <Compile Include="ExtendedMarketHoursHistoryRegressionAlgorithm.cs" />
     <Compile Include="SwitchDataModeRegressionAlgorithm.cs" />
     <Compile Include="AddRemoveOptionUniverseRegressionAlgorithm.cs" />
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />

--- a/Common/Data/HistoryRequestFactory.cs
+++ b/Common/Data/HistoryRequestFactory.cs
@@ -91,7 +91,8 @@ namespace QuantConnect.Data
             var configs = _algorithm.SubscriptionManager
                 .SubscriptionDataConfigService
                 .GetSubscriptionDataConfigs(symbol);
-            var isExtendedMarketHours = configs.IsExtendedMarketHours();
+            // hour resolution does no have extended market hours data
+            var isExtendedMarketHours = resolution != Resolution.Hour && configs.IsExtendedMarketHours();
 
             var timeSpan = resolution.ToTimeSpan();
             // make this a minimum of one second

--- a/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
+++ b/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
@@ -128,7 +128,8 @@ namespace QuantConnect.Securities
                 .ToList();
 
             var barCount = _window.Size + 1;
-            var extendedMarketHours = configurations.IsExtendedMarketHours();
+            // hour resolution does no have extended market hours data
+            var extendedMarketHours = _periodSpan != Time.OneHour && configurations.IsExtendedMarketHours();
             var configuration = configurations.First();
 
             var localStartTime = Time.GetStartTimeForTradeBars(

--- a/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
+++ b/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
@@ -120,7 +120,8 @@ namespace QuantConnect.Securities
             var configuration = configurations.First();
 
             var barCount = _window.Size + 1;
-            var extendedMarketHours = configurations.IsExtendedMarketHours();
+            // hour resolution does no have extended market hours data
+            var extendedMarketHours = _periodSpan != Time.OneHour && configurations.IsExtendedMarketHours();
             var localStartTime = Time.GetStartTimeForTradeBars(
                 security.Exchange.Hours,
                 utcTime.ConvertFromUtc(security.Exchange.TimeZone),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `HistoryRequestFactory` will not use extended market hours for hour
  resolution when determining the start time using quantity of bars.
  Adding regression test

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/4783
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve history api behavior
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Regression algorithm reproducing bug
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
