### PR TITLE
UniverseSelection SymbolCache Fix

### DIFF
--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -490,10 +490,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         {
                             _internalSubscriptionManager.RemovedSubscriptionRequest(subscription);
                             member.IsTradable = false;
-
-                            // remove symbol mappings for symbols removed from universes // TODO : THIS IS BAD!
-                            // only remove from cache if there is no universe using this data configuration
-                            SymbolCache.TryRemove(member.Symbol);
                         }
                     }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Stop UniverseSelection from removing symbols from the `SymbolCache`.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5499 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Universe Selection will often remove and re add certain subscriptions based on user or default filters. Upon removal in master we remove this symbol from our `SymbolCache`, but when this subscription is re-added it *does not* re-add this value to this `SymbolCache`. Thus causing the issue above.

This is because `UniverseSelection.ApplyUniverseSelection` creates the security the first time is is added which adds it symbol to cache in ` _securityService.CreateSecurity`, but once the security is created it exists forever, so when its re-added to the universe it uses the already created security, so the symbol cache does not get this value re-added.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All regressions are passing except those that are currently broken in Master, will address those asap.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
