### PR TITLE
Refactor logging for SubscriptionDataReader FactorFile processing

### DIFF
--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Market;
@@ -36,7 +37,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         private readonly IResultHandler _resultHandler;
         private readonly IFactorFileProvider _factorFileProvider;
         private readonly ZipDataCacheProvider _zipDataCacheProvider;
-        private readonly ConcurrentSet<Symbol> _numericalPrecisionMessageSent;
+        private readonly ConcurrentSet<Symbol> _numericalPrecisionLimitedSymbols;
         private readonly Func<SubscriptionRequest, IEnumerable<DateTime>> _tradableDaysProvider;
         private readonly IMapFileProvider _mapFileProvider;
         private readonly bool _enablePriceScaling;
@@ -62,7 +63,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             _resultHandler = resultHandler;
             _mapFileProvider = mapFileProvider;
             _factorFileProvider = factorFileProvider;
-            _numericalPrecisionMessageSent = new ConcurrentSet<Symbol>();
+            _numericalPrecisionLimitedSymbols = new ConcurrentSet<Symbol>();
             _zipDataCacheProvider = new ZipDataCacheProvider(dataProvider, isDataEphemeral: false);
             _isLiveMode = false;
             _tradableDaysProvider = tradableDaysProvider ?? (request => request.TradableDays);
@@ -95,13 +96,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             dataReader.StartDateLimited += (sender, args) => { _resultHandler.DebugMessage(args.Message); };
             dataReader.DownloadFailed += (sender, args) => { _resultHandler.ErrorMessage(args.Message, args.StackTrace); };
             dataReader.ReaderErrorDetected += (sender, args) => { _resultHandler.RuntimeError(args.Message, args.StackTrace); };
-            dataReader.NumericalPrecisionLimited += (sender, args) =>
-            {
-                if (_numericalPrecisionMessageSent.Add(args.Symbol))
-                {
-                    _resultHandler.DebugMessage(args.Message);
-                }
-            };
+            dataReader.NumericalPrecisionLimited += (sender, args) => { _numericalPrecisionLimitedSymbols.Add(args.Symbol); };
 
             var result = CorporateEventEnumeratorFactory.CreateEnumerators(
                 dataReader,
@@ -121,6 +116,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <filterpriority>2</filterpriority>
         public void Dispose()
         {
+            _resultHandler.DebugMessage($"Due to numerical precision issues in the factor file, data from the following" +
+                $" symbols was adjust to start later than the algorithms start date: { string.Join(", ", _numericalPrecisionLimitedSymbols.Take(10).Select(x => x.Value)) }");
             _zipDataCacheProvider?.DisposeSafely();
         }
     }

--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -116,8 +116,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <filterpriority>2</filterpriority>
         public void Dispose()
         {
-            _resultHandler.DebugMessage($"Due to numerical precision issues in the factor file, data from the following" +
-                $" symbols was adjust to start later than the algorithms start date: { string.Join(", ", _numericalPrecisionLimitedSymbols.Take(10).Select(x => x.Value)) }");
+            if (!_numericalPrecisionLimitedSymbols.IsNullOrEmpty())
+            {
+                _resultHandler.DebugMessage($"Due to numerical precision issues in the factor file, data from the following" +
+                    $" symbols was adjust to start later than the algorithms start date: { string.Join(", ", _numericalPrecisionLimitedSymbols.Take(10).Select(x => x.Value)) }");
+            }
+           
             _zipDataCacheProvider?.DisposeSafely();
         }
     }

--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -128,10 +128,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             if (!_numericalPrecisionLimitedWarnings.IsNullOrEmpty())
             {
                 var message = $"Due to numerical precision issues in the factor file, data for the following" +
-                    $" symbols was adjust to a later starting date: {string.Join(", ", _numericalPrecisionLimitedWarnings.Values)}";
+                    $" symbols was adjust to a later starting date: {string.Join(", ", _numericalPrecisionLimitedWarnings.Values.Take(_numericalPrecisionLimitedWarningsMaxCount))}";
 
-                // If we reached our max warnings count suggest that more are left out
-                if (_numericalPrecisionLimitedWarnings.Count == _numericalPrecisionLimitedWarningsMaxCount)
+                // If we reached our max warnings count suggest that more may have been left out
+                if (_numericalPrecisionLimitedWarnings.Count >= _numericalPrecisionLimitedWarningsMaxCount)
                 {
                     message += "...";
                 }

--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         private readonly IResultHandler _resultHandler;
         private readonly IFactorFileProvider _factorFileProvider;
         private readonly ZipDataCacheProvider _zipDataCacheProvider;
-        private readonly ConcurrentDictionary<Symbol, string> _numericalPrecisionLimitedWarnings = new ConcurrentDictionary<Symbol, string>();
+        private readonly ConcurrentDictionary<Symbol, string> _numericalPrecisionLimitedWarnings;
         private readonly int _numericalPrecisionLimitedWarningsMaxCount = 10;
         private readonly Func<SubscriptionRequest, IEnumerable<DateTime>> _tradableDaysProvider;
         private readonly IMapFileProvider _mapFileProvider;
@@ -66,6 +66,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             _mapFileProvider = mapFileProvider;
             _factorFileProvider = factorFileProvider;
             _zipDataCacheProvider = new ZipDataCacheProvider(dataProvider, isDataEphemeral: false);
+            _numericalPrecisionLimitedWarnings = new ConcurrentDictionary<Symbol, string>();
             _isLiveMode = false;
             _tradableDaysProvider = tradableDaysProvider ?? (request => request.TradableDays);
             _enablePriceScaling = enablePriceScaling;

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -257,8 +257,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                                     OnNumericalPrecisionLimited(
                                         new NumericalPrecisionLimitedEventArgs(_config.Symbol,
-                                            $"Data for symbol {_config.Symbol.Value} has been limited due to numerical precision issues in the factor file. " +
-                                            $"The starting date has been set to {_factorFile.FactorFileMinimumDate.Value.ToShortDateString()}."));
+                                            $"[{_config.Symbol.Value}, {_factorFile.FactorFileMinimumDate.Value.ToShortDateString()}]"));
                                 }
                             }
                         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Queue up logging from `SubscriptionDataReader` changing the start date of a subscription because of a factor file precision issue. 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5044 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Spam logging when having lots of assets that get adjusted because of factor file issues.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using a basic algo with GBSN running before 2016, (GBSN factor file minimum date is in 2016)

```cs
        /// <summary>
        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
        /// </summary>
        public override void Initialize()
        {
            SetStartDate(2015, 1, 1);  //Set Start Date
            SetEndDate(2018, 5, 15);    //Set End Date
            SetCash(100000);             //Set Strategy Cash

            AddUniverse(coarse => new[] { "GBSN" }
                .Select(x => QuantConnect.Symbol.Create(x, SecurityType.Equity, Market.USA)));
        }
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
