### PR TITLE
Add order related mappings to resolve type & status IDs in pure python

### DIFF
--- a/PythonToolbox/quantconnect/order.py
+++ b/PythonToolbox/quantconnect/order.py
@@ -15,4 +15,5 @@ ORDER_TYPES = ['Market', 'Limit', 'StopMarket', 'StopLimit', 'MarketOnOpen', 'Ma
 
 ORDER_DIRECTIONS = ['Buy', 'Sell', 'Hold']
 
+# Positions are based on the C# OrderStatus enum
 ORDER_STATUSES = ['New', 'Submitted', 'PartiallyFilled', 'Filled', None, 'Canceled', 'None', 'Invalid', 'CancelPending', 'UpdateSubmitted']

--- a/PythonToolbox/quantconnect/order.py
+++ b/PythonToolbox/quantconnect/order.py
@@ -1,0 +1,18 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ORDER_TYPES = ['Market', 'Limit', 'StopMarket', 'StopLimit', 'MarketOnOpen', 'MarketOnClose', 'OptionExercise']
+
+ORDER_DIRECTIONS = ['Buy', 'Sell', 'Hold']
+
+ORDER_STATUSES = ['New', 'Submitted', 'PartiallyFilled', 'Filled', None, 'Canceled', 'None', 'Invalid', 'CancelPending', 'UpdateSubmitted']


### PR DESCRIPTION
Add additional ID to description mappings for order related types and statuses

#### Description
Add additional ID to description mappings for order related types and statuses

#### Related Issue
Closes https://github.com/QuantConnect/Lean/issues/5074

#### Motivation and Context
Help have accurate mappings to descriptive type/status when working in python outside of Lean/QC environment

#### Requires Documentation Change
No

#### How Has This Been Tested?
Ingested results JSON and utilized mappings to resolve ID values in orders list

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. -> PythonToolbox static reference maps/lists.
- [X] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`