### PR TITLE
Fix coarse universe generator throwing on empty map file

### DIFF
--- a/ToolBox/CoarseUniverseGenerator/CoarseUniverseGeneratorProgram.cs
+++ b/ToolBox/CoarseUniverseGenerator/CoarseUniverseGeneratorProgram.cs
@@ -330,7 +330,7 @@ namespace QuantConnect.ToolBox.CoarseUniverseGenerator
             Log.Trace($"CoarseUniverseGeneratorProgram.PopulateSidContex(): Generating SID context from QuantQuote's map files.");
             foreach (var mapFile in mapFileResolver)
             {
-                if (exclusions.Contains(mapFile.Last().MappedSymbol))
+                if (!mapFile.Any() || exclusions.Contains(mapFile.Last().MappedSymbol))
                 {
                     continue;
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR fixes the coarse universe generator so that it skips empty map files when populating its SID context. These empty map files are occassionally generated by the random data generator.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes https://github.com/QuantConnect/lean-cli/issues/3.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At the moment a single empty map file prevents the coarse universe generator from being ran until the empty map file is removed.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this by clearing the contents of one of my map files and running the following:
```
$ msbuild QuantConnect.Lean.sln
$ cd ToolBox/bin/Debug
$ mono QuantConnect.ToolBox.exe --app=cug
```

Without the change in this PR this throws an exception, with the change it finishes correctly.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
