### PR TITLE
Remove Obsolete QCAlgorithm.OnEndOfDay()

### DIFF
--- a/Algorithm.CSharp/Benchmarks/HistoryRequestBenchmark.cs
+++ b/Algorithm.CSharp/Benchmarks/HistoryRequestBenchmark.cs
@@ -28,11 +28,11 @@ namespace QuantConnect.Algorithm.CSharp.Benchmarks
             _symbol = AddEquity("SPY").Symbol;
         }
 
-        public override void OnEndOfDay()
+        public override void OnEndOfDay(Symbol symbol)
         {
-            var minuteHistory = History(_symbol, 60, Resolution.Minute);
+            var minuteHistory = History(symbol, 60, Resolution.Minute);
             var lastHourHigh = minuteHistory.Select(minuteBar => minuteBar.High).DefaultIfEmpty(0).Max();
-            var dailyHistory = History(_symbol, 1, Resolution.Daily).First();
+            var dailyHistory = History(symbol, 1, Resolution.Daily).First();
             var dailyHigh = dailyHistory.High;
             var dailyLow = dailyHistory.Low;
             var dailyOpen = dailyHistory.Open;

--- a/Algorithm.CSharp/CustomChartingAlgorithm.cs
+++ b/Algorithm.CSharp/CustomChartingAlgorithm.cs
@@ -80,7 +80,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// OnEndOfDay Event Handler - At the end of each trading day we fire this code.
         /// To avoid flooding, we recommend running your plotting at the end of each day.
         /// </summary>
-        public override void OnEndOfDay()
+        public override void OnEndOfDay(Symbol symbol)
         {
             //Log the end of day prices:
             Plot("Trade Plot", "Price", _lastPrice);

--- a/Algorithm.CSharp/CustomDataNIFTYAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataNIFTYAlgorithm.cs
@@ -121,7 +121,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// End of a trading day event handler. This method is called at the end of the algorithm day (or multiple times if trading multiple assets).
         /// </summary>
         /// <remarks>Method is called 10 minutes before closing to allow user to close out position.</remarks>
-        public override void OnEndOfDay()
+        public override void OnEndOfDay(Symbol symbol)
         {
             Plot("Nifty Closing Price", _today.NiftyPrice);
         }

--- a/Algorithm.CSharp/FuturesMomentumAlgorithm.cs
+++ b/Algorithm.CSharp/FuturesMomentumAlgorithm.cs
@@ -92,7 +92,7 @@ namespace QuantConnect.Algorithm.CSharp
             }
         }
 
-        public override void OnEndOfDay()
+        public override void OnEndOfDay(Symbol symbol)
         {
             Plot("Indicator Signal", "EOD", IsDownTrend ? -1 : IsUpTrend ? 1 : 0);
         }

--- a/Algorithm.CSharp/IndicatorSuiteAlgorithm.cs
+++ b/Algorithm.CSharp/IndicatorSuiteAlgorithm.cs
@@ -158,8 +158,10 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Fire plotting events once per day.
         /// </summary>
-        public override void OnEndOfDay()
+        public override void OnEndOfDay(Symbol symbol)
         {
+            if (symbol != _symbol) return;
+
             if (!_indicators.BB.IsReady) return;
 
             Plot("BB", "Price", _price);

--- a/Algorithm.CSharp/MultipleSymbolConsolidationAlgorithm.cs
+++ b/Algorithm.CSharp/MultipleSymbolConsolidationAlgorithm.cs
@@ -151,7 +151,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// End of a trading day event handler. This method is called at the end of the algorithm day (or multiple times if trading multiple assets).
         /// </summary>
         /// <remarks>Method is called 10 minutes before closing to allow user to close out position.</remarks>
-        public override void OnEndOfDay()
+        public override void OnEndOfDay(Symbol symbol)
         {
             int i = 0;
             foreach (var kvp in Data.OrderBy(x => x.Value.Symbol))

--- a/Algorithm.CSharp/OnEndOfDayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OnEndOfDayRegressionAlgorithm.cs
@@ -56,14 +56,6 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
-        /// Obsolete overload to be removed.
-        /// </summary>
-        public override void OnEndOfDay()
-        {
-            _onEndOfDayCallCount++;
-        }
-
-        /// <summary>
         /// We expect it to be called for the universe selected <see cref="Symbol"/>
         /// and the post initialize manually added equity <see cref="Symbol"/>
         /// </summary>
@@ -114,10 +106,6 @@ namespace QuantConnect.Algorithm.CSharp
             if (_onEndOfDayIbmCallCount != 1)
             {
                 throw new Exception($"OnEndOfDay(IBM) unexpected count call {_onEndOfDayIbmCallCount}");
-            }
-            if (_onEndOfDayCallCount != 4)
-            {
-                throw new Exception($"OnEndOfDay() unexpected count call {_onEndOfDayCallCount}");
             }
         }
 

--- a/Algorithm.CSharp/OnEndOfDayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OnEndOfDayRegressionAlgorithm.cs
@@ -30,7 +30,6 @@ namespace QuantConnect.Algorithm.CSharp
         private int _onEndOfDaySpyCallCount;
         private int _onEndOfDayBacCallCount;
         private int _onEndOfDayIbmCallCount;
-        private int _onEndOfDayCallCount;
 
         /// <summary>
         /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.

--- a/Algorithm.CSharp/OpeningBreakoutAlgorithm.cs
+++ b/Algorithm.CSharp/OpeningBreakoutAlgorithm.cs
@@ -396,9 +396,9 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// If we're still invested by the end of the day, liquidate
         /// </summary>
-        public override void OnEndOfDay()
+        public override void OnEndOfDay(Symbol symbol)
         {
-            if (Security.Invested)
+            if (symbol == Security.Symbol && Security.Invested)
             {
                 Liquidate();
             }

--- a/Algorithm.CSharp/RegressionChannelAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionChannelAlgorithm.cs
@@ -76,11 +76,14 @@ namespace QuantConnect.Algorithm.CSharp
             }
         }
 
-        public override void OnEndOfDay()
+        public override void OnEndOfDay(Symbol symbol)
         {
-            Plot("Trade Plot", "UpperChannel", _rc.UpperChannel);
-            Plot("Trade Plot", "LowerChannel", _rc.LowerChannel);
-            Plot("Trade Plot", "Regression", _rc.LinearRegression);
+            if (symbol == _spy)
+            {
+                Plot("Trade Plot", "UpperChannel", _rc.UpperChannel);
+                Plot("Trade Plot", "LowerChannel", _rc.LowerChannel);
+                Plot("Trade Plot", "Regression", _rc.LinearRegression);
+            }
         }
     }
 }

--- a/Algorithm.Python/Benchmarks/HistoryRequestBenchmark.py
+++ b/Algorithm.Python/Benchmarks/HistoryRequestBenchmark.py
@@ -31,7 +31,7 @@ class HistoryRequestBenchmark(QCAlgorithm):
         self.SetCash(10000)
         self.symbol = self.AddEquity("SPY").Symbol
 
-    def OnEndOfDay(self):
+    def OnEndOfDay(self, symbol):
         minuteHistory = self.History([self.symbol], 60, Resolution.Minute)
         lastHourHigh = 0
         for index, row in minuteHistory.loc["SPY"].iterrows():

--- a/Algorithm.Python/CustomChartingAlgorithm.py
+++ b/Algorithm.Python/CustomChartingAlgorithm.py
@@ -84,6 +84,6 @@ class CustomChartingAlgorithm(QCAlgorithm):
             self.Plot("Trade Plot", "Sell", self.lastPrice)
             self.Liquidate()
 
-    def OnEndOfDay(self):
+    def OnEndOfDay(self, symbol):
        #Log the end of day prices:
        self.Plot("Trade Plot", "Price", self.lastPrice)

--- a/Algorithm.Python/FuturesMomentumAlgorithm.py
+++ b/Algorithm.Python/FuturesMomentumAlgorithm.py
@@ -73,7 +73,7 @@ class FuturesMomentumAlgorithm(QCAlgorithm):
             if self.Portfolio.Invested and self.IsDownTrend:
                 self.Liquidate()
 
-    def OnEndOfDay(self):
+    def OnEndOfDay(self, symbol):
         if self.IsUpTrend:
             self.Plot("Indicator Signal", "EOD",1)
         elif self.IsDownTrend:

--- a/Algorithm.Python/MultipleSymbolConsolidationAlgorithm.py
+++ b/Algorithm.Python/MultipleSymbolConsolidationAlgorithm.py
@@ -89,7 +89,7 @@ class MultipleSymbolConsolidationAlgorithm(QCAlgorithm):
 
     # End of a trading day event handler. This method is called at the end of the algorithm day (or multiple times if trading multiple assets).
     # Method is called 10 minutes before closing to allow user to close out position.
-    def OnEndOfDay(self):
+    def OnEndOfDay(self, symbol):
         
         i = 0
         for symbol in sorted(self.Data.keys()):

--- a/Algorithm.Python/RegressionChannelAlgorithm.py
+++ b/Algorithm.Python/RegressionChannelAlgorithm.py
@@ -64,7 +64,7 @@ class RegressionChannelAlgorithm(QCAlgorithm):
             self.SetHoldings(self._spy, -1)
             self.Plot("Trade Plot", "Sell", value)
 
-    def OnEndOfDay(self):
+    def OnEndOfDay(self, symbol):
         self.Plot("Trade Plot", "UpperChannel", self._rc.UpperChannel.Current.Value)
         self.Plot("Trade Plot", "LowerChannel", self._rc.LowerChannel.Current.Value)
         self.Plot("Trade Plot", "Regression", self._rc.LinearRegression.Current.Value)

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -817,6 +817,18 @@ namespace QuantConnect.Algorithm
         /// <summary>
         /// End of a trading day event handler. This method is called at the end of the algorithm day (or multiple times if trading multiple assets).
         /// </summary>
+        /// <remarks>Method is called 10 minutes before closing to allow user to close out position.</remarks>
+        /// <remarks>Deprecated because different assets have different market close times,
+        /// and because Python does not support two methods with the same name</remarks>
+        [Obsolete("This method is deprecated and will be removed after August 2021. Please use this overload: OnEndOfDay(Symbol symbol)")]
+        public virtual void OnEndOfDay()
+        {
+            
+        }
+
+        /// <summary>
+        /// End of a trading day event handler. This method is called at the end of the algorithm day (or multiple times if trading multiple assets).
+        /// </summary>
         /// <remarks>
         /// This method is left for backwards compatibility and is invoked via <see cref="OnEndOfDay(Symbol)"/>, if that method is
         /// override then this method will not be called without a called to base.OnEndOfDay(string)
@@ -824,18 +836,6 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">Asset symbol for this end of day event. Forex and equities have different closing hours.</param>
         public virtual void OnEndOfDay(string symbol)
         {
-        }
-
-        /// <summary>
-        /// End of a trading day event handler. This method is called at the end of the algorithm day (or multiple times if trading multiple assets).
-        /// </summary>
-        /// <remarks>Method is called 10 minutes before closing to allow user to close out position.</remarks>
-        /// <remarks>Deprecated because different assets have different market close times,
-        /// and because Python does not support two methods with the same name</remarks>
-        [Obsolete("This method is deprecated. Please use this overload: OnEndOfDay(Symbol symbol)")]
-        public virtual void OnEndOfDay()
-        {
-            Debug("Usage of QCAlgorithm.OnEndOfDay() without a symbol will be deprecated August 2021. Always use a symbol when using this method: OnEndOfDay(symbol)");
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -823,7 +823,7 @@ namespace QuantConnect.Algorithm
         [Obsolete("This method is deprecated and will be removed after August 2021. Please use this overload: OnEndOfDay(Symbol symbol)")]
         public virtual void OnEndOfDay()
         {
-            
+
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -817,18 +817,6 @@ namespace QuantConnect.Algorithm
         /// <summary>
         /// End of a trading day event handler. This method is called at the end of the algorithm day (or multiple times if trading multiple assets).
         /// </summary>
-        /// <remarks>Method is called 10 minutes before closing to allow user to close out position.</remarks>
-        /// <remarks>Deprecated because different assets have different market close times,
-        /// and because Python does not support two methods with the same name</remarks>
-        [Obsolete("This method is deprecated. Please use this overload: OnEndOfDay(Symbol symbol)")]
-        public virtual void OnEndOfDay()
-        {
-
-        }
-
-        /// <summary>
-        /// End of a trading day event handler. This method is called at the end of the algorithm day (or multiple times if trading multiple assets).
-        /// </summary>
         /// <remarks>
         /// This method is left for backwards compatibility and is invoked via <see cref="OnEndOfDay(Symbol)"/>, if that method is
         /// override then this method will not be called without a called to base.OnEndOfDay(string)

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -829,6 +829,18 @@ namespace QuantConnect.Algorithm
         /// <summary>
         /// End of a trading day event handler. This method is called at the end of the algorithm day (or multiple times if trading multiple assets).
         /// </summary>
+        /// <remarks>Method is called 10 minutes before closing to allow user to close out position.</remarks>
+        /// <remarks>Deprecated because different assets have different market close times,
+        /// and because Python does not support two methods with the same name</remarks>
+        [Obsolete("This method is deprecated. Please use this overload: OnEndOfDay(Symbol symbol)")]
+        public virtual void OnEndOfDay()
+        {
+            Debug("Usage of QCAlgorithm.OnEndOfDay() without a symbol will be deprecated August 2021. Always use a symbol when using this method: OnEndOfDay(symbol)");
+        }
+
+        /// <summary>
+        /// End of a trading day event handler. This method is called at the end of the algorithm day (or multiple times if trading multiple assets).
+        /// </summary>
         /// <param name="symbol">Asset symbol for this end of day event. Forex and equities have different closing hours.</param>
         public virtual void OnEndOfDay(Symbol symbol)
         {

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -110,14 +110,7 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
                             {
                                 // Since we have a EOD method implemented
                                 // Determine which one it is by inspecting its arg count
-                                int argCount;
-                                var pyArgCount = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
-                                "from inspect import signature\n" +
-                                    "def GetArgCount(method):\n" +
-                                    "   return len(signature(method).parameters)\n"
-                                ).GetAttr("GetArgCount").Invoke(endOfDayMethod);
-                                pyArgCount.TryConvert(out argCount);
-
+                                var argCount = endOfDayMethod.GetPythonArgCount();
                                 switch (argCount)
                                 {
                                     case 0: // EOD()
@@ -127,6 +120,10 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
                                         IsOnEndOfDaySymbolImplemented = true;
                                         break;
                                 }
+
+                                // Its important to note that even if both are implemented
+                                // python will only use the last implemented, meaning only one will
+                                // be used and seen.
                             }
                         }
                         attr.Dispose();

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -436,6 +436,24 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Get a python methods arg count
+        /// </summary>
+        /// <param name="method">The Python method</param>
+        /// <returns>Count of arguments</returns>
+        public static int GetPythonArgCount(this PyObject method)
+        {
+            int argCount;
+            var pyArgCount = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                "from inspect import signature\n" +
+                "def GetArgCount(method):\n" +
+                "   return len(signature(method).parameters)\n"
+            ).GetAttr("GetArgCount").Invoke(method);
+            pyArgCount.TryConvert(out argCount);
+
+            return argCount;
+        }
+
+        /// <summary>
         /// Returns an ordered enumerable where position reducing orders are executed first
         /// and the remaining orders are executed in decreasing order value.
         /// Will NOT return targets for securities that have no data yet.

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -442,15 +442,18 @@ namespace QuantConnect
         /// <returns>Count of arguments</returns>
         public static int GetPythonArgCount(this PyObject method)
         {
-            int argCount;
-            var pyArgCount = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
-                "from inspect import signature\n" +
-                "def GetArgCount(method):\n" +
-                "   return len(signature(method).parameters)\n"
-            ).GetAttr("GetArgCount").Invoke(method);
-            pyArgCount.TryConvert(out argCount);
+            using (Py.GIL())
+            {
+                int argCount;
+                var pyArgCount = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                    "from inspect import signature\n" +
+                    "def GetArgCount(method):\n" +
+                    "   return len(signature(method).parameters)\n"
+                ).GetAttr("GetArgCount").Invoke(method);
+                pyArgCount.TryConvert(out argCount);
 
-            return argCount;
+                return argCount;
+            }
         }
 
         /// <summary>

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -457,6 +457,14 @@ namespace QuantConnect.Interfaces
         /// <summary>
         /// Call this method at the end of each day of data.
         /// </summary>
+        /// <remarks>Deprecated because different assets have different market close times,
+        /// and because Python does not support two methods with the same name</remarks>
+        [Obsolete("This method is deprecated. Please use this overload: OnEndOfDay(Symbol symbol)")]
+        void OnEndOfDay();
+
+        /// <summary>
+        /// Call this method at the end of each day of data.
+        /// </summary>
         void OnEndOfDay(Symbol symbol);
 
         /// <summary>

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -457,14 +457,6 @@ namespace QuantConnect.Interfaces
         /// <summary>
         /// Call this method at the end of each day of data.
         /// </summary>
-        /// <remarks>Deprecated because different assets have different market close times,
-        /// and because Python does not support two methods with the same name</remarks>
-        [Obsolete("This method is deprecated. Please use this overload: OnEndOfDay(Symbol symbol)")]
-        void OnEndOfDay();
-
-        /// <summary>
-        /// Call this method at the end of each day of data.
-        /// </summary>
         void OnEndOfDay(Symbol symbol);
 
         /// <summary>

--- a/Engine/RealTime/BaseRealTimeHandler.cs
+++ b/Engine/RealTime/BaseRealTimeHandler.cs
@@ -210,6 +210,10 @@ namespace QuantConnect.Lean.Engine.RealTime
                         }
                     }
                 }
+
+                // we re add the algorithm end of day event because it depends on the securities
+                // tradable dates
+                AddAlgorithmEndOfDayEvent(Algorithm.UtcTime, Algorithm.EndDate, Algorithm.UtcTime);
             }
         }
     }

--- a/Engine/RealTime/BaseRealTimeHandler.cs
+++ b/Engine/RealTime/BaseRealTimeHandler.cs
@@ -112,10 +112,11 @@ namespace QuantConnect.Lean.Engine.RealTime
             else if (language == Language.Python)
             {
                 var wrapper = Algorithm as AlgorithmPythonWrapper;
-                _implementsOnEndOfDaySymbol = wrapper.IsOnEndOfDayImplemented;
-
-                // Since we can't differentiate the methods in Python we have to set this to the same
-                _implementsOnEndOfDay = _implementsOnEndOfDaySymbol;
+                if (wrapper != null)
+                {
+                    _implementsOnEndOfDaySymbol = wrapper.IsOnEndOfDaySymbolImplemented;
+                    _implementsOnEndOfDay = wrapper.IsOnEndOfDayImplemented;
+                }
             }
             else
             {

--- a/Engine/RealTime/BaseRealTimeHandler.cs
+++ b/Engine/RealTime/BaseRealTimeHandler.cs
@@ -39,6 +39,7 @@ namespace QuantConnect.Lean.Engine.RealTime
         // For performance only add OnEndOfDay Symbol scheduled events if the method is implemented.
         // When there are many securities it adds a significant overhead
         private bool _implementsOnEndOfDaySymbol;
+        private bool _implementsOnEndOfDay;
 
         /// <summary>
         /// Keep track of this event so we can remove it when we need to update it
@@ -90,8 +91,6 @@ namespace QuantConnect.Lean.Engine.RealTime
         /// </summary>
         protected void Setup(DateTime start, DateTime end, Language language, DateTime? currentUtcTime = null)
         {
-            AddAlgorithmEndOfDayEvent(start, end, currentUtcTime);
-
             if (language == Language.CSharp)
             {
                 var method = Algorithm.GetType().GetMethod("OnEndOfDay", new[] { typeof(Symbol) });
@@ -101,16 +100,30 @@ namespace QuantConnect.Lean.Engine.RealTime
                 {
                     _implementsOnEndOfDaySymbol = true;
                 }
+
+                // Also determine if we are using the soon to be deprecated EOD so we don't use it
+                // unnecessarily and post messages about its deprecation to the user
+                var eodMethod = Algorithm.GetType().GetMethod("OnEndOfDay", Type.EmptyTypes);
+                if (eodMethod != null && eodMethod.DeclaringType != typeof(QCAlgorithm))
+                {
+                    _implementsOnEndOfDay = true;
+                }
             }
             else if (language == Language.Python)
             {
                 var wrapper = Algorithm as AlgorithmPythonWrapper;
                 _implementsOnEndOfDaySymbol = wrapper.IsOnEndOfDayImplemented;
+
+                // Since we can't differentiate the methods in Python we have to set this to the same
+                _implementsOnEndOfDay = _implementsOnEndOfDaySymbol;
             }
             else
             {
                 throw new ArgumentException(nameof(language));
             }
+
+            // Here to maintain functionality until deprecation in August 2021
+            AddAlgorithmEndOfDayEvent(start, end, currentUtcTime);
         }
 
         /// <summary>
@@ -132,6 +145,9 @@ namespace QuantConnect.Lean.Engine.RealTime
         [Obsolete("This method is deprecated. It will add ScheduledEvents for the deprecated IAlgorithm.OnEndOfDay()")]
         protected void AddAlgorithmEndOfDayEvent(DateTime start, DateTime end, DateTime? currentUtcTime = null)
         {
+            // If the algorithm didn't implement it no need to support it.
+            if (!_implementsOnEndOfDay) { return; }
+
             if (_algorithmOnEndOfDay != null)
             {
                 // if we already set it once we remove the previous and
@@ -213,6 +229,7 @@ namespace QuantConnect.Lean.Engine.RealTime
 
                 // we re add the algorithm end of day event because it depends on the securities
                 // tradable dates
+                // Here to maintain functionality until deprecation in August 2021
                 AddAlgorithmEndOfDayEvent(Algorithm.UtcTime, Algorithm.EndDate, Algorithm.UtcTime);
             }
         }

--- a/Engine/RealTime/BaseRealTimeHandler.cs
+++ b/Engine/RealTime/BaseRealTimeHandler.cs
@@ -90,7 +90,6 @@ namespace QuantConnect.Lean.Engine.RealTime
         /// </summary>
         protected void Setup(DateTime start, DateTime end, Language language, DateTime? currentUtcTime = null)
         {
-            AddAlgorithmEndOfDayEvent(start, end, currentUtcTime);
 
             if (language == Language.CSharp)
             {
@@ -120,35 +119,6 @@ namespace QuantConnect.Lean.Engine.RealTime
         protected int GetScheduledEventUniqueId()
         {
             return Interlocked.Increment(ref _scheduledEventUniqueId);
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="ScheduledEvent"/> that will fire before market close by the specified time
-        /// </summary>
-        /// <param name="start">The date to start the events</param>
-        /// <param name="end">The date to end the events</param>
-        /// <param name="currentUtcTime">Specifies the current time in UTC, before which,
-        /// no events will be scheduled. Specify null to skip this filter.</param>
-        [Obsolete("This method is deprecated. It will add ScheduledEvents for the deprecated IAlgorithm.OnEndOfDay()")]
-        protected void AddAlgorithmEndOfDayEvent(DateTime start, DateTime end, DateTime? currentUtcTime = null)
-        {
-            if (_algorithmOnEndOfDay != null)
-            {
-                // if we already set it once we remove the previous and
-                // add a new one, we don't want to keep both
-                Remove(_algorithmOnEndOfDay);
-            }
-
-            // add end of day events for each tradeable day
-            _algorithmOnEndOfDay = ScheduledEventFactory.EveryAlgorithmEndOfDay(
-                Algorithm,
-                ResultHandler,
-                start,
-                end,
-                ScheduledEvent.AlgorithmEndOfDayDelta,
-                currentUtcTime);
-
-            Add(_algorithmOnEndOfDay);
         }
 
         /// <summary>
@@ -210,10 +180,6 @@ namespace QuantConnect.Lean.Engine.RealTime
                         }
                     }
                 }
-
-                // we re add the algorithm end of day event because it depends on the securities
-                // tradable dates
-                AddAlgorithmEndOfDayEvent(Algorithm.UtcTime, Algorithm.EndDate, Algorithm.UtcTime);
             }
         }
     }

--- a/Engine/RealTime/ScheduledEventFactory.cs
+++ b/Engine/RealTime/ScheduledEventFactory.cs
@@ -57,6 +57,53 @@ namespace QuantConnect.Lean.Engine.RealTime
         /// </summary>
         /// <param name="algorithm">The algorithm instance the event is fo</param>
         /// <param name="resultHandler">The result handler, used to communicate run time errors</param>
+        /// <param name="start">The date to start the events</param>
+        /// <param name="end">The date to end the events</param>
+        /// <param name="endOfDayDelta">The time difference between the market close and the event, positive time will fire before market close</param>
+        /// <param name="currentUtcTime">Specfies the current time in UTC, before which, no events will be scheduled. Specify null to skip this filter.</param>
+        /// <returns>The new <see cref="ScheduledEvent"/> that will fire near market close each tradeable dat</returns>
+        [Obsolete("This method is deprecated. It will generate ScheduledEvents for the deprecated IAlgorithm.OnEndOfDay()")]
+        public static ScheduledEvent EveryAlgorithmEndOfDay(IAlgorithm algorithm, IResultHandler resultHandler, DateTime start, DateTime end, TimeSpan endOfDayDelta, DateTime? currentUtcTime = null)
+        {
+            if (endOfDayDelta >= Time.OneDay)
+            {
+                throw new ArgumentException("Delta must be less than a day", "endOfDayDelta");
+            }
+
+            // set up an event to fire every tradeable date for the algorithm as a whole
+            var eodEventTime = Time.OneDay.Subtract(endOfDayDelta);
+
+            // create enumerable of end of day in algorithm's time zone
+            var times =
+                // for every date any exchange is open in the algorithm
+                from date in Time.EachTradeableDay(algorithm.Securities.Values, start, end)
+                    // define the time of day we want the event to fire, a little before midnight
+                let eventTime = date + eodEventTime
+                // convert the event time into UTC
+                let eventUtcTime = eventTime.ConvertToUtc(algorithm.TimeZone)
+                // perform filter to verify it's not before the current time
+                where !currentUtcTime.HasValue || eventUtcTime > currentUtcTime.Value
+                select eventUtcTime;
+
+            return new ScheduledEvent(CreateEventName("Algorithm", "EndOfDay"), times, (name, triggerTime) =>
+            {
+                try
+                {
+                    algorithm.OnEndOfDay();
+                }
+                catch (Exception err)
+                {
+                    resultHandler.RuntimeError($"Runtime error in {name} event: {err.Message}", err.StackTrace);
+                    Log.Error(err, $"ScheduledEvent.{name}:");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ScheduledEvent"/> that will fire before market close by the specified time
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance the event is fo</param>
+        /// <param name="resultHandler">The result handler, used to communicate run time errors</param>
         /// <param name="security">The security used for defining tradeable dates</param>
         /// <param name="start">The first date for the events</param>
         /// <param name="end">The date to end the events</param>
@@ -75,7 +122,7 @@ namespace QuantConnect.Lean.Engine.RealTime
             var times =
                 // for every date the exchange is open for this security
                 from date in Time.EachTradeableDay(security, start, end)
-                // get the next market close for the specified date
+                    // get the next market close for the specified date
                 let marketClose = security.Exchange.Hours.GetNextMarketClose(date, security.IsExtendedMarketHours)
                 // define the time of day we want the event to fire before marketclose
                 let eventTime = marketClose.Subtract(endOfDayDelta)

--- a/Engine/RealTime/ScheduledEventFactory.cs
+++ b/Engine/RealTime/ScheduledEventFactory.cs
@@ -85,12 +85,14 @@ namespace QuantConnect.Lean.Engine.RealTime
                 where !currentUtcTime.HasValue || eventUtcTime > currentUtcTime.Value
                 select eventUtcTime;
 
+            // Log a message warning the user this EOD will be deprecated soon
+            algorithm.Debug("Usage of QCAlgorithm.OnEndOfDay() without a symbol will be deprecated August 2021. Always use a symbol when overriding this method: OnEndOfDay(symbol)");
+
             return new ScheduledEvent(CreateEventName("Algorithm", "EndOfDay"), times, (name, triggerTime) =>
             {
                 try
                 {
                     algorithm.OnEndOfDay();
-                    algorithm.Debug("Usage of QCAlgorithm.OnEndOfDay() without a symbol will be deprecated August 2021. Always use a symbol when overriding this method: OnEndOfDay(symbol)");
                 }
                 catch (Exception err)
                 {

--- a/Engine/RealTime/ScheduledEventFactory.cs
+++ b/Engine/RealTime/ScheduledEventFactory.cs
@@ -77,7 +77,7 @@ namespace QuantConnect.Lean.Engine.RealTime
             var times =
                 // for every date any exchange is open in the algorithm
                 from date in Time.EachTradeableDay(algorithm.Securities.Values, start, end)
-                    // define the time of day we want the event to fire, a little before midnight
+                // define the time of day we want the event to fire, a little before midnight
                 let eventTime = date + eodEventTime
                 // convert the event time into UTC
                 let eventUtcTime = eventTime.ConvertToUtc(algorithm.TimeZone)
@@ -90,6 +90,7 @@ namespace QuantConnect.Lean.Engine.RealTime
                 try
                 {
                     algorithm.OnEndOfDay();
+                    algorithm.Debug("Usage of QCAlgorithm.OnEndOfDay() without a symbol will be deprecated August 2021. Always use a symbol when using this method: OnEndOfDay(symbol)");
                 }
                 catch (Exception err)
                 {
@@ -122,7 +123,7 @@ namespace QuantConnect.Lean.Engine.RealTime
             var times =
                 // for every date the exchange is open for this security
                 from date in Time.EachTradeableDay(security, start, end)
-                    // get the next market close for the specified date
+                // get the next market close for the specified date
                 let marketClose = security.Exchange.Hours.GetNextMarketClose(date, security.IsExtendedMarketHours)
                 // define the time of day we want the event to fire before marketclose
                 let eventTime = marketClose.Subtract(endOfDayDelta)

--- a/Engine/RealTime/ScheduledEventFactory.cs
+++ b/Engine/RealTime/ScheduledEventFactory.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Lean.Engine.RealTime
                 try
                 {
                     algorithm.OnEndOfDay();
-                    algorithm.Debug("Usage of QCAlgorithm.OnEndOfDay() without a symbol will be deprecated August 2021. Always use a symbol when using this method: OnEndOfDay(symbol)");
+                    algorithm.Debug("Usage of QCAlgorithm.OnEndOfDay() without a symbol will be deprecated August 2021. Always use a symbol when overriding this method: OnEndOfDay(symbol)");
                 }
                 catch (Exception err)
                 {

--- a/Tests/Engine/RealTime/BacktestingRealTimeHandlerTests.cs
+++ b/Tests/Engine/RealTime/BacktestingRealTimeHandlerTests.cs
@@ -473,6 +473,11 @@ namespace QuantConnect.Tests.Engine.RealTime
         {
             public bool OnEndOfDayFired { get; set; }
 
+            public override void OnEndOfDay()
+            {
+                OnEndOfDayFired = true;
+            }
+
             public override void OnEndOfDay(Symbol symbol)
             {
             }

--- a/Tests/Engine/RealTime/BacktestingRealTimeHandlerTests.cs
+++ b/Tests/Engine/RealTime/BacktestingRealTimeHandlerTests.cs
@@ -395,13 +395,13 @@ namespace QuantConnect.Tests.Engine.RealTime
                 _resultHandler,
                 null,
                 new TestTimeLimitManager());
-            // the generic OnEndOfDay()
-            Assert.AreEqual(1, realTimeHandler.GetScheduledEventsCount);
+
+            Assert.AreEqual(0, realTimeHandler.GetScheduledEventsCount);
 
             realTimeHandler.OnSecuritiesChanged(
                 new SecurityChanges(new[] { security }, Enumerable.Empty<Security>()));
 
-            Assert.AreEqual(1, realTimeHandler.GetScheduledEventsCount);
+            Assert.AreEqual(0, realTimeHandler.GetScheduledEventsCount);
 
             realTimeHandler.Exit();
         }

--- a/Tests/Engine/RealTime/BacktestingRealTimeHandlerTests.cs
+++ b/Tests/Engine/RealTime/BacktestingRealTimeHandlerTests.cs
@@ -414,7 +414,7 @@ namespace QuantConnect.Tests.Engine.RealTime
             IAlgorithm algorithm;
             if (language == Language.CSharp)
             {
-                algorithm = new TestAlgorithm();
+                algorithm = new TestAlgorithmB();
                 security = (algorithm as QCAlgorithm).AddEquity("SPY");
             }
             else
@@ -436,13 +436,14 @@ namespace QuantConnect.Tests.Engine.RealTime
                 _resultHandler,
                 null,
                 new TestTimeLimitManager());
-            // the generic OnEndOfDay()
-            Assert.AreEqual(1, realTimeHandler.GetScheduledEventsCount);
+            
+            // Because neither implement EOD() deprecated it should be zero
+            Assert.AreEqual(0, realTimeHandler.GetScheduledEventsCount);
 
             realTimeHandler.OnSecuritiesChanged(
                 new SecurityChanges(new[] { security }, Enumerable.Empty<Security>()));
 
-            Assert.AreEqual(2, realTimeHandler.GetScheduledEventsCount);
+            Assert.AreEqual(1, realTimeHandler.GetScheduledEventsCount);
             realTimeHandler.Exit();
         }
 
@@ -472,12 +473,24 @@ namespace QuantConnect.Tests.Engine.RealTime
         private class TestAlgorithm : AlgorithmStub
         {
             public bool OnEndOfDayFired { get; set; }
-
             public override void OnEndOfDay()
             {
                 OnEndOfDayFired = true;
             }
 
+            public override void OnEndOfDay(Symbol symbol)
+            {
+
+            }
+        }
+
+        /// <summary>
+        /// TestAlgorithmB is just for use where we need EOD() not to
+        /// be implemented, because it is deprecated.
+        /// For tests that require EOD() use TestAlgorithm
+        /// </summary>
+        private class TestAlgorithmB : AlgorithmStub
+        {
             public override void OnEndOfDay(Symbol symbol)
             {
             }

--- a/Tests/Engine/RealTime/BacktestingRealTimeHandlerTests.cs
+++ b/Tests/Engine/RealTime/BacktestingRealTimeHandlerTests.cs
@@ -473,11 +473,6 @@ namespace QuantConnect.Tests.Engine.RealTime
         {
             public bool OnEndOfDayFired { get; set; }
 
-            public override void OnEndOfDay()
-            {
-                OnEndOfDayFired = true;
-            }
-
             public override void OnEndOfDay(Symbol symbol)
             {
             }

--- a/Tests/Python/AlgorithmPythonWrapperTests.cs
+++ b/Tests/Python/AlgorithmPythonWrapperTests.cs
@@ -20,7 +20,6 @@ using QuantConnect.AlgorithmFactory.Python.Wrappers;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using org.apache.log4j.lf5.util;
 using QuantConnect.Orders;
 
 namespace QuantConnect.Tests.Python

--- a/Tests/Python/AlgorithmPythonWrapperTests.cs
+++ b/Tests/Python/AlgorithmPythonWrapperTests.cs
@@ -20,6 +20,7 @@ using QuantConnect.AlgorithmFactory.Python.Wrappers;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using org.apache.log4j.lf5.util;
 using QuantConnect.Orders;
 
 namespace QuantConnect.Tests.Python
@@ -51,6 +52,42 @@ namespace QuantConnect.Tests.Python
                 Assert.Null(algorithm.RunTimeError);
                 Assert.DoesNotThrow(() => algorithm.OnEndOfDay(Symbols.SPY));
                 Assert.Null(algorithm.RunTimeError);
+            }
+        }
+
+        [Test]
+        [TestCase("def OnEndOfDay(self): self.Name = 'EOD'\r\n    def OnEndOfDay(self, symbol): self.Name = 'EODSymbol'", "EODSymbol")]
+        [TestCase("def OnEndOfDay(self, symbol): self.Name = 'EODSymbol'\r\n    def OnEndOfDay(self): self.Name = 'EOD'", "EOD")]
+        public void OnEndOfDayBothImplemented(string code, string expectedImplementation)
+        {
+            // If we implement both OnEndOfDay functions we expect it to not throw,
+            // but only the latest will be seen and used.
+            // To test this we will have the functions set something we can verify such as Algo name
+            using (Py.GIL())
+            {
+                var algorithm = GetAlgorithm(code);
+                
+                Assert.Null(algorithm.RunTimeError);
+                Assert.DoesNotThrow(() => algorithm.OnEndOfDay());
+                Assert.Null(algorithm.RunTimeError);
+                Assert.DoesNotThrow(() => algorithm.OnEndOfDay(Symbols.SPY));
+                Assert.Null(algorithm.RunTimeError);
+
+                // Check the name
+                Assert.AreEqual(expectedImplementation, algorithm.Name);
+
+                // Check the wrapper EOD Implemented variables to confirm
+                switch (expectedImplementation)
+                {
+                    case "EOD":
+                        Assert.IsTrue(algorithm.IsOnEndOfDayImplemented);
+                        Assert.IsFalse(algorithm.IsOnEndOfDaySymbolImplemented);
+                        break;
+                    case "EODSymbol":
+                        Assert.IsTrue(algorithm.IsOnEndOfDaySymbolImplemented);
+                        Assert.IsFalse(algorithm.IsOnEndOfDayImplemented);
+                        break;
+                }
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Remove Obsolete `QCAlgorithm.OnEndOfDay()` functions and replace with `OnEndOfDay(Symbol)` across regressions.
- Place deprecation log message for users of obsolete EOD function.
- Refactor EOD scheduling logic to only schedule for what is implemented
- Add new python extension `GetPythonArgCount` to fetch a python methods parameter size
- Have `AlgorithmPythonWrapper` discern between which EOD is implemented via the new extension method.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#5155

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Part of cleaning up lean #5155 

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Any documentation referring to this method should already be up to date since we deprecated it a while back, but if not we should clean it up.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All test are passing
Addition of another unit test to assert EOD overload behavior in Python

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
