### PR TITLE
Add OutsideRth property to InteractiveBrokersOrderProperties

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1003,7 +1003,24 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             }
             else
             {
-                var ibOrder = ConvertOrder(order, contract, ibOrderId);
+                var outsideRth = false;
+
+                if (order.Type == OrderType.Limit ||
+                    order.Type == OrderType.LimitIfTouched ||
+                    order.Type == OrderType.StopMarket ||
+                    order.Type == OrderType.StopLimit)
+                {
+                    var orderProperties = order.Properties as InteractiveBrokersOrderProperties;
+                    if (orderProperties != null)
+                    {
+                        if (orderProperties.OutsideRth)
+                        {
+                            outsideRth = true;
+                        }
+                    }
+                }
+
+                var ibOrder = ConvertOrder(order, contract, ibOrderId, outsideRth);
                 _client.ClientSocket.placeOrder(ibOrder.OrderId, contract, ibOrder);
             }
         }
@@ -1695,7 +1712,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <summary>
         /// Converts a QC order to an IB order
         /// </summary>
-        private IBApi.Order ConvertOrder(Order order, Contract contract, int ibOrderId)
+        private IBApi.Order ConvertOrder(Order order, Contract contract, int ibOrderId, bool outsideRth)
         {
             var ibOrder = new IBApi.Order
             {
@@ -1708,7 +1725,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 AllOrNone = false,
                 Tif = ConvertTimeInForce(order),
                 Transmit = true,
-                Rule80A = _agentDescription
+                Rule80A = _agentDescription,
+                OutsideRth = outsideRth
             };
 
             var gtdTimeInForce = order.TimeInForce as GoodTilDateTimeInForce;

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1013,10 +1013,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                     var orderProperties = order.Properties as InteractiveBrokersOrderProperties;
                     if (orderProperties != null)
                     {
-                        if (orderProperties.OutsideRth)
-                        {
-                            outsideRth = true;
-                        }
+                        outsideRth = orderProperties.OutsideRegularTradingHours;
                     }
                 }
 

--- a/Common/Orders/InteractiveBrokersOrderProperties.cs
+++ b/Common/Orders/InteractiveBrokersOrderProperties.cs
@@ -49,6 +49,11 @@ namespace QuantConnect.Orders
         public string FaProfile { get; set; }
 
         /// <summary>
+        /// If set to true, allows orders to also trigger or fill outside of regular trading hours.
+        /// </summary>
+        public bool OutsideRth { get; set; }
+
+        /// <summary>
         /// Returns a new instance clone of this object
         /// </summary>
         public override IOrderProperties Clone()

--- a/Common/Orders/InteractiveBrokersOrderProperties.cs
+++ b/Common/Orders/InteractiveBrokersOrderProperties.cs
@@ -51,7 +51,7 @@ namespace QuantConnect.Orders
         /// <summary>
         /// If set to true, allows orders to also trigger or fill outside of regular trading hours.
         /// </summary>
-        public bool OutsideRth { get; set; }
+        public bool OutsideRegularTradingHours { get; set; }
 
         /// <summary>
         /// Returns a new instance clone of this object


### PR DESCRIPTION

#### Description
- Added the `OutsideRth` property to the `InteractiveBrokersOrderProperties` class
- Updated the IB brokerage to use this setting when placing orders:
  - only valid for these order types: `Limit`, `LimitIfTouched`, `StopMarket`, `StopLimit`
  - can be enabled by adding the following line in `Initialize()` or before submitting the order:
  ``` C#
  DefaultOrderProperties = new InteractiveBrokersOrderProperties { OutsideRth = true };
  ```

#### Related Issue
Closes #5264

#### Motivation and Context
- Allows orders to trigger or fill outside of regular market hours

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Local testing: submitted limit orders before market open with `OutsideRth = true` and verified immediate fills

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`