### PR TITLE
Adjust delisting liquidation time

### DIFF
--- a/Algorithm.CSharp/AddOptionContractExpiresRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddOptionContractExpiresRegressionAlgorithm.cs
@@ -158,7 +158,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "112093294"}
+            {"OrderListHash", "-262924291"}
         };
     }
 }

--- a/Algorithm.CSharp/AddRemoveOptionUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddRemoveOptionUniverseRegressionAlgorithm.cs
@@ -210,7 +210,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "7"},
+            {"Total Trades", "6"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
             {"Compounding Annual Return", "0%"},
@@ -229,7 +229,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$4.00"},
+            {"Total Fees", "$6.00"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
@@ -249,7 +249,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-1331137505"}
+            {"OrderListHash", "731140098"}
         };
     }
 }

--- a/Algorithm.CSharp/BacktestingBrokerageRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/BacktestingBrokerageRegressionAlgorithm.cs
@@ -335,7 +335,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-1979829476"}
+            {"OrderListHash", "-1990039314"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateOptionsFilterUniverseAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFilterUniverseAlgorithm.cs
@@ -141,7 +141,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-572432979"}
+            {"OrderListHash", "-91832511"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
@@ -180,7 +180,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "50.0482%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "485511632"}
+            {"OrderListHash", "-695205588"}
         };
     }
 }

--- a/Algorithm.CSharp/DelistedFutureLiquidateRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DelistedFutureLiquidateRegressionAlgorithm.cs
@@ -132,7 +132,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "490786648"}
+            {"OrderListHash", "528208939"}
         };
     }
 }

--- a/Algorithm.CSharp/DelistingEventsAlgorithm.cs
+++ b/Algorithm.CSharp/DelistingEventsAlgorithm.cs
@@ -179,7 +179,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "1708490606"}
+            {"OrderListHash", "-335704027"}
         };
     }
 }

--- a/Algorithm.CSharp/DelistingFutureOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DelistingFutureOptionRegressionAlgorithm.cs
@@ -103,30 +103,30 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "21"},
+            {"Total Trades", "16"},
             {"Average Win", "0.01%"},
             {"Average Loss", "-0.02%"},
-            {"Compounding Annual Return", "-0.136%"},
+            {"Compounding Annual Return", "-0.111%"},
             {"Drawdown", "0.100%"},
-            {"Expectancy", "-0.626"},
-            {"Net Profit", "-0.136%"},
-            {"Sharpe Ratio", "-1.024"},
+            {"Expectancy", "-0.679"},
+            {"Net Profit", "-0.112%"},
+            {"Sharpe Ratio", "-1.052"},
             {"Probabilistic Sharpe Ratio", "0.000%"},
-            {"Loss Rate", "77%"},
-            {"Win Rate", "23%"},
-            {"Profit-Loss Ratio", "0.62"},
+            {"Loss Rate", "80%"},
+            {"Win Rate", "20%"},
+            {"Profit-Loss Ratio", "0.61"},
             {"Alpha", "-0.001"},
-            {"Beta", "0"},
+            {"Beta", "-0.001"},
             {"Annual Standard Deviation", "0.001"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-1.189"},
+            {"Information Ratio", "-1.187"},
             {"Tracking Error", "0.115"},
-            {"Treynor Ratio", "8.638"},
-            {"Total Fees", "$48.10"},
+            {"Treynor Ratio", "1.545"},
+            {"Total Fees", "$37.00"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "-0.118"},
+            {"Sortino Ratio", "-0.128"},
             {"Return Over Maximum Drawdown", "-0.995"},
             {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
@@ -142,7 +142,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "453599139"}
+            {"OrderListHash", "657651179"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionBuySellCallIntradayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionBuySellCallIntradayRegressionAlgorithm.cs
@@ -157,7 +157,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-1127610490"}
+            {"OrderListHash", "79413316"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallITMExpiryRegressionAlgorithm.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;
@@ -127,7 +126,7 @@ namespace QuantConnect.Algorithm.CSharp
 
         private void AssertFutureOptionOrderExercise(OrderEvent orderEvent, Security future, Security optionContract)
         {
-            var expectedLiquidationTimeUtc = new DateTime(2020, 6, 19, 4, 1, 0);
+            var expectedLiquidationTimeUtc = new DateTime(2020, 6, 19, 20, 0, 0);
 
             if (orderEvent.Direction == OrderDirection.Sell && future.Holdings.Quantity != 0)
             {
@@ -242,7 +241,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-1009515759"}
+            {"OrderListHash", "-1947859887"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionCallITMGreeksExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallITMGreeksExpiryRegressionAlgorithm.cs
@@ -199,7 +199,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-67540423"}
+            {"OrderListHash", "1153646593"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallOTMExpiryRegressionAlgorithm.cs
@@ -216,7 +216,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "379995570"}
+            {"OrderListHash", "-1004351165"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionPutITMExpiryRegressionAlgorithm.cs
@@ -127,7 +127,7 @@ namespace QuantConnect.Algorithm.CSharp
 
         private void AssertFutureOptionOrderExercise(OrderEvent orderEvent, Security future, Security optionContract)
         {
-            var expectedLiquidationTimeUtc = new DateTime(2020, 6, 19, 4, 1, 0);
+            var expectedLiquidationTimeUtc = new DateTime(2020, 6, 19, 20, 0, 0);
 
             if (orderEvent.Direction == OrderDirection.Buy && future.Holdings.Quantity != 0)
             {
@@ -242,7 +242,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "1710584858"}
+            {"OrderListHash", "1657883738"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionPutOTMExpiryRegressionAlgorithm.cs
@@ -215,7 +215,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-747396984"}
+            {"OrderListHash", "-49211561"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionShortCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortCallITMExpiryRegressionAlgorithm.cs
@@ -226,7 +226,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "1467339130"}
+            {"OrderListHash", "-120798310"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionShortCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortCallOTMExpiryRegressionAlgorithm.cs
@@ -209,7 +209,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-595968426"}
+            {"OrderListHash", "-404864705"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionShortPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortPutITMExpiryRegressionAlgorithm.cs
@@ -223,7 +223,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-392680695"}
+            {"OrderListHash", "-1218521879"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionShortPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortPutOTMExpiryRegressionAlgorithm.cs
@@ -208,7 +208,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-276404966"}
+            {"OrderListHash", "-2019978457"}
         };
     }
 }

--- a/Algorithm.CSharp/FuturesAndFuturesOptionsExpiryTimeAndLiquidationRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FuturesAndFuturesOptionsExpiryTimeAndLiquidationRegressionAlgorithm.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Algorithm.CSharp
 
         private readonly DateTime _expectedExpiryWarningTime = new DateTime(2020, 6, 19);
         private readonly DateTime _expectedExpiryDelistingTime = new DateTime(2020, 6, 20);
-        private readonly DateTime _expectedLiquidationTime = new DateTime(2020, 6, 19, 0, 1, 0);
+        private readonly DateTime _expectedLiquidationTime = new DateTime(2020, 6, 19, 16, 0, 0);
 
         public override void Initialize()
         {
@@ -192,7 +192,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-674914"}
+            {"OrderListHash", "2109976361"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
@@ -116,7 +116,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-1137535376"}
+            {"OrderListHash", "-2017313615"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionChainConsistencyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionChainConsistencyRegressionAlgorithm.cs
@@ -160,7 +160,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "798403725"}
+            {"OrderListHash", "1393663292"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionExerciseAssignRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExerciseAssignRegressionAlgorithm.cs
@@ -122,18 +122,18 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "6"},
+            {"Total Trades", "4"},
             {"Average Win", "0.30%"},
-            {"Average Loss", "-0.29%"},
-            {"Compounding Annual Return", "-42.950%"},
-            {"Drawdown", "0.800%"},
-            {"Expectancy", "-0.488"},
-            {"Net Profit", "-0.715%"},
+            {"Average Loss", "-0.33%"},
+            {"Compounding Annual Return", "-24.104%"},
+            {"Drawdown", "0.400%"},
+            {"Expectancy", "-0.358"},
+            {"Net Profit", "-0.352%"},
             {"Sharpe Ratio", "0"},
             {"Probabilistic Sharpe Ratio", "0%"},
-            {"Loss Rate", "75%"},
-            {"Win Rate", "25%"},
-            {"Profit-Loss Ratio", "1.05"},
+            {"Loss Rate", "67%"},
+            {"Win Rate", "33%"},
+            {"Profit-Loss Ratio", "0.93"},
             {"Alpha", "0"},
             {"Beta", "0"},
             {"Annual Standard Deviation", "0"},
@@ -141,13 +141,13 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$3.00"},
-            {"Fitness Score", "0.5"},
+            {"Total Fees", "$2.00"},
+            {"Fitness Score", "0.376"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
             {"Sortino Ratio", "79228162514264337593543950335"},
-            {"Return Over Maximum Drawdown", "-62.774"},
-            {"Portfolio Turnover", "1.133"},
+            {"Return Over Maximum Drawdown", "-72.098"},
+            {"Portfolio Turnover", "0.752"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
             {"Total Insights Analysis Completed", "0"},
@@ -161,7 +161,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "-2045296704"}
+            {"OrderListHash", "-1004315474"}
         };
     }
 }

--- a/Algorithm.CSharp/UniverseSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UniverseSelectionRegressionAlgorithm.cs
@@ -211,7 +211,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "225687126"}
+            {"OrderListHash", "1484950465"}
         };
     }
 }

--- a/Algorithm.Python/FutureOptionCallITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionCallITMExpiryRegressionAlgorithm.py
@@ -97,7 +97,7 @@ class FutureOptionCallITMExpiryRegressionAlgorithm(QCAlgorithm):
         self.Log(f"{self.Time} -- {orderEvent.Symbol} :: Price: {self.Securities[orderEvent.Symbol].Holdings.Price} Qty: {self.Securities[orderEvent.Symbol].Holdings.Quantity} Direction: {orderEvent.Direction} Msg: {orderEvent.Message}")
 
     def AssertFutureOptionOrderExercise(self, orderEvent: OrderEvent, future: Security, optionContract: Security):
-        expectedLiquidationTimeUtc = datetime(2020, 6, 19, 4, 1, 0)
+        expectedLiquidationTimeUtc = datetime(2020, 6, 19, 20, 0, 0)
 
         if orderEvent.Direction == OrderDirection.Sell and future.Holdings.Quantity != 0:
             # We expect the contract to have been liquidated immediately

--- a/Algorithm.Python/FutureOptionPutITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionPutITMExpiryRegressionAlgorithm.py
@@ -96,7 +96,7 @@ class FutureOptionPutITMExpiryRegressionAlgorithm(QCAlgorithm):
         self.Log(f"{self.Time} -- {orderEvent.Symbol} :: Price: {self.Securities[orderEvent.Symbol].Holdings.Price} Qty: {self.Securities[orderEvent.Symbol].Holdings.Quantity} Direction: {orderEvent.Direction} Msg: {orderEvent.Message}")
 
     def AssertFutureOptionOrderExercise(self, orderEvent: OrderEvent, future: Security, optionContract: Security):
-        expectedLiquidationTimeUtc = datetime(2020, 6, 19, 4, 1, 0)
+        expectedLiquidationTimeUtc = datetime(2020, 6, 19, 20, 0, 0)
 
         if orderEvent.Direction == OrderDirection.Buy and future.Holdings.Quantity != 0:
             # We expect the contract to have been liquidated immediately

--- a/Algorithm.Python/FuturesAndFuturesOptionsExpiryTimeAndLiquidationRegressionAlgorithm.py
+++ b/Algorithm.Python/FuturesAndFuturesOptionsExpiryTimeAndLiquidationRegressionAlgorithm.py
@@ -17,7 +17,7 @@ class FuturesAndFuturesOptionsExpiryTimeAndLiquidationRegressionAlgorithm(QCAlgo
 
         self.expectedExpiryWarningTime = datetime(2020, 6, 19)
         self.expectedExpiryDelistingTime = datetime(2020, 6, 20)
-        self.expectedLiquidationTime = datetime(2020, 6, 19, 0, 1, 0)
+        self.expectedLiquidationTime = datetime(2020, 6, 19, 16, 0, 0)
 
         self.SetStartDate(2020, 1, 5)
         self.SetEndDate(2020, 12, 1)

--- a/Common/Statistics/Statistics.cs
+++ b/Common/Statistics/Statistics.cs
@@ -442,7 +442,14 @@ namespace QuantConnect.Statistics
         /// <returns>Decimal fraction for annual compounding performance</returns>
         public static decimal CompoundingAnnualPerformance(decimal startingCapital, decimal finalCapital, decimal years)
         {
-            return (years == 0 ? 0d : Math.Pow((double)finalCapital / (double)startingCapital, 1 / (double)years) - 1).SafeDecimalCast();
+            if (years == 0 || startingCapital == 0)
+            {
+                return 0;
+            }
+            var power = 1 / (double)years;
+            var baseNumber = (double)finalCapital / (double)startingCapital;
+            var result = Math.Pow(baseNumber, power) - 1;
+            return result.IsNaNOrInfinity() ? 0 : result.SafeDecimalCast();
         }
 
         /// <summary>

--- a/Engine/DataFeeds/Enumerators/DelistingEventProvider.cs
+++ b/Engine/DataFeeds/Enumerators/DelistingEventProvider.cs
@@ -19,8 +19,6 @@ using System.Collections.Generic;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Market;
-using QuantConnect.Securities.FutureOption;
-using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
 {

--- a/Tests/Common/Data/Auxiliary/DelistingTests.cs
+++ b/Tests/Common/Data/Auxiliary/DelistingTests.cs
@@ -1,0 +1,83 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using NodaTime;
+using NUnit.Framework;
+using QuantConnect.Data.Market;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Common.Data.Auxiliary
+{
+    [TestFixture]
+    public class DelistingTests
+    {
+        [Test]
+        public void AlwaysOpenExchange()
+        {
+            var time = new DateTime(2020, 1, 14);
+            var delisting = new Delisting(Symbols.BTCUSD, time, 10, DelistingType.Warning);
+
+            var liquidationTime = delisting.GetLiquidationTime(SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc));
+
+            Assert.AreEqual(new DateTime(2020, 1, 14, 23, 45, 0), liquidationTime);
+        }
+
+        [TestCase(SecurityType.Equity)]
+        [TestCase(SecurityType.Option)]
+        public void EquityAndOption(SecurityType securityType)
+        {
+            var symbol = Symbols.AAPL;
+            if (securityType == SecurityType.Option)
+            {
+                symbol = Symbols.SPY_C_192_Feb19_2016;
+            }
+            var time = new DateTime(2020, 1, 14);
+            var delisting = new Delisting(symbol, time, 10, DelistingType.Warning);
+
+            var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(delisting.Symbol.ID.Market, delisting.Symbol, delisting.Symbol.SecurityType);
+            var liquidationTime = delisting.GetLiquidationTime(exchangeHours);
+
+            Assert.AreEqual(new DateTime(2020, 1, 14, 15, 45, 0), liquidationTime);
+        }
+
+        [TestCase(SecurityType.FutureOption)]
+        [TestCase(SecurityType.Future)]
+        public void FuturesAndOption(SecurityType securityType)
+        {
+            var time = new DateTime(2020, 1, 14);
+            var symbol = Symbols.Future_CLF19_Jan2019;
+            if (securityType == SecurityType.FutureOption)
+            {
+                symbol = Symbol.CreateOption(symbol, symbol.ID.Market, OptionStyle.American, OptionRight.Call, 1, time);
+            }
+
+            var delisting = new Delisting(symbol, time, 10, DelistingType.Warning);
+
+            var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(delisting.Symbol.ID.Market, delisting.Symbol, delisting.Symbol.SecurityType);
+            var liquidationTime = delisting.GetLiquidationTime(exchangeHours);
+
+            Assert.AreEqual(new DateTime(2020, 1, 14, 16, 45, 0), liquidationTime);
+        }
+
+        [Test]
+        public void ThrowsIfNotDelistingWarning()
+        {
+            var delisting = new Delisting(Symbols.AAPL, DateTime.UtcNow, 19, DelistingType.Delisted);
+            Assert.Throws<ArgumentException>(() => delisting.GetLiquidationTime(SecurityExchangeHours.AlwaysOpen(DateTimeZone.Utc)));
+        }
+    }
+}

--- a/Tests/Python/PythonOptionTests.cs
+++ b/Tests/Python/PythonOptionTests.cs
@@ -96,7 +96,7 @@ namespace QuantConnect.Tests.Python
                     {"Tracking Error", "0"},
                     {"Treynor Ratio", "0"},
                     {"Total Fees", "$2.00"},
-                    {"OrderListHash", "-546310956"}
+                    {"OrderListHash", "1571614294"}
                     },
                     Language.Python,
                     AlgorithmStatus.Completed);
@@ -152,7 +152,7 @@ namespace QuantConnect.Tests.Python
                     {"Mean Population Magnitude", "0%"},
                     {"Rolling Averaged Population Direction", "0%"},
                     {"Rolling Averaged Population Magnitude", "0%"},
-                    {"OrderListHash", "-572432979"}
+                    {"OrderListHash", "-91832511"}
                 },
                 Language.Python,
                 AlgorithmStatus.Completed);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adjust delisting liquidation time to 15 min before market closes.
  Adding unit tests. Updating existing.
- Handle `Statistics.CompoundingAnnualPerformance` invalid calculation
  to avoid exception.
- AlgorithmManager will not handle delisting events in live trading
- Fix bug where due to a split driven liquidation matching delisting
  date a position in the option would remain open. Reproduced by
  `BasicTemplateOptionsFrameworkAlgorithm`

Regression order count explanation:
`AddRemoveOptionUniverseRegressionAlgorithm` option gets removed before it expires at 11:30
`BasicTemplateOptionsFrameworkAlgorithm` option split MOC order got in before the option expiration handling (bug in master)
`OptionExerciseAssignRegressionAlgorithm` since in master is liquidating earlier it would open a new position that also got expired
-The rest of the stats changes are due to exercise happening after in PR
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/5160
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve delisting liquidation modeling
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
