### PR TITLE
ObjectStore delete will delete file

### DIFF
--- a/Engine/Storage/LocalObjectStore.cs
+++ b/Engine/Storage/LocalObjectStore.cs
@@ -248,6 +248,19 @@ namespace QuantConnect.Lean.Engine.Storage
             {
                 _dirty = true;
 
+                try
+                {
+                    var path = GetFilePathForKey(key);
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    Log.Error(exception);
+                }
+
                 // if <= 0 we disable periodic persistence and make it synchronous
                 if (Controls.PersistenceIntervalSeconds <= 0)
                 {
@@ -275,7 +288,7 @@ namespace QuantConnect.Lean.Engine.Storage
             var contents = ReadBytes(key);
 
             // write byte array to storage directory
-            var path = Path.Combine(AlgorithmStorageRoot, $"{key.ToMD5()}.dat");
+            var path = GetFilePathForKey(key);
             File.WriteAllBytes(path, contents);
 
             return path;
@@ -324,6 +337,14 @@ namespace QuantConnect.Lean.Engine.Storage
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
+        }
+
+        /// <summary>
+        /// Get's the file path for a giving object store key
+        /// </summary>
+        private string GetFilePathForKey(string key)
+        {
+            return Path.Combine(AlgorithmStorageRoot, $"{key.ToMD5()}.dat");
         }
 
         /// <summary>

--- a/Tests/Common/Storage/LocalObjectStoreTests.cs
+++ b/Tests/Common/Storage/LocalObjectStoreTests.cs
@@ -134,6 +134,18 @@ namespace QuantConnect.Tests.Common.Storage
             }
         }
 
+        [Test]
+        public void GetFilePathAndDelete()
+        {
+            var key = "ILove";
+            _store.SaveString(key, "Pizza");
+            var path = _store.GetFilePath(key);
+
+            Assert.IsTrue(File.Exists(path));
+            _store.Delete(key);
+            Assert.IsFalse(File.Exists(path));
+        }
+
         [TestCase(FileAccess.Read, false)]
         [TestCase(FileAccess.ReadWrite, false)]
         [TestCase(0, true)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- LocalObjectStore.Delete() will also delete file from the local object
  store path if present, this will avoid the issue where restarting the
  object store will re load the same deleted file. Adding unit test.
  Issue https://github.com/QuantConnect/Lean/issues/4811

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/4811
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix bug
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests, cloud research testing
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
