### PR TITLE
Fixes issue where BidPrice/AskPrice were not adjusted for Quote Ticks

### DIFF
--- a/Algorithm.CSharp/EquityTickQuoteAdjustedModeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/EquityTickQuoteAdjustedModeRegressionAlgorithm.cs
@@ -1,0 +1,128 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Checks that the Tick BidPrice and AskPrices are adjusted like Value.
+    /// </summary>
+    public class EquityTickQuoteAdjustedModeRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _ibm;
+        private bool _bought;
+        private bool _sold;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 7);
+            SetEndDate(2013, 10, 11);
+            SetCash(100000);
+
+            _ibm = AddEquity("IBM", Resolution.Tick).Symbol;
+        }
+
+        public override void OnData(Slice data)
+        {
+            if (!data.Ticks.ContainsKey(_ibm))
+            {
+                return;
+            }
+
+            var security = Securities[_ibm];
+            if (!security.HasData)
+            {
+                return;
+            }
+
+            foreach (var tick in data.Ticks[_ibm])
+            {
+                if (tick.BidPrice != 0 && !_bought && ((tick.Value - tick.BidPrice) <= 0.05m))
+                {
+                    SetHoldings(_ibm, 1);
+                    _bought = true;
+                    return;
+                }
+                if (tick.AskPrice != 0 && _bought && !_sold && Math.Abs((double)tick.Value - (double)tick.AskPrice) <= 0.05)
+                {
+                    Liquidate(_ibm);
+                    _sold = true;
+                    return;
+                }
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "2"},
+            {"Average Win", "0%"},
+            {"Average Loss", "-0.01%"},
+            {"Compounding Annual Return", "-0.500%"},
+            {"Drawdown", "0.000%"},
+            {"Expectancy", "-1"},
+            {"Net Profit", "-0.006%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "100%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-8.769"},
+            {"Tracking Error", "0.22"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$6.41"},
+            {"Fitness Score", "0.248"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "-82.815"},
+            {"Portfolio Turnover", "0.497"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "1213851303"}
+        };
+    }
+}

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -145,6 +145,7 @@
     <Compile Include="DailyHistoryForDailyResolutionRegressionAlgorithm.cs" />
     <Compile Include="DailyHistoryForMinuteResolutionRegressionAlgorithm.cs" />
     <Compile Include="ExtendedMarketHoursHistoryRegressionAlgorithm.cs" />
+    <Compile Include="EquityTickQuoteAdjustedModeRegressionAlgorithm.cs" />
     <Compile Include="SwitchDataModeRegressionAlgorithm.cs" />
     <Compile Include="AddRemoveOptionUniverseRegressionAlgorithm.cs" />
     <Compile Include="AddRemoveSecurityRegressionAlgorithm.cs" />

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -2135,47 +2135,40 @@ namespace QuantConnect
                     break;
                 case MarketDataType.Tick:
                     var securityType = data.Symbol.SecurityType;
-                    var tick = data as Tick;
-                    if (tick == null)
+                    if (securityType != SecurityType.Equity &&
+                        securityType != SecurityType.Option &&
+                        securityType != SecurityType.Future)
                     {
                         break;
                     }
 
-                    if (securityType == SecurityType.Equity
-                        || securityType == SecurityType.Option
-                        || securityType == SecurityType.Future)
+                    var tick = data as Tick;
+                    if (tick == null || tick.TickType == TickType.OpenInterest)
                     {
-                        if (tick.TickType == TickType.OpenInterest)
-                        {
-                            break;
-                        }
-
-                        // Always adjust equity to maintain old behavior
-                        if (securityType == SecurityType.Equity || tick.TickType == TickType.Trade)
-                        {
-                            tick.Value = factor(tick.Value);
-                            if (tick.TickType == TickType.Trade)
-                            {
-                                break;
-                            }
-                        }
-
-                        tick.BidPrice = tick.BidPrice != 0 ? factor(tick.BidPrice) : 0;
-                        tick.AskPrice = tick.AskPrice != 0 ? factor(tick.AskPrice) : 0;
-
-                        if (tick.BidPrice == 0)
-                        {
-                            tick.Value = tick.AskPrice;
-                            break;
-                        }
-                        if (tick.AskPrice == 0)
-                        {
-                            tick.Value = tick.BidPrice;
-                            break;
-                        }
-
-                        tick.Value = (tick.BidPrice + tick.AskPrice) / 2m;
+                        break;
                     }
+
+                    if (tick.TickType == TickType.Trade)
+                    {
+                        tick.Value = factor(tick.Value);
+                        break;
+                    }
+
+                    tick.BidPrice = tick.BidPrice != 0 ? factor(tick.BidPrice) : 0;
+                    tick.AskPrice = tick.AskPrice != 0 ? factor(tick.AskPrice) : 0;
+
+                    if (tick.BidPrice == 0)
+                    {
+                        tick.Value = tick.AskPrice;
+                        break;
+                    }
+                    if (tick.AskPrice == 0)
+                    {
+                        tick.Value = tick.BidPrice;
+                        break;
+                    }
+
+                    tick.Value = (tick.BidPrice + tick.AskPrice) / 2m;
                     break;
                 case MarketDataType.QuoteBar:
                     var quoteBar = data as QuoteBar;

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -2141,6 +2141,8 @@ namespace QuantConnect
                         if (securityType == SecurityType.Equity)
                         {
                             tick.Value = factor(tick.Value);
+                            tick.BidPrice = factor(tick.BidPrice);
+                            tick.AskPrice = factor(tick.AskPrice);
                         }
                         if (securityType == SecurityType.Option
                             || securityType == SecurityType.Future)

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -20,10 +20,15 @@ using Newtonsoft.Json;
 using NodaTime;
 using NUnit.Framework;
 using Python.Runtime;
+using QuantConnect.Algorithm;
 using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Indicators;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Packets;
@@ -1158,6 +1163,77 @@ actualDictionary.update({'IBM': 5})
         {
             var actual = right.GetExerciseDirection(isShort);
             Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void AppliesScalingToEquityTickQuotes()
+        {
+            // This test ensures that all Ticks with TickType == TickType.Quote have adjusted BidPrice and AskPrice.
+            // Relevant issue: https://github.com/QuantConnect/Lean/issues/4788
+
+            var algo = new QCAlgorithm();
+            algo.SubscriptionManager = new SubscriptionManager();
+            algo.SubscriptionManager.SetDataManager(new DataManager(
+                new FileSystemDataFeed(),
+                new UniverseSelection(
+                    algo,
+                    new SecurityService(
+                        new CashBook(),
+                        MarketHoursDatabase.FromDataFolder(),
+                        SymbolPropertiesDatabase.FromDataFolder(),
+                        algo,
+                        null,
+                        null
+                    ),
+                    new DataPermissionManager(),
+                    new DefaultDataProvider(),
+                    Resolution.Minute
+                ),
+                algo,
+                new TimeKeeper(DateTime.UtcNow),
+                MarketHoursDatabase.FromDataFolder(),
+                false,
+                null,
+                new DataPermissionManager()
+            ));
+
+            algo.HistoryProvider = new SubscriptionDataReaderHistoryProvider();
+            algo.HistoryProvider.Initialize(
+                new HistoryProviderInitializeParameters(
+                    null,
+                    null,
+                    null,
+                    new ZipDataCacheProvider(new DefaultDataProvider()),
+                    new LocalDiskMapFileProvider(),
+                    new LocalDiskFactorFileProvider(),
+                    (_) => {},
+                    false,
+                    new DataPermissionManager()));
+
+            algo.SetStartDate(DateTime.UtcNow.AddDays(-1));
+
+            var history = algo.History(new[] { Symbols.IBM }, new DateTime(2013, 10, 7), new DateTime(2013, 10, 8), Resolution.Tick).ToList();
+            Console.WriteLine(history.Count);
+
+            foreach (var slice in history)
+            {
+                if (!slice.Ticks.ContainsKey(Symbols.IBM))
+                {
+                    continue;
+                }
+
+                foreach (var tick in slice.Ticks[Symbols.IBM])
+                {
+                    if (tick.BidPrice != 0)
+                    {
+                        Assert.LessOrEqual(Math.Abs(tick.Value - tick.BidPrice), 0.05);
+                    }
+                    if (tick.AskPrice != 0)
+                    {
+                        Assert.LessOrEqual(Math.Abs(tick.Value - tick.AskPrice), 0.05);
+                    }
+                }
+            }
         }
 
         private PyObject ConvertToPyObject(object value)

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -1172,11 +1172,11 @@ actualDictionary.update({'IBM': 5})
             // Relevant issue: https://github.com/QuantConnect/Lean/issues/4788
 
             var algo = new QCAlgorithm();
-            var fsDataFeed = new FileSystemDataFeed();
+            var dataFeed = new NullDataFeed();
 
             algo.SubscriptionManager = new SubscriptionManager();
             algo.SubscriptionManager.SetDataManager(new DataManager(
-                fsDataFeed,
+                dataFeed,
                 new UniverseSelection(
                     algo,
                     new SecurityService(
@@ -1238,8 +1238,6 @@ actualDictionary.update({'IBM': 5})
                     }
                 }
             }
-
-            fsDataFeed.Exit();
         }
 
         private PyObject ConvertToPyObject(object value)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Previously, ticks would have their prices (Tick.Value) adjusted whenever TickType == TickType.Quote, but would not have their BidPrice/AskPrice fields adjusted, thus potentially being orders of magnitude such as 4x from the actual Bid/Ask prices.

This commit applies the pricing scaling factor in a critical path where Ticks are adjusted to their scaled price. This issue only applied to Resolution.Tick && SecurityType.Equity data.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4788 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Data consistency and correctness
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit test, algorithm testing via debugger
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
