### PR TITLE
Use SafeAsManagedObject for IndicatorExtensions 

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -2233,6 +2233,27 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Safely convert PyObject to ManagedObject using Py.GIL Lock
+        /// If no type is given it will convert the PyObject's Python Type to a ManagedObject Type
+        /// in a attempt to resolve the target type to convert to.
+        /// </summary>
+        /// <param name="pyObject">PyObject to convert to managed</param>
+        /// <param name="typeToConvertTo">The target type to convert to</param>
+        /// <returns>The resulting ManagedObject</returns>
+        public static dynamic SafeAsManagedObject(this PyObject pyObject, Type typeToConvertTo = null)
+        {
+            using (Py.GIL())
+            {
+                if (typeToConvertTo == null)
+                {
+                    typeToConvertTo = pyObject.GetPythonType().AsManagedObject(typeof(Type)) as Type;
+                }
+
+                return pyObject.AsManagedObject(typeToConvertTo);
+            }
+        }
+
+        /// <summary>
         /// Wraps the provided universe selection selector checking if it returned <see cref="Universe.Unchanged"/>
         /// and returns it instead, else enumerates result as <see cref="IEnumerable{Symbol}"/>
         /// </summary>

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -352,8 +352,8 @@ namespace QuantConnect.Indicators
         /// <returns>The reference to the second indicator to allow for method chaining</returns>
         public static object Of(PyObject second, PyObject first, bool waitForFirstToReady = true)
         {
-            dynamic indicator1 = first.AsManagedObject((Type)first.GetPythonType().AsManagedObject(typeof(Type)));
-            dynamic indicator2 = second.AsManagedObject((Type)second.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicator1 = first.SafeAsManagedObject();
+            dynamic indicator2 = second.SafeAsManagedObject();
             return Of(indicator2, indicator1, waitForFirstToReady);
         }
 
@@ -367,8 +367,8 @@ namespace QuantConnect.Indicators
         // ReSharper disable once UnusedMember.Global
         public static CompositeIndicator<IndicatorDataPoint> WeightedBy(PyObject value, PyObject weight, int period)
         {
-            dynamic indicator1 = value.AsManagedObject((Type)value.GetPythonType().AsManagedObject(typeof(Type)));
-            dynamic indicator2 = weight.AsManagedObject((Type)weight.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicator1 = value.SafeAsManagedObject();
+            dynamic indicator2 = weight.SafeAsManagedObject();
             return WeightedBy(indicator1, indicator2, period);
         }
 
@@ -382,7 +382,7 @@ namespace QuantConnect.Indicators
         /// <returns>A reference to the ExponentialMovingAverage indicator to allow for method chaining</returns>
         public static ExponentialMovingAverage EMA(PyObject left, int period, decimal? smoothingFactor = null, bool waitForFirstToReady = true)
         {
-            dynamic indicator = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicator = left.SafeAsManagedObject();
             return EMA(indicator, period, smoothingFactor, waitForFirstToReady);
         }
 
@@ -395,7 +395,7 @@ namespace QuantConnect.Indicators
         /// <returns>A reference to the Maximum indicator to allow for method chaining</returns>
         public static Maximum MAX(PyObject left, int period, bool waitForFirstToReady = true)
         {
-            dynamic indicator = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicator = left.SafeAsManagedObject();
             return MAX(indicator, period, waitForFirstToReady);
         }
 
@@ -408,7 +408,7 @@ namespace QuantConnect.Indicators
         /// <returns>A reference to the Minimum indicator to allow for method chaining</returns>
         public static Minimum MIN(PyObject left, int period, bool waitForFirstToReady = true)
         {
-            dynamic indicator = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicator = left.SafeAsManagedObject();
             return MIN(indicator, period, waitForFirstToReady);
         }
 
@@ -421,7 +421,7 @@ namespace QuantConnect.Indicators
         /// <returns>The reference to the SimpleMovingAverage indicator to allow for method chaining</returns>
         public static SimpleMovingAverage SMA(PyObject left, int period, bool waitForFirstToReady = true)
         {
-            dynamic indicator = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicator = left.SafeAsManagedObject();
             return SMA(indicator, period, waitForFirstToReady);
         }
 
@@ -436,7 +436,7 @@ namespace QuantConnect.Indicators
         /// <returns>The ratio of the left to the right indicator</returns>
         public static object Over(PyObject left, decimal constant)
         {
-            dynamic indicatorLeft = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicatorLeft = left.SafeAsManagedObject();
             return Over(indicatorLeft, constant);
         }
 
@@ -452,8 +452,8 @@ namespace QuantConnect.Indicators
         /// <returns>The ratio of the left to the right indicator</returns>
         public static object Over(PyObject left, PyObject right, string name = "")
         {
-            dynamic indicatorLeft = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
-            dynamic indicatorRight = right.AsManagedObject((Type)right.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicatorLeft = left.SafeAsManagedObject();
+            dynamic indicatorRight = right.SafeAsManagedObject();
             if (name.IsNullOrEmpty())
             {
                 return Over(indicatorLeft, indicatorRight);
@@ -472,7 +472,7 @@ namespace QuantConnect.Indicators
         /// <returns>The difference of the left and right indicators</returns>
         public static object Minus(PyObject left, decimal constant)
         {
-            dynamic indicatorLeft = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicatorLeft = left.SafeAsManagedObject();
             return Minus(indicatorLeft, constant);
         }
 
@@ -488,8 +488,8 @@ namespace QuantConnect.Indicators
         /// <returns>The difference of the left and right indicators</returns>
         public static object Minus(PyObject left, PyObject right, string name = "")
         {
-            dynamic indicatorLeft = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
-            dynamic indicatorRight = right.AsManagedObject((Type)right.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicatorLeft = left.SafeAsManagedObject();
+            dynamic indicatorRight = right.SafeAsManagedObject();
             if (name.IsNullOrEmpty())
             {
                 return Minus(indicatorLeft, indicatorRight);
@@ -508,7 +508,7 @@ namespace QuantConnect.Indicators
         /// <returns>The product of the left to the right indicators</returns>
         public static object Times(PyObject left, decimal constant)
         {
-            dynamic indicatorLeft = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicatorLeft = left.SafeAsManagedObject();
             return Times(indicatorLeft, constant);
         }
 
@@ -524,8 +524,8 @@ namespace QuantConnect.Indicators
         /// <returns>The product of the left to the right indicators</returns>
         public static object Times(PyObject left, PyObject right, string name = "")
         {
-            dynamic indicatorLeft = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
-            dynamic indicatorRight = right.AsManagedObject((Type)right.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicatorLeft = left.SafeAsManagedObject();
+            dynamic indicatorRight = right.SafeAsManagedObject();
             if (name.IsNullOrEmpty())
             {
                 return Times(indicatorLeft, indicatorRight);
@@ -544,7 +544,7 @@ namespace QuantConnect.Indicators
         /// <returns>The sum of the left and right indicators</returns>
         public static object Plus(PyObject left, decimal constant)
         {
-            dynamic indicatorLeft = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicatorLeft = left.SafeAsManagedObject();
             return Plus(indicatorLeft, constant);
         }
 
@@ -560,8 +560,8 @@ namespace QuantConnect.Indicators
         /// <returns>The sum of the left and right indicators</returns>
         public static object Plus(PyObject left, PyObject right, string name = "")
         {
-            dynamic indicatorLeft = left.AsManagedObject((Type)left.GetPythonType().AsManagedObject(typeof(Type)));
-            dynamic indicatorRight = right.AsManagedObject((Type)right.GetPythonType().AsManagedObject(typeof(Type)));
+            dynamic indicatorLeft = left.SafeAsManagedObject();
+            dynamic indicatorRight = right.SafeAsManagedObject();
             if (name.IsNullOrEmpty())
             {
                 return Plus(indicatorLeft, indicatorRight);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Implement a new extension method `SafeAsManagedObject` to convert Python objects to Managed using a Py.GIL() lock. (This method also allows a default use case where target type is determined by fetching the PyObjects Python Type and converting it to a Managed type)
- For all `IndicatorExtensions` use `SafeAsManagedObject` to convert the PyObject indicators.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5483 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes the issue described in #5483 where AccessViolationException is triggered by converting without Py.GIL() lock. 

Also adding this as an extension provides a easy way to convert PyObjects using their Python Types Managed counterpart with a simple `PyObject.SafeAsManagedObject()` 

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All current tests are passing.

Unfortunately was unable to reproduce the issue in #5483, but in theory it is a possibility when attempting to access Python memory. This PR ensures that it won't happen.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
