### PR TITLE
Refactor Default Benchmark

### DIFF
--- a/Algorithm.CSharp/NullBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/NullBenchmarkRegressionAlgorithm.cs
@@ -1,0 +1,116 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using QuantConnect.Brokerages;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Basic template algorithm simply initializes the date range and cash. This is a skeleton
+    /// framework you can use for designing an algorithm.
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="using quantconnect" />
+    /// <meta name="tag" content="trading and orders" />
+    public class NullBenchmarkRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _spy;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);  //Set Start Date
+            SetEndDate(2013, 10, 08);    //Set End Date
+            SetCash(100000);             //Set Strategy Cash
+
+            // Add equity
+            _spy = AddEquity("SPY", Resolution.Hour).Symbol;
+
+            // Use our Test Brokerage Model with null default benchmark symbol
+            SetBrokerageModel(new TestBrokerageModel());
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (!Portfolio.Invested)
+            {
+                SetHoldings(_spy, 1);
+                Debug("Purchased Stock");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Total Fees", "$3.25"},
+            {"Fitness Score", "0.498"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "-1491193070"}
+        };
+
+        internal class TestBrokerageModel : DefaultBrokerageModel
+        {
+            public override Symbol DefaultBenchmark => null;
+        }
+    }
+}

--- a/Algorithm.CSharp/ZeroedBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ZeroedBenchmarkRegressionAlgorithm.cs
@@ -23,8 +23,7 @@ using QuantConnect.Securities;
 namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
-    /// Basic template algorithm simply initializes the date range and cash. This is a skeleton
-    /// framework you can use for designing an algorithm.
+    /// Regression algorithm to test zeroed benchmark through BrokerageModel override
     /// </summary>
     public class ZeroedBenchmarkRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
@@ -42,7 +41,7 @@ namespace QuantConnect.Algorithm.CSharp
             // Add equity
             _spy = AddEquity("SPY", Resolution.Hour).Symbol;
 
-            // Use our Test Brokerage Model with null default benchmark symbol
+            // Use our Test Brokerage Model with zeroed default benchmark
             SetBrokerageModel(new TestBrokerageModel());
         }
 
@@ -67,7 +66,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp };
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/ZeroedBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ZeroedBenchmarkRegressionAlgorithm.cs
@@ -26,9 +26,6 @@ namespace QuantConnect.Algorithm.CSharp
     /// Basic template algorithm simply initializes the date range and cash. This is a skeleton
     /// framework you can use for designing an algorithm.
     /// </summary>
-    /// <meta name="tag" content="using data" />
-    /// <meta name="tag" content="using quantconnect" />
-    /// <meta name="tag" content="trading and orders" />
     public class ZeroedBenchmarkRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private Symbol _spy;

--- a/Algorithm.CSharp/ZeroedBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ZeroedBenchmarkRegressionAlgorithm.cs
@@ -14,9 +14,11 @@
 */
 
 using System.Collections.Generic;
+using QuantConnect.Benchmarks;
 using QuantConnect.Brokerages;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -27,7 +29,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// <meta name="tag" content="using data" />
     /// <meta name="tag" content="using quantconnect" />
     /// <meta name="tag" content="trading and orders" />
-    public class NullBenchmarkRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    public class ZeroedBenchmarkRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private Symbol _spy;
 
@@ -110,7 +112,10 @@ namespace QuantConnect.Algorithm.CSharp
 
         internal class TestBrokerageModel : DefaultBrokerageModel
         {
-            public override Symbol DefaultBenchmark => null;
+            public override IBenchmark GetBenchmark(SecurityManager securities)
+            {
+                return new FuncBenchmark(x => 0);
+            }
         }
     }
 }

--- a/Algorithm.CSharp/ZeroedBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ZeroedBenchmarkRegressionAlgorithm.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+        public Language[] Languages { get; } = { Language.CSharp };
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.Python/ZeroedBenchmarkRegressionAlgorithm.py
+++ b/Algorithm.Python/ZeroedBenchmarkRegressionAlgorithm.py
@@ -1,0 +1,59 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System.Core")
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import QCAlgorithm
+from QuantConnect.Brokerages import *
+from QuantConnect.Benchmarks import *
+from QuantConnect.Data import *
+from QuantConnect.Securities import *
+
+### <summary>
+### Regression algorithm to test zeroed benchmark through BrokerageModel override
+### </summary>
+### <meta name="tag" content="regression test" />
+class ZeroedBenchmarkRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetCash(100000)
+        self.SetStartDate(2013,10,7)
+        self.SetEndDate(2013,10,8)
+
+        # Add Equity
+        self.AddEquity("SPY", Resolution.Hour)
+
+        # Use our Test Brokerage Model with zerod default benchmark
+        self.SetBrokerageModel(TestBrokerageModel())
+
+    def OnData(self, data):
+        '''OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+
+        Arguments:
+            data: Slice object keyed by symbol containing the stock data
+        '''
+        if not self.Portfolio.Invested:
+            self.SetHoldings("SPY", 1)
+
+class TestBrokerageModel(DefaultBrokerageModel):
+
+    def GetBenchmark(self, securities):
+        return FuncBenchmark(self.func)
+
+    def func(self, datetime):
+        return 0;

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -558,17 +558,23 @@ namespace QuantConnect.Algorithm
             // if the benchmark hasn't been set yet, set it
             if (Benchmark == null)
             {
+                // If we don't have a symbol fetch it from the Brokerage model
                 if (_benchmarkSymbol == null)
                 {
-                    _benchmarkSymbol = QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA);
+                    _benchmarkSymbol = BrokerageModel.DefaultBenchmark;
                 }
 
-                var security = Securities.CreateSecurity(_benchmarkSymbol,
-                    new List<SubscriptionDataConfig>(),
-                    leverage: 1,
-                    addToSymbolCache:false);
+                // Before we set it, ensure the benchmark symbol is not null
+                // Brokerage implementations may set it to null to have no benchmark
+                if (_benchmarkSymbol != null)
+                {
+                    var security = Securities.CreateSecurity(_benchmarkSymbol,
+                        new List<SubscriptionDataConfig>(),
+                        leverage: 1,
+                        addToSymbolCache: false);
 
-                Benchmark = new SecurityBenchmark(security);
+                    Benchmark = new SecurityBenchmark(security);
+                }
             }
 
             // perform end of time step checks, such as enforcing underlying securities are in raw data mode

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1062,9 +1062,15 @@ namespace QuantConnect.Algorithm
             // Check the cache for the symbol
             if (!SymbolCache.TryGetSymbol(ticker, out symbol))
             {
-                // Create the symbol
-                Debug($"Warning: SetBenchmark({ticker}): no existing symbol found, benchmark security will be added with {SecurityType.Equity} type.");
-                symbol = QuantConnect.Symbol.Create(ticker, SecurityType.Equity, Market.USA);
+                // Check our securities for a symbol matched with this ticker
+                symbol = Securities.FirstOrDefault(x => x.Key.Value == ticker).Key;
+
+                // If we didn't find a symbol matching our ticker, create one.
+                if (symbol == null)
+                {
+                    Debug($"Warning: SetBenchmark({ticker}): no existing symbol found, benchmark security will be added with {SecurityType.Equity} type.");
+                    symbol = QuantConnect.Symbol.Create(ticker, SecurityType.Equity, Market.USA);
+                }
             }
 
             // Send our symbol through

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1088,14 +1088,8 @@ namespace QuantConnect.Algorithm
                 throw new InvalidOperationException("Algorithm.SetBenchmark(): Cannot change Benchmark after algorithm initialized.");
             }
 
-            // Create a security from this symbol
-            var security = Securities.CreateSecurity(symbol,
-                new List<SubscriptionDataConfig>(),
-                leverage: 1,
-                addToSymbolCache: false);
-
-            // Create and set our SecurityBenchmark
-            Benchmark = new SecurityBenchmark(security);
+            // Create our security benchmark
+            Benchmark = SecurityBenchmark.CreateInstance(Securities, symbol);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1077,26 +1077,16 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">symbol to use as the benchmark</param>
         public void SetBenchmark(Symbol symbol)
         {
-            // Create the security from this symbol
-            var security = Securities.CreateSecurity(symbol,
-                new List<SubscriptionDataConfig>(),
-                leverage: 1,
-                addToSymbolCache: false);
-
-            // Send our security through
-            SetBenchmark(security);
-        }
-
-        /// <summary>
-        /// Sets the benchmark used for computing statistics of the algorithm to the specified security
-        /// </summary>
-        /// <param name="security"></param>
-        public void SetBenchmark(Security security)
-        {
             if (_locked)
             {
                 throw new InvalidOperationException("Algorithm.SetBenchmark(): Cannot change Benchmark after algorithm initialized.");
             }
+
+            // Create a security from this symbol
+            var security = Securities.CreateSecurity(symbol,
+                new List<SubscriptionDataConfig>(),
+                leverage: 1,
+                addToSymbolCache: false);
 
             // Create and set our SecurityBenchmark
             Benchmark = new SecurityBenchmark(security);

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -564,7 +564,6 @@ namespace QuantConnect.Algorithm
                     _benchmarkSymbol = BrokerageModel.DefaultBenchmark;
                 }
 
-                // Before we set it, ensure the benchmark symbol is not null
                 // Brokerage implementations may set it to null to have no benchmark
                 if (_benchmarkSymbol != null)
                 {
@@ -574,6 +573,11 @@ namespace QuantConnect.Algorithm
                         addToSymbolCache: false);
 
                     Benchmark = new SecurityBenchmark(security);
+                }
+                else
+                {
+                    // Set it to always zero value
+                    Benchmark = new FuncBenchmark(x => 0);
                 }
             }
 

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1077,19 +1077,13 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">symbol to use as the benchmark</param>
         public void SetBenchmark(Symbol symbol)
         {
-            Security security;
+            // Create the security from this symbol
+            var security = Securities.CreateSecurity(symbol,
+                new List<SubscriptionDataConfig>(),
+                leverage: 1,
+                addToSymbolCache: false);
 
-            // Check if we have that symbol in our securities
-            if (!Securities.TryGetValue(symbol, out security))
-            {
-                // Else create the security from this symbol
-                security = Securities.CreateSecurity(symbol,
-                    new List<SubscriptionDataConfig>(),
-                    leverage: 1,
-                    addToSymbolCache: false);
-            }
-
-            //Send our security through
+            // Send our security through
             SetBenchmark(security);
         }
 

--- a/Common/Benchmarks/FuncBenchmark.cs
+++ b/Common/Benchmarks/FuncBenchmark.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using Python.Runtime;
 
 namespace QuantConnect.Benchmarks
 {
@@ -35,6 +36,19 @@ namespace QuantConnect.Benchmarks
                 throw new ArgumentNullException(nameof(benchmark));
             }
             _benchmark = benchmark;
+        }
+
+        /// <summary>
+        /// Create a function benchmark from a Python function
+        /// </summary>
+        /// <param name="pyFunc"></param>
+        public FuncBenchmark(PyObject pyFunc)
+        {
+            if (!pyFunc.TryConvertToDelegate(out _benchmark))
+            {
+                throw new ArgumentException("FuncBenchmark(): Unable to convert Python function to benchmark function," +
+                    " please ensure the function supports Datetime input and decimal output");
+            }
         }
 
         /// <summary>

--- a/Common/Benchmarks/SecurityBenchmark.cs
+++ b/Common/Benchmarks/SecurityBenchmark.cs
@@ -14,6 +14,8 @@
 */
 
 using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Benchmarks
@@ -45,6 +47,24 @@ namespace QuantConnect.Benchmarks
         public decimal Evaluate(DateTime time)
         {
             return Security.Price * Security.QuoteCurrency.ConversionRate;
+        }
+
+        /// <summary>
+        /// Helper function that will create a security with the given SecurityManager
+        /// for a specific symbol and then create a SecurityBenchmark for it
+        /// </summary>
+        /// <param name="securities">SecurityService to create the security</param>
+        /// <param name="symbol">The symbol to create a security benchmark with</param>
+        /// <returns>The new SecurityBenchmark</returns>
+        public static SecurityBenchmark CreateInstance(SecurityManager securities, Symbol symbol)
+        {
+            // Create the security from this symbol
+            var security = securities.CreateSecurity(symbol,
+                new List<SubscriptionDataConfig>(),
+                leverage: 1,
+                addToSymbolCache: false);
+
+            return new SecurityBenchmark(security);
         }
     }
 }

--- a/Common/Brokerages/BinanceBrokerageModel.cs
+++ b/Common/Brokerages/BinanceBrokerageModel.cs
@@ -18,6 +18,7 @@ using QuantConnect.Securities;
 using QuantConnect.Util;
 using System;
 using System.Collections.Generic;
+using QuantConnect.Benchmarks;
 
 namespace QuantConnect.Brokerages
 {
@@ -30,11 +31,6 @@ namespace QuantConnect.Brokerages
         /// Gets a map of the default markets to be used for each security type
         /// </summary>
         public override IReadOnlyDictionary<SecurityType, string> DefaultMarkets { get; } = GetDefaultMarkets();
-
-        /// <summary>
-        /// Define the default benchmark used in this model
-        /// </summary>
-        public override Symbol DefaultBenchmark => Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Binance);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BinanceBrokerageModel"/> class
@@ -69,6 +65,17 @@ namespace QuantConnect.Brokerages
         {
             // margin trading is not currently supported by Binance
             return 1m;
+        }
+
+        /// <summary>
+        /// Get the benchmark for this model
+        /// </summary>
+        /// <param name="securities">SecurityService to create the security with if needed</param>
+        /// <returns>The benchmark for this brokerage</returns>
+        public override IBenchmark GetBenchmark(SecurityManager securities)
+        {
+            var symbol = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Binance);
+            return CreateSecurityBenchmark(securities, symbol);
         }
 
         /// <summary>

--- a/Common/Brokerages/BinanceBrokerageModel.cs
+++ b/Common/Brokerages/BinanceBrokerageModel.cs
@@ -75,7 +75,7 @@ namespace QuantConnect.Brokerages
         public override IBenchmark GetBenchmark(SecurityManager securities)
         {
             var symbol = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Binance);
-            return CreateSecurityBenchmark(securities, symbol);
+            return SecurityBenchmark.CreateInstance(securities, symbol);
         }
 
         /// <summary>

--- a/Common/Brokerages/BinanceBrokerageModel.cs
+++ b/Common/Brokerages/BinanceBrokerageModel.cs
@@ -32,6 +32,11 @@ namespace QuantConnect.Brokerages
         public override IReadOnlyDictionary<SecurityType, string> DefaultMarkets { get; } = GetDefaultMarkets();
 
         /// <summary>
+        /// Define the default benchmark used in this model
+        /// </summary>
+        public override Symbol DefaultBenchmark => Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Binance);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="BinanceBrokerageModel"/> class
         /// </summary>
         /// <param name="accountType">The type of account to be modeled, defaults to <see cref="AccountType.Cash"/></param>

--- a/Common/Brokerages/BitfinexBrokerageModel.cs
+++ b/Common/Brokerages/BitfinexBrokerageModel.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using QuantConnect.Benchmarks;
 using QuantConnect.Securities;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Util;
@@ -32,11 +33,6 @@ namespace QuantConnect.Brokerages
         /// Gets a map of the default markets to be used for each security type
         /// </summary>
         public override IReadOnlyDictionary<SecurityType, string> DefaultMarkets { get; } = GetDefaultMarkets();
-
-        /// <summary>
-        /// Define the default benchmark used in this model
-        /// </summary>
-        public override Symbol DefaultBenchmark => Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Bitfinex);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BitfinexBrokerageModel"/> class
@@ -79,6 +75,17 @@ namespace QuantConnect.Brokerages
             }
 
             throw new ArgumentException($"Invalid security type: {security.Type}", nameof(security));
+        }
+
+        /// <summary>
+        /// Get the benchmark for this model
+        /// </summary>
+        /// <param name="securities">SecurityService to create the security with if needed</param>
+        /// <returns>The benchmark for this brokerage</returns>
+        public override IBenchmark GetBenchmark(SecurityManager securities)
+        {
+            var symbol = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Bitfinex);
+            return CreateSecurityBenchmark(securities, symbol);
         }
 
         /// <summary>

--- a/Common/Brokerages/BitfinexBrokerageModel.cs
+++ b/Common/Brokerages/BitfinexBrokerageModel.cs
@@ -34,6 +34,11 @@ namespace QuantConnect.Brokerages
         public override IReadOnlyDictionary<SecurityType, string> DefaultMarkets { get; } = GetDefaultMarkets();
 
         /// <summary>
+        /// Define the default benchmark used in this model
+        /// </summary>
+        public override Symbol DefaultBenchmark => Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Bitfinex);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="BitfinexBrokerageModel"/> class
         /// </summary>
         /// <param name="accountType">The type of account to be modeled, defaults to <see cref="AccountType.Margin"/></param>

--- a/Common/Brokerages/BitfinexBrokerageModel.cs
+++ b/Common/Brokerages/BitfinexBrokerageModel.cs
@@ -85,7 +85,7 @@ namespace QuantConnect.Brokerages
         public override IBenchmark GetBenchmark(SecurityManager securities)
         {
             var symbol = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Bitfinex);
-            return CreateSecurityBenchmark(securities, symbol);
+            return SecurityBenchmark.CreateInstance(securities, symbol);
         }
 
         /// <summary>

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -209,7 +209,7 @@ namespace QuantConnect.Brokerages
         public virtual IBenchmark GetBenchmark(SecurityManager securities)
         {
             var symbol = Symbol.Create("SPY", SecurityType.Equity, Market.USA);
-            return CreateSecurityBenchmark(securities, symbol);
+            return SecurityBenchmark.CreateInstance(securities, symbol);
         }
 
         /// <summary>
@@ -389,23 +389,6 @@ namespace QuantConnect.Brokerages
         public IBuyingPowerModel GetBuyingPowerModel(Security security, AccountType accountType)
         {
             return GetBuyingPowerModel(security);
-        }
-
-        /// <summary>
-        /// Helper function for GetBenchmark that creates a SecurityBenchmark with a given symbol
-        /// </summary>
-        /// <param name="securities">SecurityService to create the security</param>
-        /// <param name="symbol">The symbol to create a security benchmark with</param>
-        /// <returns>A SecurityBenchmark for the given symbol</returns>
-        internal IBenchmark CreateSecurityBenchmark(SecurityManager securities, Symbol symbol)
-        {
-            // Create the security from this symbol
-            var security = securities.CreateSecurity(symbol,
-                new List<SubscriptionDataConfig>(),
-                leverage: 1,
-                addToSymbolCache: false);
-            
-            return new SecurityBenchmark(security);
         }
     }
 }

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -399,19 +399,12 @@ namespace QuantConnect.Brokerages
         /// <returns>A SecurityBenchmark for the given symbol</returns>
         internal IBenchmark CreateSecurityBenchmark(SecurityManager securities, Symbol symbol)
         {
-            Security security;
-
-            // Check if we have that symbol in our securities
-            if (!securities.TryGetValue(symbol, out security))
-            {
-                // Else create the security from this symbol
-                security = securities.CreateSecurity(symbol,
-                    new List<SubscriptionDataConfig>(),
-                    leverage: 1,
-                    addToSymbolCache: false);
-            }
-
-            //Send our security through
+            // Create the security from this symbol
+            var security = securities.CreateSecurity(symbol,
+                new List<SubscriptionDataConfig>(),
+                leverage: 1,
+                addToSymbolCache: false);
+            
             return new SecurityBenchmark(security);
         }
     }

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -62,6 +62,11 @@ namespace QuantConnect.Brokerages
         protected IShortableProvider ShortableProvider { get; set; }
 
         /// <summary>
+        /// Define the default benchmark used in this model
+        /// </summary>
+        public virtual Symbol DefaultBenchmark => Symbol.Create("SPY", SecurityType.Equity, Market.USA);
+        
+        /// <summary>
         /// Gets or sets the account type used by this model
         /// </summary>
         public virtual AccountType AccountType

--- a/Common/Brokerages/FxcmBrokerageModel.cs
+++ b/Common/Brokerages/FxcmBrokerageModel.cs
@@ -168,8 +168,8 @@ namespace QuantConnect.Brokerages
         /// <returns>The benchmark for this brokerage</returns>
         public override IBenchmark GetBenchmark(SecurityManager securities)
         {
-            var symbol = Symbol.Create("EURUSD", SecurityType.Future, Market.FXCM);
-            return CreateSecurityBenchmark(securities, symbol);
+            var symbol = Symbol.Create("EURUSD", SecurityType.Forex, Market.FXCM);
+            return SecurityBenchmark.CreateInstance(securities, symbol);
         }
 
         /// <summary>

--- a/Common/Brokerages/FxcmBrokerageModel.cs
+++ b/Common/Brokerages/FxcmBrokerageModel.cs
@@ -42,6 +42,11 @@ namespace QuantConnect.Brokerages
         }.ToReadOnlyDictionary();
 
         /// <summary>
+        /// Define the default benchmark used in this model
+        /// </summary>
+        public override Symbol DefaultBenchmark => Symbol.Create("EURUSD", SecurityType.Future, Market.FXCM);
+
+        /// <summary>
         /// Gets a map of the default markets to be used for each security type
         /// </summary>
         public override IReadOnlyDictionary<SecurityType, string> DefaultMarkets => DefaultMarketMap;

--- a/Common/Brokerages/FxcmBrokerageModel.cs
+++ b/Common/Brokerages/FxcmBrokerageModel.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using QuantConnect.Benchmarks;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.Slippage;
@@ -40,11 +41,6 @@ namespace QuantConnect.Brokerages
             {SecurityType.Forex, Market.FXCM},
             {SecurityType.Cfd, Market.FXCM}
         }.ToReadOnlyDictionary();
-
-        /// <summary>
-        /// Define the default benchmark used in this model
-        /// </summary>
-        public override Symbol DefaultBenchmark => Symbol.Create("EURUSD", SecurityType.Future, Market.FXCM);
 
         /// <summary>
         /// Gets a map of the default markets to be used for each security type
@@ -163,6 +159,17 @@ namespace QuantConnect.Brokerages
             var limitPrice = request.LimitPrice ?? security.Price;
 
             return IsValidOrderPrices(security, order.Type, direction, stopPrice, limitPrice, ref message);
+        }
+
+        /// <summary>
+        /// Get the benchmark for this model
+        /// </summary>
+        /// <param name="securities">SecurityService to create the security with if needed</param>
+        /// <returns>The benchmark for this brokerage</returns>
+        public override IBenchmark GetBenchmark(SecurityManager securities)
+        {
+            var symbol = Symbol.Create("EURUSD", SecurityType.Future, Market.FXCM);
+            return CreateSecurityBenchmark(securities, symbol);
         }
 
         /// <summary>

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -110,7 +110,7 @@ namespace QuantConnect.Brokerages
         public override IBenchmark GetBenchmark(SecurityManager securities)
         {
             var symbol = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX);
-            return CreateSecurityBenchmark(securities, symbol);
+            return SecurityBenchmark.CreateInstance(securities, symbol);
         }
 
         /// <summary>

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -77,6 +77,11 @@ namespace QuantConnect.Brokerages
         private readonly DateTime _stopMarketOrderSupportEndDate = new DateTime(2019, 3, 23, 1, 0, 0);
 
         /// <summary>
+        /// Define the default benchmark used in this model
+        /// </summary>
+        public override Symbol DefaultBenchmark => Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="GDAXBrokerageModel"/> class
         /// </summary>
         /// <param name="accountType">The type of account to be modelled, defaults to

--- a/Common/Brokerages/GDAXBrokerageModel.cs
+++ b/Common/Brokerages/GDAXBrokerageModel.cs
@@ -20,6 +20,7 @@ using QuantConnect.Securities;
 using QuantConnect.Orders.Fills;
 using QuantConnect.Orders.Fees;
 using System.Linq;
+using QuantConnect.Benchmarks;
 using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.Brokerages
@@ -77,11 +78,6 @@ namespace QuantConnect.Brokerages
         private readonly DateTime _stopMarketOrderSupportEndDate = new DateTime(2019, 3, 23, 1, 0, 0);
 
         /// <summary>
-        /// Define the default benchmark used in this model
-        /// </summary>
-        public override Symbol DefaultBenchmark => Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX);
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="GDAXBrokerageModel"/> class
         /// </summary>
         /// <param name="accountType">The type of account to be modelled, defaults to
@@ -104,6 +100,17 @@ namespace QuantConnect.Brokerages
         {
             // margin trading is not currently supported by GDAX
             return 1m;
+        }
+
+        /// <summary>
+        /// Get the benchmark for this model
+        /// </summary>
+        /// <param name="securities">SecurityService to create the security with if needed</param>
+        /// <returns>The benchmark for this brokerage</returns>
+        public override IBenchmark GetBenchmark(SecurityManager securities)
+        {
+            var symbol = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.GDAX);
+            return CreateSecurityBenchmark(securities, symbol);
         }
 
         /// <summary>

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using QuantConnect.Benchmarks;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;
@@ -52,14 +53,6 @@ namespace QuantConnect.Brokerages
         /// Gets a map of the default markets to be used for each security type
         /// </summary>
         IReadOnlyDictionary<SecurityType, string> DefaultMarkets { get; }
-
-        /// <summary>
-        /// Define the default benchmark used in this model
-        /// </summary>
-        Symbol DefaultBenchmark
-        {
-            get;
-        }
 
         /// <summary>
         /// Returns true if the brokerage could accept this order. This takes into account
@@ -109,6 +102,13 @@ namespace QuantConnect.Brokerages
         /// <param name="security">The security's whose leverage we seek</param>
         /// <returns>The leverage for the specified security</returns>
         decimal GetLeverage(Security security);
+
+        /// <summary>
+        /// Get the benchmark for this model
+        /// </summary>
+        /// <param name="securities">SecurityService to create the security with if needed</param>
+        /// <returns>The benchmark for this brokerage</returns>
+        IBenchmark GetBenchmark(SecurityManager securities);
 
         /// <summary>
         /// Gets a new fill model that represents this brokerage's fill behavior

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -54,6 +54,14 @@ namespace QuantConnect.Brokerages
         IReadOnlyDictionary<SecurityType, string> DefaultMarkets { get; }
 
         /// <summary>
+        /// Define the default benchmark used in this model
+        /// </summary>
+        Symbol DefaultBenchmark
+        {
+            get;
+        }
+
+        /// <summary>
         /// Returns true if the brokerage could accept this order. This takes into account
         /// order type, security type, and order size limits.
         /// </summary>

--- a/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
+++ b/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Benchmarks;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.TimeInForces;
@@ -45,11 +46,6 @@ namespace QuantConnect.Brokerages
             {SecurityType.Cfd, Market.Oanda}
         }.ToReadOnlyDictionary();
 
-        /// <summary>
-        /// Define the default benchmark used in this model
-        /// </summary>
-        public override Symbol DefaultBenchmark => null;
-
         private readonly Type[] _supportedTimeInForces =
         {
             typeof(GoodTilCanceledTimeInForce),
@@ -71,6 +67,17 @@ namespace QuantConnect.Brokerages
         /// Gets a map of the default markets to be used for each security type
         /// </summary>
         public override IReadOnlyDictionary<SecurityType, string> DefaultMarkets => DefaultMarketMap;
+
+        /// <summary>
+        /// Get the benchmark for this model
+        /// </summary>
+        /// <param name="securities">SecurityService to create the security with if needed</param>
+        /// <returns>The benchmark for this brokerage</returns>
+        public override IBenchmark GetBenchmark(SecurityManager securities)
+        {
+            // Equivalent to no benchmark
+            return new FuncBenchmark(x => 0);
+        }
 
         /// <summary>
         /// Gets a new fee model that represents this brokerage's fee structure

--- a/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
+++ b/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
@@ -45,6 +45,11 @@ namespace QuantConnect.Brokerages
             {SecurityType.Cfd, Market.Oanda}
         }.ToReadOnlyDictionary();
 
+        /// <summary>
+        /// Define the default benchmark used in this model
+        /// </summary>
+        public override Symbol DefaultBenchmark => null;
+
         private readonly Type[] _supportedTimeInForces =
         {
             typeof(GoodTilCanceledTimeInForce),

--- a/Common/Brokerages/OandaBrokerageModel.cs
+++ b/Common/Brokerages/OandaBrokerageModel.cs
@@ -14,6 +14,7 @@
 */
 
 using System.Collections.Generic;
+using QuantConnect.Benchmarks;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.Slippage;
@@ -39,11 +40,6 @@ namespace QuantConnect.Brokerages
             {SecurityType.Forex, Market.Oanda},
             {SecurityType.Cfd, Market.Oanda}
         }.ToReadOnlyDictionary();
-
-        /// <summary>
-        /// Define the default benchmark used in this model
-        /// </summary>
-        public override Symbol DefaultBenchmark => Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda);
 
         /// <summary>
         /// Gets a map of the default markets to be used for each security type
@@ -106,6 +102,17 @@ namespace QuantConnect.Brokerages
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Get the benchmark for this model
+        /// </summary>
+        /// <param name="securities">SecurityService to create the security with if needed</param>
+        /// <returns>The benchmark for this brokerage</returns>
+        public override IBenchmark GetBenchmark(SecurityManager securities)
+        {
+            var symbol = Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda);
+            return CreateSecurityBenchmark(securities, symbol);
         }
 
         /// <summary>

--- a/Common/Brokerages/OandaBrokerageModel.cs
+++ b/Common/Brokerages/OandaBrokerageModel.cs
@@ -112,7 +112,7 @@ namespace QuantConnect.Brokerages
         public override IBenchmark GetBenchmark(SecurityManager securities)
         {
             var symbol = Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda);
-            return CreateSecurityBenchmark(securities, symbol);
+            return SecurityBenchmark.CreateInstance(securities, symbol);
         }
 
         /// <summary>

--- a/Common/Brokerages/OandaBrokerageModel.cs
+++ b/Common/Brokerages/OandaBrokerageModel.cs
@@ -41,6 +41,11 @@ namespace QuantConnect.Brokerages
         }.ToReadOnlyDictionary();
 
         /// <summary>
+        /// Define the default benchmark used in this model
+        /// </summary>
+        public override Symbol DefaultBenchmark => Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda);
+
+        /// <summary>
         /// Gets a map of the default markets to be used for each security type
         /// </summary>
         public override IReadOnlyDictionary<SecurityType, string> DefaultMarkets => DefaultMarketMap;

--- a/Common/Python/BrokerageModelPythonWrapper.cs
+++ b/Common/Python/BrokerageModelPythonWrapper.cs
@@ -162,7 +162,10 @@ namespace QuantConnect.Python
         /// <returns>The benchmark for this brokerage</returns>
         public IBenchmark GetBenchmark(SecurityManager securities)
         {
-            return (_model.GetBenchmark(securities) as PyObject).GetAndDispose<IBenchmark>();
+            using (Py.GIL())
+            {
+                return (_model.GetBenchmark(securities) as PyObject).GetAndDispose<IBenchmark>();
+            }
         }
 
         /// <summary>

--- a/Common/Python/BrokerageModelPythonWrapper.cs
+++ b/Common/Python/BrokerageModelPythonWrapper.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using Python.Runtime;
+using QuantConnect.Benchmarks;
 using QuantConnect.Brokerages;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.Shortable;
@@ -89,11 +90,6 @@ namespace QuantConnect.Python
         }
 
         /// <summary>
-        /// Get the default benchmark used in this model
-        /// </summary>
-        public Symbol DefaultBenchmark => _model.DefaultBenchmark;
-
-        /// <summary>
         /// Applies the split to the specified order ticket
         /// </summary>
         /// <param name="tickets">The open tickets matching the split event</param>
@@ -157,6 +153,16 @@ namespace QuantConnect.Python
             {
                 return (_model.CanUpdateOrder(security, order, out message) as PyObject).GetAndDispose<bool>();
             }
+        }
+
+        /// <summary>
+        /// Get the benchmark for this model
+        /// </summary>
+        /// <param name="securities">SecurityService to create the security with if needed</param>
+        /// <returns>The benchmark for this brokerage</returns>
+        public IBenchmark GetBenchmark(SecurityManager securities)
+        {
+            return (_model.GetBenchmark(securities) as PyObject).GetAndDispose<IBenchmark>();
         }
 
         /// <summary>

--- a/Common/Python/BrokerageModelPythonWrapper.cs
+++ b/Common/Python/BrokerageModelPythonWrapper.cs
@@ -89,6 +89,11 @@ namespace QuantConnect.Python
         }
 
         /// <summary>
+        /// Get the default benchmark used in this model
+        /// </summary>
+        public Symbol DefaultBenchmark => _model.DefaultBenchmark;
+
+        /// <summary>
         /// Applies the split to the specified order ticket
         /// </summary>
         /// <param name="tickets">The open tickets matching the split event</param>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Have Brokerage models set the default benchmark for their brokerage.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5143 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
> Since the default benchmark is SPY it causes live trading issue when trading with crypto brokerages or generally brokerages for which the user doesn't have a SPY subscription (like IB)

Instead of using a default benchmark for all brokerages this allows a unique benchmark to be used by any brokerage implementation through overriding `GetBenchmark()` in any `IBrokerageModel`. All it needs to do is return a `IBenchmark` and it will be set for the algorithm. 

Any brokerage model that does not override the function will take on the default benchmark (SPY).

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All regressions pass as expected.
Added a new regression to test the case of 0 value benchmark for C# and Python

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
