### PR TITLE
Fix ThreadAbortException when running ToolBox

### DIFF
--- a/Common/Util/Composer.cs
+++ b/Common/Util/Composer.cs
@@ -82,7 +82,11 @@ namespace QuantConnect.Util
                 }
                 catch (Exception exception)
                 {
-                    Log.Error(exception);
+                    // ThreadAbortException is triggered when we shutdown ignore the error log
+                    if (!(exception is ThreadAbortException))
+                    {
+                        Log.Error(exception);
+                    }
                 }
                 return new List<ComposablePartDefinition>();
             });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR re-applies the changes made in #4870. These changes were later removed in #5274 which removed all usages of `Thread.Abort()` and `ThreadAbortException` because the former is obsolete in .NET 5.0. Since #4870 only introduced `ThreadAbortException`, which still [exists](https://docs.microsoft.com/en-us/dotnet/api/system.threading.threadabortexception?view=net-5.0) in .NET 5.0, we can safely re-apply these changes without breaking .NET 5.0 compatibility.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5338.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove an exception which is shown when running the ToolBox.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this locally with Mono as follows:
```
$ msbuild QuantConnect.Lean.sln

$ cd Launcher/bin/Debug

$ mono QuantConnect.ToolBox.exe --app=YahooDownloader --tickers=SPY,AAPL --resolution=Daily --from-date=19980102-00:00:00 --to-date=20210107-00:00:00 --destination-dir ../../../Data
20210224 21:05:00.601 TRACE:: Config.GetValue(): debug-mode - Using default value: False
20210224 21:05:00.617 TRACE:: Config.Get(): Configuration key not found. Key: results-destination-folder - Using default value: 
20210224 21:05:00.617 TRACE:: Config.Get(): Configuration key not found. Key: plugin-directory - Using default value: 
20210224 21:05:00.621 TRACE:: Config.Get(): Configuration key not found. Key: composer-dll-directory - Using default value: /home/jasper/Projects/Lean/Launcher/bin/Debug/
20210224 21:05:00.971 TRACE:: Config.Get(): Configuration key not found. Key: data-directory - Using default value: ../../../Data
20210224 21:05:01.014 TRACE:: Config.Get(): Configuration key not found. Key: data-directory - Using default value: ../../../Data/
20210224 21:05:01.016 TRACE:: Config.Get(): Configuration key not found. Key: version-id - Using default value: 
20210224 21:05:01.016 TRACE:: Config.Get(): Configuration key not found. Key: cache-location - Using default value: ../../../Data/
20210224 21:05:03.606 TRACE:: LeanDataWriter.Write(): Existing deleted: ../../../Data/equity/usa/daily/spy.zip
20210224 21:05:03.777 TRACE:: LeanDataWriter.Write(): Created: ../../../Data/equity/usa/daily/spy.zip
20210224 21:05:04.213 TRACE:: LeanDataWriter.Write(): Existing deleted: ../../../Data/equity/usa/daily/aapl.zip
20210224 21:05:04.254 TRACE:: LeanDataWriter.Write(): Created: ../../../Data/equity/usa/daily/aapl.zip
```

I have also tested this with .NET 5.0 as follows:
```
$ dotnet --version
5.0.103

$ cd Launcher/bin/Debug

$ dotnet run --project ../../../ToolBox -- --app=YahooDownloader --tickers=SPY,AAPL --resolution=Daily --from-date=19980102-00:00:00 --to-date=20210107-00:00:00 --destination-dir ../../../Data
20210224 21:05:47.421 TRACE:: Config.GetValue(): debug-mode - Using default value: False
20210224 21:05:47.437 TRACE:: Config.Get(): Configuration key not found. Key: results-destination-folder - Using default value: 
20210224 21:05:47.438 TRACE:: Config.Get(): Configuration key not found. Key: plugin-directory - Using default value: 
20210224 21:05:47.442 TRACE:: Config.Get(): Configuration key not found. Key: composer-dll-directory - Using default value: /home/jasper/Projects/Lean/ToolBox/bin/Debug/
20210224 21:05:47.827 TRACE:: Config.Get(): Configuration key not found. Key: data-directory - Using default value: ../../../Data
20210224 21:05:47.864 TRACE:: Config.Get(): Configuration key not found. Key: data-directory - Using default value: ../../../Data/
20210224 21:05:47.866 TRACE:: Config.Get(): Configuration key not found. Key: version-id - Using default value: 
20210224 21:05:47.866 TRACE:: Config.Get(): Configuration key not found. Key: cache-location - Using default value: ../../../Data/
20210224 21:05:50.279 TRACE:: LeanDataWriter.Write(): Existing deleted: ../../../Data/equity/usa/daily/spy.zip
20210224 21:05:50.484 TRACE:: LeanDataWriter.Write(): Created: ../../../Data/equity/usa/daily/spy.zip
20210224 21:05:50.946 TRACE:: LeanDataWriter.Write(): Existing deleted: ../../../Data/equity/usa/daily/aapl.zip
20210224 21:05:50.983 TRACE:: LeanDataWriter.Write(): Created: ../../../Data/equity/usa/daily/aapl.zip
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

I'm not sure how to add tests for this.

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->