### PR TITLE
Fixes Market On Close Fill of Equity Fill Model

### DIFF
--- a/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
@@ -196,13 +196,13 @@ namespace QuantConnect.Algorithm.CSharp
         {
             {"Total Trades", "21"},
             {"Average Win", "0%"},
-            {"Average Loss", "-1.59%"},
-            {"Compounding Annual Return", "-7.733%"},
-            {"Drawdown", "15.800%"},
+            {"Average Loss", "-1.60%"},
+            {"Compounding Annual Return", "-7.771%"},
+            {"Drawdown", "15.700%"},
             {"Expectancy", "-1"},
-            {"Net Profit", "-14.869%"},
-            {"Sharpe Ratio", "-1.183"},
-            {"Probabilistic Sharpe Ratio", "0.042%"},
+            {"Net Profit", "-14.938%"},
+            {"Sharpe Ratio", "-1.189"},
+            {"Probabilistic Sharpe Ratio", "0.041%"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
@@ -210,15 +210,15 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "0.035"},
             {"Annual Standard Deviation", "0.053"},
             {"Annual Variance", "0.003"},
-            {"Information Ratio", "-2.251"},
+            {"Information Ratio", "-2.253"},
             {"Tracking Error", "0.111"},
-            {"Treynor Ratio", "-1.766"},
+            {"Treynor Ratio", "-1.788"},
             {"Total Fees", "$21.00"},
             {"Fitness Score", "0.002"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "-2.097"},
-            {"Return Over Maximum Drawdown", "-0.49"},
+            {"Sortino Ratio", "-2.112"},
+            {"Return Over Maximum Drawdown", "-0.494"},
             {"Portfolio Turnover", "0.006"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
@@ -233,7 +233,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "1536869386"}
+            {"OrderListHash", "-988398285"}
         };
     }
 }

--- a/Tests/Common/Orders/Fills/EquityFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/EquityFillModelTests.cs
@@ -426,10 +426,10 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var reference = new DateTime(2015, 06, 05, 15, 0, 0); // before market close
             var model = new EquityFillModel();
             var order = new MarketOnCloseOrder(Symbols.SPY, 100, reference);
-            var config = CreateTradeBarConfig(Symbols.SPY);
+            var configTradeBar = CreateTradeBarConfig(Symbols.SPY);
             var security = new Security(
                 SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
-                config,
+                configTradeBar,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
                 ErrorCurrencyConverter.Instance,
@@ -439,32 +439,47 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             var time = reference;
             TimeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
-            security.SetMarketPrice(new TradeBar(time - config.Increment, Symbols.SPY, 1m, 2m, 0.5m, 1.33m, 100, config.Increment));
+            security.SetMarketPrice(new TradeBar(time - configTradeBar.Increment, Symbols.SPY, 1m, 2m, 0.5m, 1.33m, 100, configTradeBar.Increment));
+
+            var configQuoteBar = new SubscriptionDataConfig(configTradeBar, typeof(QuoteBar));
+            var configProvider = new MockSubscriptionDataConfigProvider(configQuoteBar);
+            configProvider.SubscriptionDataConfigs.Add(configTradeBar);
 
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config),
+                configProvider,
                 Time.OneHour)).OrderEvent;
+
             Assert.AreEqual(0, fill.FillQuantity);
 
             // market closes after 60min, so this is just before market Close
             time = reference.AddMinutes(59);
             TimeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
-            security.SetMarketPrice(new TradeBar(time - config.Increment, Symbols.SPY, 1.33m, 2.75m, 1.15m, 1.45m, 100, config.Increment));
+            security.SetMarketPrice(new TradeBar(time - configTradeBar.Increment, Symbols.SPY, 1.33m, 2.75m, 1.15m, 1.45m, 100, configTradeBar.Increment));
 
             fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config),
+                configProvider,
                 Time.OneHour)).OrderEvent;
             Assert.AreEqual(0, fill.FillQuantity);
 
+            const decimal expected = 1.40m;
             // market closes
             time = reference.AddMinutes(60);
             TimeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
-            security.SetMarketPrice(new TradeBar(time - config.Increment, Symbols.SPY, 1.45m, 2.0m, 1.1m, 1.40m, 100, config.Increment));
 
+            // Does not fill with quote data
+            security.SetMarketPrice(new QuoteBar(time - configTradeBar.Increment, Symbols.SPY,
+                new Bar(1.44m, 1.99m, 1.09m, 1.39m), 100,
+                new Bar(1.46m, 2.01m, 1.11m, 1.41m), 100));
+
+            fill = model.MarketOnCloseFill(security, order);
+            Assert.AreEqual(0, fill.FillQuantity);
+
+            // Fill with trade bar
+            security.SetMarketPrice(new TradeBar(time - configTradeBar.Increment, Symbols.SPY, 1.45m, 2.0m, 1.1m, expected, 100, configTradeBar.Increment));
             fill = model.MarketOnCloseFill(security, order);
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
             Assert.AreEqual(security.Close, fill.FillPrice);


### PR DESCRIPTION
#### Description
Only use trade data (`Tick` with `TickTrade` type or `TradeBar`) to get the close price, since MOC is filled with the closing auction price. Ensure that this method doesn't use trade data from the previous day by comparing the trade data end time and the next market close.

- Fix unit tests to show that the new implementation only fills with trade data from the current close market.
- Change `UpdateOrderRegressionAlgorithm` regression tests to reflect the bug fix, since it was using the closing price of the previous day.


#### Related Issue
Ref.: #4567 

#### How Has This Been Tested?
Unit and regression tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. 
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`