### PR TITLE
Bug jsonrounding maxvalue minvalue

### DIFF
--- a/Common/Util/JsonRoundingConverter.cs
+++ b/Common/Util/JsonRoundingConverter.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using ExchangeSharp;
 using Newtonsoft.Json;
 
 namespace QuantConnect.Util
@@ -33,7 +34,7 @@ namespace QuantConnect.Util
         /// Will always return false.
         /// Gets a value indicating whether this <see cref="T:Newtonsoft.Json.JsonConverter" /> can read JSON.
         /// </summary>
-        public override bool CanRead => false;
+        public override bool CanRead => true;
 
         /// <summary>
         /// Determines whether this instance can convert the specified object type.
@@ -55,7 +56,14 @@ namespace QuantConnect.Util
         /// <param name="serializer">The calling serializer.</param>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            throw new NotImplementedException();
+            if (objectType == typeof(double))
+            {
+                return Double.Parse(existingValue.ToStringInvariant(), System.Globalization.CultureInfo.InvariantCulture);
+            }
+            else
+            {
+                return Decimal.Parse(existingValue.ToStringInvariant(), System.Globalization.CultureInfo.InvariantCulture);
+            }
         }
 
         /// <summary>
@@ -66,15 +74,31 @@ namespace QuantConnect.Util
         /// <param name="serializer">The calling serializer.</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            if (value is double)
+            if (value is double @double)
             {
-                var rounded = Math.Round((double)value, FractionalDigits);
-                writer.WriteValue(rounded);
+                var rounded = Math.Round(@double, FractionalDigits);
+
+                if (rounded == double.MaxValue || rounded == double.MinValue)
+                {
+                    writer.WriteValue(rounded.ToStringInvariant());
+                }
+                else
+                {
+                    writer.WriteValue(rounded);
+                }
             }
             else
             {
                 var rounded = Math.Round((decimal)value, FractionalDigits);
-                writer.WriteValue(rounded);
+
+                if (rounded == decimal.MaxValue || rounded == decimal.MinValue)
+                {
+                    writer.WriteValue(rounded.ToStringInvariant());
+                }
+                else
+                {
+                    writer.WriteValue(rounded);
+                }
             }
         }
     }

--- a/Common/Util/JsonRoundingConverter.cs
+++ b/Common/Util/JsonRoundingConverter.cs
@@ -73,9 +73,9 @@ namespace QuantConnect.Util
         /// <param name="serializer">The calling serializer.</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            if (value is double @double)
+            if (value is double)
             {
-                var rounded = Math.Round(@double, FractionalDigits);
+                var rounded = Math.Round((double)value, FractionalDigits);
 
                 if (rounded == double.MaxValue || rounded == double.MinValue)
                 {

--- a/Common/Util/JsonRoundingConverter.cs
+++ b/Common/Util/JsonRoundingConverter.cs
@@ -14,7 +14,6 @@
 */
 
 using System;
-using ExchangeSharp;
 using Newtonsoft.Json;
 
 namespace QuantConnect.Util
@@ -58,11 +57,11 @@ namespace QuantConnect.Util
         {
             if (objectType == typeof(double))
             {
-                return Double.Parse(existingValue.ToStringInvariant(), System.Globalization.CultureInfo.InvariantCulture);
+                return Double.Parse(existingValue.ToString(), System.Globalization.CultureInfo.InvariantCulture);
             }
             else
             {
-                return Decimal.Parse(existingValue.ToStringInvariant(), System.Globalization.CultureInfo.InvariantCulture);
+                return Decimal.Parse(existingValue.ToString(), System.Globalization.CultureInfo.InvariantCulture);
             }
         }
 
@@ -80,11 +79,11 @@ namespace QuantConnect.Util
 
                 if (rounded == double.MaxValue || rounded == double.MinValue)
                 {
-                    writer.WriteValue(rounded.ToStringInvariant());
+                    writer.WriteValue(rounded.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 }
                 else
                 {
-                    writer.WriteValue(rounded);
+                    writer.WriteValue(rounded.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 }
             }
             else
@@ -93,7 +92,7 @@ namespace QuantConnect.Util
 
                 if (rounded == decimal.MaxValue || rounded == decimal.MinValue)
                 {
-                    writer.WriteValue(rounded.ToStringInvariant());
+                    writer.WriteValue(rounded.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 }
                 else
                 {

--- a/Tests/Common/Util/JsonRoundingConverterTests.cs
+++ b/Tests/Common/Util/JsonRoundingConverterTests.cs
@@ -1,4 +1,4 @@
-﻿using MachinaEngine.Statistics;
+﻿using QuantConnect.Statistics;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace MachinaEngine.Tests.Common.Util
+namespace QuantConnect.Tests.Common.Util
 {
     [TestFixture]
     public class JsonRoundingConverterTests

--- a/Tests/Common/Util/JsonRoundingConverterTests.cs
+++ b/Tests/Common/Util/JsonRoundingConverterTests.cs
@@ -1,0 +1,36 @@
+﻿using MachinaEngine.Statistics;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MachinaEngine.Tests.Common.Util
+{
+    [TestFixture]
+    public class JsonRoundingConverterTests
+    {
+        [Test]
+        public void MinMaxValueDeserializesSuccessfuly()
+        {
+            var portfolioStatistics = new PortfolioStatistics()
+            {
+                AverageWinRate = decimal.MaxValue,
+                AverageLossRate = decimal.MinValue,
+                CompoundingAnnualReturn = decimal.MaxValue
+            };
+
+            var serializedValue = JsonConvert.SerializeObject(portfolioStatistics);
+            var deserializedValue = JsonConvert.DeserializeObject<PortfolioStatistics>(serializedValue);
+
+            Assert.AreEqual(portfolioStatistics.AverageWinRate, deserializedValue.AverageWinRate);
+            Assert.AreEqual(portfolioStatistics.AverageLossRate, deserializedValue.AverageLossRate);
+            Assert.AreEqual(portfolioStatistics.CompoundingAnnualReturn, deserializedValue.CompoundingAnnualReturn);
+
+            Assert.AreEqual(portfolioStatistics.AnnualStandardDeviation, deserializedValue.AnnualStandardDeviation);
+            Assert.AreEqual(portfolioStatistics.Expectancy, deserializedValue.Expectancy);
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -479,6 +479,7 @@
     <Compile Include="Common\StringExtensionsTests.cs" />
     <Compile Include="Common\Util\ComparisonOperatorTests.cs" />
     <Compile Include="Common\Util\ConcurrentSetTests.cs" />
+    <Compile Include="Common\Util\JsonRoundingConverterTests.cs" />
     <Compile Include="Common\Util\PythonUtilTests.cs" />
     <Compile Include="Common\Util\RateGateTests.cs" />
     <Compile Include="Common\Util\ListComparerTests.cs" />


### PR DESCRIPTION
Fixed bug - decimal.MinValue and MaxValue cannot be deserialized

#### Description
After serializing decimal.MinValue or MaxValue, Newtonsoft.Json can't deserialize it by default - it thinks it's too large.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
I have encountered a bug due to which I lost 6 hours of time today! I don't want somebody else to get the same bug. I was getting very high CompoundingAnnualReturn which turned out to be greater than decimal.MaxValue and so decimal.MaxValue was serialized in a BacktestResultPacket. But it could not be deserialized because Newtonsoft.Json does not know how to handle large decimal values. So I fixed this by serializing huge decimals as strings.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
- by launching the project manually and retrieving backtestpacket (now thankfully without errors)
- with the unit test I added to the PR

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
