### PR TITLE
RoundDown fix for PeriodCountConsolidatorBase

### DIFF
--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -364,7 +364,7 @@ namespace QuantConnect.Data.Consolidators
 
             public DateTime GetRoundedBarTime(DateTime time) =>
                 Period.Value > Time.OneDay
-                    ? time.SubtractRoundDown(Period.Value, Time.OneDay)
+                    ? time // #4915 For periods larger than a day, don't use a rounding schedule.
                     : time.RoundDown(Period.Value);
         }
 

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -362,7 +362,8 @@ namespace QuantConnect.Data.Consolidators
                 Period = period;
             }
 
-            public DateTime GetRoundedBarTime(DateTime time) => time.RoundDown(Period.Value);
+            public DateTime GetRoundedBarTime(DateTime time) => 
+                time.SubtractRoundDown(Period.Value, Time.OneDay);
         }
 
         /// <summary>

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -362,8 +362,10 @@ namespace QuantConnect.Data.Consolidators
                 Period = period;
             }
 
-            public DateTime GetRoundedBarTime(DateTime time) => 
-                time.SubtractRoundDown(Period.Value, Time.OneDay);
+            public DateTime GetRoundedBarTime(DateTime time) =>
+                Period.Value > Time.OneDay
+                    ? time.SubtractRoundDown(Period.Value, Time.OneDay)
+                    : time.RoundDown(Period.Value);
         }
 
         /// <summary>

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1015,7 +1015,7 @@ namespace QuantConnect
         /// Extension method to round a datetime down by a timespan interval.
         /// </summary>
         /// <param name="dateTime">Base DateTime object we're rounding down.</param>
-        /// <param name="interval">Timespan interval to round to, must be less than one day</param>
+        /// <param name="interval">Timespan interval to round to, must be less than or equal to one day</param>
         /// <returns>Rounded datetime</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DateTime RoundDown(this DateTime dateTime, TimeSpan interval)
@@ -1045,7 +1045,7 @@ namespace QuantConnect
         /// </summary>
         /// <param name="dateTime">Base DateTime object we are subtracting and rounding down on</param>
         /// <param name="period">Period to subtract from DateTime</param>
-        /// <param name="interval">Timespan interval to round to, must be less than one day</param>
+        /// <param name="interval">Timespan interval to round to, must be less than or equal to one day</param>
         /// <returns>Rounded datetime</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DateTime SubtractRoundDown(this DateTime dateTime, TimeSpan period, TimeSpan interval)
@@ -1143,7 +1143,7 @@ namespace QuantConnect
         /// Extension method to explicitly round up to the nearest timespan interval.
         /// </summary>
         /// <param name="time">Base datetime object to round up.</param>
-        /// <param name="interval">Timespan interval for rounding, must be less than one day</param>
+        /// <param name="interval">Timespan interval for rounding, must be less than or equal to one day</param>
         /// <returns>Rounded datetime</returns>
         public static DateTime RoundUp(this DateTime time, TimeSpan interval)
         {
@@ -1167,7 +1167,7 @@ namespace QuantConnect
         /// </summary>
         /// <param name="dateTime">Base DateTime object we are adding to and rounding up on</param>
         /// <param name="period">Period to add to DateTime</param>
-        /// <param name="interval">Timespan interval to round up to, must be less than one day</param>
+        /// <param name="interval">Timespan interval to round up to, must be less than or equal to one day</param>
         /// <returns>Rounded datetime</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DateTime AddRoundUp(this DateTime dateTime, TimeSpan period, TimeSpan interval)

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1015,7 +1015,7 @@ namespace QuantConnect
         /// Extension method to round a datetime down by a timespan interval.
         /// </summary>
         /// <param name="dateTime">Base DateTime object we're rounding down.</param>
-        /// <param name="interval">Timespan interval to round to.</param>
+        /// <param name="interval">Timespan interval to round to, must be less than one day</param>
         /// <returns>Rounded datetime</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DateTime RoundDown(this DateTime dateTime, TimeSpan interval)
@@ -1026,12 +1026,31 @@ namespace QuantConnect
                 return dateTime;
             }
 
+            if (interval > TimeSpan.FromDays(1))
+            {
+                throw new ArgumentOutOfRangeException(nameof(interval),
+                    "DateTime.RoundDown(): Interval must be less than 1 day");
+            }
+
             var amount = dateTime.Ticks % interval.Ticks;
             if (amount > 0)
             {
                 return dateTime.AddTicks(-amount);
             }
             return dateTime;
+        }
+
+        /// <summary>
+        /// Extension method to subtract a period from a datetime and then round down by a timespan interval.
+        /// </summary>
+        /// <param name="dateTime">Base DateTime object we are subtracting and rounding down on</param>
+        /// <param name="period">Period to subtract from DateTime</param>
+        /// <param name="interval">Timespan interval to round to, must be less than one day</param>
+        /// <returns>Rounded datetime</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static DateTime SubtractRoundDown(this DateTime dateTime, TimeSpan period, TimeSpan interval)
+        {
+            return dateTime.Subtract(period).RoundDown(interval);
         }
 
         /// <summary>
@@ -1124,16 +1143,36 @@ namespace QuantConnect
         /// Extension method to explicitly round up to the nearest timespan interval.
         /// </summary>
         /// <param name="time">Base datetime object to round up.</param>
-        /// <param name="d">Timespan interval for rounding</param>
+        /// <param name="interval">Timespan interval for rounding, must be less than one day</param>
         /// <returns>Rounded datetime</returns>
-        public static DateTime RoundUp(this DateTime time, TimeSpan d)
+        public static DateTime RoundUp(this DateTime time, TimeSpan interval)
         {
-            if (d == TimeSpan.Zero)
+            if (interval == TimeSpan.Zero)
             {
                 // divide by zero exception
                 return time;
             }
-            return new DateTime(((time.Ticks + d.Ticks - 1) / d.Ticks) * d.Ticks);
+
+            if (interval > TimeSpan.FromDays(1))
+            {
+                throw new ArgumentOutOfRangeException(nameof(interval),
+                    "DateTime.RoundDown(): Interval must be less than 1 day");
+            }
+
+            return new DateTime(((time.Ticks + interval.Ticks - 1) / interval.Ticks) * interval.Ticks);
+        }
+
+        /// <summary>
+        /// Extension method to add a period to a datetime and then round up by a timespan interval.
+        /// </summary>
+        /// <param name="dateTime">Base DateTime object we are adding to and rounding up on</param>
+        /// <param name="period">Period to add to DateTime</param>
+        /// <param name="interval">Timespan interval to round up to, must be less than one day</param>
+        /// <returns>Rounded datetime</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static DateTime AddRoundUp(this DateTime dateTime, TimeSpan period, TimeSpan interval)
+        {
+            return dateTime.Add(period).RoundUp(interval);
         }
 
         /// <summary>

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1041,19 +1041,6 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Extension method to subtract a period from a datetime and then round down by a timespan interval.
-        /// </summary>
-        /// <param name="dateTime">Base DateTime object we are subtracting and rounding down on</param>
-        /// <param name="period">Period to subtract from DateTime</param>
-        /// <param name="interval">Timespan interval to round to, must be less than or equal to one day</param>
-        /// <returns>Rounded datetime</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static DateTime SubtractRoundDown(this DateTime dateTime, TimeSpan period, TimeSpan interval)
-        {
-            return dateTime.Subtract(period).RoundDown(interval);
-        }
-
-        /// <summary>
         /// Rounds the specified date time in the specified time zone. Careful with calling this method in a loop while modifying dateTime, check unit tests.
         /// </summary>
         /// <param name="dateTime">Date time to be rounded</param>
@@ -1160,19 +1147,6 @@ namespace QuantConnect
             }
 
             return new DateTime(((time.Ticks + interval.Ticks - 1) / interval.Ticks) * interval.Ticks);
-        }
-
-        /// <summary>
-        /// Extension method to add a period to a datetime and then round up by a timespan interval.
-        /// </summary>
-        /// <param name="dateTime">Base DateTime object we are adding to and rounding up on</param>
-        /// <param name="period">Period to add to DateTime</param>
-        /// <param name="interval">Timespan interval to round up to, must be less than or equal to one day</param>
-        /// <returns>Rounded datetime</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static DateTime AddRoundUp(this DateTime dateTime, TimeSpan period, TimeSpan interval)
-        {
-            return dateTime.Add(period).RoundUp(interval);
         }
 
         /// <summary>

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1029,7 +1029,7 @@ namespace QuantConnect
             if (interval > TimeSpan.FromDays(1))
             {
                 throw new ArgumentOutOfRangeException(nameof(interval),
-                    "DateTime.RoundDown(): Interval must be less than 1 day");
+                    "DateTime.RoundDown(): Interval must be less than or equal to 1 day");
             }
 
             var amount = dateTime.Ticks % interval.Ticks;
@@ -1143,7 +1143,7 @@ namespace QuantConnect
             if (interval > TimeSpan.FromDays(1))
             {
                 throw new ArgumentOutOfRangeException(nameof(interval),
-                    "DateTime.RoundUp(): Interval must be less than 1 day");
+                    "DateTime.RoundUp(): Interval must be less than or equal to 1 day");
             }
 
             return new DateTime(((time.Ticks + interval.Ticks - 1) / interval.Ticks) * interval.Ticks);

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1156,7 +1156,7 @@ namespace QuantConnect
             if (interval > TimeSpan.FromDays(1))
             {
                 throw new ArgumentOutOfRangeException(nameof(interval),
-                    "DateTime.RoundDown(): Interval must be less than 1 day");
+                    "DateTime.RoundUp(): Interval must be less than 1 day");
             }
 
             return new DateTime(((time.Ticks + interval.Ticks - 1) / interval.Ticks) * interval.Ticks);

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1015,8 +1015,12 @@ namespace QuantConnect
         /// Extension method to round a datetime down by a timespan interval.
         /// </summary>
         /// <param name="dateTime">Base DateTime object we're rounding down.</param>
-        /// <param name="interval">Timespan interval to round to, must be less than or equal to one day</param>
+        /// <param name="interval">Timespan interval to round to</param>
         /// <returns>Rounded datetime</returns>
+        /// <remarks>Using this with timespans greater than 1 day may have unintended
+        /// consequences. Be aware that rounding occurs against ALL time, so when using
+        /// timespan such as 30 days we will see 30 day increments but it will be based
+        /// on 30 day increments from the beginning of time.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DateTime RoundDown(this DateTime dateTime, TimeSpan interval)
         {
@@ -1024,12 +1028,6 @@ namespace QuantConnect
             {
                 // divide by zero exception
                 return dateTime;
-            }
-
-            if (interval > TimeSpan.FromDays(1))
-            {
-                throw new ArgumentOutOfRangeException(nameof(interval),
-                    "DateTime.RoundDown(): Interval must be less than or equal to 1 day");
             }
 
             var amount = dateTime.Ticks % interval.Ticks;
@@ -1130,20 +1128,18 @@ namespace QuantConnect
         /// Extension method to explicitly round up to the nearest timespan interval.
         /// </summary>
         /// <param name="time">Base datetime object to round up.</param>
-        /// <param name="interval">Timespan interval for rounding, must be less than or equal to one day</param>
+        /// <param name="interval">Timespan interval to round to</param>
         /// <returns>Rounded datetime</returns>
+        /// <remarks>Using this with timespans greater than 1 day may have unintended
+        /// consequences. Be aware that rounding occurs against ALL time, so when using
+        /// timespan such as 30 days we will see 30 day increments but it will be based
+        /// on 30 day increments from the beginning of time.</remarks>
         public static DateTime RoundUp(this DateTime time, TimeSpan interval)
         {
             if (interval == TimeSpan.Zero)
             {
                 // divide by zero exception
                 return time;
-            }
-
-            if (interval > TimeSpan.FromDays(1))
-            {
-                throw new ArgumentOutOfRangeException(nameof(interval),
-                    "DateTime.RoundUp(): Interval must be less than or equal to 1 day");
             }
 
             return new DateTime(((time.Ticks + interval.Ticks - 1) / interval.Ticks) * interval.Ticks);

--- a/Tests/Common/Data/PeriodCountConsolidatorTests.cs
+++ b/Tests/Common/Data/PeriodCountConsolidatorTests.cs
@@ -18,13 +18,11 @@ using System;
 using NUnit.Framework;
 using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
-using QuantConnect.Indicators;
-
 
 namespace QuantConnect.Tests.Common.Data
 {
-    [TestFixture]
-    class PeriodCountConsolidatorTests
+    [TestFixture, Parallelizable(ParallelScope.All)]
+    public class PeriodCountConsolidatorTests
     {
         private static readonly object[] PeriodCases =
         {
@@ -70,8 +68,8 @@ namespace QuantConnect.Tests.Common.Data
 
                 // Our asserts
                 Assert.IsNotNull(consolidated);                                 // We have a bar
-                Assert.IsTrue(consolidated.EndTime == dataTime);                // New bar time should be dataTime
-                Assert.IsTrue(consolidated.EndTime - lastBarTime == barSpan);      // The difference between the bars is the span
+                Assert.AreEqual(dataTime, consolidated.EndTime);    // New bar time should be dataTime
+                Assert.AreEqual(barSpan, consolidated.EndTime - lastBarTime);      // The difference between the bars is the span
 
                 nextBarTime = dataTime + barSpan;
                 lastBarTime = consolidated.EndTime;
@@ -110,8 +108,8 @@ namespace QuantConnect.Tests.Common.Data
 
                 // Our asserts
                 Assert.IsNotNull(consolidated);                                 // We have a bar
-                Assert.IsTrue(consolidated.EndTime == dataTime);                // New bar time should be dataTime
-                Assert.IsTrue(consolidated.EndTime - lastBarTime == barSpan);      // The difference between the bars is the span
+                Assert.AreEqual(dataTime, consolidated.EndTime);    // New bar time should be dataTime
+                Assert.AreEqual(barSpan, consolidated.EndTime - lastBarTime);      // The difference between the bars is the span
 
                 nextBarTime = dataTime + barSpan;
                 lastBarTime = consolidated.EndTime;

--- a/Tests/Common/Data/PeriodCountConsolidatorTests.cs
+++ b/Tests/Common/Data/PeriodCountConsolidatorTests.cs
@@ -1,0 +1,121 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.Market;
+using QuantConnect.Indicators;
+
+
+namespace QuantConnect.Tests.Common.Data
+{
+    [TestFixture]
+    class PeriodCountConsolidatorTests
+    {
+        private static readonly object[] PeriodCases =
+        {
+            new [] { TimeSpan.FromDays(100), TimeSpan.FromDays(10) },
+            new [] { TimeSpan.FromDays(30), TimeSpan.FromDays(1) },     //GH Issue #4915
+            new [] { TimeSpan.FromDays(10), TimeSpan.FromDays(1) },
+            new [] { TimeSpan.FromDays(1), TimeSpan.FromHours(1) },
+            new [] { TimeSpan.FromHours(10), TimeSpan.FromHours(1) },
+            new [] { TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(1) },
+            new [] { TimeSpan.FromMinutes(1), TimeSpan.FromSeconds(10) },
+            new [] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(0.1) },
+        };
+
+        [TestCaseSource(nameof(PeriodCases))]
+        public void ExpectedConsolidatedTradeBarsInPeriodMode(TimeSpan barSpan, TimeSpan updateSpan)
+        {
+            TradeBar consolidated = null;
+            var consolidator = new BaseDataConsolidator(barSpan);
+            consolidator.DataConsolidated += (sender, bar) =>
+            {
+                Assert.AreEqual(barSpan, bar.Period);              // The period matches our span
+                consolidated = bar;
+            };
+
+            var reference = new DateTime(2015, 04, 13);
+            var dataTime = reference;
+
+            var nextBarTime = reference + barSpan;
+            var lastBarTime = reference;
+
+            // First data point
+            consolidator.Update(new Tick { Time = dataTime });
+            Assert.IsNull(consolidated);
+
+            for (var i = 0; i < 10; i++)
+            {
+                // Add data on the given interval until we expect a new bar
+                while (dataTime < nextBarTime)
+                {
+                    dataTime = dataTime.Add(updateSpan);
+                    consolidator.Update(new Tick { Time = dataTime });
+                }
+
+                // Our asserts
+                Assert.IsNotNull(consolidated);                                 // We have a bar
+                Assert.IsTrue(consolidated.EndTime == dataTime);                // New bar time should be dataTime
+                Assert.IsTrue(consolidated.EndTime - lastBarTime == barSpan);      // The difference between the bars is the span
+
+                nextBarTime = dataTime + barSpan;
+                lastBarTime = consolidated.EndTime;
+            }
+        }
+
+        [TestCaseSource(nameof(PeriodCases))]
+        public void ExpectedConsolidatedQuoteBarsInPeriodMode(TimeSpan barSpan, TimeSpan updateSpan)
+        {
+            QuoteBar consolidated = null;
+            var consolidator = new QuoteBarConsolidator(barSpan);
+            consolidator.DataConsolidated += (sender, bar) =>
+            {
+                Assert.AreEqual(barSpan, bar.Period);                  // The period matches our span
+                consolidated = bar;
+            };
+
+            var reference = new DateTime(2015, 04, 13);
+            var dataTime = reference;
+
+            var nextBarTime = reference + barSpan;
+            var lastBarTime = reference;
+
+            // First data point
+            consolidator.Update(new QuoteBar { Time = dataTime });
+            Assert.IsNull(consolidated);
+
+            for (var i = 0; i < 10; i++)
+            {
+                // Add data on the given interval until we expect a new bar
+                while (dataTime < nextBarTime)
+                {
+                    dataTime = dataTime.Add(updateSpan);
+                    consolidator.Update(new QuoteBar { Time = dataTime });
+                }
+
+                // Our asserts
+                Assert.IsNotNull(consolidated);                                 // We have a bar
+                Assert.IsTrue(consolidated.EndTime == dataTime);                // New bar time should be dataTime
+                Assert.IsTrue(consolidated.EndTime - lastBarTime == barSpan);      // The difference between the bars is the span
+
+                nextBarTime = dataTime + barSpan;
+                lastBarTime = consolidated.EndTime;
+            }
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -394,6 +394,7 @@
     <Compile Include="Common\Data\FakeDataQueuehandlerSubscriptionManager.cs" />
     <Compile Include="Common\Data\Fundamental\CoarseFundamentalTests.cs" />
     <Compile Include="Common\Data\Fundamental\FineFundamentalTests.cs" />
+    <Compile Include="Common\Data\PeriodCountConsolidatorTests.cs" />
     <Compile Include="Common\Orders\Fills\EquityFillModelTests.cs" />
     <Compile Include="Common\Orders\OrderEventTests.cs" />
     <Compile Include="Common\ExtendedDictionaryTests.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Add remarks to RoundDown and RoundUp regarding timespans larger than a day
- Modify behavior of `PeriodCountConsolidatorBase` classes to still accept timespans greater than 1 day but make bars generate off of initialization time instead of skewed RoundDown schedule; see #4915 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4915 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Weird behavior using RoundDown on timespans greater than a day. It is related to the rounding method used creating a rounded schedule for *ALL* time. This creates weird behavior on consolidators bar time ranges. See #4915 

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
I don't believe this was intend for this use initially but if there is any documentation regarding using timespans greater than a day with any consolidator construction such as `TradeBarConsolidator(TimeSpan.FromDays(30));` it should be updated to reflect the new behavior.

In an example: 
`TradeBarConsolidator(TimeSpan.FromDays(30));`
- My bars will be every 30 days from when consolidator is initialized
- Lets say my consolidator is created during init at 2/14 so,
Bars:
2/14 -3/15
3/15 - 4/14
etc


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests added to cover case of 30 days. Red/green light from master to this branch

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
