### PR TITLE
Fixes LiveOptionChainProvider.FindOptionContracts

### DIFF
--- a/Tests/Common/Securities/Options/OptionChainProviderTests.cs
+++ b/Tests/Common/Securities/Options/OptionChainProviderTests.cs
@@ -92,9 +92,12 @@ namespace QuantConnect.Tests.Common.Securities.Options
 
             foreach (var symbol in new[] { Symbols.SPY, Symbols.AAPL, Symbols.MSFT })
             {
-                var result = provider.GetOptionContractList(symbol, DateTime.Today);
+                var result = provider.GetOptionContractList(symbol, DateTime.Today).ToList();
+                var countCall = result.Count(x => x.ID.OptionRight == OptionRight.Call);
+                var countPut = result.Count(x => x.ID.OptionRight == OptionRight.Put);
 
-                Assert.IsTrue(result.Any());
+                Assert.Greater(countCall, 0);
+                Assert.Greater(countPut, 0);
             }
         }
 


### PR DESCRIPTION
#### Description
`LiveOptionChainProvider.FindOptionContracts` handles the following data format:
`SPY  2021 03 26 190 000 C P  0 612 360000000`
where both existing `OptionRight.Call` and `OptionRight.Put` are declared in the same line.

#### Related Issue
Closes #5433

#### Motivation and Context
Bug fix.

#### How Has This Been Tested?
Fixed unit test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`