### PR TITLE
GetFundamental Default End Date

### DIFF
--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -804,7 +804,7 @@ namespace QuantConnect.Research
         {
             //SubscriptionRequest does not except nullable DateTimes, so set a startTime and endTime
             var startTime = start.HasValue ? (DateTime)start : QuantConnect.Time.BeginningOfTime;
-            var endTime = end.HasValue ? (DateTime)end : QuantConnect.Time.EndOfTime;
+            var endTime = end.HasValue ? (DateTime) end : DateTime.UtcNow.Date;
 
             //Collection to store our results
             var data = new Dictionary<DateTime, DataDictionary<dynamic>>();

--- a/Tests/Research/QuantBookFundamentalTests.cs
+++ b/Tests/Research/QuantBookFundamentalTests.cs
@@ -17,6 +17,7 @@ using NUnit.Framework;
 using Python.Runtime;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using QuantConnect.Data.Market;
 using QuantConnect.Logging;
 using QuantConnect.Research;
@@ -56,6 +57,19 @@ namespace QuantConnect.Tests.Research
         {
             // Reset to initial handler
             Log.LogHandler = _logHandler;
+        }
+
+        [Test]
+        public void DefaultEndDate()
+        {
+            var qb = new QuantBook();
+            var startDate = DateTime.UtcNow.Date.AddDays(-2);
+            var expectedDate = DateTime.UtcNow.Date;
+            IEnumerable<DataDictionary<dynamic>> data = qb.GetFundamental("AAPL", "ValuationRatios.PERatio", startDate);
+
+            // Check that the last day in the collection is as expected (today)
+            var lastDay = data.Last();
+            Assert.AreEqual(expectedDate, lastDay.Time);
         }
 
         [TestCaseSource(nameof(DataTestCases))]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Change GetFundamentals default end date to `DateTime.UtcNow.Date`

Before it was QuantConnect.Time.EndOfTime, which was sometime in 2050, meaning we were fill forwarding data on default calls. 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
No need to have default create a huge table with a bunch of fill forwarded data.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Dev container using Py Research 


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
