### PR TITLE
Fix Toolbox tickers parsing

### DIFF
--- a/Configuration/ToolboxArgumentParser.cs
+++ b/Configuration/ToolboxArgumentParser.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.CommandLineUtils;
 
 namespace QuantConnect.Configuration
@@ -86,6 +87,16 @@ namespace QuantConnect.Configuration
         public static Dictionary<string, object> ParseArguments(string[] args)
         {
             return ApplicationParser.Parse(ApplicationName, ApplicationDescription, ApplicationHelpText, args, Options);
+        }
+
+        /// <summary>
+        /// Helper method to get the tickers from the provided options
+        /// </summary>
+        public static List<string> GetTickers(Dictionary<string, object> optionsObject)
+        {
+            return optionsObject.ContainsKey("tickers")
+                ? (optionsObject["tickers"] as Dictionary<string, string>)?.Keys.ToList()
+                : new List<string>();
         }
     }
 }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -766,7 +766,7 @@
     <Compile Include="Symbols.cs" />
     <Compile Include="TestExtensions.cs" />
     <Compile Include="Indicators\LinearWeightedMovingAverageTests.cs" />
-    <Compile Include="ToolBox\BasicTests.cs" />
+    <Compile Include="ToolBox\ToolBoxTests.cs" />
     <Compile Include="ToolBox\PolygonHistoryTests.cs" />
     <Compile Include="ToolBox\PolygonSymbolMapperTests.cs" />
     <Compile Include="ToolBox\EstimizeTests.cs" />

--- a/Tests/ToolBox/ToolBoxTests.cs
+++ b/Tests/ToolBox/ToolBoxTests.cs
@@ -16,14 +16,14 @@
 
 using NUnit.Framework;
 using QuantConnect.Interfaces;
-using QuantConnect.Util;
 using System;
 using System.Linq;
+using QuantConnect.Configuration;
 
 namespace QuantConnect.Tests.ToolBox
 {
     [TestFixture]
-    public class BasicTests
+    public class ToolBoxTests
     {
         [Test]
         public void ComposeDataQueueHandlerInstances()
@@ -41,6 +41,17 @@ namespace QuantConnect.Tests.ToolBox
             {
                 Assert.NotNull(t.GetConstructor(Type.EmptyTypes));
             });            
+        }
+
+        [TestCase("--app=ydl --tickers=AAPL --resolution=Daily --from-date=20200820-00:00:00 --to-date=20200830-00:00:00", 1)]
+        [TestCase("--app=ydl --resolution=Daily --from-date=20200820-00:00:00 --to-date=20200830-00:00:00", 0)]
+        [TestCase("--app=ydl --tickers=AAPL,SPY,TSLA --resolution=Daily --from-date=20200820-00:00:00 --to-date=20200830-00:00:00", 3)]
+        public void CanParseTickersCorrectly(string args, int expectedCount)
+        {
+            var options = ToolboxArgumentParser.ParseArguments(args.Split(' '));
+            var tickers = ToolboxArgumentParser.GetTickers(options);
+
+            Assert.AreEqual(expectedCount, tickers.Count);
         }
     }
 }

--- a/ToolBox/Program.cs
+++ b/ToolBox/Program.cs
@@ -67,9 +67,7 @@ namespace QuantConnect.ToolBox
             {
                 var fromDate = Parse.DateTimeExact(GetParameterOrExit(optionsObject, "from-date"), "yyyyMMdd-HH:mm:ss");
                 var resolution = optionsObject.ContainsKey("resolution") ? optionsObject["resolution"].ToString() : "";
-                var tickers = optionsObject.ContainsKey("tickers")
-                    ? (optionsObject["tickers"] as Dictionary<string, object>)?.Keys.ToList()
-                    : new List<string>();
+                var tickers = ToolboxArgumentParser.GetTickers(optionsObject);
                 var toDate = optionsObject.ContainsKey("to-date")
                     ? Parse.DateTimeExact(optionsObject["to-date"].ToString(), "yyyyMMdd-HH:mm:ss")
                     : DateTime.UtcNow;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix ToolBox tickers parsing, adding unit test.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes https://github.com/QuantConnect/Lean/issues/4874
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
After https://github.com/QuantConnect/Lean/pull/4819/files `ApplicationParser` started returning `<string, string>` and the toolbox was still expecting `<string, object>`
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
