### PR TITLE
Configurable MarketOnCloseOrder Buffer

### DIFF
--- a/Algorithm.CSharp/MarketOnCloseOrderBufferRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MarketOnCloseOrderBufferRegressionAlgorithm.cs
@@ -1,0 +1,134 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class MarketOnCloseOrderBufferRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private OrderTicket _validOrderTicket;
+        private OrderTicket _invalidOrderTicket;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 4); //Set Start Date
+            SetEndDate(2013, 10, 4); //Set End Date
+
+            var ticker = "SPY";
+            AddEquity(ticker, Resolution.Minute);
+
+            // Modify our submission buffer time to 10 minutes
+            Orders.MarketOnCloseOrder.SubmissionTimeBuffer = TimeSpan.FromMinutes(10);
+        }
+
+        public override void OnData(Slice slice)
+        {
+            // Test our ability to submit MarketOnCloseOrders
+            // Because we set our buffer to 10 minutes, any order placed
+            // before 3:50PM should be accepted, any after marked invalid
+
+            if (Time.Hour == 15 && Time.Minute == 49)
+            {
+                // Will not throw an order error and execute
+                _validOrderTicket = MarketOnCloseOrder("SPY", 2);
+            }
+
+            if (Time.Hour == 15 && Time.Minute == 51)
+            {
+                // Will throw an order error and be marked invalid
+                _invalidOrderTicket = MarketOnCloseOrder("SPY", 2);
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            // Verify that our good order filled
+            if (_validOrderTicket.Status != OrderStatus.Filled)
+            {
+                throw new Exception("Valid order failed to fill");
+            }
+
+            // Verify our order was marked invalid
+            if (_invalidOrderTicket.Status != OrderStatus.Invalid)
+            {
+                throw new Exception("Invalid order was not rejected");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$1.00"},
+            {"Estimated Strategy Capacity", "$20000000000.00"},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "0"},
+            {"Return Over Maximum Drawdown", "0"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "9fd6d48c807420293f903a8d8fdefd60"}
+        };
+    }
+}

--- a/Algorithm.Python/MarketOnCloseOrderBufferRegressionAlgorithm.py
+++ b/Algorithm.Python/MarketOnCloseOrderBufferRegressionAlgorithm.py
@@ -1,0 +1,56 @@
+﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System")
+AddReference("QuantConnect.Algorithm")
+AddReference("QuantConnect.Common")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+from QuantConnect.Securities import *
+from QuantConnect.Data.Market import *
+from QuantConnect.Orders import *
+from datetime import *
+
+class MarketOnCloseOrderBufferRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetStartDate(2013,10,4)   #Set Start Date
+        self.SetEndDate(2013,10,4)    #Set End Date
+
+        self.AddEquity("SPY", Resolution.Minute)
+
+        # Modify our submission buffer time to 10 minutes
+        MarketOnCloseOrder.SubmissionTimeBuffer = timedelta(minutes=10)
+
+    def OnData(self, data):
+        # Test our ability to submit MarketOnCloseOrders
+        # Because we set our buffer to 10 minutes, any order placed
+        # before 3:50PM should be accepted, any after marked invalid
+
+        # Will not throw an order error and execute
+        if self.Time.hour == 15 and self.Time.minute == 49:
+            self.validOrderTicket = self.MarketOnCloseOrder("SPY", 2)
+
+        # Will throw an order error and be marked invalid
+        if self.Time.hour == 15 and self.Time.minute == 51:
+            self.invalidOrderTicket = self.MarketOnCloseOrder("SPY", 2)
+
+    def OnEndOfAlgorithm(self):
+        if self.validOrderTicket.Status != OrderStatus.Filled:
+            raise Exception("Valid order failed to fill")
+
+        if self.invalidOrderTicket.Status != OrderStatus.Invalid:
+            raise Exception("Invalid order was not rejected")

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -239,6 +239,7 @@
     <None Include="main.py" />
     <None Include="MarginCallEventsAlgorithm.py" />
     <None Include="MarketOnOpenOnCloseAlgorithm.py" />
+    <None Include="MarketOnCloseOrderBufferRegressionAlgorithm.py" />
     <None Include="MaximumPortfolioDrawdownFrameworkAlgorithm.py" />
     <None Include="MeanVarianceOptimizationFrameworkAlgorithm.py" />
     <None Include="MovingAverageCrossAlgorithm.py" />

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -847,15 +847,16 @@ namespace QuantConnect.Algorithm
             {
                 var nextMarketClose = security.Exchange.Hours.GetNextMarketClose(security.LocalTime, false);
 
-                // must be submitted with at least 10 minutes in trading day, add buffer allow order submission
-                var latestSubmissionTime = nextMarketClose.Subtract(Orders.MarketOnCloseOrder.DefaultSubmissionTimeBuffer);
+                // Enforce MarketOnClose submission buffer
+                var latestSubmissionTime = nextMarketClose.Subtract(Orders.MarketOnCloseOrder.SubmissionTimeBuffer);
                 if (!security.Exchange.ExchangeOpen || Time > latestSubmissionTime)
                 {
-                    // tell the user we require a 16 minute buffer, on minute data in live a user will receive the 3:44->3:45 bar at 3:45,
-                    // this is already too late to submit one of these orders, so make the user do it at the 3:43->3:44 bar so it's submitted
-                    // to the brokerage before 3:45.
+                    // Tell user the required buffer on these orders, also inform them it can be changed for special cases.
+                    // Default buffer is 15.5 minutes because with minute data a user will receive the 3:44->3:45 bar at 3:45,
+                    // if the latest time is 3:45 it is already too late to submit one of these orders
                     return OrderResponse.Error(request, OrderResponseErrorCode.MarketOnCloseOrderTooLate,
-                        "MarketOnClose orders must be placed with at least a 16 minute buffer before market close."
+                        $"MarketOnClose orders must be placed within {Orders.MarketOnCloseOrder.SubmissionTimeBuffer} before market close." +
+                        "Override this TimeSpan buffer by setting Orders.MarketOnCloseOrder.SubmissionTimeBuffer in QCAlgorithm.Initialize()."
                     );
                 }
             }

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -856,7 +856,7 @@ namespace QuantConnect.Algorithm
                     // if the latest time is 3:45 it is already too late to submit one of these orders
                     return OrderResponse.Error(request, OrderResponseErrorCode.MarketOnCloseOrderTooLate,
                         $"MarketOnClose orders must be placed within {Orders.MarketOnCloseOrder.SubmissionTimeBuffer} before market close." +
-                        "Override this TimeSpan buffer by setting Orders.MarketOnCloseOrder.SubmissionTimeBuffer in QCAlgorithm.Initialize()."
+                        " Override this TimeSpan buffer by setting Orders.MarketOnCloseOrder.SubmissionTimeBuffer in QCAlgorithm.Initialize()."
                     );
                 }
             }

--- a/Common/Orders/MarketOnCloseOrder.cs
+++ b/Common/Orders/MarketOnCloseOrder.cs
@@ -35,6 +35,13 @@ namespace QuantConnect.Orders
         public static readonly TimeSpan DefaultSubmissionTimeBuffer = TimeSpan.FromMinutes(15.5);
 
         /// <summary>
+        /// The interval before market close that an MOC order may be submitted.
+        /// </summary>
+        /// <remarks>Configurable so advanced users may modify this for special cases;
+        /// Related issue: Github #5481</remarks>
+        public static TimeSpan SubmissionTimeBuffer = DefaultSubmissionTimeBuffer;
+
+        /// <summary>
         /// MarketOnClose Order Type
         /// </summary>
         public override OrderType Type

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -1145,7 +1145,7 @@ namespace QuantConnect.Lean.Engine
                         $", Active: {algorithm.UniverseManager.ActiveSecurities.Keys.Contains(split.Symbol)}");
                 }
 
-                var latestMarketOnCloseTimeRoundedDownByResolution = nextMarketClose.Subtract(MarketOnCloseOrder.DefaultSubmissionTimeBuffer)
+                var latestMarketOnCloseTimeRoundedDownByResolution = nextMarketClose.Subtract(MarketOnCloseOrder.SubmissionTimeBuffer)
                     .RoundDownInTimeZone(configs.GetHighestResolution().ToTimeSpan(), security.Exchange.TimeZone, configs.First().DataTimeZone);
 
                 // we don't need to do anyhing until the market closes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Add a public static TimeSpan var `SubmissionTimeBuffer` to `MarketOnCloseOrder` that is modifiable in special cases. 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5481

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows more advanced users to modify this value for exchanges they know accepts OnClose Market Orders later than 15 minutes before close. 

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Adding a note to the MarketOrderOnClose documentation would be nice for this.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using a simple algo to verify behavior.

```
    public class TestAlgo : QCAlgorithm
    {
        private bool Ordered;

        public override void Initialize()
        {
            SetStartDate(2013, 10, 4); //Set Start Date
            SetEndDate(2013, 10, 10); //Set End Date

            var ticker = "SPY";
            AddEquity(ticker, Resolution.Minute);
            Orders.MarketOnCloseOrder.SubmissionTimeBuffer = TimeSpan.FromMinutes(10);
        }

        public override void OnData(Slice slice)
        {
            if (!Ordered && Time.Hour == 15 && Time.Minute == 49)
            {
               // Will not throw an order error
                MarketOnCloseOrder("SPY", 2);
                Ordered = true;
            }

            if (Time.Hour == 15 && Time.Minute == 51)
            {
                // Will throw an order error
                MarketOnCloseOrder("SPY", 2);
            }
        }
    }
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
