### PR TITLE
Update IBAutomater to v1.0.44

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -37,7 +37,6 @@ using NodaTime;
 using QuantConnect.IBAutomater;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.TimeInForces;
-using QuantConnect.Securities.Future;
 using QuantConnect.Securities.FutureOption;
 using QuantConnect.Securities.Option;
 using Bar = QuantConnect.Data.Market.Bar;

--- a/Brokerages/QuantConnect.Brokerages.csproj
+++ b/Brokerages/QuantConnect.Brokerages.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
-    <PackageReference Include="QuantConnect.IBAutomater" Version="1.0.43" />
+    <PackageReference Include="QuantConnect.IBAutomater" Version="1.0.44" />
     <PackageReference Include="RestSharp" Version="106.6.10" />
     <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />


### PR DESCRIPTION
#### Description
- When attempting to deploy to an IBKR Lite account, the error message will now be the following:
```
IBAutomater error - Code: ApiSupportNotAvailable Message: 
API support is not available for accounts that support free trading. 
Please upgrade your plan from IBKR Lite to IBKR Pro.
```
instead of a generic IBAutomater timeout error.

#### Related Issue
- https://github.com/QuantConnect/IBAutomater/pull/35

#### Motivation and Context
- Better error messages

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Tested locally and in QC cloud with an IBKR Lite account

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.