### PR TITLE
Fix Bitfinex Liquidate error with AccountType.Cash

### DIFF
--- a/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
@@ -399,6 +399,15 @@ namespace QuantConnect.Brokerages.Bitfinex
                         : OrderStatus.PartiallyFilled;
                 }
 
+                if (_algorithm.BrokerageModel.AccountType == AccountType.Cash &&
+                    order.Direction == OrderDirection.Buy)
+                {
+                    // fees are debited in the base currency, so we have to subtract them from the filled quantity
+                    fillQuantity -= orderFee.Value.Amount;
+
+                    orderFee = new ModifiedFillQuantityOrderFee(orderFee.Value);
+                }
+
                 var orderEvent = new OrderEvent
                 (
                     order.Id, symbol, updTime, status,

--- a/Common/Orders/Fees/ModifiedFillQuantityOrderFee.cs
+++ b/Common/Orders/Fees/ModifiedFillQuantityOrderFee.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Securities;
+
+namespace QuantConnect.Orders.Fees
+{
+    /// <summary>
+    /// An order fee where the fee quantity has already been subtracted from the filled quantity
+    /// </summary>
+    /// <remarks>
+    /// This type of order fee is returned by some crypto brokerages (e.g. Bitfinex and Binance)
+    /// with buy orders with cash accounts.
+    /// </remarks>
+    public class ModifiedFillQuantityOrderFee : OrderFee
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModifiedFillQuantityOrderFee"/> class
+        /// </summary>
+        /// <param name="orderFee">The order fee</param>
+        public ModifiedFillQuantityOrderFee(CashAmount orderFee)
+            : base(orderFee)
+        {
+        }
+
+        /// <summary>
+        /// Applies the order fee to the given portfolio
+        /// </summary>
+        /// <param name="portfolio">The portfolio instance</param>
+        /// <param name="fill">The order fill event</param>
+        public override void ApplyToPortfolio(SecurityPortfolioManager portfolio, OrderEvent fill)
+        {
+            // do not apply the fee twice
+        }
+    }
+}

--- a/Common/Orders/Fees/OrderFee.cs
+++ b/Common/Orders/Fees/OrderFee.cs
@@ -14,6 +14,7 @@
 */
 
 using QuantConnect.Securities;
+
 namespace QuantConnect.Orders.Fees
 {
     /// <summary>
@@ -35,6 +36,16 @@ namespace QuantConnect.Orders.Fees
             Value = new CashAmount(
                 orderFee.Amount.Normalize(),
                 orderFee.Currency);
+        }
+
+        /// <summary>
+        /// Applies the order fee to the given portfolio
+        /// </summary>
+        /// <param name="portfolio">The portfolio instance</param>
+        /// <param name="fill">The order fill event</param>
+        public virtual void ApplyToPortfolio(SecurityPortfolioManager portfolio, OrderEvent fill)
+        {
+            portfolio.CashBook[Value.Currency].AddAmount(-Value.Amount);
         }
 
         /// <summary>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -370,6 +370,7 @@
     <Compile Include="IsolatorLimitResultProvider.cs" />
     <Compile Include="ITimeProvider.cs" />
     <Compile Include="Orders\Fees\AlphaStreamsFeeModel.cs" />
+    <Compile Include="Orders\Fees\ModifiedFillQuantityOrderFee.cs" />
     <Compile Include="Orders\Fills\Fill.cs" />
     <Compile Include="Orders\Fills\FillModelParameters.cs" />
     <Compile Include="Orders\Fees\FeeModel.cs" />

--- a/Common/Securities/SecurityPortfolioModel.cs
+++ b/Common/Securities/SecurityPortfolioModel.cs
@@ -63,7 +63,8 @@ namespace QuantConnect.Securities
                     var feeThisOrder = fill.OrderFee.Value;
                     feeInAccountCurrency = portfolio.CashBook.ConvertToAccountCurrency(feeThisOrder).Amount;
                     security.Holdings.AddNewFee(feeInAccountCurrency);
-                    portfolio.CashBook[feeThisOrder.Currency].AddAmount(-feeThisOrder.Amount);
+
+                    fill.OrderFee.ApplyToPortfolio(portfolio, fill);
                 }
 
                 // apply the funds using the current settlement model


### PR DESCRIPTION

#### Description
- Moved updating of cashbook for fees from `SecurityPortfolioModel` to `OrderFee`
- Updated `BitfinexBrokerage` to handle fees in base currency (subtracted from the fill quantity)

#### Related Issue
Closes #4851 

#### Motivation and Context
- Incorrect portfolio holding after buying an asset in Bitfinex with `AccountType.Cash`

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Manually tested the example in #4851 with Bitfinex

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`