### PR TITLE
Implement Position Groups

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+
+[*.{js,yml,json,config,csproj}]
+indent_size = 2
+
+[*.sh]
+end_of_line = lf

--- a/Algorithm.CSharp/CustomBuyingPowerModelAlgorithm.cs
+++ b/Algorithm.CSharp/CustomBuyingPowerModelAlgorithm.cs
@@ -74,7 +74,11 @@ namespace QuantConnect.Algorithm.CSharp
             public override HasSufficientBuyingPowerForOrderResult HasSufficientBuyingPowerForOrder(
                 HasSufficientBuyingPowerForOrderParameters parameters)
             {
-                return new HasSufficientBuyingPowerForOrderResult(true);
+                // if portfolio doesn't have enough buying power:
+                //     parameters.Insufficient()
+
+                // this model never allows a lack of funds get in the way of buying securities
+                return parameters.Sufficient();
             }
         }
 

--- a/Algorithm/Risk/RiskManagementModelPythonWrapper.cs
+++ b/Algorithm/Risk/RiskManagementModelPythonWrapper.cs
@@ -34,8 +34,7 @@ namespace QuantConnect.Algorithm.Framework.Risk
         /// <param name="model">Model defining how risk is managed</param>
         public RiskManagementModelPythonWrapper(PyObject model)
         {
-            model.ValidateImplementationOf<IRiskManagementModel>();
-            _model = model;
+            _model = model.ValidateImplementationOf<IRiskManagementModel>();
         }
 
         /// <summary>

--- a/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
+++ b/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -108,7 +108,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             // we normalize the target buying power by the leverage so we work in the land of margin
             var targetFinalMarginPercentage = adjustedPercent / security.BuyingPowerModel.GetLeverage(security);
 
-            var positionGroup = algorithm.Portfolio.Positions.CreateDefaultGroup(security);
+            var positionGroup = algorithm.Portfolio.Positions.GetOrCreateDefaultGroup(security);
             var result = positionGroup.BuyingPowerModel.GetMaximumLotsForTargetBuyingPower(
                 algorithm.Portfolio, positionGroup, targetFinalMarginPercentage
             );

--- a/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
+++ b/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
+using QuantConnect.Securities.Positions;
 using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.Algorithm.Framework.Portfolio
@@ -107,8 +108,9 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             // we normalize the target buying power by the leverage so we work in the land of margin
             var targetFinalMarginPercentage = adjustedPercent / security.BuyingPowerModel.GetLeverage(security);
 
-            var result = security.BuyingPowerModel.GetMaximumOrderQuantityForTargetBuyingPower(
-                new GetMaximumOrderQuantityForTargetBuyingPowerParameters(algorithm.Portfolio, security, targetFinalMarginPercentage, silenceNonErrorReasons:true)
+            var positionGroup = algorithm.Portfolio.Positions.CreateDefaultGroup(security);
+            var result = positionGroup.BuyingPowerModel.GetMaximumLotsForTargetBuyingPower(
+                algorithm.Portfolio, positionGroup, targetFinalMarginPercentage
             );
 
             if (result.IsError)
@@ -122,7 +124,8 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
 
             // be sure to back out existing holdings quantity since the buying power model yields
             // the required delta quantity to reach a final target portfolio value for a symbol
-            var quantity = result.Quantity + (returnDeltaQuantity ? 0 : security.Holdings.Quantity);
+            var lotSize = security.SymbolProperties.LotSize;
+            var quantity = result.NumberOfLots * lotSize + (returnDeltaQuantity ? 0 : security.Holdings.Quantity);
 
             return new PortfolioTarget(symbol, quantity);
         }

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -835,6 +835,29 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Discretizes the <paramref name="value"/> to a maximum precision specified by <paramref name="quanta"/>. Quanta
+        /// can be an arbitrary positive number and represents the step size. Consider a quanta equal to 0.15 and rounding
+        /// a value of 1.0. Valid values would be 0.9 (6 quanta) and 1.05 (7 quanta) which would be rounded up to 1.05.
+        /// </summary>
+        /// <param name="value">The value to be rounded by discretization</param>
+        /// <param name="quanta">The maximum precision allowed by the value</param>
+        /// <param name="mode">Specifies how to handle the rounding of half value, defaulting to away from zero.</param>
+        /// <returns></returns>
+        public static decimal DiscretelyRoundBy(this decimal value, decimal quanta, MidpointRounding mode = MidpointRounding.AwayFromZero)
+        {
+            if (quanta == 0m)
+            {
+                return value;
+            }
+
+            // away from zero is the 'common sense' rounding.
+            // +0.5 rounded by 1 yields +1
+            // -0.5 rounded by 1 yields -1
+            var multiplicand = Math.Round(value / quanta, mode);
+            return quanta * multiplicand;
+        }
+
+        /// <summary>
         /// Will truncate the provided decimal, without rounding, to 3 decimal places
         /// </summary>
         /// <param name="value">The value to truncate</param>

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -2700,6 +2700,109 @@ namespace QuantConnect
         public static bool Compare<T>(this ComparisonOperatorTypes op, T arg1, T arg2) where T : IComparable
         {
             return ComparisonOperator.Compare(op, arg1, arg2);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="OrderDirection"/> that corresponds to the specified <paramref name="side"/>
+        /// </summary>
+        /// <param name="side">The position side to be converted</param>
+        /// <returns>The order direction that maps from the provided position side</returns>
+        public static OrderDirection ToOrderDirection(this PositionSide side)
+        {
+            switch (side)
+            {
+                case PositionSide.Short: return OrderDirection.Sell;
+                case PositionSide.None:  return OrderDirection.Hold;
+                case PositionSide.Long:  return OrderDirection.Buy;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(side), side, null);
+            }
+        }
+
+        /// <summary>
+        /// Determines if an order with the specified <paramref name="direction"/> would close a position with the
+        /// specified <paramref name="side"/>
+        /// </summary>
+        /// <param name="direction">The direction of the order, buy/sell</param>
+        /// <param name="side">The side of the position, long/short</param>
+        /// <returns>True if the order direction would close the position, otherwise false</returns>
+        public static bool Closes(this OrderDirection direction, PositionSide side)
+        {
+            switch (side)
+            {
+                case PositionSide.Short:
+                    switch (direction)
+                    {
+                        case OrderDirection.Buy:  return true;
+                        case OrderDirection.Sell: return false;
+                        case OrderDirection.Hold: return false;
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
+                    }
+
+                case PositionSide.Long:
+                    switch (direction)
+                    {
+                        case OrderDirection.Buy:  return false;
+                        case OrderDirection.Sell: return true;
+                        case OrderDirection.Hold: return false;
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
+                    }
+
+                case PositionSide.None:
+                    return false;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(side), side, null);
+            }
+        }
+
+        /// <summary>
+        /// Determines if the two lists are equal, including all items at the same indices.
+        /// </summary>
+        /// <typeparam name="T">The element type</typeparam>
+        /// <param name="left">The left list</param>
+        /// <param name="right">The right list</param>
+        /// <returns>True if the two lists have the same counts and items at each index evaluate as equal</returns>
+        public static bool ListEquals<T>(this IReadOnlyList<T> left, IReadOnlyList<T> right)
+        {
+            var count = left.Count;
+            if (count != right.Count)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                if (!left[i].Equals(right[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Computes a deterministic hash code based on the items in the list. This hash code is dependent on the
+        /// ordering of items.
+        /// </summary>
+        /// <typeparam name="T">The element type</typeparam>
+        /// <param name="list">The list</param>
+        /// <returns>A hash code dependent on the ordering of elements in the list</returns>
+        public static int GetListHashCode<T>(this IReadOnlyList<T> list)
+        {
+            unchecked
+            {
+                var hashCode = 17;
+                for (int i = 0; i < list.Count; i++)
+                {
+                    hashCode += (hashCode * 397) ^ list[i].GetHashCode();
+                }
+
+                return hashCode;
+            }
         }
     }
 }

--- a/Common/Orders/Order.cs
+++ b/Common/Orders/Order.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -23,6 +23,7 @@ using QuantConnect.Interfaces;
 using QuantConnect.Orders.Serialization;
 using QuantConnect.Orders.TimeInForces;
 using QuantConnect.Securities;
+using QuantConnect.Securities.Positions;
 using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.Orders
@@ -232,6 +233,20 @@ namespace QuantConnect.Orders
             BrokerId = new List<string>();
             ContingentId = 0;
             Properties = properties ?? new OrderProperties();
+        }
+
+        /// <summary>
+        /// Creates an enumerable containing each position resulting from executing this order.
+        /// </summary>
+        /// <remarks>
+        /// This is provided in anticipation of a new combo order type that will need to override this method,
+        /// returning a position for each 'leg' of the order.
+        /// </remarks>
+        /// <returns>An enumerable of positions matching the results of executing this order</returns>
+        public virtual IEnumerable<IPosition> CreatePositions(SecurityManager securities)
+        {
+            var security = securities[Symbol];
+            yield return new Position(security, Quantity);
         }
 
         /// <summary>

--- a/Common/Parse.cs
+++ b/Common/Parse.cs
@@ -186,5 +186,29 @@ namespace QuantConnect
         {
             return long.TryParse(input, numberStyle, CultureInfo.InvariantCulture, out value);
         }
+
+        /// <summary>
+        /// Parses the provided value as a an enumeration type <typeparamref name="T"/>
+        /// </summary>
+        public static T Enum<T>(string input, bool ignoreCase = true)
+            where T : struct, IConvertible
+        {
+            T value;
+            if (!TryParse(input, out value, ignoreCase))
+            {
+                throw new ArgumentException($"The provided value ({input}) was not parseable as {typeof(T).Name}");
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Parses the provided value as a an enumeration type <typeparamref name="T"/>
+        /// </summary>
+        public static bool TryParse<T>(string input, out T value, bool ignoreCase = true)
+            where T : struct, IConvertible
+        {
+            return System.Enum.TryParse<T>(input, ignoreCase, out value);
+        }
     }
 }

--- a/Common/Python/BrokerageMessageHandlerPythonWrapper.cs
+++ b/Common/Python/BrokerageMessageHandlerPythonWrapper.cs
@@ -31,9 +31,7 @@ namespace QuantConnect.Python
         /// <param name="model">The python implementation of <see cref="IBrokerageMessageHandler"/></param>
         public BrokerageMessageHandlerPythonWrapper(PyObject model)
         {
-            model.ValidateImplementationOf<IBrokerageMessageHandler>();
-
-            _model = model;
+            _model = model.ValidateImplementationOf<IBrokerageMessageHandler>();
         }
 
         /// <summary>

--- a/Common/Python/BrokerageModelPythonWrapper.cs
+++ b/Common/Python/BrokerageModelPythonWrapper.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *

--- a/Common/Python/BuyingPowerModelPythonWrapper.cs
+++ b/Common/Python/BuyingPowerModelPythonWrapper.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -143,6 +143,43 @@ namespace QuantConnect.Python
             using (Py.GIL())
             {
                 _model.SetLeverage(security, leverage);
+            }
+        }
+
+        /// <summary>
+        /// Gets the margin currently allocated to the specified holding
+        /// </summary>
+        /// <param name="security">The security to compute maintenance margin for</param>
+        /// <returns>The maintenance margin required for the </returns>
+        public decimal GetMaintenanceMargin(Security security)
+        {
+            using (Py.GIL())
+            {
+                return _model.GetMaintenanceMargin(security);
+            }
+        }
+
+        /// <summary>
+        /// The margin that must be held in order to increase the position by the provided quantity
+        /// </summary>
+        public decimal GetInitialMarginRequirement(Security security, decimal quantity)
+        {
+            using (Py.GIL())
+            {
+                return _model.GetInitialMarginRequirement(security, quantity);
+            }
+        }
+
+        /// <summary>
+        /// Gets the total margin required to execute the specified order in units of the account currency including fees
+        /// </summary>
+        /// <param name="parameters">An object containing the portfolio, the security and the order</param>
+        /// <returns>The total margin in terms of the currency quoted in the order</returns>
+        public decimal GetInitialMarginRequiredForOrder(InitialMarginRequiredForOrderParameters parameters)
+        {
+            using (Py.GIL())
+            {
+                return _model.GetInitialMarginRequiredForOrder(parameters);
             }
         }
     }

--- a/Common/Python/BuyingPowerModelPythonWrapper.cs
+++ b/Common/Python/BuyingPowerModelPythonWrapper.cs
@@ -15,7 +15,6 @@
 
 using Python.Runtime;
 using QuantConnect.Securities;
-using System;
 
 namespace QuantConnect.Python
 {
@@ -27,22 +26,12 @@ namespace QuantConnect.Python
         private readonly dynamic _model;
 
         /// <summary>
-        /// Constructor for initialising the <see cref="BuyingPowerModelPythonWrapper"/> class with wrapped <see cref="PyObject"/> object
+        /// Constructor for initializing the <see cref="BuyingPowerModelPythonWrapper"/> class with wrapped <see cref="PyObject"/> object
         /// </summary>
         /// <param name="model">Represents a security's model of buying power</param>
         public BuyingPowerModelPythonWrapper(PyObject model)
         {
-            using (Py.GIL())
-            {
-                foreach (var attributeName in new[] { "GetBuyingPower", "GetMaximumOrderQuantityForDeltaBuyingPower", "GetLeverage", "GetMaximumOrderQuantityForTargetBuyingPower", "GetReservedBuyingPowerForPosition", "HasSufficientBuyingPowerForOrder", "SetLeverage" })
-                {
-                    if (!model.HasAttr(attributeName))
-                    {
-                        throw new NotImplementedException($"IBuyingPowerModel.{attributeName} must be implemented. Please implement this missing method on {model.GetPythonType()}");
-                    }
-                }
-            }
-            _model = model;
+            _model = model.ValidateImplementationOf<IBuyingPowerModel>();
         }
 
         /// <summary>

--- a/Common/Python/BuyingPowerModelPythonWrapper.cs
+++ b/Common/Python/BuyingPowerModelPythonWrapper.cs
@@ -138,24 +138,26 @@ namespace QuantConnect.Python
         /// <summary>
         /// Gets the margin currently allocated to the specified holding
         /// </summary>
-        /// <param name="security">The security to compute maintenance margin for</param>
+        /// <param name="parameters">An object containing the security</param>
         /// <returns>The maintenance margin required for the </returns>
-        public decimal GetMaintenanceMargin(Security security)
+        public MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
         {
             using (Py.GIL())
             {
-                return _model.GetMaintenanceMargin(security);
+                return (_model.GetMaintenanceMargin(parameters) as PyObject)
+                    .GetAndDispose<MaintenanceMargin>();
             }
         }
 
         /// <summary>
         /// The margin that must be held in order to increase the position by the provided quantity
         /// </summary>
-        public decimal GetInitialMarginRequirement(Security security, decimal quantity)
+        public InitialMargin GetInitialMarginRequirement(InitialMarginParameters parameters)
         {
             using (Py.GIL())
             {
-                return _model.GetInitialMarginRequirement(security, quantity);
+                return (_model.GetInitialMarginRequirement(parameters) as PyObject)
+                    .GetAndDispose<InitialMargin>();
             }
         }
 
@@ -164,11 +166,12 @@ namespace QuantConnect.Python
         /// </summary>
         /// <param name="parameters">An object containing the portfolio, the security and the order</param>
         /// <returns>The total margin in terms of the currency quoted in the order</returns>
-        public decimal GetInitialMarginRequiredForOrder(InitialMarginRequiredForOrderParameters parameters)
+        public InitialMargin GetInitialMarginRequiredForOrder(InitialMarginRequiredForOrderParameters parameters)
         {
             using (Py.GIL())
             {
-                return _model.GetInitialMarginRequiredForOrder(parameters);
+                return (_model.GetInitialMarginRequiredForOrder(parameters) as PyObject)
+                    .GetAndDispose<InitialMargin>();
             }
         }
     }

--- a/Common/Python/BuyingPowerModelPythonWrapper.cs
+++ b/Common/Python/BuyingPowerModelPythonWrapper.cs
@@ -139,7 +139,7 @@ namespace QuantConnect.Python
         /// Gets the margin currently allocated to the specified holding
         /// </summary>
         /// <param name="parameters">An object containing the security</param>
-        /// <returns>The maintenance margin required for the </returns>
+        /// <returns>The maintenance margin required for the provided holdings quantity/cost/value</returns>
         public MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
         {
             using (Py.GIL())
@@ -152,6 +152,8 @@ namespace QuantConnect.Python
         /// <summary>
         /// The margin that must be held in order to increase the position by the provided quantity
         /// </summary>
+        /// <param name="parameters">An object containing the security and quantity</param>
+        /// <returns>The initial margin required for the provided security and quantity</returns>
         public InitialMargin GetInitialMarginRequirement(InitialMarginParameters parameters)
         {
             using (Py.GIL())

--- a/Common/Python/PythonWrapper.cs
+++ b/Common/Python/PythonWrapper.cs
@@ -30,9 +30,9 @@ namespace QuantConnect.Python
         /// <summary>
         /// Validates that the specified <see cref="PyObject"/> completely implements the provided interface type
         /// </summary>
-        /// <typeparam name="TInterface">The inteface type</typeparam>
+        /// <typeparam name="TInterface">The interface type</typeparam>
         /// <param name="model">The model implementing the interface type</param>
-        public static void ValidateImplementationOf<TInterface>(this PyObject model)
+        public static PyObject ValidateImplementationOf<TInterface>(this PyObject model)
         {
             if (!typeof(TInterface).IsInterface)
             {
@@ -51,10 +51,15 @@ namespace QuantConnect.Python
                     }
                 }
             }
+
             if (missingMembers.Any())
             {
-                throw new NotImplementedException($"{nameof(TInterface)} must be fully implemented. Missing implementations: {string.Join(", ", missingMembers)}");
+                throw new NotImplementedException($"{nameof(TInterface)} must be fully implemented. Please implement " +
+                    $"these missing methods on {model.GetPythonType()}: {string.Join(", ", missingMembers)}"
+                );
             }
+
+            return model;
         }
     }
 }

--- a/Common/Python/PythonWrapper.cs
+++ b/Common/Python/PythonWrapper.cs
@@ -50,13 +50,13 @@ namespace QuantConnect.Python
                         missingMembers.Add(member.Name);
                     }
                 }
-            }
 
-            if (missingMembers.Any())
-            {
-                throw new NotImplementedException($"{nameof(TInterface)} must be fully implemented. Please implement " +
-                    $"these missing methods on {model.GetPythonType()}: {string.Join(", ", missingMembers)}"
-                );
+                if (missingMembers.Any())
+                {
+                    throw new NotImplementedException($"{nameof(TInterface)} must be fully implemented. Please implement " +
+                        $"these missing methods on {model.GetPythonType()}: {string.Join(", ", missingMembers)}"
+                    );
+                }
             }
 
             return model;

--- a/Common/Securities/BuyingPowerModel.cs
+++ b/Common/Securities/BuyingPowerModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -134,7 +134,7 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <param name="parameters">An object containing the portfolio, the security and the order</param>
         /// <returns>The total margin in terms of the currency quoted in the order</returns>
-        protected virtual decimal GetInitialMarginRequiredForOrder(
+        public virtual decimal GetInitialMarginRequiredForOrder(
             InitialMarginRequiredForOrderParameters parameters)
         {
             //Get the order value from the non-abstract order classes (MarketOrder, LimitOrder, StopMarketOrder)
@@ -156,7 +156,7 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <param name="security">The security to compute maintenance margin for</param>
         /// <returns>The maintenance margin required for the </returns>
-        protected virtual decimal GetMaintenanceMargin(Security security)
+        public virtual decimal GetMaintenanceMargin(Security security)
         {
             return security.Holdings.AbsoluteHoldingsValue * _maintenanceMarginRequirement;
         }
@@ -217,7 +217,9 @@ namespace QuantConnect.Securities
         /// <summary>
         /// The margin that must be held in order to increase the position by the provided quantity
         /// </summary>
-        protected virtual decimal GetInitialMarginRequirement(Security security, decimal quantity)
+        /// <param name="security">The security to compute initial margin for</param>
+        /// <param name="quantity">The change in the contemplated change in shares</param>
+        public virtual decimal GetInitialMarginRequirement(Security security, decimal quantity)
         {
             return security.QuoteCurrency.ConversionRate
                    * security.SymbolProperties.ContractMultiplier

--- a/Common/Securities/BuyingPowerModel.cs
+++ b/Common/Securities/BuyingPowerModel.cs
@@ -155,8 +155,8 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Gets the margin currently allocated to the specified holding
         /// </summary>
-        /// <param name="parameters">An object containing the security</param>
-        /// <returns>The maintenance margin required for the </returns>
+        /// <param name="parameters">An object containing the security and holdings quantity/cost/value</param>
+        /// <returns>The maintenance margin required for the provided holdings quantity/cost/value</returns>
         public virtual MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
         {
             return parameters.AbsoluteHoldingsValue * _maintenanceMarginRequirement;
@@ -219,6 +219,7 @@ namespace QuantConnect.Securities
         /// The margin that must be held in order to increase the position by the provided quantity
         /// </summary>
         /// <param name="parameters">An object containing the security and quantity of shares</param>
+        /// <returns>The initial margin required for the provided security and quantity</returns>
         public virtual InitialMargin GetInitialMarginRequirement(InitialMarginParameters parameters)
         {
             var security = parameters.Security;

--- a/Common/Securities/BuyingPowerModel.cs
+++ b/Common/Securities/BuyingPowerModel.cs
@@ -159,8 +159,7 @@ namespace QuantConnect.Securities
         /// <returns>The maintenance margin required for the </returns>
         public virtual MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
         {
-            var security = parameters.Security;
-            return security.Holdings.AbsoluteHoldingsValue * _maintenanceMarginRequirement;
+            return parameters.AbsoluteHoldingsValue * _maintenanceMarginRequirement;
         }
 
         /// <summary>

--- a/Common/Securities/BuyingPowerModelExtensions.cs
+++ b/Common/Securities/BuyingPowerModelExtensions.cs
@@ -96,5 +96,49 @@ namespace QuantConnect.Securities
             // existing implementations assume certain non-account currency units, so return raw value
             return buyingPower.Value;
         }
+
+        /// <summary>
+        /// Gets the margin currently allocated to the specified holding
+        /// </summary>
+        /// <param name="model">The buying power model</param>
+        /// <param name="security">The security</param>
+        /// <returns>The maintenance margin required for the </returns>
+        public static decimal GetMaintenanceMargin(this IBuyingPowerModel model, Security security)
+        {
+            return model.GetMaintenanceMargin(new MaintenanceMarginParameters(security));
+        }
+
+        /// <summary>
+        /// Gets the margin currently allocated to the specified holding
+        /// </summary>
+        /// <param name="model">The buying power model</param>
+        /// <param name="security">The security</param>
+        /// <param name="quantity">The quantity of shares</param>
+        /// <returns>The maintenance margin required for the </returns>
+        public static decimal GetInitialMarginRequirement(this IBuyingPowerModel model, Security security, decimal quantity)
+        {
+            return model.GetInitialMarginRequirement(new InitialMarginParameters(security, quantity));
+        }
+
+        /// <summary>
+        /// Gets the total margin required to execute the specified order in units of the account currency including fees
+        /// </summary>
+        /// <param name="model">The buying power model</param>
+        /// <param name="currencyConverter">The currency converter used for converting asset values into the algorithm's
+        /// account currency. Common value is the portfolio's cashbook property: <see cref="SecurityPortfolioManager.CashBook"/></param>
+        /// <param name="security">The security</param>
+        /// <param name="order">The order being contemplated</param>
+        /// <returns>The total margin in terms of the currency quoted in the order</returns>
+        public static decimal GetInitialMarginRequiredForOrder(
+            this IBuyingPowerModel model,
+            ICurrencyConverter currencyConverter,
+            Security security,
+            Order order
+            )
+        {
+            return model.GetInitialMarginRequiredForOrder(new InitialMarginRequiredForOrderParameters(
+                currencyConverter, security, order
+            ));
+        }
     }
 }

--- a/Common/Securities/BuyingPowerModelExtensions.cs
+++ b/Common/Securities/BuyingPowerModelExtensions.cs
@@ -105,7 +105,7 @@ namespace QuantConnect.Securities
         /// <returns>The maintenance margin required for the </returns>
         public static decimal GetMaintenanceMargin(this IBuyingPowerModel model, Security security)
         {
-            return model.GetMaintenanceMargin(new MaintenanceMarginParameters(security));
+            return model.GetMaintenanceMargin(MaintenanceMarginParameters.ForCurrentHoldings(security));
         }
 
         /// <summary>

--- a/Common/Securities/BuyingPowerModelExtensions.cs
+++ b/Common/Securities/BuyingPowerModelExtensions.cs
@@ -102,7 +102,7 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <param name="model">The buying power model</param>
         /// <param name="security">The security</param>
-        /// <returns>The maintenance margin required for the </returns>
+        /// <returns>The maintenance margin required for the provided holdings quantity/cost/value</returns>
         public static decimal GetMaintenanceMargin(this IBuyingPowerModel model, Security security)
         {
             return model.GetMaintenanceMargin(MaintenanceMarginParameters.ForCurrentHoldings(security));
@@ -114,7 +114,7 @@ namespace QuantConnect.Securities
         /// <param name="model">The buying power model</param>
         /// <param name="security">The security</param>
         /// <param name="quantity">The quantity of shares</param>
-        /// <returns>The maintenance margin required for the </returns>
+        /// <returns>The initial margin required for the provided security and quantity</returns>
         public static decimal GetInitialMarginRequirement(this IBuyingPowerModel model, Security security, decimal quantity)
         {
             return model.GetInitialMarginRequirement(new InitialMarginParameters(security, quantity));

--- a/Common/Securities/CashBuyingPowerModel.cs
+++ b/Common/Securities/CashBuyingPowerModel.cs
@@ -63,7 +63,7 @@ namespace QuantConnect.Securities
             var baseCurrency = parameters.Security as IBaseCurrencySymbol;
             if (baseCurrency == null)
             {
-                return new HasSufficientBuyingPowerForOrderResult(false, $"The '{parameters.Security.Symbol.Value}' security is not supported by this cash model. Currently only SecurityType.Crypto and SecurityType.Forex are supported.");
+                return parameters.Insufficient($"The '{parameters.Security.Symbol.Value}' security is not supported by this cash model. Currently only SecurityType.Crypto and SecurityType.Forex are supported.");
             }
 
             decimal totalQuantity;
@@ -84,18 +84,15 @@ namespace QuantConnect.Securities
             // calculate reserved quantity for open orders (in quote or base currency depending on direction)
             var openOrdersReservedQuantity = GetOpenOrdersReservedQuantity(parameters.Portfolio, parameters.Security, parameters.Order);
 
-            bool isSufficient;
-            var reason = string.Empty;
             if (parameters.Order.Direction == OrderDirection.Sell)
             {
                 // can sell available and non-reserved quantities
-                isSufficient = orderQuantity <= totalQuantity - openOrdersReservedQuantity;
-                if (!isSufficient)
+                if (orderQuantity <= totalQuantity - openOrdersReservedQuantity)
                 {
-                    reason = Invariant($"Your portfolio holds {totalQuantity.Normalize()} {baseCurrency.BaseCurrencySymbol}, {openOrdersReservedQuantity.Normalize()} {baseCurrency.BaseCurrencySymbol} of which are reserved for open orders, but your Sell order is for {orderQuantity.Normalize()} {baseCurrency.BaseCurrencySymbol}. Cash Modeling trading does not permit short holdings so ensure you only sell what you have, including any additional open orders.");
+                    return parameters.Sufficient();
                 }
 
-                return new HasSufficientBuyingPowerForOrderResult(isSufficient, reason);
+                return parameters.Insufficient(Invariant($"Your portfolio holds {totalQuantity.Normalize()} {baseCurrency.BaseCurrencySymbol}, {openOrdersReservedQuantity.Normalize()} {baseCurrency.BaseCurrencySymbol} of which are reserved for open orders, but your Sell order is for {orderQuantity.Normalize()} {baseCurrency.BaseCurrencySymbol}. Cash Modeling trading does not permit short holdings so ensure you only sell what you have, including any additional open orders."));
             }
 
             if (parameters.Order.Type == OrderType.Market)
@@ -118,13 +115,12 @@ namespace QuantConnect.Securities
                     GetMaximumOrderQuantityForTargetBuyingPower(
                         new GetMaximumOrderQuantityForTargetBuyingPowerParameters(parameters.Portfolio, parameters.Security, targetPercent)).Quantity * GetOrderPrice(parameters.Security, parameters.Order);
 
-                isSufficient = orderQuantity <= Math.Abs(maximumQuantity);
-                if (!isSufficient)
+                if (orderQuantity <= Math.Abs(maximumQuantity))
                 {
-                    reason = Invariant($"Your portfolio holds {totalQuantity.Normalize()} {parameters.Security.QuoteCurrency.Symbol}, {openOrdersReservedQuantity.Normalize()} {parameters.Security.QuoteCurrency.Symbol} of which are reserved for open orders, but your Buy order is for {parameters.Order.AbsoluteQuantity.Normalize()} {baseCurrency.BaseCurrencySymbol}. Your order requires a total value of {orderQuantity.Normalize()} {parameters.Security.QuoteCurrency.Symbol}, but only a total value of {Math.Abs(maximumQuantity).Normalize()} {parameters.Security.QuoteCurrency.Symbol} is available.");
+                    return parameters.Sufficient();
                 }
 
-                return new HasSufficientBuyingPowerForOrderResult(isSufficient, reason);
+                return parameters.Insufficient(Invariant($"Your portfolio holds {totalQuantity.Normalize()} {parameters.Security.QuoteCurrency.Symbol}, {openOrdersReservedQuantity.Normalize()} {parameters.Security.QuoteCurrency.Symbol} of which are reserved for open orders, but your Buy order is for {parameters.Order.AbsoluteQuantity.Normalize()} {baseCurrency.BaseCurrencySymbol}. Your order requires a total value of {orderQuantity.Normalize()} {parameters.Security.QuoteCurrency.Symbol}, but only a total value of {Math.Abs(maximumQuantity).Normalize()} {parameters.Security.QuoteCurrency.Symbol} is available."));
             }
 
             // for limit orders, add fees to the order cost
@@ -140,13 +136,12 @@ namespace QuantConnect.Securities
                         parameters.Security.QuoteCurrency.Symbol);
             }
 
-            isSufficient = orderQuantity <= totalQuantity - openOrdersReservedQuantity - orderFee;
-            if (!isSufficient)
+            if (orderQuantity <= totalQuantity - openOrdersReservedQuantity - orderFee)
             {
-                reason = Invariant($"Your portfolio holds {totalQuantity.Normalize()} {parameters.Security.QuoteCurrency.Symbol}, {openOrdersReservedQuantity.Normalize()} {parameters.Security.QuoteCurrency.Symbol} of which are reserved for open orders, but your Buy order is for {parameters.Order.AbsoluteQuantity.Normalize()} {baseCurrency.BaseCurrencySymbol}. Your order requires a total value of {orderQuantity.Normalize()} {parameters.Security.QuoteCurrency.Symbol}, but only a total value of {(totalQuantity - openOrdersReservedQuantity - orderFee).Normalize()} {parameters.Security.QuoteCurrency.Symbol} is available.");
+                return parameters.Sufficient();
             }
 
-            return new HasSufficientBuyingPowerForOrderResult(isSufficient, reason);
+            return parameters.Insufficient(Invariant($"Your portfolio holds {totalQuantity.Normalize()} {parameters.Security.QuoteCurrency.Symbol}, {openOrdersReservedQuantity.Normalize()} {parameters.Security.QuoteCurrency.Symbol} of which are reserved for open orders, but your Buy order is for {parameters.Order.AbsoluteQuantity.Normalize()} {baseCurrency.BaseCurrencySymbol}. Your order requires a total value of {orderQuantity.Normalize()} {parameters.Security.QuoteCurrency.Symbol}, but only a total value of {(totalQuantity - openOrdersReservedQuantity - orderFee).Normalize()} {parameters.Security.QuoteCurrency.Symbol} is available."));
         }
 
         /// <summary>

--- a/Common/Securities/CashBuyingPowerModel.cs
+++ b/Common/Securities/CashBuyingPowerModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -27,6 +27,14 @@ namespace QuantConnect.Securities
     public class CashBuyingPowerModel : BuyingPowerModel
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CashBuyingPowerModel"/> class
+        /// </summary>
+        public CashBuyingPowerModel()
+            : base(1m, 0m, 0m)
+        {
+        }
+
+        /// <summary>
         /// Gets the current leverage of the security
         /// </summary>
         /// <param name="security">The security to get leverage for</param>
@@ -51,6 +59,20 @@ namespace QuantConnect.Securities
             {
                 throw new InvalidOperationException("CashBuyingPowerModel does not allow setting leverage. Cash accounts have no leverage.");
             }
+        }
+
+        /// <summary>
+        /// The margin that must be held in order to increase the position by the provided quantity
+        /// </summary>
+        /// <param name="parameters">An object containing the security and quantity of shares</param>
+        public override InitialMargin GetInitialMarginRequirement(InitialMarginParameters parameters)
+        {
+            var security = parameters.Security;
+            var quantity = parameters.Quantity;
+            return security.QuoteCurrency.ConversionRate
+                * security.SymbolProperties.ContractMultiplier
+                * security.Price
+                * quantity;
         }
 
         /// <summary>
@@ -305,7 +327,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Gets the buying power available for a trade
         /// </summary>
-        /// <param name="parameters">A parameters object containing the algorithm's potrfolio, security, and order direction</param>
+        /// <param name="parameters">A parameters object containing the algorithm's portfolio, security, and order direction</param>
         /// <returns>The buying power available for the trade</returns>
         public override BuyingPower GetBuyingPower(BuyingPowerParameters parameters)
         {

--- a/Common/Securities/ConstantBuyingPowerModel.cs
+++ b/Common/Securities/ConstantBuyingPowerModel.cs
@@ -65,7 +65,7 @@ namespace QuantConnect.Securities
         /// <returns>The maintenance margin required for the </returns>
         public override MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
         {
-            return parameters.Security.Holdings.AbsoluteQuantity * _marginRequiredPerUnitInAccountCurrency;
+            return parameters.AbsoluteQuantity * _marginRequiredPerUnitInAccountCurrency;
         }
     }
 }

--- a/Common/Securities/ConstantBuyingPowerModel.cs
+++ b/Common/Securities/ConstantBuyingPowerModel.cs
@@ -52,21 +52,20 @@ namespace QuantConnect.Securities
         /// <summary>
         /// The margin that must be held in order to increase the position by the provided quantity
         /// </summary>
-        /// <param name="security">The security to compute initial margin for</param>
-        /// <param name="quantity">The change in the contemplated change in shares</param>
-        public override decimal GetInitialMarginRequirement(Security security, decimal quantity)
+        /// <param name="parameters">An object containing the security and quantity of shares</param>
+        public override InitialMargin GetInitialMarginRequirement(InitialMarginParameters parameters)
         {
-            return quantity * _marginRequiredPerUnitInAccountCurrency;
+            return parameters.Quantity * _marginRequiredPerUnitInAccountCurrency;
         }
 
         /// <summary>
         /// Gets the margin currently allocated to the specified holding
         /// </summary>
-        /// <param name="security">The security to compute maintenance margin for</param>
+        /// <param name="parameters">An object containing the security</param>
         /// <returns>The maintenance margin required for the </returns>
-        public override decimal GetMaintenanceMargin(Security security)
+        public override MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
         {
-            return security.Holdings.AbsoluteQuantity * _marginRequiredPerUnitInAccountCurrency;
+            return parameters.Security.Holdings.AbsoluteQuantity * _marginRequiredPerUnitInAccountCurrency;
         }
     }
 }

--- a/Common/Securities/ConstantBuyingPowerModel.cs
+++ b/Common/Securities/ConstantBuyingPowerModel.cs
@@ -1,0 +1,72 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IBuyingPowerModel"/> that uses an absurdly low margin
+    /// requirement to ensure all orders have sufficient margin provided the portfolio is not underwater.
+    /// </summary>
+    public class ConstantBuyingPowerModel : BuyingPowerModel
+    {
+        private readonly decimal _marginRequiredPerUnitInAccountCurrency;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConstantBuyingPowerModel"/> class
+        /// </summary>
+        /// <param name="marginRequiredPerUnitInAccountCurrency">The constant amount of margin required per single unit
+        /// of an asset. Each unit is defined as a quantity of 1 and NOT based on the lot size.</param>
+        public ConstantBuyingPowerModel(decimal marginRequiredPerUnitInAccountCurrency)
+        {
+            _marginRequiredPerUnitInAccountCurrency = marginRequiredPerUnitInAccountCurrency;
+        }
+
+
+        /// <summary>
+        /// Sets the leverage for the applicable securities, i.e, equities
+        /// </summary>
+        /// <remarks>
+        /// This is added to maintain backwards compatibility with the old margin/leverage system
+        /// </remarks>
+        /// <param name="security"></param>
+        /// <param name="leverage">The new leverage</param>
+        public override void SetLeverage(Security security, decimal leverage)
+        {
+            // ignored -- reasoning is user has an algorithm that has margin issues and so they quickly swap
+            // this impl in, but their code calls set leverage, they would need to comment that out and such
+            // said another way -- user made the decision to ignore margin/leverage by selecting this model
+        }
+
+        /// <summary>
+        /// The margin that must be held in order to increase the position by the provided quantity
+        /// </summary>
+        /// <param name="security">The security to compute initial margin for</param>
+        /// <param name="quantity">The change in the contemplated change in shares</param>
+        public override decimal GetInitialMarginRequirement(Security security, decimal quantity)
+        {
+            return quantity * _marginRequiredPerUnitInAccountCurrency;
+        }
+
+        /// <summary>
+        /// Gets the margin currently allocated to the specified holding
+        /// </summary>
+        /// <param name="security">The security to compute maintenance margin for</param>
+        /// <returns>The maintenance margin required for the </returns>
+        public override decimal GetMaintenanceMargin(Security security)
+        {
+            return security.Holdings.AbsoluteQuantity * _marginRequiredPerUnitInAccountCurrency;
+        }
+    }
+}

--- a/Common/Securities/ConstantBuyingPowerModel.cs
+++ b/Common/Securities/ConstantBuyingPowerModel.cs
@@ -53,6 +53,7 @@ namespace QuantConnect.Securities
         /// The margin that must be held in order to increase the position by the provided quantity
         /// </summary>
         /// <param name="parameters">An object containing the security and quantity of shares</param>
+        /// <returns>The initial margin required for the provided security and quantity</returns>
         public override InitialMargin GetInitialMarginRequirement(InitialMarginParameters parameters)
         {
             return parameters.Quantity * _marginRequiredPerUnitInAccountCurrency;
@@ -62,7 +63,7 @@ namespace QuantConnect.Securities
         /// Gets the margin currently allocated to the specified holding
         /// </summary>
         /// <param name="parameters">An object containing the security</param>
-        /// <returns>The maintenance margin required for the </returns>
+        /// <returns>The maintenance margin required for the provided holdings quantity/cost/value</returns>
         public override MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
         {
             return parameters.AbsoluteQuantity * _marginRequiredPerUnitInAccountCurrency;

--- a/Common/Securities/DefaultMarginCallModel.cs
+++ b/Common/Securities/DefaultMarginCallModel.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;
+using QuantConnect.Securities.Positions;
 
 namespace QuantConnect.Securities
 {
@@ -157,10 +158,12 @@ namespace QuantConnect.Securities
             // we want a reduction so we send the inverse side of our position
             var deltaBuyingPower = (currentlyUsedBuyingPower - buyingPowerToKeep) * (security.Holdings.IsLong ? -1 : 1);
 
-            var quantity = security.BuyingPowerModel.GetMaximumOrderQuantityForDeltaBuyingPower(
-                new GetMaximumOrderQuantityForDeltaBuyingPowerParameters(Portfolio,
-                    security,
-                    deltaBuyingPower)).Quantity;
+            var positionGroup = Portfolio.Positions.CreateDefaultGroup(security);
+            var result = positionGroup.BuyingPowerModel.GetMaximumLotsForDeltaBuyingPower(
+                Portfolio, positionGroup, deltaBuyingPower
+            );
+
+            var quantity = result.NumberOfLots * security.SymbolProperties.LotSize;
 
             return new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, quantity, 0, 0, security.LocalTime.ConvertToUtc(security.Exchange.TimeZone), "Margin Call", DefaultOrderProperties?.Clone());
         }

--- a/Common/Securities/DefaultMarginCallModel.cs
+++ b/Common/Securities/DefaultMarginCallModel.cs
@@ -149,7 +149,7 @@ namespace QuantConnect.Securities
             // compute the amount of quote currency we need to liquidate in order to get within margin requirements
             var deltaAccountCurrency = totalUsedMargin - totalPortfolioValue;
 
-            var positionGroup = Portfolio.Positions.CreateDefaultGroup(security);
+            var positionGroup = Portfolio.Positions.GetOrCreateDefaultGroup(security);
 
             var currentlyUsedBuyingPower = positionGroup.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(Portfolio, positionGroup);
 

--- a/Common/Securities/DefaultMarginCallModel.cs
+++ b/Common/Securities/DefaultMarginCallModel.cs
@@ -149,8 +149,9 @@ namespace QuantConnect.Securities
             // compute the amount of quote currency we need to liquidate in order to get within margin requirements
             var deltaAccountCurrency = totalUsedMargin - totalPortfolioValue;
 
-            var currentlyUsedBuyingPower = security.BuyingPowerModel.GetReservedBuyingPowerForPosition(
-                new ReservedBuyingPowerForPositionParameters(security)).AbsoluteUsedBuyingPower;
+            var positionGroup = Portfolio.Positions.CreateDefaultGroup(security);
+
+            var currentlyUsedBuyingPower = positionGroup.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(Portfolio, positionGroup);
 
             // if currentlyUsedBuyingPower > deltaAccountCurrency, means we can keep using the diff in buying power
             var buyingPowerToKeep = Math.Max(0, currentlyUsedBuyingPower - deltaAccountCurrency);
@@ -158,10 +159,7 @@ namespace QuantConnect.Securities
             // we want a reduction so we send the inverse side of our position
             var deltaBuyingPower = (currentlyUsedBuyingPower - buyingPowerToKeep) * (security.Holdings.IsLong ? -1 : 1);
 
-            var positionGroup = Portfolio.Positions.CreateDefaultGroup(security);
-            var result = positionGroup.BuyingPowerModel.GetMaximumLotsForDeltaBuyingPower(
-                Portfolio, positionGroup, deltaBuyingPower
-            );
+            var result = positionGroup.BuyingPowerModel.GetMaximumLotsForDeltaBuyingPower(Portfolio, positionGroup, deltaBuyingPower);
 
             var quantity = result.NumberOfLots * security.SymbolProperties.LotSize;
 

--- a/Common/Securities/Future/FutureMarginModel.cs
+++ b/Common/Securities/Future/FutureMarginModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -120,7 +120,7 @@ namespace QuantConnect.Securities.Future
         /// </summary>
         /// <param name="parameters">An object containing the portfolio, the security and the order</param>
         /// <returns>The total margin in terms of the currency quoted in the order</returns>
-        protected override decimal GetInitialMarginRequiredForOrder(
+        public override decimal GetInitialMarginRequiredForOrder(
             InitialMarginRequiredForOrderParameters parameters)
         {
             //Get the order value from the non-abstract order classes (MarketOrder, LimitOrder, StopMarketOrder)
@@ -142,7 +142,7 @@ namespace QuantConnect.Securities.Future
         /// </summary>
         /// <param name="security">The security to compute maintenance margin for</param>
         /// <returns>The maintenance margin required for the </returns>
-        protected override decimal GetMaintenanceMargin(Security security)
+        public override decimal GetMaintenanceMargin(Security security)
         {
             if (security?.GetLastData() == null || security.Holdings.HoldingsCost == 0m)
                 return 0m;
@@ -163,7 +163,7 @@ namespace QuantConnect.Securities.Future
         /// <summary>
         /// The margin that must be held in order to increase the position by the provided quantity
         /// </summary>
-        protected override decimal GetInitialMarginRequirement(Security security, decimal quantity)
+        public override decimal GetInitialMarginRequirement(Security security, decimal quantity)
         {
             if (security?.GetLastData() == null || quantity == 0m)
                 return 0m;

--- a/Common/Securities/Future/FutureMarginModel.cs
+++ b/Common/Securities/Future/FutureMarginModel.cs
@@ -147,7 +147,9 @@ namespace QuantConnect.Securities.Future
         {
             var security = parameters.Security;
             if (security?.GetLastData() == null || security.Holdings.HoldingsCost == 0m)
+            {
                 return 0m;
+            }
 
             var marginReq = GetCurrentMarginRequirements(security);
 
@@ -155,11 +157,11 @@ namespace QuantConnect.Securities.Future
                 && security.Exchange.ExchangeOpen
                 && !security.Exchange.ClosingSoon)
             {
-                return marginReq.MaintenanceIntraday * security.Holdings.AbsoluteQuantity;
+                return marginReq.MaintenanceIntraday * parameters.AbsoluteQuantity;
             }
 
             // margin is per contract
-            return marginReq.MaintenanceOvernight * security.Holdings.AbsoluteQuantity;
+            return marginReq.MaintenanceOvernight * parameters.AbsoluteQuantity;
         }
 
         /// <summary>

--- a/Common/Securities/Future/FutureMarginModel.cs
+++ b/Common/Securities/Future/FutureMarginModel.cs
@@ -120,8 +120,9 @@ namespace QuantConnect.Securities.Future
         /// </summary>
         /// <param name="parameters">An object containing the portfolio, the security and the order</param>
         /// <returns>The total margin in terms of the currency quoted in the order</returns>
-        public override decimal GetInitialMarginRequiredForOrder(
-            InitialMarginRequiredForOrderParameters parameters)
+        public override InitialMargin GetInitialMarginRequiredForOrder(
+            InitialMarginRequiredForOrderParameters parameters
+            )
         {
             //Get the order value from the non-abstract order classes (MarketOrder, LimitOrder, StopMarketOrder)
             //Market order is approximated from the current security price and set in the MarketOrder Method in QCAlgorithm.
@@ -132,18 +133,19 @@ namespace QuantConnect.Securities.Future
             var feesInAccountCurrency = parameters.CurrencyConverter.
                 ConvertToAccountCurrency(fees).Amount;
 
-            var orderMargin = GetInitialMarginRequirement(parameters.Security, parameters.Order.Quantity);
+            var orderMargin = this.GetInitialMarginRequirement(parameters.Security, parameters.Order.Quantity);
 
-            return orderMargin + Math.Sign(orderMargin) * feesInAccountCurrency;
+            return new InitialMargin(orderMargin + Math.Sign(orderMargin) * feesInAccountCurrency);
         }
 
         /// <summary>
-        /// Gets the margin currently alloted to the specified holding
+        /// Gets the margin currently allotted to the specified holding
         /// </summary>
-        /// <param name="security">The security to compute maintenance margin for</param>
+        /// <param name="parameters">An object containing the security</param>
         /// <returns>The maintenance margin required for the </returns>
-        public override decimal GetMaintenanceMargin(Security security)
+        public override MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
         {
+            var security = parameters.Security;
             if (security?.GetLastData() == null || security.Holdings.HoldingsCost == 0m)
                 return 0m;
 
@@ -163,10 +165,12 @@ namespace QuantConnect.Securities.Future
         /// <summary>
         /// The margin that must be held in order to increase the position by the provided quantity
         /// </summary>
-        public override decimal GetInitialMarginRequirement(Security security, decimal quantity)
+        public override InitialMargin GetInitialMarginRequirement(InitialMarginParameters parameters)
         {
+            var security = parameters.Security;
+            var quantity = parameters.Quantity;
             if (security?.GetLastData() == null || quantity == 0m)
-                return 0m;
+                return InitialMargin.Zero;
 
             var marginReq = GetCurrentMarginRequirements(security);
 
@@ -174,11 +178,11 @@ namespace QuantConnect.Securities.Future
                 && security.Exchange.ExchangeOpen
                 && !security.Exchange.ClosingSoon)
             {
-                return marginReq.InitialIntraday * quantity;
+                return new InitialMargin(marginReq.InitialIntraday * quantity);
             }
 
             // margin is per contract
-            return marginReq.InitialOvernight * quantity;
+            return new InitialMargin(marginReq.InitialOvernight * quantity);
         }
 
         private MarginRequirementsEntry GetCurrentMarginRequirements(Security security)

--- a/Common/Securities/FutureOption/FuturesOptionsMarginModel.cs
+++ b/Common/Securities/FutureOption/FuturesOptionsMarginModel.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Securities.Option
         /// run when it comes to calculating the different market scenarios attempting to simulate VaR, resulting
         /// in a margin greater than the underlying's margin.
         /// </remarks>
-        protected override decimal GetMaintenanceMargin(Security security)
+        public override decimal GetMaintenanceMargin(Security security)
         {
             return base.GetMaintenanceMargin(((Option)security).Underlying) * FixedMarginMultiplier;
         }
@@ -62,7 +62,7 @@ namespace QuantConnect.Securities.Option
         /// run when it comes to calculating the different market scenarios attempting to simulate VaR, resulting
         /// in a margin greater than the underlying's margin.
         /// </remarks>
-        protected override decimal GetInitialMarginRequirement(Security security, decimal quantity)
+        public override decimal GetInitialMarginRequirement(Security security, decimal quantity)
         {
             return base.GetInitialMarginRequirement(((Option)security).Underlying, quantity) * FixedMarginMultiplier;
         }

--- a/Common/Securities/FutureOption/FuturesOptionsMarginModel.cs
+++ b/Common/Securities/FutureOption/FuturesOptionsMarginModel.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Securities.Option
         /// <summary>
         /// Gets the margin currently alloted to the specified holding.
         /// </summary>
-        /// <param name="security">The option to compute maintenance margin for</param>
+        /// <param name="parameters">An object containing the security</param>
         /// <returns>The maintenance margin required for the option</returns>
         /// <remarks>
         /// We fix the option to 1.5x the maintenance because of its close coupling with the underlying.
@@ -46,15 +46,15 @@ namespace QuantConnect.Securities.Option
         /// run when it comes to calculating the different market scenarios attempting to simulate VaR, resulting
         /// in a margin greater than the underlying's margin.
         /// </remarks>
-        public override decimal GetMaintenanceMargin(Security security)
+        public override MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
         {
-            return base.GetMaintenanceMargin(((Option)security).Underlying) * FixedMarginMultiplier;
+            return base.GetMaintenanceMargin(parameters.ForUnderlying()) * FixedMarginMultiplier;
         }
 
         /// <summary>
         /// The margin that must be held in order to increase the position by the provided quantity
         /// </summary>
-        /// <param name="security">The option to compute the initial margin for</param>
+        /// <param name="parameters">An object containing the security and quantity of shares</param>
         /// <returns>The initial margin required for the option (i.e. the equity required to enter a position for this option)</returns>
         /// <remarks>
         /// We fix the option to 1.5x the initial because of its close coupling with the underlying.
@@ -62,9 +62,11 @@ namespace QuantConnect.Securities.Option
         /// run when it comes to calculating the different market scenarios attempting to simulate VaR, resulting
         /// in a margin greater than the underlying's margin.
         /// </remarks>
-        public override decimal GetInitialMarginRequirement(Security security, decimal quantity)
+        public override InitialMargin GetInitialMarginRequirement(InitialMarginParameters parameters)
         {
-            return base.GetInitialMarginRequirement(((Option)security).Underlying, quantity) * FixedMarginMultiplier;
+            return new InitialMargin(FixedMarginMultiplier
+                * base.GetInitialMarginRequirement(parameters.ForUnderlying()).Value
+            );
         }
     }
 }

--- a/Common/Securities/HasSufficientBuyingPowerForOrderParameters.cs
+++ b/Common/Securities/HasSufficientBuyingPowerForOrderParameters.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *

--- a/Common/Securities/HasSufficientBuyingPowerForOrderParameters.cs
+++ b/Common/Securities/HasSufficientBuyingPowerForOrderParameters.cs
@@ -13,7 +13,9 @@
  * limitations under the License.
 */
 
+using System;
 using QuantConnect.Orders;
+using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.Securities
 {
@@ -48,6 +50,44 @@ namespace QuantConnect.Securities
             Portfolio = portfolio;
             Security = security;
             Order = order;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="HasSufficientBuyingPowerForOrderParameters"/> targeting the security's underlying.
+        /// If the security does not implement <see cref="IDerivativeSecurity"/> then an <see cref="InvalidCastException"/>
+        /// will be thrown. If the order's symbol does not match the underlying then an <see cref="ArgumentException"/> will
+        /// be thrown.
+        /// </summary>
+        /// <param name="order">The new order targeting the underlying</param>
+        /// <returns>New parameters instance suitable for invoking the sufficient capital method for the underlying security</returns>
+        public HasSufficientBuyingPowerForOrderParameters ForUnderlying(Order order)
+        {
+            var derivative = (IDerivativeSecurity) Security;
+            return new HasSufficientBuyingPowerForOrderParameters(Portfolio, derivative.Underlying, order);
+        }
+
+        /// <summary>
+        /// Creates a new result indicating that there is sufficient buying power for the contemplated order
+        /// </summary>
+        public HasSufficientBuyingPowerForOrderResult Sufficient()
+        {
+            return new HasSufficientBuyingPowerForOrderResult(true);
+        }
+
+        /// <summary>
+        /// Creates a new result indicating that there is insufficient buying power for the contemplated order
+        /// </summary>
+        public HasSufficientBuyingPowerForOrderResult Insufficient(string reason)
+        {
+            return new HasSufficientBuyingPowerForOrderResult(false, reason);
+        }
+
+        /// <summary>
+        /// Creates a new result indicating that there is insufficient buying power for the contemplated order
+        /// </summary>
+        public HasSufficientBuyingPowerForOrderResult Insufficient(FormattableString reason)
+        {
+            return new HasSufficientBuyingPowerForOrderResult(false, Invariant(reason));
         }
     }
 }

--- a/Common/Securities/HasSufficientBuyingPowerForOrderResult.cs
+++ b/Common/Securities/HasSufficientBuyingPowerForOrderResult.cs
@@ -21,12 +21,12 @@ namespace QuantConnect.Securities
     public class HasSufficientBuyingPowerForOrderResult
     {
         /// <summary>
-        /// Returns true if there is sufficient buying power to execute an order
+        /// Gets true if there is sufficient buying power to execute an order
         /// </summary>
         public bool IsSufficient { get; }
 
         /// <summary>
-        /// Returns the reason for insufficient buying power to execute an order
+        /// Gets the reason for insufficient buying power to execute an order
         /// </summary>
         public string Reason { get; }
 

--- a/Common/Securities/IBuyingPowerModel.cs
+++ b/Common/Securities/IBuyingPowerModel.cs
@@ -38,6 +38,27 @@ namespace QuantConnect.Securities
         void SetLeverage(Security security, decimal leverage);
 
         /// <summary>
+        /// Gets the margin currently allocated to the specified holding
+        /// </summary>
+        /// <param name="security">The security to compute maintenance margin for</param>
+        /// <returns>The maintenance margin required for the security holdings quantity/cost/value</returns>
+        decimal GetMaintenanceMargin(Security security);
+
+        /// <summary>
+        /// The margin that must be held in order to increase the position by the provided quantity
+        /// </summary>
+        /// <param name="security">The security to compute initial margin for</param>
+        /// <param name="quantity">The change in the contemplated change in shares</param>
+        decimal GetInitialMarginRequirement(Security security, decimal quantity);
+
+        /// <summary>
+        /// Gets the total margin required to execute the specified order in units of the account currency including fees
+        /// </summary>
+        /// <param name="parameters">An object containing the portfolio, the security and the order</param>
+        /// <returns>The total margin in terms of the currency quoted in the order</returns>
+        decimal GetInitialMarginRequiredForOrder(InitialMarginRequiredForOrderParameters parameters);
+
+        /// <summary>
         /// Check if there is sufficient buying power to execute this order.
         /// </summary>
         /// <param name="parameters">An object containing the portfolio, the security and the order</param>

--- a/Common/Securities/IBuyingPowerModel.cs
+++ b/Common/Securities/IBuyingPowerModel.cs
@@ -40,23 +40,22 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Gets the margin currently allocated to the specified holding
         /// </summary>
-        /// <param name="security">The security to compute maintenance margin for</param>
-        /// <returns>The maintenance margin required for the security holdings quantity/cost/value</returns>
-        decimal GetMaintenanceMargin(Security security);
+        /// <param name="parameters">An object containing the security and holdings quantity/cost/value</param>
+        /// <returns>The maintenance margin required for the provided holdings quantity/cost/value</returns>
+        MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters);
 
         /// <summary>
         /// The margin that must be held in order to increase the position by the provided quantity
         /// </summary>
-        /// <param name="security">The security to compute initial margin for</param>
-        /// <param name="quantity">The change in the contemplated change in shares</param>
-        decimal GetInitialMarginRequirement(Security security, decimal quantity);
+        /// <param name="parameters">An object containing the security and quantity</param>
+        InitialMargin GetInitialMarginRequirement(InitialMarginParameters parameters);
 
         /// <summary>
         /// Gets the total margin required to execute the specified order in units of the account currency including fees
         /// </summary>
         /// <param name="parameters">An object containing the portfolio, the security and the order</param>
         /// <returns>The total margin in terms of the currency quoted in the order</returns>
-        decimal GetInitialMarginRequiredForOrder(InitialMarginRequiredForOrderParameters parameters);
+        InitialMargin GetInitialMarginRequiredForOrder(InitialMarginRequiredForOrderParameters parameters);
 
         /// <summary>
         /// Check if there is sufficient buying power to execute this order.

--- a/Common/Securities/IBuyingPowerModel.cs
+++ b/Common/Securities/IBuyingPowerModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -92,7 +92,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Gets the buying power available for a trade
         /// </summary>
-        /// <param name="parameters">A parameters object containing the algorithm's potrfolio, security, and order direction</param>
+        /// <param name="parameters">A parameters object containing the algorithm's portfolio, security, and order direction</param>
         /// <returns>The buying power available for the trade</returns>
         BuyingPower GetBuyingPower(BuyingPowerParameters parameters);
     }

--- a/Common/Securities/IBuyingPowerModel.cs
+++ b/Common/Securities/IBuyingPowerModel.cs
@@ -48,6 +48,7 @@ namespace QuantConnect.Securities
         /// The margin that must be held in order to increase the position by the provided quantity
         /// </summary>
         /// <param name="parameters">An object containing the security and quantity</param>
+        /// <returns>The initial margin required for the provided security and quantity</returns>
         InitialMargin GetInitialMarginRequirement(InitialMarginParameters parameters);
 
         /// <summary>

--- a/Common/Securities/InitialMargin.cs
+++ b/Common/Securities/InitialMargin.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Result type for <see cref="IBuyingPowerModel.GetInitialMarginRequirement"/>
+    /// and <see cref="IBuyingPowerModel.GetInitialMarginRequiredForOrder"/>
+    /// </summary>
+    public class InitialMargin
+    {
+        /// <summary>
+        /// Gets an instance of <see cref="InitialMargin"/> with zero values
+        /// </summary>
+        public static InitialMargin Zero { get; } = new InitialMargin(0m);
+
+        /// <summary>
+        /// The initial margin value in account currency
+        /// </summary>
+        public decimal Value { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InitialMargin"/> class
+        /// </summary>
+        /// <param name="value">The maintenance margin</param>
+        public InitialMargin(decimal value)
+        {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Implicit operator <see cref="InitialMargin"/> -> <see cref="decimal"/>
+        /// </summary>
+        public static implicit operator decimal(InitialMargin margin)
+        {
+            return margin.Value;
+        }
+
+        /// <summary>
+        /// Implicit operator <see cref="decimal"/> -> <see cref="InitialMargin"/>
+        /// </summary>
+        public static implicit operator InitialMargin(decimal margin)
+        {
+            return new InitialMargin(margin);
+        }
+    }
+}

--- a/Common/Securities/InitialMargin.cs
+++ b/Common/Securities/InitialMargin.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Initializes a new instance of the <see cref="InitialMargin"/> class
         /// </summary>
-        /// <param name="value">The maintenance margin</param>
+        /// <param name="value">The initial margin</param>
         public InitialMargin(decimal value)
         {
             Value = value;

--- a/Common/Securities/InitialMarginParameters.cs
+++ b/Common/Securities/InitialMarginParameters.cs
@@ -1,0 +1,60 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Parameters for <see cref="IBuyingPowerModel.GetInitialMarginRequirement"/>
+    /// </summary>
+    public class InitialMarginParameters
+    {
+        /// <summary>
+        /// Gets the security
+        /// </summary>
+        public Security Security { get; }
+
+        /// <summary>
+        /// Gets the quantity
+        /// </summary>
+        public decimal Quantity { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InitialMarginParameters"/> class
+        /// </summary>
+        /// <param name="security">The security</param>
+        /// <param name="quantity">The quantity</param>
+        public InitialMarginParameters(Security security, decimal quantity)
+        {
+            Security = security;
+            Quantity = quantity;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="InitialMarginParameters"/> for the security's underlying
+        /// </summary>
+        public InitialMarginParameters ForUnderlying()
+        {
+            var derivative = Security as IDerivativeSecurity;
+            if (derivative == null)
+            {
+                throw new InvalidOperationException("ForUnderlying is only invokable for IDerivativeSecurity (Option|Future)");
+            }
+
+            return new InitialMarginParameters(derivative.Underlying, Quantity);
+        }
+    }
+}

--- a/Common/Securities/MaintenanceMargin.cs
+++ b/Common/Securities/MaintenanceMargin.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Result type for <see cref="IBuyingPowerModel.GetMaintenanceMargin"/>
+    /// </summary>
+    public class MaintenanceMargin
+    {
+        /// <summary>
+        /// Gets an instance of <see cref="MaintenanceMargin"/> with zero values.
+        /// </summary>
+        public static MaintenanceMargin Zero { get; } = new MaintenanceMargin(0m);
+
+        /// <summary>
+        /// The maintenance margin value in account currency
+        /// </summary>
+        public decimal Value { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaintenanceMargin"/> class
+        /// </summary>
+        /// <param name="value">The maintenance margin</param>
+        public MaintenanceMargin(decimal value)
+        {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Implicit operator <see cref="MaintenanceMargin"/> -> <see cref="decimal"/>
+        /// </summary>
+        public static implicit operator decimal(MaintenanceMargin margin)
+        {
+            return margin.Value;
+        }
+
+        /// <summary>
+        /// Implicit operator <see cref="decimal"/> -> <see cref="MaintenanceMargin"/>
+        /// </summary>
+        public static implicit operator MaintenanceMargin(decimal margin)
+        {
+            return new MaintenanceMargin(margin);
+        }
+    }
+}

--- a/Common/Securities/MaintenanceMarginParameters.cs
+++ b/Common/Securities/MaintenanceMarginParameters.cs
@@ -28,12 +28,76 @@ namespace QuantConnect.Securities
         public Security Security { get; }
 
         /// <summary>
+        /// Gets the quantity of the security
+        /// </summary>
+        public decimal Quantity { get; }
+
+        /// <summary>
+        /// Gets the absolute quantity of the security
+        /// </summary>
+        public decimal AbsoluteQuantity => Math.Abs(Quantity);
+
+        /// <summary>
+        /// Gets the holdings cost of the security
+        /// </summary>
+        public decimal HoldingsCost { get; }
+
+        /// <summary>
+        /// Gets the absolute holdings cost of the security
+        /// </summary>
+        public decimal AbsoluteHoldingsCost => Math.Abs(HoldingsCost);
+
+        /// <summary>
+        /// Gets the holdings value of the security
+        /// </summary>
+        public decimal HoldingsValue { get; }
+
+        /// <summary>
+        /// Gets the absolute holdings value of the security
+        /// </summary>
+        public decimal AbsoluteHoldingsValue => Math.Abs(HoldingsValue);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MaintenanceMarginParameters"/> class
         /// </summary>
         /// <param name="security">The security</param>
-        public MaintenanceMarginParameters(Security security)
+        /// <param name="quantity">The quantity</param>
+        /// <param name="holdingsCost">The holdings cost</param>
+        /// <param name="holdingsValue">The holdings value</param>
+        public MaintenanceMarginParameters(
+            Security security,
+            decimal quantity,
+            decimal holdingsCost,
+            decimal holdingsValue
+            )
         {
             Security = security;
+            Quantity = quantity;
+            HoldingsCost = holdingsCost;
+            HoldingsValue = holdingsValue;
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="MaintenanceMarginParameters"/> class to compute the maintenance margin
+        /// required to support the algorithm's current holdings
+        /// </summary>
+        public static MaintenanceMarginParameters ForCurrentHoldings(Security security)
+        {
+            return new MaintenanceMarginParameters(security,
+                security.Holdings.Quantity,
+                security.Holdings.HoldingsCost,
+                security.Holdings.HoldingsValue
+            );
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="MaintenanceMarginParameters"/> class to compute the maintenance margin
+        /// required to support the specified quantity of holdings at current market prices
+        /// </summary>
+        public static MaintenanceMarginParameters ForQuantityAtCurrentPrice(Security security, decimal quantity)
+        {
+            var value = security.Holdings.GetQuantityValue(quantity);
+            return new MaintenanceMarginParameters(security, quantity, value, value);
         }
 
         /// <summary>
@@ -47,7 +111,7 @@ namespace QuantConnect.Securities
                 throw new InvalidOperationException("ForUnderlying is only invokable for IDerivativeSecurity (Option|Future)");
             }
 
-            return new MaintenanceMarginParameters(derivative.Underlying);
+            return ForCurrentHoldings(derivative.Underlying);
         }
     }
 }

--- a/Common/Securities/MaintenanceMarginParameters.cs
+++ b/Common/Securities/MaintenanceMarginParameters.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -81,8 +81,14 @@ namespace QuantConnect.Securities
         /// Creates a new instance of the <see cref="MaintenanceMarginParameters"/> class to compute the maintenance margin
         /// required to support the algorithm's current holdings
         /// </summary>
-        public static MaintenanceMarginParameters ForCurrentHoldings(Security security)
+        public static MaintenanceMarginParameters ForCurrentHoldings(Security security, decimal? quantity = null)
         {
+            if (quantity != null)
+            {
+                var value = security.Holdings.GetQuantityValue(quantity.Value);
+                return new MaintenanceMarginParameters(security, quantity.Value, value, value);
+            }
+
             return new MaintenanceMarginParameters(security,
                 security.Holdings.Quantity,
                 security.Holdings.HoldingsCost,

--- a/Common/Securities/MaintenanceMarginParameters.cs
+++ b/Common/Securities/MaintenanceMarginParameters.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Parameters for <see cref="IBuyingPowerModel.GetMaintenanceMargin"/>
+    /// </summary>
+    public class MaintenanceMarginParameters
+    {
+        /// <summary>
+        /// Gets the security
+        /// </summary>
+        public Security Security { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaintenanceMarginParameters"/> class
+        /// </summary>
+        /// <param name="security">The security</param>
+        public MaintenanceMarginParameters(Security security)
+        {
+            Security = security;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="MaintenanceMarginParameters"/> for the security's underlying
+        /// </summary>
+        public MaintenanceMarginParameters ForUnderlying()
+        {
+            var derivative = Security as IDerivativeSecurity;
+            if (derivative == null)
+            {
+                throw new InvalidOperationException("ForUnderlying is only invokable for IDerivativeSecurity (Option|Future)");
+            }
+
+            return new MaintenanceMarginParameters(derivative.Underlying);
+        }
+    }
+}

--- a/Common/Securities/Option/OptionMarginModel.cs
+++ b/Common/Securities/Option/OptionMarginModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -68,7 +68,7 @@ namespace QuantConnect.Securities.Option
         /// </summary>
         /// <param name="parameters">An object containing the portfolio, the security and the order</param>
         /// <returns>The total margin in terms of the currency quoted in the order</returns>
-        protected override decimal GetInitialMarginRequiredForOrder(
+        public override decimal GetInitialMarginRequiredForOrder(
             InitialMarginRequiredForOrderParameters parameters)
         {
             //Get the order value from the non-abstract order classes (MarketOrder, LimitOrder, StopMarketOrder)
@@ -91,7 +91,7 @@ namespace QuantConnect.Securities.Option
         /// </summary>
         /// <param name="security">The security to compute maintenance margin for</param>
         /// <returns>The maintenance margin required for the </returns>
-        protected override decimal GetMaintenanceMargin(Security security)
+        public override decimal GetMaintenanceMargin(Security security)
         {
             return security.Holdings.AbsoluteHoldingsCost * GetMaintenanceMarginRequirement(security, security.Holdings.HoldingsCost);
         }
@@ -99,7 +99,7 @@ namespace QuantConnect.Securities.Option
         /// <summary>
         /// The margin that must be held in order to increase the position by the provided quantity
         /// </summary>
-        protected override decimal GetInitialMarginRequirement(Security security, decimal quantity)
+        public override decimal GetInitialMarginRequirement(Security security, decimal quantity)
         {
             var value = security.QuoteCurrency.ConversionRate
                         * security.SymbolProperties.ContractMultiplier

--- a/Common/Securities/Option/OptionMarginModel.cs
+++ b/Common/Securities/Option/OptionMarginModel.cs
@@ -95,7 +95,7 @@ namespace QuantConnect.Securities.Option
         public override MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
         {
             var security = parameters.Security;
-            return security.Holdings.AbsoluteHoldingsCost * GetMaintenanceMarginRequirement(security, security.Holdings.HoldingsCost);
+            return parameters.AbsoluteHoldingsCost * GetMaintenanceMarginRequirement(security, security.Holdings.HoldingsCost);
         }
 
         /// <summary>

--- a/Common/Securities/Option/OptionMarginModel.cs
+++ b/Common/Securities/Option/OptionMarginModel.cs
@@ -91,7 +91,7 @@ namespace QuantConnect.Securities.Option
         /// Gets the margin currently alloted to the specified holding
         /// </summary>
         /// <param name="parameters">An object containing the security</param>
-        /// <returns>The maintenance margin required for the </returns>
+        /// <returns>The maintenance margin required for the provided holdings quantity/cost/value</returns>
         public override MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
         {
             var security = parameters.Security;
@@ -101,6 +101,7 @@ namespace QuantConnect.Securities.Option
         /// <summary>
         /// The margin that must be held in order to increase the position by the provided quantity
         /// </summary>
+        /// <returns>The initial margin required for the provided security and quantity</returns>
         public override InitialMargin GetInitialMarginRequirement(InitialMarginParameters parameters)
         {
             var security = parameters.Security;

--- a/Common/Securities/PatternDayTradingMarginModel.cs
+++ b/Common/Securities/PatternDayTradingMarginModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -67,7 +67,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// The percentage of an order's absolute cost that must be held in free cash in order to place the order
         /// </summary>
-        protected override decimal GetInitialMarginRequirement(Security security, decimal quantity)
+        public override decimal GetInitialMarginRequirement(Security security, decimal quantity)
         {
             return base.GetInitialMarginRequirement(security, quantity) * GetMarginCorrectionFactor(security);
         }
@@ -75,7 +75,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// The percentage of the holding's absolute cost that must be held in free cash in order to avoid a margin call
         /// </summary>
-        protected override decimal GetMaintenanceMargin(Security security)
+        public override decimal GetMaintenanceMargin(Security security)
         {
             return base.GetMaintenanceMargin(security)*GetMarginCorrectionFactor(security);
         }

--- a/Common/Securities/PatternDayTradingMarginModel.cs
+++ b/Common/Securities/PatternDayTradingMarginModel.cs
@@ -67,17 +67,19 @@ namespace QuantConnect.Securities
         /// <summary>
         /// The percentage of an order's absolute cost that must be held in free cash in order to place the order
         /// </summary>
-        public override decimal GetInitialMarginRequirement(Security security, decimal quantity)
+        public override InitialMargin GetInitialMarginRequirement(InitialMarginParameters parameters)
         {
-            return base.GetInitialMarginRequirement(security, quantity) * GetMarginCorrectionFactor(security);
+            return new InitialMargin(base.GetInitialMarginRequirement(parameters).Value
+                * GetMarginCorrectionFactor(parameters.Security)
+            );
         }
 
         /// <summary>
         /// The percentage of the holding's absolute cost that must be held in free cash in order to avoid a margin call
         /// </summary>
-        public override decimal GetMaintenanceMargin(Security security)
+        public override MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
         {
-            return base.GetMaintenanceMargin(security)*GetMarginCorrectionFactor(security);
+            return base.GetMaintenanceMargin(parameters) * GetMarginCorrectionFactor(parameters.Security);
         }
 
         /// <summary>

--- a/Common/Securities/Positions/GetMaximumLotsForDeltaBuyingPowerParameters.cs
+++ b/Common/Securities/Positions/GetMaximumLotsForDeltaBuyingPowerParameters.cs
@@ -1,0 +1,98 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Defines the parameters for <see cref="IPositionGroupBuyingPowerModel.GetMaximumLotsForDeltaBuyingPower"/>
+    /// </summary>
+    public class GetMaximumLotsForDeltaBuyingPowerParameters
+    {
+        /// <summary>
+        /// Gets the algorithm's portfolio manager
+        /// </summary>
+        public SecurityPortfolioManager Portfolio { get; }
+
+        /// <summary>
+        /// Gets the position group
+        /// </summary>
+        public IPositionGroup PositionGroup { get; }
+
+        /// <summary>
+        /// The delta buying power.
+        /// </summary>
+        /// <remarks>Sign defines the position side to apply the delta, positive long, negative short side.</remarks>
+        public decimal DeltaBuyingPower { get; }
+
+        /// <summary>
+        /// True enables the <see cref="IBuyingPowerModel"/> to skip setting <see cref="GetMaximumLotsResult.Reason"/>
+        /// for non error situations, for performance
+        /// </summary>
+        public bool SilenceNonErrorReasons { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetMaximumLotsForDeltaBuyingPowerParameters"/> class
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio manager</param>
+        /// <param name="positionGroup">The position group</param>
+        /// <param name="deltaBuyingPower">The delta buying power to apply. Sign defines the position side to apply the delta</param>
+        /// <param name="silenceNonErrorReasons">True will not return <see cref="GetMaximumLotsResult.Reason"/>
+        /// set for non error situation, this is for performance</param>
+        public GetMaximumLotsForDeltaBuyingPowerParameters(
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup,
+            decimal deltaBuyingPower,
+            bool silenceNonErrorReasons = false
+            )
+        {
+            Portfolio = portfolio;
+            PositionGroup = positionGroup;
+            DeltaBuyingPower = deltaBuyingPower;
+            SilenceNonErrorReasons = silenceNonErrorReasons;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="GetMaximumLotsResult"/> with zero quantity and an error message.
+        /// </summary>
+        public GetMaximumLotsResult Error(string reason)
+        {
+            return new GetMaximumLotsResult(0, reason, true);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="GetMaximumLotsResult"/> with zero quantity and no message.
+        /// </summary>
+        public GetMaximumLotsResult Zero()
+        {
+            return new GetMaximumLotsResult(0, string.Empty, false);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="GetMaximumLotsResult"/> with zero quantity and an info message.
+        /// </summary>
+        public GetMaximumLotsResult Zero(string reason)
+        {
+            return new GetMaximumLotsResult(0, reason, false);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="GetMaximumLotsResult"/> for the specified quantity and no message.
+        /// </summary>
+        public GetMaximumLotsResult Result(decimal quantity)
+        {
+            return new GetMaximumLotsResult(quantity, string.Empty, false);
+        }
+    }
+}

--- a/Common/Securities/Positions/GetMaximumLotsForTargetBuyingPowerParameters.cs
+++ b/Common/Securities/Positions/GetMaximumLotsForTargetBuyingPowerParameters.cs
@@ -1,0 +1,98 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Defines the parameters for <see cref="IPositionGroupBuyingPowerModel.GetMaximumLotsForTargetBuyingPower"/>
+    /// </summary>
+    public class GetMaximumLotsForTargetBuyingPowerParameters
+    {
+        /// <summary>
+        /// Gets the algorithm's portfolio manager
+        /// </summary>
+        public SecurityPortfolioManager Portfolio { get; }
+
+        /// <summary>
+        /// Gets the position group
+        /// </summary>
+        public IPositionGroup PositionGroup { get; }
+
+        /// <summary>
+        /// The delta buying power.
+        /// </summary>
+        /// <remarks>Sign defines the position side to apply the delta, positive long, negative short side.</remarks>
+        public decimal TargetBuyingPower { get; }
+
+        /// <summary>
+        /// True enables the <see cref="IBuyingPowerModel"/> to skip setting <see cref="GetMaximumLotsResult.Reason"/>
+        /// for non error situations, for performance
+        /// </summary>
+        public bool SilenceNonErrorReasons { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetMaximumLotsForTargetBuyingPowerParameters"/> class
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio manager</param>
+        /// <param name="positionGroup">The position group</param>
+        /// <param name="deltaBuyingPower">The delta buying power to apply. Sign defines the position side to apply the delta</param>
+        /// <param name="silenceNonErrorReasons">True will not return <see cref="GetMaximumLotsResult.Reason"/>
+        /// set for non error situation, this is for performance</param>
+        public GetMaximumLotsForTargetBuyingPowerParameters(
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup,
+            decimal deltaBuyingPower,
+            bool silenceNonErrorReasons = false
+            )
+        {
+            Portfolio = portfolio;
+            PositionGroup = positionGroup;
+            TargetBuyingPower = deltaBuyingPower;
+            SilenceNonErrorReasons = silenceNonErrorReasons;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="GetMaximumLotsResult"/> with zero quantity and an error message.
+        /// </summary>
+        public GetMaximumLotsResult Error(string reason)
+        {
+            return new GetMaximumLotsResult(0, reason, true);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="GetMaximumLotsResult"/> with zero quantity and no message.
+        /// </summary>
+        public GetMaximumLotsResult Zero()
+        {
+            return new GetMaximumLotsResult(0, string.Empty, false);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="GetMaximumLotsResult"/> with zero quantity and an info message.
+        /// </summary>
+        public GetMaximumLotsResult Zero(string reason)
+        {
+            return new GetMaximumLotsResult(0, reason, false);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="GetMaximumLotsResult"/> for the specified quantity and no message.
+        /// </summary>
+        public GetMaximumLotsResult Result(decimal quantity)
+        {
+            return new GetMaximumLotsResult(quantity, string.Empty, false);
+        }
+    }
+}

--- a/Common/Securities/Positions/GetMaximumLotsResult.cs
+++ b/Common/Securities/Positions/GetMaximumLotsResult.cs
@@ -1,0 +1,65 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Result type for <see cref="IPositionGroupBuyingPowerModel.GetMaximumLotsForDeltaBuyingPower"/>
+    /// and <see cref="IPositionGroupBuyingPowerModel.GetMaximumLotsForTargetBuyingPower"/>
+    /// </summary>
+    public class GetMaximumLotsResult
+    {
+        /// <summary>
+        /// Returns the maximum number of lots of the position group that can be
+        /// ordered. This is a whole number and is the <see cref="IPositionGroup.Quantity"/>
+        /// </summary>
+        public decimal NumberOfLots { get; }
+
+        /// <summary>
+        /// Returns the reason for which the maximum order quantity is zero
+        /// </summary>
+        public string Reason { get; }
+
+        /// <summary>
+        /// Returns true if the zero order quantity is an error condition and will be shown to the user.
+        /// </summary>
+        public bool IsError { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetMaximumOrderQuantityResult"/> class
+        /// </summary>
+        /// <param name="numberOfLots">Returns the maximum number of lots of the position group that can be ordered</param>
+        /// <param name="reason">The reason for which the maximum order quantity is zero</param>
+        public GetMaximumLotsResult(decimal numberOfLots, string reason = null)
+        {
+            NumberOfLots = numberOfLots;
+            Reason = reason ?? string.Empty;
+            IsError = Reason != string.Empty;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetMaximumOrderQuantityResult"/> class
+        /// </summary>
+        /// <param name="numberOfLots">Returns the maximum number of lots of the position group that can be ordered</param>
+        /// <param name="reason">The reason for which the maximum order quantity is zero</param>
+        /// <param name="isError">True if the zero order quantity is an error condition</param>
+        public GetMaximumLotsResult(decimal numberOfLots, string reason, bool isError = true)
+        {
+            IsError = isError;
+            NumberOfLots = numberOfLots;
+            Reason = reason ?? string.Empty;
+        }
+    }
+}

--- a/Common/Securities/Positions/HasSufficientPositionGroupBuyingPowerForOrderParameters.cs
+++ b/Common/Securities/Positions/HasSufficientPositionGroupBuyingPowerForOrderParameters.cs
@@ -1,0 +1,86 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Linq;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Defines the parameters for <see cref="IPositionGroupBuyingPowerModel.HasSufficientBuyingPowerForOrder"/>
+    /// </summary>
+    public class HasSufficientPositionGroupBuyingPowerForOrderParameters
+    {
+        /// <summary>
+        /// Gets the order
+        /// </summary>
+        public Order Order { get; }
+
+        /// <summary>
+        /// Gets the position group representing the holdings changes contemplated by the order
+        /// </summary>
+        public IPositionGroup PositionGroup { get; }
+
+        /// <summary>
+        /// Gets the algorithm's portfolio manager
+        /// </summary>
+        public SecurityPortfolioManager Portfolio { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HasSufficientPositionGroupBuyingPowerForOrderParameters"/> class
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio manager</param>
+        /// <param name="positionGroup">The position group</param>
+        /// <param name="order">The order</param>
+        public HasSufficientPositionGroupBuyingPowerForOrderParameters(
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup,
+            Order order
+            )
+        {
+            Order = order;
+            Portfolio = portfolio;
+            PositionGroup = positionGroup;
+        }
+
+        /// <summary>
+        /// This may be called for non-combo type orders where the position group is guaranteed to have exactly one position
+        /// </summary>
+        public static implicit operator HasSufficientBuyingPowerForOrderParameters(
+            HasSufficientPositionGroupBuyingPowerForOrderParameters parameters
+            )
+        {
+            var position = parameters.PositionGroup.Single();
+            var security = parameters.Portfolio.Securities[position.Symbol];
+            return new HasSufficientBuyingPowerForOrderParameters(parameters.Portfolio, security, parameters.Order);
+        }
+
+        /// <summary>
+        /// Creates a new result indicating that there is sufficient buying power for the contemplated order
+        /// </summary>
+        public HasSufficientBuyingPowerForOrderResult Sufficient()
+        {
+            return new HasSufficientBuyingPowerForOrderResult(true);
+        }
+
+        /// <summary>
+        /// Creates a new result indicating that there is insufficient buying power for the contemplated order
+        /// </summary>
+        public HasSufficientBuyingPowerForOrderResult Insufficient(string reason)
+        {
+            return new HasSufficientBuyingPowerForOrderResult(false, reason);
+        }
+    }
+}

--- a/Common/Securities/Positions/HasSufficientPositionGroupBuyingPowerForOrderParameters.cs
+++ b/Common/Securities/Positions/HasSufficientPositionGroupBuyingPowerForOrderParameters.cs
@@ -82,5 +82,13 @@ namespace QuantConnect.Securities.Positions
         {
             return new HasSufficientBuyingPowerForOrderResult(false, reason);
         }
+
+        /// <summary>
+        /// Creates a new result indicating that there was an error
+        /// </summary>
+        public HasSufficientBuyingPowerForOrderResult Error(string reason)
+        {
+            return new HasSufficientBuyingPowerForOrderResult(false, reason);
+        }
     }
 }

--- a/Common/Securities/Positions/IPosition.cs
+++ b/Common/Securities/Positions/IPosition.cs
@@ -1,0 +1,39 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Defines a position for inclusion in a group
+    /// </summary>
+    public interface IPosition
+    {
+        /// <summary>
+        /// The symbol
+        /// </summary>
+        Symbol Symbol { get; }
+
+        /// <summary>
+        /// The quantity
+        /// </summary>
+        decimal Quantity { get; }
+
+        /// <summary>
+        /// The unit quantity. The unit quantities of a group define the group. For example, a covered
+        /// call has 100 units of stock and -1 units of call contracts.
+        /// </summary>
+        decimal UnitQuantity { get; }
+    }
+}

--- a/Common/Securities/Positions/IPositionGroup.cs
+++ b/Common/Securities/Positions/IPositionGroup.cs
@@ -1,0 +1,48 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Defines a group of positions allowing for more efficient use of portfolio margin
+    /// </summary>
+    public interface IPositionGroup : IReadOnlyCollection<IPosition>
+    {
+        /// <summary>
+        /// Gets the key identifying this group
+        /// </summary>
+        PositionGroupKey Key { get; }
+
+        /// <summary>
+        /// Gets the positions in this group
+        /// </summary>
+        IEnumerable<IPosition> Positions { get; }
+
+        /// <summary>
+        /// Gets the buying power model defining how margin works in this group
+        /// </summary>
+        IPositionGroupBuyingPowerModel BuyingPowerModel { get; }
+
+        /// <summary>
+        /// Attempts to retrieve the position with the specified symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="position">The position, if found</param>
+        /// <returns>True if the position was found, otherwise false</returns>
+        bool TryGetPosition(Symbol symbol, out IPosition position);
+    }
+}

--- a/Common/Securities/Positions/IPositionGroup.cs
+++ b/Common/Securities/Positions/IPositionGroup.cs
@@ -28,6 +28,11 @@ namespace QuantConnect.Securities.Positions
         PositionGroupKey Key { get; }
 
         /// <summary>
+        /// Gets the whole number of units in this position group
+        /// </summary>
+        decimal Quantity { get; }
+
+        /// <summary>
         /// Gets the positions in this group
         /// </summary>
         IEnumerable<IPosition> Positions { get; }

--- a/Common/Securities/Positions/IPositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Positions/IPositionGroupBuyingPowerModel.cs
@@ -13,12 +13,14 @@
  * limitations under the License.
 */
 
+using System;
+
 namespace QuantConnect.Securities.Positions
 {
     /// <summary>
     /// Represents a position group's model of buying power
     /// </summary>
-    public interface IPositionGroupBuyingPowerModel
+    public interface IPositionGroupBuyingPowerModel : IEquatable<IPositionGroupBuyingPowerModel>
     {
         /// <summary>
         /// Gets the margin currently allocated to the specified holding
@@ -39,5 +41,41 @@ namespace QuantConnect.Securities.Positions
         /// <param name="parameters">An object containing the portfolio, the security and the order</param>
         /// <returns>The total margin in terms of the currency quoted in the order</returns>
         InitialMargin GetInitialMarginRequiredForOrder(PositionGroupInitialMarginForOrderParameters parameters);
+
+        /// <summary>
+        /// Computes the impact on the portfolio's buying power from adding the position group to the portfolio. This is
+        /// a 'what if' analysis to determine what the state of the portfolio would be if these changes were applied. The
+        /// delta (before - after) is the margin requirement for adding the positions and if the margin used after the changes
+        /// are applied is less than the total portfolio value, this indicates sufficient capital.
+        /// </summary>
+        /// <param name="parameters">An object containing the portfolio and a position group containing the contemplated
+        /// changes to the portfolio</param>
+        /// <returns>Returns the portfolio's total portfolio value and margin used before and after the position changes are applied</returns>
+        ReservedBuyingPowerImpact GetReservedBuyingPowerImpact(
+            ReservedBuyingPowerImpactParameters parameters
+            );
+
+        /// <summary>
+        /// Check if there is sufficient buying power for the position group to execute this order.
+        /// </summary>
+        /// <param name="parameters">An object containing the portfolio, the position group and the order</param>
+        /// <returns>Returns buying power information for an order against a position group</returns>
+        HasSufficientBuyingPowerForOrderResult HasSufficientBuyingPowerForOrder(
+            HasSufficientPositionGroupBuyingPowerForOrderParameters parameters
+            );
+
+        /// <summary>
+        /// Computes the amount of buying power reserved by the provided position group
+        /// </summary>
+        ReservedBuyingPowerForPositionGroup GetReservedBuyingPowerForPositionGroup(
+            ReservedBuyingPowerForPositionGroupParameters parameters
+            );
+
+        /// <summary>
+        /// Gets the buying power available for a position group trade
+        /// </summary>
+        /// <param name="parameters">A parameters object containing the algorithm's portfolio, security, and order direction</param>
+        /// <returns>The buying power available for the trade</returns>
+        PositionGroupBuyingPower GetPositionGroupBuyingPower(PositionGroupBuyingPowerParameters parameters);
     }
 }

--- a/Common/Securities/Positions/IPositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Positions/IPositionGroupBuyingPowerModel.cs
@@ -1,0 +1,24 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Represents a position group's model of buying power
+    /// </summary>
+    public interface IPositionGroupBuyingPowerModel
+    {
+    }
+}

--- a/Common/Securities/Positions/IPositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Positions/IPositionGroupBuyingPowerModel.cs
@@ -72,6 +72,28 @@ namespace QuantConnect.Securities.Positions
             );
 
         /// <summary>
+        /// Get the maximum position group order quantity to obtain a position with a given buying power
+        /// percentage. Will not take into account free buying power.
+        /// </summary>
+        /// <param name="parameters">An object containing the portfolio, the position group and the target
+        ///     signed buying power percentage</param>
+        /// <returns>Returns the maximum allowed market order quantity and if zero, also the reason</returns>
+        GetMaximumLotsResult GetMaximumLotsForTargetBuyingPower(
+            GetMaximumLotsForTargetBuyingPowerParameters parameters
+            );
+
+        /// <summary>
+        /// Get the maximum market position group order quantity to obtain a delta in the buying power used by a position group.
+        /// The deltas sign defines the position side to apply it to, positive long, negative short.
+        /// </summary>
+        /// <param name="parameters">An object containing the portfolio, the position group and the delta buying power</param>
+        /// <returns>Returns the maximum allowed market order quantity and if zero, also the reason</returns>
+        /// <remarks>Used by the margin call model to reduce the position by a delta percent.</remarks>
+        GetMaximumLotsResult GetMaximumLotsForDeltaBuyingPower(
+            GetMaximumLotsForDeltaBuyingPowerParameters parameters
+            );
+
+        /// <summary>
         /// Gets the buying power available for a position group trade
         /// </summary>
         /// <param name="parameters">A parameters object containing the algorithm's portfolio, security, and order direction</param>

--- a/Common/Securities/Positions/IPositionGroupResolver.cs
+++ b/Common/Securities/Positions/IPositionGroupResolver.cs
@@ -23,6 +23,16 @@ namespace QuantConnect.Securities.Positions
     public interface IPositionGroupResolver
     {
         /// <summary>
+        /// Attempts to group the specified positions into a new <see cref="IPositionGroup"/> using an
+        /// appropriate <see cref="IPositionGroupBuyingPowerModel"/> for position groups created via this
+        /// resolver.
+        /// </summary>
+        /// <param name="positions">The positions to be grouped</param>
+        /// <param name="group">The grouped positions when this resolver is able to, otherwise null</param>
+        /// <returns>True if this resolver can group the specified positions, otherwise false</returns>
+        bool TryGroup(IReadOnlyCollection<IPosition> positions, out IPositionGroup group);
+
+        /// <summary>
         /// Resolves the position groups that exist within the specified collection of positions.
         /// </summary>
         /// <param name="positions">The collection of positions</param>

--- a/Common/Securities/Positions/IPositionGroupResolver.cs
+++ b/Common/Securities/Positions/IPositionGroupResolver.cs
@@ -1,0 +1,48 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Resolves position groups from a collection of positions.
+    /// </summary>
+    public interface IPositionGroupResolver
+    {
+        /// <summary>
+        /// Resolves the position groups that exist within the specified collection of positions.
+        /// </summary>
+        /// <param name="positions">The collection of positions</param>
+        /// <returns>An enumerable of position groups</returns>
+        PositionGroupCollection Resolve(PositionCollection positions);
+
+        /// <summary>
+        /// Determines the position groups that would be evaluated for grouping of the specified
+        /// positions were passed into the <see cref="Resolve"/> method.
+        /// </summary>
+        /// <remarks>
+        /// This function allows us to determine a set of impacted groups and run the resolver on just
+        /// those groups in order to support what-if analysis
+        /// </remarks>
+        /// <param name="groups">The existing position groups</param>
+        /// <param name="positions">The positions being changed</param>
+        /// <returns>An enumerable containing the position groups that could be impacted by the specified position changes</returns>
+        IEnumerable<IPositionGroup> GetImpactedGroups(
+            PositionGroupCollection groups,
+            IReadOnlyCollection<IPosition> positions
+            );
+    }
+}

--- a/Common/Securities/Positions/Position.cs
+++ b/Common/Securities/Positions/Position.cs
@@ -1,0 +1,63 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Defines a quantity of a security's holdings for inclusion in a position group
+    /// </summary>
+    public class Position : IPosition
+    {
+        /// <summary>
+        /// The symbol
+        /// </summary>
+        public Symbol Symbol { get; }
+
+        /// <summary>
+        /// The quantity
+        /// </summary>
+        public decimal Quantity { get; }
+
+        /// <summary>
+        /// The unit quantity. The unit quantities of a group define the group. For example, a covered
+        /// call has 100 units of stock and -1 units of call contracts.
+        /// </summary>
+        public decimal UnitQuantity { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Position"/> class
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="quantity">The quantity</param>
+        /// <param name="unitQuantity">The position's unit quantity within its group</param>
+        public Position(Symbol symbol, decimal quantity, decimal unitQuantity)
+        {
+            Symbol = symbol;
+            Quantity = quantity;
+            UnitQuantity = unitQuantity;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Position"/> class using the security's lot size
+        /// as it's unit quantity. If quantity is null, then the security's holdings quantity is used.
+        /// </summary>
+        /// <param name="security">The security</param>
+        /// <param name="quantity">The quantity, if null, the security's holdings quantity is used</param>
+        public Position(Security security, decimal? quantity = null)
+            : this(security.Symbol, quantity ?? security.Holdings.Quantity, security.SymbolProperties.LotSize)
+        {
+        }
+    }
+}

--- a/Common/Securities/Positions/Position.cs
+++ b/Common/Securities/Positions/Position.cs
@@ -13,6 +13,8 @@
  * limitations under the License.
 */
 
+using System;
+
 namespace QuantConnect.Securities.Positions
 {
     /// <summary>
@@ -47,6 +49,14 @@ namespace QuantConnect.Securities.Positions
             Symbol = symbol;
             Quantity = quantity;
             UnitQuantity = unitQuantity;
+
+#if DEBUG
+            var lots = Quantity / UnitQuantity;
+            if (lots != Math.Truncate(lots))
+            {
+                throw new InvalidOperationException("Position.Quantity must be a whole number multiple of the UnitQuantity.");
+            }
+#endif
         }
 
         /// <summary>
@@ -58,6 +68,13 @@ namespace QuantConnect.Securities.Positions
         public Position(Security security, decimal? quantity = null)
             : this(security.Symbol, quantity ?? security.Holdings.Quantity, security.SymbolProperties.LotSize)
         {
+        }
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            return $"{Symbol}: {Quantity}";
         }
     }
 }

--- a/Common/Securities/Positions/PositionCollection.cs
+++ b/Common/Securities/Positions/PositionCollection.cs
@@ -1,0 +1,102 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Provides a collection type for <see cref="IPosition"/> aimed at providing indexing for
+    /// common operations required by the resolver implementations.
+    /// </summary>
+    public class PositionCollection : IEnumerable<IPosition>
+    {
+        private readonly ImmutableDictionary<Symbol, IPosition> _positions;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionCollection"/> class
+        /// </summary>
+        /// <param name="positions">The positions to include in this collection</param>
+        public PositionCollection(ImmutableDictionary<Symbol, IPosition> positions)
+        {
+            _positions = positions;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionCollection"/> class
+        /// </summary>
+        /// <param name="positions">The positions to include in this collection</param>
+        public PositionCollection(IEnumerable<IPosition> positions)
+            : this(positions.ToImmutableDictionary(p => p.Symbol))
+        {
+        }
+
+        /// <summary>
+        /// Removes the quantities in the provided groups from this position collection.
+        /// This should be called following <see cref="IPositionGroupResolver"/> has resolved
+        /// position groups in order to update the collection of positions for the next resolver,
+        /// if one exists.
+        /// </summary>
+        /// <param name="groups">The resolved position groups</param>
+        /// <returns></returns>
+        public PositionCollection Remove(IEnumerable<IPositionGroup> groups)
+        {
+            var positions = _positions;
+            foreach (var group in groups)
+            {
+                foreach (var position in group.Positions)
+                {
+                    IPosition existing;
+                    if (!_positions.TryGetValue(position.Symbol, out existing))
+                    {
+                        throw new InvalidOperationException($"Position with symbol {position.Symbol} not found.");
+                    }
+
+                    positions = positions.SetItem(position.Symbol, existing.Deduct(position.Quantity));
+                }
+            }
+
+            return new PositionCollection(positions);
+        }
+
+        /// <summary>
+        /// Attempts to retrieve the position with the specified symbol from this collection
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="position">The position</param>
+        /// <returns>True if the position is found, otherwise false</returns>
+        public bool TryGetPosition(Symbol symbol, out IPosition position)
+        {
+            return _positions.TryGetValue(symbol, out position);
+        }
+
+        /// <summary>Returns an enumerator that iterates through the collection.</summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<IPosition> GetEnumerator()
+        {
+            return _positions.Values.GetEnumerator();
+        }
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/Common/Securities/Positions/PositionExtensions.cs
+++ b/Common/Securities/Positions/PositionExtensions.cs
@@ -1,0 +1,35 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="IPosition"/>
+    /// </summary>
+    public static class PositionExtensions
+    {
+        /// <summary>
+        /// Deducts the specified <paramref name="quantityToDeduct"/> from the specified <paramref name="position"/>
+        /// </summary>
+        /// <param name="position">The source position</param>
+        /// <param name="quantityToDeduct">The quantity to deduct</param>
+        /// <returns>A new position with the same properties but quantity reduced by the specified amount</returns>
+        public static IPosition Deduct(this IPosition position, decimal quantityToDeduct)
+        {
+            var newQuantity = position.Quantity - quantityToDeduct;
+            return new Position(position.Symbol, newQuantity, position.UnitQuantity);
+        }
+    }
+}

--- a/Common/Securities/Positions/PositionExtensions.cs
+++ b/Common/Securities/Positions/PositionExtensions.cs
@@ -78,5 +78,24 @@ namespace QuantConnect.Securities.Positions
 
             return consolidated;
         }
+
+        /// <summary>
+        /// Gets the number of lots contained within the specified <paramref name="position"/>
+        /// </summary>
+        public static decimal GetNumberOfLots(this IPosition position)
+        {
+            return position.Quantity / position.UnitQuantity;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="IPosition"/> with quantity equal to <paramref name="numberOfLots"/> times its unit quantity
+        /// </summary>
+        /// <param name="position">The position</param>
+        /// <param name="numberOfLots">The number of lots for the new position</param>
+        /// <returns>A new position with the specified number of lots</returns>
+        public static IPosition WithLots(this IPosition position, decimal numberOfLots)
+        {
+            return new Position(position.Symbol, numberOfLots * position.UnitQuantity, position.UnitQuantity);
+        }
     }
 }

--- a/Common/Securities/Positions/PositionGroup.cs
+++ b/Common/Securities/Positions/PositionGroup.cs
@@ -1,0 +1,105 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Provides a default implementation of <see cref="IPositionGroup"/>
+    /// </summary>
+    public class PositionGroup : IPositionGroup
+    {
+        /// <summary>
+        /// Gets the number of positions in the group
+        /// </summary>
+        public int Count => _positions.Count;
+
+        /// <summary>
+        /// Gets the key identifying this group
+        /// </summary>
+        public PositionGroupKey Key { get; }
+
+        /// <summary>
+        /// Gets the positions in this group
+        /// </summary>
+        public IEnumerable<IPosition> Positions => _positions.Values;
+
+        /// <summary>
+        /// Gets the buying power model defining how margin works in this group
+        /// </summary>
+        public IPositionGroupBuyingPowerModel BuyingPowerModel => Key.BuyingPowerModel;
+
+        private readonly Dictionary<Symbol, IPosition> _positions;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionGroup"/> class
+        /// </summary>
+        /// <param name="buyingPowerModel">The buying power model to use for this group</param>
+        /// <param name="positions">The positions comprising this group</param>
+        public PositionGroup(IPositionGroupBuyingPowerModel buyingPowerModel, params IPosition[] positions)
+            : this(new PositionGroupKey(buyingPowerModel, positions), positions.ToDictionary(p => p.Symbol))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionGroup"/> class
+        /// </summary>
+        /// <param name="key">The deterministic key for this group</param>
+        /// <param name="positions">The positions comprising this group</param>
+        public PositionGroup(PositionGroupKey key, params IPosition[] positions)
+            : this(key, positions.ToDictionary(p => p.Symbol))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionGroup"/> class
+        /// </summary>
+        /// <param name="key">The deterministic key for this group</param>
+        /// <param name="positions">The positions comprising this group</param>
+        public PositionGroup(PositionGroupKey key, Dictionary<Symbol, IPosition> positions)
+        {
+            Key = key;
+            _positions = positions;
+        }
+
+        /// <summary>
+        /// Attempts to retrieve the position with the specified symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="position">The position, if found</param>
+        /// <returns>True if the position was found, otherwise false</returns>
+        public bool TryGetPosition(Symbol symbol, out IPosition position)
+        {
+            return _positions.TryGetValue(symbol, out position);
+        }
+
+        /// <summary>Returns an enumerator that iterates through the collection.</summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<IPosition> GetEnumerator()
+        {
+            return Positions.GetEnumerator();
+        }
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/Common/Securities/Positions/PositionGroup.cs
+++ b/Common/Securities/Positions/PositionGroup.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,6 +34,11 @@ namespace QuantConnect.Securities.Positions
         /// Gets the key identifying this group
         /// </summary>
         public PositionGroupKey Key { get; }
+
+        /// <summary>
+        /// Gets the whole number of units in this position group
+        /// </summary>
+        public decimal Quantity { get; }
 
         /// <summary>
         /// Gets the positions in this group
@@ -75,6 +81,15 @@ namespace QuantConnect.Securities.Positions
         {
             Key = key;
             _positions = positions;
+            var firstPosition = positions.First();
+            var quantity = firstPosition.Value.Quantity / firstPosition.Value.UnitQuantity;
+#if DEBUG
+            if (quantity != Math.Truncate(quantity))
+            {
+                throw new InvalidOperationException("PositionGroup.Quantity must be a whole number.");
+            }
+#endif
+            Quantity = quantity;
         }
 
         /// <summary>
@@ -86,6 +101,13 @@ namespace QuantConnect.Securities.Positions
         public bool TryGetPosition(Symbol symbol, out IPosition position)
         {
             return _positions.TryGetValue(symbol, out position);
+        }
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            return $"{Key}: {Quantity}";
         }
 
         /// <summary>Returns an enumerator that iterates through the collection.</summary>

--- a/Common/Securities/Positions/PositionGroupBuyingPower.cs
+++ b/Common/Securities/Positions/PositionGroupBuyingPower.cs
@@ -1,0 +1,53 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Defines the result for <see cref="IPositionGroupBuyingPowerModel.GetPositionGroupBuyingPower"/>
+    /// </summary>
+    public class PositionGroupBuyingPower
+    {
+        /// <summary>
+        /// Gets the buying power
+        /// </summary>
+        public decimal Value { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionGroupBuyingPower"/> class
+        /// </summary>
+        /// <param name="buyingPower">The buying power</param>
+        public PositionGroupBuyingPower(decimal buyingPower)
+        {
+            Value = buyingPower;
+        }
+
+        /// <summary>
+        /// Implicit operator from decimal
+        /// </summary>
+        public static implicit operator PositionGroupBuyingPower(decimal result)
+        {
+            return new PositionGroupBuyingPower(result);
+        }
+
+        /// <summary>
+        /// Implicit operator to decimal
+        /// </summary>
+        public static implicit operator decimal(PositionGroupBuyingPower result)
+        {
+            return result.Value;
+        }
+    }
+}

--- a/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
@@ -16,28 +16,28 @@
 namespace QuantConnect.Securities.Positions
 {
     /// <summary>
-    /// Represents a position group's model of buying power
+    /// Provides a base class for implementations of <see cref="IPositionGroupBuyingPowerModel"/>
     /// </summary>
-    public interface IPositionGroupBuyingPowerModel
+    public abstract class PositionGroupBuyingPowerModel : IPositionGroupBuyingPowerModel
     {
         /// <summary>
         /// Gets the margin currently allocated to the specified holding
         /// </summary>
         /// <param name="parameters">An object containing the security</param>
         /// <returns>The maintenance margin required for the </returns>
-        MaintenanceMargin GetMaintenanceMargin(PositionGroupMaintenanceMarginParameters parameters);
+        public abstract MaintenanceMargin GetMaintenanceMargin(PositionGroupMaintenanceMarginParameters parameters);
 
         /// <summary>
         /// The margin that must be held in order to increase the position by the provided quantity
         /// </summary>
         /// <param name="parameters">An object containing the security and quantity</param>
-        InitialMargin GetInitialMarginRequirement(PositionGroupInitialMarginParameters parameters);
+        public abstract InitialMargin GetInitialMarginRequirement(PositionGroupInitialMarginParameters parameters);
 
         /// <summary>
         /// Gets the total margin required to execute the specified order in units of the account currency including fees
         /// </summary>
         /// <param name="parameters">An object containing the portfolio, the security and the order</param>
         /// <returns>The total margin in terms of the currency quoted in the order</returns>
-        InitialMargin GetInitialMarginRequiredForOrder(PositionGroupInitialMarginForOrderParameters parameters);
+        public abstract InitialMargin GetInitialMarginRequiredForOrder(PositionGroupInitialMarginForOrderParameters parameters);
     }
 }

--- a/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
@@ -13,6 +13,10 @@
  * limitations under the License.
 */
 
+using System.Collections.Generic;
+using System.Linq;
+using static QuantConnect.StringExtensions;
+
 namespace QuantConnect.Securities.Positions
 {
     /// <summary>
@@ -39,5 +43,232 @@ namespace QuantConnect.Securities.Positions
         /// <param name="parameters">An object containing the portfolio, the security and the order</param>
         /// <returns>The total margin in terms of the currency quoted in the order</returns>
         public abstract InitialMargin GetInitialMarginRequiredForOrder(PositionGroupInitialMarginForOrderParameters parameters);
+
+        /// <summary>
+        /// Computes the impact on the portfolio's buying power from adding the position group to the portfolio. This is
+        /// a 'what if' analysis to determine what the state of the portfolio would be if these changes were applied. The
+        /// delta (before - after) is the margin requirement for adding the positions and if the margin used after the changes
+        /// are applied is less than the total portfolio value, this indicates sufficient capital.
+        /// </summary>
+        /// <param name="parameters">An object containing the portfolio and a position group containing the contemplated
+        /// changes to the portfolio</param>
+        /// <returns>Returns the portfolio's total portfolio value and margin used before and after the position changes are applied</returns>
+        public virtual ReservedBuyingPowerImpact GetReservedBuyingPowerImpact(ReservedBuyingPowerImpactParameters parameters)
+        {
+            // This process aims to avoid having to compute buying power on the entire portfolio and instead determines
+            // the set of groups that can be impacted by the changes being contemplated. The only real way to determine
+            // the change in maintenance margin is to determine what groups we'll have after the changes and compute the
+            // margin based on that.
+            //   1. Determine impacted groups (depends on IPositionGroupResolver.GetImpactedGroups)
+            //   2. Compute the currently reserved buying power of impacted groups
+            //   3. Create position collection using impacted groups and apply contemplated changes
+            //   4. Resolve new position groups using position collection with applied contemplated changes
+            //   5. Compute the contemplated reserved buying power on these newly resolved groups
+
+            // 1. Determine impacted groups
+            var positionManager = parameters.Portfolio.Positions;
+
+            // 2. Compute current reserved buying power
+            var current = 0m;
+            var impactedGroups = new List<IPositionGroup>();
+
+            // 3. Determine set of impacted positions to be grouped
+            var impactedPositions = parameters.ContemplatedChanges.ToDictionary(p => p.Symbol);
+            foreach (var impactedGroup in positionManager.GetImpactedGroups(parameters.ContemplatedChanges))
+            {
+                impactedGroups.Add(impactedGroup);
+                current += impactedGroup.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(
+                    parameters.Portfolio, impactedGroup
+                );
+
+                foreach (var position in impactedGroup)
+                {
+                    IPosition existing;
+                    if (impactedPositions.TryGetValue(position.Symbol, out existing))
+                    {
+                        // if it already exists then combine it with the existing
+                        impactedPositions[position.Symbol] = existing.Combine(position);
+                    }
+                    else
+                    {
+                        impactedPositions[position.Symbol] = position;
+                    }
+                }
+            }
+
+            // 4. Resolve new position groups
+            var contemplatedGroups = positionManager.ResolvePositionGroups(
+                new PositionCollection(impactedPositions.Values)
+            );
+
+            // 5. Compute contemplated reserved buying power
+            var contemplated = 0m;
+            foreach (var contemplatedGroup in contemplatedGroups)
+            {
+                contemplated += contemplatedGroup.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(
+                    parameters.Portfolio, contemplatedGroup
+                );
+            }
+
+            return new ReservedBuyingPowerImpact(
+                current, contemplated, impactedGroups, parameters.ContemplatedChanges, contemplatedGroups
+            );
+        }
+
+        /// <summary>
+        /// Check if there is sufficient buying power for the position group to execute this order.
+        /// </summary>
+        /// <param name="parameters">An object containing the portfolio, the position group and the order</param>
+        /// <returns>Returns buying power information for an order against a position group</returns>
+        public virtual HasSufficientBuyingPowerForOrderResult HasSufficientBuyingPowerForOrder(
+            HasSufficientPositionGroupBuyingPowerForOrderParameters parameters
+            )
+        {
+            // The addition of position groups requires that we not only check initial margin requirements, but also
+            // that we confirm that after the changes have been applied and the new groups resolved our maintenance
+            // margin is still in a valid range (less than TPV). For this model, we use the security's sufficient buying
+            // power impl to confirm initial margin requirements and lean heavily on GetReservedBuyingPowerImpact for
+            // help with confirming that our expected maintenance margin is still less than TPV.
+            //   1. Confirm we have sufficient buying power to execute the trade using security's BP model
+            //   2. Confirm we pass position group specific checks
+            //   3. Confirm we haven't exceeded maintenance margin limits via GetReservedBuyingPowerImpact's delta
+
+            // 1. Confirm we meet initial margin requirements, accounting for buffer
+            var availableBuyingPower = this.GetPositionGroupBuyingPower(
+                parameters.Portfolio, parameters.PositionGroup, parameters.Order.Direction
+            );
+
+            // 2. Confirm we pass position group specific checks
+            var result = PassesPositionGroupSpecificBuyingPowerForOrderChecks(parameters, availableBuyingPower);
+            if (result?.IsSufficient == false)
+            {
+                return result;
+            }
+
+            // 3. Confirm that the new groupings arising from the change doesn't make maintenance margin exceed TPV
+            var deltaBuyingPower = this.GetChangeInReservedBuyingPower(parameters.Portfolio, parameters.PositionGroup);
+            if (deltaBuyingPower <= availableBuyingPower)
+            {
+                return parameters.Sufficient();
+            }
+
+            return parameters.Insufficient(Invariant(
+                $"Id: {parameters.Order.Id}, Maintenance Margin Delta: {deltaBuyingPower.Normalize()}, Free Margin: {availableBuyingPower.Value.Normalize()}"
+            ));
+        }
+
+        /// <summary>
+        /// Provides a mechanism for derived types to add their own buying power for order checks without needing to
+        /// recompute the available buying power. Implementations should return null if all checks pass and should
+        /// return an instance of <see cref="HasSufficientBuyingPowerForOrderResult"/> with IsSufficient=false if it
+        /// fails.
+        /// </summary>
+        protected virtual HasSufficientBuyingPowerForOrderResult PassesPositionGroupSpecificBuyingPowerForOrderChecks(
+            HasSufficientPositionGroupBuyingPowerForOrderParameters parameters,
+            decimal availableBuyingPower
+            )
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Computes the amount of buying power reserved by the provided position group
+        /// </summary>
+        public virtual ReservedBuyingPowerForPositionGroup GetReservedBuyingPowerForPositionGroup(
+            ReservedBuyingPowerForPositionGroupParameters parameters
+            )
+        {
+            return this.GetMaintenanceMargin(parameters.Portfolio, parameters.PositionGroup, true);
+        }
+
+        /// <summary>
+        /// Gets the buying power available for a position group trade
+        /// </summary>
+        /// <param name="parameters">A parameters object containing the algorithm's portfolio, security, and order direction</param>
+        /// <returns>The buying power available for the trade</returns>
+        public PositionGroupBuyingPower GetPositionGroupBuyingPower(PositionGroupBuyingPowerParameters parameters)
+        {
+            // SecurityPositionGroupBuyingPowerModel models buying power the same as non-grouped, so we can simply delegate
+            // to the security's model. For posterity, however, I'll lay out the process for computing the available buying
+            // power for a position group trade. There's two separate cases, one where we're increasing the position and one
+            // where we're decreasing the position and potentially crossing over zero. When decreasing the position we have
+            // to account for the reserved buying power that the position currently holds and add that to any free buying power
+            // in the portfolio.
+            //   1. Get portfolio's MarginRemaining (free buying power)
+            //   2. Determine if closing position
+            //   2a. Add reserved buying power freed up by closing the position
+            //   2b. Rebate initial buying power required for current position [to match current behavior, might not be possible]
+
+            // 1. Get MarginRemaining
+            var buyingPower = parameters.Portfolio.MarginRemaining;
+
+            // 2. Determine if closing position
+            IPositionGroup existing;
+            if (parameters.Portfolio.Positions.Groups.TryGetGroup(parameters.PositionGroup.Key, out existing) &&
+                parameters.Direction.Closes(existing.GetPositionSide()))
+            {
+                // 2a. Add reserved buying power of current position
+                buyingPower += GetReservedBuyingPowerForPositionGroup(parameters);
+
+                // 2b. Rebate the initial margin equivalent of current position
+                // this interface doesn't have a concept of initial margin as it's an impl detail of the BuyingPowerModel base class
+                buyingPower += this.GetInitialMarginRequirement(parameters.Portfolio, existing);
+            }
+
+            return buyingPower;
+        }
+
+        public virtual decimal ToAccountCurrency(SecurityPortfolioManager portfolio, CashAmount cash)
+        {
+            return portfolio.CashBook.ConvertToAccountCurrency(cash).Amount;
+        }
+
+        /// <summary>Indicates whether the current object is equal to another object of the same type.</summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.</returns>
+        public virtual bool Equals(IPositionGroupBuyingPowerModel other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return GetType() == other.GetType();
+        }
+
+        /// <summary>Determines whether the specified object is equal to the current object.</summary>
+        /// <param name="obj">The object to compare with the current object. </param>
+        /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != GetType())
+            {
+                return false;
+            }
+
+            return Equals((SecurityPositionGroupBuyingPowerModel) obj);
+        }
+
+        /// <summary>Serves as the default hash function. </summary>
+        /// <returns>A hash code for the current object.</returns>
+        public override int GetHashCode()
+        {
+            return GetType().GetHashCode();
+        }
     }
 }

--- a/Common/Securities/Positions/PositionGroupBuyingPowerModelExtensions.cs
+++ b/Common/Securities/Positions/PositionGroupBuyingPowerModelExtensions.cs
@@ -1,0 +1,129 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Orders;
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Provides methods aimed at reducing the noise introduced from having result/parameter types for each method.
+    /// These methods aim to accept raw arguments and return the desired value type directly.
+    /// </summary>
+    public static class PositionGroupBuyingPowerModelExtensions
+    {
+        /// <summary>
+        /// Gets the margin currently allocated to the specified position group
+        /// </summary>
+        public static decimal GetMaintenanceMargin(
+            this IPositionGroupBuyingPowerModel model,
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup,
+            bool isCurrentHoldings
+            )
+        {
+            return model.GetMaintenanceMargin(
+                new PositionGroupMaintenanceMarginParameters(portfolio, positionGroup, isCurrentHoldings)
+            );
+        }
+
+        /// <summary>
+        /// The margin that must be held in order to change positions by the changes defined by the provided position group
+        /// </summary>
+        public static decimal GetInitialMarginRequirement(
+            this IPositionGroupBuyingPowerModel model,
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup
+            )
+        {
+            return model.GetInitialMarginRequirement(
+                new PositionGroupInitialMarginParameters(portfolio, positionGroup)
+            ).Value;
+        }
+
+        /// <summary>
+        /// Gets the total margin required to execute the specified order in units of the account currency including fees
+        /// </summary>
+        public static decimal GetInitialMarginRequiredForOrder(
+            this IPositionGroupBuyingPowerModel model,
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup,
+            Order order
+            )
+        {
+            return model.GetInitialMarginRequiredForOrder(
+                new PositionGroupInitialMarginForOrderParameters(portfolio, positionGroup, order)
+            ).Value;
+        }
+
+        /// <summary>
+        /// Computes the amount of buying power reserved by the provided position group
+        /// </summary>
+        public static decimal GetReservedBuyingPowerForPositionGroup(
+            this IPositionGroupBuyingPowerModel model,
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup
+            )
+        {
+            return model.GetReservedBuyingPowerForPositionGroup(
+                new ReservedBuyingPowerForPositionGroupParameters(portfolio, positionGroup)
+            ).AbsoluteUsedBuyingPower;
+        }
+
+        /// <summary>
+        /// Computes the change in reserved buying power we expect the portfolio to experience if the specified position
+        /// group is added to the algorithm's holdings
+        /// </summary>
+        public static decimal GetChangeInReservedBuyingPower(
+            this IPositionGroupBuyingPowerModel model,
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup
+            )
+        {
+            return model.GetReservedBuyingPowerImpact(
+                new ReservedBuyingPowerImpactParameters(portfolio, positionGroup)
+            ).Delta;
+        }
+
+        /// <summary>
+        /// Check if there is sufficient buying power for the position group to execute this order.
+        /// </summary>
+        public static HasSufficientBuyingPowerForOrderResult HasSufficientBuyingPowerForOrder(
+            this IPositionGroupBuyingPowerModel model,
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup,
+            Order order
+            )
+        {
+            return model.HasSufficientBuyingPowerForOrder(new HasSufficientPositionGroupBuyingPowerForOrderParameters(
+                portfolio, positionGroup, order
+            ));
+        }
+
+        /// <summary>
+        /// Gets the buying power available for a position group trade
+        /// </summary>
+        public static PositionGroupBuyingPower GetPositionGroupBuyingPower(
+            this IPositionGroupBuyingPowerModel model,
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup,
+            OrderDirection direction
+            )
+        {
+            return model.GetPositionGroupBuyingPower(new PositionGroupBuyingPowerParameters(
+                portfolio, positionGroup, direction
+            ));
+        }
+    }
+}

--- a/Common/Securities/Positions/PositionGroupBuyingPowerModelExtensions.cs
+++ b/Common/Securities/Positions/PositionGroupBuyingPowerModelExtensions.cs
@@ -97,6 +97,38 @@ namespace QuantConnect.Securities.Positions
         }
 
         /// <summary>
+        /// Get the maximum position group order quantity to obtain a position with a given buying power
+        /// percentage. Will not take into account free buying power.
+        /// </summary>
+        public static GetMaximumLotsResult GetMaximumLotsForTargetBuyingPower(
+            this IPositionGroupBuyingPowerModel model,
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup,
+            decimal targetBuyingPower
+            )
+        {
+            return model.GetMaximumLotsForTargetBuyingPower(new GetMaximumLotsForTargetBuyingPowerParameters(
+                portfolio, positionGroup, targetBuyingPower
+            ));
+        }
+
+        /// <summary>
+        /// Get the maximum market position group order quantity to obtain a delta in the buying power used by a position group.
+        /// The deltas sign defines the position side to apply it to, positive long, negative short.
+        /// </summary>
+        public static GetMaximumLotsResult GetMaximumLotsForDeltaBuyingPower(
+            this IPositionGroupBuyingPowerModel model,
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup,
+            decimal deltaBuyingPower
+            )
+        {
+            return model.GetMaximumLotsForDeltaBuyingPower(new GetMaximumLotsForDeltaBuyingPowerParameters(
+                portfolio, positionGroup, deltaBuyingPower
+            ));
+        }
+
+        /// <summary>
         /// Check if there is sufficient buying power for the position group to execute this order.
         /// </summary>
         public static HasSufficientBuyingPowerForOrderResult HasSufficientBuyingPowerForOrder(

--- a/Common/Securities/Positions/PositionGroupBuyingPowerParameters.cs
+++ b/Common/Securities/Positions/PositionGroupBuyingPowerParameters.cs
@@ -1,0 +1,89 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Orders;
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Defines the parameters for <see cref="IPositionGroupBuyingPowerModel.GetPositionGroupBuyingPower"/>
+    /// </summary>
+    public class PositionGroupBuyingPowerParameters
+    {
+        /// <summary>
+        /// Gets the position group
+        /// </summary>
+        public IPositionGroup PositionGroup { get; }
+
+        /// <summary>
+        /// Gets the algorithm's portfolio manager
+        /// </summary>
+        public SecurityPortfolioManager Portfolio { get; }
+
+        /// <summary>
+        /// Gets the direction in which buying power is to be computed
+        /// </summary>
+        public OrderDirection Direction { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionGroupBuyingPowerParameters"/> class
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio manager</param>
+        /// <param name="positionGroup">The position group</param>
+        /// <param name="direction">The direction to compute buying power in</param>
+        public PositionGroupBuyingPowerParameters(
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup,
+            OrderDirection direction
+            )
+        {
+            Portfolio = portfolio;
+            Direction = direction;
+            PositionGroup = positionGroup;
+        }
+
+        /// <summary>
+        /// Creates the result using the specified buying power
+        /// </summary>
+        /// <param name="buyingPower">The buying power</param>
+        /// <param name="currency">The units the buying power is denominated in</param>
+        /// <returns>The buying power</returns>
+        public PositionGroupBuyingPower Result(decimal buyingPower, string currency)
+        {
+            // TODO: Properly account for 'currency' - not accounted for currently as only performing mechanical refactoring
+            return new PositionGroupBuyingPower(buyingPower);
+        }
+
+        /// <summary>
+        /// Creates the result using the specified buying power in units of the account currency
+        /// </summary>
+        /// <param name="buyingPower">The buying power</param>
+        /// <returns>The buying power</returns>
+        public PositionGroupBuyingPower ResultInAccountCurrency(decimal buyingPower)
+        {
+            return new PositionGroupBuyingPower(buyingPower);
+        }
+
+        /// <summary>
+        /// Implicit operator to dependent function to remove noise
+        /// </summary>
+        public static implicit operator ReservedBuyingPowerForPositionGroupParameters(
+            PositionGroupBuyingPowerParameters parameters
+            )
+        {
+            return new ReservedBuyingPowerForPositionGroupParameters(parameters.Portfolio, parameters.PositionGroup);
+        }
+    }
+}

--- a/Common/Securities/Positions/PositionGroupCollection.cs
+++ b/Common/Securities/Positions/PositionGroupCollection.cs
@@ -1,0 +1,163 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Provides a collection type for <see cref="IPositionGroup"/>
+    /// </summary>
+    public class PositionGroupCollection : IReadOnlyCollection<IPositionGroup>
+    {
+        /// <summary>
+        /// Gets an empty instance of the <see cref="PositionGroupCollection"/> class
+        /// </summary>
+        public static PositionGroupCollection Empty { get; } = new PositionGroupCollection(
+            ImmutableDictionary<PositionGroupKey, IPositionGroup>.Empty,
+            ImmutableDictionary<Symbol, ImmutableList<IPositionGroup>>.Empty
+        );
+
+        /// <summary>
+        /// Gets the number of positions in this group
+        /// </summary>
+        public int Count => _groups.Count;
+
+        /// <summary>
+        /// Gets whether or not this collection contains only default position groups
+        /// </summary>
+        public bool IsOnlyDefaultGroups
+        {
+            get
+            {
+                if (_hasNonDefaultGroups == null)
+                {
+                    _hasNonDefaultGroups = _groups.Count == 0 || _groups.All(grp => grp.Key.IsDefaultGroup);
+                }
+
+                return _hasNonDefaultGroups.Value;
+            }
+        }
+
+        private bool? _hasNonDefaultGroups;
+        private readonly ImmutableDictionary<PositionGroupKey, IPositionGroup> _groups;
+        private readonly ImmutableDictionary<Symbol, ImmutableList<IPositionGroup>> _groupsBySymbol;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionGroupCollection"/> class
+        /// </summary>
+        /// <param name="groups">The position groups keyed by their group key</param>
+        /// <param name="groupsBySymbol">The position groups keyed by the symbol of each position</param>
+        public PositionGroupCollection(
+            ImmutableDictionary<PositionGroupKey, IPositionGroup> groups,
+            ImmutableDictionary<Symbol, ImmutableList<IPositionGroup>> groupsBySymbol
+            )
+        {
+            _groups = groups;
+            _groupsBySymbol = groupsBySymbol;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionGroupCollection"/> class
+        /// </summary>
+        /// <param name="groups">The position groups</param>
+        public PositionGroupCollection(IReadOnlyCollection<IPositionGroup> groups)
+        {
+            _groups = groups.ToImmutableDictionary(g => g.Key);
+            _groupsBySymbol = groups.SelectMany(group =>
+                    group.Select(position => new {position.Symbol, group})
+                )
+                .GroupBy(item => item.Symbol)
+                .ToImmutableDictionary(
+                    item => item.Key,
+                    item => item.Select(x => x.group).ToImmutableList()
+                );
+        }
+
+        public PositionGroupCollection Add(IPositionGroup group)
+        {
+            var bySymbol = _groupsBySymbol;
+            foreach (var position in group)
+            {
+                ImmutableList<IPositionGroup> groups;
+                if (!_groupsBySymbol.TryGetValue(position.Symbol, out groups))
+                {
+                    groups = ImmutableList<IPositionGroup>.Empty;
+                }
+
+                bySymbol = _groupsBySymbol.SetItem(position.Symbol, groups.Add(group));
+            }
+
+            return new PositionGroupCollection(_groups.Add(group.Key, group), bySymbol);
+        }
+
+        /// <summary>
+        /// Determines whether or not a group with the specified key exists in this collection
+        /// </summary>
+        /// <param name="key">The group key to search for</param>
+        /// <returns>True if a group with the specified key was found, false otherwise</returns>
+        public bool Contains(PositionGroupKey key)
+        {
+            return _groups.ContainsKey(key);
+        }
+
+        /// <summary>
+        /// Attempts to retrieve the group with the specified key
+        /// </summary>
+        /// <param name="key">The group key to search for</param>
+        /// <param name="group">The position group</param>
+        /// <returns>True if group with key found, otherwise false</returns>
+        public bool TryGetGroup(PositionGroupKey key, out IPositionGroup group)
+        {
+            return _groups.TryGetValue(key, out group);
+        }
+
+        /// <summary>
+        /// Attempts to retrieve all groups that contain the provided symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="groups">The groups if any were found, otherwise null</param>
+        /// <returns>True if groups were found for the specified symbol, otherwise false</returns>
+        public bool TryGetGroups(Symbol symbol, out IReadOnlyCollection<IPositionGroup> groups)
+        {
+            ImmutableList<IPositionGroup> list;
+            if (_groupsBySymbol.TryGetValue(symbol, out list) && list?.IsEmpty == false)
+            {
+                groups = list;
+                return true;
+            }
+
+            groups = ImmutableArray<IPositionGroup>.Empty;
+            return false;
+        }
+
+        /// <summary>Returns an enumerator that iterates through the collection.</summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<IPositionGroup> GetEnumerator()
+        {
+            return _groups.Values.GetEnumerator();
+        }
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/Common/Securities/Positions/PositionGroupCollection.cs
+++ b/Common/Securities/Positions/PositionGroupCollection.cs
@@ -89,6 +89,11 @@ namespace QuantConnect.Securities.Positions
                 );
         }
 
+        /// <summary>
+        /// Creates a new <see cref="PositionGroupCollection"/> that contains all of the position groups
+        /// in this collection in addition to the specified <paramref name="group"/>. If a group with the
+        /// same key already exists then it is overwritten.
+        /// </summary>
         public PositionGroupCollection Add(IPositionGroup group)
         {
             var bySymbol = _groupsBySymbol;
@@ -114,6 +119,26 @@ namespace QuantConnect.Securities.Positions
         public bool Contains(PositionGroupKey key)
         {
             return _groups.ContainsKey(key);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IPositionGroup"/> matching the specified key. If one does not exist, then an empty
+        /// group is returned matching the unit quantities defined in the <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The position group key to search for</param>
+        /// <returns>The position group matching the specified key, or a new empty group if no matching group is found.</returns>
+        public IPositionGroup this[PositionGroupKey key]
+        {
+            get
+            {
+                IPositionGroup group;
+                if (!TryGetGroup(key, out group))
+                {
+                    return new PositionGroup(key, key.CreateEmptyPositions());
+                }
+
+                return group;
+            }
         }
 
         /// <summary>

--- a/Common/Securities/Positions/PositionGroupExtensions.cs
+++ b/Common/Securities/Positions/PositionGroupExtensions.cs
@@ -1,0 +1,43 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="IPositionGroup"/>
+    /// </summary>
+    public static class PositionGroupExtensions
+    {
+        /// <summary>
+        /// Gets the position side (long/short/none) of the specified <paramref name="group"/>
+        /// </summary>
+        public static PositionSide GetPositionSide(this IPositionGroup group)
+        {
+            if (group.Quantity > 0)
+            {
+                return PositionSide.Long;
+            }
+
+            if (group.Quantity < 0)
+            {
+                return PositionSide.Short;
+            }
+
+            return PositionSide.None;
+        }
+    }
+}

--- a/Common/Securities/Positions/PositionGroupExtensions.cs
+++ b/Common/Securities/Positions/PositionGroupExtensions.cs
@@ -14,6 +14,9 @@
 */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Util;
 
 namespace QuantConnect.Securities.Positions
 {
@@ -38,6 +41,51 @@ namespace QuantConnect.Securities.Positions
             }
 
             return PositionSide.None;
+        }
+
+        /// <summary>
+        /// Gets the position in the <paramref name="group"/> matching the provided <param name="symbol"></param>
+        /// </summary>
+        public static IPosition GetPosition(this IPositionGroup group, Symbol symbol)
+        {
+            IPosition position;
+            if (!group.TryGetPosition(symbol, out position))
+            {
+                throw new KeyNotFoundException($"No position with symbol '{symbol}' exists in the group: {group}");
+            }
+
+            return position;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="IPositionGroup"/> with the specified <paramref name="groupQuantity"/>.
+        /// If the quantity provided equals the template's quantity then the template is returned.
+        /// </summary>
+        /// <param name="template">The group template</param>
+        /// <param name="groupQuantity">The quantity of the new group</param>
+        /// <returns>A position group with the same position ratios as the template but with the specified group quantity</returns>
+        public static IPositionGroup WithQuantity(this IPositionGroup template, decimal groupQuantity)
+        {
+            if (template.Quantity == groupQuantity)
+            {
+                return template;
+            }
+
+            var positions = template.ToArray(p => p.WithLots(groupQuantity));
+            return new PositionGroup(template.Key, positions);
+        }
+
+        /// <summary>
+        /// Gets a user friendly name for the provided <paramref name="group"/>
+        /// </summary>
+        public static string GetUserFriendlyName(this IPositionGroup group)
+        {
+            if (group.Count == 1)
+            {
+                return group.Single().Symbol.ToString();
+            }
+
+            return string.Join("|", group.Select(p => p.Symbol.ToString()));
         }
     }
 }

--- a/Common/Securities/Positions/PositionGroupInitialMarginForOrderParameters.cs
+++ b/Common/Securities/Positions/PositionGroupInitialMarginForOrderParameters.cs
@@ -15,17 +15,22 @@
 
 using QuantConnect.Orders;
 
-namespace QuantConnect.Securities
+namespace QuantConnect.Securities.Positions
 {
     /// <summary>
-    /// Defines the parameters for <see cref="BuyingPowerModel.GetInitialMarginRequiredForOrder"/>
+    /// Defines parameters for <see cref="IPositionGroupBuyingPowerModel.GetInitialMarginRequiredForOrder"/>
     /// </summary>
-    public class InitialMarginRequiredForOrderParameters
+    public class PositionGroupInitialMarginForOrderParameters
     {
         /// <summary>
-        /// Gets the security
+        /// Gets the algorithm's portfolio manager
         /// </summary>
-        public Security Security { get; }
+        public SecurityPortfolioManager Portfolio { get; }
+
+        /// <summary>
+        /// Gets the position group
+        /// </summary>
+        public IPositionGroup PositionGroup { get; }
 
         /// <summary>
         /// Gets the order
@@ -33,25 +38,20 @@ namespace QuantConnect.Securities
         public Order Order { get; }
 
         /// <summary>
-        /// Gets the currency converter
+        /// Initializes a new instance of the <see cref="PositionGroupInitialMarginForOrderParameters"/> class
         /// </summary>
-        public ICurrencyConverter CurrencyConverter { get; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InitialMarginRequiredForOrderParameters"/> class
-        /// </summary>
-        /// <param name="currencyConverter">The currency converter</param>
-        /// <param name="security">The security</param>
+        /// <param name="portfolio">The algorithm's portfolio manager</param>
+        /// <param name="positionGroup">The position group</param>
         /// <param name="order">The order</param>
-        public InitialMarginRequiredForOrderParameters(
-            ICurrencyConverter currencyConverter,
-            Security security,
+        public PositionGroupInitialMarginForOrderParameters(
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup,
             Order order
             )
         {
+            Portfolio = portfolio;
+            PositionGroup = positionGroup;
             Order = order;
-            Security = security;
-            CurrencyConverter = currencyConverter;
         }
     }
 }

--- a/Common/Securities/Positions/PositionGroupInitialMarginParameters.cs
+++ b/Common/Securities/Positions/PositionGroupInitialMarginParameters.cs
@@ -1,0 +1,47 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Defines parameters for <see cref="IPositionGroupBuyingPowerModel.GetInitialMarginRequirement"/>
+    /// </summary>
+    public class PositionGroupInitialMarginParameters
+    {
+        /// <summary>
+        /// Gets the algorithm's portfolio manager
+        /// </summary>
+        public SecurityPortfolioManager Portfolio { get; }
+
+        /// <summary>
+        /// Gets the position group
+        /// </summary>
+        public IPositionGroup PositionGroup { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionGroupInitialMarginParameters"/> class
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio manager</param>
+        /// <param name="positionGroup">The position group</param>
+        public PositionGroupInitialMarginParameters(
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup
+            )
+        {
+            Portfolio = portfolio;
+            PositionGroup = positionGroup;
+        }
+    }
+}

--- a/Common/Securities/Positions/PositionGroupKey.cs
+++ b/Common/Securities/Positions/PositionGroupKey.cs
@@ -1,0 +1,142 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using QuantConnect.Util;
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Defines a unique and deterministic key for <see cref="IPositionGroup"/>
+    /// </summary>
+    public sealed class PositionGroupKey : IEquatable<PositionGroupKey>
+    {
+        /// <summary>
+        /// Gets whether or not this key defines a default group
+        /// </summary>
+        public bool IsDefaultGroup { get; }
+
+        /// <summary>
+        /// Gets the <see cref="IPositionGroupBuyingPowerModel"/> being used by the group
+        /// </summary>
+        public IPositionGroupBuyingPowerModel BuyingPowerModel { get; }
+
+        /// <summary>
+        /// Gets the unit quantities defining the ratio between position quantities in the group
+        /// </summary>
+        public IReadOnlyList<Tuple<Symbol, decimal>> UnitQuantities { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionGroupKey"/> class for groups with a single security
+        /// </summary>
+        /// <param name="buyingPowerModel">The group's buying power model</param>
+        /// <param name="security">The security</param>
+        public PositionGroupKey(IPositionGroupBuyingPowerModel buyingPowerModel, Security security)
+        {
+            IsDefaultGroup = buyingPowerModel.GetType() == typeof(SecurityPositionGroupBuyingPowerModel);
+            BuyingPowerModel = buyingPowerModel;
+            UnitQuantities = new[]
+            {
+                Tuple.Create(security.Symbol, security.SymbolProperties.LotSize)
+            };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionGroupKey"/> class
+        /// </summary>
+        /// <param name="buyingPowerModel">The group's buying power model</param>
+        /// <param name="positions">The positions comprising the group</param>
+        public PositionGroupKey(IPositionGroupBuyingPowerModel buyingPowerModel, IEnumerable<IPosition> positions)
+        {
+            BuyingPowerModel = buyingPowerModel;
+            // these have to be sorted for determinism
+            UnitQuantities = positions.Select(p => Tuple.Create(p.Symbol, p.UnitQuantity)).ToImmutableSortedSet();
+            IsDefaultGroup = UnitQuantities.Count == 1 && BuyingPowerModel.GetType() == typeof(SecurityPositionGroupBuyingPowerModel);
+        }
+
+        /// <summary>Indicates whether the current object is equal to another object of the same type.</summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.</returns>
+        public bool Equals(PositionGroupKey other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return BuyingPowerModel.Equals(other.BuyingPowerModel)
+                && UnitQuantities.ListEquals(other.UnitQuantities);
+        }
+
+        /// <summary>Determines whether the specified object is equal to the current object.</summary>
+        /// <param name="obj">The object to compare with the current object. </param>
+        /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj is PositionGroupKey && Equals((PositionGroupKey) obj);
+        }
+
+        /// <summary>Serves as the default hash function. </summary>
+        /// <returns>A hash code for the current object.</returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (BuyingPowerModel.GetHashCode() * 397) ^ UnitQuantities.GetListHashCode();
+            }
+        }
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            return $"{string.Join("|", UnitQuantities.Select(x => $"{x.Item1}:{x.Item2.Normalize()}"))}";
+        }
+
+        /// <summary>
+        /// Equals operator
+        /// </summary>
+        public static bool operator ==(PositionGroupKey left, PositionGroupKey right)
+        {
+            return Equals(left, right);
+        }
+
+        /// <summary>
+        /// Not equals operator
+        /// </summary>
+        public static bool operator !=(PositionGroupKey left, PositionGroupKey right)
+        {
+            return !Equals(left, right);
+        }
+    }
+}

--- a/Common/Securities/Positions/PositionGroupKey.cs
+++ b/Common/Securities/Positions/PositionGroupKey.cs
@@ -69,6 +69,45 @@ namespace QuantConnect.Securities.Positions
             IsDefaultGroup = UnitQuantities.Count == 1 && BuyingPowerModel.GetType() == typeof(SecurityPositionGroupBuyingPowerModel);
         }
 
+        /// <summary>
+        /// Creates a new array of empty positions with unit quantities according to this key
+        /// </summary>
+        public IPosition[] CreateEmptyPositions()
+        {
+            var positions = new IPosition[UnitQuantities.Count];
+            for (int i = 0; i < UnitQuantities.Count; i++)
+            {
+                var unitQuantity = UnitQuantities[i];
+                positions[i] = new Position(unitQuantity.Item1, 0m, unitQuantity.Item2);
+            }
+
+            return positions;
+        }
+
+        /// <summary>
+        /// Creates a new array of positions with each position quantity equaling its unit quantity
+        /// </summary>
+        public IPosition[] CreateUnitPositions()
+        {
+            var positions = new IPosition[UnitQuantities.Count];
+            for (int i = 0; i < UnitQuantities.Count; i++)
+            {
+                var unitQuantity = UnitQuantities[i];
+                positions[i] = new Position(unitQuantity.Item1, unitQuantity.Item2, unitQuantity.Item2);
+            }
+
+            return positions;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="IPositionGroup"/> with each position's quantity equaling it's unit quantity
+        /// </summary>
+        /// <returns>A new position group with quantity equal to 1</returns>
+        public IPositionGroup CreateUnitGroup()
+        {
+            return new PositionGroup(this, CreateUnitPositions());
+        }
+
         /// <summary>Indicates whether the current object is equal to another object of the same type.</summary>
         /// <param name="other">An object to compare with this object.</param>
         /// <returns>true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.</returns>

--- a/Common/Securities/Positions/PositionGroupMaintenanceMarginParameters.cs
+++ b/Common/Securities/Positions/PositionGroupMaintenanceMarginParameters.cs
@@ -1,0 +1,56 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Defines parameters for <see cref="IPositionGroupBuyingPowerModel.GetMaintenanceMargin"/>
+    /// </summary>
+    public class PositionGroupMaintenanceMarginParameters
+    {
+        /// <summary>
+        /// Gets the algorithm's portfolio manager
+        /// </summary>
+        public SecurityPortfolioManager Portfolio { get; }
+
+        /// <summary>
+        /// Gets the position group
+        /// </summary>
+        public IPositionGroup PositionGroup { get; }
+
+        /// <summary>
+        /// Gets whether or not we're computing margin for a position group we already hold or
+        /// one we are contemplating buying
+        /// </summary>
+        public bool IsCurrentHoldings { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionGroupMaintenanceMarginParameters"/> class
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio manager</param>
+        /// <param name="positionGroup">The position group</param>
+        /// <param name="isCurrentHoldings">True if the algorithm currently holds this position group, otherwise false</param>
+        public PositionGroupMaintenanceMarginParameters(
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup,
+            bool isCurrentHoldings
+            )
+        {
+            Portfolio = portfolio;
+            PositionGroup = positionGroup;
+            IsCurrentHoldings = isCurrentHoldings;
+        }
+    }
+}

--- a/Common/Securities/Positions/PositionManager.cs
+++ b/Common/Securities/Positions/PositionManager.cs
@@ -1,0 +1,109 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Responsible for managing the resolution of position groups for an algorithm
+    /// </summary>
+    public class PositionManager
+    {
+        private bool _requiresGroupResolution;
+        private Dictionary<PositionGroupKey, IPositionGroup> _groups;
+
+        private readonly SecurityManager _securities;
+        private readonly SecurityPositionGroupResolver _resolver;
+        private readonly IPositionGroupBuyingPowerModel _defaultBuyingPowerModel;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PositionManager"/> class
+        /// </summary>
+        /// <param name="securities">The algorithm's security manager</param>
+        public PositionManager(SecurityManager securities)
+        {
+            _securities = securities;
+            _groups = new Dictionary<PositionGroupKey, IPositionGroup>();
+            _defaultBuyingPowerModel = new SecurityPositionGroupBuyingPowerModel();
+            _resolver = new SecurityPositionGroupResolver(_defaultBuyingPowerModel);
+
+            // we must be notified each time our holdings change, so each time a security is added, we
+            // want to bind to its SecurityHolding.QuantityChanged event so we can trigger the resolver
+
+            securities.CollectionChanged += (sender, args) =>
+            {
+                foreach (Security security in args.NewItems)
+                {
+                    IPositionGroup group;
+                    var key = new PositionGroupKey(_defaultBuyingPowerModel, security);
+                    if (args.Action == NotifyCollectionChangedAction.Add)
+                    {
+                        if (!_groups.TryGetValue(key, out group))
+                        {
+                            // simply adding a security doesn't require group resolution until it has holdings
+                            // all we need to do is make sure we add the default SecurityPosition
+                            var position = new Position(security);
+                            _groups[key] = new PositionGroup(key, position);;
+                            security.Holdings.QuantityChanged += HoldingsOnQuantityChanged;
+                            if (security.Invested)
+                            {
+                                // if this security has holdings then we'll need to resolve position groups
+                                _requiresGroupResolution = true;
+                            }
+                        }
+                    }
+                    else if (args.Action == NotifyCollectionChangedAction.Remove)
+                    {
+                        if (_groups.TryGetValue(key, out group))
+                        {
+                            security.Holdings.QuantityChanged -= HoldingsOnQuantityChanged;
+                            if (security.Invested)
+                            {
+                                // only trigger group resolution if we had holdings in the removed security
+                                _requiresGroupResolution = true;
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        /// <summary>
+        /// Resolves the algorithm's position groups from all of its holdings
+        /// </summary>
+        public void ResolvePositionGroups()
+        {
+            if (_requiresGroupResolution)
+            {
+                _requiresGroupResolution = false;
+                var positions = new PositionCollection(_securities.ToImmutableDictionary(
+                    kvp => kvp.Key,
+                    kvp => (IPosition) new Position(kvp.Value)
+                ));
+
+                _groups = _resolver.Resolve(positions).ToDictionary(grp => grp.Key);
+            }
+        }
+
+        private void HoldingsOnQuantityChanged(object sender, SecurityHoldingQuantityChangedEventArgs e)
+        {
+            _requiresGroupResolution = true;
+        }
+    }
+}

--- a/Common/Securities/Positions/PositionManager.cs
+++ b/Common/Securities/Positions/PositionManager.cs
@@ -104,6 +104,12 @@ namespace QuantConnect.Securities.Positions
         }
 
         /// <summary>
+        /// Gets the <see cref="IPositionGroup"/> matching the specified <paramref name="key"/>. If one is not found,
+        /// then a new empty position group is returned.
+        /// </summary>
+        public IPositionGroup this[PositionGroupKey key] => Groups[key];
+
+        /// <summary>
         /// Creates a position group for the specified order, pulling
         /// </summary>
         /// <param name="order">The order</param>
@@ -180,6 +186,12 @@ namespace QuantConnect.Securities.Positions
         public PositionGroupKey CreateDefaultKey(Security security)
         {
             return new PositionGroupKey(_defaultModel, security);
+        }
+
+        public IPositionGroup CreateDefaultGroup(Security security)
+        {
+            var key = CreateDefaultKey(security);
+            return Groups[key];
         }
 
         private void HoldingsOnQuantityChanged(object sender, SecurityHoldingQuantityChangedEventArgs e)

--- a/Common/Securities/Positions/PositionManager.cs
+++ b/Common/Securities/Positions/PositionManager.cs
@@ -188,7 +188,10 @@ namespace QuantConnect.Securities.Positions
             return new PositionGroupKey(_defaultModel, security);
         }
 
-        public IPositionGroup CreateDefaultGroup(Security security)
+        /// <summary>
+        /// Gets or creates the default position group for the specified <paramref name="security"/>
+        /// </summary>
+        public IPositionGroup GetOrCreateDefaultGroup(Security security)
         {
             var key = CreateDefaultKey(security);
             return Groups[key];

--- a/Common/Securities/Positions/ReservedBuyingPowerForPositionGroup.cs
+++ b/Common/Securities/Positions/ReservedBuyingPowerForPositionGroup.cs
@@ -1,0 +1,53 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Defines the result for <see cref="IBuyingPowerModel.GetReservedBuyingPowerForPosition"/>
+    /// </summary>
+    public class ReservedBuyingPowerForPositionGroup
+    {
+        /// <summary>
+        /// Gets the reserved buying power
+        /// </summary>
+        public decimal AbsoluteUsedBuyingPower { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReservedBuyingPowerForPosition"/> class
+        /// </summary>
+        /// <param name="reservedBuyingPowerForPosition">The reserved buying power for the security's holdings</param>
+        public ReservedBuyingPowerForPositionGroup(decimal reservedBuyingPowerForPosition)
+        {
+            AbsoluteUsedBuyingPower = reservedBuyingPowerForPosition;
+        }
+
+        /// <summary>
+        /// Implicit operator to <see cref="decimal"/> to remove noise
+        /// </summary>
+        public static implicit operator decimal(ReservedBuyingPowerForPositionGroup reservedBuyingPower)
+        {
+            return reservedBuyingPower.AbsoluteUsedBuyingPower;
+        }
+
+        /// <summary>
+        /// Implicit operator to <see cref="decimal"/> to remove noise
+        /// </summary>
+        public static implicit operator ReservedBuyingPowerForPositionGroup(decimal reservedBuyingPower)
+        {
+            return new ReservedBuyingPowerForPositionGroup(reservedBuyingPower);
+        }
+    }
+}

--- a/Common/Securities/Positions/ReservedBuyingPowerForPositionGroupParameters.cs
+++ b/Common/Securities/Positions/ReservedBuyingPowerForPositionGroupParameters.cs
@@ -1,0 +1,47 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Defines the parameters for <see cref="IBuyingPowerModel.GetReservedBuyingPowerForPosition"/>
+    /// </summary>
+    public class ReservedBuyingPowerForPositionGroupParameters
+    {
+        /// <summary>
+        /// Gets the <see cref="IPositionGroup"/>
+        /// </summary>
+        public IPositionGroup PositionGroup { get; }
+
+        /// <summary>
+        /// Gets the algorithm's portfolio manager
+        /// </summary>
+        public SecurityPortfolioManager Portfolio { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReservedBuyingPowerForPositionGroupParameters"/> class
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio manager</param>
+        /// <param name="positionGroup">The position group</param>
+        public ReservedBuyingPowerForPositionGroupParameters(
+            SecurityPortfolioManager portfolio,
+            IPositionGroup positionGroup
+            )
+        {
+            Portfolio = portfolio;
+            PositionGroup = positionGroup;
+        }
+    }
+}

--- a/Common/Securities/Positions/ReservedBuyingPowerImpact.cs
+++ b/Common/Securities/Positions/ReservedBuyingPowerImpact.cs
@@ -1,0 +1,81 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Specifies the impact on buying power from changing security holdings that affects current <see cref="IPositionGroup"/>,
+    /// including the current reserved buying power, without the change, and a contemplate reserved buying power, which takes
+    /// into account a contemplated change to the algorithm's positions that impacts current position groups.
+    /// </summary>
+    public class ReservedBuyingPowerImpact
+    {
+        /// <summary>
+        /// Gets the current reserved buying power for the impacted groups
+        /// </summary>
+        public decimal Current { get; }
+
+        /// <summary>
+        /// Gets the reserved buying power for groups resolved after applying a contemplated change to the impacted groups
+        /// </summary>
+        public decimal Contemplated { get; }
+
+        /// <summary>
+        /// Gets the change in reserved buying power, <see cref="Current"/> minus <see cref="Contemplated"/>
+        /// </summary>
+        public decimal Delta { get; }
+
+        /// <summary>
+        /// Gets the impacted groups used as the basis for these reserved buying power numbers
+        /// </summary>
+        public IReadOnlyCollection<IPositionGroup> ImpactedGroups { get; }
+
+        /// <summary>
+        /// Gets the position changes being contemplated
+        /// </summary>
+        public IReadOnlyCollection<IPosition> ContemplatedChanges { get; }
+
+        /// <summary>
+        /// Gets the newly resolved groups resulting from applying the contemplated changes to the impacted groups
+        /// </summary>
+        public IReadOnlyCollection<IPositionGroup> ContemplatedGroups { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReservedBuyingPowerImpact"/> class
+        /// </summary>
+        /// <param name="current">The current reserved buying power for impacted groups</param>
+        /// <param name="contemplated">The reserved buying power for impacted groups after applying the contemplated changes</param>
+        /// <param name="impactedGroups">The groups impacted by the contemplated changes</param>
+        /// <param name="contemplatedChanges">The position changes being contemplated</param>
+        /// <param name="contemplatedGroups">The groups resulting from applying the contemplated changes</param>
+        public ReservedBuyingPowerImpact(
+            decimal current,
+            decimal contemplated,
+            IReadOnlyCollection<IPositionGroup> impactedGroups,
+            IReadOnlyCollection<IPosition> contemplatedChanges,
+            IReadOnlyCollection<IPositionGroup> contemplatedGroups
+            )
+        {
+            Current = current;
+            Contemplated = contemplated;
+            Delta = Contemplated - Current;
+            ImpactedGroups = impactedGroups;
+            ContemplatedGroups = contemplatedGroups;
+            ContemplatedChanges = contemplatedChanges;
+        }
+    }
+}

--- a/Common/Securities/Positions/ReservedBuyingPowerImpactParameters.cs
+++ b/Common/Securities/Positions/ReservedBuyingPowerImpactParameters.cs
@@ -1,0 +1,49 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Parameters for the <see cref="IPositionGroupBuyingPowerModel.GetReservedBuyingPowerImpact"/>
+    /// </summary>
+    public class ReservedBuyingPowerImpactParameters
+    {
+        /// <summary>
+        /// Gets the position changes being contemplated
+        /// </summary>
+        public IPositionGroup ContemplatedChanges { get; }
+
+        /// <summary>
+        /// Gets the algorithm's portfolio manager
+        /// </summary>
+        public SecurityPortfolioManager Portfolio { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReservedBuyingPowerImpactParameters"/> class
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio manager</param>
+        /// <param name="contemplatedChanges">The position changes being contemplated</param>
+        public ReservedBuyingPowerImpactParameters(
+            SecurityPortfolioManager portfolio,
+            IPositionGroup contemplatedChanges
+            )
+        {
+            Portfolio = portfolio;
+            ContemplatedChanges = contemplatedChanges;
+        }
+    }
+}

--- a/Common/Securities/Positions/SecurityPositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Positions/SecurityPositionGroupBuyingPowerModel.cs
@@ -18,7 +18,71 @@ namespace QuantConnect.Securities.Positions
     /// <summary>
     /// Provides an implementation of <see cref="IPositionGroupBuyingPowerModel"/> for groups containing exactly one security
     /// </summary>
-    public class SecurityPositionGroupBuyingPowerModel : IPositionGroupBuyingPowerModel
+    public class SecurityPositionGroupBuyingPowerModel : PositionGroupBuyingPowerModel
     {
+        /// <summary>
+        /// Gets the margin currently allocated to the specified holding
+        /// </summary>
+        /// <param name="parameters">An object containing the security</param>
+        /// <returns>The maintenance margin required for the </returns>
+        public override MaintenanceMargin GetMaintenanceMargin(PositionGroupMaintenanceMarginParameters parameters)
+        {
+            // SecurityPositionGroupBuyingPowerModel models buying power the same as non-grouped, so we can simply sum up
+            // the reserved buying power via the security's model. We should really only ever get a single position here,
+            // but it's not incorrect to ask the model for what the reserved buying power would be using default modeling
+            var buyingPower = 0m;
+            foreach (var position in parameters.PositionGroup)
+            {
+                var security = parameters.Portfolio.Securities[position.Symbol];
+                var result = security.BuyingPowerModel.GetMaintenanceMargin(parameters.IsCurrentHoldings
+                    ? MaintenanceMarginParameters.ForCurrentHoldings(security, position.Quantity)
+                    : MaintenanceMarginParameters.ForQuantityAtCurrentPrice(security, position.Quantity)
+                );
+
+                buyingPower += result;
+            }
+
+            return buyingPower;
+        }
+
+        /// <summary>
+        /// The margin that must be held in order to increase the position by the provided quantity
+        /// </summary>
+        /// <param name="parameters">An object containing the security and quantity</param>
+        public override InitialMargin GetInitialMarginRequirement(PositionGroupInitialMarginParameters parameters)
+        {
+            var initialMarginRequirement = 0m;
+            foreach (var position in parameters.PositionGroup)
+            {
+                var security = parameters.Portfolio.Securities[position.Symbol];
+                initialMarginRequirement += security.BuyingPowerModel.GetInitialMarginRequirement(
+                    security, position.Quantity
+                );
+            }
+
+            return initialMarginRequirement;
+        }
+
+        /// <summary>
+        /// Gets the total margin required to execute the specified order in units of the account currency including fees
+        /// </summary>
+        /// <param name="parameters">An object containing the portfolio, the security and the order</param>
+        /// <returns>The total margin in terms of the currency quoted in the order</returns>
+        public override InitialMargin GetInitialMarginRequiredForOrder(
+            PositionGroupInitialMarginForOrderParameters parameters
+            )
+        {
+            var initialMarginRequirement = 0m;
+            foreach (var position in parameters.PositionGroup)
+            {
+                // TODO : Support combo order by pull symbol-specific order
+                var security = parameters.Portfolio.Securities[position.Symbol];
+                initialMarginRequirement += security.BuyingPowerModel.GetInitialMarginRequiredForOrder(
+                    new InitialMarginRequiredForOrderParameters(parameters.Portfolio.CashBook, security, parameters.Order)
+                );
+            }
+
+            return initialMarginRequirement;
+        }
     }
 }

--- a/Common/Securities/Positions/SecurityPositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Positions/SecurityPositionGroupBuyingPowerModel.cs
@@ -1,0 +1,24 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IPositionGroupBuyingPowerModel"/> for groups containing exactly one security
+    /// </summary>
+    public class SecurityPositionGroupBuyingPowerModel : IPositionGroupBuyingPowerModel
+    {
+    }
+}

--- a/Common/Securities/Positions/SecurityPositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Positions/SecurityPositionGroupBuyingPowerModel.cs
@@ -98,6 +98,13 @@ namespace QuantConnect.Securities.Positions
             HasSufficientPositionGroupBuyingPowerForOrderParameters parameters
             )
         {
+            if (parameters.PositionGroup.Count != 1)
+            {
+                return parameters.Error(
+                    $"{nameof(SecurityPositionGroupBuyingPowerModel)} only supports position groups containing exactly one position."
+                );
+            }
+
             var position = parameters.PositionGroup.Single();
             var security = parameters.Portfolio.Securities[position.Symbol];
             return security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(

--- a/Common/Securities/Positions/SecurityPositionGroupResolver.cs
+++ b/Common/Securities/Positions/SecurityPositionGroupResolver.cs
@@ -35,6 +35,28 @@ namespace QuantConnect.Securities.Positions
         }
 
         /// <summary>
+        /// Attempts to group the specified positions into a new <see cref="IPositionGroup"/> using an
+        /// appropriate <see cref="IPositionGroupBuyingPowerModel"/> for position groups created via this
+        /// resolver.
+        /// </summary>
+        /// <param name="positions">The positions to be grouped</param>
+        /// <param name="group">The grouped positions when this resolver is able to, otherwise null</param>
+        /// <returns>True if this resolver can group the specified positions, otherwise false</returns>
+        public bool TryGroup(IReadOnlyCollection<IPosition> positions, out IPositionGroup group)
+        {
+            // we can only create default groupings containing a single security
+            if (positions.Count != 1)
+            {
+                group = null;
+                return false;
+            }
+
+            var key = new PositionGroupKey(_buyingPowerModel, positions);
+            group = new PositionGroup(key, positions.ToDictionary(p => p.Symbol));
+            return true;
+        }
+
+        /// <summary>
         /// Resolves the position groups that exist within the specified collection of positions.
         /// </summary>
         /// <param name="positions">The collection of positions</param>
@@ -75,7 +97,7 @@ namespace QuantConnect.Securities.Positions
                 {
                     if (seen.Add(group.Key))
                     {
-                        yield return @group;
+                        yield return group;
                     }
                 }
             }

--- a/Common/Securities/Positions/SecurityPositionGroupResolver.cs
+++ b/Common/Securities/Positions/SecurityPositionGroupResolver.cs
@@ -1,0 +1,84 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IPositionGroupResolver"/> that places all positions into a default group of one security.
+    /// </summary>
+    public class SecurityPositionGroupResolver : IPositionGroupResolver
+    {
+        private readonly IPositionGroupBuyingPowerModel _buyingPowerModel;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityPositionGroupResolver"/> class
+        /// </summary>
+        /// <param name="buyingPowerModel">The buying power model to use for created groups</param>
+        public SecurityPositionGroupResolver(IPositionGroupBuyingPowerModel buyingPowerModel)
+        {
+            _buyingPowerModel = buyingPowerModel;
+        }
+
+        /// <summary>
+        /// Resolves the position groups that exist within the specified collection of positions.
+        /// </summary>
+        /// <param name="positions">The collection of positions</param>
+        /// <returns>An enumerable of position groups</returns>
+        public PositionGroupCollection Resolve(PositionCollection positions)
+        {
+            return new PositionGroupCollection(positions
+                .Select(position => new PositionGroup(_buyingPowerModel, position)).ToList()
+            );
+        }
+
+        /// <summary>
+        /// Determines the position groups that would be evaluated for grouping of the specified
+        /// positions were passed into the <see cref="IPositionGroupResolver.Resolve"/> method.
+        /// </summary>
+        /// <remarks>
+        /// This function allows us to determine a set of impacted groups and run the resolver on just
+        /// those groups in order to support what-if analysis
+        /// </remarks>
+        /// <param name="groups">The existing position groups</param>
+        /// <param name="positions">The positions being changed</param>
+        /// <returns>An enumerable containing the position groups that could be impacted by the specified position changes</returns>
+        public IEnumerable<IPositionGroup> GetImpactedGroups(
+            PositionGroupCollection groups,
+            IReadOnlyCollection<IPosition> positions
+            )
+        {
+            var seen = new HashSet<PositionGroupKey>();
+            foreach (var position in positions)
+            {
+                IReadOnlyCollection<IPositionGroup> groupsForSymbol;
+                if (!groups.TryGetGroups(position.Symbol, out groupsForSymbol))
+                {
+                    continue;
+                }
+
+                foreach (var group in groupsForSymbol)
+                {
+                    if (seen.Add(group.Key))
+                    {
+                        yield return @group;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Common/Securities/Positions/readme.md
+++ b/Common/Securities/Positions/readme.md
@@ -1,0 +1,364 @@
+# Position Groups
+
+## Motivation
+
+The motivation behind the position groups feature is to enable algorithms to submit an order for a logical grouping of securities in a single action. In some cases, the margin required for the group is far less than the sum of the margin required for each piece individually. This happens when the grouping provides some sort of hedge, thereby reducing the overal risk of the position, and in some cases, can be a completely market neutral position. A simple example is a covered call strategy, which nominally consists of 100 shares of the underlying equity and short 1 option contract. Since the short contract position is _covered_ by the account holding the underlying, brokerages reduce the margin requirements. The end goal is to enable LEAN to not only accurately model such groupings, but also submit a multi-leg order so the brokerage can process it as a single order. There are some cases where submitting the legs individually is not possible due to margin requirements, but grouping them together allows the order to be successfully processed.
+
+## Design
+
+The position groups feature introduces some new abstractions and key concepts that will be covered in this section.
+
+### IPosition
+
+A position defines _some_ quantity of a security. It may be all of the security's holdings or only a fraction of the holdings. Each position defines a few key properties listed below:
+
+``` csharp
+// See: https://github.com/QuantConnect/Lean/blob/refactor-4065-position-groups/Common/Securities/Positions/IPosition.cs
+
+/// <summary>
+/// The symbol
+/// </summary>
+Symbol Symbol { get; }
+
+/// <summary>
+/// The quantity
+/// </summary>
+decimal Quantity { get; }
+
+/// <summary>
+/// The unit quantity. The unit quantities of a group define the group. For example, a covered
+/// call has 100 units of stock and -1 units of call contracts.
+/// </summary>
+decimal UnitQuantity { get; }
+
+```
+
+The `Symbol` property is everything you expect it to be, uniquely identifying which security this position is in and the `Quantity` is likewise uninteresting, denoting the directional (position for long negative for short) quantity of the position. The `UnitQuantity` defines the smallest allowable quantity increment according to the definition of the group the position belongs to. For the default group, `SecurityPositionGroup`, the `UnitQuantity` is equal to the security's lot size (`SymbolProperties.LotSize`). An equity position in a group with option contracts will have a `UnitQuantity` equal to the contract's multiplier (`SymbolProperties.ContractMultiplier`). There's an important relationship between the `Quantity` and the `UnitQuantity` which is that `Quantity/UnitQuantity` **must** always yield a whole number and denotes the number of lots. Using the covered call example from earlier, we may have 5 covered calls. Each contract will have a `UnitQuantity` equal to -1 and the underlying equity will have a `UnitQuantity` normally equal to 100, so 5 covered calls yields -5 contracts and 500 shares in the underlying.
+
+### PositionGroupKey
+
+Before diving into the `IPositionGroup` abstraction, it's important to briefly mention the `PositionGroupKey`. This class uniquely defines a position group within the algorithm and is a deterministic identifier constructed from the contained positions' `Symbol` and `UnitQuantity` properties coupled with an `IPositionGroupBuyingPowerModel`. We'll discuss modelling in a later section, but for now it's enough to understand that if two position group contain the same exact position **but** are modeled differently, then LEAN will treat them as different positions. The `UnitQuantities` list is, under the covers, an `ImmutableSortedSet` which guarantees determinism. In other words, `-1 GOOG CALL; +100 GOOG` is the same as `+100 GOOG; -1 GOOG CALL`. The `PositionGroupKey` can be used to index into collection types containing position groups as well as into the `PositionManager` (to be discussed later). This class also offers a variety of convenience functions for creating empty and unit positions and groups, which is pretty cool as it implies that the `PositionGroupKey` contains sufficient information to create an entire `IPositionGroup`. It's essentially a template for a particular group type with an exact set of symbol. More on group _types_ later.
+
+``` csharp
+
+// See: https://github.com/QuantConnect/Lean/blob/refactor-4065-position-groups/Common/Securities/Positions/PositionGroupKey.cs
+
+/// <summary>
+/// Gets whether or not this key defines a default group
+/// </summary>
+public bool IsDefaultGroup { get; }
+
+/// <summary>
+/// Gets the <see cref="IPositionGroupBuyingPowerModel"/> being used by the group
+/// </summary>
+public IPositionGroupBuyingPowerModel BuyingPowerModel { get; }
+
+/// <summary>
+/// Gets the unit quantities defining the ratio between position quantities in the group
+/// </summary>
+public IReadOnlyList<Tuple<Symbol, decimal>> UnitQuantities { get; }
+
+```
+
+
+### IPositionGroup
+
+A position group is unsurprisingly a grouping of `IPosition` instances. More importantly though, a position group contains the definition of the group, which includes the ratios between the `UnitQuantity` of its constituent positions and the `IPositionGroupBuyingPowerModel`. These definitional pieces are all contained within the `PositionGroupKey` discussed in the previous section. `IPositionGroup` implements the `IReadOnlyCollection<IPosition>` interface, which allows it to be used as an `IEnumerable<IPosition>`. The `Key` property exposes the deterministic identifier and the `Quantity` property exposes how many _units_ of the group there are. Recalling the earlier discussion in the `IPosition` section, where we showed that `Quantity/UnitQuantity` yields the number of lots; the number of lots is exactly equal to, by definition, the position group's quantity. Further, **every** position within the group **must** have the same exact number of lots, and if not, then something has gone terribly wrong! Position groups have definitions that define the ratios between the positions. We keep using the covered call example, but they can be far more complicated. Due to its simplicity, we'll continue with the covered call example, and more specifically, consider a covered call position group with a `Quantity` equalt to 5. This means that the ratio of the option contract position's `Quantity/UnitQuantity` equals 5 **and** the ratio of the equity position's `Quantity/UnitQuantity` equal 5. As mentioned earlier, modeling is an important part of the position group's definition, and as such, `IPositionGroup` directly exposes its own model via the `BuyingPowerModel` property, and in this way, `IPositionGroup` is analogous to a `Security` object, in that it's the smallest unit of modelling and trading within LEAN with respect to the position group subsystems. There are some extension methods provided that we'll touch on later and only one method is exposed directly by the interface: `TryGetPosition`, which is intended to behave identically to `IDictionary<K, V>.TryGetValue`, returning `true` and a valid `position` instance _or_ `false` and `default(IPosition)` when the group doesn't contain a position with the provided symbol.
+
+``` csharp
+// See: https://github.com/QuantConnect/Lean/blob/refactor-4065-position-groups/Common/Securities/Positions/IPositionGroup.cs
+
+/// <summary>
+/// Gets the key identifying this group
+/// </summary>
+PositionGroupKey Key { get; }
+
+/// <summary>
+/// Gets the whole number of units in this position group
+/// </summary>
+decimal Quantity { get; }
+
+/// <summary>
+/// Gets the positions in this group
+/// </summary>
+IEnumerable<IPosition> Positions { get; }
+
+/// <summary>
+/// Gets the buying power model defining how margin works in this group
+/// </summary>
+IPositionGroupBuyingPowerModel BuyingPowerModel { get; }
+
+/// <summary>
+/// Attempts to retrieve the position with the specified symbol
+/// </summary>
+/// <param name="symbol">The symbol</param>
+/// <param name="position">The position, if found</param>
+/// <returns>True if the position was found, otherwise false</returns>
+bool TryGetPosition(Symbol symbol, out IPosition position);
+
+```
+
+### IPositionGroupResolver
+
+The position group resolver is responsible for inspecting an algorithm's security holdings and creating a set of groups that minimizes the margin requirement of the entire portfolio. Some brokerages do this automatically for you, such as IB. The default resolver used to match ungrouped security holdings into the default `SecurityPositionGroup` is the `SecurityPositionGroupResolver`. Each _type_ of group (default/options/futures) will have its own resolver. The options resolver (not yet implemented), will integrate the `OptionStrategyMatcher`. The `OptionStrategyMatcher` looks at a set of security holdings with the same underlying, for example, GOOG and all GOOG option contracts, and attempts to arrange these holdings into groups to minimize the total margin required. When adding futures we'll need to add a `FutureStrategyMatcher`. The matchers work by looking at a set of definitions that define the specific ways in which securities can be grouped, such as covered call, but also more complex groupings such as the `Straddle` and `Strangle`. You can see the complete set of option strategy definitions in the `OptionStrategyDefinitions` class. The `OptionStrategyMatcher` loads all of these definitions and matches them to the algorithm's holdings. Once integrated into the yet-to-be-implemented `OptionStrategyPositionGroupResolver`, the results of the match operation will need to be projected into position group instances. Every time the algorithm's holdings change we need to evaluate at least a subset of the holdings to look for unexpected broken groups and determine whether or not breaking the group pushes the margin requirement up too high. It's entirely possible that the algorithm might **not** be able to sell that single share of GOOG from our earlier example because doing so breaks the covered call group and has the potential to increase the margin requirement beyond the maximum allowed.
+
+In addition to performing matching functions, it also serves as a descriptor for how groups are constructed and therefore, the impacts of breaking a particular group. Since running all resolvers on the entire portfolio is an expensive operation, when holdings change its beneficial to only consider groups impacted by the change. Since each _type_ of group has different rules regarding how the positions relate to one another, the resolver exposes the `GetImpactedGroups` function. The first argument is usually the entire set of groups being maintained by the `PositionManager` and the second argument represents the changes being contemplated. I say contemplated because this is part of the 'what if' analysis that is done _before_ LEAN validates an order as being executable/submittable. We ask the resolver which groups are impacted by the requested change, for example -1 GOOG. In this example, the response would include all position groups that the equity GOOG is a member of in addition to all position groups that contain a GOOG option contract. We can then apply our changed positions to this reduced set of position groups and resolve the new position groups. We can then calculate the margin requirements on this new set of position groups and verify that its within bounds. If so, the order may proceed, if not, the order is flagged as insufficient buying power.
+
+This idea of needing to run 'what if' analysis might take a minute before you're convinced that it's absolutely required, but once you understand how dynamic groups are and likewise how easily they can be broken and particularly how much margin is _saved_ through grouping (sometimes over 75%), it quickly becomes clear that breaking a group can have severe implications on the available margin in the algorithm's portfolio. Despite much effort and ample trying, we were unable to come up with a more performant mechanism and at this point are extremely confident that running 'what if' analysis is actually the only way to confidently and consistently get the correct answer everytime. This is what led to the introduction of the `GetImpactGroups`, which saves a lot of time in algorithms with hundeds of security holdings and potentially hundreds of non-default groups. Consider being long 100 securities and writing a covered call on each. With `GetImpactedGroups`, if you sell one of the underlying shares, we'll only evaluate groups related to that equity and ignore the other 99 equity/option related groups.
+
+``` csharp
+// See: https://github.com/QuantConnect/Lean/blob/refactor-4065-position-groups/Common/Securities/Positions/IPositionGroupResolver.cs
+
+/// <summary>
+/// Attempts to group the specified positions into a new <see cref="IPositionGroup"/> using an
+/// appropriate <see cref="IPositionGroupBuyingPowerModel"/> for position groups created via this
+/// resolver.
+/// </summary>
+/// <param name="positions">The positions to be grouped</param>
+/// <param name="group">The grouped positions when this resolver is able to, otherwise null</param>
+/// <returns>True if this resolver can group the specified positions, otherwise false</returns>
+bool TryGroup(IReadOnlyCollection<IPosition> positions, out IPositionGroup group);
+
+/// <summary>
+/// Resolves the position groups that exist within the specified collection of positions.
+/// </summary>
+/// <param name="positions">The collection of positions</param>
+/// <returns>An enumerable of position groups</returns>
+PositionGroupCollection Resolve(PositionCollection positions);
+
+/// <summary>
+/// Determines the position groups that would be evaluated for grouping of the specified
+/// positions were passed into the <see cref="Resolve"/> method.
+/// </summary>
+/// <remarks>
+/// This function allows us to determine a set of impacted groups and run the resolver on just
+/// those groups in order to support what-if analysis
+/// </remarks>
+/// <param name="groups">The existing position groups</param>
+/// <param name="positions">The positions being changed</param>
+/// <returns>An enumerable containing the position groups that could be impacted by the specified position changes</returns>
+IEnumerable<IPositionGroup> GetImpactedGroups(
+    PositionGroupCollection groups,
+    IReadOnlyCollection<IPosition> positions
+    );
+
+```
+
+### IPositionGroupBuyingPowerModel
+
+Another appropriately named abstraction that leaves mystery on the sidelines. This interface aims to be an `IPositionGroup`-centric one-for-one mapping of the `Security`-centric `IBuyingPowerModel`. The only operations that were not ported from the original are the ones focused on getting/setting leverage, which simply doesn't apply to position groups. As you can see from the below excerpt, position groups require their own margin calculations, their own sufficient buying power for order checks and their own functions for determining the maximum quantity for a given delta/target buying power. I won't go into all of the methods as they're identical in purpose as their `IBuyingPower` counterparts, however, there is one _added_ method, and that is the `GetReservedBuyingPowerImpact`. One of the challenges of dealing with position groups is determining how a particular trade will impact the algorithm's groups. Consider our default case of 5 units of GOOG covered call. If we try to sell 1 GOOG share, bringing our total to 499 (500 - 1) shares of GOOG, it will _break_ one of the position group units. This will likely **increase** the total margin requirement of the portfolio. The `GetReservedBuyingPowerImpact` function exists to perform this 'what if' analysis.
+
+
+``` csharp
+// See: https://github.com/QuantConnect/Lean/blob/refactor-4065-position-groups/Common/Securities/Positions/IPositionGroupBuyingPowerModel.cs
+
+/// <summary>
+/// Gets the margin currently allocated to the specified holding
+/// </summary>
+/// <param name="parameters">An object containing the security</param>
+/// <returns>The maintenance margin required for the </returns>
+MaintenanceMargin GetMaintenanceMargin(PositionGroupMaintenanceMarginParameters parameters);
+
+/// <summary>
+/// The margin that must be held in order to increase the position by the provided quantity
+/// </summary>
+/// <param name="parameters">An object containing the security and quantity</param>
+InitialMargin GetInitialMarginRequirement(PositionGroupInitialMarginParameters parameters);
+
+/// <summary>
+/// Gets the total margin required to execute the specified order in units of the account currency including fees
+/// </summary>
+/// <param name="parameters">An object containing the portfolio, the security and the order</param>
+/// <returns>The total margin in terms of the currency quoted in the order</returns>
+InitialMargin GetInitialMarginRequiredForOrder(PositionGroupInitialMarginForOrderParameters parameters);
+
+/// <summary>
+/// Computes the impact on the portfolio's buying power from adding the position group to the portfolio. This is
+/// a 'what if' analysis to determine what the state of the portfolio would be if these changes were applied. The
+/// delta (before - after) is the margin requirement for adding the positions and if the margin used after the changes
+/// are applied is less than the total portfolio value, this indicates sufficient capital.
+/// </summary>
+/// <param name="parameters">An object containing the portfolio and a position group containing the contemplated
+/// changes to the portfolio</param>
+/// <returns>Returns the portfolio's total portfolio value and margin used before and after the position changes are applied</returns>
+ReservedBuyingPowerImpact GetReservedBuyingPowerImpact(
+    ReservedBuyingPowerImpactParameters parameters
+    );
+
+/// <summary>
+/// Check if there is sufficient buying power for the position group to execute this order.
+/// </summary>
+/// <param name="parameters">An object containing the portfolio, the position group and the order</param>
+/// <returns>Returns buying power information for an order against a position group</returns>
+HasSufficientBuyingPowerForOrderResult HasSufficientBuyingPowerForOrder(
+    HasSufficientPositionGroupBuyingPowerForOrderParameters parameters
+    );
+
+/// <summary>
+/// Computes the amount of buying power reserved by the provided position group
+/// </summary>
+ReservedBuyingPowerForPositionGroup GetReservedBuyingPowerForPositionGroup(
+    ReservedBuyingPowerForPositionGroupParameters parameters
+    );
+
+/// <summary>
+/// Get the maximum position group order quantity to obtain a position with a given buying power
+/// percentage. Will not take into account free buying power.
+/// </summary>
+/// <param name="parameters">An object containing the portfolio, the position group and the target
+///     signed buying power percentage</param>
+/// <returns>Returns the maximum allowed market order quantity and if zero, also the reason</returns>
+GetMaximumLotsResult GetMaximumLotsForTargetBuyingPower(
+    GetMaximumLotsForTargetBuyingPowerParameters parameters
+    );
+
+/// <summary>
+/// Get the maximum market position group order quantity to obtain a delta in the buying power used by a position group.
+/// The deltas sign defines the position side to apply it to, positive long, negative short.
+/// </summary>
+/// <param name="parameters">An object containing the portfolio, the position group and the delta buying power</param>
+/// <returns>Returns the maximum allowed market order quantity and if zero, also the reason</returns>
+/// <remarks>Used by the margin call model to reduce the position by a delta percent.</remarks>
+GetMaximumLotsResult GetMaximumLotsForDeltaBuyingPower(
+    GetMaximumLotsForDeltaBuyingPowerParameters parameters
+    );
+
+/// <summary>
+/// Gets the buying power available for a position group trade
+/// </summary>
+/// <param name="parameters">A parameters object containing the algorithm's portfolio, security, and order direction</param>
+/// <returns>The buying power available for the trade</returns>
+PositionGroupBuyingPower GetPositionGroupBuyingPower(PositionGroupBuyingPowerParameters parameters);
+
+
+```
+
+### PositionGroupBuyingPowerModel
+
+In the spirit of `BuyingPowerModel`, we've provided a base class for position group specific models to extend, as much of the logic is agnostic to the details of the group thanks to the way the various abstractions have been defined. That being said, when integrating options groups we **will** need to add an `OptionStrategyPositionGroupBuyingPowerModel` which subclasses the default base class `PositionGroupBuyingPowerModel`. The option strategy specific type will need to reference the table provided by Interactive Brokers which describes the margin requirements for each type of option strategy. You can find this table on IB's website [here](https://www.interactivebrokers.com/en/index.php?f=26660). This link, along with research notes and heaps of information outlining the general thought pattern and some of the concerns considered, all accumulated during the initial analysis/investigation phase in the github feature request issue [#4065](https://github.com/QuantConnect/Lean/issues/4065). IB seems to be what the users want, but once that's done I think it makes sense to also implement FINRA models. The takeaway from reading all of the regulations is that FINRA provides a baseline and brokers are free make them more strict (and maybe less strict, but IIRC FINRA set a limit), and indeed brokers can decide to _not_ support the concept of grouping at all. In such cases the broker would charge margin as the simple sum of the constituent parts, ie, no savings from groupings. We'll want to have a mechanism to suport this case easily. This can be easily done by configuring the `PositionManager` to only use the `SecurityPositionGroupResolver` (more on that later though).
+
+Back to the `PositionGroupBuyingPowerModel` - you'll notice that these methods make no assumptions as to the type or structure of the position group being evaluated, and as such, uses a lot of 'what if' analysis to make determinations. A particularly interesting bit is the `GetMaximumLotsForTargetBuyingPower` function. This function _should_ be suitable for all subclasses as its phrased in the most general way possible. The `SecurityPositionGroupBuyingPowerModel` _does_ override it for backwards compatibility reasons, particularly because each `IBuyingPowerModel` implementation (I'm looking at you `CashBuyingPowerModel`) implements this functions _slightly_ differently and especially when it comes to how fees are handled. Fees can either be _part_ of the pro-rata operation or fees can be viewed as a fixed cost coming off of the top. It took a while to arrive at a logical reasoning for one or the other, but the `PositionGroupBuyingPowerModel` removes fees off of the top. The reason for this is based on this function's usage, most notably, `QCAlgorithm.SetHoldings`. The purpose of this function is to allocate a particular percentage of the total portfolio value into _something_ (a position group in this case). If the fees were part of the pro-rata allocation then that's like saying we seek a quantity where the **cost** of the order is a particular percentage of total portfolio value, whereas taking the fees off the top is saying that we seek a quantity such that **after** the trade is completed, that position group (or security) will be the requested percentage of the total portfolio value.
+
+Some time was taken to improve the Newton-Rhapson root finding. For some reason all of the `IBuyingPowerModel` implementations of this method have degraded over the years, now requiring two full iterations before returning. This is unnecessary. In a very common case, where fees are directly proportional to the total order value, it all breaks down into a simple linear equation and can by analytically solved exactly _without_ iterating at all (very common in crypto). The time should be taken to refactor the existing `IBuyingPowerModel` implementations by extracting to a single common implementation and parameterizing anything that's special.
+
+Another function worth mentioning is `HasSufficientBuyingPowerForOrder` which has to perform multiple checks now. First we determine that our free buying power is enough to cover the initial margin requirement, then we provide a mechanism via a virtual method `PassesPositionGroupSpecificBuyingPowerForOrderChecks` for subclasses to inject their own checks and finally we perform the 'what if' analysis by invoking `GetChangeInReservedBuyingPower` and verifying that the change isn't greater than the free buying power. The `SecurityPositionGroupBuyingPowerModel` overrides the `PassesPositionGroupSpecificBuyingPowerForOrderChecks` in order to invoke `security.BuyingPowerModel`.
+
+It's worth noting here that **ALL** implementations of `IPositionGroupBuyingPowerModel` should provide reasonable/idiomatic implementations of `GetHashCode` and `Equals`. This is because the model types are used in the `PositionGroupKey`, and as such, equality checks are done against it, but we want to treat these models as value types when it comes to equality checking, i.e, verify private fields are equal and the types are equal - even beter, let a tool like ReSharper implement them for you :)
+
+Also worth mentioning here is that **ALL** derived types will have to provide implementations for `GetInitialMarginRequirement`/`GetMaintenanceMargin`/`GetInitialMarginRequiredForOrder`. These functions enable us to implement the tougher functions in the base class and keeps subclasses laser focused on what makes them special, with an aim of preventing and/or reducing copy pasta. An optional override is the `PassesPositionGroupSpecificBuyingPowerForOrderChecks` which the `SecurityPositionGroupBuyingPowerModel` uses to invoke `security.BuyingPowerModel` functions directly.
+
+
+``` csharp
+// See: https://github.com/QuantConnect/Lean/blob/refactor-4065-position-groups/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
+```
+
+### SecurityPositionGroupBuyingPowerModel
+
+Provides an implementation of `IPositionGroupBuyingPowerModel` that delegates to `security.BuyingPowerModel`. This model is intended to be used with the 'default' group and its aim is to provide 100% backwards compatible behavior. Below are the overriden methods with a _very_ brief comment describing how the delegating to the security's models happens. It's important to note here that `IPositionGroup.Quantity` is, from the security's perspective, a number of lots. In our 5 covered call example, there's 5 lots of (-1 GOOG CALL & 100 GOOG) for a total of -5 GOOG CALL & 500 GOOG shares. This is a position group quantity of 5. There are 5 lots of the GOOG equity and 5 lots of -1 GOOG CALL.
+
+``` csharp
+// See: https://github.com/QuantConnect/Lean/blob/refactor-4065-position-groups/Common/Securities/Positions/SecurityPositionGroupBuyingPowerModel.cs
+
+/// <summary>
+/// Gets the margin currently allocated to the specified holding
+/// </summary>
+/// <param name="parameters">An object containing the security</param>
+/// <returns>The maintenance margin required for the </returns>
+public override MaintenanceMargin GetMaintenanceMargin(PositionGroupMaintenanceMarginParameters parameters)
+{
+    // simply delegate to security.BuyingPowerModel.GetMaintenanceMargin
+}
+
+/// <summary>
+/// The margin that must be held in order to increase the position by the provided quantity
+/// </summary>
+/// <param name="parameters">An object containing the security and quantity</param>
+public override InitialMargin GetInitialMarginRequirement(PositionGroupInitialMarginParameters parameters)
+{
+    // simply delegates to security.BuyingPowerModel.GetInitialMarginRequirement
+}
+
+/// <summary>
+/// Gets the total margin required to execute the specified order in units of the account currency including fees
+/// </summary>
+/// <param name="parameters">An object containing the portfolio, the security and the order</param>
+/// <returns>The total margin in terms of the currency quoted in the order</returns>
+public override InitialMargin GetInitialMarginRequiredForOrder(
+    PositionGroupInitialMarginForOrderParameters parameters
+    )
+{
+    // simply delegates to security.BuyingPowerModel.GetInitialMarginRequiredForOrder
+}
+
+/// <summary>
+/// Get the maximum position group order quantity to obtain a position with a given buying power
+/// percentage. Will not take into account free buying power.
+/// </summary>
+/// <param name="parameters">An object containing the portfolio, the position group and the target
+///     signed buying power percentage</param>
+/// <returns>Returns the maximum allowed market order quantity and if zero, also the reason</returns>
+public override GetMaximumLotsResult GetMaximumLotsForTargetBuyingPower(
+    GetMaximumLotsForTargetBuyingPowerParameters parameters
+    )
+{
+    // simply delegates to security.BuyingPowerModel.GetMaximumOrderQuantityForTargetBuyingPower
+    // and then converts the result which is in number of lots into a quantity using the lot size
+    var quantity = result.Quantity / security.SymbolProperties.LotSize;
+}
+
+/// <summary>
+/// Get the maximum market position group order quantity to obtain a delta in the buying power used by a position group.
+/// The deltas sign defines the position side to apply it to, positive long, negative short.
+/// </summary>
+/// <param name="parameters">An object containing the portfolio, the position group and the delta buying power</param>
+/// <returns>Returns the maximum allowed market order quantity and if zero, also the reason</returns>
+/// <remarks>Used by the margin call model to reduce the position by a delta percent.</remarks>
+public override GetMaximumLotsResult GetMaximumLotsForDeltaBuyingPower(
+    GetMaximumLotsForDeltaBuyingPowerParameters parameters
+    )
+{
+    // simply delegates to security.BuyingPowerModel.GetMaximumOrderQuantityForDeltaBuyingPower
+    // and converts the maximum quantity into number of lots using the security's lot size
+}
+
+/// <summary>
+/// Check if there is sufficient buying power for the position group to execute this order.
+/// </summary>
+/// <param name="parameters">An object containing the portfolio, the position group and the order</param>
+/// <returns>Returns buying power information for an order against a position group</returns>
+public override HasSufficientBuyingPowerForOrderResult HasSufficientBuyingPowerForOrder(
+    HasSufficientPositionGroupBuyingPowerForOrderParameters parameters
+    )
+{
+    // simply delegates to security.BuyingPowerModel.HasSufficientBuyingPowerForOrder
+}
+
+/// <summary>
+/// Additionally check initial margin requirements if the algorithm only has default position groups
+/// </summary>
+protected override HasSufficientBuyingPowerForOrderResult PassesPositionGroupSpecificBuyingPowerForOrderChecks(
+    HasSufficientPositionGroupBuyingPowerForOrderParameters parameters,
+    decimal availableBuyingPower
+    )
+{
+    // simply delegates to security.BuyingPowerModel.HasSufficientBuyingPowerForOrder for default groups
+}
+
+```
+
+## LEAN Integration
+
+The above highlights the main abstractions and key terms used throughout the position groups feature code changes and commit messages. If you don't understand anything written prior to this sentence, stop, and go read it again. The aforementioned concepts are critical to have a firm understanding in before moving forward with how it all integrates into LEAN, and the rest of this document _assumes_ that the reader understands all of the terminology by this point.
+
+### PositionManager
+
+The `PositionManager` provides a mechanism similar to `SecurityPortfolioManager` to manage positions and position groups. Event handlers are wired up such that after _every_ fill event the `PositionManager` is notified and if required, will invoke the configured `IPositionGroupResolver` to determine the latest and greatest set of groups. Any ungrouped holdings get moved into the default `SecurityPositionGroup` -- the group of last resort. ALL HOLDINGS ARE ALWAYS GROUPED.
+
+The `CompositePositionGroupResolver` needs to be added to the manager. The idea behind this guy is he would hold a list of resolvers configured by the algorithm, for example, one for options, one for futures and the last one would be the default (resolver of last resort) `SecurityPositionGroupResolver`. There's a WIP branch (`origin/refactor-4065-position-groups.wip`) that has an implementation of the composite resolver as well as having it all wired up properly in the position manager. Feel free to pull that in, minor edits are required. The order in which the resolvers are invoked is obviously important. If the `SecurityPositionGroupResolver` went _firsT_ then everything would be grouped before the other resolvers ran, so obviously he needs to run last. His entire job is to group everything that didn't get grouped. Foot stomping here. The ordering of invocation matters. **GREATLY**
+
+Once a `CompositePositionGroupResolver` is implemented, should probably start with it just having the single default resolver for simplicity (`SecurityPositionGroupResolver`), make sure all unit/regression tests are passing and that's a clean/solid breakpoint.
+
+### Other Touch Points
+
+`SecurityHolding.QuantityChanged` event was added and the `PositionManager` listens to this. Every time quantities change (fill) we need to know so that we can re-run the resolvers. `PositionManager.ResolveGroups()` is _also_ invoked via `SecurityPortfolioManager.ProcessFill` when it's a partial/completed fill event (qnantity changed). In order for all the margin maths to be correct, we must resolve groups immediately. Consider multiple market orders set to synchronous in the same `OnData` -- if we don't run the resolvers then the buying power models won't even know those orders executed because the buying power models' view of the world is through the lense of position groups, so it's incredibly important that **EVERY** time security holdings change we run the position group resolves to ensure consistent state.
+

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -42,8 +42,6 @@ namespace QuantConnect.Securities
     /// </remarks>
     public class Security : ISecurityPrice
     {
-        private readonly ICurrencyConverter _currencyConverter;
-
         private LocalTimeKeeper _localTimeKeeper;
         // using concurrent bag to avoid list enumeration threading issues
         protected readonly ConcurrentBag<SubscriptionDataConfig> SubscriptionsBag;
@@ -370,8 +368,6 @@ namespace QuantConnect.Securities
             {
                 throw new ArgumentException("symbolProperties.QuoteCurrency must match the quoteCurrency.Symbol");
             }
-
-            this._currencyConverter = currencyConverter;
 
             Symbol = symbol;
             SubscriptionsBag = new ConcurrentBag<SubscriptionDataConfig>();

--- a/Common/Securities/SecurityEventArgs.cs
+++ b/Common/Securities/SecurityEventArgs.cs
@@ -1,0 +1,37 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Defines a base class for <see cref="Security"/> related events
+    /// </summary>
+    public abstract class SecurityEventArgs
+    {
+        /// <summary>
+        /// Gets the security related to this event
+        /// </summary>
+        public Security Security { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityEventArgs"/> class
+        /// </summary>
+        /// <param name="security">The security</param>
+        protected SecurityEventArgs(Security security)
+        {
+            Security = security;
+        }
+    }
+}

--- a/Common/Securities/SecurityHolding.cs
+++ b/Common/Securities/SecurityHolding.cs
@@ -152,7 +152,6 @@ namespace QuantConnect.Securities
             }
         }
 
-
         /// <summary>
         /// Acquisition cost of the security total holdings in units of the account's currency.
         /// </summary>
@@ -226,7 +225,7 @@ namespace QuantConnect.Securities
                     return 0;
                 }
 
-                return _price * Quantity * _security.QuoteCurrency.ConversionRate * _security.SymbolProperties.ContractMultiplier;
+                return GetQuantityValue(Quantity);
             }
         }
 
@@ -429,6 +428,17 @@ namespace QuantConnect.Securities
         public virtual void UpdateMarketPrice(decimal closingPrice)
         {
             _price = closingPrice;
+        }
+
+        /// <summary>
+        /// Gets the total value of the specified <paramref name="quantity"/> of shares of this security
+        /// in the account currency
+        /// </summary>
+        /// <param name="quantity">The quantity of shares</param>
+        /// <returns>The value of the quantity of shares in the account currency</returns>
+        public virtual decimal GetQuantityValue(decimal quantity)
+        {
+            return _price * quantity * _security.QuoteCurrency.ConversionRate * _security.SymbolProperties.ContractMultiplier;
         }
 
         /// <summary>

--- a/Common/Securities/SecurityHolding.cs
+++ b/Common/Securities/SecurityHolding.cs
@@ -67,7 +67,6 @@ namespace QuantConnect.Securities
             _currencyConverter = holding._currencyConverter;
         }
 
-
         /// <summary>
         /// The security being held
         /// </summary>

--- a/Common/Securities/SecurityHoldingQuantityChangedEventArgs.cs
+++ b/Common/Securities/SecurityHoldingQuantityChangedEventArgs.cs
@@ -1,0 +1,52 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Event arguments for the <see cref="SecurityHolding.QuantityChanged"/> event.
+    /// The event data contains the previous quantity/price. The current quantity/price
+    /// can be accessed via the <see cref="SecurityEventArgs.Security"/> property
+    /// </summary>
+    public class SecurityHoldingQuantityChangedEventArgs : SecurityEventArgs
+    {
+        /// <summary>
+        /// Gets the holdings quantity before this change
+        /// </summary>
+        public decimal PreviousQuantity { get; }
+
+        /// <summary>
+        /// Gets the average holdings price before this change
+        /// </summary>
+        public decimal PreviousAveragePrice { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityHoldingQuantityChangedEventArgs"/> class
+        /// </summary>
+        /// <param name="security">The security</param>
+        /// <param name="previousAveragePrice">The security's previous average holdings price</param>
+        /// <param name="previousQuantity">The security's previous holdings quantity</param>
+        public SecurityHoldingQuantityChangedEventArgs(
+            Security security,
+            decimal previousAveragePrice,
+            decimal previousQuantity
+            )
+            : base(security)
+        {
+            PreviousQuantity = previousQuantity;
+            PreviousAveragePrice = previousAveragePrice;
+        }
+    }
+}

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -23,6 +23,7 @@ using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using QuantConnect.Orders;
 using QuantConnect.Python;
+using QuantConnect.Securities.Positions;
 using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.Securities
@@ -51,6 +52,11 @@ namespace QuantConnect.Securities
         public SecurityTransactionManager Transactions;
 
         /// <summary>
+        /// Local access to the position manager
+        /// </summary>
+        internal PositionManager Positions;
+
+        /// <summary>
         /// Gets the cash book that keeps track of all currency holdings (only settled cash)
         /// </summary>
         public CashBook CashBook { get; }
@@ -72,6 +78,7 @@ namespace QuantConnect.Securities
         {
             Securities = securityManager;
             Transactions = transactions;
+            Positions = new PositionManager(securityManager);
             MarginCallModel = new DefaultMarginCallModel(this, defaultOrderProperties);
 
             CashBook = new CashBook();

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -481,13 +481,11 @@ namespace QuantConnect.Securities
             get
             {
                 decimal sum = 0;
-                foreach (var kvp in Securities.Where((pair, i) => pair.Value.Holdings.Quantity != 0))
+                foreach (var group in Positions.Groups)
                 {
-                    var security = kvp.Value;
-                    var context = new ReservedBuyingPowerForPositionParameters(security);
-                    var reservedBuyingPower = security.BuyingPowerModel.GetReservedBuyingPowerForPosition(context);
-                    sum += reservedBuyingPower.AbsoluteUsedBuyingPower;
+                    sum += group.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(this, group);
                 }
+
                 return sum;
             }
         }
@@ -615,6 +613,7 @@ namespace QuantConnect.Securities
         public decimal GetMarginRemaining(Symbol symbol, OrderDirection direction = OrderDirection.Buy)
         {
             var security = Securities[symbol];
+
             var context = new BuyingPowerParameters(this, security, direction);
             return security.BuyingPowerModel.GetBuyingPower(context).Value;
         }

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -614,8 +614,9 @@ namespace QuantConnect.Securities
         {
             var security = Securities[symbol];
 
-            var context = new BuyingPowerParameters(this, security, direction);
-            return security.BuyingPowerModel.GetBuyingPower(context).Value;
+            var positionGroup = Positions.CreateDefaultGroup(security);
+            var parameters = new PositionGroupBuyingPowerParameters(this, positionGroup, direction);
+            return positionGroup.BuyingPowerModel.GetPositionGroupBuyingPower(parameters);
         }
 
         /// <summary>
@@ -821,16 +822,17 @@ namespace QuantConnect.Securities
                 var direction = orderSubmitRequest.Quantity > 0 ? OrderDirection.Buy : OrderDirection.Sell;
                 var security = Securities[orderSubmitRequest.Symbol];
 
-                var marginUsed = security.BuyingPowerModel.GetReservedBuyingPowerForPosition(
-                    new ReservedBuyingPowerForPositionParameters(security)
+                var positionGroup = Positions.CreateDefaultGroup(security);
+                var marginUsed = positionGroup.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(
+                    this, positionGroup
                 );
 
-                var marginRemaining = security.BuyingPowerModel.GetBuyingPower(
-                    new BuyingPowerParameters(this, security, direction)
+                var marginRemaining = positionGroup.BuyingPowerModel.GetPositionGroupBuyingPower(
+                    this, positionGroup, direction
                 );
 
                 Log.Trace("Order request margin information: " +
-                    Invariant($"MarginUsed: {marginUsed.AbsoluteUsedBuyingPower:F2}, ") +
+                    Invariant($"MarginUsed: {marginUsed:F2}, ") +
                     Invariant($"MarginRemaining: {marginRemaining.Value:F2}")
                 );
             }

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -642,6 +642,7 @@ namespace QuantConnect.Securities
         {
             var security = Securities[fill.Symbol];
             security.PortfolioModel.ProcessFill(this, security, fill);
+            Positions.ProcessFill(fill);
             InvalidateTotalPortfolioValue();
         }
 

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -614,7 +614,7 @@ namespace QuantConnect.Securities
         {
             var security = Securities[symbol];
 
-            var positionGroup = Positions.CreateDefaultGroup(security);
+            var positionGroup = Positions.GetOrCreateDefaultGroup(security);
             var parameters = new PositionGroupBuyingPowerParameters(this, positionGroup, direction);
             return positionGroup.BuyingPowerModel.GetPositionGroupBuyingPower(parameters);
         }
@@ -822,7 +822,7 @@ namespace QuantConnect.Securities
                 var direction = orderSubmitRequest.Quantity > 0 ? OrderDirection.Buy : OrderDirection.Sell;
                 var security = Securities[orderSubmitRequest.Symbol];
 
-                var positionGroup = Positions.CreateDefaultGroup(security);
+                var positionGroup = Positions.GetOrCreateDefaultGroup(security);
                 var marginUsed = positionGroup.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(
                     this, positionGroup
                 );

--- a/Common/SecurityIdentifier.cs
+++ b/Common/SecurityIdentifier.cs
@@ -40,7 +40,7 @@ namespace QuantConnect
     /// </remarks>
     [JsonConverter(typeof(SecurityIdentifierJsonConverter))]
     [ProtoContract(SkipConstructor = true)]
-    public class SecurityIdentifier : IEquatable<SecurityIdentifier>
+    public class SecurityIdentifier : IEquatable<SecurityIdentifier>, IComparable<SecurityIdentifier>, IComparable
     {
         #region Empty, DefaultDate Fields
 
@@ -872,6 +872,49 @@ namespace QuantConnect
 
         #region Equality members and ToString
 
+        /// <summary>Compares the current instance with another object of the same type and returns an integer that indicates whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object. </summary>
+        /// <param name="other">An object to compare with this instance. </param>
+        /// <returns>A value that indicates the relative order of the objects being compared. The return value has these meanings: Value Meaning Less than zero This instance precedes <paramref name="other" /> in the sort order.  Zero This instance occurs in the same position in the sort order as <paramref name="other" />. Greater than zero This instance follows <paramref name="other" /> in the sort order. </returns>
+        public int CompareTo(SecurityIdentifier other)
+        {
+            if (ReferenceEquals(this, other))
+            {
+                return 0;
+            }
+
+            if (ReferenceEquals(null, other))
+            {
+                return 1;
+            }
+
+            return string.Compare(ToString(), other.ToString(), StringComparison.Ordinal);
+        }
+
+        /// <summary>Compares the current instance with another object of the same type and returns an integer that indicates whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object.</summary>
+        /// <param name="obj">An object to compare with this instance. </param>
+        /// <returns>A value that indicates the relative order of the objects being compared. The return value has these meanings: Value Meaning Less than zero This instance precedes <paramref name="obj" /> in the sort order. Zero This instance occurs in the same position in the sort order as <paramref name="obj" />. Greater than zero This instance follows <paramref name="obj" /> in the sort order. </returns>
+        /// <exception cref="T:System.ArgumentException">
+        /// <paramref name="obj" /> is not the same type as this instance. </exception>
+        public int CompareTo(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return 1;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return 0;
+            }
+
+            if (!(obj is SecurityIdentifier))
+            {
+                throw new ArgumentException($"Object must be of type {nameof(SecurityIdentifier)}");
+            }
+
+            return CompareTo((SecurityIdentifier) obj);
+        }
+
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
         /// </summary>
@@ -948,6 +991,7 @@ namespace QuantConnect
                 props = props.Length == 0 ? "0" : props;
                 _stringRep = HasUnderlying ? $"{_symbol} {props}|{_underlying}" : $"{_symbol} {props}";
             }
+
             return _stringRep;
         }
 

--- a/Common/Util/LinqExtensions.cs
+++ b/Common/Util/LinqExtensions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -90,12 +91,38 @@ namespace QuantConnect.Util
         /// </summary>
         /// <typeparam name="T">The item type of the source enumerable</typeparam>
         /// <typeparam name="TResult">The type of the items in the output <see cref="List{T}"/></typeparam>
-        /// <param name="enumerable">The items to be placed into the enumerable</param>
+        /// <param name="enumerable">The items to be placed into the list</param>
         /// <param name="selector">Selects items from the enumerable to be placed into the <see cref="List{T}"/></param>
         /// <returns>A new <see cref="List{T}"/> containing the items in the enumerable</returns>
         public static List<TResult> ToList<T, TResult>(this IEnumerable<T> enumerable, Func<T, TResult> selector)
         {
             return enumerable.Select(selector).ToList();
+        }
+
+        /// <summary>
+        /// Creates a new array from the projected elements in the specified enumerable
+        /// </summary>
+        /// <typeparam name="T">The item type of the source enumerable</typeparam>
+        /// <typeparam name="TResult">The type of the items in the output array</typeparam>
+        /// <param name="enumerable">The items to be placed into the array</param>
+        /// <param name="selector">Selects items from the enumerable to be placed into the array</param>
+        /// <returns>A new array containing the items in the enumerable</returns>
+        public static TResult[] ToArray<T, TResult>(this IEnumerable<T> enumerable, Func<T, TResult> selector)
+        {
+            return enumerable.Select(selector).ToArray();
+        }
+
+        /// <summary>
+        /// Creates a new immutable array from the projected elements in the specified enumerable
+        /// </summary>
+        /// <typeparam name="T">The item type of the source enumerable</typeparam>
+        /// <typeparam name="TResult">The type of the items in the output array</typeparam>
+        /// <param name="enumerable">The items to be placed into the array</param>
+        /// <param name="selector">Selects items from the enumerable to be placed into the array</param>
+        /// <returns>A new array containing the items in the enumerable</returns>
+        public static ImmutableArray<TResult> ToImmutableArray<T, TResult>(this IEnumerable<T> enumerable, Func<T, TResult> selector)
+        {
+            return enumerable.Select(selector).ToImmutableArray();
         }
 
         /// <summary>

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -318,6 +318,9 @@ namespace QuantConnect.Lean.Engine
                 // process split warnings for options
                 ProcessSplitSymbols(algorithm, splitWarnings, delistings);
 
+                // after filling orders and removing/modifying securities (splits/delistings) - see if we need to re-evaluate position groups
+                algorithm.Portfolio.Positions.ResolvePositionGroups();
+
                 //Check if the user's signalled Quit: loop over data until day changes.
                 if (algorithm.Status == AlgorithmStatus.Stopped)
                 {
@@ -622,6 +625,9 @@ namespace QuantConnect.Lean.Engine
                 //If its the historical/paper trading models, wait until market orders have been "filled"
                 // Manually trigger the event handler to prevent thread switch.
                 transactions.ProcessSynchronousEvents();
+
+                // check again to see if there we need to re-resolve our position groupings
+                algorithm.Portfolio.Positions.ResolvePositionGroups();
 
                 // sample alpha charts now that we've updated time/price information and after transactions
                 // are processed so that insights closed because of new order based insights get updated

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -25,6 +25,7 @@ using QuantConnect.Logging;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Securities;
+using QuantConnect.Securities.Positions;
 using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.TransactionHandlers
@@ -723,8 +724,10 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             HasSufficientBuyingPowerForOrderResult hasSufficientBuyingPowerResult;
             try
             {
-                hasSufficientBuyingPowerResult = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(
-                    new HasSufficientBuyingPowerForOrderParameters(_algorithm.Portfolio, security, order));
+                var group = _algorithm.Portfolio.Positions.CreatePositionGroup(order);
+                hasSufficientBuyingPowerResult = group.BuyingPowerModel.HasSufficientBuyingPowerForOrder(
+                    _algorithm.Portfolio, group, order
+                );
             }
             catch (Exception err)
             {

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -174,6 +174,9 @@
     "ema-slow": 20
   },
 
+  // specify supported languages when running regression tests
+  "regression-test-languages": ["CSharp", "Python"],
+
   "environments": {
 
     // defines the 'backtesting' environment

--- a/Tests/Algorithm/AlgorithmSetHoldingsTests.cs
+++ b/Tests/Algorithm/AlgorithmSetHoldingsTests.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Tests.Algorithm
             public new decimal GetInitialMarginRequiredForOrder(
                 InitialMarginRequiredForOrderParameters parameters)
             {
-                return base.GetInitialMarginRequiredForOrder(parameters);
+                return base.GetInitialMarginRequiredForOrder(parameters).Value;
             }
 
             public new decimal GetMarginRemaining(SecurityPortfolioManager portfolio, Security security, OrderDirection direction)

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *

--- a/Tests/Common/Securities/BuyingPowerModelComparator.cs
+++ b/Tests/Common/Securities/BuyingPowerModelComparator.cs
@@ -1,0 +1,218 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Reflection;
+using NUnit.Framework;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Positions;
+
+namespace QuantConnect.Tests.Common.Securities
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="IBuyingPowerModel"/> that verifies consistency with
+    /// the <see cref="SecurityPositionGroupBuyingPowerModel"/>
+    /// </summary>
+    public class BuyingPowerModelComparator : IBuyingPowerModel
+    {
+        public SecurityPortfolioManager Portfolio { get; }
+        public IBuyingPowerModel SecurityModel { get; }
+        public IPositionGroupBuyingPowerModel PositionGroupModel { get; }
+
+        private bool reentry;
+
+        public BuyingPowerModelComparator(
+            IBuyingPowerModel securityModel,
+            IPositionGroupBuyingPowerModel positionGroupModel,
+            SecurityPortfolioManager portfolio = null,
+            ITimeKeeper timeKeeper = null,
+            IOrderProcessor orderProcessor = null
+            )
+        {
+            Portfolio = portfolio;
+            SecurityModel = securityModel;
+            PositionGroupModel = positionGroupModel;
+
+            if (portfolio == null)
+            {
+                var securities = new SecurityManager(timeKeeper ?? new TimeKeeper(DateTime.UtcNow));
+                Portfolio = new SecurityPortfolioManager(securities, new SecurityTransactionManager(null, securities));
+            }
+            if (orderProcessor != null)
+            {
+                Portfolio.Transactions.SetOrderProcessor(orderProcessor);
+            }
+        }
+
+        public decimal GetLeverage(Security security)
+        {
+            return SecurityModel.GetLeverage(security);
+        }
+
+        public void SetLeverage(Security security, decimal leverage)
+        {
+            SecurityModel.SetLeverage(security, leverage);
+        }
+
+        public MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
+        {
+            EnsureSecurityExists(parameters.Security);
+            var expected = SecurityModel.GetMaintenanceMargin(parameters);
+            if (reentry)
+            {
+                return expected;
+            }
+
+            reentry = true;
+            var actual = PositionGroupModel.GetMaintenanceMargin(new PositionGroupMaintenanceMarginParameters(
+                Portfolio, new PositionGroup(PositionGroupModel, new Position(parameters.Security, parameters.Quantity)), true
+            ));
+
+            Assert.AreEqual(expected.Value, actual.Value,
+                $"{PositionGroupModel.GetType().Name}:{nameof(GetMaintenanceMargin)}"
+            );
+
+            reentry = false;
+            return expected;
+        }
+
+        public InitialMargin GetInitialMarginRequirement(InitialMarginParameters parameters)
+        {
+            EnsureSecurityExists(parameters.Security);
+            var expected = SecurityModel.GetInitialMarginRequirement(parameters);
+            if (reentry)
+            {
+                return expected;
+            }
+
+            reentry = true;
+            var actual = PositionGroupModel.GetInitialMarginRequirement(new PositionGroupInitialMarginParameters(
+                Portfolio, new PositionGroup(PositionGroupModel, new Position(parameters.Security, parameters.Quantity))
+            ));
+
+            Assert.AreEqual(expected.Value, actual.Value,
+                $"{PositionGroupModel.GetType().Name}:{nameof(GetInitialMarginRequirement)}"
+            );
+
+            reentry = false;
+            return expected;
+        }
+
+        public InitialMargin GetInitialMarginRequiredForOrder(InitialMarginRequiredForOrderParameters parameters)
+        {
+            reentry = true;
+            EnsureSecurityExists(parameters.Security);
+            var expected = SecurityModel.GetInitialMarginRequiredForOrder(parameters);
+            if (reentry)
+            {
+                return expected;
+            }
+
+            var actual = PositionGroupModel.GetInitialMarginRequiredForOrder(new PositionGroupInitialMarginForOrderParameters(
+                Portfolio, new PositionGroup(PositionGroupModel, new Position(parameters.Security, parameters.Order.Quantity)), parameters.Order
+            ));
+
+            Assert.AreEqual(expected.Value, actual.Value,
+                $"{PositionGroupModel.GetType().Name}:{nameof(GetInitialMarginRequiredForOrder)}"
+            );
+
+            reentry = false;
+            return expected;
+        }
+
+        public HasSufficientBuyingPowerForOrderResult HasSufficientBuyingPowerForOrder(
+            HasSufficientBuyingPowerForOrderParameters parameters
+            )
+        {
+            EnsureSecurityExists(parameters.Security);
+            return SecurityModel.HasSufficientBuyingPowerForOrder(parameters);
+        }
+
+        public GetMaximumOrderQuantityResult GetMaximumOrderQuantityForTargetBuyingPower(
+            GetMaximumOrderQuantityForTargetBuyingPowerParameters parameters
+            )
+        {
+            EnsureSecurityExists(parameters.Security);
+            var expected = SecurityModel.GetMaximumOrderQuantityForTargetBuyingPower(parameters);
+            if (reentry)
+            {
+                return expected;
+            }
+
+            reentry = true;
+
+            reentry = false;
+            return expected;
+        }
+
+        public GetMaximumOrderQuantityResult GetMaximumOrderQuantityForDeltaBuyingPower(
+            GetMaximumOrderQuantityForDeltaBuyingPowerParameters parameters
+            )
+        {
+            EnsureSecurityExists(parameters.Security);
+            var expected = SecurityModel.GetMaximumOrderQuantityForDeltaBuyingPower(parameters);
+            if (reentry)
+            {
+                return expected;
+            }
+
+            reentry = true;
+
+            reentry = false;
+            return expected;
+        }
+
+        public ReservedBuyingPowerForPosition GetReservedBuyingPowerForPosition(ReservedBuyingPowerForPositionParameters parameters)
+        {
+            EnsureSecurityExists(parameters.Security);
+            var expected = SecurityModel.GetReservedBuyingPowerForPosition(parameters);
+            if (reentry)
+            {
+                return expected;
+            }
+
+            reentry = true;
+
+            reentry = false;
+            return expected;
+        }
+
+        public BuyingPower GetBuyingPower(BuyingPowerParameters parameters)
+        {
+            EnsureSecurityExists(parameters.Security);
+            var expected = SecurityModel.GetBuyingPower(parameters);
+            if (reentry)
+            {
+                return expected;
+            }
+
+            reentry = true;
+
+            reentry = false;
+            return expected;
+        }
+
+        private void EnsureSecurityExists(Security security)
+        {
+            if (!Portfolio.Securities.ContainsKey(security.Symbol))
+            {
+                var timeKeeper = (LocalTimeKeeper) typeof(Security).GetField("_localTimeKeeper", BindingFlags.NonPublic|BindingFlags.Instance).GetValue(security);
+                Portfolio.Securities[security.Symbol] = security;
+                security.SetLocalTimeKeeper(timeKeeper);
+            }
+        }
+    }
+}

--- a/Tests/Common/Securities/CashBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/CashBuyingPowerModelTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -28,6 +28,7 @@ using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Crypto;
+using QuantConnect.Securities.Positions;
 using QuantConnect.Tests.Engine;
 using QuantConnect.Tests.Engine.DataFeeds;
 
@@ -43,7 +44,7 @@ namespace QuantConnect.Tests.Common.Securities
         private SecurityPortfolioManager _portfolio;
         private BacktestingTransactionHandler _transactionHandler;
         private BacktestingBrokerage _brokerage;
-        private CashBuyingPowerModel _buyingPowerModel;
+        private IBuyingPowerModel _buyingPowerModel;
         private QCAlgorithm _algorithm;
         private LocalTimeKeeper _timeKeeper;
         private IResultHandler _resultHandler;
@@ -104,7 +105,10 @@ namespace QuantConnect.Tests.Common.Securities
                 RegisteredSecurityDataTypesProvider.Null
             );
 
-            _buyingPowerModel = new CashBuyingPowerModel();
+            _buyingPowerModel = new BuyingPowerModelComparator(
+                new CashBuyingPowerModel(),
+                new SecurityPositionGroupBuyingPowerModel()
+            );
 
             _timeKeeper = new LocalTimeKeeper(new DateTime(2019, 4, 22), DateTimeZone.Utc);
             _btcusd.SetLocalTimeKeeper(_timeKeeper);

--- a/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -35,29 +35,6 @@ namespace QuantConnect.Tests.Common.Securities
     public class FutureMarginBuyingPowerModelTests
     {
         // Test class to enable calling protected methods
-        public class TestFutureMarginModel : FutureMarginModel
-        {
-            public TestFutureMarginModel(Security security = null)
-                : base(security: security)
-            {
-            }
-
-            public new decimal GetMaintenanceMargin(Security security)
-            {
-                return base.GetMaintenanceMargin(security);
-            }
-
-            public new decimal GetInitialMarginRequirement(Security security, decimal quantity)
-            {
-                return base.GetInitialMarginRequirement(security, quantity);
-            }
-
-            public new decimal GetInitialMarginRequiredForOrder(
-                InitialMarginRequiredForOrderParameters parameters)
-            {
-                return base.GetInitialMarginRequiredForOrder(parameters);
-            }
-        }
 
         [Test]
         public void TestMarginForSymbolWithOneLinerHistory()
@@ -82,7 +59,7 @@ namespace QuantConnect.Tests.Common.Securities
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
 
-            var buyingPowerModel = new TestFutureMarginModel(futureSecurity);
+            var buyingPowerModel = new FutureMarginModel(0, futureSecurity);
             Assert.AreEqual(buyingPowerModel.MaintenanceOvernightMarginRequirement, buyingPowerModel.GetMaintenanceMargin(futureSecurity));
         }
 
@@ -107,7 +84,7 @@ namespace QuantConnect.Tests.Common.Securities
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
 
-            var buyingPowerModel = new TestFutureMarginModel();
+            var buyingPowerModel = new FutureMarginModel();
             Assert.AreEqual(0m, buyingPowerModel.GetMaintenanceMargin(futureSecurity));
         }
 
@@ -134,7 +111,7 @@ namespace QuantConnect.Tests.Common.Securities
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
 
-            var buyingPowerModel = new TestFutureMarginModel(futureSecurity);
+            var buyingPowerModel = new FutureMarginModel(0, futureSecurity);
             Assert.AreEqual(buyingPowerModel.MaintenanceOvernightMarginRequirement,
                 buyingPowerModel.GetMaintenanceMargin(futureSecurity));
 
@@ -162,7 +139,7 @@ namespace QuantConnect.Tests.Common.Securities
             const decimal price = 1.2345m;
             var time = new DateTime(2013, 1, 1);
             var futureSecurity = algorithm.AddFuture(ticker);
-            var buyingPowerModel = new TestFutureMarginModel(futureSecurity);
+            var buyingPowerModel = new FutureMarginModel(0, futureSecurity);
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, quantity);
 
@@ -186,7 +163,7 @@ namespace QuantConnect.Tests.Common.Securities
             const decimal price = 1.2345m;
             var time = new DateTime(2013, 1, 1);
             var futureSecurity = algorithm.AddFuture(ticker);
-            var buyingPowerModel = new TestFutureMarginModel();
+            var buyingPowerModel = new FutureMarginModel();
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, quantity);
 
@@ -209,7 +186,7 @@ namespace QuantConnect.Tests.Common.Securities
             const decimal price = 1.2345m;
             var time = new DateTime(2013, 1, 1);
             var futureSecurity = algorithm.AddFuture(ticker);
-            var buyingPowerModel = new TestFutureMarginModel(futureSecurity);
+            var buyingPowerModel = new FutureMarginModel(0, futureSecurity);
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
 
@@ -526,7 +503,7 @@ namespace QuantConnect.Tests.Common.Securities
             futureSecurity.Holdings.SetHoldings(100, 10 * Math.Sign(target));
             Update(futureSecurity, 100, algorithm);
 
-            var model = new TestFutureMarginModel(futureSecurity);
+            var model = new FutureMarginModel(0, futureSecurity);
             futureSecurity.BuyingPowerModel = model;
 
             var quantity = algorithm.CalculateOrderQuantity(futureSecurity.Symbol, target);
@@ -567,7 +544,7 @@ namespace QuantConnect.Tests.Common.Securities
             futureSecurity.Holdings.SetHoldings(100, 10 * -1 * Math.Sign(target));
             Update(futureSecurity, 100, algorithm);
 
-            var model = new TestFutureMarginModel(futureSecurity);
+            var model = new FutureMarginModel(0, futureSecurity);
             futureSecurity.BuyingPowerModel = model;
 
             var quantity = algorithm.CalculateOrderQuantity(futureSecurity.Symbol, target);

--- a/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
@@ -193,7 +193,7 @@ namespace QuantConnect.Tests.Common.Securities
             var initialMargin = buyingPowerModel.GetInitialMarginRequiredForOrder(
                 new InitialMarginRequiredForOrderParameters(algorithm.Portfolio.CashBook,
                     futureSecurity,
-                    new MarketOrder(futureSecurity.Symbol, quantity, algorithm.UtcTime)));
+                    new MarketOrder(futureSecurity.Symbol, quantity, algorithm.UtcTime))).Value;
 
             var initialMarginExpected = buyingPowerModel.GetInitialMarginRequirement(futureSecurity, quantity);
 

--- a/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
@@ -274,6 +274,7 @@ namespace QuantConnect.Tests.Common.Securities
             futureSecurity.BuyingPowerModel = GetModel(futureSecurity, out futureMarginModel);
             futureSecurity.Holdings.SetHoldings(20, 100);
             Update(futureSecurity, 20, algorithm);
+            algorithm.Portfolio.Positions.ResolvePositionGroups();
 
             var marginUsed = algorithm.Portfolio.TotalMarginUsed;
             Assert.IsTrue(marginUsed > 0);
@@ -305,6 +306,7 @@ namespace QuantConnect.Tests.Common.Securities
             futureSecurity.BuyingPowerModel = GetModel(futureSecurity, out futureMarginModel);
             futureSecurity.Holdings.SetHoldings(20, 100);
             Update(futureSecurity, 20, algorithm);
+            algorithm.Portfolio.Positions.ResolvePositionGroups();
 
             var marginUsed = algorithm.Portfolio.TotalMarginUsed;
             Assert.IsTrue(marginUsed > 0);
@@ -557,6 +559,7 @@ namespace QuantConnect.Tests.Common.Securities
             // set closed market for simpler math
             futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 1));
             futureSecurity.Holdings.SetHoldings(100, 10 * -1 * Math.Sign(target));
+            algorithm.Portfolio.Positions.ResolvePositionGroups();
             Update(futureSecurity, 100, algorithm);
 
             var model = GetModel(futureSecurity, out futureMarginModel, algorithm.Portfolio);

--- a/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
@@ -27,6 +27,7 @@ using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Future;
 using QuantConnect.Securities.Option;
+using QuantConnect.Securities.Positions;
 using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Common.Securities
@@ -35,6 +36,7 @@ namespace QuantConnect.Tests.Common.Securities
     public class FutureMarginBuyingPowerModelTests
     {
         // Test class to enable calling protected methods
+        private FutureMarginModel futureMarginModel;
 
         [Test]
         public void TestMarginForSymbolWithOneLinerHistory()
@@ -56,11 +58,14 @@ namespace QuantConnect.Tests.Common.Securities
                 ErrorCurrencyConverter.Instance,
                 RegisteredSecurityDataTypesProvider.Null
             );
+            futureSecurity.BuyingPowerModel = new FutureMarginModel(security: futureSecurity);
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
+            var timeKeeper = new TimeKeeper(time.ConvertToUtc(tz));
+            futureSecurity.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(tz));
 
-            var buyingPowerModel = new FutureMarginModel(0, futureSecurity);
-            Assert.AreEqual(buyingPowerModel.MaintenanceOvernightMarginRequirement, buyingPowerModel.GetMaintenanceMargin(futureSecurity));
+            var buyingPowerModel = GetModel(futureSecurity, out futureMarginModel);
+            Assert.AreEqual(futureMarginModel.MaintenanceOvernightMarginRequirement, buyingPowerModel.GetMaintenanceMargin(futureSecurity));
         }
 
         [Test]
@@ -83,8 +88,10 @@ namespace QuantConnect.Tests.Common.Securities
                 RegisteredSecurityDataTypesProvider.Null);
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
+            var timeKeeper = new TimeKeeper(time.ConvertToUtc(tz));
+            futureSecurity.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(tz));
 
-            var buyingPowerModel = new FutureMarginModel();
+            var buyingPowerModel = GetModel(futureSecurity, out futureMarginModel, timeKeeper: timeKeeper);
             Assert.AreEqual(0m, buyingPowerModel.GetMaintenanceMargin(futureSecurity));
         }
 
@@ -110,20 +117,25 @@ namespace QuantConnect.Tests.Common.Securities
             );
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, 1);
+            futureSecurity.BuyingPowerModel = new FutureMarginModel(security: futureSecurity);
+            var timeKeeper = new TimeKeeper(time.ConvertToUtc(tz));
+            futureSecurity.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(tz));
 
-            var buyingPowerModel = new FutureMarginModel(0, futureSecurity);
-            Assert.AreEqual(buyingPowerModel.MaintenanceOvernightMarginRequirement,
+            var buyingPowerModel = GetModel(futureSecurity, out futureMarginModel, timeKeeper: timeKeeper);
+            Assert.AreEqual(futureMarginModel.MaintenanceOvernightMarginRequirement,
                 buyingPowerModel.GetMaintenanceMargin(futureSecurity));
 
             // now we move forward to exact date when margin req changed
             time = new DateTime(2014, 06, 13);
+            timeKeeper.SetUtcDateTime(time.ConvertToUtc(tz));
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
-            Assert.AreEqual(buyingPowerModel.MaintenanceOvernightMarginRequirement, buyingPowerModel.GetMaintenanceMargin(futureSecurity));
+            Assert.AreEqual(futureMarginModel.MaintenanceOvernightMarginRequirement, buyingPowerModel.GetMaintenanceMargin(futureSecurity));
 
             // now we fly beyond the last line of the history file (currently) to see how margin model resolves future dates
             time = new DateTime(2016, 06, 04);
+            timeKeeper.SetUtcDateTime(time.ConvertToUtc(tz));
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
-            Assert.AreEqual(buyingPowerModel.MaintenanceOvernightMarginRequirement, buyingPowerModel.GetMaintenanceMargin(futureSecurity));
+            Assert.AreEqual(futureMarginModel.MaintenanceOvernightMarginRequirement, buyingPowerModel.GetMaintenanceMargin(futureSecurity));
         }
 
         [TestCase(1)]
@@ -139,17 +151,17 @@ namespace QuantConnect.Tests.Common.Securities
             const decimal price = 1.2345m;
             var time = new DateTime(2013, 1, 1);
             var futureSecurity = algorithm.AddFuture(ticker);
-            var buyingPowerModel = new FutureMarginModel(0, futureSecurity);
+            var buyingPowerModel = GetModel(futureSecurity, out futureMarginModel);
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, quantity);
 
             var res = buyingPowerModel.GetMaintenanceMargin(futureSecurity);
-            Assert.AreEqual(buyingPowerModel.MaintenanceOvernightMarginRequirement * futureSecurity.Holdings.AbsoluteQuantity, res);
+            Assert.AreEqual(futureMarginModel.MaintenanceOvernightMarginRequirement * futureSecurity.Holdings.AbsoluteQuantity, res);
 
             // We increase the quantity * 2, maintenance margin should DOUBLE
             futureSecurity.Holdings.SetHoldings(1.5m, quantity * 2);
             res = buyingPowerModel.GetMaintenanceMargin(futureSecurity);
-            Assert.AreEqual(buyingPowerModel.MaintenanceOvernightMarginRequirement * futureSecurity.Holdings.AbsoluteQuantity, res);
+            Assert.AreEqual(futureMarginModel.MaintenanceOvernightMarginRequirement * futureSecurity.Holdings.AbsoluteQuantity, res);
         }
 
         [TestCase(1)]
@@ -163,16 +175,15 @@ namespace QuantConnect.Tests.Common.Securities
             const decimal price = 1.2345m;
             var time = new DateTime(2013, 1, 1);
             var futureSecurity = algorithm.AddFuture(ticker);
-            var buyingPowerModel = new FutureMarginModel();
+            var buyingPowerModel = GetModel(futureSecurity, out futureMarginModel);
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
             futureSecurity.Holdings.SetHoldings(1.5m, quantity);
 
-            var initialMargin = buyingPowerModel.GetInitialMarginRequirement(futureSecurity, futureSecurity.Holdings.AbsoluteQuantity);
-            Assert.IsTrue(initialMargin > 0);
+            var initialMargin = buyingPowerModel.GetInitialMarginRequirement(futureSecurity, futureSecurity.Holdings.Quantity);
             var overnightMargin = Math.Abs(buyingPowerModel.GetMaintenanceMargin(futureSecurity));
 
             // initial margin is greater than the maintenance margin
-            Assert.Greater(initialMargin, overnightMargin);
+            Assert.Greater(Math.Abs(initialMargin), overnightMargin);
         }
 
         [TestCase(10)]
@@ -186,9 +197,9 @@ namespace QuantConnect.Tests.Common.Securities
             const decimal price = 1.2345m;
             var time = new DateTime(2013, 1, 1);
             var futureSecurity = algorithm.AddFuture(ticker);
-            var buyingPowerModel = new FutureMarginModel(0, futureSecurity);
+            var buyingPowerModel = GetModel(futureSecurity, out futureMarginModel);
             futureSecurity.SetMarketPrice(new Tick { Value = price, Time = time });
-            futureSecurity.Holdings.SetHoldings(1.5m, 1);
+            futureSecurity.Holdings.SetHoldings(1.5m, quantity);
 
             var initialMargin = buyingPowerModel.GetInitialMarginRequiredForOrder(
                 new InitialMarginRequiredForOrderParameters(algorithm.Portfolio.CashBook,
@@ -211,16 +222,17 @@ namespace QuantConnect.Tests.Common.Securities
 
             var ticker = QuantConnect.Securities.Futures.Financials.EuroDollar;
             var futureSecurity = algorithm.AddFuture(ticker);
+            var buyingPowerModel = GetModel(futureSecurity, out futureMarginModel);
             futureSecurity.Holdings.SetHoldings(20, quantity);
             Update(futureSecurity, 20, algorithm);
 
-            var marginForPosition = futureSecurity.BuyingPowerModel.GetReservedBuyingPowerForPosition(
+            var marginForPosition = buyingPowerModel.GetReservedBuyingPowerForPosition(
                 new ReservedBuyingPowerForPositionParameters(futureSecurity)).AbsoluteUsedBuyingPower;
 
             // Drop 40% price from $20 to $12
             Update(futureSecurity, 12, algorithm);
 
-            var marginForPositionAfter = futureSecurity.BuyingPowerModel.GetReservedBuyingPowerForPosition(
+            var marginForPositionAfter = buyingPowerModel.GetReservedBuyingPowerForPosition(
                 new ReservedBuyingPowerForPositionParameters(futureSecurity)).AbsoluteUsedBuyingPower;
 
             Assert.AreEqual(marginForPosition, marginForPositionAfter);
@@ -235,16 +247,17 @@ namespace QuantConnect.Tests.Common.Securities
 
             var ticker = QuantConnect.Securities.Futures.Financials.EuroDollar;
             var futureSecurity = algorithm.AddFuture(ticker);
+            var buyingPowerModel = GetModel(futureSecurity, out futureMarginModel);
             futureSecurity.Holdings.SetHoldings(20, quantity);
             Update(futureSecurity, 20, algorithm);
 
-            var marginForPosition = futureSecurity.BuyingPowerModel.GetReservedBuyingPowerForPosition(
+            var marginForPosition = buyingPowerModel.GetReservedBuyingPowerForPosition(
                 new ReservedBuyingPowerForPositionParameters(futureSecurity)).AbsoluteUsedBuyingPower;
 
             // Increase from $20 to $40
             Update(futureSecurity, 40, algorithm);
 
-            var marginForPositionAfter = futureSecurity.BuyingPowerModel.GetReservedBuyingPowerForPosition(
+            var marginForPositionAfter = buyingPowerModel.GetReservedBuyingPowerForPosition(
                 new ReservedBuyingPowerForPositionParameters(futureSecurity)).AbsoluteUsedBuyingPower;
 
             Assert.AreEqual(marginForPosition, marginForPositionAfter);
@@ -258,6 +271,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var ticker = QuantConnect.Securities.Futures.Financials.EuroDollar;
             var futureSecurity = algorithm.AddFuture(ticker);
+            futureSecurity.BuyingPowerModel = GetModel(futureSecurity, out futureMarginModel);
             futureSecurity.Holdings.SetHoldings(20, 100);
             Update(futureSecurity, 20, algorithm);
 
@@ -288,6 +302,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var ticker = QuantConnect.Securities.Futures.Financials.EuroDollar;
             var futureSecurity = algorithm.AddFuture(ticker);
+            futureSecurity.BuyingPowerModel = GetModel(futureSecurity, out futureMarginModel);
             futureSecurity.Holdings.SetHoldings(20, 100);
             Update(futureSecurity, 20, algorithm);
 
@@ -395,14 +410,14 @@ namespace QuantConnect.Tests.Common.Securities
             var ticker = QuantConnect.Securities.Futures.Financials.EuroDollar;
             var futureSecurity = algorithm.AddFuture(ticker);
             Update(futureSecurity, 100, algorithm);
-            var model = futureSecurity.BuyingPowerModel as FutureMarginModel;
+            var model = GetModel(futureSecurity, out futureMarginModel, algorithm.Portfolio);
 
             // set closed market for simpler math
             futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 1));
 
             var quantity = algorithm.CalculateOrderQuantity(futureSecurity.Symbol, target);
 
-            var expected = (algorithm.Portfolio.TotalPortfolioValue * Math.Abs(target)) / model.InitialOvernightMarginRequirement - 1 * Math.Abs(target); // -1 fees
+            var expected = (algorithm.Portfolio.TotalPortfolioValue * Math.Abs(target)) / futureMarginModel.InitialOvernightMarginRequirement - 1 * Math.Abs(target); // -1 fees
             expected -= expected % futureSecurity.SymbolProperties.LotSize;
 
             Assert.AreEqual(expected * Math.Sign(target), quantity);
@@ -432,7 +447,7 @@ namespace QuantConnect.Tests.Common.Securities
             // set closed market for simpler math
             futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 1));
             Update(futureSecurity, 100, algorithm);
-            var model = futureSecurity.BuyingPowerModel as FutureMarginModel;
+            var model = GetModel(futureSecurity, out futureMarginModel, algorithm.Portfolio);
 
             var quantity = algorithm.CalculateOrderQuantity(futureSecurity.Symbol, target);
             var request = GetOrderRequest(futureSecurity.Symbol, quantity);
@@ -460,6 +475,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var ticker = QuantConnect.Securities.Futures.Financials.EuroDollar;
             var futureSecurity = algorithm.AddFuture(ticker);
+            futureSecurity.BuyingPowerModel = GetModel(futureSecurity, out futureMarginModel, algorithm.Portfolio);
             // set closed market for simpler math
             futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 1));
             Update(futureSecurity, 100, algorithm);
@@ -503,13 +519,12 @@ namespace QuantConnect.Tests.Common.Securities
             futureSecurity.Holdings.SetHoldings(100, 10 * Math.Sign(target));
             Update(futureSecurity, 100, algorithm);
 
-            var model = new FutureMarginModel(0, futureSecurity);
-            futureSecurity.BuyingPowerModel = model;
+            var model = GetModel(futureSecurity, out futureMarginModel, algorithm.Portfolio);
 
             var quantity = algorithm.CalculateOrderQuantity(futureSecurity.Symbol, target);
 
-            var expected = (algorithm.Portfolio.TotalPortfolioValue * Math.Abs(target) - model.GetInitialMarginRequirement(futureSecurity, futureSecurity.Holdings.AbsoluteQuantity))
-                           / model.InitialOvernightMarginRequirement - 1 * Math.Abs(target); // -1 fees
+            var expected = (algorithm.Portfolio.TotalPortfolioValue * Math.Abs(target) - Math.Abs(model.GetInitialMarginRequirement(futureSecurity, futureSecurity.Holdings.Quantity)))
+                           / futureMarginModel.InitialOvernightMarginRequirement - 1 * Math.Abs(target); // -1 fees
             expected -= expected % futureSecurity.SymbolProperties.LotSize;
             Log.Trace($"Expected {expected}");
 
@@ -544,13 +559,13 @@ namespace QuantConnect.Tests.Common.Securities
             futureSecurity.Holdings.SetHoldings(100, 10 * -1 * Math.Sign(target));
             Update(futureSecurity, 100, algorithm);
 
-            var model = new FutureMarginModel(0, futureSecurity);
-            futureSecurity.BuyingPowerModel = model;
+            var model = GetModel(futureSecurity, out futureMarginModel, algorithm.Portfolio);
+            futureSecurity.BuyingPowerModel = futureMarginModel;
 
             var quantity = algorithm.CalculateOrderQuantity(futureSecurity.Symbol, target);
 
-            var expected = (algorithm.Portfolio.TotalPortfolioValue * Math.Abs(target) + model.GetInitialMarginRequirement(futureSecurity, futureSecurity.Holdings.AbsoluteQuantity))
-                           / model.InitialOvernightMarginRequirement - 1 * Math.Abs(target); // -1 fees
+            var expected = (algorithm.Portfolio.TotalPortfolioValue * Math.Abs(target) + Math.Abs(model.GetInitialMarginRequirement(futureSecurity, futureSecurity.Holdings.Quantity)))
+                           / futureMarginModel.InitialOvernightMarginRequirement - 1 * Math.Abs(target); // -1 fees
             expected -= expected % futureSecurity.SymbolProperties.LotSize;
             Log.Trace($"Expected {expected}");
 
@@ -582,7 +597,7 @@ namespace QuantConnect.Tests.Common.Securities
             var futureSecurity = algorithm.AddFuture(ticker);
             var lotSize = futureSecurity.SymbolProperties.LotSize;
             Update(futureSecurity, 100, algorithm);
-            var model = futureSecurity.BuyingPowerModel as FutureMarginModel;
+            var model = GetModel(futureSecurity, out futureMarginModel, algorithm.Portfolio);
             // Close market
             futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 1));
 
@@ -599,8 +614,8 @@ namespace QuantConnect.Tests.Common.Securities
                     futureSecurity,
                     new MarketOrder(futureSecurity.Symbol, quantityClosedMarket, DateTime.UtcNow))).IsSufficient);
 
-            var initialOvernight = model.InitialOvernightMarginRequirement;
-            var maintenanceOvernight = model.MaintenanceOvernightMarginRequirement;
+            var initialOvernight = futureMarginModel.InitialOvernightMarginRequirement;
+            var maintenanceOvernight = futureMarginModel.MaintenanceOvernightMarginRequirement;
 
             // Open market
             futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 3));
@@ -614,8 +629,8 @@ namespace QuantConnect.Tests.Common.Securities
                     futureSecurity,
                     new MarketOrder(futureSecurity.Symbol, halfQuantity, DateTime.UtcNow))).IsSufficient);
 
-            Assert.Greater(initialOvernight, model.InitialIntradayMarginRequirement);
-            Assert.Greater(maintenanceOvernight, model.MaintenanceIntradayMarginRequirement);
+            Assert.Greater(initialOvernight, futureMarginModel.InitialIntradayMarginRequirement);
+            Assert.Greater(maintenanceOvernight, futureMarginModel.MaintenanceIntradayMarginRequirement);
         }
 
         [TestCase(1)]
@@ -631,12 +646,15 @@ namespace QuantConnect.Tests.Common.Securities
             var ticker = QuantConnect.Securities.Futures.Financials.EuroDollar;
             var futureSecurity = algorithm.AddFuture(ticker);
             Update(futureSecurity, 100, algorithm);
-            var model = futureSecurity.BuyingPowerModel as FutureMarginModel;
+            var localTime = new DateTime(2020, 2, 3);
+            var utcTime = localTime.ConvertToUtc(futureSecurity.Exchange.TimeZone);
+            var timeKeeper = new TimeKeeper(utcTime, futureSecurity.Exchange.TimeZone);
+            var model = GetModel(futureSecurity, out futureMarginModel, algorithm.Portfolio);
             // this is important
-            model.EnableIntradayMargins = true;
+            futureMarginModel.EnableIntradayMargins = true;
 
             // Open market
-            futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 3));
+            futureSecurity.Exchange.SetLocalDateTimeFrontier(localTime);
 
             var quantity = algorithm.CalculateOrderQuantity(futureSecurity.Symbol, target);
             var request = GetOrderRequest(futureSecurity.Symbol, quantity);
@@ -913,6 +931,19 @@ namespace QuantConnect.Tests.Common.Securities
                 1,
                 DateTime.UtcNow,
                 "");
+        }
+
+        private static IBuyingPowerModel GetModel(
+            Security security,
+            out FutureMarginModel futureMarginModel,
+            SecurityPortfolioManager portfolio = null,
+            TimeKeeper timeKeeper = null
+            )
+        {
+            futureMarginModel = security.BuyingPowerModel as FutureMarginModel;
+            return new BuyingPowerModelComparator(futureMarginModel,
+                new SecurityPositionGroupBuyingPowerModel(), portfolio, timeKeeper
+            );
         }
     }
 }

--- a/Tests/Common/Securities/FutureOptionMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/FutureOptionMarginBuyingPowerModelTests.cs
@@ -26,33 +26,6 @@ namespace QuantConnect.Tests.Common.Securities
     [TestFixture]
     public class FutureOptionMarginBuyingPowerModelTests
     {
-        // Test class to enable calling protected methods
-        public class TestFutureMarginModel : FutureMarginModel
-        {
-            public TestFutureMarginModel(Security security = null)
-                : base(security: security)
-            {
-            }
-
-            public new decimal GetMaintenanceMargin(Security security)
-            {
-                return base.GetMaintenanceMargin(security);
-            }
-        }
-
-        // Test class to enable calling protected methods
-        public class TestFuturesOptionsMarginModel : FuturesOptionsMarginModel
-        {
-            public TestFuturesOptionsMarginModel(Option futureOption) : base(futureOption: futureOption)
-            {
-            }
-
-            public new decimal GetMaintenanceMargin(Security security)
-            {
-                return base.GetMaintenanceMargin(security);
-            }
-        }
-
         [Test]
         public void MarginForSymbolWithOneLinerHistory()
         {
@@ -85,8 +58,8 @@ namespace QuantConnect.Tests.Common.Securities
             optionSecurity.Underlying.SetMarketPrice(new Tick { Value = price, Time = time });
             optionSecurity.Underlying.Holdings.SetHoldings(1.5m, 1);
 
-            var futureBuyingPowerModel = new TestFutureMarginModel(optionSecurity.Underlying);
-            var futureOptionBuyingPowerModel = new TestFuturesOptionsMarginModel(optionSecurity);
+            var futureBuyingPowerModel = new FutureMarginModel(security: optionSecurity.Underlying);
+            var futureOptionBuyingPowerModel = new FuturesOptionsMarginModel(futureOption: optionSecurity);
 
             Assert.AreNotEqual(0m, futureOptionBuyingPowerModel.GetMaintenanceMargin(optionSecurity));
             Assert.AreEqual(futureBuyingPowerModel.GetMaintenanceMargin(optionSecurity.Underlying) * 1.5m, futureOptionBuyingPowerModel.GetMaintenanceMargin(optionSecurity));

--- a/Tests/Common/Securities/MarginCallModelTests.cs
+++ b/Tests/Common/Securities/MarginCallModelTests.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Tests.Common.Securities
             public new decimal GetInitialMarginRequiredForOrder(
                 InitialMarginRequiredForOrderParameters parameters)
             {
-                return base.GetInitialMarginRequiredForOrder(parameters);
+                return base.GetInitialMarginRequiredForOrder(parameters).Value;
             }
 
             public new decimal GetMarginRemaining(SecurityPortfolioManager portfolio, Security security, OrderDirection direction)

--- a/Tests/Common/Securities/MarginCallModelTests.cs
+++ b/Tests/Common/Securities/MarginCallModelTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -136,6 +136,7 @@ namespace QuantConnect.Tests.Common.Securities
                 Low = 1,
                 Close = 1
             });
+            portfolio.Positions.ResolvePositionGroups();
             var actual1 = buyingPowerModel.GetMarginRemaining(portfolio, security, OrderDirection.Buy);
             Assert.AreEqual(quantity / leverage, actual1);
 
@@ -172,7 +173,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var order = new MarketOrder(Symbols.AAPL, quantity, time) {Price = buyPrice};
             var fill = new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero)
-                { FillPrice = buyPrice, FillQuantity = quantity };
+                { FillPrice = buyPrice, FillQuantity = quantity, Status = OrderStatus.Filled};
             orderProcessor.AddOrder(order);
             var request = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);

--- a/Tests/Common/Securities/OptionMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionMarginBuyingPowerModelTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -32,13 +32,6 @@ namespace QuantConnect.Tests.Common.Securities
     public class OptionMarginBuyingPowerModelTests
     {
         // Test class to enable calling protected methods
-        public class TestOptionMarginModel : OptionMarginModel
-        {
-            public new decimal GetMaintenanceMargin(Security security)
-            {
-                return base.GetMaintenanceMargin(security);
-            }
-        }
 
         [Test]
         public void OptionMarginBuyingPowerModelInitializationTests()
@@ -128,7 +121,7 @@ namespace QuantConnect.Tests.Common.Securities
             optionCall.Underlying = equity;
             optionCall.Holdings.SetHoldings(1.5m, 2);
 
-            var buyingPowerModel = new TestOptionMarginModel();
+            var buyingPowerModel = new OptionMarginModel();
 
             // we expect long positions to be 100% charged.
             Assert.AreEqual(optionPut.Holdings.AbsoluteHoldingsCost, buyingPowerModel.GetMaintenanceMargin(optionPut));
@@ -173,7 +166,7 @@ namespace QuantConnect.Tests.Common.Securities
             optionCall.Underlying = equity;
             optionCall.Holdings.SetHoldings(price, -2);
 
-            var buyingPowerModel = new TestOptionMarginModel();
+            var buyingPowerModel = new OptionMarginModel();
 
             // short option positions are very expensive in terms of margin.
             // Margin = 2 * 100 * (14 + 0.2 * 196) = 10640
@@ -218,7 +211,7 @@ namespace QuantConnect.Tests.Common.Securities
             optionCall.Underlying = equity;
             optionCall.Holdings.SetHoldings(price, -2);
 
-            var buyingPowerModel = new TestOptionMarginModel();
+            var buyingPowerModel = new OptionMarginModel();
 
             // short option positions are very expensive in terms of margin.
             // Margin = 2 * 100 * (14 + 0.2 * 180 - (192 - 180)) = 7600
@@ -263,7 +256,7 @@ namespace QuantConnect.Tests.Common.Securities
             optionPut.Underlying = equity;
             optionPut.Holdings.SetHoldings(price, -2);
 
-            var buyingPowerModel = new TestOptionMarginModel();
+            var buyingPowerModel = new OptionMarginModel();
 
             // short option positions are very expensive in terms of margin.
             // Margin = 2 * 100 * (14 + 0.2 * 182) = 10080
@@ -308,7 +301,7 @@ namespace QuantConnect.Tests.Common.Securities
             optionCall.Underlying = equity;
             optionCall.Holdings.SetHoldings(price, -2);
 
-            var buyingPowerModel = new TestOptionMarginModel();
+            var buyingPowerModel = new OptionMarginModel();
 
             // short option positions are very expensive in terms of margin.
             // Margin = 2 * 100 * (14 + 0.2 * 196 - (196 - 192)) = 9840
@@ -345,7 +338,7 @@ namespace QuantConnect.Tests.Common.Securities
             optionPut.Underlying = equity;
             optionPut.Holdings.SetHoldings(price, -2);
 
-            var buyingPowerModel = new TestOptionMarginModel();
+            var buyingPowerModel = new OptionMarginModel();
 
             // short option positions are very expensive in terms of margin.
             // Margin = 2 * 100 * (0.18 + 0.2 * 200) = 8036
@@ -384,7 +377,7 @@ namespace QuantConnect.Tests.Common.Securities
             optionPut.Underlying = equity;
             optionPut.Holdings.SetHoldings(optionPriceStart, -2);
 
-            var buyingPowerModel = new TestOptionMarginModel();
+            var buyingPowerModel = new OptionMarginModel();
 
             // short option positions are very expensive in terms of margin.
             // Margin = 2 * 100 * (4.68 + 0.2 * 192) = 8616

--- a/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -28,30 +28,6 @@ namespace QuantConnect.Tests.Common.Securities
     [TestFixture]
     public class PatternDayTradingMarginBuyingPowerModelTests
     {
-        // Test class to enable calling protected methods
-        public class TestPatternDayTradingMarginModel : PatternDayTradingMarginModel
-        {
-            public TestPatternDayTradingMarginModel()
-            {
-            }
-
-            public TestPatternDayTradingMarginModel(decimal closedMarketLeverage, decimal openMarketLeverage)
-                : base(closedMarketLeverage, openMarketLeverage)
-            {
-            }
-
-            public new decimal GetInitialMarginRequiredForOrder(
-                InitialMarginRequiredForOrderParameters parameters)
-            {
-                return base.GetInitialMarginRequiredForOrder(parameters);
-            }
-
-            public new decimal GetMaintenanceMargin(Security security)
-            {
-                return base.GetMaintenanceMargin(security);
-            }
-        }
-
         private static readonly DateTime Noon = new DateTime(2016, 02, 16, 12, 0, 0);
         private static readonly DateTime Midnight = new DateTime(2016, 02, 16, 0, 0, 0);
         private static readonly DateTime NoonWeekend = new DateTime(2016, 02, 14, 12, 0, 0);
@@ -103,7 +79,7 @@ namespace QuantConnect.Tests.Common.Securities
             var leverage = 4m;
             var expected = 100 * 100m / leverage + 1;
 
-            var model = new TestPatternDayTradingMarginModel();
+            var model = new PatternDayTradingMarginModel();
             var security = CreateSecurity(Noon);
             var order = new MarketOrder(security.Symbol, 100, security.LocalTime);
 
@@ -120,7 +96,7 @@ namespace QuantConnect.Tests.Common.Securities
             var leverage = 5m;
             var expected = 100 * 100m / leverage + 1;
 
-            var model = new TestPatternDayTradingMarginModel(2m, leverage);
+            var model = new PatternDayTradingMarginModel(2m, leverage);
             var security = CreateSecurity(Noon);
             var order = new MarketOrder(security.Symbol, 100, security.LocalTime);
 
@@ -135,7 +111,7 @@ namespace QuantConnect.Tests.Common.Securities
             var leverage = 2m;
             var expected = 100 * 100m / leverage + 1;
 
-            var model = new TestPatternDayTradingMarginModel();
+            var model = new PatternDayTradingMarginModel();
 
             // Market is Closed on Tuesday, Feb, 16th 2016 at Midnight
             var security = CreateSecurity(Midnight);
@@ -168,7 +144,7 @@ namespace QuantConnect.Tests.Common.Securities
             var leverage = 3m;
             var expected = 100 * 100m / leverage + 1;
 
-            var model = new TestPatternDayTradingMarginModel(leverage, 4m);
+            var model = new PatternDayTradingMarginModel(leverage, 4m);
 
             // Market is Closed on Tuesday, Feb, 16th 2016 at Midnight
             var security = CreateSecurity(Midnight);
@@ -201,7 +177,7 @@ namespace QuantConnect.Tests.Common.Securities
             var closedLeverage = 2m;
             var openLeverage = 5m;
 
-            var model = new TestPatternDayTradingMarginModel(closedLeverage, openLeverage);
+            var model = new PatternDayTradingMarginModel(closedLeverage, openLeverage);
 
             // Market is Closed on Tuesday, Feb, 16th 2016 at 16
             var security = CreateSecurity(new DateTime(2016, 2, 16, 15, 49, 0));
@@ -220,7 +196,7 @@ namespace QuantConnect.Tests.Common.Securities
         [Test]
         public void VerifyMaintenaceMargin()
         {
-            var model = new TestPatternDayTradingMarginModel();
+            var model = new PatternDayTradingMarginModel();
 
             // Open Market
             var security = CreateSecurity(Noon);

--- a/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
@@ -85,7 +85,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
             Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
-                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)), 1e-3);
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)).Value, 1e-3);
         }
 
         [Test]
@@ -102,7 +102,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
             Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
-                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)), 1e-3);
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)).Value, 1e-3);
         }
 
         [Test]
@@ -119,7 +119,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
             Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
-                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)), 1e-3);
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)).Value, 1e-3);
 
             // Market is Closed on Monday, Feb, 15th 2016 at Noon (US President Day)
             security = CreateSecurity(NoonHoliday);
@@ -127,7 +127,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
             Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
-                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)), 1e-3);
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)).Value, 1e-3);
 
             // Market is Closed on Sunday, Feb, 14th 2016 at Noon
             security = CreateSecurity(NoonWeekend);
@@ -135,7 +135,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
             Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
-                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)), 1e-3);
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)).Value, 1e-3);
         }
 
         [Test]
@@ -152,7 +152,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
             Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
-                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)), 1e-3);
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)).Value, 1e-3);
 
             // Market is Closed on Monday, Feb, 15th 2016 at Noon (US President Day)
             security = CreateSecurity(NoonHoliday);
@@ -160,7 +160,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
             Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
-                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)), 1e-3);
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)).Value, 1e-3);
 
             // Market is Closed on Sunday, Feb, 14th 2016 at Noon
             security = CreateSecurity(NoonWeekend);
@@ -168,7 +168,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual((double)leverage, (double)model.GetLeverage(security), 1e-3);
             Assert.AreEqual((double)expected, (double)model.GetInitialMarginRequiredForOrder(
-                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)), 1e-3);
+                new InitialMarginRequiredForOrderParameters(new IdentityCurrencyConverter(Currencies.USD), security, order)).Value, 1e-3);
         }
 
         [Test]

--- a/Tests/Common/Securities/SecurityIdentifierTests.cs
+++ b/Tests/Common/Securities/SecurityIdentifierTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -26,6 +26,7 @@ using QuantConnect.Algorithm.CSharp;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Logging;
+using QuantConnect.Util;
 
 namespace QuantConnect.Tests.Common.Securities
 {
@@ -104,6 +105,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             Log.Trace(eurusd.ToString());
         }
+
         [Test]
         public void FuturesSecurityIdReturnsProperties()
         {
@@ -572,6 +574,20 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(0, fails.Count, $"The following option Symbols were not found in the expected chain:    \n{string.Join("\n", fails.Select(x => x.ID.ToString()))}");
             Assert.IsTrue(expectedChains.All(kvp => kvp.Value), $"The following option Symbols were not loaded:    \n{string.Join("\n", expectedChains.Where(kvp => !kvp.Value).Select(x => x.Key))}");
+        }
+
+        [Test]
+        public void SortsAccordingToStringRepresentation()
+        {
+            var sids = Symbols.All.ToList(s => s.ID);
+            var expected = sids
+                .Select(sid => new {symbol = sid, str = sid.ToString()})
+                .OrderBy(item => item.str)
+                .ToList(item => item.symbol);
+
+            sids.Sort();
+
+            CollectionAssert.AreEqual(expected, sids);
         }
 
         class Container

--- a/Tests/Common/Securities/SecurityMarginModelTests.cs
+++ b/Tests/Common/Securities/SecurityMarginModelTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -50,6 +50,7 @@ namespace QuantConnect.Tests.Common.Securities
             var spy = InitAndGetSecurity(algorithm, 0);
             spy.Holdings.SetHoldings(25, 100);
             spy.SetLeverage(leverage);
+            algorithm.Portfolio.Positions.ResolvePositionGroups();
 
             var spyMarginAvailable = spy.Holdings.HoldingsValue - spy.Holdings.HoldingsValue * (1 / leverage);
 
@@ -426,8 +427,8 @@ namespace QuantConnect.Tests.Common.Securities
             var requiredFreeBuyingPowerPercent = 0.05m;
             var model = security.BuyingPowerModel = new SecurityMarginModel(1, requiredFreeBuyingPowerPercent);
             security.Holdings.SetHoldings(25, 2000);
-            security.SettlementModel.ApplyFunds(
-                algo.Portfolio, security, DateTime.UtcNow.AddDays(-10), Currencies.USD, -2000 * 25);
+            security.SettlementModel.ApplyFunds(algo.Portfolio, security, DateTime.UtcNow.AddDays(-10), Currencies.USD, -2000 * 25);
+            algo.Portfolio.Positions.ResolvePositionGroups();
 
             // Margin remaining 50k + used 50k + initial margin 50k - 5k free buying power percent (5% of 100k)
             Assert.AreEqual(145000, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Sell));
@@ -450,8 +451,8 @@ namespace QuantConnect.Tests.Common.Securities
             var requiredFreeBuyingPowerPercent = 0.05m;
             var model = security.BuyingPowerModel = new SecurityMarginModel(2, requiredFreeBuyingPowerPercent);
             security.Holdings.SetHoldings(25, 2000);
-            security.SettlementModel.ApplyFunds(
-                algo.Portfolio, security, DateTime.UtcNow.AddDays(-10), Currencies.USD, -2000 * 25);
+            security.SettlementModel.ApplyFunds(algo.Portfolio, security, DateTime.UtcNow.AddDays(-10), Currencies.USD, -2000 * 25);
+            algo.Portfolio.Positions.ResolvePositionGroups();
 
             // Margin remaining 75k + used 25k + initial margin 25k - 5k free buying power percent (5% of 100k)
             Assert.AreEqual(120000, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Sell));
@@ -474,8 +475,8 @@ namespace QuantConnect.Tests.Common.Securities
             var requiredFreeBuyingPowerPercent = 0.05m;
             var model = security.BuyingPowerModel = new SecurityMarginModel(2, requiredFreeBuyingPowerPercent);
             security.Holdings.SetHoldings(25, -2000);
-            security.SettlementModel.ApplyFunds(
-                algo.Portfolio, security, DateTime.UtcNow.AddDays(-10), Currencies.USD, 2000 * 25);
+            security.SettlementModel.ApplyFunds(algo.Portfolio, security, DateTime.UtcNow.AddDays(-10), Currencies.USD, 2000 * 25);
+            algo.Portfolio.Positions.ResolvePositionGroups();
 
             // Margin remaining 75k + used 25k + initial margin 25k - 5k free buying power percent (5% of 100k)
             Assert.AreEqual(120000, model.GetBuyingPower(algo.Portfolio, security, OrderDirection.Buy));

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -312,7 +312,7 @@ namespace QuantConnect.Tests.Common.Securities
             security.SetMarketPrice(new TradeBar(time, Symbols.AAPL, buyPrice, buyPrice, buyPrice, buyPrice, 1));
 
             var order = new MarketOrder(Symbols.AAPL, quantity, time) {Price = buyPrice};
-            var fill = new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero) { FillPrice = buyPrice, FillQuantity = quantity };
+            var fill = new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero) { FillPrice = buyPrice, FillQuantity = quantity, Status = OrderStatus.Filled};
             orderProcessor.AddOrder(order);
             var request = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);
@@ -396,7 +396,7 @@ namespace QuantConnect.Tests.Common.Securities
             security.SetMarketPrice(new TradeBar(time, Symbols.AAPL, buyPrice, buyPrice, buyPrice, buyPrice, 1));
 
             var order = new MarketOrder(Symbols.AAPL, quantity, time) { Price = buyPrice };
-            var fill = new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero) { FillPrice = buyPrice, FillQuantity = quantity };
+            var fill = new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero) { FillPrice = buyPrice, FillQuantity = quantity, Status = OrderStatus.Filled };
             orderProcessor.AddOrder(order);
             var request = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);
@@ -457,7 +457,7 @@ namespace QuantConnect.Tests.Common.Securities
             security.SetMarketPrice(new TradeBar(time, Symbols.AAPL, buyPrice, buyPrice, buyPrice, buyPrice, 1));
 
             var order = new MarketOrder(Symbols.AAPL, quantity, time) { Price = buyPrice };
-            var fill = new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero) { FillPrice = buyPrice, FillQuantity = quantity };
+            var fill = new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero) { FillPrice = buyPrice, FillQuantity = quantity, Status = OrderStatus.Filled };
             orderProcessor.AddOrder(order);
             var request = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);
@@ -547,7 +547,7 @@ namespace QuantConnect.Tests.Common.Securities
             security.SetMarketPrice(new TradeBar(time, Symbols.AAPL, buyPrice, buyPrice, buyPrice, buyPrice, 1));
 
             var order = new MarketOrder(Symbols.AAPL, quantity, time) { Price = buyPrice };
-            var fill = new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero) { FillPrice = buyPrice, FillQuantity = quantity };
+            var fill = new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero) { FillPrice = buyPrice, FillQuantity = quantity, Status = OrderStatus.Filled };
             orderProcessor.AddOrder(order);
             var request = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);
@@ -633,6 +633,7 @@ namespace QuantConnect.Tests.Common.Securities
             request.SetOrderId(0);
             orderProcessor.AddTicket(new OrderTicket(null, request));
             var security = securities[Symbols.AAPL];
+            portfolio.Positions.ResolvePositionGroups();
             var hasSufficientBuyingPower = security.BuyingPowerModel.HasSufficientBuyingPowerForOrder(portfolio, security, acceptedOrder).IsSufficient;
             Assert.IsTrue(hasSufficientBuyingPower);
 
@@ -1104,7 +1105,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var order = new MarketOrder(Symbols.AAPL, quantity, time) { Price = buyPrice };
             var fill = new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero)
-                { FillPrice = buyPrice, FillQuantity = quantity };
+                { FillPrice = buyPrice, FillQuantity = quantity, Status = OrderStatus.Filled };
             orderProcessor.AddOrder(order);
             var request = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);
@@ -1173,7 +1174,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var order = new MarketOrder(Symbols.AAPL, -quantity, time) { Price = sellPrice };
             var fill = new OrderEvent(order, DateTime.UtcNow, OrderFee.Zero)
-                { FillPrice = sellPrice, FillQuantity = -quantity };
+                { FillPrice = sellPrice, FillQuantity = -quantity, Status = OrderStatus.Filled };
             orderProcessor.AddOrder(order);
             var request = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, order.Quantity, 0, 0, order.Time, null);
             request.SetOrderId(0);

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -1249,6 +1249,64 @@ actualDictionary.update({'IBM': 5})
                     }
                 }
             }
+        }
+
+        [Test]
+        [TestCase(PositionSide.Long, OrderDirection.Buy)]
+        [TestCase(PositionSide.Short, OrderDirection.Sell)]
+        [TestCase(PositionSide.None, OrderDirection.Hold)]
+        public void ToOrderDirection(PositionSide side, OrderDirection expected)
+        {
+            Assert.AreEqual(expected, side.ToOrderDirection());
+        }
+
+        [Test]
+        [TestCase(OrderDirection.Buy, PositionSide.Long, false)]
+        [TestCase(OrderDirection.Buy, PositionSide.Short, true)]
+        [TestCase(OrderDirection.Buy, PositionSide.None, false)]
+        [TestCase(OrderDirection.Sell, PositionSide.Long, true)]
+        [TestCase(OrderDirection.Sell, PositionSide.Short, false)]
+        [TestCase(OrderDirection.Sell, PositionSide.None, false)]
+        [TestCase(OrderDirection.Hold, PositionSide.Long, false)]
+        [TestCase(OrderDirection.Hold, PositionSide.Short, false)]
+        [TestCase(OrderDirection.Hold, PositionSide.None, false)]
+        public void Closes(OrderDirection direction, PositionSide side, bool expected)
+        {
+            Assert.AreEqual(expected, direction.Closes(side));
+        }
+
+        [Test]
+        public void ListEquals()
+        {
+            var left = new[] {1, 2, 3};
+            var right = new[] {1, 2, 3};
+            Assert.IsTrue(left.ListEquals(right));
+
+            right[2] = 4;
+            Assert.IsFalse(left.ListEquals(right));
+        }
+
+        [Test]
+        public void GetListHashCode()
+        {
+            var ints1 = new[] {1, 2, 3};
+            var ints2 = new[] {1, 3, 2};
+            var longs = new[] {1L, 2L, 3L};
+            var decimals = new[] {1m, 2m, 3m};
+
+            // ordering dependent
+            Assert.AreNotEqual(ints1.GetListHashCode(), ints2.GetListHashCode());
+
+            // type dependent [ dependency on typeof(T).GetHashCode() ]
+            Assert.AreNotEqual(ints1.GetListHashCode(), decimals.GetListHashCode());
+
+            // known type collision - long has same hash code as int within the int range
+            // we could take a hash of typeof(T) but this would require ListEquals to enforce exact types
+            // and we would prefer to allow typeof(T)'s GetHashCode and Equals to make this determination.
+            Assert.AreEqual(ints1.GetListHashCode(), longs.GetListHashCode());
+
+            // deterministic
+            Assert.AreEqual(ints1.GetListHashCode(), new[] {1, 2, 3}.GetListHashCode());
         }
 
         private PyObject ConvertToPyObject(object value)

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Newtonsoft.Json;
 using NodaTime;
@@ -1307,6 +1308,28 @@ actualDictionary.update({'IBM': 5})
 
             // deterministic
             Assert.AreEqual(ints1.GetListHashCode(), new[] {1, 2, 3}.GetListHashCode());
+        }
+
+        [Test]
+        [TestCase("0.999", "0.0001", "0.999")]
+        [TestCase("0.999", "0.001", "0.999")]
+        [TestCase("0.999", "0.01", "1.000")]
+        [TestCase("0.999", "0.1", "1.000")]
+        [TestCase("0.999", "1", "1.000")]
+        [TestCase("0.999", "2", "0")]
+        [TestCase("1.0", "0.15", "1.05")]
+        [TestCase("1.05", "0.15", "1.05")]
+        [TestCase("0.975", "0.15", "1.05")]
+        [TestCase("-0.975", "0.15", "-1.05")]
+        [TestCase("-1.0", "0.15", "-1.05")]
+        [TestCase("-1.05", "0.15", "-1.05")]
+        public void DiscretelyRoundBy(string valueString, string quantaString, string expectedString)
+        {
+            var value = decimal.Parse(valueString, CultureInfo.InvariantCulture);
+            var quanta = decimal.Parse(quantaString, CultureInfo.InvariantCulture);
+            var expected = decimal.Parse(expectedString, CultureInfo.InvariantCulture);
+            var actual = value.DiscretelyRoundBy(quanta);
+            Assert.AreEqual(expected, actual);
         }
 
         private PyObject ConvertToPyObject(object value)

--- a/Tests/Common/Util/LinqExtensionsTests.cs
+++ b/Tests/Common/Util/LinqExtensionsTests.cs
@@ -1,11 +1,11 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Util;
+using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.Tests.Common.Util
 {
@@ -33,6 +34,22 @@ namespace QuantConnect.Tests.Common.Util
             var actual = LinqExtensions.Except(enumerable, set);
 
             CollectionAssert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ToArray_PerformsProjection()
+        {
+            var enumerable = Enumerable.Range(0, 10);
+            var array = enumerable.ToArray(i => Invariant($"{i}"));
+            CollectionAssert.AreEqual(enumerable.Select(i => Invariant($"{i}")).ToArray(), array);
+        }
+
+        [Test]
+        public void ToImmutableArray_PerformsProjection()
+        {
+            var enumerable = Enumerable.Range(0, 10);
+            var array = enumerable.ToImmutableArray(i => Invariant($"{i}"));
+            CollectionAssert.AreEqual(enumerable.Select(i => Invariant($"{i}")).ToArray(), array);
         }
     }
 }

--- a/Tests/Python/SecurityCustomModelTests.cs
+++ b/Tests/Python/SecurityCustomModelTests.cs
@@ -113,6 +113,15 @@ class CustomBuyingPowerModel:
     def HasSufficientBuyingPowerForOrder(self, context):
         return HasSufficientBuyingPowerForOrderResult(True)
 
+    def GetMaintenanceMargin(self, context):
+        return None
+
+    def GetInitialMarginRequirement(self, context):
+        return None
+
+    def GetInitialMarginRequiredForOrder(self, context):
+        return None
+
     def SetLeverage(self, security, leverage):
         self.margin = 1.0 / float(leverage)";
 

--- a/Tests/Symbols.cs
+++ b/Tests/Symbols.cs
@@ -14,6 +14,8 @@
 */
 
 using System;
+using System.Collections.Immutable;
+using System.Linq;
 using System.Reflection;
 using QuantConnect.Brokerages;
 using QuantConnect.Securities;
@@ -21,11 +23,10 @@ using QuantConnect.Securities;
 namespace QuantConnect.Tests
 {
     /// <summary>
-    /// Provides symbol instancs for unit tests
+    /// Provides symbol instances for unit tests
     /// </summary>
     public static class Symbols
     {
-
         public static readonly Symbol SPY = CreateEquitySymbol("SPY");
         public static readonly Symbol AAPL = CreateEquitySymbol("AAPL");
         public static readonly Symbol MSFT = CreateEquitySymbol("MSFT");
@@ -63,6 +64,12 @@ namespace QuantConnect.Tests
         public static readonly Symbol ES_Future_Chain = CreateFuturesCanonicalSymbol(Futures.Indices.SP500EMini);
         public static readonly Symbol Future_ESZ18_Dec2018 = CreateFutureSymbol(Futures.Indices.SP500EMini, new DateTime(2018, 12, 21));
         public static readonly Symbol Future_CLF19_Jan2019 = CreateFutureSymbol("CL", new DateTime(2018, 12, 19));
+
+        public static readonly ImmutableArray<Symbol> All =
+            typeof(Symbols).GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Where(field => field.FieldType == typeof(Symbol))
+                .Select(field => (Symbol) field.GetValue(null))
+                .ToImmutableArray();
 
         /// <summary>
         /// Can be supplied in TestCase attribute


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR sits on top of #5258 and #5103.

These changes fundamentally change the basis for how LEAN views margin from being security-centric to position-centric. Positions can be grouped into `IPositionGroup` instances and position groups can be of different types. This PR provides the core position group types and the `SecurityPositionGroupBuyingPowerModel` to handle the buying power modeling for the 'default' position group which is 'ungrouped'. **ALL** positions are grouped. Any ungrouped quantities are placed into a default group dedicated for that security and the modeling falls back on the security's defined models. Upcoming changes will add an `OptionStrategyPositionGroupBuyingPowerModel` as well as wire up the `OptionsMatcher` as an `IPositionGroupResolver`. Position group resolvers inspect the algorithm's holdings and try to determine the best way to group securities in order to decrease total margin requirements. For example, you can decrease margin requirements when writing calls if you own the underlying stock (covered calls). Before this change LEAN would evaluate the margin requirements of each independently (underlying and short call). This leads to modelling errors and removes many of the benefits brokers provide to encourage hedged positions.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See #4065

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The main motivation is to improve overall modeling fidelity and to enable LEAN to compute margin requirements for groups instead of securities individually. The next PR in this line of work will wire in the `OptionsMatcher` which will try to group options and underlyings in such a way as to minimize maintenance margin requirements, thereby allowing the algorithm to take positions it otherwise wouldn't be able to due to insufficient margin.

Another upcoming change in this line of work is the implementation of the `ComboOrder` which will support buying/selling position groups as a unit and will require brokerage updates.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
YES! I believe these and upcoming changes warrant a dedicated section in the documentation.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Regression and unit tests -- backwards compatibility proved via `BuyingPowerModelComparator` which ensures that the `SecurityPositionGroupBuyingPowerModel` returns the same values as the security's `IBuyingPowerModel`.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed. [need to inspect python tests via travis, unable to run locally due to known environment issues -- it's not that I can't get it to work, it's that by getting it to work it breaks things I use in my full time job)
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
