### PR TITLE
Refactors Market Fill of Equity Fill Model 

### DIFF
--- a/Algorithm.CSharp/EquityTickQuoteAdjustedModeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/EquityTickQuoteAdjustedModeRegressionAlgorithm.cs
@@ -85,11 +85,11 @@ namespace QuantConnect.Algorithm.CSharp
         {
             {"Total Trades", "2"},
             {"Average Win", "0%"},
-            {"Average Loss", "-0.01%"},
-            {"Compounding Annual Return", "-0.500%"},
-            {"Drawdown", "0.000%"},
+            {"Average Loss", "-0.12%"},
+            {"Compounding Annual Return", "-9.062%"},
+            {"Drawdown", "0.100%"},
             {"Expectancy", "-1"},
-            {"Net Profit", "-0.006%"},
+            {"Net Profit", "-0.121%"},
             {"Sharpe Ratio", "0"},
             {"Probabilistic Sharpe Ratio", "0%"},
             {"Loss Rate", "100%"},
@@ -103,12 +103,12 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.22"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$6.41"},
-            {"Fitness Score", "0.248"},
+            {"Fitness Score", "0.249"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
             {"Sortino Ratio", "79228162514264337593543950335"},
-            {"Return Over Maximum Drawdown", "-82.815"},
-            {"Portfolio Turnover", "0.497"},
+            {"Return Over Maximum Drawdown", "-79.031"},
+            {"Portfolio Turnover", "0.498"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
             {"Total Insights Analysis Completed", "0"},
@@ -122,7 +122,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "1213851303"}
+            {"OrderListHash", "-1760998125"}
         };
     }
 }

--- a/Common/Orders/Fills/EquityFillModel.cs
+++ b/Common/Orders/Fills/EquityFillModel.cs
@@ -543,7 +543,7 @@ namespace QuantConnect.Orders.Fills
 
         /// <summary>
         /// Get current bid price for subscribed data
-        /// This method will try to get the most recent ask price data, so it will try to get tick quote first, then quote bar.
+        /// This method will try to get the most recent bid price data, so it will try to get tick quote first, then quote bar.
         /// If no quote, tick or bar, is available (e.g. hourly data), use trade data with preference to tick data.
         /// </summary>
         /// <param name="asset">Security which has subscribed data types</param>

--- a/Common/Orders/Fills/EquityFillModel.cs
+++ b/Common/Orders/Fills/EquityFillModel.cs
@@ -14,12 +14,14 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Python;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Securities;
+using QuantConnect.Util;
 
 namespace QuantConnect.Orders.Fills
 {
@@ -116,17 +118,8 @@ namespace QuantConnect.Orders.Fills
             // make sure the exchange is open/normal market hours before filling
             if (!IsExchangeOpen(asset, false)) return fill;
 
-            var prices = GetPricesCheckingPythonWrapper(asset, order.Direction);
-            var pricesEndTimeUtc = prices.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
-
-            // if the order is filled on stale (fill-forward) data, set a warning message on the order event
-            if (pricesEndTimeUtc.Add(Parameters.StalePriceTimeSpan) < order.Time)
-            {
-                fill.Message = $"Warning: fill at stale price ({prices.EndTime.ToStringInvariant()} {asset.Exchange.TimeZone})";
-            }
-
-            //Order [fill]price for a market order model is the current security price
-            fill.FillPrice = prices.Current;
+            // Define the last bid or ask time to set stale prices message
+            var endTime = DateTime.MinValue;
             fill.Status = OrderStatus.Filled;
 
             //Calculate the model slippage: e.g. 0.01c
@@ -136,11 +129,21 @@ namespace QuantConnect.Orders.Fills
             switch (order.Direction)
             {
                 case OrderDirection.Buy:
-                    fill.FillPrice += slip;
+                    //Order [fill]price for a buy market order model is the current security ask price
+                    fill.FillPrice = GetAskPrice(asset, out endTime) + slip;
                     break;
                 case OrderDirection.Sell:
-                    fill.FillPrice -= slip;
+                    //Order [fill]price for a buy market order model is the current security bid price
+                    fill.FillPrice = GetBidPrice(asset, out endTime) - slip;
                     break;
+            }
+
+            var endTimeUtc = endTime.ConvertToUtc(asset.Exchange.TimeZone);
+
+            // if the order is filled on stale (fill-forward) data, set a warning message on the order event
+            if (endTimeUtc.Add(Parameters.StalePriceTimeSpan) < order.Time)
+            {
+                fill.Message = $"Warning: fill at stale price ({endTime.ToStringInvariant()} {asset.Exchange.TimeZone})";
             }
 
             // assume the order completely filled
@@ -459,6 +462,144 @@ namespace QuantConnect.Orders.Fills
 
             return fill;
         }
+
+        /// <summary>
+        /// Get data types the Security is subscribed to
+        /// </summary>
+        /// <param name="asset">Security which has subscribed data types</param>
+        private HashSet<Type> GetSubscribedTypes(Security asset)
+        {
+            var subscribedTypes = Parameters
+                .ConfigProvider
+                .GetSubscriptionDataConfigs(asset.Symbol)
+                .ToHashSet(x => x.Type);
+
+            if (subscribedTypes.Count == 0)
+            {
+                throw new InvalidOperationException($"Cannot perform fill for {asset.Symbol} because no data subscription were found.");
+            }
+
+            return subscribedTypes;
+        }
+
+        /// <summary>
+        /// Get current ask price for subscribed data
+        /// This method will try to get the most recent ask price data, so it will try to get tick quote first, then quote bar.
+        /// If no quote, tick or bar, is available (e.g. hourly data), use trade data with preference to tick data.
+        /// </summary>
+        /// <param name="asset">Security which has subscribed data types</param>
+        /// <param name="endTime">Timestamp of the most recent data type</param>
+        private decimal GetAskPrice(Security asset, out DateTime endTime)
+        {
+            var subscribedTypes = GetSubscribedTypes(asset);
+
+            List<Tick> ticks = null;
+            var isTickSubscribed = subscribedTypes.Contains(typeof(Tick));
+
+            if (isTickSubscribed)
+            {
+                ticks = asset.Cache.GetAll<Tick>().ToList();
+
+                var quote = ticks.LastOrDefault(x => x.TickType == TickType.Quote && x.AskPrice > 0);
+                if (quote != null)
+                {
+                    endTime = quote.EndTime;
+                    return quote.AskPrice;
+                }
+            }
+
+            if (subscribedTypes.Contains(typeof(QuoteBar)))
+            {
+                var quoteBar = asset.Cache.GetData<QuoteBar>();
+                if (quoteBar != null)
+                {
+                    endTime = quoteBar.EndTime;
+                    return quoteBar.Ask?.Close ?? quoteBar.Close;
+                }
+            }
+
+            if (isTickSubscribed)
+            {
+                var trade = ticks.LastOrDefault(x => x.TickType == TickType.Trade && x.Price > 0);
+                if (trade != null)
+                {
+                    endTime = trade.EndTime;
+                    return trade.Price;
+                }
+            }
+
+            if (subscribedTypes.Contains(typeof(TradeBar)))
+            {
+                var tradeBar = asset.Cache.GetData<TradeBar>();
+                if (tradeBar != null)
+                {
+                    endTime = tradeBar.EndTime;
+                    return tradeBar.Close;
+                }
+            }
+
+            throw new InvalidOperationException($"Cannot get ask price to perform fill for {asset.Symbol} because no market data subscription were found.");
+        }
+
+        /// <summary>
+        /// Get current bid price for subscribed data
+        /// This method will try to get the most recent ask price data, so it will try to get tick quote first, then quote bar.
+        /// If no quote, tick or bar, is available (e.g. hourly data), use trade data with preference to tick data.
+        /// </summary>
+        /// <param name="asset">Security which has subscribed data types</param>
+        /// <param name="endTime">Timestamp of the most recent data type</param>
+        private decimal GetBidPrice(Security asset, out DateTime endTime)
+        {
+            var subscribedTypes = GetSubscribedTypes(asset);
+
+            List<Tick> ticks = null;
+            var isTickSubscribed = subscribedTypes.Contains(typeof(Tick));
+
+            if (isTickSubscribed)
+            {
+                ticks = asset.Cache.GetAll<Tick>().ToList();
+
+                var quote = ticks.LastOrDefault(x => x.TickType == TickType.Quote && x.BidPrice > 0);
+                if (quote != null)
+                {
+                    endTime = quote.EndTime;
+                    return quote.BidPrice;
+                }
+            }
+
+            if (subscribedTypes.Contains(typeof(QuoteBar)))
+            {
+                var quoteBar = asset.Cache.GetData<QuoteBar>();
+                if (quoteBar != null)
+                {
+                    endTime = quoteBar.EndTime;
+                    return quoteBar.Bid?.Close ?? quoteBar.Close;
+                }
+            }
+
+            if (isTickSubscribed)
+            {
+                var trade = ticks.LastOrDefault(x => x.TickType == TickType.Trade && x.Price > 0);
+                if (trade != null)
+                {
+                    endTime = trade.EndTime;
+                    return trade.Price;
+                }
+            }
+
+            if (subscribedTypes.Contains(typeof(TradeBar)))
+            {
+                var tradeBar = asset.Cache.GetData<TradeBar>();
+                if (tradeBar != null)
+                {
+                    endTime = tradeBar.EndTime;
+                    return tradeBar.Close;
+                }
+            }
+
+            throw new InvalidOperationException($"Cannot get bid price to perform fill for {asset.Symbol} because no market data subscription were found.");
+        }
+
 
         /// <summary>
         /// This is required due to a limitation in PythonNet to resolved


### PR DESCRIPTION
#### Description
- Create `GetBidPrice` and `GetAskPrice` methods to request the most suitable price to fill market orders.
- Fix unit tests to show that the new implementation prevents using non-market data to fill the order.
- Fix regression test: the previous market fill method would consider the last tick from the last collection of ticks that was a tick of trade type. With this PR, the model looks for the last tick with quote type. 

#### Related Issue
Ref.: #4567 

#### How Has This Been Tested?
Existing unit and regression tests.
- Market Fill does not change the core current behavior. However once accepts market data now while it could accept any other type that can set the security price.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`