### PR TITLE
Fix drawdown plotting failing on single equity point

### DIFF
--- a/Report/DrawdownCollection.cs
+++ b/Report/DrawdownCollection.cs
@@ -97,7 +97,7 @@ namespace QuantConnect.Report
             var backtestPoints = ResultsUtil.EquityPoints(backtestResult);
             var livePoints = ResultsUtil.EquityPoints(liveResult);
 
-            if (backtestPoints.Count == 0 && livePoints.Count == 0)
+            if (backtestPoints.Count < 2 && livePoints.Count < 2)
             {
                 return new Series<DateTime, double>(new DateTime[] { }, new double[] { });
             }

--- a/Tests/Report/DrawdownCollectionTests.cs
+++ b/Tests/Report/DrawdownCollectionTests.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using QuantConnect.Packets;
 using QuantConnect.Report;
 
 namespace QuantConnect.Tests.Report
@@ -40,6 +41,30 @@ namespace QuantConnect.Tests.Report
 
             Assert.AreEqual(1, collection.Count);
             Assert.AreEqual(0.2, collection.First().Drawdown, 0.0001);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void NoDrawdown(bool hasEquityPoint)
+        {
+            var strategyEquityChart = new Chart("Strategy Equity");
+            var equitySeries = new Series("Equity");
+            strategyEquityChart.AddSeries(equitySeries);
+
+            if (hasEquityPoint)
+            {
+                equitySeries.AddPoint(new DateTime(2020, 1, 1), 100000);
+            }
+
+            var backtest = new BacktestResult
+            {
+                Charts = new Dictionary<string, Chart> {[strategyEquityChart.Name] = strategyEquityChart}
+            };
+
+            var normalizedResults = DrawdownCollection.NormalizeResults(backtest, null);
+
+            Assert.AreEqual(0, normalizedResults.KeyCount);
+            Assert.AreEqual(0, normalizedResults.ValueCount);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR fixes the drawdown plotting in the report creator so that it doesn't fail if the backtest only contains a single equity point.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes an [issue reported on the forum](https://www.quantconnect.com/forum/discussion/11065/ubuntu-lean-local-docker-not-work/p1/comment-31581).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The report creator currently throws an error when the strategy equity chart only contains a single data point.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using unit tests and by running the report creator manually on [this](https://gist.github.com/jmerle/55ef8f339275a3f2489114f771c2e4c3) backtest result.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
