### PR TITLE
Live Consolidator Bug Fix

### DIFF
--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -190,7 +190,7 @@ namespace QuantConnect.Data.Consolidators
 
             if (aggregateBeforeFire)
             {
-                if (data.EndTime >= _lastEmit)
+                if (data.Time >= _lastEmit)
                 {
                     AggregateBar(ref _workingBar, data);
                 }
@@ -215,13 +215,13 @@ namespace QuantConnect.Data.Consolidators
                 }
 
                 // Set _lastEmit first because OnDataConsolidated will set _workingBar to null
-                _lastEmit = IsTimeBased && _workingBar != null ? _workingBar.Time.Add(Period ?? TimeSpan.Zero) : data.Time;
+                _lastEmit = IsTimeBased && _workingBar != null ? _workingBar.EndTime : data.Time;
                 OnDataConsolidated(_workingBar);
             }
 
             if (!aggregateBeforeFire)
             {
-                if (data.EndTime >= _lastEmit)
+                if (data.Time >= _lastEmit)
                 {
                     AggregateBar(ref _workingBar, data);
                 }
@@ -237,8 +237,8 @@ namespace QuantConnect.Data.Consolidators
             if (_workingBar != null && _period.HasValue && _period.Value != TimeSpan.Zero
                 && currentLocalTime - _workingBar.Time >= _period.Value && GetRoundedBarTime(currentLocalTime) > _lastEmit)
             {
+                _lastEmit = _workingBar.EndTime;
                 OnDataConsolidated(_workingBar);
-                _lastEmit = currentLocalTime;
             }
         }
 

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -190,7 +190,7 @@ namespace QuantConnect.Data.Consolidators
 
             if (aggregateBeforeFire)
             {
-                if (data.Time >= _lastEmit)
+                if (data.EndTime >= _lastEmit)
                 {
                     AggregateBar(ref _workingBar, data);
                 }
@@ -220,7 +220,7 @@ namespace QuantConnect.Data.Consolidators
 
             if (!aggregateBeforeFire)
             {
-                if (data.Time >= _lastEmit)
+                if (data.EndTime >= _lastEmit)
                 {
                     AggregateBar(ref _workingBar, data);
                 }

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -214,6 +214,7 @@ namespace QuantConnect.Data.Consolidators
                     }
                 }
 
+                // Set _lastEmit first because OnDataConsolidated will set _workingBar to null
                 _lastEmit = IsTimeBased && _workingBar != null ? _workingBar.Time.Add(Period ?? TimeSpan.Zero) : data.Time;
                 OnDataConsolidated(_workingBar);
             }

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -214,8 +214,8 @@ namespace QuantConnect.Data.Consolidators
                     }
                 }
 
-                OnDataConsolidated(_workingBar);
                 _lastEmit = IsTimeBased && _workingBar != null ? _workingBar.Time.Add(Period ?? TimeSpan.Zero) : data.Time;
+                OnDataConsolidated(_workingBar);
             }
 
             if (!aggregateBeforeFire)

--- a/Tests/Common/Data/PeriodCountConsolidatorTests.cs
+++ b/Tests/Common/Data/PeriodCountConsolidatorTests.cs
@@ -21,7 +21,7 @@ using QuantConnect.Data.Market;
 
 namespace QuantConnect.Tests.Common.Data
 {
-    [TestFixture]
+    [TestFixture, Parallelizable(ParallelScope.All)]
     public class PeriodCountConsolidatorTests
     {
         private static readonly object[] PeriodCases =

--- a/Tests/Common/Data/PeriodCountConsolidatorTests.cs
+++ b/Tests/Common/Data/PeriodCountConsolidatorTests.cs
@@ -21,7 +21,7 @@ using QuantConnect.Data.Market;
 
 namespace QuantConnect.Tests.Common.Data
 {
-    [TestFixture, Parallelizable(ParallelScope.All)]
+    [TestFixture]
     public class PeriodCountConsolidatorTests
     {
         private static readonly object[] PeriodCases =

--- a/Tests/Engine/DataFeeds/InternalSubscriptionManagerTests.cs
+++ b/Tests/Engine/DataFeeds/InternalSubscriptionManagerTests.cs
@@ -215,7 +215,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                     }
                 }
                 _algorithm.OnEndOfTimeStep();
-                Thread.Sleep(25);
+                Thread.Sleep(50);
             }
             Assert.IsFalse(tokenSource.IsCancellationRequested);
             Assert.AreNotEqual(0, internalDataCount);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
There was an issue observed with live data where period count based consolidators would only emit bars every other period.

Below is an example of a 1 hour consolidator in master, as you can see the  timing does not emit a bar for 11am or 1 pm
```
2021-03-18 18:00:00 : 	2021-03-18 14:00:00.919081 :: SPY: O: 394.83 H: 396.129 L: 394.69 C: 396.035 V: 7630551
2021-03-19 14:00:00 : 	2021-03-19 10:00:00.861888 :: SPY: O: 389.89 H: 390.2 L: 387.42 C: 388.54 V: 11107174
*** MISSING 11AM? ***
2021-03-19 16:00:00 : 	2021-03-19 12:00:00.800336 :: SPY: O: 389.835 H: 390.88 L: 388.33 C: 390.52 V: 10067133
*** MISSING 1PM? ***
2021-03-19 18:00:00 : 	2021-03-19 14:00:00.865996 :: SPY: O: 390.9455 H: 391.36 L: 390.24 C: 391.09 V: 6182512
```

To remedy the issue I had to adjust the logic in the consolidator update to allow the aggregation of a new bar if the bars `EndTime` was past `_lastEmit` time instead of just looking at the bars `Time` (Its start time)

An example of the issue before:
- 9AM -10AM bar streamed at 10:00:00.8 AM
- Consolidator aggregates because last emit is DateMin (first update) and 9 AM > DateMin
- Scan takes the stream time 10:00:00.8 AM, checks that we have a bar, and emits because it past 10 (bar EndTime)
- 
- 10AM - 11AM bar streamed at 11:00:00.5 AM
- Consolidator does not aggregate because last emit time is 10:00:00.8, and 10AM > 10:00:00.8 is __not true__.
- Scan takes stream time 11:00:00.5 AM, checks that we have a bar, and it is `null` because we did not aggregate. No emit

Now that check to see if we should aggregate goes against bar `endTime`, so 11 > 10:00:00.8, and it aggregates successfully.


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All unit tests still pass, same for regressions.

- Used a simulated live data feed to test bar consolidation was correct
- Also added a unit test that does red -> green from master to this branch

Tested in Live with 1 minute consolidated bars
```
2021-03-26 19:02:00 : | Consolidator  Bar at: 2021-03-26 15:02:00.421889 :: Bar Time: 2021-03-26 19:01:00 -  2021-03-26 19:02:00 : BTCUSD: O: 53689.98 H: 53726.52 L: 53676.96 C:  53683.83 V: 4.365177
2021-03-26 19:02:00 : | Data recieved at : 2021-03-26 15:02:00.421889
2021-03-26 19:03:00 : | Consolidator  Bar at: 2021-03-26 15:03:00.024438 :: Bar Time: 2021-03-26 19:02:00 -  2021-03-26 19:03:00 : BTCUSD: O: 53683.83 H: 53687.95 L: 53633.4 C:  53655.75 V: 10.67767
2021-03-26 19:03:00 : | Data recieved at : 2021-03-26 15:03:00.024438
2021-03-26 19:04:00 : | Consolidator  Bar at: 2021-03-26 15:04:00.048100 :: Bar Time: 2021-03-26 19:03:00 -  2021-03-26 19:04:00 : BTCUSD: O: 53650.01 H: 53681.24 L: 53633.81 C:  53681.13 V: 7.267019
2021-03-26 19:04:00 : | Data recieved at : 2021-03-26 15:04:00.048100

```


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
