### PR TITLE
Add RollingIndicatorHistoryWindow to allow for caching of indicator results

### DIFF
--- a/Indicators/AverageDirectionalMovementIndexRating.cs
+++ b/Indicators/AverageDirectionalMovementIndexRating.cs
@@ -25,7 +25,7 @@ namespace QuantConnect.Indicators
     public class AverageDirectionalMovementIndexRating : BarIndicator, IIndicatorWarmUpPeriodProvider
     {
         private readonly int _period;
-        private readonly RollingWindow<decimal> _adxHistory;
+        private readonly RollingIndicatorHistoryWindow _adxHistory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AverageDirectionalMovementIndexRating"/> class using the specified name and period.
@@ -37,7 +37,7 @@ namespace QuantConnect.Indicators
         {
             _period = period;
             ADX = new AverageDirectionalIndex(name + "_ADX", period);
-            _adxHistory = new RollingWindow<decimal>(period);
+            _adxHistory = new RollingIndicatorHistoryWindow(ADX, period);
         }
 
         /// <summary>
@@ -72,12 +72,6 @@ namespace QuantConnect.Indicators
         protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             ADX.Update(input);
-
-            if (ADX.IsReady)
-            {
-                _adxHistory.Add(ADX);
-            }
-
             return IsReady ? (ADX + _adxHistory[_period - 1]) / 2 : 50m;
         }
 

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -180,10 +180,11 @@
     <Compile Include="DoubleExponentialMovingAverage.cs" />
     <Compile Include="PythonIndicator.cs" />
     <Compile Include="IntradayVwap.cs" />
+    <Compile Include="RollingIndicatorHistoryWindow.cs" />
     <Compile Include="SchaffTrendCycle.cs" />
     <Compile Include="WilderMovingAverage.cs" />
     <Compile Include="FractalAdaptiveMovingAverage.cs" />
-    <Compile Include="EaseOfMovementValue.cs"/>
+    <Compile Include="EaseOfMovementValue.cs" />
     <Compile Include="FilteredIdentity.cs" />
     <Compile Include="HullMovingAverage.cs" />
     <Compile Include="MassIndex.cs" />

--- a/Indicators/RollingIndicatorHistoryWindow.cs
+++ b/Indicators/RollingIndicatorHistoryWindow.cs
@@ -1,0 +1,31 @@
+﻿namespace QuantConnect.Indicators
+{
+    /// <summary>
+    /// Wraps an indicator to allow for storing a rolling window of output results from the indicator
+    /// </summary>
+    public class RollingIndicatorHistoryWindow : RollingWindow<decimal>
+    {
+        /// <summary>
+        /// Indicator the window wraps 
+        /// </summary>
+        public IIndicator WrappedIndicator { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the RollingIndicatorHistoryWindow class
+        /// </summary>
+        /// <param name="wrappedIndicator">The indicator to wrap</param>
+        /// <param name="size">The number of results to keep in the window</param>
+        public RollingIndicatorHistoryWindow(IIndicator wrappedIndicator, int size)
+            : base(size)
+        {
+            WrappedIndicator = wrappedIndicator;
+            wrappedIndicator.Updated += (sender, indicatorDataPoint) =>
+            {
+                if (wrappedIndicator.IsReady)
+                {
+                    Add(indicatorDataPoint.Value);
+                }
+            };
+        }
+    }
+}

--- a/Tests/Indicators/RollingIndicatorHistoryWindowTests.cs
+++ b/Tests/Indicators/RollingIndicatorHistoryWindowTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Moq;
+using NUnit.Framework;
+using QuantConnect.Indicators;
+
+namespace QuantConnect.Tests.Indicators
+{
+    [TestFixture]
+    public class RollingIndicatorHistoryWindowTests
+    {
+        private Mock<IIndicator> _wrappedIndicatorMock;
+        private RollingIndicatorHistoryWindow _underTest;
+        private const int HistorySize = 3;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _wrappedIndicatorMock = new Mock<IIndicator>();
+            _underTest = new RollingIndicatorHistoryWindow(_wrappedIndicatorMock.Object, HistorySize);
+        }
+
+        [Test]
+        public void OnlyAddIfWrappedIndicatorIsReady()
+        {
+            _wrappedIndicatorMock.Setup(x => x.IsReady).Returns(false);
+            _wrappedIndicatorMock.Raise(x => x.Updated += null, _wrappedIndicatorMock.Object, new IndicatorDataPoint(DateTime.Now, 1));
+
+            _wrappedIndicatorMock.Setup(x => x.IsReady).Returns(true);
+            _wrappedIndicatorMock.Raise(x => x.Updated += null, _wrappedIndicatorMock.Object, new IndicatorDataPoint(DateTime.Now, 2));
+
+            CollectionAssert.AreEqual(new decimal[] {2}, _underTest);
+        }
+
+        [Test]
+        public void HistorySizeIsPassedCorrectly()
+        {
+            _wrappedIndicatorMock.Setup(x => x.IsReady).Returns(true);
+
+            var values = new[] {1, 2, 3, 4};
+            foreach(var value in values)
+            {
+                _wrappedIndicatorMock.Raise(x => x.Updated += null, _wrappedIndicatorMock.Object, new IndicatorDataPoint(DateTime.Now, value));
+            }
+
+            CollectionAssert.AreEqual(new decimal[] {4, 3, 2}, _underTest);
+        }
+
+        [Test]
+        public void ReturnsWrappedIndicatorCorrectly()
+        {
+            Assert.AreSame(_wrappedIndicatorMock.Object, _underTest.WrappedIndicator);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -723,6 +723,7 @@
     <Compile Include="Indicators\ParabolicStopAndReverseTests.cs" />
     <Compile Include="Indicators\PercentagePriceOscillatorTests.cs" />
     <Compile Include="Indicators\FisherTransformTests.cs" />
+    <Compile Include="Indicators\RollingIndicatorHistoryWindowTests.cs" />
     <Compile Include="Indicators\SchaffTrendCycleTests.cs" />
     <Compile Include="Indicators\SwissArmyKnifeTests.cs" />
     <Compile Include="Indicators\VolumeWeightedAveragePriceIndicatorTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Fixes #3372.

Rather than adding the rolling window to each indicator (which would be quite intrusive to the codebase), this has been created as a wrapper for an indicator that caches based upon the Updated event of the Indicator.

Additionally, this means that indicators with multiple contained Indicators (for example, the Bollinger Bands indicator which has 3 contained indicators - upper band, lower band and middle band) can be cached by having multiple RollingIndicatorHistoryWindow instances.

Usage:
`           var wrappedIndicator = algorithm.ADX(symbol, period);`
`           var history = new RollingIndicatorHistoryWindow(wrappedIndicator, historySize);`
`           ... indicator is updated ...`
`           var latestUpdate = history[0];`

#### Related Issue
#3372

#### Motivation and Context
Ability for users to cache indicator output values.

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
Unit tests included in change

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
