### PR TITLE
Fix for "Engine does not warmup live algorithms" issue

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -613,11 +613,12 @@ namespace QuantConnect.Algorithm
 
                 foreach (var config in GetMatchingSubscriptions(x, typeof(BaseData), resolution))
                 {
+                    if (config.IsInternalFeed) continue;
                     var request = _historyRequestFactory.CreateHistoryRequest(config, startAlgoTz, endAlgoTz, GetExchangeHours(x), resolution);
 
                     // apply overrides
                     var res = GetResolution(x, resolution);
-                    if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? res : (Resolution?)null;
+                    if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? res : (Resolution?) null;
                     if (extendedMarket.HasValue) request.IncludeExtendedMarketHours = extendedMarket.Value;
 
                     requests.Add(request);

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -167,14 +167,17 @@ namespace QuantConnect.Algorithm
         /// <returns></returns>
         public IEnumerable<HistoryRequest> GetWarmupHistoryRequests()
         {
+            var symbolsToWarmup = Securities.Values
+                .Where(s => s.IsTradable).Select(s => s.Symbol);
+
             if (_warmupBarCount.HasValue)
             {
-                return CreateBarCountHistoryRequests(Securities.Keys, _warmupBarCount.Value, _warmupResolution);
+                return CreateBarCountHistoryRequests(symbolsToWarmup, _warmupBarCount.Value, _warmupResolution);
             }
             if (_warmupTimeSpan.HasValue)
             {
                 var end = UtcTime.ConvertFromUtc(TimeZone);
-                return CreateDateRangeHistoryRequests(Securities.Keys, end - _warmupTimeSpan.Value, end, _warmupResolution);
+                return CreateDateRangeHistoryRequests(symbolsToWarmup, end - _warmupTimeSpan.Value, end, _warmupResolution);
             }
 
             // if not warmup requested return nothing

--- a/Common/Global.cs
+++ b/Common/Global.cs
@@ -720,6 +720,27 @@ namespace QuantConnect
     }
 
     /// <summary>
+    /// Defines the current state of algorithm warming up
+    /// </summary>
+    public enum AlgorithmWarmupState
+    {
+        /// <summary>
+        /// Not called for the warm up
+        /// </summary>
+        NotStarted,
+
+        /// <summary>
+        /// Currently processing historical data requests
+        /// </summary>
+        Running,
+
+        /// <summary>
+        /// Processed all history requested
+        /// </summary>
+        Completed
+    }
+
+    /// <summary>
     /// Specifies where a subscription's data comes from
     /// </summary>
     public enum SubscriptionTransportMedium

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -280,8 +280,9 @@ namespace QuantConnect.Securities
                 var newSecurity = securityService.CreateSecurity(symbol,
                     config,
                     addToSymbolCache: false);
-                    // Mark security as non tradable, because so far it's being created only for currency conversion
-                    security.IsTradable = false;
+
+                // Mark security as non tradable, because so far it's being created only for currency conversion
+                newSecurity.IsTradable = false;
 
                 Log.Trace($"Cash.EnsureCurrencyDataFeed(): Adding {symbol.Value} for cash {Symbol} currency feed");
 

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -280,6 +280,8 @@ namespace QuantConnect.Securities
                 var newSecurity = securityService.CreateSecurity(symbol,
                     config,
                     addToSymbolCache: false);
+                    // Mark security as non tradable, because so far it's being created only for currency conversion
+                    security.IsTradable = false;
 
                 Log.Trace($"Cash.EnsureCurrencyDataFeed(): Adding {symbol.Value} for cash {Symbol} currency feed");
 

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -710,10 +710,6 @@ namespace QuantConnect.Lean.Engine
             {
                 ProcessVolatilityHistoryRequirements(algorithm);
             }
-            else
-            {
-                _algorithm.SetFinishedWarmingUp();
-            }
 
             return ProcessSynchronizerTimeSlices(algorithm, synchronizer, cancellationToken);
         }
@@ -722,7 +718,7 @@ namespace QuantConnect.Lean.Engine
         {
             foreach (var timeSlice in synchronizer.StreamData(cancellationToken))
             {
-                if (algorithm.LiveMode && algorithm.IsWarmingUp)
+                if (algorithm.IsWarmingUp)
                 {
                     if (timeSlice.IsTimePulse)
                     {

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -42,7 +42,6 @@ using QuantConnect.Util;
 using QuantConnect.Securities.Option;
 using QuantConnect.Securities.Volatility;
 using QuantConnect.Util.RateLimit;
-using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Lean.Engine
 {
@@ -58,7 +57,6 @@ namespace QuantConnect.Lean.Engine
         private DateTime? _lastHistoryTimeUtc;
         private AlgorithmWarmupState _warmupState;
         private bool _appliedSecurityChanges;
-        private AutoResetEvent _historyProcessorEvent = new AutoResetEvent(false);
         private readonly ConcurrentQueue<TimeSlice> _historicalTimeSlicesQueue = new ConcurrentQueue<TimeSlice>();
         private readonly ConcurrentQueue<TimeSlice> _tempSynchronizerTimeSlicesQueue = new ConcurrentQueue<TimeSlice>();
 
@@ -767,7 +765,6 @@ namespace QuantConnect.Lean.Engine
                         while (_warmupState == AlgorithmWarmupState.Running)
 #pragma warning restore CA1508 // Avoid dead conditional code
                         {
-                            _historyProcessorEvent.WaitOne();
                             TimeSlice ts;
                             // Dequeue historical time slices if any
                             while (_historicalTimeSlicesQueue.TryDequeue(out ts))
@@ -915,8 +912,6 @@ namespace QuantConnect.Lean.Engine
 
                 _historicalTimeSlicesQueue.Enqueue(timeSlice);
                 _lastHistoryTimeUtc = timeSlice.Time;
-
-                _historyProcessorEvent.Set();
             }
         }
 

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -876,7 +876,7 @@ namespace QuantConnect.Lean.Engine
                             }
 
                             var config = _algorithm.SubscriptionManager.SubscriptionDataConfigService
-                                .GetSubscriptionDataConfigs(symbol, includeInternalConfigs: true)
+                                .GetSubscriptionDataConfigs(symbol)
                                 .FirstOrDefault(subscription => dataType.IsAssignableFrom(subscription.Type));
 
                             if (config == null)


### PR DESCRIPTION
#### Description
There are few things here related to addressed issue I have notied:

1) First and most improtant thing here is if we deploy an alogirhtm written using Agorithm.Framework (and probably the classical way too) in a live mode. Then Universe selection, and security additions and non-internal subscriptionDataConfigs additions are happening only once we unwrap synchronizer's data streming and run the first time slice results all the way through the Run method, to handle SecrutyChanges and add securities. Otherwise we can't construct proper history request. Thus we come up with design when Stream() spins off the synchronizer first, let it start streaming, and then calls HistoryWarmpUp requests after a couple of cycles in appropriate moment. I believe such design is quite in the spirit of laid down architecture, because there are the following comments can be found in code :

// this is hand-over logic, we spin up the data feed first and then request
// the history for warmup, so there will be some overlap between the data

2) If synchronizer is not launched before HistoryProcessor called, this line of codes does not find all the required subscriptions:
https://github.com/QuantConnect/Lean/blob/master/Engine/AlgorithmManager.cs#L806
and in result the produced timeslice contains empty bars  . 
And this line of code may be missing some symbols from yet no initialized Securities:
https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L168

3) Next thing is I made securities that are being created in Cash.cs for currency conversions Non-Tradable. Because they are not really created for trading here. And used the following filter:
var hasTradableSecurities = algorithm.Securities.Values.Any(s => s.IsTradable);
to define the moment when required Security initialization is done and when is the moment we can call history processor inside the SynchronizerProcessor.



#### Related Issue
Closes #5262 

#### Motivation and Context
An issue with live algorithm

#### Requires Documentation Change
NA

#### How Has This Been Tested?
This fixes the described issue with local algorithm. But it's worth to think of all possible scenarios and behaviours that these changes may break, I would appreciate a review from core Lean developers.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
