### PR TITLE
Adds StandardDeviationOfReturns configurability and improves greeks warmup for Futures/Index Options

### DIFF
--- a/Algorithm.Python/IndexOptionCallITMGreeksExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionCallITMGreeksExpiryRegressionAlgorithm.py
@@ -11,10 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from QuantConnect.Algorithm import *
 from QuantConnect.Data import *
+from QuantConnect.Securities import *
 from QuantConnect.Securities.Option import *
+from QuantConnect.Securities.Volatility import *
 from QuantConnect import *
 
 ### <summary>
@@ -29,7 +31,9 @@ class IndexOptionCallITMGreeksExpiryRegressionAlgorithm(QCAlgorithm):
         self.SetStartDate(2021, 1, 4)
         self.SetEndDate(2021, 1, 31)
 
-        self.spx = self.AddIndex("SPX", Resolution.Minute).Symbol
+        spx = self.AddIndex("SPX", Resolution.Minute)
+        spx.VolatilityModel = StandardDeviationOfReturnsVolatilityModel(60, Resolution.Minute, timedelta(minutes=1))
+        self.spx = spx.Symbol
 
         # Select a index option call expiring ITM, and adds it to the algorithm.
         self.spxOption = list(self.OptionChainProvider.GetOptionContractList(self.spx, self.Time))
@@ -74,11 +78,12 @@ class IndexOptionCallITMGreeksExpiryRegressionAlgorithm(QCAlgorithm):
         if any([i for i in deltas if i == 0]):
             raise Exception("Option contract Delta was equal to zero")
 
-        #if any([i for i in gammas if i == 0]):
-        #    raise AggregateException("Option contract Gamma was equal to zero")
+        # Delta is 1, therefore we expect a gamma of 0
+        if any([i for i in gammas if i == 0]):
+            raise AggregateException("Option contract Gamma was equal to zero")
 
-        #if any([i for i in lambda_ if lambda_ == 0]):
-        #    raise AggregateException("Option contract Lambda was equal to zero")
+        if any([i for i in lambda_ if lambda_ == 0]):
+            raise AggregateException("Option contract Lambda was equal to zero")
 
         if any([i for i in rho if i == 0]):
             raise Exception("Option contract Rho was equal to zero")
@@ -86,8 +91,10 @@ class IndexOptionCallITMGreeksExpiryRegressionAlgorithm(QCAlgorithm):
         if any([i for i in theta if i == 0]):
             raise Exception("Option contract Theta was equal to zero")
 
-        #if any([i for i in vega if vega == 0]):
-        #    raise AggregateException("Option contract Vega was equal to zero")
+        # The strike is far away from the underlying asset's price, and we're very close to expiry.
+        # Zero is an expected value here.
+        if any([i for i in vega if vega == 0]):
+            raise AggregateException("Option contract Vega was equal to zero")
 
         if not self.invested:
             self.SetHoldings(list(list(data.OptionChains.Values)[0].Contracts.Values)[0].Symbol, 1)

--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -597,12 +597,9 @@ namespace QuantConnect.Algorithm
             // ensure a volatility model has been set on the underlying
             if (security.VolatilityModel == VolatilityModel.Null)
             {
-                var bar = security.GetLastData();
-                if (bar == null)
-                {
-                    bar = typeof(TradeBar).GetBaseDataInstance();
-                    bar.Symbol = security.Symbol;
-                }
+                var config = configs.FirstOrDefault();
+                var bar = config?.Type.GetBaseDataInstance() ?? typeof(TradeBar).GetBaseDataInstance();
+                bar.Symbol = security.Symbol;
                 
                 var maxSupportedResolution = bar.SupportedResolutions().Max();
 

--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -597,9 +597,14 @@ namespace QuantConnect.Algorithm
             // ensure a volatility model has been set on the underlying
             if (security.VolatilityModel == VolatilityModel.Null)
             {
-                var maxSupportedResolution = (security.GetLastData() ?? typeof(TradeBar).GetBaseDataInstance())
-                    .SupportedResolutions()
-                    .Max();
+                var bar = security.GetLastData();
+                if (bar == null)
+                {
+                    bar = typeof(TradeBar).GetBaseDataInstance();
+                    bar.Symbol = security.Symbol;
+                }
+                
+                var maxSupportedResolution = bar.SupportedResolutions().Max();
 
                 var updateFrequency = maxSupportedResolution.ToTimeSpan();
                 int periods;

--- a/Common/Securities/Volatility/BaseVolatilityModel.cs
+++ b/Common/Securities/Volatility/BaseVolatilityModel.cs
@@ -17,7 +17,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Data;
+using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
+using QuantConnect.Util;
 
 namespace QuantConnect.Securities.Volatility
 {
@@ -68,6 +70,69 @@ namespace QuantConnect.Securities.Volatility
             )
         {
             return Enumerable.Empty<HistoryRequest>();
+        }
+
+        /// <summary>
+        /// Gets history requests required for warming up the greeks with the provided resolution
+        /// </summary>
+        /// <param name="security">Security to get history for</param>
+        /// <param name="utcTime">UTC time of the request (end time)</param>
+        /// <param name="resolution">Resolution of the security</param>
+        /// <param name="barCount">Number of bars to lookback for the start date</param>
+        /// <returns>Enumerable of history requests</returns>
+        /// <exception cref="InvalidOperationException">The <see cref="SubscriptionDataConfigProvider"/> has not been set</exception>
+        public IEnumerable<HistoryRequest> GetHistoryRequirements(
+            Security security, 
+            DateTime utcTime,
+            Resolution? resolution,
+            int barCount)
+        {
+            if (SubscriptionDataConfigProvider == null)
+            {
+                throw new InvalidOperationException(
+                    "BaseVolatilityModel.GetHistoryRequirements(): " +
+                    "SubscriptionDataConfigProvider was not set."
+                );
+            }
+
+            var configurations = SubscriptionDataConfigProvider
+                .GetSubscriptionDataConfigs(security.Symbol)
+                .ToList();
+            var configuration = configurations.First();
+            
+            var bar = configuration.Type.GetBaseDataInstance();
+            bar.Symbol = security.Symbol;
+            
+            var historyResolution = resolution ?? bar.SupportedResolutions().Max();
+
+            var periodSpan = historyResolution.ToTimeSpan();
+            
+            // hour resolution does no have extended market hours data
+            var extendedMarketHours = periodSpan != Time.OneHour && configurations.IsExtendedMarketHours();
+            var localStartTime = Time.GetStartTimeForTradeBars(
+                security.Exchange.Hours,
+                utcTime.ConvertFromUtc(security.Exchange.TimeZone),
+                periodSpan,
+                barCount,
+                extendedMarketHours,
+                configuration.DataTimeZone);
+            var utcStartTime = localStartTime.ConvertToUtc(security.Exchange.TimeZone);
+
+            return new[]
+            {
+                new HistoryRequest(utcStartTime,
+                                   utcTime,
+                                   configuration.Type,
+                                   configuration.Symbol,
+                                   historyResolution,
+                                   security.Exchange.Hours,
+                                   configuration.DataTimeZone,
+                                   historyResolution,
+                                   extendedMarketHours,
+                                   configurations.IsCustomData(),
+                                   configurations.DataNormalizationMode(),
+                                   LeanData.GetCommonTickTypeForCommonDataTypes(configuration.Type, security.Type))
+            };
         }
     }
 }

--- a/Common/Securities/Volatility/BaseVolatilityModel.cs
+++ b/Common/Securities/Volatility/BaseVolatilityModel.cs
@@ -97,6 +97,7 @@ namespace QuantConnect.Securities.Volatility
 
             var configurations = SubscriptionDataConfigProvider
                 .GetSubscriptionDataConfigs(security.Symbol)
+                .OrderBy(c => c.TickType)
                 .ToList();
             var configuration = configurations.First();
             

--- a/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
+++ b/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
@@ -125,6 +125,7 @@ namespace QuantConnect.Securities
 
             var configurations = SubscriptionDataConfigProvider
                 .GetSubscriptionDataConfigs(security.Symbol)
+                .OrderBy(c => c.TickType)
                 .ToList();
 
             return GetHistoryRequirements(

--- a/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
+++ b/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
@@ -127,36 +127,11 @@ namespace QuantConnect.Securities
                 .GetSubscriptionDataConfigs(security.Symbol)
                 .ToList();
 
-            var barCount = _window.Size + 1;
-            // hour resolution does no have extended market hours data
-            var extendedMarketHours = _periodSpan != Time.OneHour && configurations.IsExtendedMarketHours();
-            var configuration = configurations.First();
-
-            var localStartTime = Time.GetStartTimeForTradeBars(
-                security.Exchange.Hours,
-                utcTime.ConvertFromUtc(security.Exchange.TimeZone),
-                _periodSpan,
-                barCount,
-                extendedMarketHours,
-                configuration.DataTimeZone);
-
-            var utcStartTime = localStartTime.ConvertToUtc(security.Exchange.TimeZone);
-
-            return new[]
-            {
-                new HistoryRequest(utcStartTime,
-                                   utcTime,
-                                   typeof(TradeBar),
-                                   configuration.Symbol,
-                                   configurations.GetHighestResolution(),
-                                   security.Exchange.Hours,
-                                   configuration.DataTimeZone,
-                                   configurations.GetHighestResolution(),
-                                   extendedMarketHours,
-                                   configurations.IsCustomData(),
-                                   configurations.DataNormalizationMode(),
-                                   LeanData.GetCommonTickTypeForCommonDataTypes(typeof(TradeBar), security.Type))
-            };
+            return GetHistoryRequirements(
+                security,
+                utcTime,
+                configurations.GetHighestResolution(),
+                _window.Size + 1);
         }
     }
 }

--- a/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
+++ b/Common/Securities/Volatility/StandardDeviationOfReturnsVolatilityModel.cs
@@ -152,9 +152,14 @@ namespace QuantConnect.Securities
                 configuration.DataTimeZone);
             var utcStartTime = localStartTime.ConvertToUtc(security.Exchange.TimeZone);
 
-            var resolution = _resolution ?? (security.GetLastData() ?? typeof(TradeBar).GetBaseDataInstance())
-                .SupportedResolutions()
-                .Max();
+            var bar = security.GetLastData();
+            if (bar == null)
+            {
+                bar = typeof(TradeBar).GetBaseDataInstance();
+                bar.Symbol = security.Symbol;
+            }
+            
+            var resolution = _resolution ?? bar.SupportedResolutions().Max();
 
             return new[]
             {

--- a/Tests/Common/Securities/StandardDeviationOfReturnsVolatilityModelTests.cs
+++ b/Tests/Common/Securities/StandardDeviationOfReturnsVolatilityModelTests.cs
@@ -191,5 +191,105 @@ namespace QuantConnect.Tests.Common.Securities
             // the StandardDeviationOfReturnsVolatilityModel always uses daily
             Assert.AreEqual(Resolution.Daily, result.Resolution);
         }
+
+        [Test]
+        public void UpdatesOnCustomConfigurationParametersOneMinute()
+        {
+            const int periods = 5;
+            var reference = new DateTime(2016, 04, 06, 12, 0, 0);
+            var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
+            var timeKeeper = new TimeKeeper(referenceUtc);
+            var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, false, false);
+            var security = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                config,
+                new Cash(Currencies.USD, 0, 0),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+            security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            var model = new StandardDeviationOfReturnsVolatilityModel(periods, Resolution.Minute, TimeSpan.FromMinutes(1));
+
+            for (var i = 0; i < 5; i++)
+            {
+                if (i < 3)
+                {
+                    Assert.AreEqual(0, model.Volatility);
+                }
+                else
+                {
+                    Assert.AreNotEqual(0, model.Volatility);
+                }
+                
+                model.Update(security, new TradeBar
+                {
+                    Open = 11 + (i - 1),
+                    High = 11 + i,
+                    Low = 9 - i,
+                    Close = 11 + i,
+                    Symbol = security.Symbol,
+                    Time = reference.AddMinutes(i)
+                });
+            }
+            
+            Assert.AreNotEqual(0, model.Volatility);
+        }
+
+        [Test]
+        public void MinuteResolutionSelectedForFuturesOptions()
+        {
+            const int periods = 5;
+            var reference = new DateTime(2016, 04, 06, 12, 0, 0);
+            var referenceUtc = reference.ConvertToUtc(TimeZones.Chicago);
+            var timeKeeper = new TimeKeeper(referenceUtc);
+            var underlyingSymbol = Symbol.Create("ES", SecurityType.Future, Market.CME);
+            var futureOption = Symbol.CreateOption(
+                underlyingSymbol,
+                Market.CME,
+                OptionStyle.American,
+                OptionRight.Call,
+                0,
+                SecurityIdentifier.DefaultDate);
+            
+            var underlyingConfig = new SubscriptionDataConfig(typeof(TradeBar), underlyingSymbol, Resolution.Minute, TimeZones.Chicago, TimeZones.Chicago, true, false, false);
+            var futureOptionConfig = new SubscriptionDataConfig(typeof(TradeBar), futureOption, Resolution.Minute, TimeZones.Chicago, TimeZones.Chicago, true, false, false);
+            
+            var underlyingSecurity = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.Chicago),
+                underlyingConfig,
+                new Cash(Currencies.USD, 0, 0),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+            var futureOptionSecurity = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.Chicago),
+                futureOptionConfig,
+                new Cash(Currencies.USD, 0, 0),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            ); 
+            
+            underlyingSecurity.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.Chicago));
+            futureOptionSecurity.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.Chicago));
+            
+            var mock = new MockSubscriptionDataConfigProvider();
+            mock.SubscriptionDataConfigs.Add(underlyingConfig);
+            mock.SubscriptionDataConfigs.Add(futureOptionConfig);
+            var model = new StandardDeviationOfReturnsVolatilityModel(periods, Resolution.Minute, TimeSpan.FromMinutes(1));
+            model.SetSubscriptionDataConfigProvider(mock);
+            
+            var futureHistoryRequirements = model.GetHistoryRequirements(underlyingSecurity, referenceUtc);
+            var optionHistoryRequirements = model.GetHistoryRequirements(futureOptionSecurity, referenceUtc);
+            
+            Assert.IsTrue(futureHistoryRequirements.All(x => x.Resolution == Resolution.Minute));
+            Assert.IsTrue(optionHistoryRequirements.All(x => x.Resolution == Resolution.Minute));
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

The defaults set for the period/update frequency depending on resolution can be updated, I'd suggest reviewer(s) to review them to make sure they're reasonable defaults and sound/not buggy.

  * Makes `StandardDeviationOfReturns` configurable by users, so that
    greeks can be loaded according to user expectations and the series
    of returns that they'd like to compute for `n` periods and timespan
    of `T`, as well as resolution of the data in live mode.

  * Changes resolution to max resolution available for the default
    volatility model created for the security. Usually this only applies
    to live mode, but if creating an instance of the
    `StandardDeviationOfReturns` volatility model and no `updateFrequency`
    is provided, the resolution's time span will be used as the default
    value. Backwards compatibility for equities is maintained.

  * Changes defaults for `StandardDeviationOfReturnsVolatilityModel`
    to warmup greeks faster for other derivative asset types

  * Improves comments on `StandardDeviationOfReturns` for clarity on how
    to use the volatility model for end users

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to #4520 - this should allow for better configurability for end users, though some educational material might be required to allow users to effectively load/warmup greeks in their algorithm
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
User experience, making sure greeks warm up faster results in less confusion in usage of this part of Lean.

Thinking out loud: we might be able to automatically warm up greeks from the get-go so that greeks are never zero. I wonder if this is an avenue we'd like to explore @Martin-Molinero @jaredbroad 
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
I think we should have some documentation/usage guidelines around the greeks API, since it's not very obvious that they're required to warm up (by default a month) before Greeks are non-zero.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Futures/Index Options Greeks regression algorithms, ran existing unit tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
