### PR TITLE
Address Missing StableCoin Pairs in Crypto Exchanges

### DIFF
--- a/Common/Currencies.cs
+++ b/Common/Currencies.cs
@@ -97,6 +97,26 @@ namespace QuantConnect
         };
 
         /// <summary>
+        /// Define some StableCoins that don't have direct pairs for base currencies in our SPDB
+        /// This is because some CryptoExchanges do not define direct pairs with the stablecoins they offer.
+        ///
+        /// We use this to allow setting cash amounts for these stablecoins without needing a conversion
+        /// security.
+        /// </summary>
+        public static HashSet<Symbol> StableCoinsWithoutPairs = new HashSet<Symbol>
+        {
+            // Binance StableCoins Missing 1-1 Pairs
+            Symbol.Create("USDCUSD", SecurityType.Crypto, Market.Binance), // USD -> USDC
+            Symbol.Create("BGBPGBP", SecurityType.Crypto, Market.Binance), // GBP -> BGBP
+
+            // Coinbase StableCoins Missing 1-1 Pairs
+            Symbol.Create("USDCUSD", SecurityType.Crypto, Market.GDAX), // USD -> USDC
+
+            // Bitfinex StableCoins Missing 1-1 Pairs
+            Symbol.Create("EURSEUR", SecurityType.Crypto, Market.GDAX), // EUR -> EURS
+        };
+
+        /// <summary>
         /// Gets the currency symbol for the specified currency code
         /// </summary>
         /// <param name="currency">The currency code</param>

--- a/Common/Currencies.cs
+++ b/Common/Currencies.cs
@@ -113,7 +113,7 @@ namespace QuantConnect
             Symbol.Create("USDCUSD", SecurityType.Crypto, Market.GDAX), // USD -> USDC
 
             // Bitfinex StableCoins Missing 1-1 Pairs
-            Symbol.Create("EURSEUR", SecurityType.Crypto, Market.GDAX), // EUR -> EURS
+            Symbol.Create("EURSEUR", SecurityType.Crypto, Market.Bitfinex), // EUR -> EURS
         };
 
         /// <summary>

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -282,6 +282,14 @@ namespace QuantConnect.Securities
                 }
             }
 
+            // Special case; even if we don't have USDC-USD pair, still allow USDC cash because 1-1 with USD
+            if (Symbol == "USDC")
+            {
+                ConversionRateSecurity = null;
+                ConversionRate = 1.0m;
+                return null;
+            }
+
             // if this still hasn't been set then it's an error condition
             throw new ArgumentException($"In order to maintain cash in {Symbol} you are required to add a " +
                 $"subscription for Forex pair {Symbol}{accountCurrency} or {accountCurrency}{Symbol}"

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -282,8 +282,10 @@ namespace QuantConnect.Securities
                 }
             }
 
-            // Special case; even if we don't have USDC-USD pair, still allow USDC cash because 1-1 with USD
-            if (Symbol == "USDC")
+            // Special case for crypto markets without direct pairs (They wont be found by the above)
+            // This allows us to add cash for "StableCoins" that are 1-1 with our account currency without needing a conversion security.
+            // So far only Binance and Coinbase don't have USDCUSD pairs but can hold USDC
+            if (Currencies.StableCoinsWithoutPairs.Contains(QuantConnect.Symbol.Create(normal, SecurityType.Crypto, marketMap[SecurityType.Crypto])))
             {
                 ConversionRateSecurity = null;
                 ConversionRate = 1.0m;

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -284,7 +284,7 @@ namespace QuantConnect.Securities
 
             // Special case for crypto markets without direct pairs (They wont be found by the above)
             // This allows us to add cash for "StableCoins" that are 1-1 with our account currency without needing a conversion security.
-            // So far only Binance and Coinbase don't have USDCUSD pairs but can hold USDC
+            // Check out the StableCoinsWithoutPairs static var for those that are missing their 1-1 conversion pairs
             if (Currencies.StableCoinsWithoutPairs.Contains(QuantConnect.Symbol.Create(normal, SecurityType.Crypto, marketMap[SecurityType.Crypto])))
             {
                 ConversionRateSecurity = null;

--- a/Data/symbol-properties/symbol-properties-database.csv
+++ b/Data/symbol-properties/symbol-properties-database.csv
@@ -444,8 +444,8 @@ gdax,UMAEUR,crypto,UMA-Euro,EUR,1,0.001,0.001,UMA-EUR
 gdax,UMAGBP,crypto,UMA-British Pound,GBP,1,0.001,0.001,UMA-GBP
 gdax,UMAUSD,crypto,UMA-United States Dollar,USD,1,0.001,0.001,UMA-USD
 gdax,UNIUSD,crypto,Uniswap-United States Dollar,USD,1,0.0001,0.000001,UNI-USD
-gdax,USDCEUR,crypto,USDC-Eur,EUR,1,0.001,0.01
-gdax,USDCGBP,crypto,USDC-GBP,GBP,1,0.001,0.01
+gdax,USDCEUR,crypto,USDC-Eur,EUR,1,0.001,0.01,USDC-EUR
+gdax,USDCGBP,crypto,USDC-GBP,GBP,1,0.001,0.01,USDC-GBP
 gdax,WBTCBTC,crypto,Wrapped Bitcoin-Bitcoin,BTC,1,0.0001,0.00000001,WBTC-BTC
 gdax,WBTCUSD,crypto,Wrapped Bitcoin-United States Dollar,USD,1,0.01,0.00000001,WBTC-USD
 gdax,XLMBTC,crypto,Stellar-Bitcoin,BTC,1,0.00000001,1,XLM-BTC

--- a/Data/symbol-properties/symbol-properties-database.csv
+++ b/Data/symbol-properties/symbol-properties-database.csv
@@ -444,6 +444,8 @@ gdax,UMAEUR,crypto,UMA-Euro,EUR,1,0.001,0.001,UMA-EUR
 gdax,UMAGBP,crypto,UMA-British Pound,GBP,1,0.001,0.001,UMA-GBP
 gdax,UMAUSD,crypto,UMA-United States Dollar,USD,1,0.001,0.001,UMA-USD
 gdax,UNIUSD,crypto,Uniswap-United States Dollar,USD,1,0.0001,0.000001,UNI-USD
+gdax,USDCEUR,crypto,USDC-Eur,EUR,1,0.001,0.01
+gdax,USDCGBP,crypto,USDC-GBP,GBP,1,0.001,0.01
 gdax,WBTCBTC,crypto,Wrapped Bitcoin-Bitcoin,BTC,1,0.0001,0.00000001,WBTC-BTC
 gdax,WBTCUSD,crypto,Wrapped Bitcoin-United States Dollar,USD,1,0.01,0.00000001,WBTC-USD
 gdax,XLMBTC,crypto,Stellar-Bitcoin,BTC,1,0.00000001,1,XLM-BTC

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -611,19 +611,7 @@ namespace QuantConnect.Tests.Common.Securities
             var subscriptions = new SubscriptionManager();
             var dataManager = new DataManagerStub(TimeKeeper);
             subscriptions.SetDataManager(dataManager);
-            var abcConfig = subscriptions.Add(Symbols.SPY, Resolution.Minute, TimeZone, TimeZone);
             var securities = new SecurityManager(TimeKeeper);
-            securities.Add(
-                Symbols.SPY,
-                new Security(
-                    SecurityExchangeHours,
-                    abcConfig,
-                    new Cash(accountCurrency, 0, 1m),
-                    SymbolProperties.GetDefault(cashBook.AccountCurrency),
-                    cashBook,
-                    RegisteredSecurityDataTypesProvider.Null,
-                    new SecurityCache()));
-
 
             // Verify the behavior throws or doesn't throw depending on the case
             if (shouldThrow)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Address issues surrounding adding stable coins to algorithms without direct trading pairs for conversion.

Even though an exchange may not offer a direct conversion from a given account currency and stablecoin (ex.  GDAX USD -> USDC) we still want to be able to override some handling of these cases. In this specific example we know at GDAX USD -> USDC is a consistent 1-1 conversion. But at another exchange such as Bitfinex there is a tradable security that reflects small variances in USDC price.

To let these both exist and not have the GDAX case throw we add a condition that if there is no currency conversion security found, we first check a new static variable `*StableCoinsWithoutPairs` in the Currency class that will tell us if a given market should allow the `Cash` (USDC or other stablecoin) to be added with a 1-1 conversion without tracking a security.

*Maybe needs a better name, something more clear? Possibly relating to the fact they are all 1-1 conversion pairs without securities, or maybe a way to add this to SPD? 


I also added two missing pairs to the GDAX SPDB for
- USDC/EUR
- USDC/GBP

Source: https://pro.coinbase.com/markets

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5478 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Reference issue above

The problem is caused by underlying brokerages not having a direct pair for stablecoins from account currency. If they did Lean would generate a subscription to these assets and update its conversion rate as data for that pair flows through the engine.

This solution seeks to bypass the issue for stablecoins that we know hold a direct 1-1 conversion rate with the account currency.

Following this solution we will likely need to consider multi-leg conversions since there isn't a direct path on some of these exchanges.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a unit test that asserts behavior of this issue with a range of cases for each crypto exchange, account currency, and possible stablecoins.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
