### PR TITLE
Refactor StartDateLimited Warning Logs

### DIFF
--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -20,7 +20,6 @@ using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
-using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.Results;
@@ -138,7 +137,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             // Log our numerical precision limited warnings if any
             if (!_numericalPrecisionLimitedWarnings.IsNullOrEmpty())
             {
-                var message = $"Due to numerical precision issues in the factor file, data for the following" +
+                var message = "Due to numerical precision issues in the factor file, data for the following" +
                     $" symbols was adjust to a later starting date: {string.Join(", ", _numericalPrecisionLimitedWarnings.Values.Take(_numericalPrecisionLimitedWarningsMaxCount))}";
 
                 // If we reached our max warnings count suggest that more may have been left out
@@ -153,8 +152,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             // Log our start date adjustments because of map files
             if (!_startDateLimitedWarnings.IsNullOrEmpty())
             {
-                var message = $"The starting dates for the following symbols have been adjusted to match their" +
-                    $" map files first date: {string.Join(", ", _numericalPrecisionLimitedWarnings.Values.Take(_numericalPrecisionLimitedWarningsMaxCount))}";
+                var message = "The starting dates for the following symbols have been adjusted to match their" +
+                    $" map files first date: {string.Join(", ", _startDateLimitedWarnings.Values.Take(_startDateLimitedWarningsMaxCount))}";
 
                 // If we reached our max warnings count suggest that more may have been left out
                 if (_startDateLimitedWarnings.Count >= _startDateLimitedWarningsMaxCount)

--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -40,6 +40,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         private readonly ZipDataCacheProvider _zipDataCacheProvider;
         private readonly ConcurrentDictionary<Symbol, string> _numericalPrecisionLimitedWarnings;
         private readonly int _numericalPrecisionLimitedWarningsMaxCount = 10;
+        private readonly ConcurrentDictionary<Symbol, string> _startDateLimitedWarnings;
+        private readonly int _startDateLimitedWarningsMaxCount = 10;
         private readonly Func<SubscriptionRequest, IEnumerable<DateTime>> _tradableDaysProvider;
         private readonly IMapFileProvider _mapFileProvider;
         private readonly bool _enablePriceScaling;
@@ -67,6 +69,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             _factorFileProvider = factorFileProvider;
             _zipDataCacheProvider = new ZipDataCacheProvider(dataProvider, isDataEphemeral: false);
             _numericalPrecisionLimitedWarnings = new ConcurrentDictionary<Symbol, string>();
+            _startDateLimitedWarnings = new ConcurrentDictionary<Symbol, string>();
             _isLiveMode = false;
             _tradableDaysProvider = tradableDaysProvider ?? (request => request.TradableDays);
             _enablePriceScaling = enablePriceScaling;
@@ -95,7 +98,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 );
 
             dataReader.InvalidConfigurationDetected += (sender, args) => { _resultHandler.ErrorMessage(args.Message); };
-            dataReader.StartDateLimited += (sender, args) => { _resultHandler.DebugMessage(args.Message); };
+            dataReader.StartDateLimited += (sender, args) =>
+            {
+                // Queue this warning into our dictionary to report on dispose
+                if (_startDateLimitedWarnings.Count <= _startDateLimitedWarningsMaxCount)
+                {
+                    _startDateLimitedWarnings.TryAdd(args.Symbol, args.Message);
+                }
+            };
             dataReader.DownloadFailed += (sender, args) => { _resultHandler.ErrorMessage(args.Message, args.StackTrace); };
             dataReader.ReaderErrorDetected += (sender, args) => { _resultHandler.RuntimeError(args.Message, args.StackTrace); };
             dataReader.NumericalPrecisionLimited += (sender, args) =>
@@ -139,7 +149,22 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
 
                 _resultHandler.DebugMessage(message);
             }
-           
+
+            // Log our start date adjustments because of map files
+            if (!_startDateLimitedWarnings.IsNullOrEmpty())
+            {
+                var message = $"The starting dates for the following symbols have been adjusted to match their" +
+                    $" map files first date: {string.Join(", ", _numericalPrecisionLimitedWarnings.Values.Take(_numericalPrecisionLimitedWarningsMaxCount))}";
+
+                // If we reached our max warnings count suggest that more may have been left out
+                if (_startDateLimitedWarnings.Count >= _startDateLimitedWarningsMaxCount)
+                {
+                    message += "...";
+                }
+
+                _resultHandler.DebugMessage(message);
+            }
+
             _zipDataCacheProvider?.DisposeSafely();
         }
     }

--- a/Engine/DataFeeds/SubscriptionDataReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataReader.cs
@@ -264,14 +264,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                         if (_periodStart < mapFile.FirstDate)
                         {
-                            var originalStart = _periodStart;
                             _periodStart = mapFile.FirstDate;
 
                             OnStartDateLimited(
                                 new StartDateLimitedEventArgs(_config.Symbol,
-                                    $"The starting date for symbol {_config.Symbol.Value}," +
-                                    $" {originalStart.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}, has been adjusted to match map file first date" +
-                                    $" {mapFile.FirstDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}."));
+                                    $"[{_config.Symbol.Value}," +
+                                    $" {mapFile.FirstDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}]"));
                         }
                     }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Adjust logging of start date changes in SubscriptionEnumeratorFactory to only log once on dispose.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Request](https://github.com/QuantConnect/Lean/pull/5508#pullrequestreview-648245874) in other PR #5508 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Further reduce cluttered logs

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the following test algo to verify behavior.

```cs
    public class TestAlgo : QCAlgorithm
    {
        public override void Initialize()
        {
            SetStartDate(2000, 1, 1);  //Set Start Date
            SetEndDate(2000, 2, 1);    //Set End Date

            AddUniverse(coarse => new[] { "GBSN", "AAPL", "AAA", "AIG", "BAC", "BNO", "EEM", "FB", "GOOG", "IBM", "IWM", "NWSA" }
                .Select(x => QuantConnect.Symbol.Create(x, SecurityType.Equity, Market.USA)));
        }
    }
``` 

```
20210429 17:01:06.192 TRACE:: Debug: The starting dates for the following symbols have been adjusted to match their map files first date: [GBSN, 3/28/2016]
```

To observe more in the list simply change start date year to 1997. 

```
20210429 17:02:55.187 TRACE:: Debug: The starting dates for the following symbols have been adjusted to match their map files first date: [IBM, 1/1/1998], [GBSN, 3/28/2016], [BAC, 1/1/1998], [AAPL, 1/1/1998], [GOOG, 1/1/1998], [BNO, 1/1/1998], [IWM, 1/1/1998], [AIG, 1/1/1998], [NWSA, 1/1/1998], [FB, 1/1/1998]...
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
