### PR TITLE
Check whether storage folder exists before enumerating its contents

### DIFF
--- a/Engine/Storage/LocalObjectStore.cs
+++ b/Engine/Storage/LocalObjectStore.cs
@@ -313,7 +313,9 @@ namespace QuantConnect.Lean.Engine.Storage
                 }
 
                 // if the object store was not used, delete the empty storage directory created in Initialize.
-                if (AlgorithmStorageRoot != null && !Directory.GetFileSystemEntries(AlgorithmStorageRoot).Any())
+                if (AlgorithmStorageRoot != null &&
+                    Directory.Exists(AlgorithmStorageRoot) &&
+                    !Directory.GetFileSystemEntries(AlgorithmStorageRoot).Any())
                 {
                     Directory.Delete(AlgorithmStorageRoot);
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Added a check which ensures the storage folder still exists before checking whether it needs to be deleted in `LocalObjectStore.Dispose()`.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #5431.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It gets rid of an error which appears when running the optimizer.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and running the optimizer:
```
$ msbuild QuantConnect.Lean.sln
$ cd Optimizer.Launcher/bin/Debug
$ mono QuantConnect.Optimizer.Launcher.exe
# No longer will there be any of those:
20210329 13:52:06.212 ERROR:: LocalObjectStore.Dispose(): Error deleting storage directory. System.IO.DirectoryNotFoundException: Could not find a part of the path '/home/jasper/Projects/Lean/Launcher/bin/Debug/storage/ParameterizedAlgorithm'.
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
