### PR TITLE
Fix Breaking Unit Test

### DIFF
--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -693,9 +693,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             secondsTimeStep: 3600 * 6,
             endDate: delistingDate.AddDays(2));
 
+            Log.Error($"Finished Test DelistedEventEmitted_Equity at: {DateTime.UtcNow}");
             Assert.AreEqual(1, receivedDelistedWarning, $"Did not receive {DelistingType.Warning}");
             Assert.AreEqual(1, receivedDelisted, $"Did not receive {DelistingType.Delisted}");
-            Log.Error($"Finished Test DelistedEventEmitted_Equity at: {DateTime.UtcNow}");
         }
 
         [Test]

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -647,10 +647,11 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         [Test]
         public void DelistedEventEmitted_Equity()
         {
-            _startDate = new DateTime(2016, 2, 18);
+            Log.Error($"Starting Test DelistedEventEmitted_Equity at: {DateTime.UtcNow}");
+            _startDate = new DateTime(2016, 2, 18, 6, 0, 0);
             CustomMockedFileBaseData.StartDate = _startDate;
             _manualTimeProvider.SetCurrentTimeUtc(_startDate);
-            var delistingDate = _startDate.AddDays(1);
+            var delistingDate = _startDate.Date.AddDays(1);
 
             var autoResetEvent = new AutoResetEvent(false);
             var feed = RunDataFeed(getNextTicksFunction: handler =>
@@ -658,16 +659,14 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 autoResetEvent.Set();
                 return new[] { new Delisting(Symbols.AAPL, delistingDate, 1, DelistingType.Warning) };
             });
-
             _algorithm.AddEquity(Symbols.AAPL);
             _algorithm.OnEndOfTimeStep();
             _algorithm.SetFinishedWarmingUp();
-
             Assert.IsTrue(autoResetEvent.WaitOne(TimeSpan.FromMilliseconds(200)));
 
             var receivedDelistedWarning = 0;
             var receivedDelisted = 0;
-            ConsumeBridge(feed, TimeSpan.FromSeconds(5), ts =>
+            ConsumeBridge(feed, TimeSpan.FromSeconds(10), ts =>
             {
                 foreach (var delistingEvent in ts.Slice.Delistings)
                 {
@@ -678,10 +677,12 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
                     if (delistingEvent.Value.Type == DelistingType.Warning)
                     {
+                        Log.Error("Received Delisted Warning");
                         Interlocked.Increment(ref receivedDelistedWarning);
                     }
                     if (delistingEvent.Value.Type == DelistingType.Delisted)
                     {
+                        Log.Error("Received Delisted Event");
                         Interlocked.Increment(ref receivedDelisted);
                         // we got what we wanted, end unit test
                         _manualTimeProvider.SetCurrentTimeUtc(DateTime.UtcNow);
@@ -689,11 +690,12 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 }
             },
             alwaysInvoke: false,
-            secondsTimeStep: 3600 * 8,
+            secondsTimeStep: 3600 * 6,
             endDate: delistingDate.AddDays(2));
 
             Assert.AreEqual(1, receivedDelistedWarning, $"Did not receive {DelistingType.Warning}");
             Assert.AreEqual(1, receivedDelisted, $"Did not receive {DelistingType.Delisted}");
+            Log.Error($"Finished Test DelistedEventEmitted_Equity at: {DateTime.UtcNow}");
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Fix breaking unit test ` DelistedEventEmitted_Equity`

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is a semi-regularly failing unit test. These changes are to permanently fix it

- Adjust timeout from 5 to 10 seconds
- Adjust timestep from 8 hours to 6 hours
- Log beginning and end time under Error so it appears in Travis, can be changed later but is good for debug if the issue reemerges 

Although we bumped up the timeout to 10 seconds the test has shown to pass in a range of 3-4 seconds w/ Travis. Sometimes it may take slightly longer due to VM conditions

The time step was adjusted because we believe 8 hour steps are slightly too fast for the delisting event to be processed and emitted while the `ConsumeBridge` loop advanced time very quickly. Because of this we believe the loop advanced up to `endTime` and exited before the the events were even processed and appropriate delisting events created.


#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It is a test

Travis runs on this PR: 5/5 passed
Github runs on this PR: 3/3 passed

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
