### PR TITLE
Refactor OptionExerciseOrder.Quantity to be consistent with other Order types

### DIFF
--- a/Algorithm.CSharp/BacktestingBrokerageRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/BacktestingBrokerageRegressionAlgorithm.cs
@@ -183,9 +183,9 @@ namespace QuantConnect.Algorithm.CSharp
                 throw new Exception("OptionExercise order price should be strike price!!");
             }
 
-            if (orderEvent.Quantity != 1)
+            if (orderEvent.Quantity != -1)
             {
-                throw new Exception("OrderEvent Quantity should be 1");
+                throw new Exception("OrderEvent Quantity should be -1");
             }
         }
 
@@ -317,7 +317,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Treynor Ratio", "-0.018"},
             {"Total Fees", "$2.00"},
             {"Fitness Score", "0.213"},
-            {"OrderListHash", "-2119400842"}
+            {"OrderListHash", "904167951"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateOptionsFilterUniverseAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFilterUniverseAlgorithm.cs
@@ -141,7 +141,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-1438496252"}
+            {"OrderListHash", "687310345"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionExerciseAssignRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExerciseAssignRegressionAlgorithm.cs
@@ -161,7 +161,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-1143450142"}
+            {"OrderListHash", "-1726463684"}
         };
     }
 }

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -488,7 +488,7 @@ namespace QuantConnect.Algorithm
         /// <param name="tag">String tag for the order (optional)</param>
         public OrderTicket ExerciseOption(Symbol optionSymbol, int quantity, bool asynchronous = false, string tag = "")
         {
-            var option = (Option)Securities[optionSymbol];
+            var option = (Option) Securities[optionSymbol];
 
             var request = CreateSubmitOrderRequest(OrderType.OptionExercise, option, quantity, tag, DefaultOrderProperties?.Clone());
 
@@ -657,7 +657,9 @@ namespace QuantConnect.Algorithm
             Security security;
             if (!Securities.TryGetValue(request.Symbol, out security))
             {
-                return OrderResponse.Error(request, OrderResponseErrorCode.MissingSecurity, "You haven't requested " + request.Symbol.ToString() + " data. Add this with AddSecurity() in the Initialize() Method.");
+                return OrderResponse.Error(request, OrderResponseErrorCode.MissingSecurity,
+                    $"You haven't requested {request.Symbol} data. Add this with AddSecurity() in the Initialize() Method."
+                );
             }
 
             //Ordering 0 is useless.
@@ -677,7 +679,9 @@ namespace QuantConnect.Algorithm
 
             if (!security.IsTradable)
             {
-                return OrderResponse.Error(request, OrderResponseErrorCode.NonTradableSecurity, "The security with symbol '" + request.Symbol.ToString() + "' is marked as non-tradable.");
+                return OrderResponse.Error(request, OrderResponseErrorCode.NonTradableSecurity,
+                    $"The security with symbol '{request.Symbol}' is marked as non-tradable."
+                );
             }
 
             var price = security.Price;
@@ -685,13 +689,17 @@ namespace QuantConnect.Algorithm
             //Check the exchange is open before sending a market on close orders
             if (request.OrderType == OrderType.MarketOnClose && !security.Exchange.ExchangeOpen)
             {
-                return OrderResponse.Error(request, OrderResponseErrorCode.ExchangeNotOpen, request.OrderType + " order and exchange not open.");
+                return OrderResponse.Error(request, OrderResponseErrorCode.ExchangeNotOpen,
+                    $"{request.OrderType} order and exchange not open."
+                );
             }
 
             //Check the exchange is open before sending a exercise orders
             if (request.OrderType == OrderType.OptionExercise && !security.Exchange.ExchangeOpen)
             {
-                return OrderResponse.Error(request, OrderResponseErrorCode.ExchangeNotOpen, request.OrderType + " order and exchange not open.");
+                return OrderResponse.Error(request, OrderResponseErrorCode.ExchangeNotOpen,
+                    $"{request.OrderType} order and exchange not open."
+                );
             }
 
             if (price == 0)
@@ -704,11 +712,15 @@ namespace QuantConnect.Algorithm
             var quoteCurrency = security.QuoteCurrency.Symbol;
             if (!Portfolio.CashBook.TryGetValue(quoteCurrency, out quoteCash))
             {
-                return OrderResponse.Error(request, OrderResponseErrorCode.QuoteCurrencyRequired, request.Symbol.Value + ": requires " + quoteCurrency + " in the cashbook to trade.");
+                return OrderResponse.Error(request, OrderResponseErrorCode.QuoteCurrencyRequired,
+                    $"{request.Symbol.Value}: requires {quoteCurrency} in the cashbook to trade."
+                );
             }
             if (security.QuoteCurrency.ConversionRate == 0m)
             {
-                return OrderResponse.Error(request, OrderResponseErrorCode.ConversionRateZero, request.Symbol.Value + ": requires " + quoteCurrency + " to have a non-zero conversion rate. This can be caused by lack of data.");
+                return OrderResponse.Error(request, OrderResponseErrorCode.ConversionRateZero,
+                    $"{request.Symbol.Value}: requires {quoteCurrency} to have a non-zero conversion rate. This can be caused by lack of data."
+                );
             }
 
             // need to also check base currency existence/conversion rate on forex orders
@@ -718,18 +730,24 @@ namespace QuantConnect.Algorithm
                 var baseCurrency = ((IBaseCurrencySymbol)security).BaseCurrencySymbol;
                 if (!Portfolio.CashBook.TryGetValue(baseCurrency, out baseCash))
                 {
-                    return OrderResponse.Error(request, OrderResponseErrorCode.ForexBaseAndQuoteCurrenciesRequired, request.Symbol.Value + ": requires " + baseCurrency + " and " + quoteCurrency + " in the cashbook to trade.");
+                    return OrderResponse.Error(request, OrderResponseErrorCode.ForexBaseAndQuoteCurrenciesRequired,
+                        $"{request.Symbol.Value}: requires {baseCurrency} and {quoteCurrency} in the cashbook to trade."
+                    );
                 }
                 if (baseCash.ConversionRate == 0m)
                 {
-                    return OrderResponse.Error(request, OrderResponseErrorCode.ForexConversionRateZero, request.Symbol.Value + ": requires " + baseCurrency + " and " + quoteCurrency + " to have non-zero conversion rates. This can be caused by lack of data.");
+                    return OrderResponse.Error(request, OrderResponseErrorCode.ForexConversionRateZero,
+                        $"{request.Symbol.Value}: requires {baseCurrency} and {quoteCurrency} to have non-zero conversion rates. This can be caused by lack of data."
+                    );
                 }
             }
 
             //Make sure the security has some data:
             if (!security.HasData)
             {
-                return OrderResponse.Error(request, OrderResponseErrorCode.SecurityHasNoData, "There is no data for this symbol yet, please check the security.HasData flag to ensure there is at least one data point.");
+                return OrderResponse.Error(request, OrderResponseErrorCode.SecurityHasNoData,
+                    "There is no data for this symbol yet, please check the security.HasData flag to ensure there is at least one data point."
+                );
             }
 
             // We've already processed too many orders: max 10k
@@ -737,28 +755,43 @@ namespace QuantConnect.Algorithm
             {
                 Status = AlgorithmStatus.Stopped;
                 return OrderResponse.Error(request, OrderResponseErrorCode.ExceededMaximumOrders,
-                    $"You have exceeded maximum number of orders ({_maxOrders.ToStringInvariant()}), for unlimited orders upgrade your account."
+                    Invariant($"You have exceeded maximum number of orders ({_maxOrders}), for unlimited orders upgrade your account.")
                 );
             }
 
             if (request.OrderType == OrderType.OptionExercise)
             {
                 if (security.Type != SecurityType.Option)
-                    return OrderResponse.Error(request, OrderResponseErrorCode.NonExercisableSecurity, "The security with symbol '" + request.Symbol.ToString() + "' is not exercisable.");
+                {
+                    return OrderResponse.Error(request, OrderResponseErrorCode.NonExercisableSecurity,
+                        $"The security with symbol '{request.Symbol}' is not exercisable."
+                    );
+                }
 
                 if (security.Holdings.IsShort)
-                    return OrderResponse.Error(request, OrderResponseErrorCode.UnsupportedRequestType, "The security with symbol '" + request.Symbol.ToString() + "' has a short option position. Only long option positions are exercisable.");
+                {
+                    return OrderResponse.Error(request, OrderResponseErrorCode.UnsupportedRequestType,
+                        $"The security with symbol '{request.Symbol}' has a short option position. Only long option positions are exercisable."
+                    );
+                }
 
                 if (request.Quantity > security.Holdings.Quantity)
-                    return OrderResponse.Error(request, OrderResponseErrorCode.UnsupportedRequestType, "Cannot exercise more contracts of '" + request.Symbol.ToString() + "' than is currently available in the portfolio. ");
+                {
+                    return OrderResponse.Error(request, OrderResponseErrorCode.UnsupportedRequestType,
+                        $"Cannot exercise more contracts of '{request.Symbol}' than is currently available in the portfolio. "
+                    );
+                }
 
                 if (request.Quantity <= 0.0m)
+                {
                     OrderResponse.ZeroQuantity(request);
+                }
             }
 
             if (request.OrderType == OrderType.MarketOnClose)
             {
                 var nextMarketClose = security.Exchange.Hours.GetNextMarketClose(security.LocalTime, false);
+
                 // must be submitted with at least 10 minutes in trading day, add buffer allow order submission
                 var latestSubmissionTime = nextMarketClose.Subtract(Orders.MarketOnCloseOrder.DefaultSubmissionTimeBuffer);
                 if (!security.Exchange.ExchangeOpen || Time > latestSubmissionTime)
@@ -766,7 +799,9 @@ namespace QuantConnect.Algorithm
                     // tell the user we require a 16 minute buffer, on minute data in live a user will receive the 3:44->3:45 bar at 3:45,
                     // this is already too late to submit one of these orders, so make the user do it at the 3:43->3:44 bar so it's submitted
                     // to the brokerage before 3:45.
-                    return OrderResponse.Error(request, OrderResponseErrorCode.MarketOnCloseOrderTooLate, "MarketOnClose orders must be placed with at least a 16 minute buffer before market close.");
+                    return OrderResponse.Error(request, OrderResponseErrorCode.MarketOnCloseOrderTooLate,
+                        "MarketOnClose orders must be placed with at least a 16 minute buffer before market close."
+                    );
                 }
             }
 

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -2263,5 +2263,22 @@ namespace QuantConnect
                     return isShort ? OrderDirection.Buy : OrderDirection.Sell;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="OrderDirection"/> for the specified <paramref name="quantity"/>
+        /// </summary>
+        public static OrderDirection GetOrderDirection(decimal quantity)
+        {
+            var sign = Math.Sign(quantity);
+            switch (sign)
+            {
+                case 1:  return OrderDirection.Buy;
+                case 0:  return OrderDirection.Hold;
+                case -1: return OrderDirection.Sell;
+                default: throw new ApplicationException(
+                    $"The skies are falling and the oceans are rising! Math.Sign({quantity}) returned {sign} :/"
+                );
+            }
+        }
     }
 }

--- a/Common/Orders/OptionExercise/DefaultExerciseModel.cs
+++ b/Common/Orders/OptionExercise/DefaultExerciseModel.cs
@@ -17,6 +17,7 @@
 using System.Collections.Generic;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Securities.Option;
+using static QuantConnect.Extensions;
 
 namespace QuantConnect.Orders.OptionExercise
 {
@@ -33,51 +34,51 @@ namespace QuantConnect.Orders.OptionExercise
         public IEnumerable<OrderEvent> OptionExercise(Option option, OptionExerciseOrder order)
         {
             var underlying = option.Underlying;
-
-            var isShort = order.Quantity < 0;
             var utcTime = option.LocalTime.ConvertToUtc(option.Exchange.TimeZone);
 
             var inTheMoney = option.IsAutoExercised(underlying.Close);
-
-            // we're assigned only if we get exercised against, meaning we wrote the option and it was exercised by the buyer
-            var isAssignment = inTheMoney && isShort;
+            var isAssignment = inTheMoney && option.Holdings.IsShort;
 
             yield return new OrderEvent(
                 order.Id,
                 option.Symbol,
                 utcTime,
                 OrderStatus.Filled,
-                isShort ? OrderDirection.Buy : OrderDirection.Sell,
+                GetOrderDirection(order.Quantity),
                 0.0m,
-                -order.Quantity,
+                order.Quantity,
                 OrderFee.Zero,
-                // note whether or not we expired OTM/ITM and whether we were assigned or exercised
-                inTheMoney ? isAssignment ? "Automatic Assignment" : "Automatic Exercise" : "OTM"
-            )
-            {
-                IsAssignment = isAssignment
-            };
+                GetContractHoldingsAdjustmentFillTag(inTheMoney, isAssignment)
+            ) { IsAssignment = isAssignment };
 
+            // TODO : Support Manual Exercise of OTM contracts [ inTheMoney = false ]
             if (inTheMoney && option.ExerciseSettlement == SettlementType.PhysicalDelivery)
             {
-                var right = option.Symbol.ID.OptionRight;
-
-                // TODO : Why doesn't this method take into account the directionality of the quantity like other quantity properties/methods
-                var fillQuantity = option.GetExerciseQuantity(order.Quantity);
-                var exerciseQuantity = right == OptionRight.Call ? fillQuantity : -fillQuantity;
+                var exerciseQuantity = option.GetExerciseQuantity(order.Quantity);
 
                 yield return new OrderEvent(
                     order.Id,
                     underlying.Symbol,
                     utcTime,
                     OrderStatus.Filled,
-                    right.GetExerciseDirection(isShort),
+                    GetOrderDirection(exerciseQuantity),
                     order.Price,
                     exerciseQuantity,
                     OrderFee.Zero,
                     isAssignment ? "Option Assignment" : "Option Exercise"
                 );
             }
+        }
+
+        private static string GetContractHoldingsAdjustmentFillTag(bool inTheMoney, bool isAssignment)
+        {
+            var action = isAssignment ? "Assignment" : "Exercise";
+            if (inTheMoney)
+            {
+                return $"Automatic {action}";
+            }
+
+            return "OTM";
         }
     }
 }

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -22,8 +22,8 @@ using QuantConnect.Orders.OptionExercise;
 using Python.Runtime;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
-using QuantConnect.Util;
 using System.Collections.Generic;
+using QuantConnect.Orders;
 
 namespace QuantConnect.Securities.Option
 {
@@ -226,13 +226,45 @@ namespace QuantConnect.Securities.Option
         }
 
         /// <summary>
-        /// Returns the actual number of the underlying shares that are going to change hands on exercise. For instance, after reverse split
-        /// we may have 1 option contract with multiplier of 100 with right to buy/sell only 50 shares of underlying stock.
+        /// Returns the directional quantity of underlying shares that are going to change hands on exercise/assignment of all
+        /// contracts held by this account, taking into account the contract's <see cref="Right"/> as well as the contract's current
+        /// <see cref="ContractUnitOfTrade"/>, which may have recently changed due to a split/reverse split in the underlying security.
         /// </summary>
-        /// <returns></returns>
-        public decimal GetExerciseQuantity(decimal quantity)
+        /// <remarks>
+        /// Long option positions result in exercise while short option positions result in assignment. This function uses the term
+        /// exercise loosely to refer to both situations.
+        /// </remarks>
+        public decimal GetExerciseQuantity()
         {
-            return quantity * ContractUnitOfTrade;
+            // negate Holdings.Quantity to match an equivalent order
+            return GetExerciseQuantity(-Holdings.Quantity);
+        }
+
+        /// <summary>
+        /// Returns the directional quantity of underlying shares that are going to change hands on exercise/assignment of the
+        /// specified <paramref name="exerciseOrderQuantity"/>, taking into account the contract's <see cref="Right"/> as well
+        /// as the contract's current <see cref="ContractUnitOfTrade"/>, which may have recently changed due to a split/reverse
+        /// split in the underlying security.
+        /// </summary>
+        /// <remarks>
+        /// Long option positions result in exercise while short option positions result in assignment. This function uses the term
+        /// exercise loosely to refer to both situations.
+        /// </remarks>
+        /// <paramref name="exerciseOrderQuantity">The quantity of contracts being exercised as provided by the <see cref="OptionExerciseOrder"/>.
+        /// A negative value indicates exercise (we are long and the order quantity is negative to bring us (closer) to zero.
+        /// A positive value indicates assignment (we are short and the order quantity is positive to bring us (closer) to zero.</paramref>
+        public decimal GetExerciseQuantity(decimal exerciseOrderQuantity)
+        {
+            // when exerciseOrderQuantity > 0 [ we are short ]
+            //      && right == call => we sell to contract holder  => negative
+            //      && right == put  => we buy from contract holder => positive
+
+            // when exerciseOrderQuantity < 0 [ we are long ]
+            //      && right == call => we buy from contract holder => positive
+            //      && right == put  => we sell to contract holder  => negative
+
+            var sign = Right == OptionRight.Call ? -1 : 1;
+            return sign * exerciseOrderQuantity * ContractUnitOfTrade;
         }
 
         /// <summary>
@@ -437,7 +469,7 @@ namespace QuantConnect.Securities.Option
         public void SetFilter(PyObject universeFunc)
         {
             ContractFilter = new FuncSecurityDerivativeFilter(universe =>
-            {              
+            {
                 var optionUniverse = universe as OptionFilterUniverse;
                 using (Py.GIL())
                 {

--- a/Common/Securities/Option/OptionPortfolioModel.cs
+++ b/Common/Securities/Option/OptionPortfolioModel.cs
@@ -78,7 +78,7 @@ namespace QuantConnect.Securities.Option
 
                 case SettlementType.Cash:
 
-                    var cashQuantity = option.GetIntrinsicValue(underlying.Close) * option.ContractUnitOfTrade * optionQuantity;
+                    var cashQuantity = -option.GetIntrinsicValue(underlying.Close) * option.ContractUnitOfTrade * optionQuantity;
 
                     // we add cash equivalent to portfolio
                     option.SettlementModel.ApplyFunds(portfolio, option, fill.UtcTime, cashQuote.Symbol, cashQuantity);

--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -165,7 +165,7 @@ namespace QuantConnect
         /// </summary>
         /// <param name="symbol">Symbol object to create OSI ticker from</param>
         /// <returns>The OSI ticker representation</returns>
-        public static string GenerateOptionTickerOSI(Symbol symbol)
+        public static string GenerateOptionTickerOSI(this Symbol symbol)
         {
             if (symbol.SecurityType != SecurityType.Option)
             {

--- a/Engine/Results/RegressionResultHandler.cs
+++ b/Engine/Results/RegressionResultHandler.cs
@@ -15,12 +15,15 @@
 */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
 using QuantConnect.Configuration;
 using QuantConnect.Data;
+using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using QuantConnect.Orders;
@@ -36,21 +39,28 @@ namespace QuantConnect.Lean.Engine.Results
     {
         private Language Language => Config.GetValue<Language>("algorithm-language");
 
-        private DateTime _lastAlphaRuntimeStatisticsDate;
         private DateTime _testStartTime;
+        private DateTime _lastRuntimeStatisticsDate;
+        private DateTime _lastAlphaRuntimeStatisticsDate;
 
-        private StreamWriter _writer;
+        private TextWriter _writer;
         private readonly object _sync = new object();
+        private readonly ConcurrentQueue<string> _preInitializeLines;
+        private readonly Dictionary<string, string> _currentRuntimeStatistics;
         private readonly Dictionary<string, string> _currentAlphaRuntimeStatistics;
 
         // this defaults to false since it can create massive files. a full regression run takes about 800MB
         // for each folder (800MB for ./passed and 800MB for ./regression)
         private static readonly bool HighFidelityLogging = Config.GetBool("regression-high-fidelity-logging", false);
 
+        private static readonly bool IsTest = !Process.GetCurrentProcess().ProcessName.Contains("Lean.Launcher");
+
         /// <summary>
         /// Gets the path used for logging all portfolio changing events, such as orders, TPV, daily holdings values
         /// </summary>
-        public string LogFilePath => $"./regression/{AlgorithmId}.{Language.ToLower()}.details.log";
+        public string LogFilePath => IsTest
+            ? $"./regression/{AlgorithmId}.{Language.ToLower()}.details.log"
+            : $"./{AlgorithmId}/{DateTime.Now:yyyy-MM-dd-hh-mm-ss}.{Language.ToLower()}.details.log";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RegressionResultHandler"/> class
@@ -58,6 +68,8 @@ namespace QuantConnect.Lean.Engine.Results
         public RegressionResultHandler()
         {
             _testStartTime = DateTime.UtcNow;
+            _preInitializeLines = new ConcurrentQueue<string>();
+            _currentRuntimeStatistics = new Dictionary<string, string>();
             _currentAlphaRuntimeStatistics = new Dictionary<string, string>();
         }
 
@@ -75,8 +87,17 @@ namespace QuantConnect.Lean.Engine.Results
                 fileInfo.Delete();
             }
 
-            _writer = new StreamWriter(LogFilePath);
-            _writer.WriteLine($"{_testStartTime}: Starting regression test");
+            lock (_sync)
+            {
+                _writer = new StreamWriter(LogFilePath);
+                WriteLine($"{_testStartTime}: Starting regression test");
+
+                string line;
+                while (_preInitializeLines.TryDequeue(out line))
+                {
+                    WriteLine(line);
+                }
+            }
         }
 
         /// <summary>
@@ -86,10 +107,10 @@ namespace QuantConnect.Lean.Engine.Results
         {
             lock (_sync)
             {
-                _writer.WriteLine($"{Algorithm.UtcTime}: Total Portfolio Value: {Algorithm.Portfolio.TotalPortfolioValue}");
+                WriteLine($"{Algorithm.UtcTime}: Total Portfolio Value: {Algorithm.Portfolio.TotalPortfolioValue}");
 
                 // write the entire cashbook each day, includes current conversion rates and total value of cash holdings
-                _writer.WriteLine(Algorithm.Portfolio.CashBook);
+                WriteLine($"{Environment.NewLine}{Algorithm.Portfolio.CashBook}");
 
                 foreach (var kvp in Algorithm.Securities)
                 {
@@ -101,7 +122,7 @@ namespace QuantConnect.Lean.Engine.Results
                     }
 
                     // detailed logging of security holdings
-                    _writer.WriteLine(
+                    WriteLine(
                         $"{Algorithm.UtcTime}: " +
                         $"Holdings: {symbol.Value} ({symbol.ID}): " +
                         $"Price: {security.Price} " +
@@ -127,7 +148,13 @@ namespace QuantConnect.Lean.Engine.Results
 
             lock (_sync)
             {
-                _writer.WriteLine($"{Algorithm.UtcTime}: Order: {order}  OrderEvent: {newEvent}");
+                WriteLine("==============================================================");
+                WriteLine($"    Order: {order} Tag: {order.Tag}");
+                WriteLine($"    Event: {newEvent}");
+                WriteLine($" Position: {Algorithm.Portfolio[newEvent.Symbol].Quantity}");
+                WriteLine($"     Cash: {Algorithm.Portfolio.Cash:0.00}");
+                WriteLine($"Portfolio: {Algorithm.Portfolio.TotalPortfolioValue:0.00}");
+                WriteLine("==============================================================");
             }
 
             base.OrderEvent(newEvent);
@@ -153,7 +180,7 @@ namespace QuantConnect.Lean.Engine.Results
                             {
                                 // only log new or updated values
                                 _currentAlphaRuntimeStatistics[kvp.Key] = kvp.Value;
-                                _writer.WriteLine($"{Algorithm.Time}: AlphaRuntimeStatistics: {kvp.Key}: {kvp.Value}");
+                                WriteLine($"AlphaRuntimeStatistics: {kvp.Key}: {kvp.Value}");
                             }
                         }
                     }
@@ -164,6 +191,143 @@ namespace QuantConnect.Lean.Engine.Results
             catch (Exception exception)
             {
                 Log.Error(exception);
+            }
+        }
+
+        /// <summary>
+        /// Send list of security asset types the algortihm uses to browser.
+        /// </summary>
+        public override void SecurityType(List<SecurityType> types)
+        {
+            base.SecurityType(types);
+
+            var sorted = types.Select(type => type.ToString()).OrderBy(type => type);
+            WriteLine($"SecurityTypes: {string.Join("|", sorted)}");
+        }
+
+        /// <summary>
+        /// Send a debug message back to the browser console.
+        /// </summary>
+        /// <param name="message">Message we'd like shown in console.</param>
+        public override void DebugMessage(string message)
+        {
+            base.DebugMessage(message);
+
+            WriteLine($"DebugMessage: {message}");
+        }
+
+        /// <summary>
+        /// Send an error message back to the browser highlighted in red with a stacktrace.
+        /// </summary>
+        /// <param name="message">Error message we'd like shown in console.</param>
+        /// <param name="stacktrace">Stacktrace information string</param>
+        public override void ErrorMessage(string message, string stacktrace = "")
+        {
+            base.ErrorMessage(message, stacktrace);
+
+            stacktrace = string.IsNullOrEmpty(stacktrace) ? null : Environment.NewLine + stacktrace;
+            WriteLine($"ErrorMessage: {message}{stacktrace}");
+        }
+
+        /// <summary>
+        /// Send a logging message to the log list for storage.
+        /// </summary>
+        /// <param name="message">Message we'd in the log.</param>
+        public override void LogMessage(string message)
+        {
+            base.LogMessage(message);
+
+            WriteLine($"LogMessage: {message}");
+        }
+
+        /// <summary>
+        /// Send a runtime error message back to the browser highlighted with in red
+        /// </summary>
+        /// <param name="message">Error message.</param>
+        /// <param name="stacktrace">Stacktrace information string</param>
+        public override void RuntimeError(string message, string stacktrace = "")
+        {
+            base.RuntimeError(message, stacktrace);
+
+            stacktrace = string.IsNullOrEmpty(stacktrace) ? null : Environment.NewLine + stacktrace;
+            WriteLine($"RuntimeError: {message}{stacktrace}");
+        }
+
+        /// <summary>
+        /// Send a system debug message back to the browser console.
+        /// </summary>
+        /// <param name="message">Message we'd like shown in console.</param>
+        public override void SystemDebugMessage(string message)
+        {
+            base.SystemDebugMessage(message);
+
+            WriteLine($"SystemDebugMessage: {message}");
+        }
+
+        /// <summary>
+        /// Set the current runtime statistics of the algorithm.
+        /// These are banner/title statistics which show at the top of the live trading results.
+        /// </summary>
+        /// <param name="key">Runtime headline statistic name</param>
+        /// <param name="value">Runtime headline statistic value</param>
+        public override void RuntimeStatistic(string key, string value)
+        {
+            try
+            {
+                if (HighFidelityLogging || _lastRuntimeStatisticsDate != Algorithm.Time.Date)
+                {
+                    _lastRuntimeStatisticsDate = Algorithm.Time.Date;
+
+                    string existingValue;
+                    if (!_currentRuntimeStatistics.TryGetValue(key, out existingValue) || existingValue != value)
+                    {
+                        _currentRuntimeStatistics[key] = value;
+                        WriteLine($"RuntimeStatistic: {key}: {value}");
+                    }
+                }
+
+                base.RuntimeStatistic(key, value);
+            }
+            catch (Exception exception)
+            {
+                Log.Error(exception);
+            }
+        }
+
+        /// <summary>
+        /// Save an algorithm message to the log store. Uses a different timestamped method of adding messaging to interweve debug and logging messages.
+        /// </summary>
+        /// <param name="message">String message to store</param>
+        protected override void AddToLogStore(string message)
+        {
+            base.AddToLogStore(message);
+
+            WriteLine($"AddToLogStore: {message}");
+        }
+
+        /// <summary>
+        /// Event fired each time that we add/remove securities from the data feed
+        /// </summary>
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            base.OnSecuritiesChanged(changes);
+
+            if (changes.AddedSecurities.Count > 0)
+            {
+                var added = changes.AddedSecurities
+                    .Select(security => security.Symbol.ToString())
+                    .OrderBy(symbol => symbol);
+
+                WriteLine($"OnSecuritiesChanged:ADD: {string.Join("|", added)}");
+            }
+
+            if (changes.RemovedSecurities.Count > 0)
+            {
+                var removed = changes.RemovedSecurities
+                    .Select(security => security.Symbol.ToString())
+                    .OrderBy(symbol => symbol);
+
+                WriteLine($"OnSecuritiesChanged:REM: {string.Join("|", removed)}");
             }
         }
 
@@ -181,7 +345,7 @@ namespace QuantConnect.Lean.Engine.Results
                     lock (_sync)
                     {
                         // aggregate slice data
-                        _writer.WriteLine($"{Algorithm.UtcTime}: Slice Time: {slice.Time:o} Slice Count: {slice.Count}");
+                        WriteLine($"Slice Time: {slice.Time:o} Slice Count: {slice.Count}");
                         var data = new Dictionary<Symbol, List<BaseData>>();
                         foreach (var kvp in slice.Bars)
                         {
@@ -225,7 +389,7 @@ namespace QuantConnect.Lean.Engine.Results
                         {
                             foreach (var item in kvp.Value)
                             {
-                                _writer.WriteLine($"{Algorithm.UtcTime}: Slice: DataTime: {item.EndTime} {item}");
+                                WriteLine($"{Algorithm.UtcTime}: Slice: DataTime: {item.EndTime} {item}");
                             }
                         }
                     }
@@ -254,11 +418,80 @@ namespace QuantConnect.Lean.Engine.Results
             {
                 if (_writer != null)
                 {
+                    // only log final statistics and we want them to all be together
+                    foreach (var kvp in RuntimeStatistics.OrderBy(kvp => kvp.Key))
+                    {
+                        WriteLine($"{kvp.Key,-15}\t{kvp.Value}");
+                    }
+
                     var end = DateTime.UtcNow;
                     var delta = end - _testStartTime;
-                    _writer.WriteLine($"{end}: Completed regression test, took: {delta.TotalSeconds:0.0} seconds");
+                    WriteLine($"{end}: Completed regression test, took: {delta.TotalSeconds:0.0} seconds");
                     _writer.DisposeSafely();
                     _writer = null;
+                }
+                else
+                {
+                    string line;
+                    while (_preInitializeLines.TryDequeue(out line))
+                    {
+                        Console.WriteLine(line);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// We want to make algorithm messages end up in both the standard regression log file {algorithm}.{language}.log
+        /// as well as the details log {algorithm}.{language}.details.log. The details log is focused on providing a log
+        /// dedicated solely to the algorithm's behavior, void of all <see cref="QuantConnect.Logging.Log"/> messages
+        /// </summary>
+        protected override void ConfigureConsoleTextWriter(IAlgorithm algorithm)
+        {
+            // configure Console.WriteLine and Console.Error.WriteLine to both logs, syslog and details.log
+            // when 'forward-console-messages' is set to false, it guarantees synchronous logging of these messages
+
+            if (Config.GetBool("forward-console-messages", true))
+            {
+                // we need to forward Console.Write messages to the algorithm's Debug function
+                Console.SetOut(new FuncTextWriter(msg =>
+                {
+                    algorithm.Debug(msg);
+                    WriteLine($"DEBUG: {msg}");
+                }));
+                Console.SetError(new FuncTextWriter(msg =>
+                {
+                    algorithm.Error(msg);
+                    WriteLine($"ERROR: {msg}");
+                }));
+            }
+            else
+            {
+                // we need to forward Console.Write messages to the standard Log functions
+                Console.SetOut(new FuncTextWriter(msg =>
+                {
+                    Log.Trace(msg);
+                    WriteLine($"DEBUG: {msg}");
+                }));
+                Console.SetError(new FuncTextWriter(msg =>
+                {
+                    Log.Error(msg);
+                    WriteLine($"ERROR: {msg}");
+                }));
+            }
+        }
+
+        private void WriteLine(string message)
+        {
+            lock (_sync)
+            {
+                if (_writer == null)
+                {
+                    _preInitializeLines.Enqueue(message);
+                }
+                else
+                {
+                    _writer.WriteLine($"{Algorithm.Time:O}: {message}");
                 }
             }
         }

--- a/QuantConnect.Lean.sln.DotSettings
+++ b/QuantConnect.Lean.sln.DotSettings
@@ -1,10 +1,36 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-    <s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_INVOCATION_PARS/@EntryValue">INSIDE</s:String>
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_INVOCATION_LPAR/@EntryValue">True</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_INVOCATION_RPAR/@EntryValue">True</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceDoWhileStatementBraces/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceFixedStatementBraces/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceForeachStatementBraces/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceForStatementBraces/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceIfStatementBraces/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceLockStatementBraces/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceUsingStatementBraces/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceWhileStatementBraces/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RemoveRedundantBraces/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_FOR/@EntryValue">Required</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_FOREACH/@EntryValue">Required</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_IFELSE/@EntryValue">Required</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_WHILE/@EntryValue">Required</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/LOCAL_FUNCTION_BODY/@EntryValue">ExpressionBody</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_BINARY_EXPRESSIONS_CHAIN/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_METHOD_DECL_PARS/@EntryValue">OUTSIDE</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_FORMAL_PARAMETERS_ON_LINE/@EntryValue">4</s:Int64>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSOR_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_ANONYMOUSMETHOD_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_TYPE_CONSTRAINTS_ON_SAME_LINE/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_WHILE_ON_NEW_LINE/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_DECLARATION_LPAR/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_DECLARATION_RPAR/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_EXTENDS_LIST_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_PARAMETERS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_VERBATIM_INTERPOLATED_STRINGS/@EntryValue">WRAP_IF_LONG</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=Antivirus/@EntryIndexedValue">DO_NOTHING</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>

--- a/Tests/Common/Orders/OrderTests.cs
+++ b/Tests/Common/Orders/OrderTests.cs
@@ -153,9 +153,9 @@ namespace QuantConnect.Tests.Common.Orders
                 new ValueTestParameters("OptionShortStopMarketOrder", option, new StopMarketOrder(Symbols.SPY_P_192_Feb19_2016, -quantity, pricePlusDelta, time), -quantity*pricePlusDelta),
                 new ValueTestParameters("OptionShortStopMarketOrder", option, new StopMarketOrder(Symbols.SPY_P_192_Feb19_2016, -quantity, priceMinusDelta, time), -quantity*price),
 
-                new ValueTestParameters("OptionExercisetOrderPut", option, new OptionExerciseOrder(Symbols.SPY_P_192_Feb19_2016, quantity, time), quantity*option.Symbol.ID.StrikePrice),
+                new ValueTestParameters("OptionExerciseOrderPut", option, new OptionExerciseOrder(Symbols.SPY_P_192_Feb19_2016, quantity, time), quantity*option.Symbol.ID.StrikePrice),
                 new ValueTestParameters("OptionAssignmentOrderPut", option, new OptionExerciseOrder(Symbols.SPY_P_192_Feb19_2016, -quantity, time), -quantity*option.Symbol.ID.StrikePrice),
-                new ValueTestParameters("OptionExercisetOrderCall", option, new OptionExerciseOrder(Symbols.SPY_C_192_Feb19_2016, quantity, time), quantity*option.Symbol.ID.StrikePrice),
+                new ValueTestParameters("OptionExerciseOrderCall", option, new OptionExerciseOrder(Symbols.SPY_C_192_Feb19_2016, quantity, time), quantity*option.Symbol.ID.StrikePrice),
                 new ValueTestParameters("OptionAssignmentOrderCall", option, new OptionExerciseOrder(Symbols.SPY_C_192_Feb19_2016, -quantity, time), -quantity*option.Symbol.ID.StrikePrice),
 
 

--- a/Tests/Common/Securities/Options/OptionPortfolioModelTests.cs
+++ b/Tests/Common/Securities/Options/OptionPortfolioModelTests.cs
@@ -14,88 +14,114 @@
 */
 
 using System;
+using System.Linq;
 using NodaTime;
 using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Brokerages.Backtesting;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
+using QuantConnect.Lean.Engine.Results;
+using QuantConnect.Lean.Engine.TransactionHandlers;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Option;
+using QuantConnect.Tests.Engine;
 
 namespace QuantConnect.Tests.Common.Securities.Options
 {
     [TestFixture]
     public class OptionPortfolioModelTests
     {
+        private IResultHandler _resultHandler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _resultHandler = new TestResultHandler(Console.WriteLine);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _resultHandler.Exit();
+        }
+
         [Test]
-        public void NonAccountCurrencyOption_Exercise()
+        public void OptionExercise_NonAccountCurrency()
         {
-            var reference = new DateTime(2016, 02, 16, 11, 53, 30);
-            SecurityPortfolioManager portfolio;
-            var security = InitializeTest(reference, out portfolio);
+            var algorithm = new QCAlgorithm();
+            var securities = new SecurityManager(new TimeKeeper(DateTime.Now, TimeZones.NewYork));
+            var transactions = new SecurityTransactionManager(null, securities);
+            var transactionHandler = new BacktestingTransactionHandler();
+            var portfolio = new SecurityPortfolioManager(securities, transactions);
 
-            var cash = new Cash("EUR", 0, 10);
-            portfolio.CashBook.Add("EUR", cash);
-            var option = new Option(
+            var EUR = new Cash("EUR", 100*192, 10);
+            portfolio.CashBook.Add("EUR", EUR);
+            portfolio.SetCash("USD", 0, 1);
+            algorithm.Securities = securities;
+            transactionHandler.Initialize(algorithm, new BacktestingBrokerage(algorithm), _resultHandler);
+            transactions.SetOrderProcessor(transactionHandler);
+
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                    CreateTradeBarConfig(Symbols.SPY),
+                    EUR,
+                    SymbolProperties.GetDefault(EUR.Symbol),
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null,
+                    new SecurityCache()
+                )
+            );
+            securities.Add(
                 Symbols.SPY_C_192_Feb19_2016,
-                SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc),
-                cash,
-                new OptionSymbolProperties(SymbolProperties.GetDefault("EUR")),
-                portfolio.CashBook,
-                RegisteredSecurityDataTypesProvider.Null,
-                new SecurityCache()
+                new Option(
+                    SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                    CreateTradeBarConfig(Symbols.SPY_C_192_Feb19_2016),
+                    EUR,
+                    new OptionSymbolProperties(new SymbolProperties("EUR", "EUR", 100, 0.01m, 1)),
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null
+                )
             );
-            option.Underlying = security;
-            security.SetMarketPrice(new Tick { Value = 1000 });
-            portfolio.Securities.Add(option);
-            var fakeOrderProcessor = new FakeOrderProcessor();
-            portfolio.Transactions.SetOrderProcessor(fakeOrderProcessor);
+            securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 1);
+            securities[Symbols.SPY].SetMarketPrice(new Tick { Value = 200 });
 
-            var fillPrice = 1000m;
-            var fillQuantity = 1;
-            option.ExerciseSettlement = SettlementType.Cash;
-            var orderFee = new OrderFee(new CashAmount(1, "EUR"));
-            var order = new OptionExerciseOrder(Symbols.SPY_C_192_Feb19_2016, fillQuantity, DateTime.UtcNow);
-            fakeOrderProcessor.AddOrder(order);
-            var orderDirection = fillQuantity > 0 ? OrderDirection.Buy : OrderDirection.Sell;
-            var fill = new OrderEvent(order.Id, option.Symbol, reference, OrderStatus.Filled, orderDirection, fillPrice, fillQuantity, orderFee);
-            portfolio.ProcessFill(fill);
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, -1, 0, 0, securities.UtcTime, ""));
+            var option = (Option)securities[Symbols.SPY_C_192_Feb19_2016];
+            var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
+            option.Underlying = securities[Symbols.SPY];
 
-            // (1000 (price) - 192 (call strike)) * 1 quantity => 808 EUR
-            Assert.AreEqual(10, option.Holdings.TotalFees); // 1 * 10 (conversion rate to account currency)
-            // 808 - 1000 (price) - 1 fee
-            Assert.AreEqual(-193, portfolio.CashBook["EUR"].Amount);
-            // 100000 initial amount, no fee deducted
-            Assert.AreEqual(100000, portfolio.CashBook[Currencies.USD].Amount);
+            var fills = option.OptionExerciseModel.OptionExercise(option, order).ToList();
+
+            Assert.AreEqual(2, fills.Count);
+            Assert.IsFalse(fills[0].IsAssignment);
+            Assert.AreEqual("Automatic Exercise", fills[0].Message);
+            Assert.AreEqual("Option Exercise", fills[1].Message);
+
+            foreach (var fill in fills)
+            {
+                portfolio.ProcessFill(fill);
+            }
+
+            // now we have long position in SPY with average price equal to strike
+            var newUnderlyingHoldings = securities[Symbols.SPY].Holdings;
+            // we added 100*192 EUR (strike price) at beginning, all consumed by exercise
+            Assert.AreEqual(0, EUR.Amount);
+            Assert.AreEqual(0, portfolio.CashBook["USD"].Amount);
+            Assert.AreEqual(100, newUnderlyingHoldings.Quantity);
+            Assert.AreEqual(192.0, newUnderlyingHoldings.AveragePrice);
+
+            // and long call option position has disappeared
+            Assert.AreEqual(0, securities[Symbols.SPY_C_192_Feb19_2016].Holdings.Quantity);
         }
 
-        private Security InitializeTest(DateTime reference, out SecurityPortfolioManager portfolio)
+        private static SubscriptionDataConfig CreateTradeBarConfig(Symbol symbol)
         {
-            var security = new Security(
-                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
-                CreateTradeBarConfig(),
-                new Cash(Currencies.USD, 0, 1m),
-                SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null,
-                new SecurityCache()
-            );
-            security.SetMarketPrice(new Tick { Value = 100 });
-            var timeKeeper = new TimeKeeper(reference);
-            var securityManager = new SecurityManager(timeKeeper);
-            securityManager.Add(security);
-            var transactionManager = new SecurityTransactionManager(null, securityManager);
-            portfolio = new SecurityPortfolioManager(securityManager, transactionManager);
-            portfolio.SetCash(Currencies.USD, 100 * 1000m, 1m);
-            Assert.AreEqual(0, security.Holdings.Quantity);
-            Assert.AreEqual(100 * 1000m, portfolio.CashBook[Currencies.USD].Amount);
-            return security;
-        }
-
-        private static SubscriptionDataConfig CreateTradeBarConfig()
-        {
-            return new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
+            return new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, false);
         }
     }
 }

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -1250,7 +1250,8 @@ namespace QuantConnect.Tests.Common.Securities
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 1);
             securities[Symbols.SPY].SetMarketPrice(new Tick { Value = 200 });
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, 1, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_C_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, -holdings, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_C_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -1259,6 +1260,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(2, fills.Count);
             Assert.IsFalse(fills[0].IsAssignment);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
             Assert.AreEqual("Automatic Exercise", fills[0].Message);
             Assert.AreEqual("Option Exercise", fills[1].Message);
 
@@ -1318,7 +1320,8 @@ namespace QuantConnect.Tests.Common.Securities
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 100);
             securities[Symbols.SPY].SetMarketPrice(new Tick { Value = 20 });
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, 100, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_C_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, -holdings, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_C_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -1327,6 +1330,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(1, fills.Count);
             Assert.AreEqual("OTM", fills[0].Message);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
 
             foreach (var fill in fills)
             {
@@ -1383,7 +1387,8 @@ namespace QuantConnect.Tests.Common.Securities
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, 100);
             securities[Symbols.SPY].SetMarketPrice(new Tick { Value = 2000 });
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, 100, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_P_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, -holdings, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_P_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -1448,7 +1453,8 @@ namespace QuantConnect.Tests.Common.Securities
             );
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, 1);
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, 1, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_P_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, -holdings, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_P_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -1457,6 +1463,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(2, fills.Count);
             Assert.IsFalse(fills[0].IsAssignment);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
             Assert.AreEqual("Automatic Exercise", fills[0].Message);
             Assert.AreEqual("Option Exercise", fills[1].Message);
 
@@ -1518,7 +1525,8 @@ namespace QuantConnect.Tests.Common.Securities
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 2);
             securities[Symbols.SPY].SetMarketPrice(new Tick { Value = 200 });
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, 1, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_C_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, -holdings/2, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_C_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -1527,6 +1535,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(2, fills.Count);
             Assert.IsFalse(fills[0].IsAssignment);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
             Assert.AreEqual("Automatic Exercise", fills[0].Message);
             Assert.AreEqual("Option Exercise", fills[1].Message);
 
@@ -1585,7 +1594,8 @@ namespace QuantConnect.Tests.Common.Securities
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, -1);
             securities[Symbols.SPY].SetMarketPrice(new Tick { Value = 200 });
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, -1, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_C_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, -holdings, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_C_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -1594,6 +1604,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(2, fills.Count);
             Assert.IsTrue(fills[0].IsAssignment);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
             Assert.AreEqual("Automatic Assignment", fills[0].Message);
             Assert.AreEqual("Option Assignment", fills[1].Message);
 
@@ -1659,7 +1670,8 @@ namespace QuantConnect.Tests.Common.Securities
             );
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, -1);
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, -1, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_P_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, -holdings, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_P_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -1668,6 +1680,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(2, fills.Count);
             Assert.IsTrue(fills[0].IsAssignment);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
             Assert.AreEqual("Automatic Assignment", fills[0].Message);
             Assert.AreEqual("Option Assignment", fills[1].Message);
 
@@ -1730,7 +1743,8 @@ namespace QuantConnect.Tests.Common.Securities
             );
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, -2);
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, -1, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_P_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, -holdings/2, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_P_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -1739,6 +1753,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(2, fills.Count);
             Assert.IsTrue(fills[0].IsAssignment);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
             Assert.AreEqual("Automatic Assignment", fills[0].Message);
             Assert.AreEqual("Option Assignment", fills[1].Message);
 
@@ -1802,7 +1817,8 @@ namespace QuantConnect.Tests.Common.Securities
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 1);
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, 1, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_C_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, -holdings, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_C_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -1812,6 +1828,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(1, fills.Count);
             Assert.IsFalse(fills[0].IsAssignment);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
             Assert.AreEqual("Automatic Exercise", fills[0].Message);
 
             foreach (var fill in fills)
@@ -1868,7 +1885,8 @@ namespace QuantConnect.Tests.Common.Securities
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 190 });
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 100);
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, 100, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_C_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, -holdings, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_C_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -1879,6 +1897,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(1, fills.Count);
             Assert.IsFalse(fills[0].IsAssignment);
             Assert.AreEqual("OTM", fills[0].Message);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
 
             foreach (var fill in fills)
             {
@@ -1933,7 +1952,8 @@ namespace QuantConnect.Tests.Common.Securities
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 189 });
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, 1);
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, 1, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_P_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, -holdings, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_P_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -1943,6 +1963,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(1, fills.Count);
             Assert.IsFalse(fills[0].IsAssignment);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
             Assert.AreEqual("Automatic Exercise", fills[0].Message);
 
             foreach (var fill in fills)
@@ -2002,7 +2023,8 @@ namespace QuantConnect.Tests.Common.Securities
             var option = (Option)securities[Symbols.SPY_C_192_Feb19_2016];
             option.Underlying = securities[Symbols.SPY];
 
-            var order = new OptionExerciseOrder(Symbols.SPY_C_192_Feb19_2016, 10, time.AddSeconds(1));
+            var holdings = securities[Symbols.SPY_C_192_Feb19_2016].Holdings.Quantity;
+            var order = new OptionExerciseOrder(Symbols.SPY_C_192_Feb19_2016, -holdings, time.AddSeconds(1));
             orderProcessor.AddOrder(order);
             var request = new SubmitOrderRequest(OrderType.OptionExercise, option.Type, option.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);
@@ -2012,7 +2034,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 150 });
 
-            order = new OptionExerciseOrder(Symbols.SPY_C_192_Feb19_2016, 10, time.AddSeconds(1));
+            order = new OptionExerciseOrder(Symbols.SPY_C_192_Feb19_2016, -holdings, time.AddSeconds(1));
             orderProcessor.AddOrder(order);
             request = new SubmitOrderRequest(OrderType.OptionExercise, option.Type, option.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);
@@ -2065,7 +2087,8 @@ namespace QuantConnect.Tests.Common.Securities
             var option = (Option)securities[Symbols.SPY_C_192_Feb19_2016];
             option.Underlying = securities[Symbols.SPY];
 
-            var order = new OptionExerciseOrder(Symbols.SPY_C_192_Feb19_2016, -10, time.AddSeconds(1));
+            var holdings = securities[Symbols.SPY_C_192_Feb19_2016].Holdings.Quantity;
+            var order = new OptionExerciseOrder(Symbols.SPY_C_192_Feb19_2016, -holdings, time.AddSeconds(1));
             orderProcessor.AddOrder(order);
             var request = new SubmitOrderRequest(OrderType.OptionExercise, option.Type, option.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);
@@ -2075,7 +2098,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 150 });
 
-            order = new OptionExerciseOrder(Symbols.SPY_C_192_Feb19_2016, -10, time.AddSeconds(1));
+            order = new OptionExerciseOrder(Symbols.SPY_C_192_Feb19_2016, -holdings, time.AddSeconds(1));
             orderProcessor.AddOrder(order);
             request = new SubmitOrderRequest(OrderType.OptionExercise, option.Type, option.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);
@@ -2124,7 +2147,8 @@ namespace QuantConnect.Tests.Common.Securities
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, 2);
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, 1, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_C_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, -holdings/2, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_C_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -2134,6 +2158,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(1, fills.Count);
             Assert.IsFalse(fills[0].IsAssignment);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
             Assert.AreEqual("Automatic Exercise", fills[0].Message);
 
             foreach (var fill in fills)
@@ -2191,7 +2216,8 @@ namespace QuantConnect.Tests.Common.Securities
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 195 });
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, -1);
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, -1, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_C_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, -holdings, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_C_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -2201,6 +2227,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(1, fills.Count);
             Assert.IsTrue(fills[0].IsAssignment);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
             Assert.AreEqual("Automatic Assignment", fills[0].Message);
 
             // we are simulating assignment by calling a method for this
@@ -2260,7 +2287,8 @@ namespace QuantConnect.Tests.Common.Securities
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 10 });
             securities[Symbols.SPY_C_192_Feb19_2016].Holdings.SetHoldings(1, -100);
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, -100, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_C_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_C_192_Feb19_2016, -holdings, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_C_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -2271,6 +2299,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(1, fills.Count);
             Assert.IsFalse(fills[0].IsAssignment);
             Assert.AreEqual("OTM", fills[0].Message);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
 
             // we are simulating assignment by calling a method for this
             var portfolioModel = (OptionPortfolioModel)option.PortfolioModel;
@@ -2331,7 +2360,8 @@ namespace QuantConnect.Tests.Common.Securities
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 189 });
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, -1);
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, -1, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_P_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, -holdings, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_P_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -2341,6 +2371,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(1, fills.Count);
             Assert.IsTrue(fills[0].IsAssignment);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
             Assert.AreEqual("Automatic Assignment", fills[0].Message);
 
             // we are simulating assignment by calling a method for this
@@ -2402,7 +2433,8 @@ namespace QuantConnect.Tests.Common.Securities
             securities[Symbols.SPY].SetMarketPrice(new TradeBar { Time = securities.UtcTime, Symbol = Symbols.SPY, Close = 189 });
             securities[Symbols.SPY_P_192_Feb19_2016].Holdings.SetHoldings(1, -2);
 
-            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, -1, 0, 0, securities.UtcTime, ""));
+            var holdings = securities[Symbols.SPY_P_192_Feb19_2016].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.OptionExercise, SecurityType.Option, Symbols.SPY_P_192_Feb19_2016, -holdings/2, 0, 0, securities.UtcTime, ""));
             var option = (Option)securities[Symbols.SPY_P_192_Feb19_2016];
             var order = (OptionExerciseOrder)transactions.GetOrders(x => true).First();
             option.Underlying = securities[Symbols.SPY];
@@ -2412,6 +2444,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(1, fills.Count);
             Assert.IsTrue(fills[0].IsAssignment);
+            Assert.AreEqual(order.Quantity, fills[0].FillQuantity);
             Assert.AreEqual("Automatic Assignment", fills[0].Message);
 
             // we are simulating assignment by calling a method for this

--- a/Tests/Python/PythonOptionTests.cs
+++ b/Tests/Python/PythonOptionTests.cs
@@ -96,7 +96,7 @@ namespace QuantConnect.Tests.Python
                     {"Tracking Error", "0"},
                     {"Treynor Ratio", "0"},
                     {"Total Fees", "$1.00"},
-                    {"OrderListHash", "-1843155373"}
+                    {"OrderListHash", "1284171158"}
                     },
                     Language.Python,
                     AlgorithmStatus.Completed);
@@ -152,7 +152,7 @@ namespace QuantConnect.Tests.Python
                     {"Mean Population Magnitude", "0%"},
                     {"Rolling Averaged Population Direction", "0%"},
                     {"Rolling Averaged Population Magnitude", "0%"},
-                    {"OrderListHash", "-1438496252"}
+                    {"OrderListHash", "687310345"}
                 },
                 Language.Python,
                 AlgorithmStatus.Completed);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
All order types in LEAN use directional quantities to indicate the change in holdings resulting from filling the order except `OptionExerciseOrder`. This order type was initially set up to only support positive quantities indicating exercise of an options contract. Option assignment was later implemented and used negative quantities. This discrepancy appears to be due to organic evolution and this change aims to bring this order type into alignment with the other order types to maintain consistency of the `Order` abstraction,.

#### Description
* Improve information tracked in regression's {algorithm}.{lang}.details.log

> Greatly improves information tracked for regression tests. See commit message for more details.

* Fix typo in options OrderTests test case name

* Update SymbolRepresentation.GenerationOptionTickerOSI to extension method

> Far more convenient as an extension method

* Improve R# default code formatting rules

> Many of these rule changes focus on improving the readability of code,
with a particular emphasis on multi-line constructs, chained method calls
and multi-line method invocations/declarations.

* Add braces, use string interpolation and limit long lines

* Refactor OptionExerciseOrder.Quantity to indicate change in #contracts

> For all other order types, the Order.Quantity indicates the change in the algorithm's
holdings upon order execution for the order's symbol. For OptionExerciseOrder, this
convention was broken. It appears as though only exercise was initially implemented,
in which case only long positions were supported and a code comment indicated that
only positive values of quantity were acceptable, indicating the number of contracts
to exercise. At a later date, assignment simulation was added and utilized a negative
order quantity. This caused some major inconsistencies in how models view exercise
orders compared to all other order types. This change brings OptionExerciseOrder.Quantity
into alignment with the other order types by making it represent the change in holdings
quantity upon order execution.

> Fixes OptionPortfolioModelTests to go through the exercise model to ensure consistency
and completeness of the test.

> This change was originally going to be much larger, but in order to minimize risks and to
make for an easier review experience, the additional changes will be committed separately
and pushed in their own PR. Some of the issues identified include:
=Manual Exercise (especially for OTM) is not covered
=Margin Calculations (in particular taking into account opposing contracts held)
=Brokerage.OptionPositionAssigned is raised for exercise (later filtered by tx handler)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #4766

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See #4766 TL;DR; `OptionExerciseOrder.Quantity` didn't follow LEAN conventions for order quantity. Upon execution, the order's quantity should represent the change in holdings, but for `OptionExerciseOrder`, positive values indicated an exercise while negative values indicated assignment.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Perhaps. The `QCAlgorithm.ExcerciseOption` method will accept positive or negative values here. Since you must be long the contract, we don't need to validate based on the quantity supplied. The `SubmitOrderRequest.Quantity` ends up being negative to match the `Order.Quantity` as is convention, but for backwards compatibility and also just from the way the method is phrased, it makes sense to accept positive values here. Also, if you look at something like `QCAlgorithm.Buy` or `QCAlgorithm.Sell`, we do something similar, where the direction is implied by the method and we use `Math.Abs(quantity)` to ensure the sign of quantity is correct per the method called.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing unit and regression tests. The original outline of this PR was broader in scope when I wasn't as familiar. As I became more familiar with the stack, it became obvious these quantity consistency changes could be made with a scalpel rather than a hammer.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [-] Breaking change (fix or feature that would cause existing functionality to change)
* _kind of_ -- algorithms that depend on `Order.Quantity` or `OrderEvent.Quantity` and are expecting positive to imply exercise and negative to imply assignment would be affected. @jaredbroad -- we need to determine if this is an acceptable level of breaking change. I suspect the actual number of algorithms impacted to be minimal, but worthy of a check.
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
