### PR TITLE
Fixed QuantBook import path for CSharp example

### DIFF
--- a/Research/BasicCSharpQuantBookTemplate.ipynb
+++ b/Research/BasicCSharpQuantBookTemplate.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#load \"QuantConnect.csx\"\n",
+    "#load \"../QuantConnect.csx\"\n",
     "var qb = new QuantBook();\n",
     "\n",
     "// Selecting asset data\n",


### PR DESCRIPTION
Now requires a relative path for loading QuantBook.csx