### PR TITLE
Fixes weeklies parsing, causing certain futures to be inaccessible in QCAlgorithm

### DIFF
--- a/Common/Securities/Future/FutureSymbol.cs
+++ b/Common/Securities/Future/FutureSymbol.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Securities.Future
             {
                 // Use our FutureExpiryFunctions to determine standard contracts dates.
                 var expiryFunction = FuturesExpiryFunctions.FuturesExpiryFunction(symbol);
-                var monthsToAdd = FuturesExpiryUtilityFunctions.ExpiresInPreviousMonth(symbol.ID.Symbol, contractExpirationDate);
+                var monthsToAdd = FuturesExpiryUtilityFunctions.GetDeltaBetweenContractMonthAndContractExpiry(symbol.ID.Symbol, contractExpirationDate);
                 var contractMonth = contractExpirationDate.AddDays(-(contractExpirationDate.Day - 1))
                     .AddMonths(monthsToAdd);
 

--- a/Common/Securities/Future/FutureSymbol.cs
+++ b/Common/Securities/Future/FutureSymbol.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,16 +30,20 @@ namespace QuantConnect.Securities.Future
         /// <returns>True if symbol expiration matches standard expiration</returns>
         public static bool IsStandard(Symbol symbol)
         {
-            var contractExpirationDate = symbol.ID.Date;
+            var contractExpirationDate = symbol.ID.Date.Date;
 
             try
             {
                 // Use our FutureExpiryFunctions to determine standard contracts dates.
                 var expiryFunction = FuturesExpiryFunctions.FuturesExpiryFunction(symbol);
-                var standardExpirationDate = expiryFunction(contractExpirationDate);
+                var monthsToAdd = FuturesExpiryUtilityFunctions.ExpiresInPreviousMonth(symbol.ID.Symbol, contractExpirationDate);
+                var contractMonth = contractExpirationDate.AddDays(-(contractExpirationDate.Day - 1))
+                    .AddMonths(monthsToAdd);
+
+                var standardExpirationDate = expiryFunction(contractMonth);
 
                 // Return true if the dates match
-                return contractExpirationDate.Date == standardExpirationDate.Date;
+                return contractExpirationDate == standardExpirationDate.Date;
             }
             catch
             {

--- a/Common/Securities/Future/FuturesExpiryFunctions.cs
+++ b/Common/Securities/Future/FuturesExpiryFunctions.cs
@@ -180,8 +180,8 @@ namespace QuantConnect.Securities.Future
             {new DateTime(2022, 7, 1), new DateTime(2022, 8, 3) },
             {new DateTime(2022, 8, 1), new DateTime(2022, 8, 31) },
             {new DateTime(2022, 9, 1), new DateTime(2022, 10, 5) },
-            {new DateTime(2022, 10, 1), new DateTime(2022, 9, 2) },
-            {new DateTime(2022, 11, 1), new DateTime(2022, 9, 30) },
+            {new DateTime(2022, 10, 1), new DateTime(2022, 11, 2) },
+            {new DateTime(2022, 11, 1), new DateTime(2022, 11, 30) },
             {new DateTime(2022, 12, 1), new DateTime(2023, 1, 5) },
         };
 

--- a/Common/Securities/Future/FuturesExpiryFunctions.cs
+++ b/Common/Securities/Future/FuturesExpiryFunctions.cs
@@ -47,8 +47,7 @@ namespace QuantConnect.Securities.Future
 
         /// <summary>
         /// The USDA publishes a report containing contract prices for the contract month.
-        /// You can generate the report dates here: https://mpr.datamart.ams.usda.gov/menu.do?path=Products\Dairy\All%20Dairy\(DY_CL102)%20National%20Dairy%20Products%20Prices%20-%20Monthly
-        /// And you can see future publication dates at https://usda.library.cornell.edu/concern/publications/zs25x847n
+        /// You can see future publication dates at https://www.ams.usda.gov/rules-regulations/mmr/dmr (Advanced and Class Price Release Dates)
         /// These dates are erratic and requires maintenance of a separate list instead of using holiday entries in MHDB.
         /// </summary>
         /// <remarks>We only report the publication date of the report. In order to get accurate last trade dates, subtract one (plus holidays) from the value's date</remarks>
@@ -165,6 +164,25 @@ namespace QuantConnect.Securities.Future
             {new DateTime(2021, 3, 1), new DateTime(2021, 3, 31) },
             {new DateTime(2021, 4, 1), new DateTime(2021, 5, 5) },
             {new DateTime(2021, 5, 1), new DateTime(2021, 6, 3) },
+            {new DateTime(2021, 6, 1), new DateTime(2021, 6, 30) },
+            {new DateTime(2021, 7, 1), new DateTime(2021, 8, 4) },
+            {new DateTime(2021, 8, 1), new DateTime(2021, 9, 1) },
+            {new DateTime(2021, 9, 1), new DateTime(2021, 9, 29) },
+            {new DateTime(2021, 10, 1), new DateTime(2021, 11, 3) },
+            {new DateTime(2021, 11, 1), new DateTime(2021, 12, 1) },
+            {new DateTime(2021, 12, 1), new DateTime(2022, 1, 5) },
+            {new DateTime(2022, 1, 1), new DateTime(2022, 2, 2) },
+            {new DateTime(2022, 2, 1), new DateTime(2022, 3, 2) },
+            {new DateTime(2022, 3, 1), new DateTime(2022, 3, 30) },
+            {new DateTime(2022, 4, 1), new DateTime(2022, 5, 4) },
+            {new DateTime(2022, 5, 1), new DateTime(2022, 6, 2) },
+            {new DateTime(2022, 6, 1), new DateTime(2022, 6, 29) },
+            {new DateTime(2022, 7, 1), new DateTime(2022, 8, 3) },
+            {new DateTime(2022, 8, 1), new DateTime(2022, 8, 31) },
+            {new DateTime(2022, 9, 1), new DateTime(2022, 10, 5) },
+            {new DateTime(2022, 10, 1), new DateTime(2022, 9, 2) },
+            {new DateTime(2022, 11, 1), new DateTime(2022, 9, 30) },
+            {new DateTime(2022, 12, 1), new DateTime(2023, 1, 5) },
         };
 
         /// <summary>

--- a/Common/Securities/Future/FuturesExpiryUtilityFunctions.cs
+++ b/Common/Securities/Future/FuturesExpiryUtilityFunctions.cs
@@ -335,16 +335,17 @@ namespace QuantConnect.Securities.Future
         }
 
         /// <summary>
-        /// Returns the number of months prior to the contract month that the future expires
+        /// Gets the number of months between the contract month and the expiry date.
         /// </summary>
-        /// <param name="underlying">The future symbol</param>
-        /// <param name="expiryDate">Expiry date to use to look up contract month delta</param>
-        /// <returns>The number of months prior it expires</returns>
-        public static int ExpiresInPreviousMonth(string underlying, DateTime? expiryDate = null)
+        /// <param name="underlying">The future symbol ticker</param>
+        /// <param name="expiryDate">Expiry date to use to look up contract month delta. Only used for dairy, since we need to lookup its contract month in a pre-defined table.</param>
+        /// <returns>The number of months between the contract month and the contract expiry</returns>
+        public static int GetDeltaBetweenContractMonthAndContractExpiry(string underlying, DateTime? expiryDate = null)
         {
             int value;
             if (expiryDate != null && _dairyUnderlying.Contains(underlying))
             {
+                // Dairy can expire in the month following the contract month.
                 var dairyReportDate = expiryDate.Value.Date.AddDays(1);
                 if (_reverseDairyReportDates.ContainsKey(dairyReportDate))
                 {

--- a/Common/Securities/Future/FuturesExpiryUtilityFunctions.cs
+++ b/Common/Securities/Future/FuturesExpiryUtilityFunctions.cs
@@ -25,6 +25,19 @@ namespace QuantConnect.Securities.Future
     /// </summary>
     public static class FuturesExpiryUtilityFunctions
     {
+        private static readonly Dictionary<DateTime, DateTime> _reverseDairyReportDates = FuturesExpiryFunctions.DairyReportDates
+            .ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+
+        private static readonly HashSet<string> _dairyUnderlying = new HashSet<string>
+        {
+            "CB",
+            "CSC",
+            "DC",
+            "DY",
+            "GDK",
+            "GNF"
+        };
+
         /// <summary>
         /// Method to retrieve n^th succeeding/preceding business day for a given day
         /// </summary>
@@ -325,15 +338,29 @@ namespace QuantConnect.Securities.Future
         /// Returns the number of months prior to the contract month that the future expires
         /// </summary>
         /// <param name="underlying">The future symbol</param>
+        /// <param name="expiryDate">Expiry date to use to look up contract month delta</param>
         /// <returns>The number of months prior it expires</returns>
-        public static int ExpiresInPreviousMonth(string underlying)
+        public static int ExpiresInPreviousMonth(string underlying, DateTime? expiryDate = null)
         {
             int value;
+            if (expiryDate != null && _dairyUnderlying.Contains(underlying))
+            {
+                var dairyReportDate = expiryDate.Value.Date.AddDays(1);
+                if (_reverseDairyReportDates.ContainsKey(dairyReportDate))
+                {
+                    var contractMonth = _reverseDairyReportDates[dairyReportDate];
+                    // Gets the distance between two months in months
+                    return ((contractMonth.Year - dairyReportDate.Year) * 12) + contractMonth.Month - dairyReportDate.Month;
+                }
+
+                return 0;
+            }
+
             return ExpiriesPriorMonth.TryGetValue(underlying, out value) ? value : 0;
         }
 
         /// <summary>
-        /// Extracts Date portion of list of DateTimes for 
+        /// Extracts Date portion of list of DateTimes
         /// </summary>
         /// <param name="dateTimeList">List of DateTimes (with optional time portion) to filter</param>
         /// <returns>List of DateTimes with default time (00:00:00)</returns>

--- a/Common/SecurityIdentifier.cs
+++ b/Common/SecurityIdentifier.cs
@@ -155,8 +155,8 @@ namespace QuantConnect
         /// Gets the date component of this identifier. For equities this
         /// is the first date the security traded. Technically speaking,
         /// in LEAN, this is the first date mentioned in the map_files.
-        /// For options this is the expiry date. For futures this is the
-        /// settlement date. For forex and cfds this property will throw an
+        /// For futures and options this is the expiry date of the contract.
+        /// For other asset classes, this property will throw an
         /// exception as the field is not specified.
         /// </summary>
         public DateTime Date

--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -527,7 +527,7 @@ namespace QuantConnect.Util
                     // GH review comment:
                     // We skip adding the expiry component to maintain backwards compatibility. @Jay-Jay-D let me know if
                     // you'd like to fix this and reprocess futures data
-                    var monthsToAdd = FuturesExpiryUtilityFunctions.ExpiresInPreviousMonth(symbol.ID.Symbol);// expiryDate.Date);
+                    var monthsToAdd = FuturesExpiryUtilityFunctions.GetDeltaBetweenContractMonthAndContractExpiry(symbol.ID.Symbol);// expiryDate.Date);
                     var contractYearMonth = expiryDate.AddMonths(monthsToAdd).ToStringInvariant(DateFormat.YearMonth);
 
                     if (isHourOrDaily)

--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -524,10 +524,7 @@ namespace QuantConnect.Util
 
                 case SecurityType.Future:
                     var expiryDate = symbol.ID.Date;
-                    // GH review comment:
-                    // We skip adding the expiry component to maintain backwards compatibility. @Jay-Jay-D let me know if
-                    // you'd like to fix this and reprocess futures data
-                    var monthsToAdd = FuturesExpiryUtilityFunctions.GetDeltaBetweenContractMonthAndContractExpiry(symbol.ID.Symbol);// expiryDate.Date);
+                    var monthsToAdd = FuturesExpiryUtilityFunctions.GetDeltaBetweenContractMonthAndContractExpiry(symbol.ID.Symbol, expiryDate.Date);
                     var contractYearMonth = expiryDate.AddMonths(monthsToAdd).ToStringInvariant(DateFormat.YearMonth);
 
                     if (isHourOrDaily)

--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -524,7 +524,10 @@ namespace QuantConnect.Util
 
                 case SecurityType.Future:
                     var expiryDate = symbol.ID.Date;
-                    var monthsToAdd = FuturesExpiryUtilityFunctions.ExpiresInPreviousMonth(symbol.ID.Symbol); 
+                    // GH review comment:
+                    // We skip adding the expiry component to maintain backwards compatibility. @Jay-Jay-D let me know if
+                    // you'd like to fix this and reprocess futures data
+                    var monthsToAdd = FuturesExpiryUtilityFunctions.ExpiresInPreviousMonth(symbol.ID.Symbol);// expiryDate.Date);
                     var contractYearMonth = expiryDate.AddMonths(monthsToAdd).ToStringInvariant(DateFormat.YearMonth);
 
                     if (isHourOrDaily)
@@ -767,8 +770,8 @@ namespace QuantConnect.Util
             }
             if (type == typeof(Tick))
             {
-                if (securityType == SecurityType.Forex || 
-                    securityType == SecurityType.Cfd || 
+                if (securityType == SecurityType.Forex ||
+                    securityType == SecurityType.Cfd ||
                     securityType == SecurityType.Crypto)
                 {
                     return TickType.Quote;

--- a/Tests/Common/Securities/FutureFilterTests.cs
+++ b/Tests/Common/Securities/FutureFilterTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -90,6 +90,37 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
+        public void WeeklysFilterDoesNotFilterStandardContractWithExpiryMonthPriorOrAfterContractMonth()
+        {
+            var underlying = new Tick { Value = 10m, Time = new DateTime(2020, 1, 1) };
+
+            Func<FutureFilterUniverse, FutureFilterUniverse> universeFunc = universe => universe;
+
+            Func<IDerivativeSecurityFilterUniverse, IDerivativeSecurityFilterUniverse> func =
+                universe => universeFunc(universe as FutureFilterUniverse).ApplyTypesFilter();
+
+            var filter = new FuncSecurityDerivativeFilter(func);
+            var symbols = new[]
+            {
+                Symbol.CreateFuture("CL", Market.NYMEX, new DateTime(2020, 11, 20)),
+                Symbol.CreateFuture("DC", Market.CME, new DateTime(2021, 2, 2)),
+                Symbol.CreateFuture("HO", Market.NYMEX, new DateTime(2020, 12, 31)),
+                Symbol.CreateFuture("DY", Market.CME, new DateTime(2021, 2, 2)),
+                Symbol.CreateFuture("YO", Market.NYMEX, new DateTime(2021, 4, 30)),
+                Symbol.CreateFuture("NG", Market.NYMEX, new DateTime(2020, 11, 25))
+            };
+
+            var standardContracts = filter.Filter(new FutureFilterUniverse(symbols, underlying)).ToList();
+            Assert.AreEqual(6, standardContracts.Count);
+            Assert.AreEqual(symbols[0], standardContracts[0]);
+            Assert.AreEqual(symbols[1], standardContracts[1]);
+            Assert.AreEqual(symbols[2], standardContracts[2]);
+            Assert.AreEqual(symbols[3], standardContracts[3]);
+            Assert.AreEqual(symbols[4], standardContracts[4]);
+            Assert.AreEqual(symbols[5], standardContracts[5]);
+        }
+
+        [Test]
         public void FilterAllowBothTypes()
         {
             var time = new DateTime(2016, 02, 17, 13, 0, 0);
@@ -153,7 +184,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var expiry1 = new DateTime(2016, 12, 02);
             var expiry2 = new DateTime(2016, 12, 09);
-            var expiry3 = new DateTime(2016, 12, 16); 
+            var expiry3 = new DateTime(2016, 12, 16);
             var expiry4 = new DateTime(2016, 12, 23);
 
             var underlying = new Tick { Value = 10m, Time = new DateTime(2016, 02, 26) };
@@ -221,7 +252,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var expiry1 = new DateTime(2016, 1, 02);
             var expiry2 = new DateTime(2016, 3, 09);
-            var expiry3 = new DateTime(2016, 8, 16); 
+            var expiry3 = new DateTime(2016, 8, 16);
             var expiry4 = new DateTime(2016, 12, 23);
 
             var underlying = new Tick { Value = 10m, Time = new DateTime(2016, 02, 26) };

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -170,5 +170,15 @@ namespace QuantConnect.Tests.Common
 
             Assert.AreEqual(ticker, result);
         }
+
+        [TestCase("DC", 2023, 1, 4, "DC04Z22", true)] // Contract month is 2022-12, expires on 2023-01-04. Same situation with the rest of the test cases.
+        [TestCase("DY", 2022, 10, 4, "DY04U22", true)]
+        [TestCase("GDK", 2022, 11, 1, "GDK01V22", true)]
+        public void GenerateFutureTickerExpiringInNextMonth(string ticker, int year, int month, int day, string expectedValue, bool doubleDigitsYear)
+        {
+            var result = SymbolRepresentation.GenerateFutureTicker(ticker, new DateTime(year, month, day), doubleDigitsYear);
+
+            Assert.AreEqual(expectedValue, result);
+        }
     }
 }


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
  The FuturesExpiryFunction expects the contract month of the Future,
  not the expiration. As a result, the contract gets filtered as a
  weekly contract, rather than as a standard due to the discrepancy
  between the expiry dates when the contract month differs from the
  expiry date's month.

  A very important fact to note is that futures can and do expire prior
  to the contract month. BZ,(brent crude financial futures) expire two
  months prior to the contract month, CL one month prior, etc.

  There has been an addition that contains a "reverse" futures expiry function
  lookup table. We use this to lookup the contract month to re-calculate
  the Future expiry.

  This PR also fixes dairy and adds extra expiry dates. Dairy can have
  an expiry *after* the contract month, so a new path was added to the
  SymbolRepresentation to ensure that these contracts are loaded
  correctly.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A (thanks to Aram Darakchian for pointing out this issue on Slack)
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes bug, improving stability and usability of product
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A - tests will be added soon
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed. (new tests must be added, tests might not be passing)
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
