### PR TITLE
Bug 4927 Value Error

### DIFF
--- a/Common/Python/PandasConverter.cs
+++ b/Common/Python/PandasConverter.cs
@@ -135,18 +135,12 @@ namespace QuantConnect.Python
 
                 foreach (var kvp in data)
                 {
-                    var index = new List<DateTime>();
-                    var values = new List<double>();
-
-                    foreach (var item in kvp.Value)
-                    {
-                        index.Add(item.EndTime);
-                        values.Add((double)item.Value);
-                    }
-                    pyDict.SetItem(kvp.Key.ToLowerInvariant(), _pandas.Series(values, index));
+                    var index = kvp.Value.Select(x => x.EndTime);
+                    var values = kvp.Value.Select(x => x.Value);
+                    pyDict.SetItem(kvp.Key.ToLowerInvariant(), _pandas.Series(data: values, index: index));
                 }
 
-                return _pandas.DataFrame(pyDict, columns: data.Keys.Select(x => x.ToLowerInvariant()).OrderBy(x => x));
+                return _pandas.DataFrame.from_dict(pyDict);
             }
         }
 

--- a/Common/Python/PandasConverter.cs
+++ b/Common/Python/PandasConverter.cs
@@ -135,8 +135,15 @@ namespace QuantConnect.Python
 
                 foreach (var kvp in data)
                 {
-                    var index = kvp.Value.Select(x => x.EndTime);
-                    var values = kvp.Value.Select(x => x.Value);
+                    var index = new List<DateTime>();
+                    var values = new List<double>();
+
+                    foreach (var item in kvp.Value)
+                    {
+                        index.Add(item.EndTime);
+                        values.Add((double)item.Value);
+                    }
+
                     pyDict.SetItem(kvp.Key.ToLowerInvariant(), _pandas.Series(data: values, index: index));
                 }
 

--- a/Common/Python/PandasConverter.cs
+++ b/Common/Python/PandasConverter.cs
@@ -140,7 +140,7 @@ namespace QuantConnect.Python
                     pyDict.SetItem(kvp.Key.ToLowerInvariant(), _pandas.Series(data: values, index: index));
                 }
 
-                return _pandas.DataFrame.from_dict(pyDict);
+                return _pandas.DataFrame(pyDict, columns: data.Keys.Select(x => x.ToLowerInvariant()).OrderBy(x => x));
             }
         }
 

--- a/Indicators/CompositeIndicator.cs
+++ b/Indicators/CompositeIndicator.cs
@@ -156,6 +156,12 @@ namespace QuantConnect.Indicators
                     newLeftData = null;
                     newRightData = null;
                 }
+                else
+                {
+                    // Fill forward time
+                    Current = (IndicatorDataPoint)Current.Clone();
+                    Current.Time = MaxTime(updated);
+                }
             };
 
             Right.Updated += (sender, updated) =>
@@ -170,6 +176,12 @@ namespace QuantConnect.Indicators
                     // reset these to null after each update
                     newLeftData = null;
                     newRightData = null;
+                }
+                else
+                {
+                    // Fill forward time
+                    Current = (IndicatorDataPoint)Current.Clone();
+                    Current.Time = MaxTime(updated);
                 }
             };
         }

--- a/Tests/Indicators/CompositeIndicatorTests.cs
+++ b/Tests/Indicators/CompositeIndicatorTests.cs
@@ -93,5 +93,43 @@ namespace QuantConnect.Tests.Indicators
             Assert.AreEqual(left.PeriodsSinceMaximum, 0);
             Assert.AreEqual(right.PeriodsSinceMinimum, 0);
         }
+
+        [Test]
+        public void TimeAdvancesWithDataToBothSides()
+        {
+            var left = new Maximum("left", 2);
+            var right = new Minimum("right", 2);
+            var composite = new CompositeIndicator<IndicatorDataPoint>(left, right, (l, r) => l.Current.Value + r.Current.Value);
+
+            Assert.AreEqual(DateTime.MinValue, composite.Current.Time);
+
+            left.Update(DateTime.Today, 1m);
+            right.Update(DateTime.Today, -1m);
+
+            Assert.AreEqual(DateTime.Today, composite.Current.Time);
+
+            left.Update(DateTime.Today.AddDays(1), -1m);
+            right.Update(DateTime.Today.AddDays(1), 1m);
+
+            Assert.AreEqual(DateTime.Today.AddDays(1), composite.Current.Time);
+        }
+
+        [Test]
+        public void TimeAdvancesWithDataToOnlyOneSide()
+        {
+            var left = new Maximum("left", 2);
+            var right = new Minimum("right", 2);
+            var composite = new CompositeIndicator<IndicatorDataPoint>(left, right, (l, r) => l.Current.Value + r.Current.Value);
+
+            Assert.AreEqual(DateTime.MinValue, composite.Current.Time);
+
+            left.Update(DateTime.Today, 1m);
+
+            Assert.AreEqual(DateTime.Today, composite.Current.Time);
+
+            left.Update(DateTime.Today.AddDays(1), -1m);
+
+            Assert.AreEqual(DateTime.Today.AddDays(1), composite.Current.Time);
+        }
     }
 }

--- a/Tests/Indicators/CompositeIndicatorTests.cs
+++ b/Tests/Indicators/CompositeIndicatorTests.cs
@@ -22,6 +22,8 @@ namespace QuantConnect.Tests.Indicators
     [TestFixture]
     public class CompositeIndicatorTests
     {
+        public DateTime Today = DateTime.Today;
+
         [Test]
         public void CompositeIsReadyWhenBothAre()
         {
@@ -29,26 +31,26 @@ namespace QuantConnect.Tests.Indicators
             var right = new Delay(2);
             var composite = new CompositeIndicator<IndicatorDataPoint>(left, right, (l, r) => l.Current.Value + r.Current.Value);
 
-            left.Update(DateTime.Today.AddSeconds(0), 1m);
-            right.Update(DateTime.Today.AddSeconds(0), 1m);
+            left.Update(Today.AddSeconds(0), 1m);
+            right.Update(Today.AddSeconds(0), 1m);
             Assert.IsFalse(composite.IsReady);
             Assert.IsFalse(composite.Left.IsReady);
             Assert.IsFalse(composite.Right.IsReady);
 
-            left.Update(DateTime.Today.AddSeconds(1), 2m);
-            right.Update(DateTime.Today.AddSeconds(1), 2m);
+            left.Update(Today.AddSeconds(1), 2m);
+            right.Update(Today.AddSeconds(1), 2m);
             Assert.IsFalse(composite.IsReady);
             Assert.IsTrue(composite.Left.IsReady);
             Assert.IsFalse(composite.Right.IsReady);
 
-            left.Update(DateTime.Today.AddSeconds(2), 3m);
-            right.Update(DateTime.Today.AddSeconds(2), 3m);
+            left.Update(Today.AddSeconds(2), 3m);
+            right.Update(Today.AddSeconds(2), 3m);
             Assert.IsTrue(composite.IsReady);
             Assert.IsTrue(composite.Left.IsReady);
             Assert.IsTrue(composite.Right.IsReady);
 
-            left.Update(DateTime.Today.AddSeconds(3), 4m);
-            right.Update(DateTime.Today.AddSeconds(3), 4m);
+            left.Update(Today.AddSeconds(3), 4m);
+            right.Update(Today.AddSeconds(3), 4m);
             Assert.IsTrue(composite.IsReady);
             Assert.IsTrue(composite.Left.IsReady);
             Assert.IsTrue(composite.Right.IsReady);
@@ -66,22 +68,25 @@ namespace QuantConnect.Tests.Indicators
                 return l.Current.Value + r.Current.Value;
             });
 
-            left.Update(DateTime.Today, 1m);
-            right.Update(DateTime.Today, 1m);
+            left.Update(Today, 1m);
+            right.Update(Today, 1m);
             Assert.AreEqual(2m, composite.Current.Value);
         }
 
         [Test]
-        public void ResetsProperly() {
+        public void ResetsProperly()
+        {
             var left = new Maximum("left", 2);
             var right = new Minimum("right", 2);
             var composite = new CompositeIndicator<IndicatorDataPoint>(left, right, (l, r) => l.Current.Value + r.Current.Value);
 
-            left.Update(DateTime.Today, 1m);
-            right.Update(DateTime.Today,-1m);
 
-            left.Update(DateTime.Today.AddDays(1), -1m);
-            right.Update(DateTime.Today.AddDays(1), 1m);
+
+            left.Update(Today, 1m);
+            right.Update(Today, -1m);
+
+            left.Update(Today.AddDays(1), -1m);
+            right.Update(Today.AddDays(1), 1m);
 
             Assert.AreEqual(left.PeriodsSinceMaximum, 1);
             Assert.AreEqual(right.PeriodsSinceMinimum, 1);
@@ -103,15 +108,15 @@ namespace QuantConnect.Tests.Indicators
 
             Assert.AreEqual(DateTime.MinValue, composite.Current.Time);
 
-            left.Update(DateTime.Today, 1m);
-            right.Update(DateTime.Today, -1m);
+            left.Update(Today, 1m);
+            right.Update(Today, -1m);
 
-            Assert.AreEqual(DateTime.Today, composite.Current.Time);
+            Assert.AreEqual(Today, composite.Current.Time);
 
-            left.Update(DateTime.Today.AddDays(1), -1m);
-            right.Update(DateTime.Today.AddDays(1), 1m);
+            left.Update(Today.AddDays(1), -1m);
+            right.Update(Today.AddDays(1), 1m);
 
-            Assert.AreEqual(DateTime.Today.AddDays(1), composite.Current.Time);
+            Assert.AreEqual(Today.AddDays(1), composite.Current.Time);
         }
 
         [Test]
@@ -123,13 +128,13 @@ namespace QuantConnect.Tests.Indicators
 
             Assert.AreEqual(DateTime.MinValue, composite.Current.Time);
 
-            left.Update(DateTime.Today, 1m);
+            left.Update(Today, 1m);
 
-            Assert.AreEqual(DateTime.Today, composite.Current.Time);
+            Assert.AreEqual(Today, composite.Current.Time);
 
-            left.Update(DateTime.Today.AddDays(1), -1m);
+            left.Update(Today.AddDays(1), -1m);
 
-            Assert.AreEqual(DateTime.Today.AddDays(1), composite.Current.Time);
+            Assert.AreEqual(Today.AddDays(1), composite.Current.Time);
         }
 
         [Test]
@@ -143,11 +148,11 @@ namespace QuantConnect.Tests.Indicators
             Assert.AreEqual(0m, composite.Current.Value);
 
             // Update one side, should still be base value
-            left.Update(DateTime.Today, 1m);
+            left.Update(Today, 1m);
             Assert.AreEqual(0m, composite.Current.Value);
 
             // Update the other side, should be updated
-            right.Update(DateTime.Today, 1m);
+            right.Update(Today, 1m);
             Assert.AreEqual(2m, composite.Current.Value);
         }
     }

--- a/Tests/Indicators/CompositeIndicatorTests.cs
+++ b/Tests/Indicators/CompositeIndicatorTests.cs
@@ -131,5 +131,24 @@ namespace QuantConnect.Tests.Indicators
 
             Assert.AreEqual(DateTime.Today.AddDays(1), composite.Current.Time);
         }
+
+        [Test]
+        public void DoesNotUpdateUntilDataUpdatedOnBothSides()
+        {
+            var left = new Identity("left");
+            var right = new Identity("right");
+            var composite = new CompositeIndicator<IndicatorDataPoint>(left, right, (l, r) => l.Current.Value + r.Current.Value);
+
+            // Base value assertion
+            Assert.AreEqual(0m, composite.Current.Value);
+
+            // Update one side, should still be base value
+            left.Update(DateTime.Today, 1m);
+            Assert.AreEqual(0m, composite.Current.Value);
+
+            // Update the other side, should be updated
+            right.Update(DateTime.Today, 1m);
+            Assert.AreEqual(2m, composite.Current.Value);
+        }
     }
 }

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -26,6 +26,8 @@ using QuantConnect.Securities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Indicators;
+using QuantConnect.Research;
 using QuantConnect.Tests.ToolBox;
 using QuantConnect.ToolBox;
 using QuantConnect.Util;
@@ -220,6 +222,29 @@ namespace QuantConnect.Tests.Python
                 Assert.AreEqual(2, dataFrame.columns.__len__().AsManagedObject(typeof(int)));
                 var count = dataFrame.__len__().AsManagedObject(typeof(int));
                 Assert.AreEqual(10, count);
+            }
+        }
+
+        [Test]
+        public void DataFrameColumnsAreAligned()
+        {
+            var qb = new QuantBook();
+            qb.AddEquity("SPY");
+            var bb = new BollingerBands(30, 2);
+
+            using (Py.GIL())
+            {
+                dynamic bbdf = qb.Indicator(bb, "SPY", 360, Resolution.Daily);
+                var lastIndex = bbdf.last_valid_index();
+                var lastRow = bbdf.loc[lastIndex];
+
+                // Verify each column matches the BollingerBand properties
+                Assert.AreEqual(bb.BandWidth.Current.Value, lastRow["bandwidth"].As<decimal>());
+                Assert.AreEqual(bb.Current.Value, lastRow["bollingerbands"].As<decimal>());
+                Assert.AreEqual(bb.LowerBand.Current.Value, lastRow["lowerband"].As<decimal>());
+                Assert.AreEqual(bb.MiddleBand.Current.Value, lastRow["middleband"].As<decimal>());
+                Assert.AreEqual(bb.Price.Current.Value, lastRow["price"].As<decimal>());
+                Assert.AreEqual(bb.UpperBand.Current.Value, lastRow["upperband"].As<decimal>());
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
After looking into the problem it became clear that the issue was not caused by pandas but by the data given to it. For the specific issue linked to this PR (#4927), in the set of indicator data points being converted to a `DataFrame` there was a property called `PercentB` for the BollingerBand indicator, this property had repeated index values after the date 4/18 which caused the Value Error. 

This property uses `CompositeIndicator` which was found to not fill forward properly and update the properties time. With these changes, if the conditions to update the `CompositeIndicator` are not met, it now creates a clone of the last point with the latest time. This way the indicator current.Time is always up to date.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4927 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Example research was breaking, ended up being unrelated to research but still required fixing.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests ran and passed.
Research notebook is working again.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
