### PR TITLE
Block SetWarmUp after Algorithm has compeleted initialization

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -369,6 +369,7 @@
     <Compile Include="USEnergyInformationAdministrationAlgorithm.cs" />
     <Compile Include="UserDefinedUniverseAlgorithm.cs" />
     <Compile Include="VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs" />
+    <Compile Include="WarmUpAfterIntializeRegression.cs" />
     <Compile Include="WarmupAlgorithm.cs" />
     <Compile Include="WarmupConversionRatesRegressionAlgorithm.cs" />
     <Compile Include="WarmupHistoryAlgorithm.cs" />

--- a/Algorithm.CSharp/WarmUpAfterIntializeRegression.cs
+++ b/Algorithm.CSharp/WarmUpAfterIntializeRegression.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm to test warming up after initialize behavior, should throw if used outside of initialize
+    /// Reference GH Issue #4939
+    /// </summary>
+    public class WarmUpAfterIntializeRegression : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);  //Set Start Date
+            SetEndDate(2013, 10, 11);    //Set End Date
+            SetCash(100000);
+            var equity = AddEquity("SPY");
+        }
+
+        public override void OnData(Slice slice)
+        {
+            // Should throw and set Algorithm status to be runtime error
+            SetWarmUp(TimeSpan.FromDays(2));
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+        };
+    }
+}

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -51,6 +51,11 @@ namespace QuantConnect.Algorithm
         /// <param name="timeSpan">The amount of time to warm up, this does not take into account market hours/weekends</param>
         public void SetWarmup(TimeSpan timeSpan)
         {
+            if (!IsWarmingUp)
+            {
+                throw new InvalidOperationException("QCAlgorithm.SetWarmup(): This method cannot be used after algorithm initialized");
+            }
+
             _warmupBarCount = null;
             _warmupTimeSpan = timeSpan;
             _warmupResolution = null;
@@ -72,6 +77,11 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution to request</param>
         public void SetWarmup(TimeSpan timeSpan, Resolution resolution)
         {
+            if (!IsWarmingUp)
+            {
+                throw new InvalidOperationException("QCAlgorithm.SetWarmup(): This method cannot be used after algorithm initialized");
+            }
+
             _warmupBarCount = null;
             _warmupTimeSpan = timeSpan;
             _warmupResolution = resolution;
@@ -96,6 +106,11 @@ namespace QuantConnect.Algorithm
         /// <param name="barCount">The number of data points requested for warm up</param>
         public void SetWarmup(int barCount)
         {
+            if (!IsWarmingUp)
+            {
+                throw new InvalidOperationException("QCAlgorithm.SetWarmup(): This method cannot be used after algorithm initialized");
+            }
+
             _warmupTimeSpan = null;
             _warmupBarCount = barCount;
             _warmupResolution = null;
@@ -121,6 +136,11 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution to request</param>
         public void SetWarmup(int barCount, Resolution resolution)
         {
+            if (!IsWarmingUp)
+            {
+                throw new InvalidOperationException("QCAlgorithm.SetWarmup(): This method cannot be used after algorithm initialized");
+            }
+
             _warmupTimeSpan = null;
             _warmupBarCount = barCount;
             _warmupResolution = resolution;

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -51,14 +51,7 @@ namespace QuantConnect.Algorithm
         /// <param name="timeSpan">The amount of time to warm up, this does not take into account market hours/weekends</param>
         public void SetWarmup(TimeSpan timeSpan)
         {
-            if (!IsWarmingUp)
-            {
-                throw new InvalidOperationException("QCAlgorithm.SetWarmup(): This method cannot be used after algorithm initialized");
-            }
-
-            _warmupBarCount = null;
-            _warmupTimeSpan = timeSpan;
-            _warmupResolution = null;
+            SetWarmUp(timeSpan, null);
         }
 
         /// <summary>
@@ -75,9 +68,9 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="timeSpan">The amount of time to warm up, this does not take into account market hours/weekends</param>
         /// <param name="resolution">The resolution to request</param>
-        public void SetWarmup(TimeSpan timeSpan, Resolution resolution)
+        public void SetWarmup(TimeSpan timeSpan, Resolution? resolution)
         {
-            if (!IsWarmingUp)
+            if (!_locked)
             {
                 throw new InvalidOperationException("QCAlgorithm.SetWarmup(): This method cannot be used after algorithm initialized");
             }
@@ -92,7 +85,7 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="timeSpan">The amount of time to warm up, this does not take into account market hours/weekends</param>
         /// <param name="resolution">The resolution to request</param>
-        public void SetWarmUp(TimeSpan timeSpan, Resolution resolution)
+        public void SetWarmUp(TimeSpan timeSpan, Resolution? resolution)
         {
             SetWarmup(timeSpan, resolution);
         }
@@ -106,14 +99,7 @@ namespace QuantConnect.Algorithm
         /// <param name="barCount">The number of data points requested for warm up</param>
         public void SetWarmup(int barCount)
         {
-            if (!IsWarmingUp)
-            {
-                throw new InvalidOperationException("QCAlgorithm.SetWarmup(): This method cannot be used after algorithm initialized");
-            }
-
-            _warmupTimeSpan = null;
-            _warmupBarCount = barCount;
-            _warmupResolution = null;
+            SetWarmUp(barCount, null);
         }
 
         /// <summary>
@@ -134,9 +120,9 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="barCount">The number of data points requested for warm up</param>
         /// <param name="resolution">The resolution to request</param>
-        public void SetWarmup(int barCount, Resolution resolution)
+        public void SetWarmup(int barCount, Resolution? resolution)
         {
-            if (!IsWarmingUp)
+            if (_locked)
             {
                 throw new InvalidOperationException("QCAlgorithm.SetWarmup(): This method cannot be used after algorithm initialized");
             }
@@ -152,7 +138,7 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="barCount">The number of data points requested for warm up</param>
         /// <param name="resolution">The resolution to request</param>
-        public void SetWarmUp(int barCount, Resolution resolution)
+        public void SetWarmUp(int barCount, Resolution? resolution)
         {
             SetWarmup(barCount, resolution);
         }

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The resolution to request</param>
         public void SetWarmup(TimeSpan timeSpan, Resolution? resolution)
         {
-            if (!_locked)
+            if (_locked)
             {
                 throw new InvalidOperationException("QCAlgorithm.SetWarmup(): This method cannot be used after algorithm initialized");
             }

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -77,7 +77,8 @@ namespace QuantConnect.Tests
             var nonDefaultStatuses = new Dictionary<string, AlgorithmStatus>
             {
                 {"TrainingInitializeRegressionAlgorithm", AlgorithmStatus.RuntimeError},
-                {"OnOrderEventExceptionRegression", AlgorithmStatus.RuntimeError}
+                {"OnOrderEventExceptionRegression", AlgorithmStatus.RuntimeError},
+                {"WarmUpAfterIntializeRegression", AlgorithmStatus.RuntimeError }
             };
 
             // find all regression algorithms in Algorithm.CSharp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Now we throw an error when SetWarmUp is called after Algorithm Initialization

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4939

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Shouldn't be able to mess with warmup settings after warmup has already occurred. 

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All previous regressions pass, included new regression that intentionally throws and is checked for runtime error status.


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
