### PR TITLE
LiveDataBasedDelistingEventProvider Fix 

### DIFF
--- a/Engine/DataFeeds/Enumerators/DelistingEventProvider.cs
+++ b/Engine/DataFeeds/Enumerators/DelistingEventProvider.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// <param name="factorFile">The factor file to use</param>
         /// <param name="mapFile">The <see cref="MapFile"/> to use</param>
         /// <param name="startTime">Start date for the data request</param>
-        public void Initialize(
+        public virtual void Initialize(
             SubscriptionDataConfig config,
             FactorFile factorFile,
             MapFile mapFile,

--- a/Engine/DataFeeds/Enumerators/LiveDataBasedDelistingEventProvider.cs
+++ b/Engine/DataFeeds/Enumerators/LiveDataBasedDelistingEventProvider.cs
@@ -21,6 +21,7 @@ using QuantConnect.Logging;
 using QuantConnect.Interfaces;
 using QuantConnect.Data.Market;
 using System.Collections.Generic;
+using QuantConnect.Data.Auxiliary;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
 {
@@ -32,7 +33,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
     {
         private readonly SubscriptionDataConfig _dataConfig;
         private readonly IDataQueueHandler _dataQueueHandler;
-        private readonly IEnumerator<BaseData> _delistingEnumerator;
+        private IEnumerator<BaseData> _delistingEnumerator;
         
         /// <summary>
         /// Creates a new instance
@@ -42,7 +43,24 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
             _dataConfig = new SubscriptionDataConfig(dataConfig, typeof(Delisting));
 
             _dataQueueHandler = dataQueueHandler;
-            _delistingEnumerator = dataQueueHandler.Subscribe(_dataConfig, (sender, args) =>
+        }
+
+        /// <summary>
+        /// Initializes this instance
+        /// </summary>
+        /// <param name="config">The <see cref="SubscriptionDataConfig"/></param>
+        /// <param name="factorFile">The factor file to use</param>
+        /// <param name="mapFile">The <see cref="MapFile"/> to use</param>
+        /// <param name="startTime">Start date for the data request</param>
+        public override void Initialize(
+            SubscriptionDataConfig config,
+            FactorFile factorFile,
+            MapFile mapFile,
+            DateTime startTime)
+        {
+            base.Initialize(config, factorFile, mapFile, startTime);
+
+            _delistingEnumerator = _dataQueueHandler.Subscribe(_dataConfig, (sender, args) =>
             {
                 if (_delistingEnumerator != null && _delistingEnumerator.MoveNext())
                 {

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -665,7 +665,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var receivedDelistedWarning = 0;
             var receivedDelisted = 0;
-            ConsumeBridge(feed, TimeSpan.FromSeconds(10), ts =>
+            ConsumeBridge(feed, TimeSpan.FromSeconds(5), ts =>
             {
                 foreach (var delistingEvent in ts.Slice.Delistings)
                 {

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -647,7 +647,6 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         [Test]
         public void DelistedEventEmitted_Equity()
         {
-            Log.Error($"Starting Test DelistedEventEmitted_Equity at: {DateTime.UtcNow}");
             _startDate = new DateTime(2016, 2, 18, 6, 0, 0);
             CustomMockedFileBaseData.StartDate = _startDate;
             _manualTimeProvider.SetCurrentTimeUtc(_startDate);
@@ -677,12 +676,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
                     if (delistingEvent.Value.Type == DelistingType.Warning)
                     {
-                        Log.Error("Received Delisted Warning");
                         Interlocked.Increment(ref receivedDelistedWarning);
                     }
                     if (delistingEvent.Value.Type == DelistingType.Delisted)
                     {
-                        Log.Error("Received Delisted Event");
                         Interlocked.Increment(ref receivedDelisted);
                         // we got what we wanted, end unit test
                         _manualTimeProvider.SetCurrentTimeUtc(DateTime.UtcNow);
@@ -690,10 +687,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 }
             },
             alwaysInvoke: false,
-            secondsTimeStep: 3600 * 6,
+            secondsTimeStep: 3600 * 8,
             endDate: delistingDate.AddDays(2));
 
-            Log.Error($"Finished Test DelistedEventEmitted_Equity at: {DateTime.UtcNow}");
             Assert.AreEqual(1, receivedDelistedWarning, $"Did not receive {DelistingType.Warning}");
             Assert.AreEqual(1, receivedDelisted, $"Did not receive {DelistingType.Delisted}");
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR fixes a bug with the `LiveDataBasedDelistingEventProvider` which was actually the cause of `DelistedEventEmitted_Equity` failing regularly.

The problem was that when trying to create a `LiveDelistingEventProviderEnumerator`, using the `TryCreate()` function, it created a provider (`LiveDataBasedDelistingEventProvider`) that in construction would immediately subscribe to the given `dataQueueHandler` and start consuming data. In this instance this consumption would set the delisting date for a security as soon as it received the data to do so, but at the same time when we finally create the `LiveDelistingEventProviderEnumerator` it calls on the `Provider`'s `Initialize()` where it pulls the delisting date from a map file. This creates a race condition on the `delistingDate` value because if it sets the delisting date first, but then `Initialize()` is called, we overwrite the delisting date we just received from the datafeed.

The data from our test `DelistedEventEmitted_Equity` was emitting regularly enough, that sometimes we would have processed the delisting data before `Initialize()` was called, which then overwrites the delisting date.

Even though the delisting warning data point continued to emit over and over again in this test, there is a `IdentityDataConsolidator` feeding this provider that would recognize the point is repeated and *NOT* push it through more than once.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related PR #5466 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Very annoying unit test breaking inconsistently finally resolved.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests all pass.

To prove this issue in master, all one needs to do is add a small `Thread.Sleep()` between 
`LiveDelistingEventProviderEnumerator.TryCreates()` creation of the `delistingEventProvider` and `enumerator`. If you do this the problem reproduce *every* time, instead of just once in awhile

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
