### PR TITLE
Move report statistics JSON output to in-memory string as out param

### DIFF
--- a/Report/Program.cs
+++ b/Report/Program.cs
@@ -74,7 +74,10 @@ namespace QuantConnect.Report
 
             // Generate the html content
             Log.Trace("QuantConnect.Report.Main(): Starting content compile...");
-            var html = report.Compile();
+            string html;
+            string _;
+
+            report.Compile(out html, out _);
 
             //Write it to target destination.
             if (destination != string.Empty)

--- a/Report/Report.cs
+++ b/Report/Report.cs
@@ -134,9 +134,9 @@ namespace QuantConnect.Report
         /// Compile the backtest data into a report
         /// </summary>
         /// <returns></returns>
-        public string Compile()
+        public void Compile(out string html, out string reportStatistics)
         {
-            var html = File.ReadAllText(_template);
+            html = File.ReadAllText(_template);
             var statistics = new Dictionary<string, object>();
 
             // Render the output and replace the report section
@@ -154,22 +154,7 @@ namespace QuantConnect.Report
                 statistics[reportElement.JsonKey] = reportElement.Result;
             }
 
-            try
-            {
-                if (File.Exists(StatisticsFileName))
-                {
-                    File.Delete(StatisticsFileName);
-                }
-
-                File.WriteAllText(StatisticsFileName, JsonConvert.SerializeObject(statistics, Formatting.None));
-                Log.Trace($"Report.Compile(): Statistics have been written to disk: {StatisticsFileName}");
-            }
-            catch (Exception err)
-            {
-                Log.Error(err, $"Writing statistics to output file {StatisticsFileName} failed.");
-            }
-
-            return html;
+            reportStatistics = JsonConvert.SerializeObject(statistics, Formatting.None);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
To avoid any issues with potential file flushing and OS-level issues, the statistics report JSON is set as a string in memory and not written to disk.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensure stability/correctness
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
