### PR TITLE
Fixes Stop Market Fill of Equity Fill Model

### DIFF
--- a/Algorithm.CSharp/StopLossOnOrderEventRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StopLossOnOrderEventRegressionAlgorithm.cs
@@ -73,16 +73,16 @@ namespace QuantConnect.Algorithm.CSharp
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "2"},
-            {"Average Win", "0.00%"},
-            {"Average Loss", "0%"},
-            {"Compounding Annual Return", "0.273%"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0.00%"},
+            {"Compounding Annual Return", "-0.156%"},
             {"Drawdown", "0.000%"},
-            {"Expectancy", "0"},
-            {"Net Profit", "0.003%"},
+            {"Expectancy", "-1"},
+            {"Net Profit", "-0.002%"},
             {"Sharpe Ratio", "0"},
             {"Probabilistic Sharpe Ratio", "0%"},
-            {"Loss Rate", "0%"},
-            {"Win Rate", "100%"},
+            {"Loss Rate", "100%"},
+            {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
             {"Alpha", "0"},
             {"Beta", "0"},
@@ -92,11 +92,11 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.22"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$2.00"},
-            {"Fitness Score", "0.076"},
+            {"Fitness Score", "0.038"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
             {"Sortino Ratio", "79228162514264337593543950335"},
-            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "-82.952"},
             {"Portfolio Turnover", "0.076"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
@@ -111,7 +111,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-174329712"}
+            {"OrderListHash", "1338491664"}
         };
     }
 }


### PR DESCRIPTION
#### Description
Only use trade data (`Tick` with `TickTrade` type or `TradeBar`) to get the high and low prices, since stop market orders are triggered with high and low prices. The fill price is the worst-case scenario between the stop price and the bid/ask, unless there is a gap and the open price is used instead.
https://www1.interactivebrokers.com/en/index.php?f=609

- Fix unit tests to show that the new implementation only fills with high and low values of trade data.
- Change `StopLossOnOrderEventRegressionAlgorithm` regression tests to reflect the bug fix. The change results from the price gap handling as the both TradeBar and QuoteBar high and low triggers the stop loss.

**Note**: This PR also changes statistics of `UpdateOrderRegressionAlgorithm`. However, since #5131 also does, it would be better to address it once #5131 is merged.

#### Related Issue
Ref.: #4567 
Closes #4546

#### How Has This Been Tested?
Unit and regression tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. 
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`