### PR TITLE
Fix Bitfinex brokerage currency mapping

### DIFF
--- a/Brokerages/Bitfinex/BitfinexBrokerage.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.cs
@@ -280,7 +280,7 @@ namespace QuantConnect.Brokerages.Bitfinex
             {
                 if (item.Balance > 0)
                 {
-                    list.Add(new CashAmount(item.Balance, item.Currency.ToUpperInvariant()));
+                    list.Add(new CashAmount(item.Balance, GetLeanCurrency(item.Currency)));
                 }
             }
 


### PR DESCRIPTION

#### Description
- Fixed currency mapping from brokerage currency to LEAN currency

#### Related Issue
Closes #5008 

#### Motivation and Context
- The cashbook was updated with the incorrect currency when loading initial balances
- Order fill events were emitted with the incorrect currency for the order fee

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Tested locally with `UST` cash balance and `USDTUSD` market orders.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`