### PR TITLE
BaseSetupHandler increase history request period

### DIFF
--- a/Engine/Setup/BaseSetupHandler.cs
+++ b/Engine/Setup/BaseSetupHandler.cs
@@ -72,7 +72,7 @@ namespace QuantConnect.Lean.Engine.Setup
                 var resolution = configs.GetHighestResolution();
                 var startTime = historyRequestFactory.GetStartTimeAlgoTz(
                     cash.ConversionRateSecurity.Symbol,
-                    1,
+                    10,
                     resolution,
                     hours,
                     configToUse.DataTimeZone);


### PR DESCRIPTION
#### Description
Bitfinex exchange may return us an empty result - if we request data for a small time interval during which no trades occurred - for example 1 minute interval - can happen even with most liquid pairs, like "ETHUSD" - would be good to have some time margin  for such scenario. and pump more data to warm up conversion rates

#### Related Issue
NA

#### Motivation and Context
Make sure portfolio evaluation is defined at algo start

#### Requires Documentation Change
NA

#### How Has This Been Tested?
It happened once there was no conversion rates

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
