### PR TITLE
Removes Assets that Are Not Invested and Not Tradable From Capacity Valculations

### DIFF
--- a/Algorithm.CSharp/AddAlphaModelAlgorithm.cs
+++ b/Algorithm.CSharp/AddAlphaModelAlgorithm.cs
@@ -130,7 +130,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.369"},
             {"Treynor Ratio", "-4.159"},
             {"Total Fees", "$14.46"},
-            {"Estimated Strategy Capacity", "$38000000.00"},
+            {"Estimated Strategy Capacity", "$39000000.00"},
             {"Fitness Score", "0.408"},
             {"Kelly Criterion Estimate", "16.438"},
             {"Kelly Criterion Probability Value", "0.314"},

--- a/Algorithm.CSharp/AddOptionContractExpiresRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddOptionContractExpiresRegressionAlgorithm.cs
@@ -139,7 +139,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.058"},
             {"Treynor Ratio", "2.117"},
             {"Total Fees", "$2.00"},
-            {"Estimated Strategy Capacity", "$45000000.00"},
+            {"Estimated Strategy Capacity", "$46000000.00"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/AddOptionContractFromUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddOptionContractFromUniverseRegressionAlgorithm.cs
@@ -191,7 +191,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.043"},
             {"Treynor Ratio", "0.291"},
             {"Total Fees", "$2.00"},
-            {"Estimated Strategy Capacity", "$2800000.00"},
+            {"Estimated Strategy Capacity", "$2900000.00"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/AddRemoveSecurityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddRemoveSecurityRegressionAlgorithm.cs
@@ -131,7 +131,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.073"},
             {"Treynor Ratio", "2.978"},
             {"Total Fees", "$26.48"},
-            {"Estimated Strategy Capacity", "$4400000.00"},
+            {"Estimated Strategy Capacity", "$56000000.00"},
             {"Fitness Score", "0.374"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesAlgorithm.cs
@@ -147,7 +147,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.507"},
             {"Treynor Ratio", "1.04"},
             {"Total Fees", "$15207.00"},
-            {"Estimated Strategy Capacity", "$7700.00"},
+            {"Estimated Strategy Capacity", "$7800.00"},
             {"Fitness Score", "0.033"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
@@ -161,7 +161,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$3.00"},
-            {"Estimated Strategy Capacity", "$74000.00"},
+            {"Estimated Strategy Capacity", "$6900000.00"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0.327"},
             {"Kelly Criterion Probability Value", "1"},

--- a/Algorithm.CSharp/CoarseFineFundamentalRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CoarseFineFundamentalRegressionAlgorithm.cs
@@ -181,7 +181,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.148"},
             {"Treynor Ratio", "-1.399"},
             {"Total Fees", "$2.00"},
-            {"Estimated Strategy Capacity", "$42000000.00"},
+            {"Estimated Strategy Capacity", "$43000000.00"},
             {"Fitness Score", "0.076"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/CoarseFineOptionUniverseChainRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CoarseFineOptionUniverseChainRegressionAlgorithm.cs
@@ -164,7 +164,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "3.578"},
             {"Treynor Ratio", "391705233723350"},
             {"Total Fees", "$13.00"},
-            {"Estimated Strategy Capacity", "$3000000.00"},
+            {"Estimated Strategy Capacity", "$38000000.00"},
             {"Fitness Score", "0.232"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/CoarseFundamentalTop3Algorithm.cs
+++ b/Algorithm.CSharp/CoarseFundamentalTop3Algorithm.cs
@@ -136,7 +136,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.125"},
             {"Treynor Ratio", "-0.605"},
             {"Total Fees", "$11.63"},
-            {"Estimated Strategy Capacity", "$46000000.00"},
+            {"Estimated Strategy Capacity", "$430000000.00"},
             {"Fitness Score", "0.012"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/DelistingFutureOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DelistingFutureOptionRegressionAlgorithm.cs
@@ -123,7 +123,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.117"},
             {"Treynor Ratio", "1.617"},
             {"Total Fees", "$37.00"},
-            {"Estimated Strategy Capacity", "$400000.00"},
+            {"Estimated Strategy Capacity", "$600000.00"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/EquityTradeAndQuotesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/EquityTradeAndQuotesRegressionAlgorithm.cs
@@ -184,7 +184,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.126"},
             {"Treynor Ratio", "-1.311"},
             {"Total Fees", "$669.76"},
-            {"Estimated Strategy Capacity", "$210000.00"},
+            {"Estimated Strategy Capacity", "$220000.00"},
             {"Fitness Score", "0.021"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/InceptionDateSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/InceptionDateSelectionRegressionAlgorithm.cs
@@ -116,7 +116,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.074"},
             {"Treynor Ratio", "0.58"},
             {"Total Fees", "$14.84"},
-            {"Estimated Strategy Capacity", "$6300000.00"},
+            {"Estimated Strategy Capacity", "$66000000.00"},
             {"Fitness Score", "0.2"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/MACDTrendAlgorithm.cs
+++ b/Algorithm.CSharp/MACDTrendAlgorithm.cs
@@ -118,7 +118,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.213"},
             {"Treynor Ratio", "-0.838"},
             {"Total Fees", "$468.55"},
-            {"Estimated Strategy Capacity", "$730000000.00"},
+            {"Estimated Strategy Capacity", "$750000000.00"},
             {"Fitness Score", "0.013"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
@@ -97,7 +97,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$12.00"},
-            {"Estimated Strategy Capacity", "$310000.00"},
+            {"Estimated Strategy Capacity", "$320000.00"},
             {"Fitness Score", "0.5"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/OptionRenameRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionRenameRegressionAlgorithm.cs
@@ -163,7 +163,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.002"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$4.00"},
-            {"Estimated Strategy Capacity", "$760000.00"},
+            {"Estimated Strategy Capacity", "$770000.00"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/OptionSplitRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionSplitRegressionAlgorithm.cs
@@ -146,7 +146,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.18"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$2.00"},
-            {"Estimated Strategy Capacity", "$88000.00"},
+            {"Estimated Strategy Capacity", "$90000.00"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/PortfolioRebalanceOnSecurityChangesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/PortfolioRebalanceOnSecurityChangesRegressionAlgorithm.cs
@@ -117,7 +117,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.208"},
             {"Treynor Ratio", "-0.848"},
             {"Total Fees", "$138.00"},
-            {"Estimated Strategy Capacity", "$47000000.00"},
+            {"Estimated Strategy Capacity", "$150000000.00"},
             {"Fitness Score", "0.027"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "1"},

--- a/Algorithm.CSharp/RenkoConsolidatorAlgorithm.cs
+++ b/Algorithm.CSharp/RenkoConsolidatorAlgorithm.cs
@@ -136,7 +136,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.139"},
             {"Treynor Ratio", "5.253"},
             {"Total Fees", "$129.35"},
-            {"Estimated Strategy Capacity", "$890000000.00"},
+            {"Estimated Strategy Capacity", "$910000000.00"},
             {"Fitness Score", "0.062"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
@@ -212,7 +212,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.071"},
             {"Treynor Ratio", "2.182"},
             {"Total Fees", "$34.54"},
-            {"Estimated Strategy Capacity", "$3200000.00"},
+            {"Estimated Strategy Capacity", "$2900000.00"},
             {"Fitness Score", "0.75"},
             {"Kelly Criterion Estimate", "23.96"},
             {"Kelly Criterion Probability Value", "0.075"},

--- a/Algorithm.CSharp/SectorExposureRiskFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/SectorExposureRiskFrameworkAlgorithm.cs
@@ -102,7 +102,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.135"},
             {"Treynor Ratio", "9.693"},
             {"Total Fees", "$25.46"},
-            {"Estimated Strategy Capacity", "$84000000.00"},
+            {"Estimated Strategy Capacity", "$190000000.00"},
             {"Fitness Score", "0.004"},
             {"Kelly Criterion Estimate", "-11.788"},
             {"Kelly Criterion Probability Value", "0.793"},

--- a/Algorithm.CSharp/SectorWeightingFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/SectorWeightingFrameworkAlgorithm.cs
@@ -128,7 +128,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.518"},
             {"Treynor Ratio", "0.34"},
             {"Total Fees", "$32.42"},
-            {"Estimated Strategy Capacity", "$49000000.00"},
+            {"Estimated Strategy Capacity", "$98000000.00"},
             {"Fitness Score", "0.093"},
             {"Kelly Criterion Estimate", "-50.377"},
             {"Kelly Criterion Probability Value", "0.689"},

--- a/Algorithm.CSharp/SetAccountCurrencyCashBuyingPowerModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SetAccountCurrencyCashBuyingPowerModelRegressionAlgorithm.cs
@@ -255,7 +255,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$48.58"},
-            {"Estimated Strategy Capacity", "$9000.00"},
+            {"Estimated Strategy Capacity", "$9200.00"},
             {"Fitness Score", "0.5"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/SetHoldingsFutureRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SetHoldingsFutureRegressionAlgorithm.cs
@@ -173,7 +173,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.201"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$1753.80"},
-            {"Estimated Strategy Capacity", "$2500000.00"},
+            {"Estimated Strategy Capacity", "$2600000.00"},
             {"Fitness Score", "0.5"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/StandardDeviationExecutionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StandardDeviationExecutionModelRegressionAlgorithm.cs
@@ -92,7 +92,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.098"},
             {"Treynor Ratio", "9.268"},
             {"Total Fees", "$245.52"},
-            {"Estimated Strategy Capacity", "$370000.00"},
+            {"Estimated Strategy Capacity", "$410000.00"},
             {"Fitness Score", "0.616"},
             {"Kelly Criterion Estimate", "34.534"},
             {"Kelly Criterion Probability Value", "0.444"},

--- a/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
@@ -214,7 +214,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.11"},
             {"Treynor Ratio", "-1.716"},
             {"Total Fees", "$21.00"},
-            {"Estimated Strategy Capacity", "$2700000000.00"},
+            {"Estimated Strategy Capacity", "$3100000000.00"},
             {"Fitness Score", "0.001"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},

--- a/Algorithm.CSharp/VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/VolumeWeightedAveragePriceExecutionModelRegressionAlgorithm.cs
@@ -94,7 +94,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.089"},
             {"Treynor Ratio", "2.918"},
             {"Total Fees", "$404.26"},
-            {"Estimated Strategy Capacity", "$420000.00"},
+            {"Estimated Strategy Capacity", "$300000.00"},
             {"Fitness Score", "0.936"},
             {"Kelly Criterion Estimate", "34.534"},
             {"Kelly Criterion Probability Value", "0.444"},

--- a/Common/CapacityEstimate.cs
+++ b/Common/CapacityEstimate.cs
@@ -44,7 +44,7 @@ namespace QuantConnect
         private HashSet<SymbolCapacity> _monitoredSymbolCapacitySet;
         private DateTime _nextSnapshotDate;
         private TimeSpan _snapshotPeriod;
-        private Symbol _smallestAssetSymbol = null;
+        private Symbol _smallestAssetSymbol;
 
         /// <summary>
         /// The total capacity of the strategy at a point in time

--- a/Common/CapacityEstimate.cs
+++ b/Common/CapacityEstimate.cs
@@ -21,7 +21,7 @@ using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
 
-namespace QuantConnect.Lean.Engine.Results
+namespace QuantConnect
 {
     /// <summary>
     /// Estimates dollar volume capacity of algorithm (in account currency) using all Symbols in the portfolio.

--- a/Common/CapacityEstimate.cs
+++ b/Common/CapacityEstimate.cs
@@ -135,8 +135,15 @@ namespace QuantConnect
                 }
 
                 var smallestAsset = _capacityBySymbol.Values
+                    // Do not account securities that have been delisted since the last snapshot
+                    .Where(c => !c.Security.IsDelisted)
                     .OrderBy(c => c.MarketCapacityDollarVolume)
-                    .First();
+                    .FirstOrDefault();
+
+                if (smallestAsset == null)
+                {
+                    return;
+                }
 
                 _smallestAssetSymbol = smallestAsset.Security.Symbol;
 

--- a/Common/Statistics/StatisticsBuilder.cs
+++ b/Common/Statistics/StatisticsBuilder.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Statistics
             decimal startingCapital,
             decimal totalFees,
             int totalTransactions,
-            decimal estimatedStrategyCapacity)
+            CapacityEstimate estimatedStrategyCapacity)
         {
             var equity = ChartPointToDictionary(pointsEquity);
 
@@ -57,7 +57,7 @@ namespace QuantConnect.Statistics
 
             var totalPerformance = GetAlgorithmPerformance(firstDate, lastDate, trades, profitLoss, equity, pointsPerformance, pointsBenchmark, startingCapital);
             var rollingPerformances = GetRollingPerformances(firstDate, lastDate, trades, profitLoss, equity, pointsPerformance, pointsBenchmark, startingCapital);
-            var summary = GetSummary(totalPerformance, totalFees, totalTransactions, estimatedStrategyCapacity);
+            var summary = GetSummary(totalPerformance, estimatedStrategyCapacity, totalFees, totalTransactions);
 
             return new StatisticsResults(totalPerformance, rollingPerformances, summary);
         }
@@ -166,7 +166,7 @@ namespace QuantConnect.Statistics
         /// <summary>
         /// Returns a summary of the algorithm performance as a dictionary
         /// </summary>
-        private static Dictionary<string, string> GetSummary(AlgorithmPerformance totalPerformance, decimal totalFees, int totalTransactions, decimal estimatedStrategyCapacity)
+        private static Dictionary<string, string> GetSummary(AlgorithmPerformance totalPerformance, CapacityEstimate estimatedStrategyCapacity, decimal totalFees, int totalTransactions)
         {
             return new Dictionary<string, string>
             {
@@ -190,7 +190,8 @@ namespace QuantConnect.Statistics
                 { "Tracking Error", Math.Round((double)totalPerformance.PortfolioStatistics.TrackingError, 3).ToStringInvariant() },
                 { "Treynor Ratio", Math.Round((double)totalPerformance.PortfolioStatistics.TreynorRatio, 3).ToStringInvariant() },
                 { "Total Fees", "$" + totalFees.ToStringInvariant("0.00") },
-                { "Estimated Strategy Capacity", "$" + estimatedStrategyCapacity.RoundToSignificantDigits(2).ToStringInvariant() }
+                { "Estimated Strategy Capacity", "$" + estimatedStrategyCapacity.Capacity.RoundToSignificantDigits(2).ToStringInvariant() },
+                { "Lowest Capacity Asset", estimatedStrategyCapacity.LowestCapacityAsset.ToString() },
             };
         }
 

--- a/Common/Statistics/StatisticsBuilder.cs
+++ b/Common/Statistics/StatisticsBuilder.cs
@@ -168,6 +168,14 @@ namespace QuantConnect.Statistics
         /// </summary>
         private static Dictionary<string, string> GetSummary(AlgorithmPerformance totalPerformance, CapacityEstimate estimatedStrategyCapacity, decimal totalFees, int totalTransactions)
         {
+            var capacity = 0m;
+            var lowestCapacitySymbol = Symbol.Empty;
+            if (estimatedStrategyCapacity != null)
+            {
+                capacity = estimatedStrategyCapacity.Capacity;
+                lowestCapacitySymbol = estimatedStrategyCapacity.LowestCapacityAsset ?? Symbol.Empty;
+            }
+
             return new Dictionary<string, string>
             {
                 { "Total Trades", totalTransactions.ToStringInvariant() },
@@ -190,8 +198,8 @@ namespace QuantConnect.Statistics
                 { "Tracking Error", Math.Round((double)totalPerformance.PortfolioStatistics.TrackingError, 3).ToStringInvariant() },
                 { "Treynor Ratio", Math.Round((double)totalPerformance.PortfolioStatistics.TreynorRatio, 3).ToStringInvariant() },
                 { "Total Fees", "$" + totalFees.ToStringInvariant("0.00") },
-                { "Estimated Strategy Capacity", "$" + estimatedStrategyCapacity.Capacity.RoundToSignificantDigits(2).ToStringInvariant() },
-                { "Lowest Capacity Asset", estimatedStrategyCapacity.LowestCapacityAsset.ToString() },
+                { "Estimated Strategy Capacity", "$" + capacity.RoundToSignificantDigits(2).ToStringInvariant() },
+                { "Lowest Capacity Asset", lowestCapacitySymbol.ToString() },
             };
         }
 

--- a/Common/Statistics/StatisticsBuilder.cs
+++ b/Common/Statistics/StatisticsBuilder.cs
@@ -172,7 +172,7 @@ namespace QuantConnect.Statistics
             var lowestCapacitySymbol = Symbol.Empty;
             if (estimatedStrategyCapacity != null)
             {
-                capacity = estimatedStrategyCapacity.Capacity;
+                capacity = estimatedStrategyCapacity.Capacity.Value;
                 lowestCapacitySymbol = estimatedStrategyCapacity.LowestCapacityAsset ?? Symbol.Empty;
             }
 

--- a/Common/SymbolCapacity.cs
+++ b/Common/SymbolCapacity.cs
@@ -21,7 +21,7 @@ using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
 
-namespace QuantConnect.Lean.Engine.Results
+namespace QuantConnect
 {
     /// <summary>
     /// Per-symbol capacity estimations, tightly coupled with the <see cref="CapacityEstimate"/> class.

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -202,8 +202,8 @@ namespace QuantConnect.Lean.Engine.Results
                         runtimeStatistics.Add(pair.Key, pair.Value);
                     }
                 }
-                var summary = GenerateStatisticsResults(performanceCharts, estimatedStrategyCapacity: _capacityEstimate.Capacity).Summary;
-                GetAlgorithmRuntimeStatistics(summary, runtimeStatistics, _capacityEstimate.Capacity);
+                var summary = GenerateStatisticsResults(performanceCharts, estimatedStrategyCapacity: _capacityEstimate).Summary;
+                GetAlgorithmRuntimeStatistics(summary, runtimeStatistics, _capacityEstimate);
 
                 var progress = (decimal)_daysProcessed / _jobDays;
                 if (progress > 0.999m) progress = 0.999m;
@@ -347,8 +347,8 @@ namespace QuantConnect.Lean.Engine.Results
                     var charts = new Dictionary<string, Chart>(Charts);
                     var orders = new Dictionary<int, Order>(TransactionHandler.Orders);
                     var profitLoss = new SortedDictionary<DateTime, decimal>(Algorithm.Transactions.TransactionRecord);
-                    var statisticsResults = GenerateStatisticsResults(charts, profitLoss, _capacityEstimate.Capacity);
-                    var runtime = GetAlgorithmRuntimeStatistics(statisticsResults.Summary, capacityEstimate: _capacityEstimate.Capacity);
+                    var statisticsResults = GenerateStatisticsResults(charts, profitLoss, _capacityEstimate);
+                    var runtime = GetAlgorithmRuntimeStatistics(statisticsResults.Summary, capacityEstimate: _capacityEstimate);
 
                     FinalStatistics = statisticsResults.Summary;
 

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -532,8 +532,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// Gets the algorithm runtime statistics
         /// </summary>
         protected Dictionary<string, string> GetAlgorithmRuntimeStatistics(Dictionary<string, string> summary,
-            Dictionary<string, string> runtimeStatistics = null,
-            decimal? capacityEstimate = null)
+            Dictionary<string, string> runtimeStatistics = null, CapacityEstimate capacityEstimate = null)
         {
             if (runtimeStatistics == null)
             {
@@ -560,7 +559,7 @@ namespace QuantConnect.Lean.Engine.Results
             runtimeStatistics["Volume"] = accountCurrencySymbol + Algorithm.Portfolio.TotalSaleVolume.ToStringInvariant("N2");
             if (capacityEstimate != null)
             {
-                runtimeStatistics["Capacity"] = accountCurrencySymbol + capacityEstimate.Value.RoundToSignificantDigits(2).ToFinancialFigures();
+                runtimeStatistics["Capacity"] = accountCurrencySymbol + capacityEstimate.Capacity.RoundToSignificantDigits(2).ToFinancialFigures();
             }
 
             return runtimeStatistics;
@@ -569,8 +568,8 @@ namespace QuantConnect.Lean.Engine.Results
         /// <summary>
         /// Will generate the statistics results and update the provided runtime statistics
         /// </summary>
-        protected StatisticsResults GenerateStatisticsResults(Dictionary<string, Chart> charts,
-            SortedDictionary<DateTime, decimal> profitLoss = null, decimal estimatedStrategyCapacity = 0m)
+        protected StatisticsResults GenerateStatisticsResults(Dictionary<string, Chart> charts, 
+            SortedDictionary<DateTime, decimal> profitLoss = null, CapacityEstimate estimatedStrategyCapacity = null)
         {
             var statisticsResults = new StatisticsResults();
             if (profitLoss == null)

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -559,7 +559,7 @@ namespace QuantConnect.Lean.Engine.Results
             runtimeStatistics["Volume"] = accountCurrencySymbol + Algorithm.Portfolio.TotalSaleVolume.ToStringInvariant("N2");
             if (capacityEstimate != null)
             {
-                runtimeStatistics["Capacity"] = accountCurrencySymbol + capacityEstimate.Capacity.RoundToSignificantDigits(2).ToFinancialFigures();
+                runtimeStatistics["Capacity"] = accountCurrencySymbol + capacityEstimate.Capacity.Value.RoundToSignificantDigits(2).ToFinancialFigures();
             }
 
             return runtimeStatistics;

--- a/Tests/Common/Statistics/StatisticsBuilderTests.cs
+++ b/Tests/Common/Statistics/StatisticsBuilderTests.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Tests.Common.Statistics
                     100000m,
                     0m,
                     1,
-                    0m);
+                    null);
             }, "Misaligned values provided, but we still generate statistics");
         }
 
@@ -122,7 +122,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 100000m,
                 0m,
                 1,
-                0m);
+                null);
 
             Assert.AreEqual(1, Math.Round(performance.TotalPerformance.PortfolioStatistics.Beta, 5));
             Assert.AreEqual(0, performance.TotalPerformance.PortfolioStatistics.Drawdown);


### PR DESCRIPTION
#### Description
Removes assets that are not invested and not tradable from capacity calculations. In the previous calculations, assets that were not invested were part of the calculations until the end of the execution. 
This PR also adds the smallest capacity asset to the results to help developers understand why their algorithms have low capacity.

#### Motivation and Context
Bug fix.

#### How Has This Been Tested?
Regression test. Also an Alpha in the market with a capacity of $250k being updated to $4mi.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`