### PR TITLE
Limit Futures Resolutions in BaseData

### DIFF
--- a/Common/Data/BaseData.cs
+++ b/Common/Data/BaseData.cs
@@ -237,6 +237,11 @@ namespace QuantConnect.Data
                 return MinuteResolution;
             }
 
+            if (Symbol.SecurityType == SecurityType.Future)
+            {
+                return new List<Resolution> { Resolution.Minute, Resolution.Second, Resolution.Tick };
+            }
+
             return AllResolutions;
         }
 

--- a/Common/Data/BaseData.cs
+++ b/Common/Data/BaseData.cs
@@ -64,6 +64,11 @@ namespace QuantConnect.Data
         protected static readonly List<Resolution> MinuteResolution = new List<Resolution> { Resolution.Minute };
 
         /// <summary>
+        /// A list of high <see cref="Resolution"/>, including minute, second, and tick.
+        /// </summary>
+        protected static readonly List<Resolution> HighResolution = new List<Resolution> { Resolution.Minute, Resolution.Second, Resolution.Tick };
+
+        /// <summary>
         /// Market Data Type of this data - does it come in individual price packets or is it grouped into OHLC.
         /// </summary>
         /// <remarks>Data is classed into two categories - streams of instantaneous prices and groups of OHLC data.</remarks>
@@ -239,7 +244,7 @@ namespace QuantConnect.Data
 
             if (Symbol.SecurityType == SecurityType.Future)
             {
-                return new List<Resolution> { Resolution.Minute, Resolution.Second, Resolution.Tick };
+                return HighResolution;
             }
 
             return AllResolutions;

--- a/Report/PortfolioLooper/PortfolioLooperAlgorithm.cs
+++ b/Report/PortfolioLooper/PortfolioLooperAlgorithm.cs
@@ -44,8 +44,6 @@ namespace QuantConnect.Report
                 switch (symbol.SecurityType)
                 {
                     case SecurityType.Option:
-                        resolution = Resolution.Minute;
-                        break;
                     case SecurityType.Future:
                         resolution = Resolution.Minute;
                         break;

--- a/Report/PortfolioLooper/PortfolioLooperAlgorithm.cs
+++ b/Report/PortfolioLooper/PortfolioLooperAlgorithm.cs
@@ -40,7 +40,20 @@ namespace QuantConnect.Report
         {
             foreach (var symbol in orders.Select(x => x.Symbol).Distinct())
             {
-                var resolution = symbol.SecurityType == SecurityType.Option ? Resolution.Minute : Resolution.Daily;
+                Resolution resolution;
+                switch (symbol.SecurityType)
+                {
+                    case SecurityType.Option:
+                        resolution = Resolution.Minute;
+                        break;
+                    case SecurityType.Future:
+                        resolution = Resolution.Minute;
+                        break;
+                    default:
+                        resolution = Resolution.Daily;
+                        break;
+                }
+
                 var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, false, false);
                 var security = Securities.CreateSecurity(symbol, configs, 0m);
                 if (symbol.SecurityType == SecurityType.Crypto)

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -218,7 +218,7 @@ namespace QuantConnect.Tests.Algorithm
                     asset = qcAlgorithm.AddForex(ticker, Resolution.Daily);
                     break;
                 case SecurityType.Future:
-                    asset = qcAlgorithm.AddFuture(ticker, Resolution.Daily);
+                    asset = qcAlgorithm.AddFuture(ticker, Resolution.Minute);
                     break;
                 default:
                     throw new Exception($"SecurityType {securityType} is not valid for this test");
@@ -279,7 +279,7 @@ namespace QuantConnect.Tests.Algorithm
                     asset = qcAlgorithm.AddForex(ticker, Resolution.Daily);
                     break;
                 case SecurityType.Future:
-                    asset = qcAlgorithm.AddFuture(ticker, Resolution.Daily);
+                    asset = qcAlgorithm.AddFuture(ticker, Resolution.Minute);
                     break;
                 default:
                     throw new Exception($"SecurityType {securityType} is not valid for this test");
@@ -350,7 +350,7 @@ namespace QuantConnect.Tests.Algorithm
                     asset = qcAlgorithm.AddForex(ticker, Resolution.Daily);
                     break;
                 case SecurityType.Future:
-                    asset = qcAlgorithm.AddFuture(ticker, Resolution.Daily);
+                    asset = qcAlgorithm.AddFuture(ticker, Resolution.Minute);
                     break;
                 default:
                     throw new Exception($"SecurityType {securityType} is not valid for this test");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Limit futures resolutions to those that are supported (minute/second/tick) in `BaseData.SupportedResolutions`


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4976 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug was silently failing on master, now it will crash the algorithm and alert the user that the resolution is not supported.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using the linked issues example with Resolution.Daily and Resolution.Minute

Resolution.Minute is good and has no errors as expected

Resolution.Daily now throws 
```
20201201 17:04:16.158 ERROR:: WorkerThread.<.ctor>b__7_0(): WorkerThread(): exception thrown when running task System.ArgumentException: Sorry Daily is not a supported resolution for ZipEntryName and SecurityType.Future. Please change your AddData to use one of the supported resolutions (Minute,Second,Tick).
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
