### PR TITLE
Do not terminate algorithm for exceptions in GDAX Fill Monitor

### DIFF
--- a/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
@@ -539,7 +539,12 @@ namespace QuantConnect.Brokerages.GDAX
 
                         if (response.StatusCode != HttpStatusCode.OK)
                         {
-                            throw new Exception($"GDAXBrokerage.FillMonitorAction(): request failed: [{(int)response.StatusCode}] {response.StatusDescription}, Content: {response.Content}, ErrorMessage: {response.ErrorMessage}");
+                            OnMessage(new BrokerageMessageEvent(
+                                BrokerageMessageType.Warning,
+                                -1,
+                                $"GDAXBrokerage.FillMonitorAction(): request failed: [{(int)response.StatusCode}] {response.StatusDescription}, Content: {response.Content}, ErrorMessage: {response.ErrorMessage}"));
+
+                            continue;
                         }
 
                         var fills = JsonConvert.DeserializeObject<List<Messages.Fill>>(response.Content);
@@ -560,7 +565,7 @@ namespace QuantConnect.Brokerages.GDAX
             }
             catch (Exception exception)
             {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, -1, exception.Message));
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, -1, exception.Message));
             }
 
             Log.Trace("GDAXBrokerage.FillMonitorAction(): task ended");

--- a/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
+++ b/Brokerages/GDAX/GDAXBrokerage.Messaging.cs
@@ -560,7 +560,7 @@ namespace QuantConnect.Brokerages.GDAX
             }
             catch (Exception exception)
             {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, -1, exception.Message));
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, -1, exception.Message));
             }
 
             Log.Trace("GDAXBrokerage.FillMonitorAction(): task ended");


### PR DESCRIPTION

#### Description
- An exception in the GDAX Fill Monitor no longer terminates the algorithm

#### Related Issue
Closes #4909 

#### Motivation and Context
- Occasional API call failures should not terminate a live algorithm

#### Requires Documentation Change
No.

#### How Has This Been Tested?
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`