### PR TITLE
Local Object Store Refactor and Fixes

### DIFF
--- a/Engine/Storage/LocalObjectStore.cs
+++ b/Engine/Storage/LocalObjectStore.cs
@@ -171,6 +171,10 @@ namespace QuantConnect.Lean.Engine.Storage
             {
                 throw new ArgumentNullException(nameof(key));
             }
+            if (key.Contains("?"))
+            {
+                throw new ArgumentException($"LocalObjectStore.SaveBytes(): char '?' is not supported in the key {key}");
+            }
             if (!Controls.StoragePermissions.HasFlag(FileAccess.Write))
             {
                 throw new InvalidOperationException($"LocalObjectStore.SaveBytes(): {NoWritePermissionsError}");

--- a/Engine/Storage/LocalObjectStore.cs
+++ b/Engine/Storage/LocalObjectStore.cs
@@ -314,8 +314,9 @@ namespace QuantConnect.Lean.Engine.Storage
 
                 // if the object store was not used, delete the empty storage directory created in Initialize.
                 // can be null if not initialized
-                if (AlgorithmStorageRoot != null && !Directory.EnumerateFileSystemEntries(AlgorithmStorageRoot).Any())
+                if (AlgorithmStorageRoot != null && !Directory.GetFiles(AlgorithmStorageRoot).Any() && !Directory.GetFiles(TempObjectStorage).Any())
                 {
+                    Directory.Delete(TempObjectStorage);
                     Directory.Delete(AlgorithmStorageRoot);
                 }
             }

--- a/Engine/Storage/LocalObjectStore.cs
+++ b/Engine/Storage/LocalObjectStore.cs
@@ -344,7 +344,7 @@ namespace QuantConnect.Lean.Engine.Storage
         /// Get's a file path for a given key.
         /// Internal use only because it does not guarantee the existence of the file.
         /// </summary>
-        private string PathForKey(string key)
+        protected string PathForKey(string key)
         {
             // We use an encoded filename because certain keys will cause problems with persisting
             // data to a file; we use Base64 because it allow us to use all chars except '?' in our

--- a/Engine/Storage/LocalObjectStore.cs
+++ b/Engine/Storage/LocalObjectStore.cs
@@ -289,15 +289,11 @@ namespace QuantConnect.Lean.Engine.Storage
                 );
             }
 
-            // Get the persist lock to stop interval persisting
-            lock (_persistLock)
-            {
-                // Persist to ensure the file is up to date
-                PersistData(this);
+            // Persist to ensure pur files are up to date
+            Persist();
 
-                // Fetch the path to file and return it
-                return PathForKey(key);
-            }
+            // Fetch the path to file and return it
+            return PathForKey(key);
         }
 
         /// <summary>

--- a/Engine/Storage/LocalObjectStore.cs
+++ b/Engine/Storage/LocalObjectStore.cs
@@ -19,6 +19,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
@@ -112,7 +113,7 @@ namespace QuantConnect.Lean.Engine.Storage
                 foreach (var file in Directory.EnumerateFiles(AlgorithmStorageRoot))
                 {
                     var contents = File.ReadAllBytes(file);
-                    var key = Path.GetFileName(file);
+                    var key = Base64ToKey(Path.GetFileName(file));
                     _storage[key] = contents;
                 }
             }
@@ -357,7 +358,8 @@ namespace QuantConnect.Lean.Engine.Storage
         /// </summary>
         private string PathForKey(string key)
         {
-            return Path.Combine(AlgorithmStorageRoot, $"{key}");
+            var base64string = KeyToBase64(key);
+            return Path.Combine(AlgorithmStorageRoot, $"{base64string}");
         }
 
         /// <summary>
@@ -437,6 +439,28 @@ namespace QuantConnect.Lean.Engine.Storage
         private static double BytesToMb(long bytes)
         {
             return bytes / 1024.0 / 1024.0;
+        }
+
+        /// <summary>
+        /// Convert a given key to a Base64 string
+        /// </summary>
+        /// <param name="key">Key to be encoded</param>
+        /// <returns>Base64 hash string</returns>
+        private static string KeyToBase64(string key)
+        {
+            var textAsBytes = Encoding.UTF8.GetBytes(key);
+            return Convert.ToBase64String(textAsBytes);
+        }
+
+        /// <summary>
+        /// Convert a given Base64 string back to a key
+        /// </summary>
+        /// <param name="hash">Hash to be decoded</param>
+        /// <returns>Key string</returns>
+        private static string Base64ToKey(string hash)
+        {
+            var textAsBytes = Convert.FromBase64String(hash);
+            return Encoding.UTF8.GetString(textAsBytes);
         }
     }
 }

--- a/Engine/Storage/LocalObjectStore.cs
+++ b/Engine/Storage/LocalObjectStore.cs
@@ -59,6 +59,7 @@ namespace QuantConnect.Lean.Engine.Storage
         private TimeSpan _persistenceInterval;
         private readonly string _storageRoot = Path.GetFullPath(Config.Get("object-store-root", "./storage"));
         private readonly ConcurrentDictionary<string, byte[]> _storage = new ConcurrentDictionary<string, byte[]>();
+        private string TempObjectStorage => Path.Combine(AlgorithmStorageRoot, "temp");
 
         /// <summary>
         /// Provides access to the controls governing behavior of this instance, such as the persistence interval
@@ -85,6 +86,7 @@ namespace QuantConnect.Lean.Engine.Storage
 
             // create the root path if it does not exist
             Directory.CreateDirectory(AlgorithmStorageRoot);
+            Directory.CreateDirectory(TempObjectStorage);
 
             Log.Trace($"LocalObjectStore.Initialize(): Storage Root: {new FileInfo(AlgorithmStorageRoot).FullName}");
 
@@ -344,7 +346,7 @@ namespace QuantConnect.Lean.Engine.Storage
         /// </summary>
         private string GetFilePathForKey(string key)
         {
-            return Path.Combine(AlgorithmStorageRoot, $"{key.ToMD5()}.dat");
+            return Path.Combine(TempObjectStorage, $"{key.ToMD5()}.dat");
         }
 
         /// <summary>

--- a/Tests/Common/Storage/LocalObjectStoreTests.cs
+++ b/Tests/Common/Storage/LocalObjectStoreTests.cs
@@ -348,6 +348,29 @@ namespace QuantConnect.Tests.Common.Storage
             }
         }
 
+        [Test]
+        public void OversizedObject()
+        {
+            // Create a big byte array
+            var bytesToWrite = new byte[7000000];
+
+            // Attempt to save it to local store with 5MB cap
+            Assert.IsFalse(_store.SaveBytes("test", bytesToWrite));
+        }
+
+        [Test]
+        public void TooManyObjects()
+        {
+            // Write 100 Files first, should not throw
+            for (int i = _store.Count(); i < 100; i++)
+            {
+                Assert.IsTrue(_store.SaveString($"{i}", $"{i}"));
+            }
+
+            // Write 1 more; should throw
+            Assert.IsFalse(_store.SaveString("breaker", "gotem"));
+        }
+
         public class TestSettings
         {
             public int EmaFastPeriod { get; set; }

--- a/Tests/Common/Storage/LocalObjectStoreTests.cs
+++ b/Tests/Common/Storage/LocalObjectStoreTests.cs
@@ -305,6 +305,46 @@ namespace QuantConnect.Tests.Common.Storage
             Assert.IsFalse(Directory.Exists("./LocalObjectStoreTests/unused"));
         }
 
+        [Test]
+        public void DisposeDoesNotDeleteStoreFiles()
+        {
+            using (var store = new LocalObjectStore())
+            {
+                store.Initialize("test", 0, 0, "", new Controls() {PersistenceIntervalSeconds = -1});
+                Assert.IsTrue(Directory.Exists("./LocalObjectStoreTests/test"));
+
+                var validData = new byte[1024 * 1024 * 4];
+                var saved = store.SaveBytes("a.txt", validData);
+
+                Assert.IsTrue(saved);
+                Assert.IsTrue(File.Exists("./LocalObjectStoreTests/test/a.txt"));
+            }
+
+            // Check that it still exists
+            Assert.IsTrue(File.Exists("./LocalObjectStoreTests/test/a.txt"));
+        }
+
+        [Test]
+        public void DisposeDoesNotDeleteTempFiles()
+        {
+            string path;
+            using (var store = new LocalObjectStore())
+            {
+                store.Initialize("test", 0, 0, "", new Controls());
+                Assert.IsTrue(Directory.Exists("./LocalObjectStoreTests/test"));
+
+                var validData = new byte[1024 * 1024 * 4];
+                var saved = store.SaveBytes("a.txt", validData);
+                path = store.GetFilePath("a.txt");
+
+                Assert.IsTrue(saved);
+                Assert.IsTrue(File.Exists(path));
+            }
+
+            // Check that it still exists
+            Assert.IsTrue(File.Exists(path));
+        }
+
         public class TestSettings
         {
             public int EmaFastPeriod { get; set; }

--- a/Tests/Common/Storage/LocalObjectStoreTests.cs
+++ b/Tests/Common/Storage/LocalObjectStoreTests.cs
@@ -232,7 +232,7 @@ namespace QuantConnect.Tests.Common.Storage
         [TestCase("test/123", "./LocalObjectStoreTests/CSharp-TestAlgorithm/dGVzdC8xMjM=")]
         [TestCase("**abc**", "./LocalObjectStoreTests/CSharp-TestAlgorithm/KiphYmMqKg==")]
         [TestCase("<random>", "./LocalObjectStoreTests/CSharp-TestAlgorithm/PHJhbmRvbT4=")]
-        [TestCase("?|", "./LocalObjectStoreTests/CSharp-TestAlgorithm/P3w=")]
+        [TestCase("|", "./LocalObjectStoreTests/CSharp-TestAlgorithm/fA==")]
         public void GetFilePathReturnsFileName(string key, string expectedRelativePath)
         {
             var expectedPath = Path.GetFullPath(expectedRelativePath).Replace("\\", "/");

--- a/Tests/Common/Storage/LocalObjectStoreTests.cs
+++ b/Tests/Common/Storage/LocalObjectStoreTests.cs
@@ -221,8 +221,8 @@ namespace QuantConnect.Tests.Common.Storage
             Assert.IsTrue(error.Message.Contains("Please use ObjectStore.ContainsKey(key)"));
         }
 
-        [TestCase("my_key", "./LocalObjectStoreTests/CSharp-TestAlgorithm/9ed6e46a3ff88783ff75296a4ba523f9.dat")]
-        [TestCase("test/123", "./LocalObjectStoreTests/CSharp-TestAlgorithm/0a2557f6be73a1b8a6abe84104899591.dat")]
+        [TestCase("my_key", "./LocalObjectStoreTests/CSharp-TestAlgorithm/temp/9ed6e46a3ff88783ff75296a4ba523f9.dat")]
+        [TestCase("test/123", "./LocalObjectStoreTests/CSharp-TestAlgorithm/temp/0a2557f6be73a1b8a6abe84104899591.dat")]
         public void GetFilePathReturnsFileName(string key, string expectedRelativePath)
         {
             var expectedPath = Path.GetFullPath(expectedRelativePath).Replace("\\", "/");

--- a/Tests/Common/Storage/LocalObjectStoreTests.cs
+++ b/Tests/Common/Storage/LocalObjectStoreTests.cs
@@ -223,8 +223,8 @@ namespace QuantConnect.Tests.Common.Storage
             Assert.IsTrue(error.Message.Contains("Please use ObjectStore.ContainsKey(key)"));
         }
 
-        [TestCase("my_key", "./LocalObjectStoreTests/CSharp-TestAlgorithm/temp/9ed6e46a3ff88783ff75296a4ba523f9.dat")]
-        [TestCase("test/123", "./LocalObjectStoreTests/CSharp-TestAlgorithm/temp/0a2557f6be73a1b8a6abe84104899591.dat")]
+        [TestCase("my_key", "./LocalObjectStoreTests/CSharp-TestAlgorithm/my_key")]
+        [TestCase("test123", "./LocalObjectStoreTests/CSharp-TestAlgorithm/test123")]
         public void GetFilePathReturnsFileName(string key, string expectedRelativePath)
         {
             var expectedPath = Path.GetFullPath(expectedRelativePath).Replace("\\", "/");
@@ -324,27 +324,6 @@ namespace QuantConnect.Tests.Common.Storage
 
             // Check that it still exists
             Assert.IsTrue(File.Exists("./LocalObjectStoreTests/test/a.txt"));
-        }
-
-        [Test]
-        public void DisposeDoesNotDeleteTempFiles()
-        {
-            string path;
-            using (var store = new LocalObjectStore())
-            {
-                store.Initialize("test", 0, 0, "", new Controls());
-                Assert.IsTrue(Directory.Exists("./LocalObjectStoreTests/test"));
-
-                var validData = new byte[1024 * 1024 * 4];
-                var saved = store.SaveBytes("a.txt", validData);
-                path = store.GetFilePath("a.txt");
-
-                Assert.IsTrue(saved);
-                Assert.IsTrue(File.Exists(path));
-            }
-
-            // Check that it still exists
-            Assert.IsTrue(File.Exists(path));
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Refactor LocalObjectStore to no longer use temp copies of an object in `GetFilePath`, instead use the local copy, this fixes issue #4811.
- `GetFilePath` persists data before giving the requester the path.
- Fix for control checks to save data, logic was broken as it never counted the new data being added.
- Store data using conversion of keys to Base64 to handle odd key strings in path. The only limitation in chars in the key string is having '?' in the key. In a spot divisible by 3 this will cause Base64 to output '/' which is the only breaking case.
- New tests to prove behaviour

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4811 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

`LocalObjectStore`'s `GetFilePath` currently writes a copy of a requested object to a file in the ObjectStore's storage directory and returns this copies path; this works fine until you start Lean again and the copy is loaded into the LocalObjectStore as its own object.

To resolve this I have dropped the use of temp files altogether and will only store one file for each object, now when the user calls `GetFilePath` we ensure the data is written to storage and then return a path to it . This way there are no duplicates, the file is still retained and we can ensure the data in the file is up to date when requested.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All regressions ran and passed, LocalObjectStore tests all pass, Travis tests pass in docker

Verified behaviour in Issue #4811 does not occur

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
