### PR TITLE
Fixes options order crashing ReportGenerator

### DIFF
--- a/Common/Symbol.cs
+++ b/Common/Symbol.cs
@@ -307,6 +307,10 @@ namespace QuantConnect
                 throw new ArgumentNullException(nameof(value));
             }
             ID = sid;
+            if (ID.HasUnderlying)
+            {
+                Underlying = new Symbol(ID.Underlying, ID.Underlying.Symbol);
+            }
 
             Value = value.LazyToUpper();
         }

--- a/Report/PortfolioLooper/PortfolioLooper.cs
+++ b/Report/PortfolioLooper/PortfolioLooper.cs
@@ -128,6 +128,9 @@ namespace QuantConnect.Report
             // More initialization, this time with Algorithm and other misc. classes
             _resultHandler.Initialize(job, new Messaging.Messaging(), new Api.Api(), transactions);
             _resultHandler.SetAlgorithm(Algorithm, Algorithm.Portfolio.TotalPortfolioValue);
+
+            Algorithm.Transactions.SetOrderProcessor(transactions);
+
             transactions.Initialize(Algorithm, new BacktestingBrokerage(Algorithm), _resultHandler);
             feed.Initialize(Algorithm, job, _resultHandler, null, null, null, _dataManager, null, null);
 

--- a/Tests/Common/SymbolTests.cs
+++ b/Tests/Common/SymbolTests.cs
@@ -587,6 +587,23 @@ namespace QuantConnect.Tests.Common
             Assert.IsTrue(nonCanonicalFutureOption.Value.StartsWith(expectedFutureOptionTicker));
         }
 
+        [Test]
+        public void SymbolWithSidContainingUnderlyingCreatedWithoutNullUnderlying()
+        {
+            var future = Symbol.CreateFuture("ES", Market.CME, new DateTime(2020, 6, 19));
+            var optionSid = SecurityIdentifier.GenerateOption(
+                future.ID.Date,
+                future.ID,
+                future.ID.Market,
+                3500m,
+                OptionRight.Call,
+                OptionStyle.American);
+
+            var option = new Symbol(optionSid, "ES");
+            Assert.IsNotNull(option.Underlying);
+            Assert.AreEqual(future, option.Underlying);
+        }
+
         class OldSymbol
         {
             public string Value { get; set; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Fixes a crash in the Report Generator caused by an option order having no `Underlying` in its Symbol when constructed in the `OrderJsonConverter`

 Additionally, adds functionality to the Symbol constructor to create an underlying Symbol if the SID provided has an underlying SID.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4951 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fixes, squash all bugs
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
