### PR TITLE
Fix IB future chain being started at reset hours

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2924,19 +2924,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         }
 
         /// <summary>
-        /// Returns whether the time can be advanced or not.
+        /// Returns whether selection can take place or not.
         /// </summary>
-        /// <param name="securityType">The security type</param>
-        /// <returns>true if the time can be advanced</returns>
-        public bool CanAdvanceTime(SecurityType securityType)
+        /// <returns>True if selection can take place</returns>
+        public bool CanPerformSelection()
         {
-            if (securityType == SecurityType.Future)
-            {
-                // we need to call the IB API only for futures
-                return !_ibAutomater.IsWithinScheduledServerResetTimes() && IsConnected;
-            }
-
-            return true;
+            return !_ibAutomater.IsWithinScheduledServerResetTimes() && IsConnected;
         }
 
         /// <summary>

--- a/Common/Interfaces/IDataQueueUniverseProvider.cs
+++ b/Common/Interfaces/IDataQueueUniverseProvider.cs
@@ -33,10 +33,11 @@ namespace QuantConnect.Interfaces
         IEnumerable<Symbol> LookupSymbols(Symbol symbol, bool includeExpired, string securityCurrency = null);
 
         /// <summary>
-        /// Returns whether the time can be advanced or not.
+        /// Returns whether selection can take place or not.
         /// </summary>
-        /// <param name="securityType">The security type</param>
-        /// <returns>true if the time can be advanced</returns>
-        bool CanAdvanceTime(SecurityType securityType);
+        /// <remarks>This is useful to avoid a selection taking place during invalid times, for example IB reset times or when not connected,
+        /// because if allowed selection would fail since IB isn't running and would kill the algorithm</remarks>
+        /// <returns>True if selection can take place</returns>
+        bool CanPerformSelection();
     }
 }

--- a/Engine/DataFeeds/Enumerators/DataQueueFuturesChainUniverseDataCollectionEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/DataQueueFuturesChainUniverseDataCollectionEnumerator.cs
@@ -88,16 +88,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
 
             if (_needNewCurrent)
             {
-                var now = _timeProvider.GetUtcNow();
-                // in live trading, we might be initialized during a period where time might no be allowed to advance
-                // for example during IB reset times, let's skip this case and retry again
-                if (now == default(DateTime))
+                if (!_universeProvider.CanPerformSelection())
                 {
                     Current = null;
                     return true;
                 }
 
-                var localTime = now.RoundDown(_subscriptionRequest.Configuration.Increment)
+                var localTime = _timeProvider.GetUtcNow()
+                    .RoundDown(_subscriptionRequest.Configuration.Increment)
                     .ConvertFromUtc(_subscriptionRequest.Configuration.ExchangeTimeZone);
 
                 // loading the list of futures contracts and converting them into zip entries

--- a/Engine/DataFeeds/Enumerators/DataQueueFuturesChainUniverseDataCollectionEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/DataQueueFuturesChainUniverseDataCollectionEnumerator.cs
@@ -88,8 +88,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
 
             if (_needNewCurrent)
             {
-                var localTime = _timeProvider.GetUtcNow()
-                    .RoundDown(_subscriptionRequest.Configuration.Increment)
+                var now = _timeProvider.GetUtcNow();
+                // in live trading, we might be initialized during a period where time might no be allowed to advance
+                // for example during IB reset times, let's skip this case and retry again
+                if (now == default(DateTime))
+                {
+                    Current = null;
+                    return true;
+                }
+
+                var localTime = now.RoundDown(_subscriptionRequest.Configuration.Increment)
                     .ConvertFromUtc(_subscriptionRequest.Configuration.ExchangeTimeZone);
 
                 // loading the list of futures contracts and converting them into zip entries

--- a/Engine/DataFeeds/Enumerators/DataQueueOptionChainUniverseDataCollectionEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/DataQueueOptionChainUniverseDataCollectionEnumerator.cs
@@ -105,8 +105,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
 
             if (_needNewCurrent)
             {
-                var localTime = _timeProvider.GetUtcNow()
-                    .RoundDown(_subscriptionRequest.Configuration.Increment)
+                var now = _timeProvider.GetUtcNow();
+                // in live trading, we might be initialized during a period where time might no be allowed to advance
+                // for example during IB reset times, let's skip this case and retry again
+                if (now == default(DateTime))
+                {
+                    Current = null;
+                    return true;
+                }
+
+                var localTime = now.RoundDown(_subscriptionRequest.Configuration.Increment)
                     .ConvertFromUtc(_subscriptionRequest.Configuration.ExchangeTimeZone);
 
                 // loading the list of futures contracts and converting them into zip entries

--- a/Engine/DataFeeds/Enumerators/DataQueueOptionChainUniverseDataCollectionEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/DataQueueOptionChainUniverseDataCollectionEnumerator.cs
@@ -105,16 +105,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
 
             if (_needNewCurrent)
             {
-                var now = _timeProvider.GetUtcNow();
-                // in live trading, we might be initialized during a period where time might no be allowed to advance
-                // for example during IB reset times, let's skip this case and retry again
-                if (now == default(DateTime))
+                if (!_universeProvider.CanPerformSelection())
                 {
                     Current = null;
                     return true;
                 }
 
-                var localTime = now.RoundDown(_subscriptionRequest.Configuration.Increment)
+                var localTime = _timeProvider.GetUtcNow()
+                    .RoundDown(_subscriptionRequest.Configuration.Increment)
                     .ConvertFromUtc(_subscriptionRequest.Configuration.ExchangeTimeZone);
 
                 // loading the list of futures contracts and converting them into zip entries

--- a/Engine/DataFeeds/LiveSynchronizer.cs
+++ b/Engine/DataFeeds/LiveSynchronizer.cs
@@ -181,7 +181,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>The <see cref="ITimeProvider"/> to use</returns>
         protected override ITimeProvider GetTimeProvider()
         {
-            return new RealTimeProvider();
+            return RealTimeProvider.Instance;
         }
 
         /// <summary>

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -355,10 +355,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     throw new NotSupportedException("The DataQueueHandler does not support Options.");
                 }
 
-                var timeProvider = new PredicateTimeProvider(_timeProvider,
-                    time => symbolUniverse.CanAdvanceTime(config.SecurityType));
-
-                var enumeratorFactory = new OptionChainUniverseSubscriptionEnumeratorFactory(configure, symbolUniverse, timeProvider);
+                var enumeratorFactory = new OptionChainUniverseSubscriptionEnumeratorFactory(configure, symbolUniverse, _timeProvider);
                 enumerator = enumeratorFactory.CreateEnumerator(request, _dataProvider);
 
                 enumerator = new FrontierAwareEnumerator(enumerator, _frontierTimeProvider, tzOffsetProvider);
@@ -373,10 +370,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     throw new NotSupportedException("The DataQueueHandler does not support Futures.");
                 }
 
-                var timeProvider = new PredicateTimeProvider(_timeProvider,
-                    time => symbolUniverse.CanAdvanceTime(config.SecurityType));
-
-                var enumeratorFactory = new FuturesChainUniverseSubscriptionEnumeratorFactory(symbolUniverse, timeProvider);
+                var enumeratorFactory = new FuturesChainUniverseSubscriptionEnumeratorFactory(symbolUniverse, _timeProvider);
                 enumerator = enumeratorFactory.CreateEnumerator(request, _dataProvider);
 
                 enumerator = new FrontierAwareEnumerator(enumerator, _frontierTimeProvider, tzOffsetProvider);

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/FuturesChainUniverseSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/FuturesChainUniverseSubscriptionEnumeratorFactoryTests.cs
@@ -139,7 +139,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 return _timeProvider.GetUtcNow().Date.Day >= 18 ? _symbolList2 : _symbolList1;
             }
 
-            public bool CanAdvanceTime(SecurityType securityType)
+            public bool CanPerformSelection()
             {
                 return true;
             }

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactoryTests.cs
@@ -263,7 +263,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 return _timeProvider.GetUtcNow().Date.Day >= 20 ? _symbolList2 : _symbolList1;
             }
 
-            public bool CanAdvanceTime(SecurityType securityType)
+            public bool CanPerformSelection()
             {
                 return true;
             }

--- a/Tests/Engine/DataFeeds/FuncDataQueueHandlerUniverseProvider.cs
+++ b/Tests/Engine/DataFeeds/FuncDataQueueHandlerUniverseProvider.cs
@@ -28,24 +28,24 @@ namespace QuantConnect.Tests.Engine.DataFeeds
     public class FuncDataQueueHandlerUniverseProvider : FuncDataQueueHandler, IDataQueueUniverseProvider
     {
         private readonly Func<Symbol, bool, string, IEnumerable<Symbol>> _lookupSymbolsFunction;
-        private readonly Func<SecurityType, bool> _canAdvanceTimeFunction;
+        private readonly Func<bool> _canPerformSelectionFunction;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FuncDataQueueHandlerUniverseProvider"/> class
         /// </summary>
         /// <param name="getNextTicksFunction">The functional implementation for the <see cref="FuncDataQueueHandler.GetNextTicks"/> function</param>
         /// <param name="lookupSymbolsFunction">The functional implementation for the <see cref="IDataQueueUniverseProvider.LookupSymbols"/> function</param>
-        /// <param name="canAdvanceTimeFunction">The functional implementation for the <see cref="IDataQueueUniverseProvider.CanAdvanceTime"/> function</param>
+        /// <param name="canPerformSelectionFunction">The functional implementation for the <see cref="IDataQueueUniverseProvider.CanPerformSelection"/> function</param>
         /// <param name="timeProvider">The time provider instance to use</param>
         public FuncDataQueueHandlerUniverseProvider(
             Func<FuncDataQueueHandler, IEnumerable<BaseData>> getNextTicksFunction,
             Func<Symbol, bool, string, IEnumerable<Symbol>> lookupSymbolsFunction,
-            Func<SecurityType, bool> canAdvanceTimeFunction,
+            Func<bool> canPerformSelectionFunction,
             ITimeProvider timeProvider)
             : base(getNextTicksFunction, timeProvider)
         {
             _lookupSymbolsFunction = lookupSymbolsFunction;
-            _canAdvanceTimeFunction = canAdvanceTimeFunction;
+            _canPerformSelectionFunction = canPerformSelectionFunction;
         }
 
         /// <summary>
@@ -61,13 +61,12 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         }
 
         /// <summary>
-        /// Returns whether the time can be advanced or not.
+        /// Returns whether selection can take place or not.
         /// </summary>
-        /// <param name="securityType">The security type</param>
-        /// <returns>true if the time can be advanced</returns>
-        public bool CanAdvanceTime(SecurityType securityType)
+        /// <returns>True if selection can take place</returns>
+        public bool CanPerformSelection()
         {
-            return _canAdvanceTimeFunction(securityType);
+            return _canPerformSelectionFunction();
         }
     }
 }

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -777,6 +777,36 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Assert.IsTrue(fineWasCalled);
         }
 
+        [TestCase(SecurityType.Future)]
+        [TestCase(SecurityType.Option)]
+        public void AddChainUniverseCanNotAdvanceTime(SecurityType securityType)
+        {
+            _algorithm.UniverseSettings.Resolution = Resolution.Daily;
+            _algorithm.Transactions.SetOrderProcessor(new FakeOrderProcessor());
+            // this reproduces GH issue #5245 where time can not advance and will keep it's default value
+            var feed = RunDataFeed(lookupSymbolsFunction: null, canAdvanceTime: type => false);
+
+            if (securityType == SecurityType.Future)
+            {
+                _algorithm.AddFuture(Futures.Metals.Gold);
+            }
+            else
+            {
+                _algorithm.AddOption("AAPL");
+            }
+            // will add the universe
+            _algorithm.OnEndOfTimeStep();
+            ConsumeBridge(feed, TimeSpan.FromSeconds(2), ts =>
+            {
+                if (ts.UniverseData.Count > 0)
+                {
+                }
+            }, secondsTimeStep: 60 * 60 * 3, // 3 hour time step
+                alwaysInvoke: true);
+
+            Assert.AreNotEqual(AlgorithmStatus.RuntimeError, _algorithm.Status);
+        }
+
         [Test]
         public void ConstituentsUniverse()
         {
@@ -1114,7 +1144,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
 
         private IDataFeed RunDataFeed(Resolution resolution = Resolution.Second, List<string> equities = null, List<string> forex = null, List<string> crypto = null,
-            Func<FuncDataQueueHandler, IEnumerable<BaseData>> getNextTicksFunction = null)
+            Func<FuncDataQueueHandler, IEnumerable<BaseData>> getNextTicksFunction = null,
+            Func<Symbol, bool, string, IEnumerable<Symbol>> lookupSymbolsFunction = null,
+            Func<SecurityType, bool> canAdvanceTime = null)
         {
             _algorithm.SetStartDate(_startDate);
 
@@ -1147,7 +1179,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             // result handler is used due to dependency in SubscriptionDataReader
             var resultHandler = new BacktestingResultHandler();
 
-            _dataQueueHandler = new FuncDataQueueHandler(getNextTicksFunction, _manualTimeProvider);
+            _dataQueueHandler = new FuncDataQueueHandlerUniverseProvider(getNextTicksFunction, lookupSymbolsFunction, canAdvanceTime, _manualTimeProvider);
 
             _feed = new TestableLiveTradingDataFeed(_dataQueueHandler);
             var mapFileProvider = new LocalDiskMapFileProvider();

--- a/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
+++ b/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
@@ -367,13 +367,12 @@ namespace QuantConnect.ToolBox.IQFeed
         }
 
         /// <summary>
-        /// Returns whether the time can be advanced or not.
+        /// Returns whether selection can take place or not.
         /// </summary>
-        /// <param name="securityType">The security type</param>
-        /// <returns>true if the time can be advanced</returns>
-        public bool CanAdvanceTime(SecurityType securityType)
+        /// <returns>True if selection can take place</returns>
+        public bool CanPerformSelection()
         {
-            return _symbolUniverse.CanAdvanceTime(securityType);
+            return _symbolUniverse.CanPerformSelection();
         }
 
         /// <summary>

--- a/ToolBox/IQFeed/IQFeedDataQueueUniverseProvider.cs
+++ b/ToolBox/IQFeed/IQFeedDataQueueUniverseProvider.cs
@@ -198,11 +198,10 @@ namespace QuantConnect.ToolBox.IQFeed
         }
 
         /// <summary>
-        /// Returns whether the time can be advanced or not.
+        /// Returns whether selection can take place or not.
         /// </summary>
-        /// <param name="securityType">The security type</param>
-        /// <returns>true if the time can be advanced</returns>
-        public bool CanAdvanceTime(SecurityType securityType)
+        /// <returns>True if selection can take place</returns>
+        public bool CanPerformSelection()
         {
             return true;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix IB future chain being started at reset hours
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/5245
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Live trading `System.ArgumentOutOfRangeException: Ticks must be between DateTime.MinValue.Ticks and DateTime.MaxValue.Ticks.`
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
