### PR TITLE
Enable logging when building and uploading stubs

### DIFF
--- a/ci_build_stubs.sh
+++ b/ci_build_stubs.sh
@@ -73,7 +73,7 @@ function publish_stubs {
     TWINE_USERNAME="__token__" \
     TWINE_PASSWORD="$PYPI_API_TOKEN" \
     TWINE_REPOSITORY="$PYPI_REPO" \
-    twine upload "$STUBS_DIR/dist/*" &>/dev/null
+    twine upload "$STUBS_DIR/dist/*"
 
     if [ $? -ne 0 ]; then
         echo "PyPI publishing failed"

--- a/ci_build_stubs.sh
+++ b/ci_build_stubs.sh
@@ -68,7 +68,7 @@ function publish_stubs {
     # This API token should be valid for the current $PYPI_REPO and should include the "pypi-" prefix
 
     cd $STUBS_DIR
-    python setup.py --quiet sdist bdist_wheel
+    python setup.py sdist bdist_wheel
 
     TWINE_USERNAME="__token__" \
     TWINE_PASSWORD="$PYPI_API_TOKEN" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR enables the `twine upload` and `python setup.py sdist bdist_wheel` logging in the script that builds the stubs. Currently the former command fails for an unknown reason, the logging should make clear what is happening (everything works fine on my fork, that's the weird thing).

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without the logging we won't know what goes wrong.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've ran this myself in several Travis builds of my fork before hiding the logging.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
