### PR TITLE
Fixes crash in rolling sharpe calculation when using daily resolution in report generator

### DIFF
--- a/Report/ReportElements/DailyReturnsReportElement.cs
+++ b/Report/ReportElements/DailyReturnsReportElement.cs
@@ -53,8 +53,8 @@ namespace QuantConnect.Report.ReportElements
             var liveSeries = new Series<DateTime, double>(liveReturns.Keys, liveReturns.Values);
 
             // The following two operations are equivalent to the Pandas `DataFrame.resample(...)` method
-            var backtestResampled = backtestSeries.ResampleEquivalence(date => date.Date, s => s.TotalReturns()).DropMissing() * 100;
-            var liveResampled = liveSeries.ResampleEquivalence(date => date.Date, s => s.TotalReturns()).DropMissing() * 100;
+            var backtestResampled = backtestSeries.ResampleEquivalence(date => date.Date, s => s.LastValue()).PercentChange().DropMissing() * 100;
+            var liveResampled = liveSeries.ResampleEquivalence(date => date.Date, s => s.LastValue()).PercentChange().DropMissing() * 100;
 
             var base64 = "";
             using (Py.GIL())

--- a/Report/Rolling.cs
+++ b/Report/Rolling.cs
@@ -35,7 +35,9 @@ namespace QuantConnect.Report
         /// <returns>Rolling beta</returns>
         public static Series<DateTime, double> Beta(Series<DateTime, double> equityCurve, Series<DateTime, double> benchmarkSeries, int windowSize = 132)
         {
-            var dailyReturnsSeries = equityCurve.ResampleEquivalence(date => date.Date, s => s.TotalReturns());
+            var dailyReturnsSeries = equityCurve.ResampleEquivalence(date => date.Date, s => s.LastValue())
+                .PercentChange();
+
             var benchmarkReturns = benchmarkSeries.ResampleEquivalence(date => date.Date, s => s.LastValue())
                 .CumulativeReturns();
 
@@ -71,7 +73,9 @@ namespace QuantConnect.Report
                 return equityCurve;
             }
 
-            var dailyReturns = equityCurve.ResampleEquivalence(date => date.Date, s => s.TotalReturns());
+            var dailyReturns = equityCurve.ResampleEquivalence(date => date.Date, s => s.LastValue())
+                .PercentChange();
+
             var rollingSharpeData = new List<KeyValuePair<DateTime, double>>();
             var firstDate = equityCurve.FirstKey();
 


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
To maintain consistency between calculations, we will use the end of day equity value to calculate the returns per day.

This fixes a bug where daily equity series would zero out and result in an exception being thrown since no elements were being passed to the Sharpe calculation.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensure report generator works for all valid inputs
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
