### PR TITLE
OpenInterest Bug Fixes

### DIFF
--- a/Algorithm.CSharp/OptionOpenInterestRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionOpenInterestRegressionAlgorithm.cs
@@ -143,7 +143,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
             {"Sortino Ratio", "79228162514264337593543950335"},
-            {"Return Over Maximum Drawdown", "-254.23"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
             {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},

--- a/Algorithm.CSharp/OptionTimeSliceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionTimeSliceRegressionAlgorithm.cs
@@ -1,0 +1,101 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm to test time slice irregularities when adding options
+    /// after algorithm initialization
+    /// </summary>
+    public class OptionTimeSliceRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _symbol;
+        private DateTime _lastSliceTime = DateTime.MinValue;
+
+        public override void Initialize()
+        {
+            SetStartDate(2014, 6, 6);
+            SetEndDate(2014, 6, 9);
+
+            var aapl = AddEquity("aapl", Resolution.Minute);
+            aapl.SetDataNormalizationMode(DataNormalizationMode.Raw);
+            _symbol = aapl.Symbol;
+        }
+
+        public override void OnData(Slice data)
+        {
+            // Compare our previous slice time to this slice
+            // Because of issues with Delisting data we have to let Auxiliary data pass through GH #5207
+            if (Time.Ticks - _lastSliceTime.Ticks < 1000 && data.Values.Any(x => x.DataType != MarketDataType.Auxiliary))
+            {
+                throw new Exception($"Emitted two slices within 1000 ticks of each other.");
+            }
+
+            // Store our slice time
+            _lastSliceTime = Time;
+
+            var underlyingPrice = Securities[_symbol].Price;
+            var contractSymbol = OptionChainProvider.GetOptionContractList(_symbol, Time)
+                .Where(x => x.ID.StrikePrice - underlyingPrice > 0)
+                .OrderBy(x => x.ID.Date)
+                .FirstOrDefault();
+
+            if (contractSymbol != null)
+            {
+                var contract = AddOptionContract(contractSymbol);
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Information Ratio", "-11.978"},
+            {"OrderListHash", "371857150"}
+        };
+    }
+}
+

--- a/Algorithm.CSharp/OptionTimeSliceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionTimeSliceRegressionAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -28,6 +28,7 @@ namespace QuantConnect.Algorithm.CSharp
     public class OptionTimeSliceRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private Symbol _symbol;
+        private Symbol _optionSymbol;
         private DateTime _lastSliceTime = DateTime.MinValue;
 
         public override void Initialize()
@@ -60,7 +61,15 @@ namespace QuantConnect.Algorithm.CSharp
 
             if (contractSymbol != null)
             {
-                var contract = AddOptionContract(contractSymbol);
+                _optionSymbol = AddOptionContract(contractSymbol).Symbol;
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_optionSymbol == null)
+            {
+                throw new Exception("No option symbol was added!");
             }
         }
 
@@ -93,8 +102,32 @@ namespace QuantConnect.Algorithm.CSharp
             {"Profit-Loss Ratio", "0"},
             {"Alpha", "0"},
             {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
             {"Information Ratio", "-11.978"},
-            {"OrderListHash", "371857150"}
+            {"Tracking Error", "0.011"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
         };
     }
 }

--- a/Algorithm.Python/OptionOpenInterestRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionOpenInterestRegressionAlgorithm.py
@@ -50,7 +50,7 @@ class OptionOpenInterestRegressionAlgorithm(QCAlgorithm):
                        contract.Symbol.ID.OptionRight == OptionRight.Call and \
                        contract.Symbol.ID.Date == datetime(2016, 1, 15):
 
-                        history = self.History(contract.Symbol, timedelta(1))["openinterest"]
+                        history = self.History(OpenInterest, contract.Symbol, timedelta(1))["openinterest"]
                         if len(history.index) == 0 or 0 in history.values:
                             raise ValueError("Regression test failed: open interest history request is empty")
 

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -22,7 +22,6 @@ using NodaTime.TimeZones;
 using QuantConnect.Benchmarks;
 using QuantConnect.Brokerages;
 using QuantConnect.Data;
-using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Notifications;
@@ -46,7 +45,6 @@ using QuantConnect.Algorithm.Framework.Portfolio;
 using QuantConnect.Algorithm.Framework.Risk;
 using QuantConnect.Algorithm.Framework.Selection;
 using QuantConnect.Algorithm.Selection;
-using QuantConnect.Data.Shortable;
 using QuantConnect.Storage;
 
 namespace QuantConnect.Algorithm

--- a/Common/Data/BaseDataRequest.cs
+++ b/Common/Data/BaseDataRequest.cs
@@ -1,0 +1,81 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Data
+{
+    /// <summary>
+    /// Abstract sharing logic for data requests
+    /// </summary>
+    public abstract class BaseDataRequest
+    {
+        private readonly Lazy<DateTime> _localStartTime;
+        private readonly Lazy<DateTime> _localEndTime;
+
+        /// <summary>
+        /// Gets the beginning of the requested time interval in UTC
+        /// </summary>
+        public DateTime StartTimeUtc { get; protected set; }
+
+        /// <summary>
+        /// Gets the end of the requested time interval in UTC
+        /// </summary>
+        public DateTime EndTimeUtc { get; protected set;  }
+
+        /// <summary>
+        /// Gets the <see cref="StartTimeUtc"/> in the security's exchange time zone
+        /// </summary>
+        public DateTime StartTimeLocal => _localStartTime.Value;
+
+        /// <summary>
+        /// Gets the <see cref="EndTimeUtc"/> in the security's exchange time zone
+        /// </summary>
+        public DateTime EndTimeLocal => _localEndTime.Value;
+
+        /// <summary>
+        /// Gets the exchange hours used for processing fill forward requests
+        /// </summary>
+        public SecurityExchangeHours ExchangeHours { get; }
+
+        /// <summary>
+        /// Initializes the base data request
+        /// </summary>
+        /// <param name="startTimeUtc">The start time for this request,</param>
+        /// <param name="endTimeUtc">The start time for this request</param>
+        /// <param name="exchangeHours">The exchange hours for this request</param>
+        /// <param name="tickType">The tick type of this request</param>
+        protected  BaseDataRequest(DateTime startTimeUtc,
+            DateTime endTimeUtc,
+            SecurityExchangeHours exchangeHours,
+            TickType tickType)
+        {
+            StartTimeUtc = startTimeUtc;
+            EndTimeUtc = endTimeUtc;
+            ExchangeHours = exchangeHours;
+
+            // open interest data comes in once a day before market open,
+            // make the subscription start from midnight and use always open exchange
+            if (tickType == TickType.OpenInterest)
+            {
+                ExchangeHours = SecurityExchangeHours.AlwaysOpen(ExchangeHours.TimeZone);
+            }
+
+            _localStartTime = new Lazy<DateTime>(() => StartTimeUtc.ConvertFromUtc(ExchangeHours.TimeZone));
+            _localEndTime = new Lazy<DateTime>(() => EndTimeUtc.ConvertFromUtc(ExchangeHours.TimeZone));
+        }
+    }
+}

--- a/Common/Data/HistoryRequest.cs
+++ b/Common/Data/HistoryRequest.cs
@@ -23,29 +23,14 @@ namespace QuantConnect.Data
     /// <summary>
     /// Represents a request for historical data
     /// </summary>
-    public class HistoryRequest
+    public class HistoryRequest : BaseDataRequest
     {
         private Resolution? _fillForwardResolution;
-
-        /// <summary>
-        /// Gets the start time of the request.
-        /// </summary>
-        public DateTime StartTimeUtc { get; set; }
-
-        /// <summary>
-        /// Gets the end time of the request.
-        /// </summary>
-        public DateTime EndTimeUtc { get; set; }
 
         /// <summary>
         /// Gets the symbol to request data for
         /// </summary>
         public Symbol Symbol { get; set; }
-
-        /// <summary>
-        /// Gets the exchange hours used for processing fill forward requests
-        /// </summary>
-        public SecurityExchangeHours ExchangeHours { get; set; }
 
         /// <summary>
         /// Gets the requested data resolution
@@ -98,7 +83,6 @@ namespace QuantConnect.Data
         /// </summary>
         public DataNormalizationMode DataNormalizationMode { get; set; }
 
-
         /// <summary>
         /// Initializes a new instance of the <see cref="HistoryRequest"/> class from the specified parameters
         /// </summary>
@@ -126,11 +110,9 @@ namespace QuantConnect.Data
             bool isCustomData,
             DataNormalizationMode dataNormalizationMode,
             TickType tickType)
+            : base(startTimeUtc, endTimeUtc, exchangeHours, tickType)
         {
-            StartTimeUtc = startTimeUtc;
-            EndTimeUtc = endTimeUtc;
             Symbol = symbol;
-            ExchangeHours = exchangeHours;
             DataTimeZone = dataTimeZone;
             Resolution = resolution;
             FillForwardResolution = fillForwardResolution;
@@ -149,19 +131,10 @@ namespace QuantConnect.Data
         /// <param name="startTimeUtc">The start time for this request,</param>
         /// <param name="endTimeUtc">The start time for this request</param>
         public HistoryRequest(SubscriptionDataConfig config, SecurityExchangeHours hours, DateTime startTimeUtc, DateTime endTimeUtc)
+            : this(startTimeUtc, endTimeUtc, config.Type, config.Symbol, config.Resolution,
+                hours, config.DataTimeZone, config.FillDataForward ? config.Resolution : (Resolution?)null,
+                config.ExtendedMarketHours, config.IsCustomData, config.DataNormalizationMode, config.TickType)
         {
-            StartTimeUtc = startTimeUtc;
-            EndTimeUtc = endTimeUtc;
-            Symbol = config.Symbol;
-            ExchangeHours = hours;
-            Resolution = config.Resolution;
-            FillForwardResolution = config.FillDataForward ? config.Resolution : (Resolution?) null;
-            IncludeExtendedMarketHours = config.ExtendedMarketHours;
-            DataType = config.Type;
-            IsCustomData = config.IsCustomData;
-            DataNormalizationMode = config.DataNormalizationMode;
-            DataTimeZone = config.DataTimeZone;
-            TickType = config.TickType;
         }
     }
 }

--- a/Common/Data/UniverseSelection/SubscriptionRequest.cs
+++ b/Common/Data/UniverseSelection/SubscriptionRequest.cs
@@ -104,11 +104,7 @@ namespace QuantConnect.Data.UniverseSelection
             Security = security;
             Configuration = configuration;
 
-            // open interest data comes in once a day before market open,
-            // make the subscription start from midnight
-            StartTimeUtc = configuration.TickType == TickType.OpenInterest ?
-                startTimeUtc.ConvertFromUtc(Configuration.ExchangeTimeZone).Date.ConvertToUtc(Configuration.ExchangeTimeZone) :
-                startTimeUtc;
+            StartTimeUtc = startTimeUtc;
 
             EndTimeUtc = endTimeUtc;
 

--- a/Common/Data/UniverseSelection/SubscriptionRequest.cs
+++ b/Common/Data/UniverseSelection/SubscriptionRequest.cs
@@ -22,56 +22,27 @@ namespace QuantConnect.Data.UniverseSelection
     /// <summary>
     /// Defines the parameters required to add a subscription to a data feed.
     /// </summary>
-    public class SubscriptionRequest
+    public class SubscriptionRequest : BaseDataRequest
     {
-        private readonly Lazy<DateTime> _localStartTime;
-        private readonly Lazy<DateTime> _localEndTime;
-
         /// <summary>
         /// Gets true if the subscription is a universe
         /// </summary>
-        public bool IsUniverseSubscription { get; private set; }
+        public bool IsUniverseSubscription { get; }
 
         /// <summary>
         /// Gets the universe this subscription resides in
         /// </summary>
-        public Universe Universe { get; private set; }
+        public Universe Universe { get; }
 
         /// <summary>
         /// Gets the security. This is the destination of data for non-internal subscriptions.
         /// </summary>
-        public Security Security { get; private set; }
+        public Security Security { get; }
 
         /// <summary>
         /// Gets the subscription configuration. This defines how/where to read the data.
         /// </summary>
-        public SubscriptionDataConfig Configuration { get; private set; }
-
-        /// <summary>
-        /// Gets the beginning of the requested time interval in UTC
-        /// </summary>
-        public DateTime StartTimeUtc { get; private set; }
-
-        /// <summary>
-        /// Gets the end of the requested time interval in UTC
-        /// </summary>
-        public DateTime EndTimeUtc { get; private set; }
-
-        /// <summary>
-        /// Gets the <see cref="StartTimeUtc"/> in the security's exchange time zone
-        /// </summary>
-        public DateTime StartTimeLocal
-        {
-            get { return _localStartTime.Value; }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="EndTimeUtc"/> in the security's exchange time zone
-        /// </summary>
-        public DateTime EndTimeLocal
-        {
-            get { return _localEndTime.Value; }
-        }
+        public SubscriptionDataConfig Configuration { get; }
 
         /// <summary>
         /// Gets the tradable days specified by this request, in the security's data time zone
@@ -98,18 +69,19 @@ namespace QuantConnect.Data.UniverseSelection
             SubscriptionDataConfig configuration,
             DateTime startTimeUtc,
             DateTime endTimeUtc)
+            : base(startTimeUtc, endTimeUtc, security.Exchange.Hours, configuration.TickType)
         {
             IsUniverseSubscription = isUniverseSubscription;
             Universe = universe;
             Security = security;
             Configuration = configuration;
 
-            StartTimeUtc = startTimeUtc;
-
-            EndTimeUtc = endTimeUtc;
-
-            _localStartTime = new Lazy<DateTime>(() => StartTimeUtc.ConvertFromUtc(Configuration.ExchangeTimeZone));
-            _localEndTime = new Lazy<DateTime>(() => EndTimeUtc.ConvertFromUtc(Configuration.ExchangeTimeZone));
+            // open interest data comes in once a day before market open,
+            // make the subscription start from midnight and use always open exchange
+            if (Configuration.TickType == TickType.OpenInterest)
+            {
+                StartTimeUtc = StartTimeUtc.ConvertFromUtc(ExchangeHours.TimeZone).Date.ConvertToUtc(ExchangeHours.TimeZone);
+            }
         }
 
         /// <summary>

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -503,7 +503,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     exchangeHours.TimeZone,
                     fillForward,
                     extendedMarketHours,
-                    isInternalFeed,
+                    // if the subscription data types were not provided and the tick type is OpenInterest we make it internal
+                    subscriptionDataTypes == null && tickType == TickType.OpenInterest || isInternalFeed,
                     isCustomData,
                     isFilteredSubscription: isFilteredSubscription,
                     tickType: tickType,

--- a/Engine/DataFeeds/Enumerators/SubscriptionFilterEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/SubscriptionFilterEnumerator.cs
@@ -127,7 +127,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                     try
                     {
                         // Ensure the data time is after subscription start time
-                        if (current.EndTime < _startTime)
+                        if (current.EndTime < _startTime && current.DataType != MarketDataType.Auxiliary)
                         {
                             continue;
                         }

--- a/Engine/DataFeeds/Enumerators/SubscriptionFilterEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/SubscriptionFilterEnumerator.cs
@@ -37,7 +37,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
 
         private readonly bool _liveMode;
         private readonly Security _security;
-        private readonly DateTime _startTime;
         private readonly DateTime _endTime;
         private readonly bool _extendedMarketHours;
         private readonly SecurityExchangeHours _exchangeHours;
@@ -50,17 +49,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// <param name="resultHandler">Result handler reference used to send errors</param>
         /// <param name="enumerator">The source enumerator to be wrapped</param>
         /// <param name="security">The security who's data is being enumerated</param>
-        /// <param name="startTime">The start time of the subscription</param>
         /// <param name="endTime">The end time of the subscription</param>
         /// <param name="extendedMarketHours">True if extended market hours are enabled</param>
         /// <param name="liveMode">True if live mode</param>
         /// <param name="securityExchangeHours">The security exchange hours instance to use</param>
         /// <returns>A new instance of the <see cref="SubscriptionFilterEnumerator"/> class that has had it's <see cref="DataFilterError"/>
         /// event subscribed to to send errors to the result handler</returns>
-        public static SubscriptionFilterEnumerator WrapForDataFeed(IResultHandler resultHandler, IEnumerator<BaseData> enumerator, Security security, DateTime startTime, DateTime endTime, bool extendedMarketHours, bool liveMode,
+        public static SubscriptionFilterEnumerator WrapForDataFeed(IResultHandler resultHandler, IEnumerator<BaseData> enumerator, Security security, DateTime endTime, bool extendedMarketHours, bool liveMode,
             SecurityExchangeHours securityExchangeHours)
         {
-            var filter = new SubscriptionFilterEnumerator(enumerator, security, startTime, endTime, extendedMarketHours, liveMode, securityExchangeHours);
+            var filter = new SubscriptionFilterEnumerator(enumerator, security, endTime, extendedMarketHours, liveMode, securityExchangeHours);
             filter.DataFilterError += (sender, exception) =>
             {
                 Log.Error(exception, "WrapForDataFeed");
@@ -74,17 +72,15 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// </summary>
         /// <param name="enumerator">The source enumerator to be wrapped</param>
         /// <param name="security">The security containing an exchange and data filter</param>
-        /// <param name="startTime">The start time of the subscription</param>
         /// <param name="endTime">The end time of the subscription</param>
         /// <param name="extendedMarketHours">True if extended market hours are enabled</param>
         /// <param name="liveMode">True if live mode</param>
         /// <param name="securityExchangeHours">The security exchange hours instance to use</param>
-        public SubscriptionFilterEnumerator(IEnumerator<BaseData> enumerator, Security security, DateTime startTime, DateTime endTime, bool extendedMarketHours, bool liveMode, SecurityExchangeHours securityExchangeHours)
+        public SubscriptionFilterEnumerator(IEnumerator<BaseData> enumerator, Security security, DateTime endTime, bool extendedMarketHours, bool liveMode, SecurityExchangeHours securityExchangeHours)
         {
             _liveMode = liveMode;
             _enumerator = enumerator;
             _security = security;
-            _startTime = startTime;
             _endTime = endTime;
             _exchangeHours = securityExchangeHours;
             _dataFilter = _security.DataFilter;

--- a/Engine/DataFeeds/Enumerators/SubscriptionFilterEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/SubscriptionFilterEnumerator.cs
@@ -127,6 +127,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                     try
                     {
                         // Ensure the data time is after subscription start time
+                        // We must skip Auxiliary data as it will cause problems with delisting processing GH #5207
                         if (current.EndTime < _startTime && current.DataType != MarketDataType.Auxiliary)
                         {
                             continue;

--- a/Engine/DataFeeds/Enumerators/SubscriptionFilterEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/SubscriptionFilterEnumerator.cs
@@ -127,7 +127,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                     try
                     {
                         // Ensure the data time is after subscription start time
-                        if (current.Time < _startTime)
+                        if (current.EndTime < _startTime)
                         {
                             continue;
                         }

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -211,7 +211,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             // optionally apply exchange/user filters
             if (request.Configuration.IsFilteredSubscription)
             {
-                enumerator = SubscriptionFilterEnumerator.WrapForDataFeed(_resultHandler, enumerator, request.Security, request.StartTimeLocal,
+                enumerator = SubscriptionFilterEnumerator.WrapForDataFeed(_resultHandler, enumerator, request.Security,
                     request.EndTimeLocal, request.Configuration.ExtendedMarketHours, false, request.ExchangeHours);
             }
 

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -211,7 +211,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             // optionally apply exchange/user filters
             if (request.Configuration.IsFilteredSubscription)
             {
-                enumerator = SubscriptionFilterEnumerator.WrapForDataFeed(_resultHandler, enumerator, request.Security, request.StartTimeLocal, request.EndTimeLocal, request.Configuration.ExtendedMarketHours, false);
+                enumerator = SubscriptionFilterEnumerator.WrapForDataFeed(_resultHandler, enumerator, request.Security, request.StartTimeLocal,
+                    request.EndTimeLocal, request.Configuration.ExtendedMarketHours, false, request.ExchangeHours);
             }
 
             return enumerator;

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -211,7 +211,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             // optionally apply exchange/user filters
             if (request.Configuration.IsFilteredSubscription)
             {
-                enumerator = SubscriptionFilterEnumerator.WrapForDataFeed(_resultHandler, enumerator, request.Security, request.EndTimeLocal, request.Configuration.ExtendedMarketHours, false);
+                enumerator = SubscriptionFilterEnumerator.WrapForDataFeed(_resultHandler, enumerator, request.Security, request.StartTimeLocal, request.EndTimeLocal, request.Configuration.ExtendedMarketHours, false);
             }
 
             return enumerator;

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -258,7 +258,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // define market hours and user filters to incoming data
                 if (request.Configuration.IsFilteredSubscription)
                 {
-                    enumerator = new SubscriptionFilterEnumerator(enumerator, request.Security, request.StartTimeLocal, localEndTime, request.Configuration.ExtendedMarketHours, true, request.ExchangeHours);
+                    enumerator = new SubscriptionFilterEnumerator(enumerator, request.Security, localEndTime, request.Configuration.ExtendedMarketHours, true, request.ExchangeHours);
                 }
 
                 // finally, make our subscriptions aware of the frontier of the data feed, prevents future data from spewing into the feed

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -258,7 +258,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // define market hours and user filters to incoming data
                 if (request.Configuration.IsFilteredSubscription)
                 {
-                    enumerator = new SubscriptionFilterEnumerator(enumerator, request.Security, localEndTime, request.Configuration.ExtendedMarketHours, true);
+                    enumerator = new SubscriptionFilterEnumerator(enumerator, request.Security, request.StartTimeLocal, localEndTime, request.Configuration.ExtendedMarketHours, true);
                 }
 
                 // finally, make our subscriptions aware of the frontier of the data feed, prevents future data from spewing into the feed

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -258,7 +258,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // define market hours and user filters to incoming data
                 if (request.Configuration.IsFilteredSubscription)
                 {
-                    enumerator = new SubscriptionFilterEnumerator(enumerator, request.Security, request.StartTimeLocal, localEndTime, request.Configuration.ExtendedMarketHours, true);
+                    enumerator = new SubscriptionFilterEnumerator(enumerator, request.Security, request.StartTimeLocal, localEndTime, request.Configuration.ExtendedMarketHours, true, request.ExchangeHours);
                 }
 
                 // finally, make our subscriptions aware of the frontier of the data feed, prevents future data from spewing into the feed

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -365,11 +365,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         }
                     }
 
-                    // Filter out any data that is before the period start for the subscription
-                    // To deal with OpenInterest data that only comes in once per day, we will check it against the periodStart date
-                    // it will later be filtered based on the start time by the SubscriptionFilterEnumerator which is after the FFEnumerator
-                    if ((_config.TickType != TickType.OpenInterest && instance.EndTime < _periodStart) ||
-                        (_config.TickType == TickType.OpenInterest && instance.EndTime < _periodStart.Date))
+                    if (instance.EndTime < _periodStart)
                     {
                         // keep reading until we get a value on or after the start
                         _previous = instance;

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -366,7 +366,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     }
 
                     // To deal with OpenInterest data that only comes in once per day, we will check it against the periodStart date
-                    if ((_config.TickType == TickType.OpenInterest && instance.EndTime < _periodStart.Date) || instance.EndTime < _periodStart)
+                    if ((_config.TickType == TickType.OpenInterest && instance.EndTime < _periodStart.Date) || 
+                        (_config.TickType != TickType.OpenInterest && instance.EndTime < _periodStart))
                     {
                         // keep reading until we get a value on or after the start
                         _previous = instance;

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -365,9 +365,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         }
                     }
 
+                    // Filter out any data that is before the period start for the subscription
                     // To deal with OpenInterest data that only comes in once per day, we will check it against the periodStart date
-                    if ((_config.TickType == TickType.OpenInterest && instance.EndTime < _periodStart.Date) || 
-                        (_config.TickType != TickType.OpenInterest && instance.EndTime < _periodStart))
+                    // it will later be filtered based on the start time by the SubscriptionFilterEnumerator which is after the FFEnumerator
+                    if ((_config.TickType != TickType.OpenInterest && instance.EndTime < _periodStart) ||
+                        (_config.TickType == TickType.OpenInterest && instance.EndTime < _periodStart.Date))
                     {
                         // keep reading until we get a value on or after the start
                         _previous = instance;

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -365,7 +365,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         }
                     }
 
-                    if (instance.EndTime < _periodStart)
+                    // To deal with OpenInterest data that only comes in once per day, we will check it against the periodStart date
+                    if ((_config.TickType == TickType.OpenInterest && instance.EndTime < _periodStart.Date) || instance.EndTime < _periodStart)
                     {
                         // keep reading until we get a value on or after the start
                         _previous = instance;

--- a/Engine/DataFeeds/TimeSliceFactory.cs
+++ b/Engine/DataFeeds/TimeSliceFactory.cs
@@ -174,7 +174,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 for (var i = 0; i < list.Count; i++)
                 {
                     var baseData = list[i];
-                    if (!packet.Configuration.IsInternalFeed && !(baseData is OpenInterest))
+                    if (!packet.Configuration.IsInternalFeed)
                     {
                         // this is all the data that goes into the algorithm
                         allDataForAlgorithm.Add(baseData);
@@ -253,46 +253,52 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                                     break;
                             }
 
-                            // special handling of options data to build the option chain
-                            if (symbol.SecurityType == SecurityType.Option || symbol.SecurityType == SecurityType.FutureOption)
-                            {
-                                if (optionChains == null)
-                                {
-                                    optionChains = new OptionChains(algorithmTime);
-                                }
-
-                                if (baseData.DataType == MarketDataType.OptionChain)
-                                {
-                                    optionChains[baseData.Symbol] = (OptionChain)baseData;
-                                }
-                                else if (!HandleOptionData(algorithmTime, baseData, optionChains, packet.Security, sliceFuture, optionUnderlyingUpdates))
-                                {
-                                    continue;
-                                }
-                            }
-
-                            // special handling of futures data to build the futures chain
-                            if (symbol.SecurityType == SecurityType.Future)
-                            {
-                                if (futuresChains == null)
-                                {
-                                    futuresChains = new FuturesChains(algorithmTime);
-                                }
-                                if (baseData.DataType == MarketDataType.FuturesChain)
-                                {
-                                    futuresChains[baseData.Symbol] = (FuturesChain)baseData;
-                                }
-                                else if (!HandleFuturesData(algorithmTime, baseData, futuresChains, packet.Security))
-                                {
-                                    continue;
-                                }
-                            }
-
                             // this is data used to update consolidators
                             // do not add it if it is a Suspicious tick
                             if (tick == null || !tick.Suspicious)
                             {
                                 consolidatorUpdate.Add(baseData);
+                            }
+                        }
+
+                        // special handling of options data to build the option chain
+                        if (symbol.SecurityType == SecurityType.Option || symbol.SecurityType == SecurityType.FutureOption)
+                        {
+                            // internal feeds, like open interest, will not create the chain but will update it if it exists
+                            // this is because the open interest could arrive at some closed market hours in which there is no other data and we don't
+                            // want to generate a chain object in this case
+                            if (optionChains == null && !packet.Configuration.IsInternalFeed)
+                            {
+                                optionChains = new OptionChains(algorithmTime);
+                            }
+
+                            if (baseData.DataType == MarketDataType.OptionChain)
+                            {
+                                optionChains[baseData.Symbol] = (OptionChain)baseData;
+                            }
+                            else if (optionChains != null && !HandleOptionData(algorithmTime, baseData, optionChains, packet.Security, sliceFuture, optionUnderlyingUpdates))
+                            {
+                                continue;
+                            }
+                        }
+
+                        // special handling of futures data to build the futures chain
+                        if (symbol.SecurityType == SecurityType.Future)
+                        {
+                            // internal feeds, like open interest, will not create the chain but will update it if it exists
+                            // this is because the open interest could arrive at some closed market hours in which there is no other data and we don't
+                            // want to generate a chain object in this case
+                            if (futuresChains == null && !packet.Configuration.IsInternalFeed)
+                            {
+                                futuresChains = new FuturesChains(algorithmTime);
+                            }
+                            if (baseData.DataType == MarketDataType.FuturesChain)
+                            {
+                                futuresChains[baseData.Symbol] = (FuturesChain)baseData;
+                            }
+                            else if (futuresChains != null && !HandleFuturesData(algorithmTime, baseData, futuresChains, packet.Security))
+                            {
+                                continue;
                             }
                         }
 

--- a/Engine/DataFeeds/TimeSliceFactory.cs
+++ b/Engine/DataFeeds/TimeSliceFactory.cs
@@ -174,7 +174,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 for (var i = 0; i < list.Count; i++)
                 {
                     var baseData = list[i];
-                    if (!packet.Configuration.IsInternalFeed)
+                    if (!packet.Configuration.IsInternalFeed && !(baseData is OpenInterest))
                     {
                         // this is all the data that goes into the algorithm
                         allDataForAlgorithm.Add(baseData);

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -180,7 +180,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             // so to combat this we deliberately filter the results from the data reader to fix these cases
             // which only apply to non-tick data
 
-            reader = new SubscriptionFilterEnumerator(reader, security, startTimeLocal, endTimeLocal, config.ExtendedMarketHours, false, request.ExchangeHours);
+            reader = new SubscriptionFilterEnumerator(reader, security, endTimeLocal, config.ExtendedMarketHours, false, request.ExchangeHours);
             reader = new FilterEnumerator<BaseData>(reader, data =>
             {
                 // allow all ticks

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -180,7 +180,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             // so to combat this we deliberately filter the results from the data reader to fix these cases
             // which only apply to non-tick data
 
-            reader = new SubscriptionFilterEnumerator(reader, security, startTimeLocal, endTimeLocal, config.ExtendedMarketHours, false);
+            reader = new SubscriptionFilterEnumerator(reader, security, startTimeLocal, endTimeLocal, config.ExtendedMarketHours, false, request.ExchangeHours);
             reader = new FilterEnumerator<BaseData>(reader, data =>
             {
                 // allow all ticks

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -180,7 +180,7 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             // so to combat this we deliberately filter the results from the data reader to fix these cases
             // which only apply to non-tick data
 
-            reader = new SubscriptionFilterEnumerator(reader, security, endTimeLocal, config.ExtendedMarketHours, false);
+            reader = new SubscriptionFilterEnumerator(reader, security, startTimeLocal, endTimeLocal, config.ExtendedMarketHours, false);
             reader = new FilterEnumerator<BaseData>(reader, data =>
             {
                 // allow all ticks

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -200,7 +200,6 @@ namespace QuantConnect.Tests.Algorithm
             cacheProvider.DisposeSafely();
         }
 
-
         [Test]
         public void GetLastKnownPriceOfIlliquidAsset_TestData()
         {
@@ -220,6 +219,43 @@ namespace QuantConnect.Tests.Algorithm
             var lastKnownPrice = _algorithm.GetLastKnownPrice(option);
             Assert.IsNotNull(lastKnownPrice);
             Assert.AreEqual(barTime.AddMinutes(1), lastKnownPrice.EndTime);
+        }
+
+        [Test]
+        public void TickResolutionOpenInterestHistoryRequestIsNoFiltered()
+        {
+            _algorithm = new QCAlgorithm();
+            _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(_algorithm));
+            _algorithm.HistoryProvider = new SubscriptionDataReaderHistoryProvider();
+            var dataProvider = new DefaultDataProvider();
+            var zipCacheProvider = new ZipDataCacheProvider(dataProvider);
+            _algorithm.HistoryProvider.Initialize(new HistoryProviderInitializeParameters(
+                null,
+                null,
+                dataProvider,
+                zipCacheProvider,
+                new LocalDiskMapFileProvider(),
+                new LocalDiskFactorFileProvider(),
+                null,
+                false,
+                new DataPermissionManager()));
+            var start = new DateTime(2014, 6, 05);
+            _algorithm.SetStartDate(start);
+            _algorithm.SetDateTime(start.AddDays(2));
+
+            var optionSymbol = Symbol.CreateOption("TWX", Market.USA, OptionStyle.American, OptionRight.Call, 23, new DateTime(2015, 1, 17));
+            var result = _algorithm.History(new[] { optionSymbol }, start, start.AddDays(2), Resolution.Minute, fillForward:false).ToList();
+
+            zipCacheProvider.DisposeSafely();
+            Assert.IsNotEmpty(result);
+
+            var openInterests = result.Select(slice => slice.Get(typeof(OpenInterest)) as DataDictionary<OpenInterest>).Where(dataDictionary => dataDictionary.Count > 0).ToList();
+
+            Assert.AreEqual(2, openInterests.Count);
+            Assert.AreEqual(new DateTime(2014, 06, 05, 6, 32, 0), openInterests[0].Single().Value.Time);
+            Assert.AreEqual(optionSymbol, openInterests[0].Single().Value.Symbol);
+            Assert.AreEqual(new DateTime(2014, 06, 06, 6, 32, 0), openInterests[1].Single().Value.Time);
+            Assert.AreEqual(optionSymbol, openInterests[1].Single().Value.Symbol);
         }
 
         private class TestHistoryProvider : HistoryProviderBase

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -222,7 +222,43 @@ namespace QuantConnect.Tests.Algorithm
         }
 
         [Test]
-        public void TickResolutionOpenInterestHistoryRequestIsNoFiltered()
+        public void TickResolutionOpenInterestHistoryRequestIsNotFilteredWhenRequestedExplicitly()
+        {
+            _algorithm = new QCAlgorithm();
+            _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(_algorithm));
+            _algorithm.HistoryProvider = new SubscriptionDataReaderHistoryProvider();
+            var dataProvider = new DefaultDataProvider();
+            var zipCacheProvider = new ZipDataCacheProvider(dataProvider);
+            _algorithm.HistoryProvider.Initialize(new HistoryProviderInitializeParameters(
+                null,
+                null,
+                dataProvider,
+                zipCacheProvider,
+                new LocalDiskMapFileProvider(),
+                new LocalDiskFactorFileProvider(),
+                null,
+                false,
+                new DataPermissionManager()));
+            var start = new DateTime(2014, 6, 05);
+            _algorithm.SetStartDate(start);
+            _algorithm.SetDateTime(start.AddDays(2));
+
+            _algorithm.UniverseSettings.FillForward = false;
+            var optionSymbol = Symbol.CreateOption("TWX", Market.USA, OptionStyle.American, OptionRight.Call, 23, new DateTime(2015, 1, 17));
+            var openInterests = _algorithm.History<OpenInterest>(optionSymbol, start, start.AddDays(2), Resolution.Minute).ToList();
+
+            zipCacheProvider.DisposeSafely();
+            Assert.IsNotEmpty(openInterests);
+
+            Assert.AreEqual(2, openInterests.Count);
+            Assert.AreEqual(new DateTime(2014, 06, 05, 6, 32, 0), openInterests[0].Time);
+            Assert.AreEqual(optionSymbol, openInterests[0].Symbol);
+            Assert.AreEqual(new DateTime(2014, 06, 06, 6, 32, 0), openInterests[1].Time);
+            Assert.AreEqual(optionSymbol, openInterests[1].Symbol);
+        }
+
+        [Test]
+        public void TickResolutionOpenInterestHistoryRequestIsFilteredByDefault_SingleSymbol()
         {
             _algorithm = new QCAlgorithm();
             _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(_algorithm));
@@ -248,14 +284,48 @@ namespace QuantConnect.Tests.Algorithm
 
             zipCacheProvider.DisposeSafely();
             Assert.IsNotEmpty(result);
+            Assert.IsTrue(result.Any(slice => slice.ContainsKey(optionSymbol)));
 
             var openInterests = result.Select(slice => slice.Get(typeof(OpenInterest)) as DataDictionary<OpenInterest>).Where(dataDictionary => dataDictionary.Count > 0).ToList();
 
-            Assert.AreEqual(2, openInterests.Count);
-            Assert.AreEqual(new DateTime(2014, 06, 05, 6, 32, 0), openInterests[0].Single().Value.Time);
-            Assert.AreEqual(optionSymbol, openInterests[0].Single().Value.Symbol);
-            Assert.AreEqual(new DateTime(2014, 06, 06, 6, 32, 0), openInterests[1].Single().Value.Time);
-            Assert.AreEqual(optionSymbol, openInterests[1].Single().Value.Symbol);
+            Assert.AreEqual(0, openInterests.Count);
+        }
+
+        [Test]
+        public void TickResolutionOpenInterestHistoryRequestIsFilteredByDefault_MultipleSymbols()
+        {
+            _algorithm = new QCAlgorithm();
+            _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(_algorithm));
+            _algorithm.HistoryProvider = new SubscriptionDataReaderHistoryProvider();
+            var dataProvider = new DefaultDataProvider();
+            var zipCacheProvider = new ZipDataCacheProvider(dataProvider);
+            _algorithm.HistoryProvider.Initialize(new HistoryProviderInitializeParameters(
+                null,
+                null,
+                dataProvider,
+                zipCacheProvider,
+                new LocalDiskMapFileProvider(),
+                new LocalDiskFactorFileProvider(),
+                null,
+                false,
+                new DataPermissionManager()));
+            var start = new DateTime(2014, 6, 05);
+            _algorithm.SetStartDate(start);
+            _algorithm.SetDateTime(start.AddDays(2));
+
+            var optionSymbol = Symbol.CreateOption("TWX", Market.USA, OptionStyle.American, OptionRight.Call, 23, new DateTime(2015, 1, 17));
+            var optionSymbol2 = Symbol.CreateOption("AAPL", Market.USA, OptionStyle.American, OptionRight.Call, 500, new DateTime(2015, 1, 17));
+            var result = _algorithm.History(new[] { optionSymbol, optionSymbol2 }, start, start.AddDays(2), Resolution.Minute, fillForward: false).ToList();
+
+            zipCacheProvider.DisposeSafely();
+            Assert.IsNotEmpty(result);
+
+            Assert.IsTrue(result.Any(slice => slice.ContainsKey(optionSymbol)));
+            Assert.IsTrue(result.Any(slice => slice.ContainsKey(optionSymbol2)));
+
+            var openInterests = result.Select(slice => slice.Get(typeof(OpenInterest)) as DataDictionary<OpenInterest>).Where(dataDictionary => dataDictionary.Count > 0).ToList();
+
+            Assert.AreEqual(0, openInterests.Count);
         }
 
         private class TestHistoryProvider : HistoryProviderBase


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- OpenInterest will be added as an internal feed and will not be added by default in history requests
- HistoryRequests and SubscriptionRequest will use AlwaysOpen exchange
  for open interest requests. Adding unit test reproducing the issue
- Adding `BaseDataRequest` to avoid duplication logic.

- `OptionOpenInterestRegressionAlgorithm.cs` stats changed because now they are calculated at a different time, because open interest data points are not being filtered by the exchange hours.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5093 & data requests filtering out valid open interest data points
Related to https://github.com/QuantConnect/Lean/pull/1002/files

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This PR seeks to address some of the complications with Subscription data triggering a second timeslice for one DateTime. 

In the main branch when data is added in OnData() (meaning a timeslice has been emitted) the subscription is set to start +1 Tick after the current algorithm time to offset it from the current slice time, this was introduced in #4879, and was successful for equities because the first piece of data would arrive on the appropriate increment (resolution of the security). The problem with Options though, is we also have data for OpenInterest & Delisting data, and because this data is handled differently then other datatypes, we emit old data that has been filled forward, triggering the bug where we see a TimeSlice + 1 Tick ahead of the last one.

~The filtering of data in this PR seeks to reject datapoints that are before the StartTime, thus stopping the emitting of that datapoint at +1 Tick. Now this caused a problem with the algorithm manager recognizing delistings so we had to let that piece of data through or else automatic option exercise would fail.~ The PR sets OpenInterest so that it never triggers an `OnData` call by itself and will avoid OpenInterest from being filtered by exchange hours

The following is from testing the algorithm in the linked issue to see at what point the exception was triggered and what the contents of the offending TimeSlice were.
```
	LEGEND:
	D - Delisting
	OC - Option Chain
	OI - Open Interest
	PR:
	- 8/6 12AM +1 Tick D
	- 8/7 9:31 + 1 Tick D
	- 8/10 9:31 + 1 Tick D
	- 8/11 9:31 + 1 Tick D
	- 8/12 9:31 + 1 Tick D
	MASTER:
	- 8/6 12AM + 1 Tick D
	- 8/7 9:31 + 1 Tick OC, OI, D
	- 8/10 9:31 + 1 Tick D
	- 8/11 9:31 + 1 Tick OC, OI, D
        - 8/12 9:31 + 1 Tick OC, OI, D
```
As you can see the Option Chain and Open Interest data no longer emits at that time, but as we cannot filter out the delisting without causing more issues it remains.


Other attempts at solutions were made closer to the creation of the subscription but unfortunately due to some limitations in the Datafeed stack its difficult to control a subscriptions start time without a refactor to the subscription process. Because the function that create new subscription for the algo has no say in the startTime (AddSecurity only creates the SubscriptionDataConfig), and the actual creation of the subscription requests with the start time is in multiple places (UserDefinedUniverse, UniverseSelection, DataManager, etc.) There is not a unified way to increment the start time ONLY when the algorithm is already running.


#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
