### PR TITLE
Fix MACD WarmUpPeriod and Updating

### DIFF
--- a/Indicators/MovingAverageConvergenceDivergence.cs
+++ b/Indicators/MovingAverageConvergenceDivergence.cs
@@ -79,14 +79,14 @@ namespace QuantConnect.Indicators
         {
             if (fastPeriod >= slowPeriod)
             {
-                throw new ArgumentException("MovingAverageConvergenceDivergence: fastPeriod must be less than slowPeriod", "fastPeriod, slowPeriod");
+                throw new ArgumentException("MovingAverageConvergenceDivergence: fastPeriod must be less than slowPeriod", $"{nameof(fastPeriod)}, {nameof(slowPeriod)}");
             }
             
             Fast = type.AsIndicator(name + "_Fast", fastPeriod);
             Slow = type.AsIndicator(name + "_Slow", slowPeriod);
             Signal = type.AsIndicator(name + "_Signal", signalPeriod);
             Histogram = new Identity(name + "_Histogram");
-            WarmUpPeriod = Math.Max(fastPeriod, slowPeriod) + signalPeriod - 1;
+            WarmUpPeriod = slowPeriod + signalPeriod - 1;
         }
 
         /// <summary>

--- a/Indicators/MovingAverageConvergenceDivergence.cs
+++ b/Indicators/MovingAverageConvergenceDivergence.cs
@@ -80,7 +80,7 @@ namespace QuantConnect.Indicators
             Slow = type.AsIndicator(name + "_Slow", slowPeriod);
             Signal = type.AsIndicator(name + "_Signal", signalPeriod);
             Histogram = new Identity(name + "_Histogram");
-            WarmUpPeriod = signalPeriod;
+            WarmUpPeriod = Math.Max(fastPeriod, slowPeriod) + signalPeriod;
         }
 
         /// <summary>
@@ -95,8 +95,16 @@ namespace QuantConnect.Indicators
 
             var macd = Fast.Current.Value - Slow.Current.Value;
 
-            Signal.Update(input.Time, macd);
-            Histogram.Update(input.Time, macd - Signal.Current.Value);
+            if (Fast.IsReady && Slow.IsReady)
+            {
+                Signal.Update(input.Time, macd);
+            }
+                
+            if (Signal.IsReady)
+            {
+                Histogram.Update(input.Time, macd - Signal.Current.Value);
+            }
+
             return macd;
         }
 

--- a/Indicators/MovingAverageConvergenceDivergence.cs
+++ b/Indicators/MovingAverageConvergenceDivergence.cs
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+using System;
 
 namespace QuantConnect.Indicators
 {

--- a/Indicators/MovingAverageConvergenceDivergence.cs
+++ b/Indicators/MovingAverageConvergenceDivergence.cs
@@ -77,6 +77,11 @@ namespace QuantConnect.Indicators
         public MovingAverageConvergenceDivergence(string name, int fastPeriod, int slowPeriod, int signalPeriod, MovingAverageType type = MovingAverageType.Exponential)
             : base(name)
         {
+            if (fastPeriod >= slowPeriod)
+            {
+                throw new ArgumentException("MovingAverageConvergenceDivergence: fastPeriod must be less than slowPeriod", "fastPeriod, slowPeriod");
+            }
+            
             Fast = type.AsIndicator(name + "_Fast", fastPeriod);
             Slow = type.AsIndicator(name + "_Slow", slowPeriod);
             Signal = type.AsIndicator(name + "_Signal", signalPeriod);

--- a/Indicators/SchaffTrendCycle.cs
+++ b/Indicators/SchaffTrendCycle.cs
@@ -86,7 +86,7 @@ namespace QuantConnect.Indicators
             _PF = new Identity(name + "_PF");
             _PFF = type.AsIndicator(3).Of(_PF, false);
 
-            WarmUpPeriod = cyclePeriod;
+            WarmUpPeriod = _MACD.WarmUpPeriod;
         }
 
         /// <summary>

--- a/QuantConnect.Lean.sln
+++ b/QuantConnect.Lean.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30104.148
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 15.0.0.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantConnect.Lean.Launcher", "Launcher\QuantConnect.Lean.Launcher.csproj", "{09E7B916-E58B-4021-BD8B-C10B4446E226}"
 EndProject
@@ -16,7 +16,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantConnect.Lean.Engine", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantConnect.Algorithm", "Algorithm\QuantConnect.Algorithm.csproj", "{3240ACA4-BDD4-4D24-AC36-BBB651C39212}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QuantConnect", "Common\QuantConnect.csproj", "{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantConnect", "Common\QuantConnect.csproj", "{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantConnect.Logging", "Logging\QuantConnect.Logging.csproj", "{01911409-86BE-4E7D-9947-DF714138610D}"
 EndProject
@@ -92,12 +92,12 @@ Global
 		{3240ACA4-BDD4-4D24-AC36-BBB651C39212}.Release|x64.Build.0 = Release|x64
 		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Debug|x64.Build.0 = Debug|Any CPU
+		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Debug|x64.ActiveCfg = Debug|x64
+		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Debug|x64.Build.0 = Debug|x64
 		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Release|x64.ActiveCfg = Release|Any CPU
-		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Release|x64.Build.0 = Release|Any CPU
+		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Release|x64.ActiveCfg = Release|x64
+		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Release|x64.Build.0 = Release|x64
 		{01911409-86BE-4E7D-9947-DF714138610D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{01911409-86BE-4E7D-9947-DF714138610D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01911409-86BE-4E7D-9947-DF714138610D}.Debug|x64.ActiveCfg = Debug|x64

--- a/QuantConnect.Lean.sln
+++ b/QuantConnect.Lean.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30104.148
 MinimumVisualStudioVersion = 15.0.0.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantConnect.Lean.Launcher", "Launcher\QuantConnect.Lean.Launcher.csproj", "{09E7B916-E58B-4021-BD8B-C10B4446E226}"
 EndProject
@@ -16,7 +16,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantConnect.Lean.Engine", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantConnect.Algorithm", "Algorithm\QuantConnect.Algorithm.csproj", "{3240ACA4-BDD4-4D24-AC36-BBB651C39212}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantConnect", "Common\QuantConnect.csproj", "{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QuantConnect", "Common\QuantConnect.csproj", "{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantConnect.Logging", "Logging\QuantConnect.Logging.csproj", "{01911409-86BE-4E7D-9947-DF714138610D}"
 EndProject
@@ -92,12 +92,12 @@ Global
 		{3240ACA4-BDD4-4D24-AC36-BBB651C39212}.Release|x64.Build.0 = Release|x64
 		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Debug|x64.ActiveCfg = Debug|x64
-		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Debug|x64.Build.0 = Debug|x64
+		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Debug|x64.Build.0 = Debug|Any CPU
 		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Release|x64.ActiveCfg = Release|x64
-		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Release|x64.Build.0 = Release|x64
+		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Release|x64.ActiveCfg = Release|Any CPU
+		{2545C0B4-FABB-49C9-8DD1-9AD7EE23F86B}.Release|x64.Build.0 = Release|Any CPU
 		{01911409-86BE-4E7D-9947-DF714138610D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{01911409-86BE-4E7D-9947-DF714138610D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01911409-86BE-4E7D-9947-DF714138610D}.Debug|x64.ActiveCfg = Debug|x64

--- a/Tests/Indicators/MovingAverageConvergenceDivergenceTests.cs
+++ b/Tests/Indicators/MovingAverageConvergenceDivergenceTests.cs
@@ -32,6 +32,14 @@ namespace QuantConnect.Tests.Indicators
         protected override string TestColumnName => "MACD";
 
         [Test]
+        public void FastPeriodLessThanSlowPeriod()
+        {
+            var a = new MovingAverageConvergenceDivergence(fastPeriod: 2, slowPeriod: 3, signalPeriod: 2);
+            Assert.Throws<ArgumentException>(() => new MovingAverageConvergenceDivergence(fastPeriod: 3, slowPeriod: 3, signalPeriod: 2));
+            Assert.Throws<ArgumentException>(() => new MovingAverageConvergenceDivergence(fastPeriod: 4, slowPeriod: 3, signalPeriod: 2));
+        }
+
+        [Test]
         public void ComparesWithExternalDataMacdHistogram()
         {
             var macd = CreateIndicator();

--- a/Tests/Indicators/MovingAverageConvergenceDivergenceTests.cs
+++ b/Tests/Indicators/MovingAverageConvergenceDivergenceTests.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using NUnit.Framework;
 using QuantConnect.Indicators;
 
@@ -60,6 +61,62 @@ namespace QuantConnect.Tests.Indicators
                     delta: 1e-4
                 )
             );
+        }
+
+        [Test]
+        public void ComparesWithExternalDataMacdValue()
+        {
+            var macd = CreateIndicator();
+            TestHelper.TestIndicator(
+                macd,
+                TestFileName,
+                "MACD",
+                (ind, expected) => Assert.AreEqual(
+                    expected,
+                    (double)((MovingAverageConvergenceDivergence)ind).Current.Value,
+                    delta: 1e-4
+                )
+            );
+        }
+
+        [Test]
+        public override void WarmsUpProperly()
+        {
+            int fastPeriod = 3,
+                slowPeriod = 4,
+                signalPeriod = 2;
+            var macd = new MovingAverageConvergenceDivergence(fastPeriod: fastPeriod, slowPeriod: slowPeriod, signalPeriod: signalPeriod);
+
+            Assert.IsFalse(macd.Signal.IsReady);
+            Assert.IsFalse(macd.Histogram.IsReady);
+            Assert.IsFalse(macd.IsReady);
+
+            for (var i = 0; i < fastPeriod; i++)
+            {
+                Assert.IsFalse(macd.Fast.IsReady);
+                macd.Update(new IndicatorDataPoint(DateTime.Today.AddSeconds(i), i));
+            }
+            Assert.IsTrue(macd.Fast.IsReady);
+
+
+            for (var i = fastPeriod; i < slowPeriod; i++)
+            {
+                Assert.IsFalse(macd.Slow.IsReady);
+                macd.Update(new IndicatorDataPoint(DateTime.Today.AddSeconds(i), i));
+            }
+            Assert.IsTrue(macd.Slow.IsReady);
+
+
+            for (var i = slowPeriod; i < macd.WarmUpPeriod; i++)
+            {
+                Assert.IsFalse(macd.Signal.IsReady);
+                Assert.IsFalse(macd.Histogram.IsReady);
+                Assert.IsFalse(macd.IsReady);
+                macd.Update(new IndicatorDataPoint(DateTime.Today.AddSeconds(i), i));
+            }
+            Assert.IsTrue(macd.Signal.IsReady);
+            Assert.IsTrue(macd.Histogram.IsReady);
+            Assert.IsTrue(macd.IsReady);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The WarmUpPeriod of the MACD is corrected to include all internal indicators. In addition, we now only update the `Signal` and `Histogram` when the internal indicators used in their computations are ready.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Close #5109

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Before this change, the MACD indicator could be ready while it's internal indicators are not ready. The backtest shared in the related issue demonstrates this.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The new indicator was run in the Cloud in[ this backtest](https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_720865fb20fe671956a8afec7c7499da.html). The logs show the indicator now has the correct `IsReady` state.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why --> This probably needs a test added, but I'm not sure how to add unit tests to LEAN yet.
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
