### PR TITLE
Allow Saving of Octet Stream in API

### DIFF
--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -824,15 +824,27 @@ namespace QuantConnect.Api
             var client  = new RestClient(uri.Scheme + "://" + uri.Host);
             var request = new RestRequest(uri.PathAndQuery, Method.GET);
 
-            // If the response is not a zip or octet-stream then it is not data, don't write it.
+            // MAke a request for the data at the link
             var response = client.Execute(request);
-            if (response.ContentType != "application/zip" && response.ContentType != "application/octet-stream")
+
+            // If the response is JSON it doesn't contain any data, try and extract the message and write it
+            if (response.ContentType == "application/json")
             {
-                var message = JObject.Parse(response.Content)["message"].Value<string>();
-                Log.Error($"Api.DownloadData(): Failed to download zip for {symbol} {resolution} data for date {date}, Api response: {message}");
+                try
+                {
+                    var contentObj = JObject.Parse(response.Content);
+                    var message = contentObj["message"].Value<string>();
+                    Log.Error($"Api.DownloadData(): Failed to download zip for {symbol} {resolution} data for date {date}, Api response: {message}");
+                }
+                catch
+                {
+                    Log.Error($"Api.DownloadData(): Failed to download zip for {symbol} {resolution} data for date {date}. Api response could not be parsed.");
+                }
+
                 return false;
             }
             
+            // Any other case save the content to given path
             response.RawBytes.SaveAs(path);
             return true;
         }

--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -828,7 +828,7 @@ namespace QuantConnect.Api
             var response = client.Execute(request);
 
             // If the response is JSON it doesn't contain any data, try and extract the message and write it
-            if (response.ContentType == "application/json")
+            if (response.ContentType.ToLowerInvariant() == "application/json")
             {
                 try
                 {

--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -824,9 +824,9 @@ namespace QuantConnect.Api
             var client  = new RestClient(uri.Scheme + "://" + uri.Host);
             var request = new RestRequest(uri.PathAndQuery, Method.GET);
 
-            // If the response is not a zip then it is not data, don't write it.
+            // If the response is not a zip or octet-stream then it is not data, don't write it.
             var response = client.Execute(request);
-            if (response.ContentType != "application/zip")
+            if (response.ContentType != "application/zip" && response.ContentType != "application/octet-stream")
             {
                 var message = JObject.Parse(response.Content)["message"].Value<string>();
                 Log.Error($"Api.DownloadData(): Failed to download zip for {symbol} {resolution} data for date {date}, Api response: {message}");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Refactor PR solution #5022 to allow all types except `Application/JSON` to save to path


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5057

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This issue arose after changes #5020 which stopped the saving of response content that wasn't "application/zip" because it was creating corrupted files when the response was a message or error from the web api. 

This refactors the original solution to allow other types to save and only catch `application/json` messages which we expect when it fails.

This, amongst other issues with the data portal, highlights a need for refactor and unification of behavior of the data api endpoints and then a accompanying refactor in Lean. 

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Can successfully download and save zips (Tested with Spy second data) and Octet-Stream (to zip files) (Tested with Oanda Minute Data)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
