### PR TITLE
Add missing connection check in IB brokerage GetHistory

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2938,6 +2938,16 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <remarks>For IB history limitations see https://www.interactivebrokers.com/en/software/api/apiguide/tables/historical_data_limitations.htm </remarks>
         public override IEnumerable<BaseData> GetHistory(HistoryRequest request)
         {
+            if (!IsConnected)
+            {
+                OnMessage(
+                    new BrokerageMessageEvent(
+                        BrokerageMessageType.Warning,
+                        "GetHistoryWhenDisconnected",
+                        "History requests cannot be submitted when disconnected."));
+                yield break;
+            }
+
             // skipping universe and canonical symbols
             if (!CanSubscribe(request.Symbol) ||
                 (request.Symbol.ID.SecurityType == SecurityType.Option && request.Symbol.IsCanonical()) ||


### PR DESCRIPTION

#### Description
- Added a missing connection check in IB brokerage `GetHistory()`

#### Related Issue
n/a

#### Motivation and Context
- Prevents algorithm termination with IB error `504 (Not connected)` when history requests are submitted during IB reset times

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Included unit test

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.