### PR TITLE
Regression Test Set Fix

### DIFF
--- a/Algorithm.CSharp/MarketOnCloseOrderBufferRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MarketOnCloseOrderBufferRegressionAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -60,6 +60,9 @@ namespace QuantConnect.Algorithm.CSharp
 
         public override void OnEndOfAlgorithm()
         {
+            // Set it back to default for other regressions
+            Orders.MarketOnCloseOrder.SubmissionTimeBuffer = Orders.MarketOnCloseOrder.DefaultSubmissionTimeBuffer;
+
             // Verify that our good order filled
             if (_validOrderTicket.Status != OrderStatus.Filled)
             {

--- a/Algorithm.Python/MarketOnCloseOrderBufferRegressionAlgorithm.py
+++ b/Algorithm.Python/MarketOnCloseOrderBufferRegressionAlgorithm.py
@@ -1,4 +1,4 @@
-﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
 # Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,6 +49,9 @@ class MarketOnCloseOrderBufferRegressionAlgorithm(QCAlgorithm):
             self.invalidOrderTicket = self.MarketOnCloseOrder("SPY", 2)
 
     def OnEndOfAlgorithm(self):
+        # Set it back to default for other regressions
+        MarketOnCloseOrder.SubmissionTimeBuffer = MarketOnCloseOrder.DefaultSubmissionTimeBuffer;
+
         if self.validOrderTicket.Status != OrderStatus.Filled:
             raise Exception("Valid order failed to fill")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Quick fix for regressions breaking when run in sequence

- Reset `SubmissionTimeBuffer` in `MarketOnCloseOrderBufferRegressionAlgorithm` `OnEndOfAlgorithm`

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
PR for this regression test initial commit #5516

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Regressions were failing when run together because of a minor bug, this PR fixes the issue.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All regressions are back to normal when ran together

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
