### PR TITLE
Add IB brokerage message event filtering

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1353,7 +1353,10 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 }
             }
 
-            OnMessage(new BrokerageMessageEvent(brokerageMessageType, errorCode, errorMsg));
+            if (!FilteredCodes.Contains(errorCode))
+            {
+                OnMessage(new BrokerageMessageEvent(brokerageMessageType, errorCode, errorMsg));
+            }
         }
 
         /// <summary>
@@ -3375,6 +3378,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private static readonly HashSet<int> InvalidatingCodes = new HashSet<int>
         {
             105, 106, 107, 109, 110, 111, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 129, 131, 132, 133, 134, 135, 136, 137, 140, 141, 146, 147, 148, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 163, 167, 168, 201, 313,314,315,325,328,329,334,335,336,337,338,339,340,341,342,343,345,347,348,349,350,352,353,355,356,358,359,360,361,362,363,364,367,368,369,370,371,372,373,374,375,376,377,378,379,380,382,383,387,388,389,390,391,392,393,394,395,396,397,398,400,401,402,403,405,406,407,408,409,410,411,412,413,417,418,419,421,423,424,427,428,429,433,434,435,436,437,439,440,441,442,443,444,445,446,447,448,449,10002,10006,10007,10008,10009,10010,10011,10012,10014,10020,2102
+        };
+
+        // these are warning messages not sent as brokerage message events
+        private static readonly HashSet<int> FilteredCodes = new HashSet<int>
+        {
+            1100, 1101, 1102, 2103, 2104, 2105, 2106, 2107, 2108, 2119, 2157, 2158
         };
     }
 }


### PR DESCRIPTION

#### Description
- Added brokerage message event filtering for the following list of IB warnings:

	* 1100 - Connectivity between IB and Trader Workstation has been lost.
	* 1101 - Connectivity between IB and TWS has been restored - data lost.
	* 1102 - Connectivity between IB and Trader Workstation has been restored - data maintained. 
	* 2103 - Market data farm connection is broken
	* 2104 - Market data farm connection is OK
	* 2105 - HMDS data farm connection is broken
	* 2106 - HMDS data farm connection is OK
	* 2107 - HMDS data farm connection is inactive but should be available upon demand
	* 2108 - Market data farm connection is inactive but should be available upon demand
	* 2119 - Market data farm is connecting
	* 2157 - Sec-def data farm connection is broken
	* 2158 - Sec-def data farm connection is OK

> Note: These errors will still be included in the QC system logs, but no longer included in user logs.

#### Related Issue
n/a

#### Motivation and Context
- Avoid flooding user logs with unnecessary messages.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Locally and in QC cloud with IB live algorithm.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.