### PR TITLE
Set Account Base Currency from Brokerage in Live Mode

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1135,6 +1135,8 @@ namespace QuantConnect.Algorithm
                     "Cannot change AccountCurrency after algorithm initialized.");
             }
 
+            Debug($"Changing account currency from {AccountCurrency} to {accountCurrency}...");
+
             Portfolio.SetAccountCurrency(accountCurrency);
         }
 

--- a/Brokerages/Alpaca/AlpacaBrokerage.cs
+++ b/Brokerages/Alpaca/AlpacaBrokerage.cs
@@ -117,6 +117,8 @@ namespace QuantConnect.Brokerages.Alpaca
         {
             if (IsConnected) return;
 
+            AccountBaseCurrency = GetAccountBaseCurrency();
+
             _sockClient.Connect();
         }
 
@@ -153,8 +155,7 @@ namespace QuantConnect.Brokerages.Alpaca
 
             return new List<CashAmount>
             {
-                new CashAmount(balance.TradableCash,
-                    Currencies.USD)
+                new CashAmount(balance.TradableCash, balance.Currency)
             };
         }
 
@@ -291,6 +292,19 @@ namespace QuantConnect.Brokerages.Alpaca
             {
                 yield return item;
             }
+        }
+
+        /// <summary>
+        /// Gets the account base currency
+        /// </summary>
+        private string GetAccountBaseCurrency()
+        {
+            CheckRateLimiting();
+
+            var task = _alpacaTradingClient.GetAccountAsync();
+            var balance = task.SynchronouslyAwaitTaskResult();
+
+            return balance.Currency;
         }
 
         #endregion

--- a/Brokerages/Binance/BinanceBrokerage.cs
+++ b/Brokerages/Binance/BinanceBrokerage.cs
@@ -118,6 +118,11 @@ namespace QuantConnect.Brokerages.Binance
         public override bool IsConnected => WebSocket.IsOpen;
 
         /// <summary>
+        /// Returns the brokerage account's base currency
+        /// </summary>
+        public override string AccountBaseCurrency => "USDT";
+
+        /// <summary>
         /// Creates wss connection
         /// </summary>
         public override void Connect()

--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -224,6 +224,11 @@ namespace QuantConnect.Brokerages
         public virtual bool AccountInstantlyUpdated => false;
 
         /// <summary>
+        /// Returns the brokerage account's base currency
+        /// </summary>
+        public virtual string AccountBaseCurrency { get; protected set; } = Currencies.USD;
+
+        /// <summary>
         /// Gets the history for the requested security
         /// </summary>
         /// <param name="request">The historical data request</param>

--- a/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.Messaging.cs
@@ -59,8 +59,6 @@ namespace QuantConnect.Brokerages.Fxcm
         private readonly Dictionary<string, AutoResetEvent> _mapRequestsToAutoResetEvents = new Dictionary<string, AutoResetEvent>();
         private readonly HashSet<string> _pendingHistoryRequests = new HashSet<string>();
 
-        private string _fxcmAccountCurrency = Currencies.USD;
-
         private void LoadInstruments()
         {
             // Note: requestTradingSessionStatus() MUST be called just after login
@@ -246,7 +244,7 @@ namespace QuantConnect.Brokerages.Fxcm
                 }
 
                 // get account base currency
-                _fxcmAccountCurrency = message.getParameter("BASE_CRNCY").getValue();
+                AccountBaseCurrency = message.getParameter("BASE_CRNCY").getValue();
 
                 _mapRequestsToAutoResetEvents[_currentRequest].Set();
                 _mapRequestsToAutoResetEvents.Remove(_currentRequest);

--- a/Brokerages/Fxcm/FxcmBrokerage.cs
+++ b/Brokerages/Fxcm/FxcmBrokerage.cs
@@ -431,7 +431,7 @@ namespace QuantConnect.Brokerages.Fxcm
 
             //Adds the account currency to the cashbook.
             cashBook.Add(new CashAmount(Convert.ToDecimal(_accounts[_accountId].getCashOutstanding()),
-                _fxcmAccountCurrency));
+                AccountBaseCurrency));
 
             // include cash balances from currency swaps for open Forex positions
             foreach (var trade in _openPositions.Values)

--- a/Brokerages/GDAX/GDAXBrokerage.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.cs
@@ -35,7 +35,13 @@ namespace QuantConnect.Brokerages.GDAX
     {
         private const int MaxDataPointsPerHistoricalRequest = 300;
 
-        private static readonly HashSet<string> FiatCurrencies = new List<string> { "EUR", "GBP", "USD" }.ToHashSet();
+        // These are the only currencies accepted for fiat deposits
+        private static readonly HashSet<string> FiatCurrencies = new List<string>
+        {
+            Currencies.EUR,
+            Currencies.GBP,
+            Currencies.USD
+        }.ToHashSet();
 
         #region IBrokerage
         /// <summary>

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1325,6 +1325,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// </summary>
         private void HandleUpdateAccountValue(object sender, IB.UpdateAccountValueEventArgs e)
         {
+            //Log.Trace($"HandleUpdateAccountValue(): Key:{e.Key} Value:{e.Value} Currency:{e.Currency} AccountName:{e.AccountName}");
+
             try
             {
                 _accountData.AccountProperties[e.Currency + ":" + e.Key] = e.Value;
@@ -1336,6 +1338,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     _accountData.CashBalances.AddOrUpdate(e.Currency, cashBalance);
 
                     OnAccountChanged(new AccountEvent(e.Currency, cashBalance));
+                }
+
+                // IB does not explicitly return the account base currency, but we can find out using exchange rates returned
+                if (e.Key == AccountValueKeys.ExchangeRate && e.Currency != "BASE" && e.Value.ToDecimal() == 1)
+                {
+                    AccountBaseCurrency = e.Currency;
                 }
             }
             catch (Exception err)
@@ -3070,8 +3078,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private static class AccountValueKeys
         {
             public const string CashBalance = "CashBalance";
-            // public const string AccruedCash = "AccruedCash";
-            // public const string NetLiquidationByCurrency = "NetLiquidationByCurrency";
+            public const string ExchangeRate = "ExchangeRate";
         }
 
         // these are fatal errors from IB

--- a/Brokerages/Oanda/OandaBrokerage.cs
+++ b/Brokerages/Oanda/OandaBrokerage.cs
@@ -20,7 +20,6 @@ using System.Linq;
 using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
-using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using QuantConnect.Packets;

--- a/Brokerages/Oanda/OandaBrokerage.cs
+++ b/Brokerages/Oanda/OandaBrokerage.cs
@@ -83,6 +83,11 @@ namespace QuantConnect.Brokerages.Oanda
         }
 
         /// <summary>
+        /// Returns the brokerage account's base currency
+        /// </summary>
+        public override string AccountBaseCurrency => _api.AccountBaseCurrency;
+
+        /// <summary>
         /// Connects the client to the broker's remote servers
         /// </summary>
         public override void Connect()

--- a/Brokerages/Oanda/OandaRestApiBase.cs
+++ b/Brokerages/Oanda/OandaRestApiBase.cs
@@ -28,7 +28,6 @@ using QuantConnect.Orders;
 using QuantConnect.Packets;
 using QuantConnect.Securities;
 using QuantConnect.Util;
-using Timer = System.Timers.Timer;
 
 namespace QuantConnect.Brokerages.Oanda
 {

--- a/Brokerages/Oanda/OandaRestApiBase.cs
+++ b/Brokerages/Oanda/OandaRestApiBase.cs
@@ -183,7 +183,7 @@ namespace QuantConnect.Brokerages.Oanda
                         var symbolsToSubscribe = SubscribedSymbols;
                         // restart streaming session
                         SubscribeSymbols(symbolsToSubscribe);
-                        
+
                     } while (!_streamingCancellationTokenSource.IsCancellationRequested);
                 },
                 TaskCreationOptions.LongRunning
@@ -280,6 +280,8 @@ namespace QuantConnect.Brokerages.Oanda
         /// </summary>
         public override void Connect()
         {
+            AccountBaseCurrency = GetAccountBaseCurrency();
+
             // Register to the event session to receive events.
             StartTransactionStream();
 
@@ -301,6 +303,11 @@ namespace QuantConnect.Brokerages.Oanda
 
             _isConnected = false;
         }
+
+        /// <summary>
+        /// Gets the account base currency
+        /// </summary>
+        public abstract string GetAccountBaseCurrency();
 
         /// <summary>
         /// Gets the list of available tradable instruments/products from Oanda

--- a/Brokerages/Oanda/OandaRestApiV1.cs
+++ b/Brokerages/Oanda/OandaRestApiV1.cs
@@ -65,6 +65,15 @@ namespace QuantConnect.Brokerages.Oanda
         }
 
         /// <summary>
+        /// Gets the account base currency
+        /// </summary>
+        public override string GetAccountBaseCurrency()
+        {
+            // The OANDA v1 REST API is deprecated
+            return Currencies.USD;
+        }
+
+        /// <summary>
         /// Gets the list of available tradable instruments/products from Oanda
         /// </summary>
         public override List<string> GetInstrumentList()

--- a/Brokerages/Oanda/OandaRestApiV20.cs
+++ b/Brokerages/Oanda/OandaRestApiV20.cs
@@ -83,6 +83,16 @@ namespace QuantConnect.Brokerages.Oanda
         }
 
         /// <summary>
+        /// Gets the account base currency
+        /// </summary>
+        public override string GetAccountBaseCurrency()
+        {
+            var response = _apiRest.GetAccount(Authorization, AccountId);
+
+            return response.Account.Currency;
+        }
+
+        /// <summary>
         /// Gets the list of available tradable instruments/products from Oanda
         /// </summary>
         public override List<string> GetInstrumentList()

--- a/Common/Currencies.cs
+++ b/Common/Currencies.cs
@@ -28,6 +28,16 @@ namespace QuantConnect
         public static string USD = "USD";
 
         /// <summary>
+        /// EUR currency string
+        /// </summary>
+        public static string EUR = "EUR";
+
+        /// <summary>
+        /// GBP currency string
+        /// </summary>
+        public static string GBP = "GBP";
+
+        /// <summary>
         /// Null currency used when a real one is not required
         /// </summary>
         public const string NullCurrency = "QCC";

--- a/Common/Interfaces/IBrokerage.cs
+++ b/Common/Interfaces/IBrokerage.cs
@@ -113,6 +113,11 @@ namespace QuantConnect.Interfaces
         bool AccountInstantlyUpdated { get; }
 
         /// <summary>
+        /// Returns the brokerage account's base currency
+        /// </summary>
+        string AccountBaseCurrency { get; }
+
+        /// <summary>
         /// Gets the history for the requested security
         /// </summary>
         /// <param name="request">The historical data request</param>

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -294,10 +294,19 @@ namespace QuantConnect.Securities
         /// <returns>A <see cref="string"/> that represents the current <see cref="Cash"/>.</returns>
         public override string ToString()
         {
+            return ToString(Currencies.USD);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="string"/> that represents the current <see cref="Cash"/>.
+        /// </summary>
+        /// <returns>A <see cref="string"/> that represents the current <see cref="Cash"/>.</returns>
+        public string ToString(string accountCurrency)
+        {
             // round the conversion rate for output
             var rate = ConversionRate;
             rate = rate < 1000 ? rate.RoundToSignificantDigits(5) : Math.Round(rate, 2);
-            return Invariant($"{Symbol}: {CurrencySymbol}{Amount,15:0.00} @ {rate,10:0.00####} = ${Math.Round(ValueInAccountCurrency, 2)}");
+            return Invariant($"{Symbol}: {CurrencySymbol}{Amount,15:0.00} @ {rate,10:0.00####} = {Currencies.GetCurrencySymbol(accountCurrency)}{Math.Round(ValueInAccountCurrency, 2)}");
         }
 
         private static IEnumerable<KeyValuePair<SecurityDatabaseKey, SymbolProperties>> GetAvailableSymbolPropertiesDatabaseEntries(

--- a/Common/Securities/CashBook.cs
+++ b/Common/Securities/CashBook.cs
@@ -195,7 +195,7 @@ namespace QuantConnect.Securities
             sb.AppendLine(Invariant($"Symbol {"Quantity",13}    {"Conversion",10} = Value in {AccountCurrency}"));
             foreach (var value in _currencies.Select(x => x.Value))
             {
-                sb.AppendLine(value.ToString());
+                sb.AppendLine(value.ToString(AccountCurrency));
             }
             sb.AppendLine("-------------------------------------------------");
             sb.AppendLine("CashBook Total Value:                " +

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -458,7 +458,9 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="value">Current equity value.</param>
         protected virtual void SampleEquity(DateTime time, decimal value)
         {
-            Sample("Strategy Equity", "Equity", 0, SeriesType.Candle, time, value);
+            var accountCurrencySymbol = Currencies.GetCurrencySymbol(Algorithm.AccountCurrency);
+
+            Sample("Strategy Equity", "Equity", 0, SeriesType.Candle, time, value, accountCurrencySymbol);
         }
 
         /// <summary>
@@ -525,13 +527,15 @@ namespace QuantConnect.Lean.Engine.Results
                 runtimeStatistics["Probabilistic Sharpe Ratio"] = "0%";
             }
 
-            runtimeStatistics["Unrealized"] = "$" + Algorithm.Portfolio.TotalUnrealizedProfit.ToStringInvariant("N2");
-            runtimeStatistics["Fees"] = "-$" + Algorithm.Portfolio.TotalFees.ToStringInvariant("N2");
-            runtimeStatistics["Net Profit"] = "$" + Algorithm.Portfolio.TotalProfit.ToStringInvariant("N2");
+            var accountCurrencySymbol = Currencies.GetCurrencySymbol(Algorithm.AccountCurrency);
+
+            runtimeStatistics["Unrealized"] = accountCurrencySymbol + Algorithm.Portfolio.TotalUnrealizedProfit.ToStringInvariant("N2");
+            runtimeStatistics["Fees"] = $"-{accountCurrencySymbol}{Algorithm.Portfolio.TotalFees.ToStringInvariant("N2")}";
+            runtimeStatistics["Net Profit"] = accountCurrencySymbol + Algorithm.Portfolio.TotalProfit.ToStringInvariant("N2");
             runtimeStatistics["Return"] = GetNetReturn().ToStringInvariant("P");
-            runtimeStatistics["Equity"] = "$" + Algorithm.Portfolio.TotalPortfolioValue.ToStringInvariant("N2");
-            runtimeStatistics["Holdings"] = "$" + Algorithm.Portfolio.TotalHoldingsValue.ToStringInvariant("N2");
-            runtimeStatistics["Volume"] = "$" + Algorithm.Portfolio.TotalSaleVolume.ToStringInvariant("N2");
+            runtimeStatistics["Equity"] = accountCurrencySymbol + Algorithm.Portfolio.TotalPortfolioValue.ToStringInvariant("N2");
+            runtimeStatistics["Holdings"] = accountCurrencySymbol + Algorithm.Portfolio.TotalHoldingsValue.ToStringInvariant("N2");
+            runtimeStatistics["Volume"] = accountCurrencySymbol + Algorithm.Portfolio.TotalSaleVolume.ToStringInvariant("N2");
 
             return runtimeStatistics;
         }

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -199,8 +199,6 @@ namespace QuantConnect.Lean.Engine.Setup
 
                 if (brokerage.AccountBaseCurrency != algorithm.AccountCurrency)
                 {
-                    Log.Trace($"BrokerageSetupHandler.Setup(): Changing account currency from {algorithm.AccountCurrency} to {brokerage.AccountBaseCurrency}");
-
                     algorithm.SetAccountCurrency(brokerage.AccountBaseCurrency);
                 }
 

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -275,6 +275,8 @@ namespace QuantConnect.Lean.Engine.Setup
                     return false;
                 }
 
+                Log.Trace($"BrokerageSetupHandler.Setup(): {brokerage.Name} account base currency: {brokerage.AccountBaseCurrency}");
+
                 Log.Trace("BrokerageSetupHandler.Setup(): Fetching cash balance from brokerage...");
                 try
                 {

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -255,13 +255,6 @@ namespace QuantConnect.Lean.Engine.Setup
                         //Initialise the algorithm, get the required data:
                         algorithm.Initialize();
 
-                        if (algorithm.AccountCurrency != Currencies.USD)
-                        {
-                            throw new NotImplementedException(
-                                "BrokerageSetupHandler.Setup(): calling 'QCAlgorithm.SetAccountCurrency()' " +
-                                "is only supported in backtesting for now.");
-                        }
-
                         if (liveJob.Brokerage != "PaperBrokerage")
                         {
                             //Zero the CashBook - we'll populate directly from brokerage

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -195,7 +195,11 @@ namespace QuantConnect.Lean.Engine.Setup
                     return false;
                 }
 
-                Log.Trace($"BrokerageSetupHandler.Setup(): {brokerage.Name} account base currency: {brokerage.AccountBaseCurrency}");
+                var message = $"{brokerage.Name} account base currency: {brokerage.AccountBaseCurrency}";
+
+                Log.Trace($"BrokerageSetupHandler.Setup(): {message}");
+
+                algorithm.Debug(message);
 
                 if (brokerage.AccountBaseCurrency != algorithm.AccountCurrency)
                 {

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -100,7 +100,7 @@
   "fxcm-account-id": "",
 
   // iqfeed configuration
-  "iqfeed-host": "127.0.0.1", 
+  "iqfeed-host": "127.0.0.1",
   "iqfeed-username": "",
   "iqfeed-password": "",
   "iqfeed-productName": "",

--- a/Tests/Algorithm/AlgorithmLiveTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmLiveTradingTests.cs
@@ -88,6 +88,7 @@ namespace QuantConnect.Tests.Algorithm
             public void Connect() {}
             public void Disconnect() {}
             public bool AccountInstantlyUpdated { get; } = true;
+            public string AccountBaseCurrency => Currencies.USD;
             public IEnumerable<BaseData> GetHistory(HistoryRequest request) { return Enumerable.Empty<BaseData>(); }
             public DateTime LastSyncDateTimeUtc { get; } = DateTime.UtcNow;
             public bool ShouldPerformCashSync(DateTime currentTimeUtc) { return false; }

--- a/Tests/Brokerages/GDAX/GDAXBrokerageTests.cs
+++ b/Tests/Brokerages/GDAX/GDAXBrokerageTests.cs
@@ -140,6 +140,8 @@ namespace QuantConnect.Tests.Brokerages.GDAX
         [Test]
         public void ConnectTest()
         {
+            SetupResponse(_accountsData);
+
             _wss.Setup(m => m.Connect()).Raises(m => m.Open += null, EventArgs.Empty).Verifiable();
             _wss.Setup(m => m.IsOpen).Returns(false);
             _unit.Connect();

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -128,6 +128,7 @@ namespace QuantConnect.Tests.Engine.Setup
             var brokerage = new Mock<IBrokerage>();
 
             brokerage.Setup(x => x.IsConnected).Returns(true);
+            brokerage.Setup(x => x.AccountBaseCurrency).Returns(Currencies.USD);
             brokerage.Setup(x => x.GetCashBalance()).Returns(new List<CashAmount>());
             brokerage.Setup(x => x.GetAccountHoldings()).Returns(getHoldings);
             brokerage.Setup(x => x.GetOpenOrders()).Returns(getOrders);
@@ -181,6 +182,7 @@ namespace QuantConnect.Tests.Engine.Setup
             var objectStore = new Mock<IObjectStore>();
 
             brokerage.Setup(x => x.IsConnected).Returns(true);
+            brokerage.Setup(x => x.AccountBaseCurrency).Returns(Currencies.USD);
             brokerage.Setup(x => x.GetCashBalance()).Returns(new List<CashAmount>());
             brokerage.Setup(x => x.GetAccountHoldings()).Returns(new List<Holding>
             {
@@ -228,6 +230,7 @@ namespace QuantConnect.Tests.Engine.Setup
             var objectStore = new Mock<IObjectStore>();
 
             brokerage.Setup(x => x.IsConnected).Returns(true);
+            brokerage.Setup(x => x.AccountBaseCurrency).Returns(Currencies.USD);
             brokerage.Setup(x => x.GetCashBalance()).Returns(new List<CashAmount>());
             brokerage.Setup(x => x.GetAccountHoldings()).Returns(new List<Holding>
             {
@@ -283,6 +286,7 @@ namespace QuantConnect.Tests.Engine.Setup
             var objectStore = new Mock<IObjectStore>();
 
             brokerage.Setup(x => x.IsConnected).Returns(true);
+            brokerage.Setup(x => x.AccountBaseCurrency).Returns(Currencies.USD);
             brokerage.Setup(x => x.GetCashBalance()).Returns(new List<CashAmount>());
             brokerage.Setup(x => x.GetAccountHoldings()).Returns(new List<Holding>());
             brokerage.Setup(x => x.GetOpenOrders()).Returns(new List<Order>());
@@ -324,6 +328,7 @@ namespace QuantConnect.Tests.Engine.Setup
             var objectStore = new Mock<IObjectStore>();
 
             brokerage.Setup(x => x.IsConnected).Returns(true);
+            brokerage.Setup(x => x.AccountBaseCurrency).Returns(Currencies.USD);
             brokerage.Setup(x => x.GetCashBalance()).Returns(
                 hasCashBalance
                     ? new List<CashAmount>

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -356,15 +356,11 @@ namespace QuantConnect.Tests.Engine.Setup
             Assert.IsTrue(setupHandler.Setup(new SetupHandlerParameters(dataManager.UniverseSelection, algorithm, brokerage.Object, job, resultHandler.Object,
                 transactionHandler.Object, realTimeHandler.Object, objectStore.Object)));
 
-            if (hasCashBalance || hasHoldings)
+            if (!hasCashBalance && !hasHoldings)
             {
-                Assert.AreEqual(0, algorithm.DebugMessages.Count);
-            }
-            else
-            {
-                Assert.AreEqual(1, algorithm.DebugMessages.Count);
+                Assert.That(algorithm.DebugMessages.Count > 0);
 
-                Assert.That(algorithm.DebugMessages.First().Contains("No cash balances or holdings were found in the brokerage account."));
+                Assert.That(algorithm.DebugMessages.Any(x => x.Contains("No cash balances or holdings were found in the brokerage account.")));
             }
         }
 


### PR DESCRIPTION

#### Description
- Added a new property: `IBrokerage.AccountBaseCurrency`
- All brokerage implementations now set `IBrokerage.AccountBaseCurrency` after a successful connection
- In `BrokerageSetupHandler.Setup()` the USD account currency check has been removed and the algorithm account currency is set equal to the brokerage account base currency
- The `brokerage.Connect()` method is now called before `algorithm.Initialize()`
- `CashBook.ToString()` now returns the correct account currency symbol, instead of the hardcoded `$` sign

#### Related Issue
#110

#### Motivation and Context
- Enable users with non-USD accounts to use their brokerage account base currency

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Tested locally and in cloud with all brokerages

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.