### PR TITLE
Fix MeanVarianceOptimization Portfolio

### DIFF
--- a/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.cs
@@ -22,6 +22,7 @@ using QuantConnect.Algorithm.Framework.Alphas;
 using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Scheduling;
+using QuantConnect.Util;
 
 namespace QuantConnect.Algorithm.Framework.Portfolio
 {
@@ -233,6 +234,12 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         protected override Dictionary<Insight, double> DetermineTargetPercent(List<Insight> activeInsights)
         {
             var targets = new Dictionary<Insight, double>();
+
+            // If we have no insights just return an empty target list
+            if (activeInsights.IsNullOrEmpty())
+            {
+                return targets;
+            }
 
             var symbols = activeInsights.Select(x => x.Symbol).ToList();
 

--- a/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.py
@@ -1,4 +1,4 @@
-﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
 # Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -95,6 +95,11 @@ class MeanVarianceOptimizationPortfolioConstructionModel(PortfolioConstructionMo
         Returns:
         """
         targets = {}
+
+        # If we have no insights just return an empty target list
+        if len(activeInsights) == 0:
+            return targets
+
         symbols = [insight.Symbol for insight in activeInsights]
 
         # Create a dictionary keyed by the symbols in the insights with an pandas.Series as value to create a data frame


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Stop MeanVarianceOptimization Portfolio from attempting to process an empty list of insights that is currently causing MeanVarianceOptimizationFrameworkAlgorithm to fail in regression. 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5547

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
After the updates to ROC in #5501 that stopped it from emitting values before its ready, this optimization portfolio needed to be adjusted because its alpha now requires an extra turn to be ready before emitting insights. This caused an issue because the optimizer assumed that there were always insights so when it received an empty list on the first turn it attempted to optimize on that empty list of `insights`, thus triggering a bug in python where that list and later formed matrix were empty and dividing by the size of the matrix was a divide by zero case.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All regressions passing

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
