### PR TITLE
5052 - Adds missing constructor routing

### DIFF
--- a/Common/Data/Consolidators/RenkoConsolidator.cs
+++ b/Common/Data/Consolidators/RenkoConsolidator.cs
@@ -140,6 +140,7 @@ namespace QuantConnect.Data.Consolidators
             PyObject volumeSelector = null,
             bool evenBars = true
             )
+        : this(barSize, evenBars)
         {
             EpsilonCheck(barSize);
 

--- a/Common/Data/Consolidators/RenkoConsolidator.cs
+++ b/Common/Data/Consolidators/RenkoConsolidator.cs
@@ -134,16 +134,12 @@ namespace QuantConnect.Data.Consolidators
         /// <param name="volumeSelector">Extracts the volume from a data instance. The default value is null which does
         /// not aggregate volume per bar.</param>
         /// <param name="evenBars">When true bar open/close will be a multiple of the barSize</param>
-        public RenkoConsolidator(
-            decimal barSize,
+        public RenkoConsolidator(decimal barSize,
             PyObject selector,
             PyObject volumeSelector = null,
-            bool evenBars = true
-            )
-        : this(barSize, evenBars)
+            bool evenBars = true)
+            : this(barSize, evenBars)
         {
-            EpsilonCheck(barSize);
-
             if (selector != null)
             {
                 if (!selector.TryConvertToDelegate(out _selector))
@@ -169,8 +165,6 @@ namespace QuantConnect.Data.Consolidators
             {
                 _volumeSelector = x => 0;
             }
-
-            _evenBars = evenBars;
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Adds a missing call needed to route the Python constructor to the correct base constructor.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#5052 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
RenkoConsolidatorAlgorithm.py no longer throws a div by zero error
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
RenkoConsolidatorAlgorithm.py passes
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x ] All new and existing tests passed.
- [x ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
