### PR TITLE
ApiDataProvider Zip Download Fixes

### DIFF
--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -20,6 +20,7 @@ using System.Net;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using QuantConnect.Interfaces;
+using QuantConnect.Logging;
 using QuantConnect.Orders;
 using RestSharp;
 using RestSharp.Extensions;
@@ -819,6 +820,8 @@ namespace QuantConnect.Api
             var response = client.Execute(request);
             if (response.ContentType != "application/zip")
             {
+                var message = JObject.Parse(response.Content)["message"].Value<string>();
+                Log.Trace($"Api.DownloadData(): Failed to download zip for {symbol} {resolution} data for date {date}, Api response: {message}");
                 return false;
             }
             

--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -821,7 +821,7 @@ namespace QuantConnect.Api
             if (response.ContentType != "application/zip")
             {
                 var message = JObject.Parse(response.Content)["message"].Value<string>();
-                Log.Trace($"Api.DownloadData(): Failed to download zip for {symbol} {resolution} data for date {date}, Api response: {message}");
+                Log.Error($"Api.DownloadData(): Failed to download zip for {symbol} {resolution} data for date {date}, Api response: {message}");
                 return false;
             }
             

--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -814,8 +814,15 @@ namespace QuantConnect.Api
             var uri     = new Uri(link.DataLink);
             var client  = new RestClient(uri.Scheme + "://" + uri.Host);
             var request = new RestRequest(uri.PathAndQuery, Method.GET);
-            client.DownloadData(request).SaveAs(path);
 
+            // If the response is not a zip then it is not data, don't write it.
+            var response = client.Execute(request);
+            if (response.ContentType != "application/zip")
+            {
+                return false;
+            }
+            
+            response.RawBytes.SaveAs(path);
             return true;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Stop the download and saving of bad responses from web api to zip files

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4556
Related #4994

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Using ApiDataProvider will create files even if the API response is not actually data. This fix seeks to stop the creation of these files since Lean will then load in corrupted data causing more problems down the line.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using the example in issue #4994

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
