### PR TITLE
Adds data parsing for malformed option contracts for InteractiveBrokers

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -999,7 +999,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             return $"{contract.ToString().ToUpperInvariant()} {contract.LastTradeDateOrContractMonth.ToStringInvariant()} {contract.Strike.ToStringInvariant()} {contract.Right}";
         }
 
-        private static string GetContractDescription(Contract contract)
+        public static string GetContractDescription(Contract contract)
         {
             return $"{contract} {contract.PrimaryExch ?? string.Empty} {contract.LastTradeDateOrContractMonth.ToStringInvariant()} {contract.Strike.ToStringInvariant()} {contract.Right}";
         }
@@ -2266,10 +2266,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 {
                     // Try our best to recover from a malformed contract.
                     // You can read more about malformed contracts at the ParseMalformedContract method's documentation.
-                    var ibSecurityType = ConvertSecurityType(securityType);
                     var exchange = GetSymbolExchange(securityType, market);
 
-                    contract = InteractiveBrokersSymbolMapper.ParseMalformedContractOptionSymbol(contract, ibSecurityType, exchange);
+                    contract = InteractiveBrokersSymbolMapper.ParseMalformedContractOptionSymbol(contract, exchange);
                     ibSymbol = contract.Symbol;
                 }
 

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2293,6 +2293,13 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                 if (securityType == SecurityType.Option)
                 {
+                    if (contract.LastTradeDateOrContractMonth == "0")
+                    {
+                        // Try our best to recover from a malformed contract.
+                        // You can read more about malformed contracts at the ParseMalformedContract method's documentation.
+                        contract = InteractiveBrokersSymbolMapper.ParseMalformedContractOptionSymbol(contract);
+                    }
+
                     var expiryDate = DateTime.ParseExact(contract.LastTradeDateOrContractMonth, DateFormat.EightCharacter, CultureInfo.InvariantCulture);
                     var right = contract.Right == IB.RightType.Call ? OptionRight.Call : OptionRight.Put;
                     var strike = Convert.ToDecimal(contract.Strike);

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapper.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapper.cs
@@ -17,10 +17,13 @@ using Newtonsoft.Json;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities.Future;
 using QuantConnect.Securities.FutureOption;
+using IB = QuantConnect.Brokerages.InteractiveBrokers.Client;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using IBApi;
 
 namespace QuantConnect.Brokerages.InteractiveBrokers
 {
@@ -205,6 +208,56 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             }
 
             return ticker;
+        }
+
+        /// <summary>
+        /// Parses a contract for options with malformed data.
+        /// Malformed data usually manifests itself by having "0" assigned to some values
+        /// we expect, like the contract's expiry date. The contract is returned by IB
+        /// like this, usually due to a high amount of data subscriptions that are active
+        /// in an account, surpassing IB's imposed limit. Read more about this here: https://interactivebrokers.github.io/tws-api/rtd_fqa_errors.html#rtd_common_errors_maxmktdata
+        ///
+        /// We are provided a string in the Symbol in malformed contracts that can be
+        /// parsed to construct the clean contract, which is done by this method.
+        /// </summary>
+        /// <param name="malformedContract">Malformed contract (for options), i.e. a contract with invalid values ("0") in some of its fields</param>
+        /// <returns>Clean Contract for the option</returns>
+        /// <remarks>
+        /// The malformed contract returns data similar to the following when calling <see cref="InteractiveBrokersBrokerage.GetContractDetails"/>:
+        /// OPT SPY JUN2021 350 P [SPY 210618P00350000 100] USD 0 0 0
+        ///
+        /// ... which the contents inside [] follow the pattern:
+        ///
+        /// [SYMBOL YY_MM_DD_OPTIONRIGHT_STRIKE(divide by 1000) MULTIPLIER]
+        /// </remarks>
+        public static Contract ParseMalformedContractOptionSymbol(Contract malformedContract)
+        {
+            var contractInfoSplit = malformedContract.Symbol.Substring(malformedContract.Symbol.IndexOf('['))
+                .Replace("[", "")
+                .Replace("]", "")
+                .Split(' ');
+
+            var contractSymbol = contractInfoSplit[0];
+            var contractSpecification = contractInfoSplit[1];
+            var multiplier = contractInfoSplit[2];
+            var year = "20" + contractSpecification.Substring(0, 2);
+            var month = contractSpecification.Substring(2, 2);
+            var day = contractSpecification.Substring(4, 2);
+            var contractRight = contractSpecification[6] == 'C' ? IB.RightType.Call : IB.RightType.Put;
+            var contractStrike = long.Parse(contractSpecification.Substring(7), CultureInfo.InvariantCulture) / 1000.0;
+
+            return new Contract
+            {
+                Symbol = contractSymbol,
+                Multiplier = multiplier,
+                LastTradeDateOrContractMonth = year + month + day,
+                Right = contractRight,
+                Strike = contractStrike,
+                Exchange = "SMART",
+                SecType = IB.SecurityType.Option,
+                IncludeExpired = false,
+                Currency = "USD"
+            };
         }
     }
 }

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapper.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapper.cs
@@ -234,7 +234,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// </remarks>
         public static Contract ParseMalformedContractOptionSymbol(Contract malformedContract, string exchange = "Smart")
         {
-            Log.Trace($"InteractiveBrokersSymbolMapper.ParseMalformedContractOptionSymbol(): Parsing malformed contract: \"{malformedContract}\" with config: {InteractiveBrokersBrokerage.GetContractDescription(malformedContract)} and trading class: \"{malformedContract.TradingClass}\"");
+            Log.Trace($"InteractiveBrokersSymbolMapper.ParseMalformedContractOptionSymbol(): Parsing malformed contract: {InteractiveBrokersBrokerage.GetContractDescription(malformedContract)} with trading class: \"{malformedContract.TradingClass}\"");
 
             var contractInfoSplit = malformedContract.Symbol.Substring(malformedContract.Symbol.IndexOf('['))
                 .Replace("[", "")

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapper.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapper.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using IBApi;
+using QuantConnect.Logging;
 
 namespace QuantConnect.Brokerages.InteractiveBrokers
 {
@@ -230,8 +231,10 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         ///
         /// [SYMBOL YY_MM_DD_OPTIONRIGHT_STRIKE(divide by 1000) MULTIPLIER]
         /// </remarks>
-        public static Contract ParseMalformedContractOptionSymbol(Contract malformedContract)
+        public static Contract ParseMalformedContractOptionSymbol(Contract malformedContract, string ibSecurityType, string exchange = "Smart")
         {
+            Log.Trace($"InteractiveBrokersSymbolMapper.ParseMalformedContractOptionSymbol(): Parsing malformed contract: \"{malformedContract}\" for SecType: \"{malformedContract.SecType}\" on exchange: \"{malformedContract.Exchange}\" with Symbol: \"{malformedContract.Symbol}\" and trading class: \"{malformedContract.TradingClass}\"");
+
             var contractInfoSplit = malformedContract.Symbol.Substring(malformedContract.Symbol.IndexOf('['))
                 .Replace("[", "")
                 .Replace("]", "")
@@ -253,10 +256,10 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 LastTradeDateOrContractMonth = year + month + day,
                 Right = contractRight,
                 Strike = contractStrike,
-                Exchange = "SMART",
-                SecType = IB.SecurityType.Option,
+                Exchange = exchange,
+                SecType = ibSecurityType,
                 IncludeExpired = false,
-                Currency = "USD"
+                Currency = malformedContract.Currency
             };
         }
     }

--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapperTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapperTests.cs
@@ -1,11 +1,11 @@
 ﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,9 +14,11 @@
 */
 
 using System;
+using IBApi;
 using NUnit.Framework;
 using QuantConnect.Brokerages.InteractiveBrokers;
 using QuantConnect.Data.Auxiliary;
+using IB = QuantConnect.Brokerages.InteractiveBrokers.Client;
 
 namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
 {
@@ -96,5 +98,42 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
             Assert.Throws<ArgumentException>(() => mapper.GetBrokerageSymbol(symbol));
         }
 
+        [Test]
+        public void MalformedContractSymbolCreatesOptionContract()
+        {
+            var malformedContract = new Contract
+            {
+                IncludeExpired = false,
+                Currency = "USD",
+                Multiplier = "100",
+                Symbol = "SPY JUN2021 345 P [SPY 210618P00345000 100]",
+                SecType = IB.SecurityType.Option,
+            };
+
+            var expectedContract = new Contract
+            {
+                Symbol = "SPY",
+                Multiplier = "100",
+                LastTradeDateOrContractMonth = "20210618",
+                Right = IB.RightType.Put,
+                Strike = 345.0,
+                Exchange = "SMART",
+                SecType = IB.SecurityType.Option,
+                IncludeExpired = false,
+                Currency = "USD"
+            };
+
+            var actualContract = InteractiveBrokersSymbolMapper.ParseMalformedContractOptionSymbol(malformedContract);
+
+            Assert.AreEqual(expectedContract.Symbol, actualContract.Symbol);
+            Assert.AreEqual(expectedContract.Multiplier, actualContract.Multiplier);
+            Assert.AreEqual(expectedContract.LastTradeDateOrContractMonth, actualContract.LastTradeDateOrContractMonth);
+            Assert.AreEqual(expectedContract.Right, actualContract.Right);
+            Assert.AreEqual(expectedContract.Strike, actualContract.Strike);
+            Assert.AreEqual(expectedContract.Exchange, actualContract.Exchange);
+            Assert.AreEqual(expectedContract.SecType, actualContract.SecType);
+            Assert.AreEqual(expectedContract.IncludeExpired, actualContract.IncludeExpired);
+            Assert.AreEqual(expectedContract.Currency, actualContract.Currency);
+        }
     }
 }

--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapperTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapperTests.cs
@@ -117,13 +117,13 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
                 LastTradeDateOrContractMonth = "20210618",
                 Right = IB.RightType.Put,
                 Strike = 345.0,
-                Exchange = "SMART",
+                Exchange = "Smart",
                 SecType = IB.SecurityType.Option,
                 IncludeExpired = false,
                 Currency = "USD"
             };
 
-            var actualContract = InteractiveBrokersSymbolMapper.ParseMalformedContractOptionSymbol(malformedContract);
+            var actualContract = InteractiveBrokersSymbolMapper.ParseMalformedContractOptionSymbol(malformedContract, IB.SecurityType.Option);
 
             Assert.AreEqual(expectedContract.Symbol, actualContract.Symbol);
             Assert.AreEqual(expectedContract.Multiplier, actualContract.Multiplier);

--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapperTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapperTests.cs
@@ -123,7 +123,7 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
                 Currency = "USD"
             };
 
-            var actualContract = InteractiveBrokersSymbolMapper.ParseMalformedContractOptionSymbol(malformedContract, IB.SecurityType.Option);
+            var actualContract = InteractiveBrokersSymbolMapper.ParseMalformedContractOptionSymbol(malformedContract);
 
             Assert.AreEqual(expectedContract.Symbol, actualContract.Symbol);
             Assert.AreEqual(expectedContract.Multiplier, actualContract.Multiplier);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Some contracts come in malformed from IB when downloading our account holdings. We attempt to detect whenever this happens with our options Symbols and try to recover the contract.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #5083 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Attempts to recover from fatal error.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
