### PR TITLE
Fix ambiguous future symbol error in IB brokerage

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1861,7 +1861,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                                         _futuresExchanges[symbol.ID.Market] :
                                         symbol.ID.Market;
 
-                var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(symbol.ID.Market, contract.Symbol, SecurityType.Future, Currencies.USD);
+                var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(
+                    symbol.ID.Market,
+                    symbol.ID.Symbol,
+                    SecurityType.Future,
+                    Currencies.USD);
+
                 contract.Multiplier = Convert.ToInt32(symbolProperties.ContractMultiplier).ToStringInvariant();
 
                 contract.IncludeExpired = includeExpired;
@@ -2741,9 +2746,14 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             else if (securityType == SecurityType.Future)
             {
                 string market;
-                if (_symbolPropertiesDatabase.TryGetMarket(contract.Symbol, securityType, out market))
+                if (_symbolPropertiesDatabase.TryGetMarket(lookupName, securityType, out market))
                 {
-                    var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(market, contract.Symbol, securityType, Currencies.USD);
+                    var symbolProperties = _symbolPropertiesDatabase.GetSymbolProperties(
+                        market,
+                        lookupName,
+                        securityType,
+                        Currencies.USD);
+
                     contract.Multiplier = Convert.ToInt32(symbolProperties.ContractMultiplier).ToStringInvariant();
                 }
 


### PR DESCRIPTION

#### Description
- IB contracts used for subscriptions and future chain requests now include the Multiplier field, which is loaded from the symbol properties database.
- The `GetFuturesContractExchange()` method was unused and has been removed

#### Related Issue
Closes #2924 

#### Motivation and Context
- Solves the ambiguity for IB future contracts with same ticker but different contract multipliers.
- When loading future contracts for `Futures.Metals.Silver` (`SI`) (or subscribing to a single future contract) we will only request contracts with the `5000` multiplier (which is specified in the symbol properties database) instead of throwing the following exception:
```
ErrorCode: 200 - The contract description specified for SI is ambiguous; you must specify the multiplier or trading class.
```

**Note**: for now LEAN does not support future contracts with duplicate tickers but different multipliers in the SPDB, 
so for the `SI` example above the `1000` multiplier contracts are not supported.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Live algorithm subscribing to the SI future 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`