### PR TITLE
DataNormalizationMode Applies to AddSecurity

### DIFF
--- a/Algorithm.CSharp/RawDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RawDataRegressionAlgorithm.cs
@@ -14,12 +14,7 @@
 */
 
 using System;
-using QuantConnect.Data.UniverseSelection;
-using QuantConnect.Orders;
-using QuantConnect.Orders.Fees;
-using QuantConnect.Securities;
 using System.Collections.Generic;
-using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Interfaces;
@@ -99,7 +94,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp };
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/RawDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RawDataRegressionAlgorithm.cs
@@ -1,0 +1,152 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Orders;
+using QuantConnect.Orders.Fees;
+using QuantConnect.Securities;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// In this algorithm we demonstrate how to use the raw data for our securities
+    /// and verify that the behavior is correct.
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="regression test" />
+    public class RawDataRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private const string Ticker = "GOOGL";
+        private readonly FactorFile _factorFile = FactorFile.Read(Ticker, "USA");
+        private readonly IEnumerator<decimal> _expectedRawPrices = new List<decimal> { 1158.1100m, 1158.7200m,
+            1131.7800m, 1114.2800m, 1119.6100m, 1114.5500m, 1135.3200m, 567.59000m, 571.4900m, 545.3000m, 540.6400m }.GetEnumerator();
+        private Symbol _googl;
+
+        public override void Initialize()
+        {
+            SetStartDate(2014, 3, 25);      //Set Start Date
+            SetEndDate(2014, 4, 7);         //Set End Date
+            SetCash(100000);                            //Set Strategy Cash
+
+            // Set our DataNormalizationMode to raw
+            UniverseSettings.DataNormalizationMode = DataNormalizationMode.Raw;
+            _googl = AddEquity(Ticker, Resolution.Daily).Symbol;
+
+            // Prime our expected values
+            _expectedRawPrices.MoveNext();
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (!Portfolio.Invested)
+            {
+                SetHoldings(_googl, 1);
+            }
+
+            if (data.Bars.ContainsKey(_googl))
+            {
+                var googlData = data.Bars[_googl];
+
+                // Assert our volume matches what we expected
+                if (_expectedRawPrices.Current != googlData.Close)
+                {
+                    // Our values don't match lets try and give a reason why
+                    var dayFactor = _factorFile.GetPriceScaleFactor(googlData.Time);
+                    var probableRawPrice = googlData.Close / dayFactor; // Undo adjustment
+
+                    if (_expectedRawPrices.Current == probableRawPrice)
+                    {
+                        throw new Exception($"Close price was incorrect; it appears to be the adjusted value");
+                    }
+                    else
+                    {
+                        throw new Exception($"Close price was incorrect; Data may have changed.");
+                    }
+                }
+
+                // Move to our next expected value
+                _expectedRawPrices.MoveNext();
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "-85.948%"},
+            {"Drawdown", "7.300%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "-7.251%"},
+            {"Sharpe Ratio", "-3.008"},
+            {"Probabilistic Sharpe Ratio", "3.159%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "-0.831"},
+            {"Beta", "-0.223"},
+            {"Annual Standard Deviation", "0.262"},
+            {"Annual Variance", "0.069"},
+            {"Information Ratio", "-2.045"},
+            {"Tracking Error", "0.289"},
+            {"Treynor Ratio", "3.525"},
+            {"Total Fees", "$1.00"},
+            {"Estimated Strategy Capacity", "$110000000.00"},
+            {"Fitness Score", "0.006"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "-3.445"},
+            {"Return Over Maximum Drawdown", "-11.853"},
+            {"Portfolio Turnover", "0.084"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "3702afa2a5d1634ed451768917394502"}
+        };
+    }
+}

--- a/Algorithm.Python/RawDataRegressionAlgorithm.py
+++ b/Algorithm.Python/RawDataRegressionAlgorithm.py
@@ -1,0 +1,67 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clr import AddReference
+AddReference("System.Core")
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Algorithm")
+
+from System import *
+from QuantConnect import *
+from QuantConnect.Algorithm import QCAlgorithm
+from QuantConnect.Data.Auxiliary import FactorFile
+from QuantConnect.Data.UniverseSelection import *
+from QuantConnect.Orders import OrderStatus
+from QuantConnect.Orders.Fees import ConstantFeeModel
+
+_ticker = "GOOGL";
+_factorFile = FactorFile.Read(_ticker, "USA");
+_expectedRawPrices = [ 1158.1100, 1158.7200,
+1131.7800, 1114.2800, 1119.6100, 1114.5500, 1135.3200, 567.59000, 571.4900, 545.3000, 540.6400 ]
+
+# <summary>
+# In this algorithm we demonstrate how to use the raw data for our securities
+# and verify that the behavior is correct.
+# </summary>
+# <meta name="tag" content="using data" />
+# <meta name="tag" content="regression test" />
+class RawDataRegressionAlgorithm(QCAlgorithm):
+
+        def Initialize(self):
+            self.SetStartDate(2014, 3, 25);    
+            self.SetEndDate(2014, 4, 7);         
+            self.SetCash(100000);                            
+
+            # Set our DataNormalizationMode to raw
+            self.UniverseSettings.DataNormalizationMode = DataNormalizationMode.Raw;
+            self._googl = self.AddEquity(_ticker, Resolution.Daily).Symbol;
+        
+
+        def OnData(self, data):
+            if not self.Portfolio.Invested:
+                self.SetHoldings(self._googl, 1);
+
+            if (data.Bars.ContainsKey(self._googl)):
+                googlData = data.Bars[self._googl];
+
+                # Assert our volume matches what we expected
+                if _expectedRawPrices.pop(0) != googlData.Close:
+                    # Our values don't match lets try and give a reason why
+                    dayFactor = _factorFile.GetPriceScaleFactor(googlData.Time);
+                    probableRawPrice = googlData.Close / dayFactor; # Undo adjustment
+
+                    if _expectedRawPrices.Current == probableRawPrice:
+                        raise Exception("Close price was incorrect; it appears to be the adjusted value")
+                    else:
+                        raise Exception("Close price was incorrect; Data may have changed.")
+            

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2257,7 +2257,7 @@ namespace QuantConnect.Algorithm
                 symbol = QuantConnect.Symbol.Create(ticker, securityType, market);
             }
 
-            var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillDataForward, extendedMarketHours);
+            var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillDataForward, extendedMarketHours, dataNormalizationMode: UniverseSettings.DataNormalizationMode);
             var security = Securities.CreateSecurity(symbol, configs, leverage);
 
             AddToUserDefinedUniverse(security, configs);

--- a/Engine/DataFeeds/SubscriptionUtils.cs
+++ b/Engine/DataFeeds/SubscriptionUtils.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -101,10 +101,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             continue;
                         }
 
-                        var requestMode = config.DataNormalizationMode;
-                        var mode = requestMode != DataNormalizationMode.Raw
-                            ? requestMode
-                            : DataNormalizationMode.Adjusted;
+
+                        var mode = config.DataNormalizationMode;
+
                         // We update our price scale factor when the date changes for non fill forward bars or if we haven't initialized yet.
                         // We don't take into account auxiliary data because we don't scale it and because the underlying price data could be fill forwarded
                         if (enablePriceScale && data?.Time.Date > lastTradableDate && data.DataType != MarketDataType.Auxiliary && (!data.IsFillForward || lastTradableDate == DateTime.MinValue))

--- a/Engine/DataFeeds/SubscriptionUtils.cs
+++ b/Engine/DataFeeds/SubscriptionUtils.cs
@@ -101,8 +101,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             continue;
                         }
 
-
-                        var mode = config.DataNormalizationMode;
+                        // In the even we have "Raw" configuration, we will force our subscription data
+                        // to precalculate adjusted data. The data will still be emitted as raw, but
+                        // if the config is changed at any point it can emit adjusted data as well
+                        // See SubscriptionData.Create() and PrecalculatedSubscriptionData for more
+                        var requestMode = config.DataNormalizationMode;
+                        var mode = requestMode != DataNormalizationMode.Raw
+                            ? requestMode
+                            : DataNormalizationMode.Adjusted;
 
                         // We update our price scale factor when the date changes for non fill forward bars or if we haven't initialized yet.
                         // We don't take into account auxiliary data because we don't scale it and because the underlying price data could be fill forwarded

--- a/Engine/DataFeeds/SubscriptionUtils.cs
+++ b/Engine/DataFeeds/SubscriptionUtils.cs
@@ -101,7 +101,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             continue;
                         }
 
-                        // In the even we have "Raw" configuration, we will force our subscription data
+                        // In the event we have "Raw" configuration, we will force our subscription data
                         // to precalculate adjusted data. The data will still be emitted as raw, but
                         // if the config is changed at any point it can emit adjusted data as well
                         // See SubscriptionData.Create() and PrecalculatedSubscriptionData for more

--- a/Tests/Algorithm/AlgorithmUniverseSettingsTests.cs
+++ b/Tests/Algorithm/AlgorithmUniverseSettingsTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -84,6 +84,47 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(symbol, security.Symbol);
             Assert.AreEqual(spy, security);
             Assert.AreEqual(expected, security.DataNormalizationMode);
+        }
+
+        [Test]
+        public void CheckManualSecurityDataNormalizationModePersistenceAfterUniverseSetting()
+        {
+            var tuple = GetAlgorithmAndDataManager();
+            var algorithm = tuple.Item1;
+            var dataManager = tuple.Item2;
+
+            // Set our universe mode to raw
+            var universeMode = DataNormalizationMode.Raw;
+            algorithm.UniverseSettings.DataNormalizationMode = universeMode;
+
+            // Verify that the security was set to raw
+            var spy = algorithm.AddEquity("SPY");
+            Assert.AreEqual(universeMode, spy.DataNormalizationMode);
+
+            // Modify the mode of the security manually
+            var manualMode = DataNormalizationMode.TotalReturn;
+            spy.SetDataNormalizationMode(manualMode);
+            Assert.AreEqual(manualMode, spy.DataNormalizationMode);
+
+            var symbol = spy.Symbol;
+            algorithm.AddUniverse(coarse => new[] { symbol });
+            // OnEndOfTimeStep will add all pending universe additions
+            algorithm.OnEndOfTimeStep();
+
+            var changes = dataManager.UniverseSelection
+                .ApplyUniverseSelection(
+                    algorithm.UniverseManager.First().Value,
+                    algorithm.UtcTime,
+                    new BaseDataCollection(algorithm.UtcTime, null, Enumerable.Empty<CoarseFundamental>()));
+
+            Assert.AreEqual(1, changes.AddedSecurities.Count());
+
+            var security = changes.AddedSecurities.First();
+            Assert.AreEqual(symbol, security.Symbol);
+            Assert.AreEqual(spy, security);
+
+            // Assert that our manual setting persisted
+            Assert.AreEqual(manualMode, security.DataNormalizationMode);
         }
 
         private Tuple<QCAlgorithm, DataManager> GetAlgorithmAndDataManager()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Apply our `UniverseSettings.DataNormalizationMode` to securities added at the `QCAlgorithm` layer meaning `AddEquity`, `AddCrypto`, etc.
- Add comments on why `SubscriptionUtils.Create` is forcing Adjusted mode on SubscriptionData

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5524 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To unify data behavior the setting for `DataNormalizationMode` should apply to securities added in the algo.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- All tests still passing
- Included regression testing raw DNM (red/green from master)
- Additional unit test asserting manual DNM setting persistence

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
