### PR TITLE
Scheduled Universe Timed Triggers Bug

### DIFF
--- a/Common/Data/UniverseSelection/ScheduledUniverse.cs
+++ b/Common/Data/UniverseSelection/ScheduledUniverse.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -113,9 +113,11 @@ namespace QuantConnect.Data.UniverseSelection
         }
 
         /// <summary>
-        /// Returns an enumerator that defines when this user defined universe will be invoked
+        /// Get an enumerator of UTC DateTimes that defines when this universe will be invoked
         /// </summary>
-        /// <returns>An enumerator of DateTime that defines when this universe will be invoked</returns>
+        /// <param name="startTimeUtc">The start time of the range in UTC</param>
+        /// <param name="endTimeUtc">The end time of the range in UTC</param>
+        /// <returns>An enumerator of UTC DateTimes that defines when this universe will be invoked</returns>
         public IEnumerable<DateTime> GetTriggerTimes(DateTime startTimeUtc, DateTime endTimeUtc, MarketHoursDatabase marketHoursDatabase)
         {
             var startTimeLocal = startTimeUtc.ConvertFromUtc(Configuration.ExchangeTimeZone);
@@ -123,10 +125,21 @@ namespace QuantConnect.Data.UniverseSelection
 
             // define date/time rule enumerable
             var dates = _dateRule.GetDates(startTimeLocal, endTimeLocal);
-            foreach (var time in _timeRule.CreateUtcEventTimes(dates))
+            var times = _timeRule.CreateUtcEventTimes(dates).GetEnumerator();
+
+            // Make sure and filter out any times before our start time
+            // GH #5440
+            while (times.Current < startTimeUtc)
             {
-                yield return time;
+                times.MoveNext();
             }
+
+            while (times.MoveNext())
+            {
+                yield return times.Current;
+            }
+
+            times.Dispose();
         }
 
         private static SubscriptionDataConfig CreateConfiguration(DateTimeZone timeZone, IDateRule dateRule, ITimeRule timeRule)

--- a/Common/Data/UniverseSelection/ScheduledUniverse.cs
+++ b/Common/Data/UniverseSelection/ScheduledUniverse.cs
@@ -129,16 +129,18 @@ namespace QuantConnect.Data.UniverseSelection
 
             // Make sure and filter out any times before our start time
             // GH #5440
-            while (times.Current < startTimeUtc)
+            do
             {
                 times.MoveNext();
             }
+            while (times.Current < startTimeUtc);
 
-            while (times.MoveNext())
+            // Start yielding times
+            do
             {
                 yield return times.Current;
             }
-
+            while (times.MoveNext());
             times.Dispose();
         }
 

--- a/Common/Data/UniverseSelection/ScheduledUniverse.cs
+++ b/Common/Data/UniverseSelection/ScheduledUniverse.cs
@@ -133,6 +133,7 @@ namespace QuantConnect.Data.UniverseSelection
             {
                 if (!times.MoveNext())
                 {
+                    times.Dispose();
                     yield break;
                 }
             }

--- a/Common/Data/UniverseSelection/ScheduledUniverse.cs
+++ b/Common/Data/UniverseSelection/ScheduledUniverse.cs
@@ -131,7 +131,10 @@ namespace QuantConnect.Data.UniverseSelection
             // GH #5440
             do
             {
-                times.MoveNext();
+                if (!times.MoveNext())
+                {
+                    yield break;
+                }
             }
             while (times.Current < startTimeUtc);
 

--- a/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
+++ b/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
@@ -33,9 +33,9 @@ namespace QuantConnect.Tests.Common.Data.UniverseSelection
         [Test]
         public void TimeTriggeredIsCorrect()
         {
-            // Set up for the test; start time is 1/5/2000 a wednesday at 10AM
+            // Set up for the test; start time is 1/5/2000 a wednesday at 3PM
             var timezone = TimeZones.NewYork;
-            var start = new DateTime(2000, 1, 5, 10, 0, 0);
+            var start = new DateTime(2000, 1, 5, 15, 0, 0);
             var end = new DateTime(2000, 2, 1);
             var timekeeper = new TimeKeeper(start, timezone);
 
@@ -89,9 +89,6 @@ namespace QuantConnect.Tests.Common.Data.UniverseSelection
 
                 // Assert that this time is indeed 12PM local time
                 Assert.IsTrue(localTime.Hour == 12 && localTime.Minute == 0);
-
-                // Assert we aren't receiving dates after our end
-                Assert.IsTrue(localTime < end);
             }
         }
     }

--- a/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
+++ b/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
@@ -18,13 +18,9 @@ using System.Collections.Generic;
 using System.Linq;
 using NodaTime;
 using NUnit.Framework;
-using QuantConnect.Algorithm.Framework.Selection;
-using QuantConnect.Data;
-using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Scheduling;
 using QuantConnect.Securities;
-using QuantConnect.Logging;
 
 namespace QuantConnect.Tests.Common.Data.UniverseSelection
 {

--- a/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
+++ b/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
@@ -1,0 +1,98 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Scheduling;
+using QuantConnect.Securities;
+using QuantConnect.Logging;
+
+namespace QuantConnect.Tests.Common.Data.UniverseSelection
+{
+    [TestFixture]
+    public class ScheduledUniverseTests
+    {
+        [Test]
+        public void TimeTriggeredIsCorrect()
+        {
+            // Set up for the test; start time is 1/5/2000 a wednesday at 10AM
+            var timezone = TimeZones.NewYork;
+            var start = new DateTime(2000, 1, 5, 10, 0, 0);
+            var end = new DateTime(2000, 2, 1);
+            var timekeeper = new TimeKeeper(start, timezone);
+
+            var spy = new Security(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                new SubscriptionDataConfig(
+                    typeof(TradeBar),
+                    Symbol.Create("SPY", SecurityType.Equity, QuantConnect.Market.USA),
+                    Resolution.Minute,
+                    timezone,
+                    timezone,
+                    false,
+                    false,
+                    false
+                ),
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+
+            var securities = new SecurityManager(timekeeper)
+            {
+                spy
+            };
+
+            var dateRules = new DateRules(securities, timezone);
+            var timeRules = new TimeRules(securities, timezone);
+
+            // Schedule our universe for 12PM each day
+            var universe = new ScheduledUniverse( 
+                dateRules.EveryDay(spy.Symbol), timeRules.At(12, 0),
+                (time =>
+                {
+                    Log.Trace($"{time} : {timekeeper.GetTimeIn(timezone)}");
+                    return new List<Symbol>();
+                })
+            );
+
+            // Get our trigger times, these will be in UTC
+            var triggerTimesUtc = universe.GetTriggerTimes(start.ConvertToUtc(timezone), end.ConvertToUtc(timezone), MarketHoursDatabase.AlwaysOpen);
+
+            foreach (var time in triggerTimesUtc)
+            {
+                // Convert our UTC time back to our timezone
+                var localTime = time.ConvertFromUtc(timezone);
+
+                // Assert we aren't receiving dates prior to our start
+                Assert.IsTrue(localTime > start);
+
+                // Assert that this time is indeed 12PM local time
+                Assert.IsTrue(localTime.Hour == 12 && localTime.Minute == 0);
+
+                // Assert we aren't receiving dates after our end
+                Assert.IsTrue(localTime < end);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Address an issue with Scheduled Universe selection being triggered immediately in Live deployment if it is *AFTER* the scheduled event time already.

- Refactor `ScheduledUniverse` get trigger times to filter out any times before `StartTimeUtc`
- Add unit test for this specific case (red/green from master) and also no trigger times case (relevant to refactor)


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5440 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If an algo was deployed live with a `ScheduledUniverse` selection at 12pm and it was after this time, `ScheduledUniverse` `GetTriggerTimes()` would queue up an event for 12pm that day. Because this is backdated our subscriptionSynchronizer would emit it immediately on deployment. 

We want it to only occur at the appropriate time, and this PR addresses that.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test cases added, running regressions currently.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
