### PR TITLE
Remove unused OpenJDK from DockerfileLeanFoundation

### DIFF
--- a/DockerfileLeanFoundation
+++ b/DockerfileLeanFoundation
@@ -21,8 +21,7 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test && apt-get update
 RUN add-apt-repository ppa:apt-fast/stable && apt-get update && apt-get -y install apt-fast
 RUN apt-fast install -y git bzip2 clang cmake curl unzip wget python3-pip python-opengl zlib1g-dev \
     xvfb libxrender1 libxtst6 libxi6 libglib2.0-dev libopenmpi-dev libstdc++6 openmpi-bin \
-    r-base pandoc libcurl4-openssl-dev \
-    openjdk-8-jdk openjdk-8-jre
+    r-base pandoc libcurl4-openssl-dev
 
 # Install IB Gateway: Installs to ~/Jts
 RUN wget https://cdn.quantconnect.com/interactive/ibgateway-stable-standalone-linux-x64-v978.2c.sh && \
@@ -153,7 +152,7 @@ RUN pip install --no-cache-dir      \
     pyflux==0.4.15                  \
     optuna==2.3.0                   \
     findiff==0.8.5                  \
-    sktime==0.3.0                   \ 
+    sktime==0.3.0                   \
     sktime-dl==0.1.0                \
     hyperopt==0.2.5                 \
     bayesian-optimization==1.2.0    \


### PR DESCRIPTION

#### Description
- Removed the OpenJDK install from the DockerfileLeanFoundation as it is no longer required for IB brokerge integration

#### Motivation and Context
- Since IBAutomater 1.0.35 (https://github.com/QuantConnect/IBAutomater/pull/28, merged in #4984) we are using the Java Runtime bundled with IBGateway, so

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.