### PR TITLE
Feature 5162 - LimitIfTouched Orders

### DIFF
--- a/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
@@ -1,0 +1,132 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Basic algorithm demonstrating how to place LimitIfTouched orders.
+    /// </summary>
+    /// <meta name="tag" content="trading and orders" />
+    /// <meta name="tag" content="placing orders" />`
+    /// <meta name="tag" content="limit if touched order"/>
+    public class LimitIfTouchedRegressionAlgorithm: QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private SubmitOrderRequest request;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);  //Set Start Date
+            SetEndDate(2013, 10, 15);    //Set End Date
+            SetCash(100000);             //Set Strategy Cash
+            // Find more symbols here: http://quantconnect.com/data
+            AddSecurity(SecurityType.Equity, "SPY", Resolution.Second);
+        }
+        
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">TradeBars IDictionary object with your stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (data.ContainsKey("SPY"))
+            {
+                if (Time.Second == 0 && Time.Minute == 0 && Transactions.GetOpenOrders().Count < 1)
+                {
+                    var goLong = Time < StartDate.AddDays(2);
+                    var negative = goLong ? 1 : -1;
+                    request = new SubmitOrderRequest(OrderType.LimitIfTouched, SecurityType.Equity, "SPY",
+                        negative * 10, 0, data["SPY"].Price - (decimal) 0.5 * negative,
+                        data["SPY"].Price - (decimal) negative, UtcTime, $"LIT - {UtcTime}");
+                    Transactions.AddOrder(request);
+                    Debug($"Submitted: {request.Tag}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Order fill event handler. On an order fill update the resulting information is passed to this method.
+        /// </summary>
+        /// <param name="orderEvent">Order event details containing details of the events</param>
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            Debug($"{orderEvent}");
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally => true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages => new[] { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "5"},
+            {"Average Win", "0.02%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "1.451%"},
+            {"Drawdown", "0.000%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0.034%"},
+            {"Sharpe Ratio", "4.704"},
+            {"Probabilistic Sharpe Ratio", "77.396%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "100%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0.003"},
+            {"Beta", "0.015"},
+            {"Annual Standard Deviation", "0.003"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-4.187"},
+            {"Tracking Error", "0.183"},
+            {"Treynor Ratio", "0.989"},
+            {"Total Fees", "$5.00"},
+            {"Fitness Score", "0.012"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "17.591"},
+            {"Return Over Maximum Drawdown", "172.635"},
+            {"Portfolio Turnover", "0.012"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "291160226"}
+        };
+    }
+}

--- a/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
@@ -33,7 +33,7 @@ namespace QuantConnect.Algorithm.CSharp
         private int _negative;
 
         // We assert the following occur in FIFO order in OnOrderEvent
-        readonly private Queue<string> _expectedEvents = new Queue<string>(new[]
+        private readonly Queue<string> _expectedEvents = new Queue<string>(new[]
         {
             "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 152.8807 USD LimitPrice: 152.519 TriggerPrice: 151.769 OrderFee: 1 USD",
             "Time: 10/10/2013 15:55:00 OrderID: 73 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 153.9225 USD LimitPrice: 153.8898 TriggerPrice: 153.1398 OrderFee: 1 USD",
@@ -46,16 +46,16 @@ namespace QuantConnect.Algorithm.CSharp
         public override void Initialize()
         {
             SetStartDate(2013, 10, 07); //Set Start Date
-            SetEndDate(2013, 10, 15); //Set End Date
+            SetEndDate(2013, 10, 11); //Set End Date
             SetCash(100000); //Set Strategy Cash
             // Find more symbols here: http://quantconnect.com/data
-            AddSecurity(SecurityType.Equity, "SPY", Resolution.Minute);
+            AddEquity("SPY");
         }
 
         /// <summary>
         /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
         /// </summary>
-        /// <param name="data">TradeBars IDictionary object with your stock data</param>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
         public override void OnData(Slice data)
         {
             if (!data.ContainsKey("SPY"))
@@ -84,14 +84,12 @@ namespace QuantConnect.Algorithm.CSharp
                 if (_request.Quantity == 1)
                 {
                     Transactions.CancelOpenOrders();
-                    _request.Cancel();
                     _request = null;
                     return;
                 }
 
                 var newQuantity = _request.Quantity - _negative;
-                _request.UpdateQuantity(newQuantity,
-                    $"LIT - Quantity: {newQuantity}");
+                _request.UpdateQuantity(newQuantity, $"LIT - Quantity: {newQuantity}");
             }
         }
 
@@ -130,12 +128,12 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "3"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "-0.337%"},
+            {"Compounding Annual Return", "-0.625%"},
             {"Drawdown", "0.000%"},
             {"Expectancy", "0"},
             {"Net Profit", "-0.008%"},
-            {"Sharpe Ratio", "-10.159"},
-            {"Probabilistic Sharpe Ratio", "0.000%"},
+            {"Sharpe Ratio", "-13.588"},
+            {"Probabilistic Sharpe Ratio", "0%"},
             {"Loss Rate", "0%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
@@ -143,15 +141,15 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "-0.001"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-4.216"},
-            {"Tracking Error", "0.186"},
-            {"Treynor Ratio", "2.299"},
+            {"Information Ratio", "-8.779"},
+            {"Tracking Error", "0.22"},
+            {"Treynor Ratio", "3.431"},
             {"Total Fees", "$3.00"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "-13.601"},
-            {"Return Over Maximum Drawdown", "-43.396"},
+            {"Sortino Ratio", "-15.79"},
+            {"Return Over Maximum Drawdown", "-82.891"},
             {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},

--- a/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
@@ -73,7 +73,7 @@ namespace QuantConnect.Algorithm.CSharp
                 var orderRequest = new SubmitOrderRequest(OrderType.LimitIfTouched, SecurityType.Equity, "SPY",
                     _negative * 10, 0,
                     data["SPY"].Price - (decimal) _negative, data["SPY"].Price - (decimal) 0.25 * _negative, UtcTime,
-                    $"LIT - {UtcTime.ToString(CultureInfo.InvariantCulture)}, Quantity: {_negative * 10}");
+                    $"LIT - {UtcTime.ToString(DateFormat.US, CultureInfo.InvariantCulture)}, Quantity: {_negative * 10}");
                 _request = Transactions.AddOrder(orderRequest);
                 Debug($"Submitted: {_request.Tag}");
                 return;
@@ -93,7 +93,7 @@ namespace QuantConnect.Algorithm.CSharp
                     new UpdateOrderFields
                     {
                         Quantity = _request.Quantity - _negative,
-                        Tag = $"LIT - Time: {UtcTime.ToString(CultureInfo.InvariantCulture)}, Quantity: {_request.Quantity - _negative}"
+                        Tag = $"LIT - Time: {UtcTime.ToString(DateFormat.US, CultureInfo.InvariantCulture)}, Quantity: {_request.Quantity - _negative}"
                     }));
             }
         }
@@ -112,8 +112,6 @@ namespace QuantConnect.Algorithm.CSharp
                 {
                     throw new Exception($"orderEvent {orderEvent.Id} differed from {expected}");
                 }
-
-                Debug($"{orderEvent}");
             }
         }
 
@@ -171,7 +169,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "013f0be632044268fcb72f087872bb94"}
+            {"OrderListHash", "21eabcf9fd410ea14403b44213ebfdec"}
         };
     }
 }

--- a/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
@@ -170,7 +170,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "943725620"}
+            {"OrderListHash", "8f880d593654395d8dd6dc75c3ce2330"}
         };
     }
 }

--- a/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
@@ -35,9 +35,9 @@ namespace QuantConnect.Algorithm.CSharp
         // We assert the following occur in FIFO order in OnOrderEvent
         readonly private Queue<string> _expectedEvents = new Queue<string>(new[]
         {
-            "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 152.8624 USD LimitPrice: 152.519 TriggerPrice: 151.769 OrderFee: 1 USD",
-            "Time: 10/10/2013 15:47:00 OrderID: 73 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 153.8677 USD LimitPrice: 153.8898 TriggerPrice: 153.1398 OrderFee: 1 USD",
-            "Time: 10/11/2013 14:00:00 OrderID: 74 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 154.8768 USD LimitPrice: 154.8768 TriggerPrice: 154.1268 OrderFee: 1 USD",
+            "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 152.519 USD LimitPrice: 152.519 TriggerPrice: 151.769 OrderFee: 1 USD",
+            "Time: 10/10/2013 15:55:00 OrderID: 73 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 153.8898 USD LimitPrice: 153.8898 TriggerPrice: 153.1398 OrderFee: 1 USD",
+            "Time: 10/11/2013 14:02:00 OrderID: 74 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 154.9317 USD LimitPrice: 154.9317 TriggerPrice: 154.1817 OrderFee: 1 USD",
         });
 
         /// <summary>
@@ -134,28 +134,28 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "3"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "-0.344%"},
+            {"Compounding Annual Return", "-0.355%"},
             {"Drawdown", "0.000%"},
             {"Expectancy", "0"},
             {"Net Profit", "-0.008%"},
-            {"Sharpe Ratio", "-10.164"},
+            {"Sharpe Ratio", "-10.093"},
             {"Probabilistic Sharpe Ratio", "0.000%"},
             {"Loss Rate", "0%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
             {"Alpha", "-0.002"},
-            {"Beta", "-0.001"},
+            {"Beta", "-0.002"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
             {"Information Ratio", "-4.216"},
             {"Tracking Error", "0.186"},
-            {"Treynor Ratio", "2.304"},
+            {"Treynor Ratio", "2.247"},
             {"Total Fees", "$3.00"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "-13.582"},
-            {"Return Over Maximum Drawdown", "-43.394"},
+            {"Sortino Ratio", "-15.984"},
+            {"Return Over Maximum Drawdown", "-43.392"},
             {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
@@ -170,7 +170,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-489124022"}
+            {"OrderListHash", "943725620"}
         };
     }
 }

--- a/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;
@@ -72,7 +73,7 @@ namespace QuantConnect.Algorithm.CSharp
                 var orderRequest = new SubmitOrderRequest(OrderType.LimitIfTouched, SecurityType.Equity, "SPY",
                     _negative * 10, 0,
                     data["SPY"].Price - (decimal) _negative, data["SPY"].Price - (decimal) 0.25 * _negative, UtcTime,
-                    $"LIT - {UtcTime}, Quantity: {_negative * 10}");
+                    $"LIT - {UtcTime.ToString(CultureInfo.InvariantCulture)}, Quantity: {_negative * 10}");
                 _request = Transactions.AddOrder(orderRequest);
                 Debug($"Submitted: {_request.Tag}");
                 return;

--- a/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
@@ -35,9 +35,9 @@ namespace QuantConnect.Algorithm.CSharp
         // We assert the following occur in FIFO order in OnOrderEvent
         readonly private Queue<string> _expectedEvents = new Queue<string>(new[]
         {
-            "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 152.519 USD LimitPrice: 152.519 TriggerPrice: 151.769 OrderFee: 1 USD",
-            "Time: 10/10/2013 15:55:00 OrderID: 73 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 153.8898 USD LimitPrice: 153.8898 TriggerPrice: 153.1398 OrderFee: 1 USD",
-            "Time: 10/11/2013 14:02:00 OrderID: 74 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 154.9317 USD LimitPrice: 154.9317 TriggerPrice: 154.1817 OrderFee: 1 USD",
+            "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 152.8807 USD LimitPrice: 152.519 TriggerPrice: 151.769 OrderFee: 1 USD",
+            "Time: 10/10/2013 15:55:00 OrderID: 73 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 153.9225 USD LimitPrice: 153.8898 TriggerPrice: 153.1398 OrderFee: 1 USD",
+            "Time: 10/11/2013 14:02:00 OrderID: 74 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 154.9643 USD LimitPrice: 154.9317 TriggerPrice: 154.1817 OrderFee: 1 USD",
         });
 
         /// <summary>
@@ -134,28 +134,28 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "3"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "-0.355%"},
+            {"Compounding Annual Return", "-0.337%"},
             {"Drawdown", "0.000%"},
             {"Expectancy", "0"},
             {"Net Profit", "-0.008%"},
-            {"Sharpe Ratio", "-10.093"},
+            {"Sharpe Ratio", "-10.159"},
             {"Probabilistic Sharpe Ratio", "0.000%"},
             {"Loss Rate", "0%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
             {"Alpha", "-0.002"},
-            {"Beta", "-0.002"},
+            {"Beta", "-0.001"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
             {"Information Ratio", "-4.216"},
             {"Tracking Error", "0.186"},
-            {"Treynor Ratio", "2.247"},
+            {"Treynor Ratio", "2.299"},
             {"Total Fees", "$3.00"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "-15.984"},
-            {"Return Over Maximum Drawdown", "-43.392"},
+            {"Sortino Ratio", "-13.601"},
+            {"Return Over Maximum Drawdown", "-43.396"},
             {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
@@ -170,7 +170,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "8f880d593654395d8dd6dc75c3ce2330"}
+            {"OrderListHash", "475ce10474bd16b15e79c751f4e6b79a"}
         };
     }
 }

--- a/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.Algorithm.CSharp
                     new UpdateOrderFields
                     {
                         Quantity = _request.Quantity - _negative,
-                        Tag = $"LIT - Time: {UtcTime}, Quantity: {_request.Quantity - _negative}"
+                        Tag = $"LIT - Time: {UtcTime.ToString(CultureInfo.InvariantCulture)}, Quantity: {_request.Quantity - _negative}"
                     }));
             }
         }
@@ -171,7 +171,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "475ce10474bd16b15e79c751f4e6b79a"}
+            {"OrderListHash", "013f0be632044268fcb72f087872bb94"}
         };
     }
 }

--- a/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
@@ -75,7 +75,6 @@ namespace QuantConnect.Algorithm.CSharp
                     data["SPY"].Price - (decimal) _negative, data["SPY"].Price - (decimal) 0.25 * _negative, UtcTime,
                     $"LIT - {UtcTime.ToString(DateFormat.US, CultureInfo.InvariantCulture)}, Quantity: {_negative * 10}");
                 _request = Transactions.AddOrder(orderRequest);
-                Debug($"Submitted: {_request.Tag}");
                 return;
             }
 
@@ -123,7 +122,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages => new[] { Language.CSharp };
+        public Language[] Languages => new[] { Language.CSharp, Language.Python };
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.Algorithm.CSharp
 
         private readonly CircularQueue<OrderType> _orderTypesQueue = new CircularQueue<OrderType>(Enum.GetValues(typeof(OrderType))
                                                                         .OfType<OrderType>()
-                                                                        .Where (x => x != OrderType.OptionExercise));
+                                                                        .Where (x => x != OrderType.OptionExercise && x != OrderType.LimitIfTouched));
         private readonly List<OrderTicket> _tickets = new List<OrderTicket>();
 
         /// <summary>

--- a/Algorithm.Python/LimitIfTouchedRegressionAlgorithm.py
+++ b/Algorithm.Python/LimitIfTouchedRegressionAlgorithm.py
@@ -1,18 +1,35 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from QuantConnect import *
+from QuantConnect.Orders import *
 from QuantConnect.Algorithm import *
-from QuantConnect.Orders import SubmitOrderRequest, OrderType, UpdateOrderRequest, UpdateOrderFields, OrderEvent
-from QuantConnect import SecurityType, Resolution
 from collections import deque
 from datetime import timedelta
 
 
+### <summary>
+### Basic algorithm demonstrating how to place LimitIfTouched orders.
+### </summary>
+### <meta name="tag" content="trading and orders" />
+### <meta name="tag" content="placing orders" />`
+### <meta name="tag" content="limit if touched order"/>
 class LimitIfTouchedRegressionAlgorithm(QCAlgorithm):
     _expectedEvents = deque([
-        "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: "
-        "-1 FillPrice: 152.8807 USD LimitPrice: 152.519 TriggerPrice: 151.769 OrderFee: 1 USD",
-        "Time: 10/10/2013 15:55:00 OrderID: 73 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: "
-        "-1 FillPrice: 153.9225 USD LimitPrice: 153.8898 TriggerPrice: 153.1398 OrderFee: 1 USD",
-        "Time: 10/11/2013 14:02:00 OrderID: 74 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: "
-        "-1 FillPrice: 154.9643 USD LimitPrice: 154.9317 TriggerPrice: 154.1817 OrderFee: 1 USD "
+        "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 152.8807 USD LimitPrice: 152.519 TriggerPrice: 151.769 OrderFee: 1 USD",
+        "Time: 10/10/2013 15:55:00 OrderID: 73 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 153.9225 USD LimitPrice: 153.8898 TriggerPrice: 153.1398 OrderFee: 1 USD",
+        "Time: 10/11/2013 14:02:00 OrderID: 74 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 154.9643 USD LimitPrice: 154.9317 TriggerPrice: 154.1817 OrderFee: 1 USD"
     ])
 
     def Initialize(self):
@@ -22,26 +39,30 @@ class LimitIfTouchedRegressionAlgorithm(QCAlgorithm):
         self.AddSecurity(SecurityType.Equity, "SPY", Resolution.Minute)
 
     def OnData(self, data):
-        if self.Transactions.GetOpenOrders().Count < 1:
-            self._negative = 1 if self.Time < self.StartDate.__add__(timedelta(days=2)) else -1
-            orderRequest = self.SubmitOrderRequest(OrderType.LimitIfTouched, SecurityType.Equity, "SPY",
-                                                   data["SPY"].Price - self._negative,
-                                                   data["SPY"].Price - 0.25 * self._negative, self.UtcTime,
-                                                   f"LIT - {self.UtcTime}, Quantity: {self._negative * 10}")
-            self._request = self.Transactions.AddOrder(orderRequest)
-
-        if self._request is not None:
-            if self._request.Quantity == 1:
-                self.Transactions.CancelOpenOrders()
-                del self._request
+        if data.ContainsKey("SPY"):
+            if len(self.Transactions.GetOpenOrders()) == 0:
+                self._negative = 1 if self.Time.day < 9 else -1
+                orderRequest = SubmitOrderRequest(OrderType.LimitIfTouched, SecurityType.Equity, "SPY",
+                                                  self._negative * 10, 0,
+                                                  data["SPY"].Price - self._negative,
+                                                  data["SPY"].Price - 0.25 * self._negative, self.UtcTime,
+                                                  f"LIT - Quantity: {self._negative * 10}")
+                self._request = self.Transactions.AddOrder(orderRequest)
                 return
 
-            new_quantity = self._request.Quantity - self._negative
-            self._request.UpdateQuantity(new_quantity,
-                                         f"LIT - Time: {self.UtcTime}, Quantity: {new_quantity}")
-    
+            if self._request is not None:
+                if self._request.Quantity == 1:
+                    self.Transactions.CancelOpenOrders()
+                    self._request.Cancel()
+                    self._request = None
+                    return
+
+                new_quantity = int(self._request.Quantity - self._negative)
+                self._request.UpdateQuantity(new_quantity,
+                                             f"LIT - Quantity: {new_quantity}")
+
     def OnOrderEvent(self, orderEvent):
-        if orderEvent.Status == OrderEvent.Filled:
-            expected = self._expectedEvents.pop()
-            if orderEvent.ToString() != expected:
-                raise Exception(f"orderEvent {orderEvent.Id} differed from {expected}")
+        if orderEvent.Status == OrderStatus.Filled:
+            expected = self._expectedEvents.popleft()
+            # if orderEvent.ToString() != expected:
+            #     raise Exception(f"orderEvent {orderEvent.Id} differed from {expected}")

--- a/Algorithm.Python/LimitIfTouchedRegressionAlgorithm.py
+++ b/Algorithm.Python/LimitIfTouchedRegressionAlgorithm.py
@@ -34,9 +34,9 @@ class LimitIfTouchedRegressionAlgorithm(QCAlgorithm):
 
     def Initialize(self):
         self.SetStartDate(2013, 10, 7)
-        self.SetEndDate(2013, 10, 15)
+        self.SetEndDate(2013, 10, 11)
         self.SetCash(100000)
-        self.AddSecurity(SecurityType.Equity, "SPY", Resolution.Minute)
+        self.AddEquity("SPY")
 
     def OnData(self, data):
         if data.ContainsKey("SPY"):
@@ -53,16 +53,14 @@ class LimitIfTouchedRegressionAlgorithm(QCAlgorithm):
             if self._request is not None:
                 if self._request.Quantity == 1:
                     self.Transactions.CancelOpenOrders()
-                    self._request.Cancel()
                     self._request = None
                     return
 
                 new_quantity = int(self._request.Quantity - self._negative)
-                self._request.UpdateQuantity(new_quantity,
-                                             f"LIT - Quantity: {new_quantity}")
+                self._request.UpdateQuantity(new_quantity, f"LIT - Quantity: {new_quantity}")
 
     def OnOrderEvent(self, orderEvent):
         if orderEvent.Status == OrderStatus.Filled:
             expected = self._expectedEvents.popleft()
-            # if orderEvent.ToString() != expected:
-            #     raise Exception(f"orderEvent {orderEvent.Id} differed from {expected}")
+            if orderEvent.ToString() != expected:
+                raise Exception(f"orderEvent {orderEvent.Id} differed from {expected}")

--- a/Algorithm.Python/LimitIfTouchedRegressionAlgorithm.py
+++ b/Algorithm.Python/LimitIfTouchedRegressionAlgorithm.py
@@ -1,0 +1,47 @@
+from QuantConnect.Algorithm import *
+from QuantConnect.Orders import SubmitOrderRequest, OrderType, UpdateOrderRequest, UpdateOrderFields, OrderEvent
+from QuantConnect import SecurityType, Resolution
+from collections import deque
+from datetime import timedelta
+
+
+class LimitIfTouchedRegressionAlgorithm(QCAlgorithm):
+    _expectedEvents = deque([
+        "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: "
+        "-1 FillPrice: 152.8807 USD LimitPrice: 152.519 TriggerPrice: 151.769 OrderFee: 1 USD",
+        "Time: 10/10/2013 15:55:00 OrderID: 73 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: "
+        "-1 FillPrice: 153.9225 USD LimitPrice: 153.8898 TriggerPrice: 153.1398 OrderFee: 1 USD",
+        "Time: 10/11/2013 14:02:00 OrderID: 74 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: "
+        "-1 FillPrice: 154.9643 USD LimitPrice: 154.9317 TriggerPrice: 154.1817 OrderFee: 1 USD "
+    ])
+
+    def Initialize(self):
+        self.SetStartDate(2013, 10, 7)
+        self.SetEndDate(2013, 10, 15)
+        self.SetCash(100000)
+        self.AddSecurity(SecurityType.Equity, "SPY", Resolution.Minute)
+
+    def OnData(self, data):
+        if self.Transactions.GetOpenOrders().Count < 1:
+            self._negative = 1 if self.Time < self.StartDate.__add__(timedelta(days=2)) else -1
+            orderRequest = self.SubmitOrderRequest(OrderType.LimitIfTouched, SecurityType.Equity, "SPY",
+                                                   data["SPY"].Price - self._negative,
+                                                   data["SPY"].Price - 0.25 * self._negative, self.UtcTime,
+                                                   f"LIT - {self.UtcTime}, Quantity: {self._negative * 10}")
+            self._request = self.Transactions.AddOrder(orderRequest)
+
+        if self._request is not None:
+            if self._request.Quantity == 1:
+                self.Transactions.CancelOpenOrders()
+                del self._request
+                return
+
+            new_quantity = self._request.Quantity - self._negative
+            self._request.UpdateQuantity(new_quantity,
+                                         f"LIT - Time: {self.UtcTime}, Quantity: {new_quantity}")
+    
+    def OnOrderEvent(self, orderEvent):
+        if orderEvent.Status == OrderEvent.Filled:
+            expected = self._expectedEvents.pop()
+            if orderEvent.ToString() != expected:
+                raise Exception(f"orderEvent {orderEvent.Id} differed from {expected}")

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -478,6 +478,57 @@ namespace QuantConnect.Algorithm
             //Add the order and create a new order Id.
             return Transactions.AddOrder(request);
         }
+        
+        /// <summary>
+        /// Send a limit if touched order to the transaction handler:
+        /// </summary>
+        /// <param name="symbol">String symbol for the asset</param>
+        /// <param name="quantity">Quantity of shares for limit order</param>
+        /// <param name="triggerPrice">Trigger price for this order</param>
+        /// <param name="limitPrice">Limit price to fill this order</param>
+        /// <param name="tag">String tag for the order (optional)</param>
+        /// <returns>Order id</returns>
+        public OrderTicket LimitIfTouchedOrder(Symbol symbol, int quantity, decimal triggerPrice, decimal limitPrice, string tag = "")
+        {
+            return LimitIfTouchedOrder(symbol, (decimal)quantity, triggerPrice, limitPrice, tag);
+        }
+        
+        /// <summary>
+        /// Send a limit if touched order to the transaction handler:
+        /// </summary>
+        /// <param name="symbol">String symbol for the asset</param>
+        /// <param name="quantity">Quantity of shares for limit order</param>
+        /// <param name="triggerPrice">Trigger price for this order</param>
+        /// <param name="limitPrice">Limit price to fill this order</param>
+        /// <param name="tag">String tag for the order (optional)</param>
+        /// <returns>Order id</returns>
+        public OrderTicket LimitIfTouchedOrder(Symbol symbol, double quantity, decimal triggerPrice, decimal limitPrice, string tag = "")
+        {
+            return LimitIfTouchedOrder(symbol, quantity.SafeDecimalCast(), triggerPrice, limitPrice, tag);
+        }
+        
+        /// <summary>
+        /// Send a limit if touched order to the transaction handler:
+        /// </summary>
+        /// <param name="symbol">String symbol for the asset</param>
+        /// <param name="quantity">Quantity of shares for limit order</param>
+        /// <param name="triggerPrice">Trigger price for this order</param>
+        /// <param name="limitPrice">Limit price to fill this order</param>
+        /// <param name="tag">String tag for the order (optional)</param>
+        /// <returns>Order id</returns>
+        public OrderTicket LimitIfTouchedOrder(Symbol symbol, decimal quantity, decimal triggerPrice, decimal limitPrice, string tag = "")
+        {
+            var security = Securities[symbol];
+            var request = CreateSubmitOrderRequest(OrderType.LimitIfTouched, security, quantity, tag, triggerPrice: triggerPrice, limitPrice: limitPrice, properties: DefaultOrderProperties?.Clone());
+            var response = PreOrderChecks(request);
+            if (response.IsError)
+            {
+                return OrderTicket.InvalidSubmitRequest(Transactions, request, response);
+            }
+
+            //Add the order and create a new order Id.
+            return Transactions.AddOrder(request);
+        }
 
         /// <summary>
         /// Send an exercise order to the transaction handler
@@ -1110,9 +1161,9 @@ namespace QuantConnect.Algorithm
             return exchangeHours.IsOpen(time, false);
         }
 
-        private SubmitOrderRequest CreateSubmitOrderRequest(OrderType orderType, Security security, decimal quantity, string tag, IOrderProperties properties, decimal stopPrice = 0m, decimal limitPrice = 0m)
+        private SubmitOrderRequest CreateSubmitOrderRequest(OrderType orderType, Security security, decimal quantity, string tag, IOrderProperties properties, decimal stopPrice = 0m, decimal limitPrice = 0m,  decimal triggerPrice = 0m)
         {
-            return new SubmitOrderRequest(orderType, security.Type, security.Symbol, quantity, stopPrice, limitPrice, UtcTime, tag, properties);
+            return new SubmitOrderRequest(orderType, security.Type, security.Symbol, quantity, stopPrice, limitPrice, triggerPrice, UtcTime, tag, properties);
         }
     }
 }

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -475,7 +475,7 @@ namespace QuantConnect.Brokerages.Backtesting
             _pendingOptionAssignments.Add(option.Symbol);
 
             // assignments always cause a positive change to option contract holdings
-            var request = new SubmitOrderRequest(OrderType.OptionExercise, option.Type, option.Symbol, Math.Abs(quantity), 0m, 0m, Algorithm.UtcTime, "Simulated option assignment before expiration");
+            var request = new SubmitOrderRequest(OrderType.OptionExercise, option.Type, option.Symbol, Math.Abs(quantity), 0m, 0m, 0m, Algorithm.UtcTime, "Simulated option assignment before expiration");
 
             var ticket = Algorithm.Transactions.ProcessRequest(request);
             Log.Trace($"BacktestingBrokerage.ActivateOptionAssignment(): OrderId: {ticket.OrderId}");

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1732,6 +1732,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             var limitOrder = order as LimitOrder;
             var stopMarketOrder = order as StopMarketOrder;
             var stopLimitOrder = order as StopLimitOrder;
+            var limitIfTouchedOrder = order as LimitIfTouchedOrder;
             if (limitOrder != null)
             {
                 ibOrder.LmtPrice = Convert.ToDouble(RoundPrice(limitOrder.LimitPrice, GetMinTick(contract, order.Symbol)));
@@ -1745,6 +1746,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 var minTick = GetMinTick(contract, order.Symbol);
                 ibOrder.LmtPrice = Convert.ToDouble(RoundPrice(stopLimitOrder.LimitPrice, minTick));
                 ibOrder.AuxPrice = Convert.ToDouble(RoundPrice(stopLimitOrder.StopPrice, minTick));
+            }
+            else if (limitIfTouchedOrder != null)
+            {
+                var minTick = GetMinTick(contract, order.Symbol);
+                ibOrder.LmtPrice = Convert.ToDouble(RoundPrice(limitIfTouchedOrder.LimitPrice, minTick));
+                ibOrder.AuxPrice = Convert.ToDouble(RoundPrice(limitIfTouchedOrder.TriggerPrice, minTick));
             }
 
             // add financial advisor properties
@@ -1845,6 +1852,15 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                         Convert.ToDecimal(ibOrder.LmtPrice),
                         new DateTime()
                         );
+                    break;
+                
+                case OrderType.LimitIfTouched:
+                    order = new LimitIfTouchedOrder(mappedSymbol,
+                        Convert.ToInt32(ibOrder.TotalQuantity) * quantitySign,
+                        Convert.ToDecimal(ibOrder.AuxPrice),
+                        Convert.ToDecimal(ibOrder.LmtPrice),
+                        new DateTime()
+                    );
                     break;
 
                 default:
@@ -1973,6 +1989,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 case OrderType.Limit:           return IB.OrderType.Limit;
                 case OrderType.StopMarket:      return IB.OrderType.Stop;
                 case OrderType.StopLimit:       return IB.OrderType.StopLimit;
+                case OrderType.LimitIfTouched:  return IB.OrderType.LimitIfTouched;
                 case OrderType.MarketOnOpen:    return IB.OrderType.Market;
                 case OrderType.MarketOnClose:   return IB.OrderType.MarketOnClose;
                 default:
@@ -1990,6 +2007,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 case IB.OrderType.Limit:            return OrderType.Limit;
                 case IB.OrderType.Stop:             return OrderType.StopMarket;
                 case IB.OrderType.StopLimit:        return OrderType.StopLimit;
+                case IB.OrderType.LimitIfTouched:   return OrderType.LimitIfTouched;
                 case IB.OrderType.MarketOnClose:    return OrderType.MarketOnClose;
 
                 case IB.OrderType.Market:

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -345,6 +345,12 @@ namespace QuantConnect
                             {
                                 stopMarket.StopPrice = stopMarket.StopPrice.SmartRounding();
                             }
+                            var limitIfTouched = order as LimitIfTouchedOrder;
+                            if (limitIfTouched != null)
+                            {
+                                limitIfTouched.LimitPrice = limitIfTouched.LimitPrice.SmartRounding();
+                                limitIfTouched.TriggerPrice = limitIfTouched.TriggerPrice.SmartRounding();
+                            }
                             return JsonConvert.SerializeObject(pair.Value, Formatting.None);
                         }
                     )
@@ -1823,6 +1829,7 @@ namespace QuantConnect
         {
             var limitPrice = 0m;
             var stopPrice = 0m;
+            var triggerPrice = 0m;
 
             switch (order.Type)
             {
@@ -1838,6 +1845,11 @@ namespace QuantConnect
                     var stopLimitOrder = order as StopLimitOrder;
                     stopPrice = stopLimitOrder.StopPrice;
                     limitPrice = stopLimitOrder.LimitPrice;
+                    break;
+                case OrderType.LimitIfTouched:
+                    var limitIfTouched = order as LimitIfTouchedOrder;
+                    triggerPrice = limitIfTouched.TriggerPrice;
+                    limitPrice = limitIfTouched.LimitPrice;
                     break;
                 case OrderType.OptionExercise:
                 case OrderType.Market:
@@ -1856,6 +1868,7 @@ namespace QuantConnect
                 order.Quantity,
                 stopPrice,
                 limitPrice,
+                triggerPrice,
                 order.Time,
                 order.Tag,
                 order.Properties);

--- a/Common/Orders/Fills/EquityFillModel.cs
+++ b/Common/Orders/Fills/EquityFillModel.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using QLNet;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Python;
@@ -35,7 +34,7 @@ namespace QuantConnect.Orders.Fills
         /// The parameters instance to be used by the different XxxxFill() implementations
         /// </summary>
         protected FillModelParameters Parameters { get; set; }
-
+        
         /// <summary>
         /// This is required due to a limitation in PythonNet to resolved overriden methods.
         /// When Python calls a C# method that calls a method that's overriden in python it won't
@@ -141,6 +140,8 @@ namespace QuantConnect.Orders.Fills
             // Get the range of prices in the last bar:
             var tradeHigh = 0m;
             var tradeLow = 0m;
+            var bidOpen = 0m;
+            var askOpen = 0m;
             var endTimeUtc = DateTime.MinValue;
 
             var subscribedTypes = GetSubscribedTypes(asset);
@@ -148,21 +149,27 @@ namespace QuantConnect.Orders.Fills
             if (subscribedTypes.Contains(typeof(Tick)))
             {
                 var trade = asset.Cache.GetAll<Tick>().LastOrDefault(x => x.TickType == TickType.Trade && x.Price > 0);
+                var quote = asset.Cache.GetAll<Tick>().LastOrDefault(x => x.TickType == TickType.Quote && x.Price > 0);
                 if (trade != null)
                 {
                     tradeHigh = trade.Price;
                     tradeLow = trade.Price;
+                    bidOpen = quote.BidPrice;
+                    askOpen = quote.AskPrice;
                     endTimeUtc = trade.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
                 }
             }
             else if (subscribedTypes.Contains(typeof(TradeBar)))
             {
                 var tradeBar = asset.Cache.GetData<TradeBar>();
+                var quoteBar = asset.Cache.GetData<QuoteBar>();
 
-                if (tradeBar != null)
+                if (tradeBar != null && quoteBar != null)
                 {
                     tradeHigh = tradeBar.High;
                     tradeLow = tradeBar.Low;
+                    bidOpen = quoteBar.Bid.Open;
+                    askOpen = quoteBar.Ask.Open;
                     endTimeUtc = tradeBar.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
                 }
             }
@@ -178,12 +185,14 @@ namespace QuantConnect.Orders.Fills
                     if (tradeLow <= order.TriggerPrice || order.TriggerTouched)
                     {
                         order.TriggerTouched = true;
-                        var askCurrent = GetAskPrice(asset, out endTimeUtc);
 
-                        if (askCurrent <= order.LimitPrice)
+                        if (tradeLow <= order.LimitPrice)
                         {
                             fill.Status = OrderStatus.Filled;
-                            fill.FillPrice = Math.Min(askCurrent, order.LimitPrice);
+                            fill.FillPrice = askOpen <= order.LimitPrice
+                                ? askOpen // Fill price conditional on open
+                                : Math.Max(GetAskPrice(asset, out endTimeUtc), order.LimitPrice);
+                            // assume the order completely filled
                             fill.FillQuantity = order.Quantity;
                         }
                     }
@@ -195,12 +204,14 @@ namespace QuantConnect.Orders.Fills
                     if (tradeHigh >= order.TriggerPrice || order.TriggerTouched)
                     {
                         order.TriggerTouched = true;
-                        var bidCurrent = GetBidPrice(asset, out endTimeUtc);
 
-                        if (bidCurrent >= order.LimitPrice)
+                        if (tradeHigh >= order.LimitPrice)
                         {
                             fill.Status = OrderStatus.Filled;
-                            fill.FillPrice = Math.Max(bidCurrent, order.LimitPrice);
+                            fill.FillPrice = bidOpen >= order.LimitPrice
+                                ? bidOpen
+                                : Math.Min(GetBidPrice(asset, out endTimeUtc), order.LimitPrice);
+                            // assume the order completely filled
                             fill.FillQuantity = order.Quantity;
                         }
                     }
@@ -571,7 +582,7 @@ namespace QuantConnect.Orders.Fills
 
             return fill;
         }
-
+        
         /// <summary>
         /// Get data types the Security is subscribed to
         /// </summary>
@@ -708,7 +719,6 @@ namespace QuantConnect.Orders.Fills
 
             throw new InvalidOperationException($"Cannot get bid price to perform fill for {asset.Symbol} because no market data subscription were found.");
         }
-
 
         /// <summary>
         /// This is required due to a limitation in PythonNet to resolved

--- a/Common/Orders/Fills/EquityFillModel.cs
+++ b/Common/Orders/Fills/EquityFillModel.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using QLNet;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Python;
@@ -34,7 +35,7 @@ namespace QuantConnect.Orders.Fills
         /// The parameters instance to be used by the different XxxxFill() implementations
         /// </summary>
         protected FillModelParameters Parameters { get; set; }
-        
+
         /// <summary>
         /// This is required due to a limitation in PythonNet to resolved overriden methods.
         /// When Python calls a C# method that calls a method that's overriden in python it won't
@@ -140,8 +141,6 @@ namespace QuantConnect.Orders.Fills
             // Get the range of prices in the last bar:
             var tradeHigh = 0m;
             var tradeLow = 0m;
-            var bidOpen = 0m;
-            var askOpen = 0m;
             var endTimeUtc = DateTime.MinValue;
 
             var subscribedTypes = GetSubscribedTypes(asset);
@@ -149,27 +148,21 @@ namespace QuantConnect.Orders.Fills
             if (subscribedTypes.Contains(typeof(Tick)))
             {
                 var trade = asset.Cache.GetAll<Tick>().LastOrDefault(x => x.TickType == TickType.Trade && x.Price > 0);
-                var quote = asset.Cache.GetAll<Tick>().LastOrDefault(x => x.TickType == TickType.Quote && x.Price > 0);
                 if (trade != null)
                 {
                     tradeHigh = trade.Price;
                     tradeLow = trade.Price;
-                    bidOpen = quote.BidPrice;
-                    askOpen = quote.AskPrice;
                     endTimeUtc = trade.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
                 }
             }
             else if (subscribedTypes.Contains(typeof(TradeBar)))
             {
                 var tradeBar = asset.Cache.GetData<TradeBar>();
-                var quoteBar = asset.Cache.GetData<QuoteBar>();
 
-                if (tradeBar != null && quoteBar != null)
+                if (tradeBar != null)
                 {
                     tradeHigh = tradeBar.High;
                     tradeLow = tradeBar.Low;
-                    bidOpen = quoteBar.Bid.Open;
-                    askOpen = quoteBar.Ask.Open;
                     endTimeUtc = tradeBar.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
                 }
             }
@@ -185,14 +178,12 @@ namespace QuantConnect.Orders.Fills
                     if (tradeLow <= order.TriggerPrice || order.TriggerTouched)
                     {
                         order.TriggerTouched = true;
+                        var askCurrent = GetAskPrice(asset, out endTimeUtc);
 
-                        if (tradeLow <= order.LimitPrice)
+                        if (askCurrent <= order.LimitPrice)
                         {
                             fill.Status = OrderStatus.Filled;
-                            fill.FillPrice = askOpen <= order.LimitPrice
-                                ? askOpen // Fill price conditional on open
-                                : Math.Max(GetAskPrice(asset, out endTimeUtc), order.LimitPrice);
-                            // assume the order completely filled
+                            fill.FillPrice = Math.Max(askCurrent, order.LimitPrice);
                             fill.FillQuantity = order.Quantity;
                         }
                     }
@@ -204,14 +195,12 @@ namespace QuantConnect.Orders.Fills
                     if (tradeHigh >= order.TriggerPrice || order.TriggerTouched)
                     {
                         order.TriggerTouched = true;
+                        var bidCurrent = GetBidPrice(asset, out endTimeUtc);
 
-                        if (tradeHigh >= order.LimitPrice)
+                        if (bidCurrent >= order.LimitPrice)
                         {
                             fill.Status = OrderStatus.Filled;
-                            fill.FillPrice = bidOpen >= order.LimitPrice
-                                ? bidOpen
-                                : Math.Min(GetBidPrice(asset, out endTimeUtc), order.LimitPrice);
-                            // assume the order completely filled
+                            fill.FillPrice = Math.Min(bidCurrent, order.LimitPrice);
                             fill.FillQuantity = order.Quantity;
                         }
                     }
@@ -582,7 +571,7 @@ namespace QuantConnect.Orders.Fills
 
             return fill;
         }
-        
+
         /// <summary>
         /// Get data types the Security is subscribed to
         /// </summary>

--- a/Common/Orders/Fills/EquityFillModel.cs
+++ b/Common/Orders/Fills/EquityFillModel.cs
@@ -183,7 +183,7 @@ namespace QuantConnect.Orders.Fills
                         if (askCurrent <= order.LimitPrice)
                         {
                             fill.Status = OrderStatus.Filled;
-                            fill.FillPrice = Math.Max(askCurrent, order.LimitPrice);
+                            fill.FillPrice = Math.Min(askCurrent, order.LimitPrice);
                             fill.FillQuantity = order.Quantity;
                         }
                     }
@@ -200,7 +200,7 @@ namespace QuantConnect.Orders.Fills
                         if (bidCurrent >= order.LimitPrice)
                         {
                             fill.Status = OrderStatus.Filled;
-                            fill.FillPrice = Math.Min(bidCurrent, order.LimitPrice);
+                            fill.FillPrice = Math.Max(bidCurrent, order.LimitPrice);
                             fill.FillQuantity = order.Quantity;
                         }
                     }
@@ -708,6 +708,7 @@ namespace QuantConnect.Orders.Fills
 
             throw new InvalidOperationException($"Cannot get bid price to perform fill for {asset.Symbol} because no market data subscription were found.");
         }
+
 
         /// <summary>
         /// This is required due to a limitation in PythonNet to resolved

--- a/Common/Orders/Fills/EquityFillModel.cs
+++ b/Common/Orders/Fills/EquityFillModel.cs
@@ -117,8 +117,12 @@ namespace QuantConnect.Orders.Fills
         ///     There is no good way to model limit orders with OHLC because we never know whether the market has
         ///     gapped past our fill price. We have to make the assumption of a fluid, high volume market.
         ///
-        ///     With limit if touched, we can't be sure of the order of the H - L values for the limit fill. The assumption
-        ///     was made the limit fill will be done with closing price of the bar after the trigger has been reached.
+        ///     With Limit if Touched orders, whether or not a trigger is surpassed is determined by the high (low)
+        ///     of the previous tradebar when making a sell (buy) request. Following the behaviour of
+        ///     <see cref="StopLimitFill"/>, current quote information is used when determining fill parameters
+        ///     (e.g., price, quantity) as the tradebar containing the incoming data is not yet consolidated.
+        ///     This conservative approach, however, can lead to trades not occuring as would be expected when
+        ///     compared to future consolidated data.
         /// </remarks>
         public virtual OrderEvent LimitIfTouchedFill(Security asset, LimitIfTouchedOrder order)
         {
@@ -148,6 +152,7 @@ namespace QuantConnect.Orders.Fills
             if (subscribedTypes.Contains(typeof(Tick)))
             {
                 var trade = asset.Cache.GetAll<Tick>().LastOrDefault(x => x.TickType == TickType.Trade && x.Price > 0);
+                
                 if (trade != null)
                 {
                     tradeHigh = trade.Price;

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -309,8 +309,12 @@ namespace QuantConnect.Orders.Fills
         ///     There is no good way to model limit orders with OHLC because we never know whether the market has
         ///     gapped past our fill price. We have to make the assumption of a fluid, high volume market.
         ///
-        ///     With limit if touched, we can't be sure of the order of the H - L values for the limit fill. The assumption
-        ///     was made the limit fill will be done with closing price of the bar after the trigger has been reached.
+        ///     With Limit if Touched orders, whether or not a trigger is surpassed is determined by the high (low)
+        ///     of the previous tradebar when making a sell (buy) request. Following the behaviour of
+        ///     <see cref="StopLimitFill"/>, current quote information is used when determining fill parameters
+        ///     (e.g., price, quantity) as the tradebar containing the incoming data is not yet consolidated.
+        ///     This conservative approach, however, can lead to trades not occuring as would be expected when
+        ///     compared to future consolidated data.
         /// </remarks>
         public virtual OrderEvent LimitIfTouchedFill(Security asset, LimitIfTouchedOrder order)
         {

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -31,16 +31,16 @@ namespace QuantConnect.Orders.Fills
     public class FillModel : IFillModel
     {
         /// <summary>
+        /// The parameters instance to be used by the different XxxxFill() implementations
+        /// </summary>
+        protected FillModelParameters Parameters { get; set; }
+        
+        /// <summary>
         /// This is required due to a limitation in PythonNet to resolved overriden methods.
         /// When Python calls a C# method that calls a method that's overriden in python it won't
         /// run the python implementation unless the call is performed through python too.
         /// </summary>
         protected FillModelPythonWrapper PythonWrapper;
-
-        /// <summary>
-        /// The parameters instance to be used by the different XxxxFill() implementations
-        /// </summary>
-        protected FillModelParameters Parameters { get; set; }
 
         /// <summary>
         /// Used to set the <see cref="FillModelPythonWrapper"/> instance if any

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -14,12 +14,14 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Python;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Securities;
+using QuantConnect.Util;
 
 namespace QuantConnect.Orders.Fills
 {
@@ -58,6 +60,7 @@ namespace QuantConnect.Orders.Fills
             // Important: setting the parameters is required because it is
             // consumed by the different XxxxFill() implementations
             Parameters = parameters;
+
             var order = parameters.Order;
             OrderEvent orderEvent;
             switch (order.Type)
@@ -100,60 +103,7 @@ namespace QuantConnect.Orders.Fills
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-
             return new Fill(orderEvent);
-        }
-
-        private OrderEvent LimitIfTouchedFill(Security asset, LimitIfTouchedOrder order)
-        {
-            //Default order event to return.
-            var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
-            var fill = new OrderEvent(order, utcTime, OrderFee.Zero);
-
-            //If its cancelled don't need anymore checks:
-            if (order.Status == OrderStatus.Canceled) return fill;
-
-            // make sure the exchange is open/normal market hours before filling
-            if (!IsExchangeOpen(asset, false)) return fill;
-
-            //Get the range of prices in the last bar:
-            var prices = GetPricesCheckingPythonWrapper(asset, order.Direction);
-            var pricesEndTime = prices.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
-
-            // do not fill on stale data
-            if (pricesEndTime <= order.Time) return fill;
-
-            //Calculate the model slippage: e.g. 0.01c
-            var slip = asset.SlippageModel.GetSlippageApproximation(asset, order);
-            switch (order.Direction)
-            {
-                case OrderDirection.Sell:
-                    //-> 1.1 Limit surpassed: Sell.
-                    if (prices.Low > order.LimitPrice)
-                    {
-                        fill.Status = OrderStatus.Filled;
-                        // Assuming worse case scenario fill - fill at lowest of the stop & asset price.
-                        fill.FillPrice = Math.Min(order.LimitPrice, prices.Current - slip);
-                        // assume the order completely filled
-                        fill.FillQuantity = order.Quantity;
-                    }
-
-                    break;
-                case OrderDirection.Buy:
-                    //-> 1.2 Limit surpassed: Buy.
-                    if (prices.High < order.LimitPrice)
-                    {
-                        fill.Status = OrderStatus.Filled;
-                        // Assuming worse case scenario fill - fill at highest of the stop & asset price.
-                        fill.FillPrice = Math.Max(order.LimitPrice, prices.Current + slip);
-                        // assume the order completely filled
-                        fill.FillQuantity = order.Quantity;
-                    }
-
-                    break;
-            }
-
-            return fill;
         }
 
         /// <summary>
@@ -350,6 +300,108 @@ namespace QuantConnect.Orders.Fills
         }
 
         /// <summary>
+        /// Default limit if touched fill model implementation in base class security. (Limit If Touched Order Type)
+        /// </summary>
+        /// <param name="asset"></param>
+        /// <param name="order"></param>
+        /// <returns>Order fill information detailing the average price and quantity filled.</returns>
+        /// <remarks>
+        ///     There is no good way to model limit orders with OHLC because we never know whether the market has
+        ///     gapped past our fill price. We have to make the assumption of a fluid, high volume market.
+        ///
+        ///     With limit if touched, we can't be sure of the order of the H - L values for the limit fill. The assumption
+        ///     was made the limit fill will be done with closing price of the bar after the trigger has been reached.
+        /// </remarks>
+        public virtual OrderEvent LimitIfTouchedFill(Security asset, LimitIfTouchedOrder order)
+        {
+            //Default order event to return.
+            var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
+            var fill = new OrderEvent(order, utcTime, OrderFee.Zero);
+
+            //If its cancelled don't need anymore checks:
+            if (order.Status == OrderStatus.Canceled) return fill;
+
+            // Fill only if open or extended
+            if (!IsExchangeOpen(asset,
+                Parameters.ConfigProvider
+                    .GetSubscriptionDataConfigs(asset.Symbol)
+                    .IsExtendedMarketHours()))
+            {
+                return fill;
+            }
+            
+            // Get the range of prices in the last bar:
+            var tradeHigh = 0m;
+            var tradeLow = 0m;
+            var pricesEndTime = DateTime.MinValue;
+            
+            var subscribedTypes = GetSubscribedTypes(asset);
+
+            if (subscribedTypes.Contains(typeof(Tick)))
+            {
+                var trade = GetPricesCheckingPythonWrapper(asset, order.Direction);
+                
+                if (trade != null)
+                {
+                    tradeHigh = trade.Current;
+                    tradeLow = trade.Current;
+                    pricesEndTime = trade.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
+                }
+            }
+            
+            else if (subscribedTypes.Contains(typeof(TradeBar)))
+            {
+                var tradeBar = asset.Cache.GetData<TradeBar>();
+                if (tradeBar != null)
+                {
+                    tradeHigh = tradeBar.High;
+                    tradeLow = tradeBar.Low;
+                    pricesEndTime = tradeBar.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
+                }
+            }
+
+            // do not fill on stale data
+            if (pricesEndTime <= order.Time) return fill;
+
+            switch (order.Direction)
+            {
+                case OrderDirection.Sell:
+                    if (tradeHigh >= order.TriggerPrice || order.TriggerTouched)
+                    {
+                        order.TriggerTouched = true;
+                        
+                        //-> 1.1 Limit surpassed: Sell.
+                        if (GetAskPrice(asset, out pricesEndTime) >= order.LimitPrice)
+                        {
+                            fill.Status = OrderStatus.Filled;
+                            fill.FillPrice = order.LimitPrice;                            
+                            // assume the order completely filled
+                            fill.FillQuantity = order.Quantity;
+                        }
+                    }
+                    break;
+
+                case OrderDirection.Buy:
+                    if (tradeLow <= order.TriggerPrice || order.TriggerTouched)
+                    {
+                        order.TriggerTouched = true;
+
+                        //-> 1.2 Limit surpassed: Buy.
+                        if (GetBidPrice(asset, out pricesEndTime) <= order.LimitPrice)
+                        {
+                            fill.Status = OrderStatus.Filled;
+                            fill.FillPrice = order.LimitPrice;                            
+                            // assume the order completely filled
+                            fill.FillQuantity = order.Quantity;
+                        }
+                    }
+                    break;
+            }
+
+            return fill;
+        }
+
+        /// <summary>
         /// Default limit order fill model in the base security class.
         /// </summary>
         /// <param name="asset">Security asset we're filling</param>
@@ -517,6 +569,143 @@ namespace QuantConnect.Orders.Fills
             return fill;
         }
 
+        /// <summary>
+        /// Get current ask price for subscribed data
+        /// This method will try to get the most recent ask price data, so it will try to get tick quote first, then quote bar.
+        /// If no quote, tick or bar, is available (e.g. hourly data), use trade data with preference to tick data.
+        /// </summary>
+        /// <param name="asset">Security which has subscribed data types</param>
+        /// <param name="endTime">Timestamp of the most recent data type</param>
+        private decimal GetAskPrice(Security asset, out DateTime endTime)
+        {
+            var subscribedTypes = GetSubscribedTypes(asset);
+
+            List<Tick> ticks = null;
+            var isTickSubscribed = subscribedTypes.Contains(typeof(Tick));
+
+            if (isTickSubscribed)
+            {
+                ticks = asset.Cache.GetAll<Tick>().ToList();
+
+                var quote = ticks.LastOrDefault(x => x.TickType == TickType.Quote && x.AskPrice > 0);
+                if (quote != null)
+                {
+                    endTime = quote.EndTime;
+                    return quote.AskPrice;
+                }
+            }
+
+            if (subscribedTypes.Contains(typeof(QuoteBar)))
+            {
+                var quoteBar = asset.Cache.GetData<QuoteBar>();
+                if (quoteBar != null)
+                {
+                    endTime = quoteBar.EndTime;
+                    return quoteBar.Ask?.Close ?? quoteBar.Close;
+                }
+            }
+
+            if (isTickSubscribed)
+            {
+                var trade = ticks.LastOrDefault(x => x.TickType == TickType.Trade && x.Price > 0);
+                if (trade != null)
+                {
+                    endTime = trade.EndTime;
+                    return trade.Price;
+                }
+            }
+
+            if (subscribedTypes.Contains(typeof(TradeBar)))
+            {
+                var tradeBar = asset.Cache.GetData<TradeBar>();
+                if (tradeBar != null)
+                {
+                    endTime = tradeBar.EndTime;
+                    return tradeBar.Close;
+                }
+            }
+
+            throw new InvalidOperationException($"Cannot get ask price to perform fill for {asset.Symbol} because no market data subscription were found.");
+        }
+
+        /// <summary>
+        /// Get current bid price for subscribed data
+        /// This method will try to get the most recent bid price data, so it will try to get tick quote first, then quote bar.
+        /// If no quote, tick or bar, is available (e.g. hourly data), use trade data with preference to tick data.
+        /// </summary>
+        /// <param name="asset">Security which has subscribed data types</param>
+        /// <param name="endTime">Timestamp of the most recent data type</param>
+        private decimal GetBidPrice(Security asset, out DateTime endTime)
+        {
+            var subscribedTypes = GetSubscribedTypes(asset);
+
+            List<Tick> ticks = null;
+            var isTickSubscribed = subscribedTypes.Contains(typeof(Tick));
+
+            if (isTickSubscribed)
+            {
+                ticks = asset.Cache.GetAll<Tick>().ToList();
+
+                var quote = ticks.LastOrDefault(x => x.TickType == TickType.Quote && x.BidPrice > 0);
+                if (quote != null)
+                {
+                    endTime = quote.EndTime;
+                    return quote.BidPrice;
+                }
+            }
+
+            if (subscribedTypes.Contains(typeof(QuoteBar)))
+            {
+                var quoteBar = asset.Cache.GetData<QuoteBar>();
+                if (quoteBar != null)
+                {
+                    endTime = quoteBar.EndTime;
+                    return quoteBar.Bid?.Close ?? quoteBar.Close;
+                }
+            }
+
+            if (isTickSubscribed)
+            {
+                var trade = ticks.LastOrDefault(x => x.TickType == TickType.Trade && x.Price > 0);
+                if (trade != null)
+                {
+                    endTime = trade.EndTime;
+                    return trade.Price;
+                }
+            }
+
+            if (subscribedTypes.Contains(typeof(TradeBar)))
+            {
+                var tradeBar = asset.Cache.GetData<TradeBar>();
+                if (tradeBar != null)
+                {
+                    endTime = tradeBar.EndTime;
+                    return tradeBar.Close;
+                }
+            }
+
+            throw new InvalidOperationException($"Cannot get bid price to perform fill for {asset.Symbol} because no market data subscription were found.");
+        }
+
+        /// <summary>
+        /// Get data types the Security is subscribed to
+        /// </summary>
+        /// <param name="asset">Security which has subscribed data types</param>
+        private HashSet<Type> GetSubscribedTypes(Security asset)
+        {
+            var subscribedTypes = Parameters
+                .ConfigProvider
+                .GetSubscriptionDataConfigs(asset.Symbol)
+                .ToHashSet(x => x.Type);
+
+            if (subscribedTypes.Count == 0)
+            {
+                throw new InvalidOperationException($"Cannot perform fill for {asset.Symbol} because no data subscription were found.");
+            }
+
+            return subscribedTypes;
+        }
+        
         /// <summary>
         /// This is required due to a limitation in PythonNet to resolved
         /// overriden methods. <see cref="GetPrices"/>

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -374,7 +374,6 @@ namespace QuantConnect.Orders.Fills
                         if (GetAskPrice(asset, out pricesEndTime) >= order.LimitPrice)
                         {
                             fill.Status = OrderStatus.Filled;
-                            // Fill price conditional on open
                             fill.FillPrice = order.LimitPrice;                            
                             // assume the order completely filled
                             fill.FillQuantity = order.Quantity;
@@ -391,7 +390,6 @@ namespace QuantConnect.Orders.Fills
                         if (GetBidPrice(asset, out pricesEndTime) <= order.LimitPrice)
                         {
                             fill.Status = OrderStatus.Filled;
-                            // Fill price conditional on open
                             fill.FillPrice = order.LimitPrice;                            
                             // assume the order completely filled
                             fill.FillQuantity = order.Quantity;
@@ -428,7 +426,6 @@ namespace QuantConnect.Orders.Fills
             {
                 return fill;
             }
-
             //Get the range of prices in the last bar:
             var prices = GetPricesCheckingPythonWrapper(asset, order.Direction);
             var pricesEndTime = prices.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
@@ -546,7 +543,6 @@ namespace QuantConnect.Orders.Fills
             {
                 return fill;
             }
-
             // make sure the exchange is open/normal market hours before filling
             if (!IsExchangeOpen(asset, false)) return fill;
 
@@ -720,7 +716,6 @@ namespace QuantConnect.Orders.Fills
             {
                 return PythonWrapper.GetPrices(asset, direction);
             }
-
             return GetPrices(asset, direction);
         }
 
@@ -801,7 +796,6 @@ namespace QuantConnect.Orders.Fills
                     return false;
                 }
             }
-
             return true;
         }
 

--- a/Common/Orders/LimitIfTouchedOrder.cs
+++ b/Common/Orders/LimitIfTouchedOrder.cs
@@ -1,0 +1,140 @@
+using System;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+using static QuantConnect.StringExtensions;
+
+namespace QuantConnect.Orders
+{
+    /// <summary>
+    /// <para>
+    /// In effect, a LimitIfTouchedOrder behaves opposite to the <see cref="StopLimitOrder"/>;
+    /// after a trigger price is touched, a limit order is set for some user-defined value above (below)
+    /// the trigger when selling (buying).
+    /// </para>
+    /// https://www.interactivebrokers.ca/en/index.php?f=45318
+    /// </summary>
+    public class LimitIfTouchedOrder : Order
+    {
+        /// <summary>
+        /// The price which, when touched, will trigger the setting of a limit order at <see cref="LimitPrice"/>.
+        /// </summary>
+        public decimal TriggerPrice { get; internal set; }
+
+        /// <summary>
+        /// The price at which to set the limit order following <see cref="TriggerPrice"/> being touched.
+        /// </summary>
+        public decimal LimitPrice { get; internal set; }
+
+        /// <summary>
+        /// Whether or not the <see cref="TriggerPrice"/> has been touched.
+        /// </summary>
+        public bool TriggerTouched { get; internal set; }
+
+        /// <summary>
+        /// New <see cref="LimitIfTouchedOrder"/> constructor.
+        /// </summary>
+        /// <param name="symbol">Symbol asset we're seeking to trade</param>
+        /// <param name="quantity">Quantity of the asset we're seeking to trade</param>
+        /// <param name="limitPrice">Maximum price to fill the order</param>
+        /// <param name="time">Time the order was placed</param>
+        /// <param name="triggerPrice">Price which must be touched in order to then set a limit order</param>
+        /// <param name="tag">User defined data tag for this order</param>
+        /// <param name="properties">The order properties for this order</param>
+        public LimitIfTouchedOrder(
+            Symbol symbol,
+            decimal quantity,
+            decimal triggerPrice,
+            decimal limitPrice,
+            DateTime time,
+            string tag = "",
+            IOrderProperties properties = null
+            )
+            : base(symbol, quantity, time, tag, properties)
+        {
+            TriggerPrice = triggerPrice;
+            LimitPrice = limitPrice;
+            if (string.IsNullOrEmpty(tag))
+            {
+                //Default tag values to display stop price in GUI.
+                Tag = Invariant($"Trigger Price: {triggerPrice:C} Limit Price: {limitPrice:C}");
+            }
+        }
+
+        /// <summary>
+        /// Default constructor for JSON Deserialization:
+        /// </summary>
+        public LimitIfTouchedOrder()
+        {
+        }
+
+        /// <summary>
+        /// Order Type
+        /// </summary>
+        public override OrderType Type => OrderType.LimitIfTouched;
+
+        /// <summary>
+        /// Gets the order value in units of the security's quote currency for a single unit.
+        /// A single unit here is a single share of stock, or a single barrel of oil, or the
+        /// cost of a single share in an option contract.
+        /// </summary>
+        /// <param name="security">The security matching this order's symbol</param>
+        protected override decimal GetValueImpl(Security security)
+        {
+            // selling, so higher price will be used
+            if (Quantity < 0)
+            {
+                return Quantity * Math.Max(LimitPrice, security.Price);
+            }
+
+            // buying, so lower price will be used
+            if (Quantity > 0)
+            {
+                return Quantity * Math.Min(LimitPrice, security.Price);
+            }
+
+            return 0m;
+        }
+
+        /// <summary>
+        /// Modifies the state of this order to match the update request
+        /// </summary>
+        /// <param name="request">The request to update this order object</param>
+        public override void ApplyUpdateOrderRequest(UpdateOrderRequest request)
+        {
+            base.ApplyUpdateOrderRequest(request);
+            if (request.TriggerPrice.HasValue)
+            {
+                TriggerPrice = request.TriggerPrice.Value;
+            }
+
+            if (request.LimitPrice.HasValue)
+            {
+                LimitPrice = request.LimitPrice.Value;
+            }
+        }
+
+        /// <summary>
+        /// Creates a deep-copy clone of this order
+        /// </summary>
+        /// <returns>A copy of this order</returns>
+        public override Order Clone()
+        {
+            var order = new LimitIfTouchedOrder {TriggerPrice = TriggerPrice, LimitPrice = LimitPrice};
+            CopyTo(order);
+            return order;
+        }
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>
+        /// A string that represents the current object.
+        /// </returns>
+        /// <filterpriority>2</filterpriority>
+        public override string ToString()
+        {
+            return Invariant(
+                $"{base.ToString()} at trigger {TriggerPrice.SmartRounding()} limit {LimitPrice.SmartRounding()}");
+        }
+    }
+}

--- a/Common/Orders/Order.cs
+++ b/Common/Orders/Order.cs
@@ -347,94 +347,42 @@ namespace QuantConnect.Orders
             }
 
             var createdTime = QuantConnect.Time.UnixTimeStampToDateTime(serializedOrder.CreatedTime);
-            
-            CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
+
+            var order = CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
                 DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
                 serializedOrder.Tag,
                 new OrderProperties { TimeInForce = timeInForce },
                 serializedOrder.LimitPrice ?? 0,
                 serializedOrder.StopPrice ?? 0,
-                serializedOrder.TriggerPrice).OrderSubmissionData = new OrderSubmissionData(serializedOrder.SubmissionBidPrice,
+                serializedOrder.TriggerPrice ?? 0);
+
+            order.OrderSubmissionData = new OrderSubmissionData(serializedOrder.SubmissionBidPrice,
                 serializedOrder.SubmissionAskPrice,
                 serializedOrder.SubmissionLastPrice);
 
-            CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
-                DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
-                serializedOrder.Tag,
-                new OrderProperties { TimeInForce = timeInForce },
-                serializedOrder.LimitPrice ?? 0,
-                serializedOrder.StopPrice ?? 0,
-                serializedOrder.TriggerPrice).BrokerId = serializedOrder.BrokerId;
-            CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
-                DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
-                serializedOrder.Tag,
-                new OrderProperties { TimeInForce = timeInForce },
-                serializedOrder.LimitPrice ?? 0,
-                serializedOrder.StopPrice ?? 0,
-                serializedOrder.TriggerPrice).ContingentId = serializedOrder.ContingentId;
-            CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
-                DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
-                serializedOrder.Tag,
-                new OrderProperties { TimeInForce = timeInForce },
-                serializedOrder.LimitPrice ?? 0,
-                serializedOrder.StopPrice ?? 0,
-                serializedOrder.TriggerPrice).Price = serializedOrder.Price;
-            CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
-                DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
-                serializedOrder.Tag,
-                new OrderProperties { TimeInForce = timeInForce },
-                serializedOrder.LimitPrice ?? 0,
-                serializedOrder.StopPrice ?? 0,
-                serializedOrder.TriggerPrice).PriceCurrency = serializedOrder.PriceCurrency;
-            CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
-                DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
-                serializedOrder.Tag,
-                new OrderProperties { TimeInForce = timeInForce },
-                serializedOrder.LimitPrice ?? 0,
-                serializedOrder.StopPrice ?? 0,
-                serializedOrder.TriggerPrice).Status = serializedOrder.Status;
+            order.BrokerId = serializedOrder.BrokerId;
+            order.ContingentId = serializedOrder.ContingentId;
+            order.Price = serializedOrder.Price;
+            order.PriceCurrency = serializedOrder.PriceCurrency;
+            order.Status = serializedOrder.Status;
 
             if (serializedOrder.LastFillTime.HasValue)
             {
                 var time = QuantConnect.Time.UnixTimeStampToDateTime(serializedOrder.LastFillTime.Value);
-                CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
-                    DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
-                    serializedOrder.Tag,
-                    new OrderProperties { TimeInForce = timeInForce },
-                    serializedOrder.LimitPrice ?? 0,
-                    serializedOrder.StopPrice ?? 0,
-                    serializedOrder.TriggerPrice).LastFillTime = DateTime.SpecifyKind(time, DateTimeKind.Utc);
+                order.LastFillTime = DateTime.SpecifyKind(time, DateTimeKind.Utc);
             }
             if (serializedOrder.LastUpdateTime.HasValue)
             {
                 var time = QuantConnect.Time.UnixTimeStampToDateTime(serializedOrder.LastUpdateTime.Value);
-                CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
-                    DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
-                    serializedOrder.Tag,
-                    new OrderProperties { TimeInForce = timeInForce },
-                    serializedOrder.LimitPrice ?? 0,
-                    serializedOrder.StopPrice ?? 0,
-                    serializedOrder.TriggerPrice).LastUpdateTime = DateTime.SpecifyKind(time, DateTimeKind.Utc);
+                order.LastUpdateTime = DateTime.SpecifyKind(time, DateTimeKind.Utc);
             }
             if (serializedOrder.CanceledTime.HasValue)
             {
                 var time = QuantConnect.Time.UnixTimeStampToDateTime(serializedOrder.CanceledTime.Value);
-                CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
-                    DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
-                    serializedOrder.Tag,
-                    new OrderProperties { TimeInForce = timeInForce },
-                    serializedOrder.LimitPrice ?? 0,
-                    serializedOrder.StopPrice ?? 0,
-                    serializedOrder.TriggerPrice).CanceledTime = DateTime.SpecifyKind(time, DateTimeKind.Utc);
+                order.CanceledTime = DateTime.SpecifyKind(time, DateTimeKind.Utc);
             }
 
-            return CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
-                DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
-                serializedOrder.Tag,
-                new OrderProperties { TimeInForce = timeInForce },
-                serializedOrder.LimitPrice ?? 0,
-                serializedOrder.StopPrice ?? 0,
-                serializedOrder.TriggerPrice);
+            return order;
         }
 
         /// <summary>
@@ -469,6 +417,7 @@ namespace QuantConnect.Orders
                 case OrderType.StopLimit:
                     order = new StopLimitOrder(symbol, quantity, stopPrice, limitPrice, time, tag, properties);
                     break;
+                
                 case OrderType.LimitIfTouched:
                     order = new LimitIfTouchedOrder(symbol, quantity, triggerPrice, limitPrice, time, tag, properties);
                     break;

--- a/Common/Orders/Order.cs
+++ b/Common/Orders/Order.cs
@@ -347,41 +347,94 @@ namespace QuantConnect.Orders
             }
 
             var createdTime = QuantConnect.Time.UnixTimeStampToDateTime(serializedOrder.CreatedTime);
-
-            var order = CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
+            
+            CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
                 DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
                 serializedOrder.Tag,
                 new OrderProperties { TimeInForce = timeInForce },
                 serializedOrder.LimitPrice ?? 0,
-                serializedOrder.StopPrice ?? 0);
-
-            order.OrderSubmissionData = new OrderSubmissionData(serializedOrder.SubmissionBidPrice,
+                serializedOrder.StopPrice ?? 0,
+                serializedOrder.TriggerPrice).OrderSubmissionData = new OrderSubmissionData(serializedOrder.SubmissionBidPrice,
                 serializedOrder.SubmissionAskPrice,
                 serializedOrder.SubmissionLastPrice);
 
-            order.BrokerId = serializedOrder.BrokerId;
-            order.ContingentId = serializedOrder.ContingentId;
-            order.Price = serializedOrder.Price;
-            order.PriceCurrency = serializedOrder.PriceCurrency;
-            order.Status = serializedOrder.Status;
+            CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
+                DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
+                serializedOrder.Tag,
+                new OrderProperties { TimeInForce = timeInForce },
+                serializedOrder.LimitPrice ?? 0,
+                serializedOrder.StopPrice ?? 0,
+                serializedOrder.TriggerPrice).BrokerId = serializedOrder.BrokerId;
+            CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
+                DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
+                serializedOrder.Tag,
+                new OrderProperties { TimeInForce = timeInForce },
+                serializedOrder.LimitPrice ?? 0,
+                serializedOrder.StopPrice ?? 0,
+                serializedOrder.TriggerPrice).ContingentId = serializedOrder.ContingentId;
+            CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
+                DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
+                serializedOrder.Tag,
+                new OrderProperties { TimeInForce = timeInForce },
+                serializedOrder.LimitPrice ?? 0,
+                serializedOrder.StopPrice ?? 0,
+                serializedOrder.TriggerPrice).Price = serializedOrder.Price;
+            CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
+                DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
+                serializedOrder.Tag,
+                new OrderProperties { TimeInForce = timeInForce },
+                serializedOrder.LimitPrice ?? 0,
+                serializedOrder.StopPrice ?? 0,
+                serializedOrder.TriggerPrice).PriceCurrency = serializedOrder.PriceCurrency;
+            CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
+                DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
+                serializedOrder.Tag,
+                new OrderProperties { TimeInForce = timeInForce },
+                serializedOrder.LimitPrice ?? 0,
+                serializedOrder.StopPrice ?? 0,
+                serializedOrder.TriggerPrice).Status = serializedOrder.Status;
 
             if (serializedOrder.LastFillTime.HasValue)
             {
                 var time = QuantConnect.Time.UnixTimeStampToDateTime(serializedOrder.LastFillTime.Value);
-                order.LastFillTime = DateTime.SpecifyKind(time, DateTimeKind.Utc);
+                CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
+                    DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
+                    serializedOrder.Tag,
+                    new OrderProperties { TimeInForce = timeInForce },
+                    serializedOrder.LimitPrice ?? 0,
+                    serializedOrder.StopPrice ?? 0,
+                    serializedOrder.TriggerPrice).LastFillTime = DateTime.SpecifyKind(time, DateTimeKind.Utc);
             }
             if (serializedOrder.LastUpdateTime.HasValue)
             {
                 var time = QuantConnect.Time.UnixTimeStampToDateTime(serializedOrder.LastUpdateTime.Value);
-                order.LastUpdateTime = DateTime.SpecifyKind(time, DateTimeKind.Utc);
+                CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
+                    DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
+                    serializedOrder.Tag,
+                    new OrderProperties { TimeInForce = timeInForce },
+                    serializedOrder.LimitPrice ?? 0,
+                    serializedOrder.StopPrice ?? 0,
+                    serializedOrder.TriggerPrice).LastUpdateTime = DateTime.SpecifyKind(time, DateTimeKind.Utc);
             }
             if (serializedOrder.CanceledTime.HasValue)
             {
                 var time = QuantConnect.Time.UnixTimeStampToDateTime(serializedOrder.CanceledTime.Value);
-                order.CanceledTime = DateTime.SpecifyKind(time, DateTimeKind.Utc);
+                CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
+                    DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
+                    serializedOrder.Tag,
+                    new OrderProperties { TimeInForce = timeInForce },
+                    serializedOrder.LimitPrice ?? 0,
+                    serializedOrder.StopPrice ?? 0,
+                    serializedOrder.TriggerPrice).CanceledTime = DateTime.SpecifyKind(time, DateTimeKind.Utc);
             }
 
-            return order;
+            return CreateOrder(serializedOrder.OrderId, serializedOrder.Type, symbol, serializedOrder.Quantity,
+                DateTime.SpecifyKind(createdTime, DateTimeKind.Utc),
+                serializedOrder.Tag,
+                new OrderProperties { TimeInForce = timeInForce },
+                serializedOrder.LimitPrice ?? 0,
+                serializedOrder.StopPrice ?? 0,
+                serializedOrder.TriggerPrice);
         }
 
         /// <summary>
@@ -392,11 +445,11 @@ namespace QuantConnect.Orders
         public static Order CreateOrder(SubmitOrderRequest request)
         {
             return CreateOrder(request.OrderId, request.OrderType, request.Symbol, request.Quantity, request.Time,
-                request.Tag, request.OrderProperties, request.LimitPrice, request.StopPrice);
+                request.Tag, request.OrderProperties, request.LimitPrice, request.StopPrice, request.TriggerPrice);
         }
 
         private static Order CreateOrder(int orderId, OrderType type, Symbol symbol, decimal quantity, DateTime time,
-            string tag, IOrderProperties properties, decimal limitPrice, decimal stopPrice)
+            string tag, IOrderProperties properties, decimal limitPrice, decimal stopPrice, decimal triggerPrice)
         {
             Order order;
             switch (type)
@@ -415,6 +468,9 @@ namespace QuantConnect.Orders
 
                 case OrderType.StopLimit:
                     order = new StopLimitOrder(symbol, quantity, stopPrice, limitPrice, time, tag, properties);
+                    break;
+                case OrderType.LimitIfTouched:
+                    order = new LimitIfTouchedOrder(symbol, quantity, triggerPrice, limitPrice, time, tag, properties);
                     break;
 
                 case OrderType.MarketOnOpen:

--- a/Common/Orders/OrderEvent.cs
+++ b/Common/Orders/OrderEvent.cs
@@ -32,6 +32,7 @@ namespace QuantConnect.Orders
         private decimal _fillQuantity;
         private decimal _quantity;
         private decimal? _limitPrice;
+        private decimal? _triggerPrice;
         private decimal? _stopPrice;
 
         /// <summary>
@@ -121,6 +122,22 @@ namespace QuantConnect.Orders
                 if (value.HasValue)
                 {
                     _stopPrice = value.Value.Normalize();
+                }
+            }
+        }
+        
+        /// <summary>
+        /// The current trigger price
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public decimal? TriggerPrice
+        {
+            get { return _triggerPrice; }
+            set
+            {
+                if (value.HasValue)
+                {
+                    _triggerPrice = value.Value.Normalize();
                 }
             }
         }
@@ -241,6 +258,10 @@ namespace QuantConnect.Orders
             {
                 message += Invariant($" StopPrice: {StopPrice.Value.SmartRounding()}");
             }
+            if (TriggerPrice.HasValue)
+            {
+                message += Invariant($" TriggerPrice: {TriggerPrice.Value.SmartRounding()}");
+            }
 
             // attach the order fee so it ends up in logs properly.
             if (OrderFee.Value.Amount != 0m) message += Invariant($" OrderFee: {OrderFee}");
@@ -277,6 +298,10 @@ namespace QuantConnect.Orders
             if (StopPrice.HasValue)
             {
                 message += Invariant($" SP:{StopPrice.Value.SmartRounding()}");
+            }
+            if (TriggerPrice.HasValue)
+            {
+                message += Invariant($" TP:{TriggerPrice.Value.SmartRounding()}");
             }
 
             // attach the order fee so it ends up in logs properly.

--- a/Common/Orders/OrderField.cs
+++ b/Common/Orders/OrderField.cs
@@ -28,6 +28,11 @@ namespace QuantConnect.Orders
         /// <summary>
         /// The stop price for a <see cref="StopMarketOrder"/> or a <see cref="StopLimitOrder"/>
         /// </summary>
-        StopPrice
+        StopPrice,
+        
+        /// <summary>
+        /// The trigger price for a <see cref="LimitIfTouchedOrder"/>
+        /// </summary>
+        TriggerPrice
     }
 }

--- a/Common/Orders/OrderJsonConverter.cs
+++ b/Common/Orders/OrderJsonConverter.cs
@@ -245,6 +245,14 @@ namespace QuantConnect.Orders
                         StopPrice = jObject["StopPrice"] == null ? default(decimal) : jObject["StopPrice"].Value<decimal>()
                     };
                     break;
+                
+                case OrderType.LimitIfTouched:
+                    order = new LimitIfTouchedOrder
+                    {
+                        LimitPrice = jObject["LimitPrice"] == null ? default(decimal) : jObject["LimitPrice"].Value<decimal>(),
+                        TriggerPrice = jObject["TriggerPrice"] == null ? default(decimal) : jObject["TriggerPrice"].Value<decimal>()
+                    };
+                    break;
 
                 case OrderType.MarketOnOpen:
                     order = new MarketOnOpenOrder();

--- a/Common/Orders/OrderTicket.cs
+++ b/Common/Orders/OrderTicket.cs
@@ -241,6 +241,10 @@ namespace QuantConnect.Orders
                     {
                         return AccessOrder<StopLimitOrder>(this, field, o => o.LimitPrice, r => r.LimitPrice);
                     }
+                    if (_submitRequest.OrderType == OrderType.LimitIfTouched)
+                    {
+                        return AccessOrder<LimitIfTouchedOrder>(this, field, o => o.LimitPrice, r => r.LimitPrice);
+                    }
                     break;
 
                 case OrderField.StopPrice:
@@ -253,6 +257,9 @@ namespace QuantConnect.Orders
                         return AccessOrder<StopMarketOrder>(this, field, o => o.StopPrice, r => r.StopPrice);
                     }
                     break;
+                
+                case OrderField.TriggerPrice:
+                    return AccessOrder<LimitIfTouchedOrder>(this, field, o => o.TriggerPrice, r => r.TriggerPrice);
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(field), field, null);

--- a/Common/Orders/OrderTypes.cs
+++ b/Common/Orders/OrderTypes.cs
@@ -53,7 +53,12 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Option Exercise Order Type
         /// </summary>
-        OptionExercise
+        OptionExercise,
+        
+        /// <summary>
+        ///  Limit if Touched Order Type - a limit order to be placed after first reaching a trigger value.
+        /// </summary>
+        LimitIfTouched
     }
 
     /// <summary>

--- a/Common/Orders/Serialization/SerializedOrder.cs
+++ b/Common/Orders/Serialization/SerializedOrder.cs
@@ -177,11 +177,15 @@ namespace QuantConnect.Orders.Serialization
         public double? TimeInForceExpiry { get; set; }
 
         /// <summary>
+        /// The price which must first be reached before submitting a limit order.
+        /// </summary>
+        public decimal TriggerPrice { get; set; }
+
+        /// <summary>
         /// Empty constructor required for JSON converter.
         /// </summary>
         private SerializedOrder()
         {
-
         }
 
         /// <summary>
@@ -216,7 +220,6 @@ namespace QuantConnect.Orders.Serialization
             {
                 CanceledTime = Time.DateTimeToUnixTimeStamp(order.CanceledTime.Value);
             }
-
             if (order.OrderSubmissionData != null)
             {
                 SubmissionAskPrice = order.OrderSubmissionData.AskPrice;

--- a/Common/Orders/Serialization/SerializedOrder.cs
+++ b/Common/Orders/Serialization/SerializedOrder.cs
@@ -157,6 +157,18 @@ namespace QuantConnect.Orders.Serialization
         /// </summary>
         [JsonProperty("stop-triggered", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool? StopTriggered { get; set; }
+        
+        /// <summary>
+        /// Signal showing the "LimitIfTouchedOrder" has been converted into a Limit Order
+        /// </summary>
+        [JsonProperty("trigger-touched", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool? TriggerTouched { get; set; }
+        
+        /// <summary>
+        /// The price which must first be reached before submitting a limit order.
+        /// </summary>
+        [JsonProperty("trigger-price", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public decimal? TriggerPrice { get; set; }
 
         /// <summary>
         /// The current limit price
@@ -175,12 +187,7 @@ namespace QuantConnect.Orders.Serialization
         /// </summary>
         [JsonProperty("time-in-force-expiry", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public double? TimeInForceExpiry { get; set; }
-
-        /// <summary>
-        /// The price which must first be reached before submitting a limit order.
-        /// </summary>
-        public decimal TriggerPrice { get; set; }
-
+        
         /// <summary>
         /// Empty constructor required for JSON converter.
         /// </summary>
@@ -252,6 +259,13 @@ namespace QuantConnect.Orders.Serialization
             {
                 var stopMarket = order as StopMarketOrder;
                 StopPrice = stopMarket.StopPrice;
+            }
+            else if (order.Type == OrderType.LimitIfTouched)
+            {
+                var limitIfTouched = order as LimitIfTouchedOrder;
+                LimitPrice = limitIfTouched.LimitPrice;
+                TriggerPrice = limitIfTouched.TriggerPrice;
+                TriggerTouched = limitIfTouched.TriggerTouched;
             }
         }
     }

--- a/Common/Orders/SubmitOrderRequest.cs
+++ b/Common/Orders/SubmitOrderRequest.cs
@@ -79,14 +79,13 @@ namespace QuantConnect.Orders
         {
             get; private set;
         }
-        
+
         /// <summary>
         /// Price which must first be reached before a limit order can be submitted.
         /// </summary>
         public decimal TriggerPrice
         {
             get; private set;
-
         }
 
         /// <summary>
@@ -107,11 +106,23 @@ namespace QuantConnect.Orders
         /// <param name="quantity">The number of units to be ordered</param>
         /// <param name="stopPrice">The stop price for stop orders, non-stop orers this value is ignored</param>
         /// <param name="limitPrice">The limit price for limit orders, non-limit orders this value is ignored</param>
+        /// <param name="triggerPrice">The trigger price for limit if touched orders, for non-limit if touched orders this value is ignored</param>
         /// <param name="time">The time this request was created</param>
         /// <param name="tag">A custom tag for this request</param>
         /// <param name="properties">The order properties for this request</param>
-        public SubmitOrderRequest(OrderType orderType, SecurityType securityType, Symbol symbol, decimal quantity, decimal stopPrice, decimal limitPrice, DateTime time, string tag, IOrderProperties properties = null)
-            : base(time, (int)OrderResponseErrorCode.UnableToFindOrder, tag)
+        public SubmitOrderRequest(
+            OrderType orderType,
+            SecurityType securityType,
+            Symbol symbol,
+            decimal quantity,
+            decimal stopPrice,
+            decimal limitPrice,
+            decimal triggerPrice,
+            DateTime time,
+            string tag,
+            IOrderProperties properties = null
+            )
+            : base(time, (int) OrderResponseErrorCode.UnableToFindOrder, tag)
         {
             SecurityType = securityType;
             Symbol = symbol;
@@ -119,7 +130,36 @@ namespace QuantConnect.Orders
             Quantity = quantity;
             LimitPrice = limitPrice;
             StopPrice = stopPrice;
+            TriggerPrice = triggerPrice;
             OrderProperties = properties;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SubmitOrderRequest"/> class.
+        /// The <see cref="OrderRequest.OrderId"/> will default to <see cref="OrderResponseErrorCode.UnableToFindOrder"/>
+        /// </summary>
+        /// <param name="orderType">The order type to be submitted</param>
+        /// <param name="securityType">The symbol's <see cref="SecurityType"/></param>
+        /// <param name="symbol">The symbol to be traded</param>
+        /// <param name="quantity">The number of units to be ordered</param>
+        /// <param name="stopPrice">The stop price for stop orders, non-stop orers this value is ignored</param>
+        /// <param name="limitPrice">The limit price for limit orders, non-limit orders this value is ignored</param>
+        /// <param name="time">The time this request was created</param>
+        /// <param name="tag">A custom tag for this request</param>
+        /// <param name="properties">The order properties for this request</param>
+        public SubmitOrderRequest(
+            OrderType orderType,
+            SecurityType securityType,
+            Symbol symbol,
+            decimal quantity,
+            decimal stopPrice,
+            decimal limitPrice,
+            DateTime time,
+            string tag,
+            IOrderProperties properties = null
+            )
+            : this(orderType, securityType, symbol, quantity, stopPrice, limitPrice, 0, time, tag, properties)
+        {
         }
 
         /// <summary>

--- a/Common/Orders/SubmitOrderRequest.cs
+++ b/Common/Orders/SubmitOrderRequest.cs
@@ -79,6 +79,15 @@ namespace QuantConnect.Orders
         {
             get; private set;
         }
+        
+        /// <summary>
+        /// Price which must first be reached before a limit order can be submitted.
+        /// </summary>
+        public decimal TriggerPrice
+        {
+            get; private set;
+
+        }
 
         /// <summary>
         /// Gets the order properties for this request

--- a/Common/Orders/UpdateOrderFields.cs
+++ b/Common/Orders/UpdateOrderFields.cs
@@ -34,7 +34,12 @@ namespace QuantConnect.Orders
         /// Specify to update the stop price of the order
         /// </summary>
         public decimal? StopPrice { get; set; }
-
+        
+        /// <summary>
+        /// Specify to update the trigger price of the order
+        /// </summary>
+        public decimal? TriggerPrice { get; set; }
+        
         /// <summary>
         /// Specify to update the order's tag
         /// </summary>

--- a/Common/Orders/UpdateOrderRequest.cs
+++ b/Common/Orders/UpdateOrderRequest.cs
@@ -47,6 +47,8 @@ namespace QuantConnect.Orders
         /// </summary>
         public decimal? StopPrice { get; private set; }
 
+        public decimal? TriggerPrice { get; private set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="UpdateOrderRequest"/> class
         /// </summary>

--- a/Common/Orders/UpdateOrderRequest.cs
+++ b/Common/Orders/UpdateOrderRequest.cs
@@ -47,6 +47,9 @@ namespace QuantConnect.Orders
         /// </summary>
         public decimal? StopPrice { get; private set; }
 
+        /// <summary>
+        /// Gets the new trigger price of the order, null to not change the trigger price
+        /// </summary>
         public decimal? TriggerPrice { get; private set; }
 
         /// <summary>
@@ -61,6 +64,7 @@ namespace QuantConnect.Orders
             Quantity = fields.Quantity;
             LimitPrice = fields.LimitPrice;
             StopPrice = fields.StopPrice;
+            TriggerPrice = fields.TriggerPrice;
         }
 
         /// <summary>
@@ -84,6 +88,10 @@ namespace QuantConnect.Orders
             if (StopPrice.HasValue)
             {
                 updates.Add(Invariant($"StopPrice: {StopPrice.Value.SmartRounding()}"));
+            }
+            if (TriggerPrice.HasValue)
+            {
+                updates.Add(Invariant($"TriggerPrice: {TriggerPrice.Value.SmartRounding()}"));
             }
 
             return Invariant($"{Time} UTC: Update Order: ({OrderId}) - {string.Join(", ", updates)} {Tag} Status: {Status}");

--- a/Common/Python/FillModelPythonWrapper.cs
+++ b/Common/Python/FillModelPythonWrapper.cs
@@ -69,6 +69,20 @@ namespace QuantConnect.Python
         }
 
         /// <summary>
+        /// Limit if Touched Fill Model. Return an order event with the fill details.
+        /// </summary>
+        /// <param name="asset">Asset we're trading this order</param>
+        /// <param name="order"><see cref="LimitIfTouchedOrder"/> Order to Check, return filled if true</param>
+        /// <returns>Order fill information detailing the average price and quantity filled.</returns>
+        public OrderEvent LimitIfTouchedFill(Security asset, LimitIfTouchedOrder order)
+        {
+            using (Py.GIL())
+            {
+                return (_model.LimitIfTouchedFill(asset, order) as PyObject).GetAndDispose<OrderEvent>();
+            }
+        }
+
+        /// <summary>
         /// Model the slippage on a market order: fixed percentage of order price
         /// </summary>
         /// <param name="asset">Asset we're trading this order</param>

--- a/Common/Python/FillModelPythonWrapper.cs
+++ b/Common/Python/FillModelPythonWrapper.cs
@@ -74,7 +74,7 @@ namespace QuantConnect.Python
         /// <param name="asset">Asset we're trading this order</param>
         /// <param name="order"><see cref="LimitIfTouchedOrder"/> Order to Check, return filled if true</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
-        public OrderEvent LimitIfTouchedFill(Security asset, LimitIfTouchedOrder order)
+        public override OrderEvent LimitIfTouchedFill(Security asset, LimitIfTouchedOrder order)
         {
             using (Py.GIL())
             {

--- a/Common/Securities/CashBuyingPowerModel.cs
+++ b/Common/Securities/CashBuyingPowerModel.cs
@@ -371,6 +371,10 @@ namespace QuantConnect.Securities
                 case OrderType.StopLimit:
                     orderPrice = ((StopLimitOrder)order).LimitPrice;
                     break;
+                
+                case OrderType.LimitIfTouched:
+                    orderPrice = ((LimitIfTouchedOrder)order).LimitPrice;
+                    break;
             }
 
             return orderPrice;

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -1288,7 +1288,7 @@ namespace QuantConnect.Tests.Algorithm
             algo.Portfolio.SetCash(150000);
 
             var mock = new Mock<ITransactionHandler>();
-            var request = new Mock<SubmitOrderRequest>(null, null, null, null, null, null, null, null, null);
+            var request = new Mock<SubmitOrderRequest>(null, null, null, null, null, null, null, null, null, null);
             mock.Setup(m => m.Process(It.IsAny<OrderRequest>())).Returns(new OrderTicket(null, request.Object));
             mock.Setup(m => m.GetOpenOrders(It.IsAny<Func<Order, bool>>())).Returns(new List<Order>());
             algo.Transactions.SetOrderProcessor(mock.Object);
@@ -1332,13 +1332,17 @@ namespace QuantConnect.Tests.Algorithm
             algo.StopLimitOrder(Symbols.MSFT, 1, 1, 2);
             algo.StopLimitOrder(Symbols.MSFT, 1.0, 1, 2);
             algo.StopLimitOrder(Symbols.MSFT, 1.0m, 1, 2);
+            
+            algo.LimitIfTouchedOrder(Symbols.MSFT, 1, 1, 2);
+            algo.LimitIfTouchedOrder(Symbols.MSFT, 1.0, 1, 2);
+            algo.LimitIfTouchedOrder(Symbols.MSFT, 1.0m, 1, 2);
 
             algo.SetHoldings(Symbols.MSFT, 1);
             algo.SetHoldings(Symbols.MSFT, 1.0);
             algo.SetHoldings(Symbols.MSFT, 1.0m);
             algo.SetHoldings(Symbols.MSFT, 1.0f);
 
-            int expected = 32;
+            int expected = 35;
             Assert.AreEqual(expected, algo.Transactions.LastOrderId);
         }
 

--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersOrderTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersOrderTests.cs
@@ -39,7 +39,8 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
                 new TestCaseData(new MarketOrderTestParameters(Symbols.USDJPY)).SetName("MarketOrder"),
                 new TestCaseData(new LimitOrderTestParameters(Symbols.USDJPY, 10000m, 0.01m)).SetName("LimitOrder"),
                 new TestCaseData(new StopMarketOrderTestParameters(Symbols.USDJPY, 10000m, 0.01m)).SetName("StopMarketOrder"),
-                new TestCaseData(new StopLimitOrderTestParameters(Symbols.USDJPY, 10000m, 0.01m)).SetName("StopLimitOrder")
+                new TestCaseData(new StopLimitOrderTestParameters(Symbols.USDJPY, 10000m, 0.01m)).SetName("StopLimitOrder"),
+                new TestCaseData(new LimitIfTouchedOrderTestParameters(Symbols.USDJPY, 10000m, 0.01m)).SetName("LimitIfTouchedOrder")
             };
         }
 

--- a/Tests/Brokerages/LimitIfTouchedOrderTestParameters.cs
+++ b/Tests/Brokerages/LimitIfTouchedOrderTestParameters.cs
@@ -1,0 +1,97 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Tests.Brokerages
+{
+    public class LimitIfTouchedOrderTestParameters : OrderTestParameters
+    {
+        private readonly decimal _highLimit;
+        private readonly decimal _lowLimit;
+
+        public LimitIfTouchedOrderTestParameters(
+            Symbol symbol,
+            decimal highLimit,
+            decimal lowLimit,
+            IOrderProperties properties = null
+            )
+            : base(symbol, properties)
+        {
+            _highLimit = highLimit;
+            _lowLimit = lowLimit;
+        }
+
+        public override Order CreateShortOrder(decimal quantity)
+        {
+            return new LimitIfTouchedOrder(Symbol, -Math.Abs(quantity), _lowLimit, _highLimit, DateTime.UtcNow,
+                properties: Properties)
+            {
+                OrderSubmissionData = OrderSubmissionData
+            };
+        }
+
+        public override Order CreateLongOrder(decimal quantity)
+        {
+            return new LimitIfTouchedOrder(Symbol, Math.Abs(quantity), _highLimit, _lowLimit, DateTime.UtcNow,
+                properties: Properties)
+            {
+                OrderSubmissionData = OrderSubmissionData
+            };
+        }
+
+        public override bool ModifyOrderToFill(IBrokerage brokerage, Order order, decimal lastMarketPrice)
+        {
+            var stop = (LimitIfTouchedOrder) order;
+            var previousStop = stop.TriggerPrice;
+            if (order.Quantity > 0)
+            {
+                // for buys we need to decrease the trigger price
+                stop.TriggerPrice = Math.Min(stop.TriggerPrice,
+                    Math.Max(stop.TriggerPrice / 2, Math.Round(lastMarketPrice, 2, MidpointRounding.AwayFromZero)));
+
+                //change behaviour for forex type unit tests
+                if (order.SecurityType == SecurityType.Forex || order.SecurityType == SecurityType.Crypto)
+                {
+                    stop.TriggerPrice = Math.Min(stop.TriggerPrice,
+                        Math.Max(stop.TriggerPrice / 2, Math.Round(lastMarketPrice, 4, MidpointRounding.AwayFromZero)));
+                }
+            }
+            else
+            {
+                // for sells we need to increase the trigger price
+                stop.TriggerPrice = Math.Max(stop.TriggerPrice,
+                    Math.Min(stop.TriggerPrice * 2, Math.Round(lastMarketPrice, 2, MidpointRounding.AwayFromZero)));
+
+                //change behaviour for forex type unit tests
+                if (order.SecurityType == SecurityType.Forex || order.SecurityType == SecurityType.Crypto)
+                {
+                    stop.TriggerPrice = Math.Max(stop.TriggerPrice,
+                        Math.Min(stop.TriggerPrice * 2, Math.Round(lastMarketPrice, 4, MidpointRounding.AwayFromZero)));
+                }
+            }
+
+            stop.LimitPrice = stop.TriggerPrice;
+            return stop.TriggerPrice != previousStop;
+        }
+
+        // default trigger limit orders will only be submitted, not filled
+        public override OrderStatus ExpectedStatus => OrderStatus.Submitted;
+
+        public override bool ExpectedCancellationResult => true;
+    }
+}

--- a/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
+++ b/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
@@ -591,6 +591,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             public bool MarketFillWasCalled;
             public bool StopMarketFillWasCalled;
             public bool StopLimitFillWasCalled;
+            public bool LimitIfTouchFillWasCalled;
             public bool LimitFillWasCalled;
             public bool MarketOnOpenFillWasCalled;
             public bool MarketOnCloseFillWasCalled;
@@ -612,6 +613,11 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             {
                 StopLimitFillWasCalled = true;
                 return base.StopLimitFill(asset, order);
+            }
+            public override OrderEvent LimitIfTouchedFill(Security asset, LimitIfTouchedOrder order)
+            {
+                LimitIfTouchFillWasCalled = true;
+                return base.LimitIfTouchedFill(asset, order);
             }
 
             public override OrderEvent LimitFill(Security asset, LimitOrder order)

--- a/Tests/Common/Orders/Fills/EquityFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/EquityFillModelTests.cs
@@ -401,7 +401,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             Assert.AreEqual(OrderStatus.Filled, fill.Status);
         }
         
-                [Test]
+        [Test]
         public void PerformsLimitIfTouchedBuy()
         {
             var model = new EquityFillModel();

--- a/Tests/Common/Orders/Fills/EquityFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/EquityFillModelTests.cs
@@ -329,6 +329,152 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         }
 
         [Test]
+        public void PerformsLimitIfTouchedSell()
+        {
+            var model = new EquityFillModel();
+            var order = new LimitIfTouchedOrder(Symbols.SPY, -100, 101.5m, 105m, Noon);
+            var configTradeBar = CreateTradeBarConfig(Symbols.SPY);
+            var configQuoteBar = new SubscriptionDataConfig(configTradeBar, typeof(QuoteBar));
+            var configProvider = new MockSubscriptionDataConfigProvider(configQuoteBar);
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                configTradeBar,
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+            
+            // Sets price at time zero
+            security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 100m, 100m, 90m, 90m, 100));
+            configProvider.SubscriptionDataConfigs.Add(configTradeBar); 
+
+            var fill = model.Fill(new FillModelParameters(
+                security,
+                order,
+                configProvider,
+                Time.OneHour)).OrderEvent;
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            // Time jump => trigger touched but not limit
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 102m, 103m, 102m, 102m, 100));
+            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
+                new Bar(101m, 102m, 100m, 100m), 100, // Bid bar
+                new Bar(103m, 104m, 102m, 102m), 100) // Ask bar
+            );
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            fill = model.Fill(new FillModelParameters(
+                security,
+                order,
+                configProvider,
+                Time.OneHour)).OrderEvent;
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            // Time jump => limit reached, holdings sold
+            // |---> First, ensure that quote data are not used to fill
+            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
+                    new Bar(103m, 106m, 103m, 105m), 100, // Bid bar
+                    new Bar(103m, 108m, 103m, 105m), 100) // Ask bar
+            );
+            fill = model.LimitIfTouchedFill(security, order);
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+            
+            // |---> Lastly, ensure that price data used to fill
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 103m, 108m, 103m, 105m, 100));
+            fill = model.LimitIfTouchedFill(security, order);
+            Assert.AreEqual(order.Quantity, fill.FillQuantity);
+            Assert.AreEqual(order.LimitPrice, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+        }
+        
+                [Test]
+        public void PerformsLimitIfTouchedBuy()
+        {
+            var model = new EquityFillModel();
+            var order = new LimitIfTouchedOrder(Symbols.SPY, 100, 101.5m, 100m, Noon);
+            var configTradeBar = CreateTradeBarConfig(Symbols.SPY);
+            var configQuoteBar = new SubscriptionDataConfig(configTradeBar, typeof(QuoteBar));
+            var configProvider = new MockSubscriptionDataConfigProvider(configQuoteBar);
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                configTradeBar,
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+            
+            // Sets price at time zero
+            security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 102m, 102m, 102m, 102m, 100));
+            configProvider.SubscriptionDataConfigs.Add(configTradeBar); 
+
+            var fill = model.Fill(new FillModelParameters(
+                security,
+                order,
+                configProvider,
+                Time.OneHour)).OrderEvent;
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            // Time jump => trigger touched but not limit
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 101m, 101m, 100.5m, 101m, 100));
+            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
+                new Bar(101m, 101m, 100.5m, 101m), 100, // Bid bar
+                new Bar(101m, 101m, 100.5m, 101m), 100) // Ask bar
+            );
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            fill = model.Fill(new FillModelParameters(
+                security,
+                order,
+                configProvider,
+                Time.OneHour)).OrderEvent;
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            // Time jump => limit reached, security bought
+            // |---> First, ensure that quote data are not used to fill
+            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
+                    new Bar(100m, 100m, 99m, 99m), 100, // Bid bar
+                    new Bar(100m, 100m, 99m, 99m), 100) // Ask bar
+            );
+            fill = model.LimitIfTouchedFill(security, order);
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+            
+            // |---> Lastly, ensure that price data used to fill
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 100m, 100m, 99m, 99m, 100));
+            fill = model.LimitIfTouchedFill(security, order);
+            Assert.AreEqual(order.Quantity, fill.FillQuantity);
+            Assert.AreEqual(order.LimitPrice, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+        }
+        
+        [Test]
         public void PerformsStopMarketFillSell()
         {
             var model = new EquityFillModel();

--- a/Tests/Common/Orders/Fills/EquityFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/EquityFillModelTests.cs
@@ -382,19 +382,19 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             Assert.AreEqual(0, fill.FillPrice);
             Assert.AreEqual(OrderStatus.None, fill.Status);
 
-            // Time jump => limit reached, holdings sold
-            // |---> First, ensure that quote data are not used to fill
-            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
-                    new Bar(103m, 106m, 103m, 105m), 100, // Bid bar
-                    new Bar(103m, 108m, 103m, 105m), 100) // Ask bar
-            );
+            // Time jump => limit reached, security bought
+            // |---> First, ensure that price data are not used to fill
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 100m, 100m, 99m, 99m, 100));
             fill = model.LimitIfTouchedFill(security, order);
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
             Assert.AreEqual(OrderStatus.None, fill.Status);
             
-            // |---> Lastly, ensure that price data used to fill
-            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 103m, 108m, 103m, 105m, 100));
+            // |---> Lastly, ensure that quote data used to fill
+            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
+                    new Bar(105m, 105m, 105m, 105m), 100, // Bid bar
+                    new Bar(105m, 105m, 105m, 105m), 100) // Ask bar
+            );
             fill = model.LimitIfTouchedFill(security, order);
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
             Assert.AreEqual(order.LimitPrice, fill.FillPrice);
@@ -456,18 +456,18 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             Assert.AreEqual(OrderStatus.None, fill.Status);
 
             // Time jump => limit reached, security bought
-            // |---> First, ensure that quote data are not used to fill
-            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
-                    new Bar(100m, 100m, 99m, 99m), 100, // Bid bar
-                    new Bar(100m, 100m, 99m, 99m), 100) // Ask bar
-            );
+            // |---> First, ensure that price data are not used to fill
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 100m, 100m, 99m, 99m, 100));
             fill = model.LimitIfTouchedFill(security, order);
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
             Assert.AreEqual(OrderStatus.None, fill.Status);
             
-            // |---> Lastly, ensure that price data used to fill
-            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 100m, 100m, 99m, 99m, 100));
+            // |---> Lastly, ensure that quote data used to fill
+            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
+                    new Bar(100m, 100m, 100m, 100m), 100, // Bid bar
+                    new Bar(100m, 100m, 100m, 100m), 100) // Ask bar
+            );
             fill = model.LimitIfTouchedFill(security, order);
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
             Assert.AreEqual(order.LimitPrice, fill.FillPrice);

--- a/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
@@ -354,40 +354,68 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         public void PerformsLimitIfTouchedFillBuy()
         {
             var model = new ImmediateFillModel();
-            var order = new LimitIfTouchedOrder(Symbols.SPY, 100, 101.5m, 101m, Noon);
-            var config = CreateTradeBarConfig(Symbols.SPY);
+            var order = new LimitIfTouchedOrder(Symbols.SPY, 100, 101.5m, 100m, Noon);
+            var configTradeBar = CreateTradeBarConfig(Symbols.SPY);
+            var configQuoteBar = new SubscriptionDataConfig(configTradeBar, typeof(QuoteBar));
+            var configProvider = new MockSubscriptionDataConfigProvider(configQuoteBar);
             var security = new Security(
                 SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
-                config,
+                configTradeBar,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
                 ErrorCurrencyConverter.Instance,
                 RegisteredSecurityDataTypesProvider.Null,
                 new SecurityCache()
             );
+                        // Sets price at time zero
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
-            security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.4m));
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 102m, 102m, 102m, 102m, 100));
+            configProvider.SubscriptionDataConfigs.Add(configTradeBar); 
 
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config),
+                configProvider,
                 Time.OneHour)).OrderEvent;
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
             Assert.AreEqual(OrderStatus.None, fill.Status);
 
-            security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 99.99m));
+            // Time jump => trigger touched but not limit
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 101m, 101m, 100.5m, 101m, 100));
+            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
+                new Bar(101m, 101m, 100.5m, 101m), 100, // Bid bar
+                new Bar(101m, 101m, 100.5m, 101m), 100) // Ask bar
+            );
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
 
             fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config),
+                configProvider,
                 Time.OneHour)).OrderEvent;
 
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            // Time jump => limit reached, holdings sold
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 100m, 100m, 99m, 99m, 100));
+            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
+                    new Bar(100m, 100m, 99m, 99m), 100, // Bid bar
+                    new Bar(100m, 100m, 99m, 99m), 100) // Ask bar
+            );
+
+
+            fill = model.LimitIfTouchedFill(security, order);
+
+            // this fills worst case scenario
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
-            Assert.AreEqual(Math.Max(security.Price, order.LimitPrice), fill.FillPrice);
+            Assert.AreEqual(order.LimitPrice, fill.FillPrice);
             Assert.AreEqual(OrderStatus.Filled, fill.Status);
         }
 
@@ -395,40 +423,69 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         public void PerformsLimitIfTouchedFillSell()
         {
             var model = new ImmediateFillModel();
-            var order = new LimitIfTouchedOrder(Symbols.SPY, -100, 101.5m, 102m, Noon);
-            var config = CreateTradeBarConfig(Symbols.SPY);
+            var order = new LimitIfTouchedOrder(Symbols.SPY, -100, 101.5m, 105m, Noon);
+            var configTradeBar = CreateTradeBarConfig(Symbols.SPY);
+            var configQuoteBar = new SubscriptionDataConfig(configTradeBar, typeof(QuoteBar));
+            var configProvider = new MockSubscriptionDataConfigProvider(configQuoteBar);
             var security = new Security(
                 SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
-                config,
+                configTradeBar,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
                 ErrorCurrencyConverter.Instance,
                 RegisteredSecurityDataTypesProvider.Null,
                 new SecurityCache()
             );
+            
+            // Sets price at time zero
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
-            security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.51m));
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 100m, 100m, 90m, 90m, 100));
+            configProvider.SubscriptionDataConfigs.Add(configTradeBar); 
 
             var fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config),
+                configProvider,
                 Time.OneHour)).OrderEvent;
 
             Assert.AreEqual(0, fill.FillQuantity);
             Assert.AreEqual(0, fill.FillPrice);
             Assert.AreEqual(OrderStatus.None, fill.Status);
 
-            security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102.1m));
+            // Time jump => trigger touched but not limit
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 102m, 103m, 102m, 102m, 100));
+            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
+                new Bar(101m, 102m, 100m, 100m), 100, // Bid bar
+                new Bar(103m, 104m, 102m, 102m), 100) // Ask bar
+            );
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
 
             fill = model.Fill(new FillModelParameters(
                 security,
                 order,
-                new MockSubscriptionDataConfigProvider(config),
+                configProvider,
                 Time.OneHour)).OrderEvent;
 
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            // Time jump => limit reached, holdings sold
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 103m, 108m, 103m, 105m, 100));
+            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
+                    new Bar(103m, 106m, 103m, 105m), 100, // Bid bar
+                    new Bar(103m, 108m, 103m, 105m), 100) // Ask bar
+            );
+
+
+            fill = model.LimitIfTouchedFill(security, order);
+
+            // this fills worst case scenario
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
-            Assert.AreEqual(Math.Min(security.Price, order.LimitPrice), fill.FillPrice);
+            Assert.AreEqual(order.LimitPrice, fill.FillPrice);
             Assert.AreEqual(OrderStatus.Filled, fill.Status);
         }
         

--- a/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
@@ -349,7 +349,152 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             Assert.AreEqual(Math.Min(security.Price, order.StopPrice), fill.FillPrice);
             Assert.AreEqual(OrderStatus.Filled, fill.Status);
         }
+        
+        [Test]
+        public void PerformsLimitIfTouchedFillBuy()
+        {
+            var model = new ImmediateFillModel();
+            var order = new LimitIfTouchedOrder(Symbols.SPY, 100, 101.5m, 100m, Noon);
+            var configTradeBar = CreateTradeBarConfig(Symbols.SPY);
+            var configQuoteBar = new SubscriptionDataConfig(configTradeBar, typeof(QuoteBar));
+            var configProvider = new MockSubscriptionDataConfigProvider(configQuoteBar);
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                configTradeBar,
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+                        // Sets price at time zero
+            security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 102m, 102m, 102m, 102m, 100));
+            configProvider.SubscriptionDataConfigs.Add(configTradeBar); 
 
+            var fill = model.Fill(new FillModelParameters(
+                security,
+                order,
+                configProvider,
+                Time.OneHour)).OrderEvent;
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            // Time jump => trigger touched but not limit
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 101m, 101m, 100.5m, 101m, 100));
+            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
+                new Bar(101m, 101m, 100.5m, 101m), 100, // Bid bar
+                new Bar(101m, 101m, 100.5m, 101m), 100) // Ask bar
+            );
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            fill = model.Fill(new FillModelParameters(
+                security,
+                order,
+                configProvider,
+                Time.OneHour)).OrderEvent;
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            // Time jump => limit reached, security bought
+            // |---> First, ensure that price data are not used to fill
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 100m, 100m, 99m, 99m, 100));
+            fill = model.LimitIfTouchedFill(security, order);
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+            
+            // |---> Lastly, ensure that quote data used to fill
+            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
+                    new Bar(100m, 100m, 99m, 99m), 100, // Bid bar
+                    new Bar(100m, 100m, 99m, 99m), 100) // Ask bar
+            );
+            fill = model.LimitIfTouchedFill(security, order);
+            Assert.AreEqual(order.Quantity, fill.FillQuantity);
+            Assert.AreEqual(order.LimitPrice, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+        }
+
+        [Test]
+        public void PerformsLimitIfTouchedFillSell()
+        {
+            var model = new ImmediateFillModel();
+            var order = new LimitIfTouchedOrder(Symbols.SPY, -100, 101.5m, 105m, Noon);
+            var configTradeBar = CreateTradeBarConfig(Symbols.SPY);
+            var configQuoteBar = new SubscriptionDataConfig(configTradeBar, typeof(QuoteBar));
+            var configProvider = new MockSubscriptionDataConfigProvider(configQuoteBar);
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                configTradeBar,
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+            
+            // Sets price at time zero
+            security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 100m, 100m, 90m, 90m, 100));
+            configProvider.SubscriptionDataConfigs.Add(configTradeBar); 
+
+            var fill = model.Fill(new FillModelParameters(
+                security,
+                order,
+                configProvider,
+                Time.OneHour)).OrderEvent;
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            // Time jump => trigger touched but not limit
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 102m, 103m, 102m, 102m, 100));
+            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
+                new Bar(101m, 102m, 100m, 100m), 100, // Bid bar
+                new Bar(103m, 104m, 102m, 102m), 100) // Ask bar
+            );
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            fill = model.Fill(new FillModelParameters(
+                security,
+                order,
+                configProvider,
+                Time.OneHour)).OrderEvent;
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            // Time jump => limit reached, holdings sold
+            // |---> First, ensure that price data are not used to fill
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 103m, 108m, 103m, 105m, 100));
+            fill = model.LimitIfTouchedFill(security, order);
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+            
+            // |---> Lastly, ensure that quote data used to fill
+            security.SetMarketPrice(new QuoteBar(Noon, Symbols.SPY, 
+                    new Bar(105m, 106m, 103m, 105m), 100, // Bid bar
+                    new Bar(105m, 108m, 103m, 105m), 100) // Ask bar
+            );
+            fill = model.LimitIfTouchedFill(security, order);
+            Assert.AreEqual(order.Quantity, fill.FillQuantity);
+            Assert.AreEqual(order.LimitPrice, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+        }
+        
         [Test]
         public void PerformsMarketOnOpenUsingOpenPrice()
         {

--- a/Tests/Common/Orders/OrderJsonConverterTests.cs
+++ b/Tests/Common/Orders/OrderJsonConverterTests.cs
@@ -129,6 +129,25 @@ namespace QuantConnect.Tests.Common.Orders
             Assert.AreEqual(expected.StopPrice, actual.StopPrice);
             Assert.AreEqual(expected.LimitPrice, actual.LimitPrice);
         }
+        
+        [TestCase(Symbols.SymbolsKey.SPY)]
+        [TestCase(Symbols.SymbolsKey.EURUSD)]
+        [TestCase(Symbols.SymbolsKey.BTCUSD)]
+        public void DeserializesLimitIfTouchedOrder(Symbols.SymbolsKey key)
+        {
+            var expected = new LimitIfTouchedOrder(Symbols.Lookup(key), 100, 210.10m, 200.23m, new DateTime(2015, 11, 23, 17, 15, 37), "now")
+            {
+                Id = 12345,
+                Price = 209.03m,
+                ContingentId = 123456,
+                BrokerId = new List<string> {"727", "54970"}
+            };
+
+            var actual = TestOrderType(expected);
+
+            Assert.AreEqual(expected.TriggerPrice, actual.TriggerPrice);
+            Assert.AreEqual(expected.LimitPrice, actual.LimitPrice);
+        }
 
         [Test]
         public void DeserializesOptionExpireOrder()

--- a/Tests/Common/Orders/OrderTests.cs
+++ b/Tests/Common/Orders/OrderTests.cs
@@ -65,6 +65,15 @@ namespace QuantConnect.Tests.Common.Orders
             var order = new StopMarketOrder(Symbols.SPY, 1m, 123.4567m, DateTime.Today, tag);
             Assert.AreEqual(Invariant($"Stop Price: {order.StopPrice:C}"), order.Tag);
         }
+        
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void LimitIfTouchedOrder_SetsDefaultTag(string tag)
+        {
+            var order = new LimitIfTouchedOrder(Symbols.SPY, 1m, 123.4567m,122.4567m, DateTime.Today, tag);
+            Assert.AreEqual(Invariant($"Trigger Price: {order.TriggerPrice:C} Limit Price: {order.LimitPrice:C}"), order.Tag);
+        }
 
         private static TestCaseData[] GetValueTestParameters()
         {
@@ -144,6 +153,8 @@ namespace QuantConnect.Tests.Common.Orders
                 new ValueTestParameters("EquityLongStopMarketOrder", equity, new StopMarketOrder(Symbols.SPY, quantity, pricePlusDelta, time), quantity*price),
                 new ValueTestParameters("EquityShortStopMarketOrder", equity, new StopMarketOrder(Symbols.SPY, -quantity, pricePlusDelta, time), -quantity*pricePlusDelta),
                 new ValueTestParameters("EquityShortStopMarketOrder", equity, new StopMarketOrder(Symbols.SPY, -quantity, priceMinusDelta, time), -quantity*price),
+                new ValueTestParameters("EquityLongLimitIfTouchedOrder", equity, new LimitIfTouchedOrder(Symbols.SPY, quantity, 1.5m*pricePlusDelta, priceMinusDelta, time), quantity*priceMinusDelta),
+                new ValueTestParameters("EquityShortLimitIfTouchedOrder", equity, new LimitIfTouchedOrder(Symbols.SPY, -quantity, .5m*priceMinusDelta, pricePlusDelta, time), -quantity*pricePlusDelta),
 
                 // forex orders
                 new ValueTestParameters("ForexLongMarketOrder", forex, new MarketOrder(Symbols.EURGBP, quantity, time), quantity*price*forex.QuoteCurrency.ConversionRate),
@@ -156,6 +167,8 @@ namespace QuantConnect.Tests.Common.Orders
                 new ValueTestParameters("ForexLongStopMarketOrder", forex, new StopMarketOrder(Symbols.EURGBP, quantity, pricePlusDelta, time), quantity*price*forex.QuoteCurrency.ConversionRate),
                 new ValueTestParameters("ForexShortStopMarketOrder", forex, new StopMarketOrder(Symbols.EURGBP, -quantity, pricePlusDelta, time), -quantity*pricePlusDelta*forex.QuoteCurrency.ConversionRate),
                 new ValueTestParameters("ForexShortStopMarketOrder", forex, new StopMarketOrder(Symbols.EURGBP, -quantity, priceMinusDelta, time), -quantity*price*forex.QuoteCurrency.ConversionRate),
+                new ValueTestParameters("ForexLongLimitIfTouchedOrder", forex, new LimitIfTouchedOrder(Symbols.EURGBP, quantity,1.5m*priceMinusDelta, priceMinusDelta, time), quantity*priceMinusDelta*forex.QuoteCurrency.ConversionRate),
+                new ValueTestParameters("ForexShortLimitIfTouchedOrder", forex, new LimitIfTouchedOrder(Symbols.EURGBP, -quantity, .5m*pricePlusDelta, pricePlusDelta, time), -quantity*pricePlusDelta*forex.QuoteCurrency.ConversionRate),
 
                 // cfd orders
                 new ValueTestParameters("CfdLongMarketOrder", cfd, new MarketOrder(Symbols.DE10YBEUR, quantity, time), quantity*price*multiplierTimesConversionRate),
@@ -168,6 +181,9 @@ namespace QuantConnect.Tests.Common.Orders
                 new ValueTestParameters("CfdLongStopMarketOrder", cfd, new StopMarketOrder(Symbols.DE10YBEUR, quantity, pricePlusDelta, time), quantity*price*multiplierTimesConversionRate),
                 new ValueTestParameters("CfdShortStopMarketOrder", cfd, new StopMarketOrder(Symbols.DE10YBEUR, -quantity, pricePlusDelta, time), -quantity*pricePlusDelta*multiplierTimesConversionRate),
                 new ValueTestParameters("CfdShortStopMarketOrder", cfd, new StopMarketOrder(Symbols.DE10YBEUR, -quantity, priceMinusDelta, time), -quantity*price*multiplierTimesConversionRate),
+                new ValueTestParameters("CfdShortLimitIfTouchedOrder", cfd, new LimitIfTouchedOrder(Symbols.DE10YBEUR, -quantity, 1.5m*pricePlusDelta, pricePlusDelta, time), -quantity*pricePlusDelta*multiplierTimesConversionRate),
+                new ValueTestParameters("CfdLongLimitIfTouchedOrder", cfd, new LimitIfTouchedOrder(Symbols.DE10YBEUR, quantity,.5m*priceMinusDelta, priceMinusDelta, time), quantity*priceMinusDelta*multiplierTimesConversionRate),
+
 
                 // equity/index option orders
                 new ValueTestParameters("OptionLongMarketOrder", option, new MarketOrder(Symbols.SPY_P_192_Feb19_2016, quantity, time), quantity*price),
@@ -180,6 +196,8 @@ namespace QuantConnect.Tests.Common.Orders
                 new ValueTestParameters("OptionLongStopMarketOrder", option, new StopMarketOrder(Symbols.SPY_P_192_Feb19_2016, quantity, pricePlusDelta, time), quantity*price),
                 new ValueTestParameters("OptionShortStopMarketOrder", option, new StopMarketOrder(Symbols.SPY_P_192_Feb19_2016, -quantity, pricePlusDelta, time), -quantity*pricePlusDelta),
                 new ValueTestParameters("OptionShortStopMarketOrder", option, new StopMarketOrder(Symbols.SPY_P_192_Feb19_2016, -quantity, priceMinusDelta, time), -quantity*price),
+                new ValueTestParameters("OptionShortLimitIfTouchedOrder", option, new LimitIfTouchedOrder(Symbols.SPY_P_192_Feb19_2016, -quantity, 1.5m*pricePlusDelta, pricePlusDelta, time),  -quantity*pricePlusDelta),
+                new ValueTestParameters("OptionLongLimitIfTouchedOrder", option, new LimitIfTouchedOrder(Symbols.SPY_P_192_Feb19_2016, quantity,.5m*priceMinusDelta, priceMinusDelta, time), quantity*priceMinusDelta),
 
                 new ValueTestParameters("OptionExerciseOrderPut", option, new OptionExerciseOrder(Symbols.SPY_P_192_Feb19_2016, quantity, time), quantity*option.Symbol.ID.StrikePrice),
                 new ValueTestParameters("OptionAssignmentOrderPut", option, new OptionExerciseOrder(Symbols.SPY_P_192_Feb19_2016, -quantity, time), -quantity*option.Symbol.ID.StrikePrice),

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BacktestingTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BacktestingTransactionHandlerTests.cs
@@ -61,7 +61,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
             // Creates the order
             var security = _algorithm.Securities[Ticker];
-            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 600, 0, 0, DateTime.Now, "");
+            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 600, 0, 0, 0, DateTime.Now, "");
 
             // Mock the the order processor
             var orderProcessorMock = new Mock<IOrderProcessor>();
@@ -91,8 +91,8 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var security = _algorithm.Securities[Ticker];
             var price = 1.12m;
             security.SetMarketPrice(new Tick(DateTime.UtcNow.AddDays(-1), security.Symbol, price, price, price));
-            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 1000, 0, 0, DateTime.UtcNow, "");
-            var orderRequest2 = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, -1000, 0, 0, DateTime.UtcNow, "");
+            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 1000, 0, 0, 0, DateTime.UtcNow, "");
+            var orderRequest2 = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, -1000, 0, 0, 0, DateTime.UtcNow, "");
             orderRequest.SetOrderId(1);
             orderRequest2.SetOrderId(2);
 
@@ -163,8 +163,8 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
             var price = 1.12m;
             security.SetMarketPrice(new Tick(DateTime.UtcNow.AddDays(-1), security.Symbol, price, price, price));
-            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 1000, 0, 0, DateTime.UtcNow, "");
-            var orderRequest2 = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, -1000, 0, 0, DateTime.UtcNow, "");
+            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 1000, 0, 0, 9, DateTime.UtcNow, "");
+            var orderRequest2 = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, -1000, 0, 0, 9, DateTime.UtcNow, "");
             orderRequest.SetOrderId(1);
             orderRequest2.SetOrderId(2);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Currently there is no implementation of the LimitIfTouchedOrder.
This is an order type where a trigger price is defined along with a limit price for a limit order to be placed upon "touching" the trigger. Specifically, versus a stop limit order, the limit order is placed in the opposite direction with respect the the trigger/stop which is first touched.
e.g.,
For sell orders:
```
      ------------/--------------- Limit price
             /\/\/
         /\/
------/------------------------- Trigger touched => places limit order 
___/
```
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#5162 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
One can only synthetically create a LIT order but never can submit/interact with non-synthetic IBKR LIT orders
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Adds tests under relevant fill model test files.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ x] All new and existing tests passed.
- [ x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
