### PR TITLE
Removes SevenZipSharp library from ToolBox

### DIFF
--- a/Compression/Compression.cs
+++ b/Compression/Compression.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -872,6 +873,45 @@ namespace QuantConnect
                 {
                     yield return entry.FileName;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Extracts a 7-zip archive to disk, using the 7-zip CLI utility
+        /// </summary>
+        /// <param name="inputFile">Path to the 7z file</param>
+        /// <param name="outputDirectory">Directory to output contents of 7z</param>
+        /// <param name="execTimeout">Timeout in seconds for how long we should wait for the extraction to complete</param>
+        /// <exception cref="Exception">The extraction failed because of a timeout or the exit code was not 0</exception>
+        public static void Extract7ZipArchive(string inputFile, string outputDirectory = null, int execTimeout = 60)
+        {
+            outputDirectory = outputDirectory ?? $"{Guid.NewGuid()}";
+
+            var zipper = OS.IsWindows ? "C:/Program Files/7-Zip/7z.exe" : "7z";
+            var psi = new ProcessStartInfo(zipper, " e " + inputFile + " -o" + outputDirectory)
+            {
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden,
+                UseShellExecute = false,
+                RedirectStandardOutput = true
+            };
+
+            var process = new Process();
+            process.StartInfo = psi;
+            process.Start();
+
+            while (!process.StandardOutput.EndOfStream)
+            {
+                process.StandardOutput.ReadLine();
+            }
+
+            if (!process.WaitForExit(execTimeout * 1000))
+            {
+                throw new Exception($"Timed out extracting 7Zip archive: {inputFile} ({execTimeout} seconds)");
+            }
+            if (process.ExitCode > 0)
+            {
+                throw new Exception($"Compression.Extract7ZipArchive(): 7Zip exited unsuccessfully (code {process.ExitCode})");
             }
         }
     }

--- a/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesConverter.cs
+++ b/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesConverter.cs
@@ -81,8 +81,6 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
             var totalFilesProcessed = 0;
             var start = DateTime.MinValue;
 
-            var zipper = OS.IsWindows ? "C:/Program Files/7-Zip/7z.exe" : "7z";
-
             var symbolMultipliers = LoadSymbolMultipliers();
 
             //Extract each file massively in parallel.
@@ -103,34 +101,8 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
                         Directory.CreateDirectory(csvFileInfo.DirectoryName);
 
                         Log.Trace("AlgoSeekFuturesConverter.Convert(): Extracting " + file);
-                        var psi = new ProcessStartInfo(zipper, " e " + file.FullName + " -o" + _source.FullName)
-                        {
-                            CreateNoWindow = true,
-                            WindowStyle = ProcessWindowStyle.Hidden,
-                            UseShellExecute = false,
-                            RedirectStandardOutput = true
-                        };
 
-                        var process = new Process();
-                        process.StartInfo = psi;
-                        process.Start();
-
-                        while (!process.StandardOutput.EndOfStream)
-                        {
-                            process.StandardOutput.ReadLine();
-                        }
-
-                        if (!process.WaitForExit(ExecTimeout * 1000))
-                        {
-                            Log.Error("7Zip timed out: " + file);
-                        }
-                        else
-                        {
-                            if (process.ExitCode > 0)
-                            {
-                                Log.Error("7Zip Exited Unsuccessfully: " + file);
-                            }
-                        }
+                        Compression.Extract7ZipArchive(file.FullName, _source.FullName);
                     }
 
                     // setting up local processors

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -91,7 +91,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
     <PackageReference Include="QuantConnect.pythonnet" Version="1.0.5.30" />
-    <PackageReference Include="SevenZipSharp" Version="0.64" />
     <PackageReference Include="SharpZipLib" Version="1.2.0" />
     <PackageReference Include="SuperSocket.ClientEngine.Core" Version="0.10.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
  - Library removal required for update to .NET 5.0 since it's not
    compatible with it and Linux is unsupported.

  * Adds new extract 7z functionality to Compression project
  * Refactors AlgoSeekFuturesConverter 7z extract
  * Refactors DukascopyDataDownloader 7z extract
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to #452 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
.NET 5.0 migration efforts
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Cloud
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
