### PR TITLE
feature-5179-Adds a pre-build event to Toolbox Project to copy config.json from Launcher to Toolbox output directory

### DIFF
--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -168,4 +168,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <Exec Command="if $(ConfigurationName) == Debug copy &quot;$(SolutionDir)\Launcher\config.json&quot; &quot;$(TargetDir)\config.json&quot;&#xD;&#xA;if $(ConfigurationName) == Release copy &quot;$(SolutionDir)\Launcher\config.json&quot; &quot;$(TargetDir)\config.json&quot;" />
+  </Target>
 </Project>


### PR DESCRIPTION
Automatically copy config.json from Lean.Launcher project to output directory of Toolbox

#### Description
Added this to the pre-build event on the Toolbox project 

if $(ConfigurationName) == Debug copy "$(SolutionDir)\Launcher\config.json" "$(TargetDir)\config.json"
if $(ConfigurationName) == Release copy "$(SolutionDir)\Launcher\config.json" "$(TargetDir)\config.json"


#### Related Issue
https://github.com/QuantConnect/Lean/issues/5179

#### Motivation and Context
Easier development

#### Requires Documentation Change
None

#### How Has This Been Tested?
Changed config.json and verified copy in both release and debug mode

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`


