### PR TITLE
Fixes various bugs in strategy capacity estimation for reports

### DIFF
--- a/Tests/Report/Capacity/StrategyCapacityTests.cs
+++ b/Tests/Report/Capacity/StrategyCapacityTests.cs
@@ -30,17 +30,17 @@ namespace QuantConnect.Tests.Report.Capacity
     public class StrategyCapacityTests
     {
         [TestCase(nameof(SpyBondPortfolioRebalance), 2900000)]
-        [TestCase(nameof(BeastVsPenny), 180000)]
+        [TestCase(nameof(BeastVsPenny), 370000)]
         [TestCase(nameof(MonthlyRebalanceHourly), 11000000)]
         [TestCase(nameof(MonthlyRebalanceDaily), 11000000)]
-        [TestCase(nameof(IntradayMinuteScalping), 26000000)]
-        [TestCase("IntradayMinuteScalpingBTCETH", 130000)]
-        [TestCase("IntradayMinuteScalpingEURUSD", 2400000)]
-        [TestCase("IntradayMinuteScalpingGBPJPY", 2200000)]
-        [TestCase("IntradayMinuteScalpingTRYJPY", 2300000)]
-        [TestCase(nameof(CheeseMilkHourlyRebalance), 52000)]
-        [TestCase(nameof(IntradayMinuteScalpingFuturesES), 20000000)]
-        [TestCase(nameof(EmaPortfolioRebalance100), 200)]
+        [TestCase(nameof(IntradayMinuteScalping), 31000000)]
+        [TestCase("IntradayMinuteScalpingBTCETH", 13000)]
+        [TestCase("IntradayMinuteScalpingEURUSD", 4800000)]
+        [TestCase("IntradayMinuteScalpingGBPJPY", 4700000)]
+        [TestCase("IntradayMinuteScalpingTRYJPY", 4300000)]
+        [TestCase(nameof(CheeseMilkHourlyRebalance), 57000)]
+        [TestCase(nameof(IntradayMinuteScalpingFuturesES), 36000000)]
+        [TestCase(nameof(EmaPortfolioRebalance100), 2600)]
         public void TestCapacity(string strategy, int expectedCapacity)
         {
             var backtest = JsonConvert.DeserializeObject<BacktestResult>(File.ReadAllText(Path.Combine("Report", "Capacity", "Strategies", $"{strategy}.json")), new OrderJsonConverter());


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
  * Fixes potential mapping issue, caused by not mapping Symbols before
    reading data off disk

  * Fixes issue where some results would evaluate to zero capacity

  * Loads of refactoring, mostly resulting in cleaner code

Capacity estimation was tested by crafting and running a series of 12 tests, trading at different frequencies and different assets.

These tests are:

| Strategy Name                   | Link                                                                                                                 | Strategy                                                                                                               |
|---------------------------------|----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
| BeastVsPenny                    | https://github.com/QuantConnect/Lean/blob/master/Tests/Report/Capacity/Strategies/BeastVsPenny.cs                    | Tests capacity by trading SPY (beast) alongside a small cap stock (ABUS)                                               |
| CheeseMilkHourlyRebalance       | https://github.com/QuantConnect/Lean/blob/master/Tests/Report/Capacity/Strategies/CheeseMilkHourlyRebalance.cs       | Tests an illiquid asset that has bursts of liquidity around 11:00 A.M. Central Time with an hourly in and out strategy |
| EmaPortfolioRebalance           | https://github.com/QuantConnect/Lean/blob/master/Tests/Report/Capacity/Strategies/EmaPortfolioRebalance100.cs        | Tests a wide variety of liquid and illiquid stocks together, with bins of 20 ranging from micro-cap to mega-cap stocks |
| IntradayMinuteScalping          | https://github.com/QuantConnect/Lean/blob/master/Tests/Report/Capacity/Strategies/IntradayMinuteScalping.cs          | Scalps SPY using an EMA cross strategy                                                                                 |
| IntradayMinuteScalpingBTCETH    | Same as IntradayMinuteScalping using BTCETH as an asset instead                                                      | Scalps BTCETH using an EMA cross strategy                                                                              |
| IntradayMinuteScalpingEURUSD    | Same as IntradayMinuteScalping using EURUSD as an asset instead                                                      | Scalps EURUSD using an EMA cross strategy                                                                              |
| IntradayMinuteScalpingFuturesES | https://github.com/QuantConnect/Lean/blob/master/Tests/Report/Capacity/Strategies/IntradayMinuteScalpingFuturesES.cs | Scalps ES futures using an EMA cross strategy                                                                          |
| IntradayMinuteScalpingGBPJPY    | Same as IntradayMinuteScalping using GBPJPY as an asset instead                                                      | Scalps GBPJPY using an EMA cross strategy                                                                              |
| IntradayMinuteScalpingTRYJPY    | Same as IntradayMinuteScalping using TRYJPY as an asset instead                                                      | Scalps TRYJPY using an EMA cross strategy                                                                              |
| MonthlyRebalanceDaily           | https://github.com/QuantConnect/Lean/blob/master/Tests/Report/Capacity/Strategies/MonthlyRebalanceDaily.cs           | Rebalances 10 stocks each month at the month start                                                                     |
| MonthlyRebalanceHourly          | https://github.com/QuantConnect/Lean/blob/master/Tests/Report/Capacity/Strategies/MonthlyRebalanceHourly.cs          | Rebalances 10 stocks approximately each hour                                                                           |
| SpyBondPortfolioRebalance       | https://github.com/QuantConnect/Lean/blob/master/Tests/Report/Capacity/Strategies/SpyBondPortfolioRebalance.cs       | Rebalances between SPY and BND each day after market open                                                              |

Penalties that have been factored in to the capacity estimation are:

  * Strategies with higher frequencies are penalized for constant trading
  * Illiquid assets are penalized based on their forward-looking rolling 5 to 120-minute volume, depending on how much dollar volume the asset has in a minute. The more dollar volume per minute, the shorter the look-forward window is. In general, the less liquid they are, the more it impacts capacity.
  * For crypto, lack of market depth will result in lower capacity
  * Some constants are used to calculate the capacity. Potentially will be replaced in the future

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensure reports are generated successfully/correctly
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally, failing test is now passing and sanity checks w/ Jared 🙂 
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
