### PR TITLE
Fix index of out bounds (#5427)

### DIFF
--- a/Algorithm.Framework/Alphas/PearsonCorrelationPairsTradingAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/PearsonCorrelationPairsTradingAlphaModel.cs
@@ -124,12 +124,19 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 .Select(x =>
                 {
                     var array = x.Select(b => Math.Log((double)b.Price)).ToArray();
-                    for (var i = array.Length - 1; i > 0; i--)
+                    if (array.Length > 1)
                     {
-                        array[i] = array[i] - array[i - 1];
+                        for (var i = array.Length - 1; i > 0; i--)
+                        {
+                            array[i] = array[i] - array[i - 1];
+                        }
+                        array[0] = array[1];
+                        return array;
                     }
-                    array[0] = array[1];
-                    return array;
+                    else
+                    {
+                        return new double[0];
+                    }
                 }).ToArray();
         }
     }


### PR DESCRIPTION
Fix index of out bounds (#5427)

See [Issue 5427](https://github.com/QuantConnect/Lean/issues/5427)

<!--- Provide a general summary of your changes in the Title above -->

#### Description
Added a check for appropriate array length.

#### Related Issue
See [Issue 5427](https://github.com/QuantConnect/Lean/issues/5427)

#### Motivation and Context
Fixes #5427 

#### Requires Documentation Change
No changes required

#### How Has This Been Tested?
I have checked that the error reported in #5427 does no longer occur with an algorithm that caused it before in a reproducible fashion.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why --> Not applicable
- [ x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>` 

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
