### PR TITLE
Removes extra day added to CBOE Time causing data to shift one day forward

### DIFF
--- a/Common/Data/Custom/CBOE/CBOE.cs
+++ b/Common/Data/Custom/CBOE/CBOE.cs
@@ -90,8 +90,8 @@ namespace QuantConnect.Data.Custom.CBOE
 
             return new CBOE
             {
-                // Add a day delay to the data so that we LEAN doesn't assume that we get the data at 00:00 the day of
-                Time = QuantConnect.Parse.DateTime(csv[0]).AddDays(1),
+                // A one day delay is added to the end time automatically
+                Time = QuantConnect.Parse.DateTime(csv[0]),
                 Symbol = config.Symbol,
                 Open = open,
                 High = high,

--- a/Tests/Common/Data/Custom/CBOETests.cs
+++ b/Tests/Common/Data/Custom/CBOETests.cs
@@ -1,0 +1,47 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Data;
+
+namespace QuantConnect.Tests.Common.Data.Custom
+{
+    [TestFixture]
+    public class CBOETests
+    {
+        [Test]
+        public void EndTimeShiftedOneDayForward()
+        {
+            var date = new DateTime(2020, 5, 21);
+            var cboe = new QuantConnect.Data.Custom.CBOE.CBOE();
+            var cboeData = "2020-05-21,1,1,1,1";
+            var symbol = new Symbol(SecurityIdentifier.GenerateBase(typeof(QuantConnect.Data.Custom.CBOE.CBOE), "VIX", QuantConnect.Market.USA), "VIX");
+            var actual = cboe.Reader(new SubscriptionDataConfig(
+                typeof(QuantConnect.Data.Custom.CBOE.CBOE),
+                symbol,
+                Resolution.Daily,
+                QuantConnect.TimeZones.Utc,
+                QuantConnect.TimeZones.Utc,
+                false,
+                false,
+                false,
+                true), cboeData, date, false);
+
+            Assert.AreEqual(date, actual.Time);
+            Assert.AreEqual(date.AddDays(1), actual.EndTime);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
CBOE had an extra day added to its EndTime as a result of setting the Period to one day. This PR fixes that by removing the extra added day, since the TradeBar EndTime implementation does that for us already.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #5095 issue at the bottom of the page
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Consistency, data correctness
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Cloud, data is negatively lagged one day as expected v.s. in master
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
