### PR TITLE
Fix universe selection symbol cache removal

### DIFF
--- a/Algorithm.CSharp/UniverseSelectionSymbolCacheRemovalRegressionTest.cs
+++ b/Algorithm.CSharp/UniverseSelectionSymbolCacheRemovalRegressionTest.cs
@@ -1,0 +1,147 @@
+ 
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm reproducing github issue #5191 where the symbol was removed from the cache
+    /// even if a subscription is still present
+    /// </summary>
+    public class UniverseSelectionSymbolCacheRemovalRegressionTest : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private bool _optionWasRemoved;
+        private Symbol _optionContract;
+        private Symbol _equitySymbol;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2014, 06, 05);
+            SetEndDate(2014, 06, 23);
+
+            AddEquity("AAPL", Resolution.Daily);
+            _equitySymbol = AddEquity("TWX", Resolution.Minute).Symbol;
+
+            var contracts = OptionChainProvider.GetOptionContractList(_equitySymbol, UtcTime).ToList();
+
+            var callOptionSymbol = contracts
+                .Where(c => c.ID.OptionRight == OptionRight.Call)
+                .OrderBy(c => c.ID.Date)
+                .First();
+            _optionContract = AddOptionContract(callOptionSymbol).Symbol;
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            var symbol = SymbolCache.GetSymbol("TWX");
+            if (symbol == null)
+            {
+                throw new Exception("Unexpected removal of symbol from cache!");
+            }
+
+            foreach (var dataDelisting in data.Delistings.Where(pair => pair.Value.Type == DelistingType.Delisted))
+            {
+                if (dataDelisting.Key != _optionContract)
+                {
+                    throw new Exception("Unexpected delisting event!");
+                }
+                _optionWasRemoved = true;
+            }
+
+            if (!Portfolio.Invested)
+            {
+                SetHoldings("AAPL", 0.1);
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_optionWasRemoved)
+            {
+                throw new Exception("Option contract was not removed!");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "-3.072%"},
+            {"Drawdown", "0.400%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "-0.162%"},
+            {"Sharpe Ratio", "-2.017"},
+            {"Probabilistic Sharpe Ratio", "23.009%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "-0.024"},
+            {"Beta", "-0.007"},
+            {"Annual Standard Deviation", "0.012"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-4.487"},
+            {"Tracking Error", "0.053"},
+            {"Treynor Ratio", "3.645"},
+            {"Total Fees", "$1.00"},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "-3.347"},
+            {"Return Over Maximum Drawdown", "-8.314"},
+            {"Portfolio Turnover", "0.006"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "112416549"}
+        };
+    }
+}

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -490,12 +490,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         {
                             _internalSubscriptionManager.RemovedSubscriptionRequest(subscription);
                             member.IsTradable = false;
+
+                            // remove symbol mappings for symbols removed from universes // TODO : THIS IS BAD!
+                            // only remove from cache if there is no universe using this data configuration
+                            SymbolCache.TryRemove(member.Symbol);
                         }
                     }
                 }
-
-                // remove symbol mappings for symbols removed from universes // TODO : THIS IS BAD!
-                SymbolCache.TryRemove(member.Symbol);
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Only remove symbol from cache during universe selection if there is no
  other universe using it. Adding regression test reproducing issue

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/5191
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
User experience
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
