### PR TITLE
Reserve Names for Pandas Mapper

### DIFF
--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -84,6 +84,9 @@ def mapper(key):
     if keyType is Symbol:
         return str(key.ID)
     if keyType is str:
+        reserved = ['high', 'low', 'open', 'close']
+        if key in reserved:
+            return key
         kvp = SymbolCache.TryGetSymbol(key, None)
         if kvp[0]:
             return str(kvp[1].ID)

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -288,7 +288,7 @@ def Test(dataFrame):
                 var Test = PythonEngine.ModuleFromString("testModule",
     $@"
 def Test1(dataFrame):
-    # Should not throw, access LOW ticker data
+    # Should not throw, access all LOW ticker data
     data = dataFrame.loc['LOW']
 def Test2(dataFrame):
     # Bad accessor, expected to throw
@@ -297,7 +297,7 @@ def Test3(dataFrame):
     # Bad key, expected to throw
     data = dataFrame.loc['low']
 def Test4(dataFrame):
-    # Should not throw, also access data lows
+    # Should not throw, access data column low for all tickers
     data = dataFrame.low
 ");
 

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -256,7 +256,7 @@ def Test(dataFrame):
     if data.__len__() != 10:
         raise Exception('Expected 10 data points')
     lowData = data.low
-    if data.empty is 0:
+    if lowData.empty:
         raise Exception('LOW history low data is empty')").GetAttr("Test");
 
                 Assert.DoesNotThrow(() => test(dataFrame));

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -223,6 +223,47 @@ namespace QuantConnect.Tests.Python
             }
         }
 
+        /// <summary>
+        /// Specific issues for symbol LOW, reference GH issue #4886
+        /// </summary>
+        [Test]
+        public void HandlesOddTickers()
+        {
+            var converter = new PandasConverter();
+            var symbol = Symbols.LOW;
+
+            var rawBars = Enumerable
+                .Range(0, 10)
+                .Select(i => new TradeBar(DateTime.UtcNow.AddMinutes(i), symbol, i + 101m, i + 102m, i + 100m, i + 101m, 0m))
+                .ToArray();
+
+            // GetDataFrame with argument of type IEnumerable<TradeBar>
+            var history = GetHistory(symbol, Resolution.Minute, rawBars);
+            dynamic dataFrame = converter.GetDataFrame(history);
+
+            // Add LOW to our symbol cache
+            SymbolCache.Set("LOW", Symbols.LOW);
+
+            using (Py.GIL())
+            {
+
+                dynamic test = PythonEngine.ModuleFromString("testModule",
+    $@"
+def Test(dataFrame):
+    data = dataFrame.loc['LOW']
+    if data.empty:
+        raise Exception('LOW history data is empty')
+    if data.__len__() != 10:
+        raise Exception('Expected 10 data points')
+    lowData = data.low
+    if data.empty is 0:
+        raise Exception('LOW history low data is empty')").GetAttr("Test");
+
+                Assert.DoesNotThrow(() => test(dataFrame));
+
+            }
+        }
+
         [TestCase("'SPY'", true)]
         [TestCase("symbol")]
         [TestCase("str(symbol.ID)")]

--- a/Tests/Symbols.cs
+++ b/Tests/Symbols.cs
@@ -34,6 +34,7 @@ namespace QuantConnect.Tests
         public static readonly Symbol LODE = CreateEquitySymbol("LODE");
         public static readonly Symbol IBM = CreateEquitySymbol("IBM");
         public static readonly Symbol GOOG = CreateEquitySymbol("GOOG");
+        public static readonly Symbol LOW = CreateEquitySymbol("LOW");
 
         public static readonly Symbol USDJPY = CreateForexSymbol("USDJPY");
         public static readonly Symbol EURUSD = CreateForexSymbol("EURUSD");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Force pandas mapper to not convert strings 'low' 'high' 'close' and 'open' to symbol before indexing dataframe. Now those keywords are reserved and won't attempt to be converted.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4886 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Pandas bug specific to stock ticker LOW, when requesting history for LOW and attempting to access history `.low` values pandas would convert the request for `.low` to symbol LOW which pandas dataframe does not have a value for thus causing the issue.

I reserved more than just low since it is possible that other tickers may fit some of those column names in the future. 

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Added a test that red/greened from master to this pr.
- Confirmed original behavior DataFrame.loc["LOW"] can return a dataframe just for LOW ticker
- Confirmed DataFrame.low is now working



#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
