### PR TITLE
Fix UniverseSelectionAddAndRemove race condition

### DIFF
--- a/Tests/Engine/DataFeeds/InternalSubscriptionManagerTests.cs
+++ b/Tests/Engine/DataFeeds/InternalSubscriptionManagerTests.cs
@@ -246,27 +246,34 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                                 return first ? new[] { "IBM" } : new[] { "AAPL" };
                             }
                     );
+
+                    // The custom exchange has to pick up the universe selection data point and push it into the universe subscription
+                    Thread.Sleep(100);
                 }
                 else if (!timeSlice.IsTimePulse)
                 {
                     if (first)
                     {
                         Assert.IsTrue(_algorithm.SubscriptionManager.SubscriptionDataConfigService
-                            .GetSubscriptionDataConfigs(Symbols.IBM, includeInternalConfigs: true).Any(config => config.Resolution == Resolution.Second));
-                        Assert.IsFalse(_algorithm.SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(Symbols.AAPL, includeInternalConfigs: true).Any());
+                            .GetSubscriptionDataConfigs(Symbols.IBM, includeInternalConfigs: true).Any(config => config.Resolution == Resolution.Second),
+                            "IBM subscription was not found");
+                        Assert.IsFalse(_algorithm.SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(Symbols.AAPL, includeInternalConfigs: true).Any(),
+                            "Unexpected AAPL subscription was found");
                         first = false;
                     }
                     else
                     {
                         Assert.IsTrue(_algorithm.SubscriptionManager.SubscriptionDataConfigService
-                            .GetSubscriptionDataConfigs(Symbols.AAPL, includeInternalConfigs: true).Any(config => config.Resolution == Resolution.Second));
-                        Assert.IsFalse(_algorithm.SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(Symbols.IBM, includeInternalConfigs: true).Any());
+                            .GetSubscriptionDataConfigs(Symbols.AAPL, includeInternalConfigs: true).Any(config => config.Resolution == Resolution.Second),
+                            "AAPL subscription was not found");
+                        Assert.IsFalse(_algorithm.SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(Symbols.IBM, includeInternalConfigs: true).Any(),
+                            "Unexpected IBM subscription was found");
                         break;
                     }
                 }
                 _algorithm.OnEndOfTimeStep();
             }
-            Assert.IsFalse(tokenSource.IsCancellationRequested);
+            Assert.IsFalse(tokenSource.IsCancellationRequested, "Test timed out");
         }
 
         private static TestCaseData[] DataTypeTestCases

--- a/Tests/Engine/DataFeeds/InternalSubscriptionManagerTests.cs
+++ b/Tests/Engine/DataFeeds/InternalSubscriptionManagerTests.cs
@@ -221,7 +221,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Assert.AreNotEqual(0, internalDataCount);
         }
 
-        [Test]
+        [Test, Category("TravisExclude")]
         public void UniverseSelectionAddAndRemove()
         {
             _algorithm.SetLiveMode(true);
@@ -245,9 +245,6 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                                 return !manualEvent.WaitOne(0) ? new[] { "IBM" } : new[] { "AAPL" };
                             }
                     );
-
-                    // The custom exchange has to pick up the universe selection data point and push it into the universe subscription
-                    Thread.Sleep(100);
                 }
                 else if (!timeSlice.IsTimePulse)
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix unit test UniverseSelectionAddAndRemove thread race condition

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/5128
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix unit test failing
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running unit test
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
