### PR TITLE
Fix Base Account Currency message for PaperBrokerage

### DIFF
--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -195,7 +195,7 @@ namespace QuantConnect.Lean.Engine.Setup
                     return false;
                 }
 
-                var message = $"{brokerage.Name} account base currency: {brokerage.AccountBaseCurrency}";
+                var message = $"{brokerage.Name} account base currency: {brokerage.AccountBaseCurrency ?? algorithm.AccountCurrency}";
 
                 Log.Trace($"BrokerageSetupHandler.Setup(): {message}");
 


### PR DESCRIPTION

#### Description
- In live mode, when the brokerage does not return a base account currency, we now display the default algorithm account currency (USD) in the message.

#### Related Issue
n/a

#### Motivation and Context
- The displayed message was not showing the default currency (USD)

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Cloud deployment to Paper brokerage:
  - previous message: `Paper Brokerage account base currency:`
  - new message: `Paper Brokerage account base currency: USD`

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.