### PR TITLE
Expand Filtering of Contracts by type to Futures

### DIFF
--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -399,6 +399,7 @@
     <Compile Include="Securities\BuyingPowerModel.cs" />
     <Compile Include="Securities\BuyingPowerModelExtensions.cs" />
     <Compile Include="Securities\BuyingPowerParameters.cs" />
+    <Compile Include="Securities\ContractSecurityFilterUniverse.cs" />
     <Compile Include="Securities\Future\FutureSymbol.cs" />
     <Compile Include="Securities\GetMaximumOrderQuantityForDeltaBuyingPowerParameters.cs" />
     <Compile Include="Securities\RegisteredSecurityDataTypesProvider.cs" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -399,6 +399,7 @@
     <Compile Include="Securities\BuyingPowerModel.cs" />
     <Compile Include="Securities\BuyingPowerModelExtensions.cs" />
     <Compile Include="Securities\BuyingPowerParameters.cs" />
+    <Compile Include="Securities\Future\FutureSymbol.cs" />
     <Compile Include="Securities\GetMaximumOrderQuantityForDeltaBuyingPowerParameters.cs" />
     <Compile Include="Securities\RegisteredSecurityDataTypesProvider.cs" />
     <Compile Include="Securities\ErrorCurrencyConverter.cs" />

--- a/Common/Securities/ContractSecurityFilterUniverse.cs
+++ b/Common/Securities/ContractSecurityFilterUniverse.cs
@@ -155,7 +155,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Refreshes this filter universe
         /// </summary>
-        /// <param name="allSymbols">All the options contract symbols</param>
+        /// <param name="allSymbols">All the contract symbols for the Universe</param>
         /// <param name="underlying">The current underlying last data point</param>
         public virtual void Refresh(IEnumerable<Symbol> allSymbols, BaseData underlying)
         {

--- a/Common/Securities/ContractSecurityFilterUniverse.cs
+++ b/Common/Securities/ContractSecurityFilterUniverse.cs
@@ -1,0 +1,295 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Python.Runtime;
+using QuantConnect.Data;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Base class for contract symbols filtering universes.
+    /// Used by OptionFilterUniverse and FutureFilterUniverse
+    /// </summary>
+    public abstract class ContractSecurityFilterUniverse<T> : IDerivativeSecurityFilterUniverse
+    where T: ContractSecurityFilterUniverse<T>
+    {
+        /// <summary>
+        /// Defines listed contract types
+        /// </summary>
+        public enum Type : int
+        {
+            /// <summary>
+            /// Standard contracts
+            /// </summary>
+            Standard = 1,
+
+            /// <summary>
+            /// Non standard weekly contracts
+            /// </summary>
+            Weeklys = 2
+        }
+
+        internal IEnumerable<Symbol> _allSymbols;
+
+        /// <summary>
+        /// The underlying price data
+        /// </summary>
+        public BaseData Underlying
+        {
+            get
+            {
+                // underlying value changes over time, so accessing it makes universe dynamic
+                _isDynamic = true;
+                return _underlying;
+            }
+        }
+
+        protected BaseData _underlying;
+
+        /// <summary>
+        /// True if the universe is dynamic and filter needs to be reapplied
+        /// </summary>
+        public bool IsDynamic => _isDynamic;
+
+        //TODO: Naming Conventions
+        internal bool _isDynamic;
+        protected Type _type = Type.Standard;
+
+        /// <summary>
+        /// Constructs ContractSecurityFilterUniverse
+        /// </summary>
+        protected ContractSecurityFilterUniverse()
+        {
+        }
+
+        /// <summary>
+        /// Constructs ContractSecurityFilterUniverse
+        /// </summary>
+        protected ContractSecurityFilterUniverse(IEnumerable<Symbol> allSymbols, BaseData underlying)
+        {
+            _allSymbols = allSymbols;
+            _underlying = underlying;
+            _type = Type.Standard;
+            _isDynamic = false;
+        }
+
+        /// <summary>
+        /// Includes universe of non-standard weeklys contracts (if any) into selection
+        /// </summary>
+        /// <returns></returns>
+        public T IncludeWeeklys()
+        {
+            _type |= Type.Weeklys;
+            return (T) this;
+        }
+
+        /// <summary>
+        /// Sets universe of weeklys contracts (if any) as a selection
+        /// </summary>
+        /// <returns></returns>
+        public T WeeklysOnly()
+        {
+            _type = Type.Weeklys;
+            return (T) this;
+        }
+
+        /// <summary>
+        /// Returns universe, filtered by contract type
+        /// </summary>
+        /// <returns></returns>
+        internal T ApplyTypesFilter()
+        {
+            // memoization map for ApplyTypesFilter()
+            var memoizedMap = new Dictionary<DateTime, bool>();
+
+            Func<Symbol, bool> memoizedIsStandardType = symbol =>
+            {
+                var dt = symbol.ID.Date;
+
+                bool result;
+                if (memoizedMap.TryGetValue(dt, out result))
+                    return result;
+                var res = IsStandard(symbol);
+                memoizedMap[dt] = res;
+
+                return res;
+            };
+
+            _allSymbols = _allSymbols.Where(x =>
+            {
+                switch (_type)
+                {
+                    case Type.Weeklys:
+                        return !memoizedIsStandardType(x);
+                    case Type.Standard:
+                        return memoizedIsStandardType(x);
+                    case Type.Standard | Type.Weeklys:
+                        return true;
+                    default:
+                        return false;
+                }
+            }).ToList();
+
+            return (T) this;
+        }
+
+        /// <summary>
+        /// Function to determine if the given symbol is a standard contract
+        /// </summary>
+        /// <returns>True if standard type</returns>
+        protected abstract bool IsStandard(Symbol symbol);
+
+        /// <summary>
+        /// Returns front month contract
+        /// </summary>
+        /// <returns></returns>
+        public virtual T FrontMonth()
+        {
+            var ordered = this.OrderBy(x => x.ID.Date).ToList();
+            if (ordered.Count == 0) return (T) this;
+            var frontMonth = ordered.TakeWhile(x => ordered[0].ID.Date == x.ID.Date);
+
+            _allSymbols = frontMonth.ToList();
+            return (T) this;
+        }
+
+        /// <summary>
+        /// Returns a list of back month contracts
+        /// </summary>
+        /// <returns></returns>
+        public virtual T BackMonths()
+        {
+            var ordered = this.OrderBy(x => x.ID.Date).ToList();
+            if (ordered.Count == 0) return (T) this;
+            var backMonths = ordered.SkipWhile(x => ordered[0].ID.Date == x.ID.Date);
+
+            _allSymbols = backMonths.ToList();
+            return (T) this;
+        }
+
+        /// <summary>
+        /// Returns first of back month contracts
+        /// </summary>
+        /// <returns></returns>
+        public T BackMonth()
+        {
+            return BackMonths().FrontMonth();
+        }
+
+        /// <summary>
+        /// Applies filter selecting options contracts based on a range of expiration dates relative to the current day
+        /// </summary>
+        /// <param name="minExpiry">The minimum time until expiry to include, for example, TimeSpan.FromDays(10)
+        /// would exclude contracts expiring in more than 10 days</param>
+        /// <param name="maxExpiry">The maximum time until expiry to include, for example, TimeSpan.FromDays(10)
+        /// would exclude contracts expiring in less than 10 days</param>
+        /// <returns></returns>
+        public virtual T Expiration(TimeSpan minExpiry, TimeSpan maxExpiry)
+        {
+            if (_underlying == null)
+            {
+                return (T) this;
+            }
+
+            if (maxExpiry > Time.MaxTimeSpan) maxExpiry = Time.MaxTimeSpan;
+
+            var minExpiryToDate = _underlying.Time.Date + minExpiry;
+            var maxExpiryToDate = _underlying.Time.Date + maxExpiry;
+
+            _allSymbols = _allSymbols
+                .Where(symbol => symbol.ID.Date >= minExpiryToDate && symbol.ID.Date <= maxExpiryToDate)
+                .ToList();
+
+            return (T) this;
+        }
+
+        /// <summary>
+        /// Applies filter selecting contracts based on a range of expiration dates relative to the current day
+        /// </summary>
+        /// <param name="minExpiryDays">The minimum time, expressed in days, until expiry to include, for example, 10
+        /// would exclude contracts expiring in more than 10 days</param>
+        /// <param name="maxExpiryDays">The maximum time, expressed in days, until expiry to include, for example, 10
+        /// would exclude contracts expiring in less than 10 days</param>
+        /// <returns></returns>
+        public T Expiration(int minExpiryDays, int maxExpiryDays)
+        {
+            return Expiration(TimeSpan.FromDays(minExpiryDays), TimeSpan.FromDays(maxExpiryDays));
+        }
+
+        /// <summary>
+        /// Explicitly sets the selected contract symbols for this universe.
+        /// This overrides and and all other methods of selecting symbols assuming it is called last.
+        /// </summary>
+        /// <param name="contracts">The option contract symbol objects to select</param>
+        public T Contracts(PyObject contracts)
+        {
+            _allSymbols = contracts.ConvertToSymbolEnumerable();
+            return (T) this;
+        }
+
+        /// <summary>
+        /// Explicitly sets the selected contract symbols for this universe.
+        /// This overrides and and all other methods of selecting symbols assuming it is called last.
+        /// </summary>
+        /// <param name="contracts">The option contract symbol objects to select</param>
+        public T Contracts(IEnumerable<Symbol> contracts)
+        {
+            _allSymbols = contracts.ToList();
+            return (T) this;
+        }
+
+        /// <summary>
+        /// Sets a function used to filter the set of available contract filters. The input to the 'contractSelector'
+        /// function will be the already filtered list if any other filters have already been applied.
+        /// </summary>
+        /// <param name="contractSelector">The option contract symbol objects to select</param>
+        public T Contracts(Func<IEnumerable<Symbol>, IEnumerable<Symbol>> contractSelector)
+        {
+            // force materialization using ToList
+            _allSymbols = contractSelector(_allSymbols).ToList();
+            return (T) this;
+        }
+
+        /// <summary>
+        /// Instructs the engine to only filter contracts on the first time step of each market day.
+        /// </summary>
+        public T OnlyApplyFilterAtMarketOpen()
+        {
+            _isDynamic = false;
+            return (T) this;
+        }
+
+        /// <summary>
+        /// IEnumerable interface method implementation
+        /// </summary>
+        public IEnumerator<Symbol> GetEnumerator()
+        {
+            return _allSymbols.GetEnumerator();
+        }
+
+        /// <summary>
+        /// IEnumerable interface method implementation
+        /// </summary>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _allSymbols.GetEnumerator();
+        }
+    }
+}

--- a/Common/Securities/Future/Future.cs
+++ b/Common/Securities/Future/Future.cs
@@ -205,7 +205,7 @@ namespace QuantConnect.Securities.Future
             {
                 var futureUniverse = universe as FutureFilterUniverse;
                 var result = universeFunc(futureUniverse);
-                return result.ApplyOptionTypesFilter();
+                return result.ApplyTypesFilter();
             };
 
             ContractFilter = new FuncSecurityDerivativeFilter(func);

--- a/Common/Securities/Future/Future.cs
+++ b/Common/Securities/Future/Future.cs
@@ -204,7 +204,8 @@ namespace QuantConnect.Securities.Future
             Func<IDerivativeSecurityFilterUniverse, IDerivativeSecurityFilterUniverse> func = universe =>
             {
                 var futureUniverse = universe as FutureFilterUniverse;
-                return universeFunc(futureUniverse);
+                var result = universeFunc(futureUniverse);
+                return result.ApplyOptionTypesFilter();
             };
 
             ContractFilter = new FuncSecurityDerivativeFilter(func);

--- a/Common/Securities/Future/FutureFilterUniverse.cs
+++ b/Common/Securities/Future/FutureFilterUniverse.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using QuantConnect.Data;
 using System.Linq;
-using System.Collections;
 using QuantConnect.Securities.Future;
 using QuantConnect.Util;
 
@@ -33,16 +32,14 @@ namespace QuantConnect.Securities
         /// Constructs FutureFilterUniverse
         /// </summary>
         public FutureFilterUniverse(IEnumerable<Symbol> allSymbols, BaseData underlying)
+            : base(allSymbols, underlying)
         {
-            _allSymbols = allSymbols;
-            _underlying = underlying;
-            _isDynamic = false;
         }
 
         /// <summary>
         /// Determine if the given Future contract symbol is standard
         /// </summary>
-        /// <returns></returns>
+        /// <returns>True if contract is standard</returns>
         protected override bool IsStandard(Symbol symbol)
         {
             return FutureSymbol.IsStandard(symbol);
@@ -51,8 +48,8 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Applies filter selecting futures contracts based on expiration cycles. See <see cref="FutureExpirationCycles"/> for details
         /// </summary>
-        /// <param name="months"></param>
-        /// <returns></returns>
+        /// <param name="months">Months to select contracts from</param>
+        /// <returns>Universe with filter applied</returns>
         public FutureFilterUniverse ExpirationCycle(int[] months)
         {
             var monthHashSet = months.ToHashSet();
@@ -68,33 +65,39 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Filters universe
         /// </summary>
-        /// <param name="universe"></param>
-        /// <param name="predicate"></param>
-        /// <returns></returns>
+        /// <param name="universe">Universe to apply the filter too</param>
+        /// <param name="predicate">Bool function to determine which Symbol are filtered</param>
+        /// <returns><see cref="FutureFilterUniverse"/> with filter applied</returns>
         public static FutureFilterUniverse Where(this FutureFilterUniverse universe, Func<Symbol, bool> predicate)
         {
-            universe._allSymbols = universe._allSymbols.Where(predicate).ToList();
-            universe._isDynamic = true;
+            universe.AllSymbols = universe.AllSymbols.Where(predicate).ToList();
+            universe.IsDynamicInternal = true;
             return universe;
         }
 
         /// <summary>
         /// Maps universe
         /// </summary>
+        /// <param name="universe">Universe to apply the filter too</param>
+        /// <param name="mapFunc">Symbol function to determine which Symbols are filtered</param>
+        /// <returns><see cref="FutureFilterUniverse"/> with filter applied</returns>
         public static FutureFilterUniverse Select(this FutureFilterUniverse universe, Func<Symbol, Symbol> mapFunc)
         {
-            universe._allSymbols = universe._allSymbols.Select(mapFunc).ToList();
-            universe._isDynamic = true;
+            universe.AllSymbols = universe.AllSymbols.Select(mapFunc).ToList();
+            universe.IsDynamicInternal = true;
             return universe;
         }
 
         /// <summary>
         /// Binds universe
         /// </summary>
+        /// <param name="universe">Universe to apply the filter too</param>
+        /// <param name="mapFunc">Symbols function to determine which Symbols are filtered</param>
+        /// <returns><see cref="FutureFilterUniverse"/> with filter applied</returns>
         public static FutureFilterUniverse SelectMany(this FutureFilterUniverse universe, Func<Symbol, IEnumerable<Symbol>> mapFunc)
         {
-            universe._allSymbols = universe._allSymbols.SelectMany(mapFunc).ToList();
-            universe._isDynamic = true;
+            universe.AllSymbols = universe.AllSymbols.SelectMany(mapFunc).ToList();
+            universe.IsDynamicInternal = true;
             return universe;
         }
     }

--- a/Common/Securities/Future/FutureSymbol.cs
+++ b/Common/Securities/Future/FutureSymbol.cs
@@ -24,34 +24,27 @@ namespace QuantConnect.Securities.Future
     public static class FutureSymbol
     {
         /// <summary>
-        /// Returns true if the option is a standard contract that expires 3rd Friday of the month
+        /// Determine if a given Futures contract is a standard contract.
         /// </summary>
         /// <param name="symbol">Future symbol</param>
-        /// <returns></returns>
+        /// <returns>True if symbol expiration matches standard expiration</returns>
         public static bool IsStandard(Symbol symbol)
         {
-            var date = symbol.ID.Date;
-            var symbolToCheck = symbol.HasUnderlying ? symbol.Underlying : symbol;
+            var contractExpirationDate = symbol.ID.Date;
 
             try
             {
                 // Use our FutureExpiryFunctions to determine standard contracts dates.
-                var expiryFunction = FuturesExpiryFunctions.FuturesExpiryFunction(symbolToCheck);
-                var standardDate = expiryFunction(date);
+                var expiryFunction = FuturesExpiryFunctions.FuturesExpiryFunction(symbol);
+                var standardExpirationDate = expiryFunction(contractExpirationDate);
 
-                // If the date on this symbol and the nearest standard date are equal then it is a standard contract
-                if (date == standardDate)
-                {
-                    return true;
-                }
-
-                // Date is non-standard, return false
-                return false;
+                // Return true if the dates match
+                return contractExpirationDate == standardExpirationDate;
             }
             catch
             {
-                Log.Error($"Could not find standard date for {symbolToCheck}, will be classified as weekly (non-standard)");
-                return false;
+                Log.Error($"Could not find standard date for {symbol}, will be classified as standard");
+                return true;
             }
         }
 
@@ -59,7 +52,7 @@ namespace QuantConnect.Securities.Future
         /// Returns true if the future contract is a weekly contract
         /// </summary>
         /// <param name="symbol">Future symbol</param>
-        /// <returns></returns>
+        /// <returns>True if symbol is non-standard contract</returns>
         public static bool IsWeekly(Symbol symbol)
         {
             return !IsStandard(symbol);

--- a/Common/Securities/Future/FutureSymbol.cs
+++ b/Common/Securities/Future/FutureSymbol.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuantConnect.Securities.Future
+{
+    /// <summary>
+    /// Static class contains common utility methods specific to symbols representing the future contracts
+    /// </summary>
+    public static class FutureSymbol
+    {
+        /// <summary>
+        /// Returns true if the option is a standard contract that expires 3rd Friday of the month
+        /// </summary>
+        /// <param name="symbol">Option symbol</param>
+        /// <returns></returns>
+        public static bool IsStandard(Symbol symbol)
+        {
+            var date = symbol.ID.Date;
+            var symbolToCheck = symbol.HasUnderlying ? symbol.Underlying : symbol;
+
+            // Use our FutureExpiryFunctions to determine standard contracts dates.
+            var expiryFunction = FuturesExpiryFunctions.FuturesExpiryFunction(symbolToCheck);
+            var standardDate = expiryFunction(date);
+
+            // If the date on this symbol and the nearest standard date are equal then it is a standard contract
+            if (date == standardDate)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true if the future contract is a weekly contract
+        /// </summary>
+        /// <param name="symbol">Future symbol</param>
+        /// <returns></returns>
+        public static bool IsWeekly(Symbol symbol)
+        {
+            return !IsStandard(symbol);
+        }
+    }
+}

--- a/Common/Securities/Future/FutureSymbol.cs
+++ b/Common/Securities/Future/FutureSymbol.cs
@@ -1,8 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using QuantConnect.Logging;
 
 namespace QuantConnect.Securities.Future
 {
@@ -14,24 +26,33 @@ namespace QuantConnect.Securities.Future
         /// <summary>
         /// Returns true if the option is a standard contract that expires 3rd Friday of the month
         /// </summary>
-        /// <param name="symbol">Option symbol</param>
+        /// <param name="symbol">Future symbol</param>
         /// <returns></returns>
         public static bool IsStandard(Symbol symbol)
         {
             var date = symbol.ID.Date;
             var symbolToCheck = symbol.HasUnderlying ? symbol.Underlying : symbol;
 
-            // Use our FutureExpiryFunctions to determine standard contracts dates.
-            var expiryFunction = FuturesExpiryFunctions.FuturesExpiryFunction(symbolToCheck);
-            var standardDate = expiryFunction(date);
-
-            // If the date on this symbol and the nearest standard date are equal then it is a standard contract
-            if (date == standardDate)
+            try
             {
-                return true;
-            }
+                // Use our FutureExpiryFunctions to determine standard contracts dates.
+                var expiryFunction = FuturesExpiryFunctions.FuturesExpiryFunction(symbolToCheck);
+                var standardDate = expiryFunction(date);
 
-            return false;
+                // If the date on this symbol and the nearest standard date are equal then it is a standard contract
+                if (date == standardDate)
+                {
+                    return true;
+                }
+
+                // Date is non-standard, return false
+                return false;
+            }
+            catch
+            {
+                Log.Error($"Could not find standard date for {symbolToCheck}, will be classified as weekly (non-standard)");
+                return false;
+            }
         }
 
         /// <summary>

--- a/Common/Securities/Future/FutureSymbol.cs
+++ b/Common/Securities/Future/FutureSymbol.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Securities.Future
                 var standardExpirationDate = expiryFunction(contractExpirationDate);
 
                 // Return true if the dates match
-                return contractExpirationDate == standardExpirationDate;
+                return contractExpirationDate.Date == standardExpirationDate.Date;
             }
             catch
             {

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -458,7 +458,7 @@ namespace QuantConnect.Securities.Option
             {
                 var optionUniverse = universe as OptionFilterUniverse;
                 var result = universeFunc(optionUniverse);
-                return result.ApplyOptionTypesFilter();
+                return result.ApplyTypesFilter();
             });
         }
 
@@ -496,7 +496,7 @@ namespace QuantConnect.Securities.Option
                             $"filter function is not a valid argument, please return either a OptionFilterUniverse or a list of symbols");
                     }
                 }
-                return optionUniverse.ApplyOptionTypesFilter();
+                return optionUniverse.ApplyTypesFilter();
             });
         }
 

--- a/Common/Securities/Option/OptionFilterUniverse.cs
+++ b/Common/Securities/Option/OptionFilterUniverse.cs
@@ -18,8 +18,6 @@ using System;
 using System.Collections.Generic;
 using QuantConnect.Data;
 using System.Linq;
-using System.Collections;
-using Python.Runtime;
 using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Securities
@@ -27,50 +25,8 @@ namespace QuantConnect.Securities
     /// <summary>
     /// Represents options symbols universe used in filtering.
     /// </summary>
-    public class OptionFilterUniverse : IDerivativeSecurityFilterUniverse
+    public class OptionFilterUniverse : ContractSecurityFilterUniverse<OptionFilterUniverse>
     {
-        /// <summary>
-        /// Defines listed option types
-        /// </summary>
-        public enum Type : int
-        {
-            /// <summary>
-            /// Listed stock options that expire 3rd Friday of the month
-            /// </summary>
-            Standard = 1,
-
-            /// <summary>
-            /// Weeklys options that expire every week
-            /// These are options listed with approximately one week to expiration
-            /// </summary>
-            Weeklys = 2
-        }
-
-        internal IEnumerable<Symbol> _allSymbols;
-
-        /// <summary>
-        /// The underlying price data
-        /// </summary>
-        public BaseData Underlying
-        {
-            get
-            {
-                // underlying value changes over time, so accessing it makes universe dynamic
-                _isDynamic = true;
-                return _underlying;
-            }
-        }
-
-        private BaseData _underlying;
-
-        /// <summary>
-        /// True if the universe is dynamic and filter needs to be reapplied
-        /// </summary>
-        public bool IsDynamic => _isDynamic;
-
-        internal bool _isDynamic;
-
-        private Type _type = Type.Standard;
         // Fields used in relative strikes filter
         private List<decimal> _uniqueStrikes;
         private bool _refreshUniqueStrikes;
@@ -106,100 +62,12 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Includes universe of weeklys options (if any) into selection
+        /// Determine if the given Option contract symbol is standard
         /// </summary>
         /// <returns></returns>
-        public OptionFilterUniverse IncludeWeeklys()
+        protected override bool IsStandard(Symbol symbol)
         {
-            _type |= Type.Weeklys;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets universe of weeklys options (if any) as a selection
-        /// </summary>
-        /// <returns></returns>
-        public OptionFilterUniverse WeeklysOnly()
-        {
-            _type = Type.Weeklys;
-            return this;
-        }
-
-        /// <summary>
-        /// Returns universe, filtered by option type
-        /// </summary>
-        /// <returns></returns>
-        internal OptionFilterUniverse ApplyOptionTypesFilter()
-        {
-            // memoization map for ApplyOptionTypesFilter()
-            var memoizedMap = new Dictionary<DateTime, bool>();
-
-            Func<Symbol, bool> memoizedIsStandardType = symbol =>
-            {
-                var dt = symbol.ID.Date;
-
-                bool result;
-                if (memoizedMap.TryGetValue(dt, out result))
-                    return result;
-                var res = OptionSymbol.IsStandard(symbol);
-                memoizedMap[dt] = res;
-
-                return res;
-            };
-
-            _allSymbols = _allSymbols.Where(x =>
-            {
-                switch (_type)
-                {
-                    case Type.Weeklys:
-                        return !memoizedIsStandardType(x);
-                    case Type.Standard:
-                        return memoizedIsStandardType(x);
-                    case Type.Standard | Type.Weeklys:
-                        return true;
-                    default:
-                        return false;
-                }
-            }).ToList();
-
-            return this;
-        }
-
-        /// <summary>
-        /// Returns front month contract
-        /// </summary>
-        /// <returns></returns>
-        public OptionFilterUniverse FrontMonth()
-        {
-            var ordered = this.OrderBy(x => x.ID.Date).ToList();
-            if (ordered.Count == 0) return this;
-            var frontMonth = ordered.TakeWhile(x => ordered[0].ID.Date == x.ID.Date);
-
-            _allSymbols = frontMonth.ToList();
-            return this;
-        }
-
-        /// <summary>
-        /// Returns a list of back month contracts
-        /// </summary>
-        /// <returns></returns>
-        public OptionFilterUniverse BackMonths()
-        {
-            var ordered = this.OrderBy(x => x.ID.Date).ToList();
-            if (ordered.Count == 0) return this;
-            var backMonths = ordered.SkipWhile(x => ordered[0].ID.Date == x.ID.Date);
-
-            _allSymbols = backMonths.ToList();
-            return this;
-        }
-
-        /// <summary>
-        /// Returns first of back month contracts
-        /// </summary>
-        /// <returns></returns>
-        public OptionFilterUniverse BackMonth()
-        {
-            return BackMonths().FrontMonth();
+            return OptionSymbol.IsStandard(symbol);
         }
 
         /// <summary>
@@ -303,79 +171,6 @@ namespace QuantConnect.Securities
             return this;
         }
 
-        /// <summary>
-        /// Applies filter selecting options contracts based on a range of expiration dates relative to the current day
-        /// </summary>
-        /// <param name="minExpiry">The minimum time until expiry to include, for example, TimeSpan.FromDays(10)
-        /// would exclude contracts expiring in more than 10 days</param>
-        /// <param name="maxExpiry">The maxmium time until expiry to include, for example, TimeSpan.FromDays(10)
-        /// would exclude contracts expiring in less than 10 days</param>
-        /// <returns></returns>
-        public OptionFilterUniverse Expiration(TimeSpan minExpiry, TimeSpan maxExpiry)
-        {
-            if (_underlying == null)
-            {
-                return this;
-            }
-
-            if (maxExpiry > Time.MaxTimeSpan) maxExpiry = Time.MaxTimeSpan;
-
-            var minExpiryToDate = _underlying.Time.Date + minExpiry;
-            var maxExpiryToDate = _underlying.Time.Date + maxExpiry;
-
-            _allSymbols = _allSymbols
-                .Where(symbol => symbol.ID.Date >= minExpiryToDate && symbol.ID.Date <= maxExpiryToDate)
-                .ToList();
-
-            return this;
-        }
-
-        /// <summary>
-        /// Applies filter selecting options contracts based on a range of expiration dates relative to the current day
-        /// </summary>
-        /// <param name="minExpiryDays">The minimum time, expressed in days, until expiry to include, for example, 10
-        /// would exclude contracts expiring in more than 10 days</param>
-        /// <param name="maxExpiryDays">The maximum time, expressed in days, until expiry to include, for example, 10
-        /// would exclude contracts expiring in less than 10 days</param>
-        /// <returns></returns>
-        public OptionFilterUniverse Expiration(int minExpiryDays, int maxExpiryDays)
-        {
-            return Expiration(TimeSpan.FromDays(minExpiryDays), TimeSpan.FromDays(maxExpiryDays));
-        }
-
-        /// <summary>
-        /// Explicitly sets the selected contract symbols for this universe.
-        /// This overrides and and all other methods of selecting symbols assuming it is called last.
-        /// </summary>
-        /// <param name="contracts">The option contract symbol objects to select</param>
-        public OptionFilterUniverse Contracts(PyObject contracts)
-        {
-            _allSymbols = contracts.ConvertToSymbolEnumerable();
-            return this;
-        }
-
-        /// <summary>
-        /// Explicitly sets the selected contract symbols for this universe.
-        /// This overrides and and all other methods of selecting symbols assuming it is called last.
-        /// </summary>
-        /// <param name="contracts">The option contract symbol objects to select</param>
-        public OptionFilterUniverse Contracts(IEnumerable<Symbol> contracts)
-        {
-            _allSymbols = contracts.ToList();
-            return this;
-        }
-
-        /// <summary>
-        /// Sets a function used to filter the set of available contract filters. The input to the 'contractSelector'
-        /// function will be the already filtered list if any other filters have already been applied.
-        /// </summary>
-        /// <param name="contractSelector">The option contract symbol objects to select</param>
-        public OptionFilterUniverse Contracts(Func<IEnumerable<Symbol>, IEnumerable<Symbol>> contractSelector)
-        {
-            // force materialization using ToList
-            _allSymbols = contractSelector(_allSymbols).ToList();
-            return this;
-        }
 
         /// <summary>
         /// Sets universe of call options (if any) as a selection
@@ -391,31 +186,6 @@ namespace QuantConnect.Securities
         public OptionFilterUniverse PutsOnly()
         {
             return Contracts(contracts => contracts.Where(x => x.ID.OptionRight == OptionRight.Put));
-        }
-
-        /// <summary>
-        /// Instructs the engine to only filter options contracts on the first time step of each market day.
-        /// </summary>
-        public OptionFilterUniverse OnlyApplyFilterAtMarketOpen()
-        {
-            _isDynamic = false;
-            return this;
-        }
-
-        /// <summary>
-        /// IEnumerable interface method implementation
-        /// </summary>
-        public IEnumerator<Symbol> GetEnumerator()
-        {
-            return _allSymbols.GetEnumerator();
-        }
-
-        /// <summary>
-        /// IEnumerable interface method implementation
-        /// </summary>
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return _allSymbols.GetEnumerator();
         }
     }
 

--- a/Tests/Common/Securities/FutureFilterTests.cs
+++ b/Tests/Common/Securities/FutureFilterTests.cs
@@ -90,6 +90,65 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
+        public void FilterAllowBothTypes()
+        {
+            var time = new DateTime(2016, 02, 17, 13, 0, 0);
+            var underlying = new Tick { Value = 10m, Time = time };
+
+            // Include Weeklys to get both types of contracts through
+            Func<FutureFilterUniverse, FutureFilterUniverse> universeFunc = universe => universe.IncludeWeeklys();
+
+            Func<IDerivativeSecurityFilterUniverse, IDerivativeSecurityFilterUniverse> func =
+                universe => universeFunc(universe as FutureFilterUniverse).ApplyTypesFilter();
+
+            var filter = new FuncSecurityDerivativeFilter(func);
+            var symbols = new[]
+            {
+                Symbol.CreateFuture("VX", Market.CBOE, time.AddDays(0)), // 0 Standard!!
+                Symbol.CreateFuture("VX", Market.CBOE, time.AddDays(1)), // 1
+                Symbol.CreateFuture("VX", Market.CBOE, time.AddDays(2)), // 2
+                Symbol.CreateFuture("VX", Market.CBOE, time.AddDays(8)), // 8
+                Symbol.CreateFuture("VX", Market.CBOE, time.AddDays(16)), // 16
+                Symbol.CreateFuture("VX", Market.CBOE, time.AddDays(28)), // 28 Standard!!
+            };
+
+            var filtered = filter.Filter(new FutureFilterUniverse(symbols, underlying)).ToList();
+            Assert.AreEqual(6, filtered.Count);
+            Assert.AreEqual(symbols, filtered);
+        }
+
+        [Test]
+        public void FilterOutStandards()
+        {
+            var time = new DateTime(2016, 02, 17, 13, 0, 0);
+            var underlying = new Tick { Value = 10m, Time = time };
+
+            // Weeklys only to drop standard contracts
+            Func<FutureFilterUniverse, FutureFilterUniverse> universeFunc = universe => universe.WeeklysOnly();
+
+            Func<IDerivativeSecurityFilterUniverse, IDerivativeSecurityFilterUniverse> func =
+                universe => universeFunc(universe as FutureFilterUniverse).ApplyTypesFilter();
+
+            var filter = new FuncSecurityDerivativeFilter(func);
+            var symbols = new[]
+            {
+                Symbol.CreateFuture("VX", Market.CBOE, time.AddDays(0)), // 0 Standard!!
+                Symbol.CreateFuture("VX", Market.CBOE, time.AddDays(1)), // 1
+                Symbol.CreateFuture("VX", Market.CBOE, time.AddDays(2)), // 2
+                Symbol.CreateFuture("VX", Market.CBOE, time.AddDays(8)), // 8
+                Symbol.CreateFuture("VX", Market.CBOE, time.AddDays(16)), // 16
+                Symbol.CreateFuture("VX", Market.CBOE, time.AddDays(28)), // 28 Standard!!
+            };
+
+            var filtered = filter.Filter(new FutureFilterUniverse(symbols, underlying)).ToList();
+            Assert.AreEqual(4, filtered.Count);
+            Assert.AreEqual(symbols[1], filtered[0]);
+            Assert.AreEqual(symbols[2], filtered[1]);
+            Assert.AreEqual(symbols[3], filtered[2]);
+            Assert.AreEqual(symbols[4], filtered[3]);
+        }
+
+        [Test]
         public void FiltersFrontMonth()
         {
             var expiry1 = new DateTime(2016, 12, 02);
@@ -189,6 +248,29 @@ namespace QuantConnect.Tests.Common.Securities
 
             var filtered = filter.Filter(new FutureFilterUniverse(symbols, underlying)).ToList();
             Assert.AreEqual(5, filtered.Count);
+        }
+
+        [Test]
+        public void FilterTypeDoesNotBreakOnMissingExpiryFunction()
+        {
+            var time = new DateTime(2016, 02, 17, 13, 0, 0);
+            var underlying = new Tick { Value = 10m, Time = time };
+
+            // By Default only includes standards
+            Func<FutureFilterUniverse, FutureFilterUniverse> universeFunc = universe => universe;
+
+            Func<IDerivativeSecurityFilterUniverse, IDerivativeSecurityFilterUniverse> func =
+                universe => universeFunc(universe as FutureFilterUniverse).ApplyTypesFilter();
+
+            var filter = new FuncSecurityDerivativeFilter(func);
+            var symbols = new[]
+            {
+                Symbol.CreateFuture("VX", Market.USA, time.AddDays(0)), // There is no Expiry function for VX on Market.USA
+            };
+
+            // Since this is a unidentifiable symbol for our expiry functions it will return false and be filtered out
+            var filtered = filter.Filter(new FutureFilterUniverse(symbols, underlying)).ToList();
+            Assert.AreEqual(0, filtered.Count);
         }
     }
 }

--- a/Tests/Common/Securities/FutureFilterTests.cs
+++ b/Tests/Common/Securities/FutureFilterTests.cs
@@ -62,7 +62,7 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
-        public void FiltersOutWeeklys()
+        public void FiltersOutWeeklysByDefault()
         {
             var time = new DateTime(2016, 02, 17, 13, 0, 0);
             var underlying = new Tick { Value = 10m, Time = time };
@@ -268,9 +268,10 @@ namespace QuantConnect.Tests.Common.Securities
                 Symbol.CreateFuture("VX", Market.USA, time.AddDays(0)), // There is no Expiry function for VX on Market.USA
             };
 
-            // Since this is a unidentifiable symbol for our expiry functions it will return false and be filtered out
+            // Since this is a unidentifiable symbol for our expiry functions it will return true and be passed through
             var filtered = filter.Filter(new FutureFilterUniverse(symbols, underlying)).ToList();
-            Assert.AreEqual(0, filtered.Count);
+            Assert.AreEqual(1, filtered.Count);
+            Assert.AreEqual(symbols[0], filtered[0]);
         }
     }
 }

--- a/Tests/Common/Securities/FutureFilterTests.cs
+++ b/Tests/Common/Securities/FutureFilterTests.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Tests.Common.Securities
             Func<FutureFilterUniverse, FutureFilterUniverse> universeFunc = universe => universe;
 
             Func<IDerivativeSecurityFilterUniverse, IDerivativeSecurityFilterUniverse> func =
-                universe => universeFunc(universe as FutureFilterUniverse).ApplyOptionTypesFilter();
+                universe => universeFunc(universe as FutureFilterUniverse).ApplyTypesFilter();
 
             var filter = new FuncSecurityDerivativeFilter(func);
             var symbols = new[]

--- a/Tests/Common/Securities/OptionFilterTests.cs
+++ b/Tests/Common/Securities/OptionFilterTests.cs
@@ -324,7 +324,7 @@ namespace QuantConnect.Tests.Common.Securities
             Func<OptionFilterUniverse, OptionFilterUniverse> universeFunc = universe => universe;
 
             Func<IDerivativeSecurityFilterUniverse, IDerivativeSecurityFilterUniverse> func =
-                universe => universeFunc(universe as OptionFilterUniverse).ApplyOptionTypesFilter();
+                universe => universeFunc(universe as OptionFilterUniverse).ApplyTypesFilter();
 
             var filter = new FuncSecurityDerivativeFilter(func);
             var symbols = new[]
@@ -365,7 +365,7 @@ namespace QuantConnect.Tests.Common.Securities
             Func<OptionFilterUniverse, OptionFilterUniverse> universeFunc = universe => universe;
 
             Func<IDerivativeSecurityFilterUniverse, IDerivativeSecurityFilterUniverse> func =
-                universe => universeFunc(universe as OptionFilterUniverse).ApplyOptionTypesFilter();
+                universe => universeFunc(universe as OptionFilterUniverse).ApplyTypesFilter();
 
             var filter = new FuncSecurityDerivativeFilter(func);
             var symbols = new[]
@@ -402,7 +402,7 @@ namespace QuantConnect.Tests.Common.Securities
             Func<OptionFilterUniverse, OptionFilterUniverse> universeFunc = universe => universe.WeeklysOnly();
 
             Func<IDerivativeSecurityFilterUniverse, IDerivativeSecurityFilterUniverse> func =
-                universe => universeFunc(universe as OptionFilterUniverse).ApplyOptionTypesFilter();
+                universe => universeFunc(universe as OptionFilterUniverse).ApplyTypesFilter();
 
             var filter = new FuncSecurityDerivativeFilter(func);
             var symbols = new[]
@@ -436,7 +436,7 @@ namespace QuantConnect.Tests.Common.Securities
             Func<OptionFilterUniverse, OptionFilterUniverse> universeFunc = universe => universe.IncludeWeeklys();
 
             Func<IDerivativeSecurityFilterUniverse, IDerivativeSecurityFilterUniverse> func =
-                universe => universeFunc(universe as OptionFilterUniverse).ApplyOptionTypesFilter();
+                universe => universeFunc(universe as OptionFilterUniverse).ApplyTypesFilter();
 
             var filter = new FuncSecurityDerivativeFilter(func);
             var symbols = new[]

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -2023,7 +2023,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             else if (securityType == SecurityType.Future)
             {
                 var future = algorithm.AddFuture(Futures.Indices.SP500EMini, Resolution.Minute);
-                future.SetFilter(x => x);
+                future.SetFilter(x => x.IncludeWeeklys());
                 exchangeTimeZone = future.Exchange.TimeZone;
             }
             else

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -2023,6 +2023,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             else if (securityType == SecurityType.Future)
             {
                 var future = algorithm.AddFuture(Futures.Indices.SP500EMini, Resolution.Minute);
+                // Must include weeklys because the contracts returned by the lookup, futureSymbol1 & futureSymbol2, are non-standard
                 future.SetFilter(x => x.IncludeWeeklys());
                 exchangeTimeZone = future.Exchange.TimeZone;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Support filtering Future contracts by Standard or Weeklys
- Combine core filtering logic of Options and Futures contracts into new base class `ContractSecurityFilterUniverse<T>` to reduce code duplication
- Addition of tests to verify correct behaviour of filters


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4725 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Just as with Options we expect Futures to only include standard contracts by default. This PR implements the functionality to filter out these contracts with the same interface as OptionFilterUniverse, (i.e. .IncludeWeeklys(), WeeklysOnly). Now by default (just like Options) Futures contracts will not include weeklys, you must use the filter functions above to allow them through the filter.

Also upon inspection it was clear that both filter setups (OptionsFilterUniverse & FutureFilterUniverse) were basically exactly the same except a couple of unique filters. So instead of expanding the duplication of code I combined their core logic into a shared base class and then left the unique functions for implementation in their respective classes. 

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Test built to cover case of filtering out weeklys, standards, and neither 
- Test for symbols without an expiry function (flags as standard by default**) 
- Ran Live Paper Trading through IB to observe the Weekly contracts for "VX" being filtered out as described in #4725 
- Will test in the cloud

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
