### PR TITLE
Fix timestamps in custom data algorithms

### DIFF
--- a/Algorithm.CSharp/CustomDataBitcoinAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataBitcoinAlgorithm.cs
@@ -153,7 +153,8 @@ namespace QuantConnect.Algorithm.CSharp
                 try
                 {
                     string[] data = line.Split(',');
-                    coin.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture).AddDays(1);
+                    coin.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture);
+                    coin.EndTime = coin.Time.AddDays(1);
                     coin.Open = Convert.ToDecimal(data[1], CultureInfo.InvariantCulture);
                     coin.High = Convert.ToDecimal(data[2], CultureInfo.InvariantCulture);
                     coin.Low = Convert.ToDecimal(data[3], CultureInfo.InvariantCulture);

--- a/Algorithm.CSharp/CustomDataBitcoinAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataBitcoinAlgorithm.cs
@@ -58,7 +58,7 @@ namespace QuantConnect.Algorithm.CSharp
                 //Weather used as a tradable asset, like stocks, futures etc.
                 if (data.Close != 0)
                 {
-                    Order("BTC", (Portfolio.MarginRemaining / Math.Abs(data.Close + 1)));
+                    SetHoldings("BTC", 1);
                 }
                 Console.WriteLine("Buying BTC 'Shares': BTC: " + data.Close);
             }
@@ -117,7 +117,7 @@ namespace QuantConnect.Algorithm.CSharp
 
                 //return "http://my-ftp-server.com/futures-data-" + date.ToString("Ymd") + ".zip";
                 // OR simply return a fixed small data file. Large files will slow down your backtest
-                return new SubscriptionDataSource("https://www.quandl.com/api/v3/datasets/BCHARTS/BITSTAMPUSD.csv?order=asc", SubscriptionTransportMedium.RemoteFile);
+                return new SubscriptionDataSource("https://www.quantconnect.com/api/v2/proxy/quandl/api/v3/datasets/BCHARTS/BITSTAMPUSD.csv?order=asc&api_key=WyAazVXnq7ATy_fefTqm", SubscriptionTransportMedium.RemoteFile);
             }
 
             /// <summary>
@@ -153,7 +153,7 @@ namespace QuantConnect.Algorithm.CSharp
                 try
                 {
                     string[] data = line.Split(',');
-                    coin.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture);
+                    coin.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture).AddDays(1);
                     coin.Open = Convert.ToDecimal(data[1], CultureInfo.InvariantCulture);
                     coin.High = Convert.ToDecimal(data[2], CultureInfo.InvariantCulture);
                     coin.Low = Convert.ToDecimal(data[3], CultureInfo.InvariantCulture);

--- a/Algorithm.CSharp/CustomDataBitcoinAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataBitcoinAlgorithm.cs
@@ -58,6 +58,8 @@ namespace QuantConnect.Algorithm.CSharp
                 //Weather used as a tradable asset, like stocks, futures etc.
                 if (data.Close != 0)
                 {
+                    // It's only OK to use SetHoldings with crypto when using custom data. When trading with built-in crypto data, 
+                    // use the cashbook. Reference https://github.com/QuantConnect/Lean/blob/master/Algorithm.Python/BasicTemplateCryptoAlgorithm.py 
                     SetHoldings("BTC", 1);
                 }
                 Console.WriteLine("Buying BTC 'Shares': BTC: " + data.Close);

--- a/Algorithm.CSharp/CustomDataNIFTYAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataNIFTYAlgorithm.cs
@@ -77,7 +77,7 @@ namespace QuantConnect.Algorithm.CSharp
             {
 
                 _today.NiftyPrice = Convert.ToDouble(data["NIFTY"].Close);
-                if (_today.Date == data["NIFTY"].EndTime)
+                if (_today.Date == data["NIFTY"].Time)
                 {
                     _prices.Add(_today);
 
@@ -91,7 +91,7 @@ namespace QuantConnect.Algorithm.CSharp
                 var quantity = (int)(Portfolio.MarginRemaining * 0.9m / data["NIFTY"].Close);
                 var highestNifty = (from pair in _prices select pair.NiftyPrice).Max();
                 var lowestNifty = (from pair in _prices select pair.NiftyPrice).Min();
-                
+
                 if (Time.DayOfWeek == DayOfWeek.Wednesday) //prices.Count >= minimumCorrelationHistory &&
                 {
                     //List<double> niftyPrices = (from pair in prices select pair.NiftyPrice).ToList();
@@ -180,7 +180,7 @@ namespace QuantConnect.Algorithm.CSharp
                 //Date,       Open       High        Low       Close     Volume      Turnover
                 //2011-09-13  7792.9    7799.9     7722.65    7748.7    116534670    6107.78
                 var data = line.Split(',');
-                index.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture);
+                index.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture).AddDays(1);
                 index.Open = Convert.ToDecimal(data[1], CultureInfo.InvariantCulture);
                 index.High = Convert.ToDecimal(data[2], CultureInfo.InvariantCulture);
                 index.Low = Convert.ToDecimal(data[3], CultureInfo.InvariantCulture);
@@ -246,7 +246,7 @@ namespace QuantConnect.Algorithm.CSharp
             try
             {
                 var data = line.Split(',');
-                currency.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture);
+                currency.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture).AddDays(1);
                 currency.Close = Convert.ToDecimal(data[1], CultureInfo.InvariantCulture);
                 currency.Symbol = "USDINR";
                 currency.Value = currency.Close;

--- a/Algorithm.CSharp/CustomDataNIFTYAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataNIFTYAlgorithm.cs
@@ -180,7 +180,8 @@ namespace QuantConnect.Algorithm.CSharp
                 //Date,       Open       High        Low       Close     Volume      Turnover
                 //2011-09-13  7792.9    7799.9     7722.65    7748.7    116534670    6107.78
                 var data = line.Split(',');
-                index.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture).AddDays(1);
+                index.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture);
+                index.EndTime = index.Time.AddDays(1);
                 index.Open = Convert.ToDecimal(data[1], CultureInfo.InvariantCulture);
                 index.High = Convert.ToDecimal(data[2], CultureInfo.InvariantCulture);
                 index.Low = Convert.ToDecimal(data[3], CultureInfo.InvariantCulture);
@@ -246,7 +247,8 @@ namespace QuantConnect.Algorithm.CSharp
             try
             {
                 var data = line.Split(',');
-                currency.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture).AddDays(1);
+                currency.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture);
+                currency.EndTime = currency.Time.AddDays(1);
                 currency.Close = Convert.ToDecimal(data[1], CultureInfo.InvariantCulture);
                 currency.Symbol = "USDINR";
                 currency.Value = currency.Close;

--- a/Algorithm.CSharp/CustomDataPropertiesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataPropertiesRegressionAlgorithm.cs
@@ -114,29 +114,29 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "1"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "155.262%"},
+            {"Compounding Annual Return", "157.498%"},
             {"Drawdown", "84.800%"},
             {"Expectancy", "0"},
-            {"Net Profit", "5123.242%"},
-            {"Sharpe Ratio", "2.067"},
-            {"Probabilistic Sharpe Ratio", "68.833%"},
+            {"Net Profit", "5319.081%"},
+            {"Sharpe Ratio", "2.086"},
+            {"Probabilistic Sharpe Ratio", "69.456%"},
             {"Loss Rate", "0%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "1.732"},
-            {"Beta", "0.037"},
-            {"Annual Standard Deviation", "0.841"},
-            {"Annual Variance", "0.707"},
-            {"Information Ratio", "1.902"},
-            {"Tracking Error", "0.848"},
-            {"Treynor Ratio", "46.992"},
+            {"Alpha", "1.736"},
+            {"Beta", "0.142"},
+            {"Annual Standard Deviation", "0.84"},
+            {"Annual Variance", "0.706"},
+            {"Information Ratio", "1.925"},
+            {"Tracking Error", "0.846"},
+            {"Treynor Ratio", "12.904"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "2.238"},
-            {"Return Over Maximum Drawdown", "1.832"},
+            {"Sortino Ratio", "2.269"},
+            {"Return Over Maximum Drawdown", "1.858"},
             {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
@@ -151,7 +151,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "1f54fb75ebcc0daafa5d45bfbaa4fbcb"}
+            {"OrderListHash", "0d80bb47bd16b5bc6989a4c1c7aa8349"}
         };
 
         /// <summary>
@@ -242,7 +242,7 @@ namespace QuantConnect.Algorithm.CSharp
                 try
                 {
                     string[] data = line.Split(',');
-                    coin.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture);
+                    coin.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture).AddDays(1);
                     coin.Open = Convert.ToDecimal(data[1], CultureInfo.InvariantCulture);
                     coin.High = Convert.ToDecimal(data[2], CultureInfo.InvariantCulture);
                     coin.Low = Convert.ToDecimal(data[3], CultureInfo.InvariantCulture);

--- a/Algorithm.CSharp/CustomDataPropertiesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataPropertiesRegressionAlgorithm.cs
@@ -124,7 +124,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
             {"Alpha", "1.736"},
-            {"Beta", "0.142"},
+            {"Beta", "0.136"},
             {"Annual Standard Deviation", "0.84"},
             {"Annual Variance", "0.706"},
             {"Information Ratio", "1.925"},
@@ -242,7 +242,8 @@ namespace QuantConnect.Algorithm.CSharp
                 try
                 {
                     string[] data = line.Split(',');
-                    coin.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture).AddDays(1);
+                    coin.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture);
+                    coin.EndTime = coin.Time.AddDays(1);
                     coin.Open = Convert.ToDecimal(data[1], CultureInfo.InvariantCulture);
                     coin.High = Convert.ToDecimal(data[2], CultureInfo.InvariantCulture);
                     coin.Low = Convert.ToDecimal(data[3], CultureInfo.InvariantCulture);

--- a/Algorithm.CSharp/CustomDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataRegressionAlgorithm.cs
@@ -84,29 +84,29 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "1"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "155.262%"},
+            {"Compounding Annual Return", "157.497%"},
             {"Drawdown", "84.800%"},
             {"Expectancy", "0"},
-            {"Net Profit", "5123.170%"},
-            {"Sharpe Ratio", "2.066"},
-            {"Probabilistic Sharpe Ratio", "68.832%"},
+            {"Net Profit", "5319.007%"},
+            {"Sharpe Ratio", "2.086"},
+            {"Probabilistic Sharpe Ratio", "69.456%"},
             {"Loss Rate", "0%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "1.732"},
-            {"Beta", "0.037"},
-            {"Annual Standard Deviation", "0.841"},
-            {"Annual Variance", "0.707"},
-            {"Information Ratio", "1.902"},
-            {"Tracking Error", "0.848"},
-            {"Treynor Ratio", "46.996"},
+            {"Alpha", "1.736"},
+            {"Beta", "0.136"},
+            {"Annual Standard Deviation", "0.84"},
+            {"Annual Variance", "0.706"},
+            {"Information Ratio", "1.925"},
+            {"Tracking Error", "0.846"},
+            {"Treynor Ratio", "12.903"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "2.238"},
-            {"Return Over Maximum Drawdown", "1.832"},
+            {"Sortino Ratio", "2.269"},
+            {"Return Over Maximum Drawdown", "1.858"},
             {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
@@ -121,7 +121,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "0e7d560d0db2829adb19d3e403c30d97"}
+            {"OrderListHash", "50faa37f15732bf5c24ad1eeaa335bc7"}
         };
 
         /// <summary>
@@ -212,7 +212,7 @@ namespace QuantConnect.Algorithm.CSharp
                 try
                 {
                     string[] data = line.Split(',');
-                    coin.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture);
+                    coin.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture).AddDays(1);
                     coin.Open = Convert.ToDecimal(data[1], CultureInfo.InvariantCulture);
                     coin.High = Convert.ToDecimal(data[2], CultureInfo.InvariantCulture);
                     coin.Low = Convert.ToDecimal(data[3], CultureInfo.InvariantCulture);

--- a/Algorithm.CSharp/CustomDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataRegressionAlgorithm.cs
@@ -212,7 +212,8 @@ namespace QuantConnect.Algorithm.CSharp
                 try
                 {
                     string[] data = line.Split(',');
-                    coin.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture).AddDays(1);
+                    coin.Time = DateTime.Parse(data[0], CultureInfo.InvariantCulture);
+                    coin.EndTime = coin.Time.AddDays(1);
                     coin.Open = Convert.ToDecimal(data[1], CultureInfo.InvariantCulture);
                     coin.High = Convert.ToDecimal(data[2], CultureInfo.InvariantCulture);
                     coin.Low = Convert.ToDecimal(data[3], CultureInfo.InvariantCulture);

--- a/Algorithm.Python/CustomDataBitcoinAlgorithm.py
+++ b/Algorithm.Python/CustomDataBitcoinAlgorithm.py
@@ -52,7 +52,9 @@ class CustomDataBitcoinAlgorithm(QCAlgorithm):
         # If we don't have any weather "SHARES" -- invest"
         if not self.Portfolio.Invested:
             # Weather used as a tradable asset, like stocks, futures etc.
-            self.SetHoldings("BTC", 1)
+            # It's only OK to use SetHoldings with crypto when using custom data. When trading with built-in crypto data, 
+            # use the cashbook. Reference https://github.com/QuantConnect/Lean/blob/master/Algorithm.Python/BasicTemplateCryptoAlgorithm.py 
+            self.SetHoldings("BTC", 1) 
             self.Debug("Buying BTC 'Shares': BTC: {0}".format(close))
 
         self.Debug("Time: {0} {1}".format(datetime.now(), close))

--- a/Algorithm.Python/CustomDataBitcoinAlgorithm.py
+++ b/Algorithm.Python/CustomDataBitcoinAlgorithm.py
@@ -67,7 +67,7 @@ class Bitcoin(PythonData):
 
         #return "http://my-ftp-server.com/futures-data-" + date.ToString("Ymd") + ".zip";
         # OR simply return a fixed small data file. Large files will slow down your backtest
-        return SubscriptionDataSource("https://www.quandl.com/api/v3/datasets/BCHARTS/BITSTAMPUSD.csv?order=asc", SubscriptionTransportMedium.RemoteFile);
+        return SubscriptionDataSource("https://www.quantconnect.com/api/v2/proxy/quandl/api/v3/datasets/BCHARTS/BITSTAMPUSD.csv?order=asc&api_key=WyAazVXnq7ATy_fefTqm", SubscriptionTransportMedium.RemoteFile);
 
 
     def Reader(self, config, line, date, isLiveMode):
@@ -111,7 +111,7 @@ class Bitcoin(PythonData):
             value = data[4]
             if value == 0: return None
 
-            coin.Time = datetime.strptime(data[0], "%Y-%m-%d")
+            coin.Time = datetime.strptime(data[0], "%Y-%m-%d") + timedelta(days=1)
             coin.Value = value
             coin["Open"] = float(data[1])
             coin["High"] = float(data[2])

--- a/Algorithm.Python/CustomDataBitcoinAlgorithm.py
+++ b/Algorithm.Python/CustomDataBitcoinAlgorithm.py
@@ -111,7 +111,8 @@ class Bitcoin(PythonData):
             value = data[4]
             if value == 0: return None
 
-            coin.Time = datetime.strptime(data[0], "%Y-%m-%d") + timedelta(days=1)
+            coin.Time = datetime.strptime(data[0], "%Y-%m-%d")
+            coin.EndTime = coin.Time + timedelta(days=1)
             coin.Value = value
             coin["Open"] = float(data[1])
             coin["High"] = float(data[2])

--- a/Algorithm.Python/CustomDataNIFTYAlgorithm.py
+++ b/Algorithm.Python/CustomDataNIFTYAlgorithm.py
@@ -72,7 +72,7 @@ class CustomDataNIFTYAlgorithm(QCAlgorithm):
         if self.Time.weekday() != 2: return
 
         cur_qnty = self.Portfolio["NIFTY"].Quantity
-        quantity = math.floor(self.Portfolio.MarginRemaining * 0.9) / data["NIFTY"].Close
+        quantity = int(self.Portfolio.MarginRemaining * 0.9 / data["NIFTY"].Close)
         hi_nifty = max(price.NiftyPrice for price in self.prices)
         lo_nifty = min(price.NiftyPrice for price in self.prices)
 
@@ -102,7 +102,7 @@ class Nifty(PythonData):
             # Date,       Open       High        Low       Close     Volume      Turnover
             # 2011-09-13  7792.9    7799.9     7722.65    7748.7    116534670    6107.78
             data = line.split(',')
-            index.Time = datetime.strptime(data[0], "%Y-%m-%d")
+            index.Time = datetime.strptime(data[0], "%Y-%m-%d") + timedelta(days=1)
             index.Value = data[4]
             index["Open"] = float(data[1])
             index["High"] = float(data[2])
@@ -131,7 +131,7 @@ class DollarRupee(PythonData):
 
         try:
             data = line.split(',')
-            currency.Time = datetime.strptime(data[0], "%Y-%m-%d")
+            currency.Time = datetime.strptime(data[0], "%Y-%m-%d") + timedelta(days=1)
             currency.Value = data[1]
             currency["Close"] = float(data[1])
 

--- a/Algorithm.Python/CustomDataNIFTYAlgorithm.py
+++ b/Algorithm.Python/CustomDataNIFTYAlgorithm.py
@@ -102,7 +102,8 @@ class Nifty(PythonData):
             # Date,       Open       High        Low       Close     Volume      Turnover
             # 2011-09-13  7792.9    7799.9     7722.65    7748.7    116534670    6107.78
             data = line.split(',')
-            index.Time = datetime.strptime(data[0], "%Y-%m-%d") + timedelta(days=1)
+            index.Time = datetime.strptime(data[0], "%Y-%m-%d")
+            index.EndTime = index.Time + timedelta(days=1)
             index.Value = data[4]
             index["Open"] = float(data[1])
             index["High"] = float(data[2])
@@ -131,7 +132,8 @@ class DollarRupee(PythonData):
 
         try:
             data = line.split(',')
-            currency.Time = datetime.strptime(data[0], "%Y-%m-%d") + timedelta(days=1)
+            currency.Time = datetime.strptime(data[0], "%Y-%m-%d")
+            currency.EndTime = currency.Time + timedelta(days=1)
             currency.Value = data[1]
             currency["Close"] = float(data[1])
 

--- a/Algorithm.Python/CustomDataPropertiesRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataPropertiesRegressionAlgorithm.py
@@ -124,7 +124,8 @@ class Bitcoin(PythonData):
 
         try:
             data = line.split(',')
-            coin.Time = datetime.strptime(data[0], "%Y-%m-%d") + timedelta(days=1)
+            coin.Time = datetime.strptime(data[0], "%Y-%m-%d")
+            coin.EndTime = coin.Time + timedelta(days=1)
             coin.Value = float(data[4])
             coin["Open"] = float(data[1])
             coin["High"] = float(data[2])

--- a/Algorithm.Python/CustomDataPropertiesRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataPropertiesRegressionAlgorithm.py
@@ -124,7 +124,7 @@ class Bitcoin(PythonData):
 
         try:
             data = line.split(',')
-            coin.Time = datetime.strptime(data[0], "%Y-%m-%d")
+            coin.Time = datetime.strptime(data[0], "%Y-%m-%d") + timedelta(days=1)
             coin.Value = float(data[4])
             coin["Open"] = float(data[1])
             coin["High"] = float(data[2])

--- a/Algorithm.Python/CustomDataRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataRegressionAlgorithm.py
@@ -98,7 +98,7 @@ class Bitcoin(PythonData):
 
         try:
             data = line.split(',')
-            coin.Time = datetime.strptime(data[0], "%Y-%m-%d")
+            coin.Time = datetime.strptime(data[0], "%Y-%m-%d") + timedelta(days=1)
             coin.Value = float(data[4])
             coin["Open"] = float(data[1])
             coin["High"] = float(data[2])

--- a/Algorithm.Python/CustomDataRegressionAlgorithm.py
+++ b/Algorithm.Python/CustomDataRegressionAlgorithm.py
@@ -98,7 +98,8 @@ class Bitcoin(PythonData):
 
         try:
             data = line.split(',')
-            coin.Time = datetime.strptime(data[0], "%Y-%m-%d") + timedelta(days=1)
+            coin.Time = datetime.strptime(data[0], "%Y-%m-%d")
+            coin.EndTime = coin.Time + timedelta(days=1)
             coin.Value = float(data[4])
             coin["Open"] = float(data[1])
             coin["High"] = float(data[2])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The timestamps of custom data daily bars were moved back by 1 day to remove lookahead bias. In addition, some trading logic was adjusted to ensure both languages (python and C#) performed the same when backtesting the same algorithm.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Close #5424 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Daily data from custom sources were being pumped into the algorithm 1 day early.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run locally and in QC Cloud.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why --> -- No, I just changed the `ExpectedStatistics` when necessary.
- [ ] All new and existing tests passed. -- No, there are open GH issues for some tests failing.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
