### PR TITLE
CoinApi small bug fixup

### DIFF
--- a/ToolBox/CoinApi/CoinApiDataQueueHandler.cs
+++ b/ToolBox/CoinApi/CoinApiDataQueueHandler.cs
@@ -260,7 +260,7 @@ namespace QuantConnect.ToolBox.CoinApi
 
         private void SendHelloMessage(IEnumerable<string> subscribeFilter)
         {
-            var list = subscribeFilter.ToList();
+            var list = subscribeFilter.Select(x => string.Concat(x, "$")).ToList();
             if (list.Count == 0)
             {
                 // If we use a null or empty filter in the CoinAPI hello message


### PR DESCRIPTION

#### Description
Subscribe filter values need to be locked by $ sign. See
https://docs.coinapi.io/#endpoints-2

Filter data to symbols whose identifiers match at least one of the listed prefixes. If symbol is ended with $ character then exact match is used instead of prefix match. (optional, if not provided then stream will not filtered by symbols)

Otherwise, for example, it may stream for ETH_USD mask:
ETH_USD
ETH_USDT
ETH_USDC
and other ETH_[whatever-dollar-derivative-coin]

#### Related Issue
NA

#### Motivation and Context
Fixing a bug

#### Requires Documentation Change
NA

#### How Has This Been Tested?
Real time algorithm

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
