### PR TITLE
Notebook fix for `DirectoryNotFoundException` on linux/mac

### DIFF
--- a/Research/run_docker_notebook.sh
+++ b/Research/run_docker_notebook.sh
@@ -61,7 +61,7 @@ fi
 
 echo "Starting docker container; container id is:"
 sudo docker run -d --rm -p 8888:8888 \
-    --mount type=bind,source=$data_dir,target=/Data,readonly \
+    --mount type=bind,source=$data_dir,target=/home/Data,readonly \
     --mount type=bind,source=$notebook_dir,target=/Lean/Launcher/bin/Debug/Notebooks \
     $image
 


### PR DESCRIPTION
When running Notebook locally with docker, a `DirectoryNotFoundException` occur.

#### Description
This exception happen when we try to instantiate `QuantBook`.
```python
qb = QuantBook()
```

#### Exception
```
DirectoryNotFoundException                Traceback (most recent call last)
<ipython-input-2-427fabfba9aa> in <module>
----> 1 qb = QuantBook()

DirectoryNotFoundException: Could not find a part of the path "/home/Data/market-hours/market-hours-database.json".
  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) [0x00164] in <b0e1ad7573a24fd5a9f2af9595e677e7>:0 
  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.IO.FileOptions options, System.String msgPath, System.Boolean bFromProxy, System.Boolean useLongPath, System.Boolean checkHost) [0x00000] in <b0e1ad7573a24fd5a9f2af9595e677e7>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileStream..ctor(string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,int,System.IO.FileOptions,string,bool,bool,bool)
  at System.IO.StreamReader..ctor (System.String path, System.Text.Encoding encoding, System.Boolean detectEncodingFromByteOrderMarks, System.Int32 bufferSize, System.Boolean checkHost) [0x00067] in <b0e1ad7573a24fd5a9f2af9595e677e7>:0 
  at System.IO.StreamReader..ctor (System.String path, System.Text.Encoding encoding, System.Boolean detectEncodingFromByteOrderMarks, System.Int32 bufferSize) [0x00000] in <b0e1ad7573a24fd5a9f2af9595e677e7>:0 
  at System.IO.StreamReader..ctor (System.String path, System.Boolean detectEncodingFromByteOrderMarks) [0x0000d] in <b0e1ad7573a24fd5a9f2af9595e677e7>:0 
  at System.IO.StreamReader..ctor (System.String path) [0x00000] in <b0e1ad7573a24fd5a9f2af9595e677e7>:0 
  at (wrapper remoting-invoke-with-check) System.IO.StreamReader..ctor(string)
  at System.IO.File.ReadAllText (System.String path) [0x00000] in <b0e1ad7573a24fd5a9f2af9595e677e7>:0 
  at QuantConnect.Securities.MarketHoursDatabase.FromFile (System.String path) [0x00000] in <e2b18afcfef646d2853f071d544bd356>:0 
  at QuantConnect.Securities.MarketHoursDatabase.FromDataFolder (System.String dataFolder) [0x00028] in <e2b18afcfef646d2853f071d544bd356>:0 
  at QuantConnect.Securities.MarketHoursDatabase.FromDataFolder () [0x00005] in <e2b18afcfef646d2853f071d544bd356>:0 
  at QuantConnect.Algorithm.QCAlgorithm..ctor () [0x001e1] in <c0911610d8994f9bbec83ecbf4cea040>:0 
  at QuantConnect.Research.QuantBook..ctor () [0x00000] in <2b5ded7bd0194845a166350e5b25782b>:0 
  at (wrapper managed-to-native) System.Reflection.MonoCMethod.InternalInvoke(System.Reflection.MonoCMethod,object,object[],System.Exception&)
  at System.Reflection.MonoCMethod.InternalInvoke (System.Object obj, System.Object[] parameters) [0x00002] in <b0e1ad7573a24fd5a9f2af9595e677e7>:0 
```

