### PR TITLE
Support 2-leg currency conversions

### DIFF
--- a/Algorithm.CSharp/SetCashOnDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SetCashOnDataRegressionAlgorithm.cs
@@ -59,7 +59,7 @@ namespace QuantConnect.Algorithm.CSharp
             else
             {
                 var cash = Portfolio.CashBook["EUR"];
-                if (cash.ConversionRateSecurity == null
+                if (cash.CurrencyConversion == null
                     || cash.ConversionRate == 0)
                 {
                     throw new Exception("Expected 'EUR' Cash to be fully set");

--- a/Algorithm.CSharp/TwoLegCurrencyConversionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TwoLegCurrencyConversionRegressionAlgorithm.cs
@@ -38,9 +38,18 @@ namespace QuantConnect.Algorithm.CSharp
             SetAccountCurrency("ETH");
             SetCash("ETH", 100000);
             SetCash("LTC", 100000);
+            SetCash("USD", 100000);
 
             _ethUsdSymbol = AddCrypto("ETHUSD", Resolution.Minute).Symbol;
             _ltcUsdSymbol = AddCrypto("LTCUSD", Resolution.Minute).Symbol;
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (!Portfolio.Invested)
+            {
+                MarketOrder(_ltcUsdSymbol, 1);
+            }
         }
 
         public override void OnEndOfAlgorithm()
@@ -97,7 +106,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "0"},
+            {"Total Trades", "1"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
             {"Compounding Annual Return", "0%"},
@@ -117,12 +126,12 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$0.00"},
-            {"Estimated Strategy Capacity", "$0"},
+            {"Estimated Strategy Capacity", "$1800.00"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
             {"Sortino Ratio", "79228162514264337593543950335"},
-            {"Return Over Maximum Drawdown", "-137.671"},
+            {"Return Over Maximum Drawdown", "-139.899"},
             {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
@@ -137,7 +146,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+            {"OrderListHash", "9ffe1c1c11cbeaa5cc2d18048c4f3049"}
         };
     }
 }

--- a/Algorithm.CSharp/TwoLegCurrencyConversionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TwoLegCurrencyConversionRegressionAlgorithm.cs
@@ -1,0 +1,143 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm which tests that a two leg currency conversion happens correctly
+    /// </summary>
+    public class TwoLegCurrencyConversionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _ethUsdSymbol;
+        private Symbol _ltcUsdSymbol;
+
+        public override void Initialize()
+        {
+            SetStartDate(2018, 04, 04);
+            SetEndDate(2018, 04, 04);
+
+            // GDAX doesn't have LTCETH or ETHLTC, but they do have ETHUSD and LTCUSD to form a path between ETH and LTC
+            SetAccountCurrency("ETH");
+            SetCash("ETH", 100000);
+            SetCash("LTC", 100000);
+
+            _ethUsdSymbol = AddCrypto("ETHUSD", Resolution.Minute).Symbol;
+            _ltcUsdSymbol = AddCrypto("LTCUSD", Resolution.Minute).Symbol;
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            var ltcCash = Portfolio.CashBook["LTC"];
+
+            var conversionSymbols = ltcCash.CurrencyConversion.ConversionRateSecurities
+                .Select(x => x.Symbol)
+                .ToList();
+
+            if (conversionSymbols.Count != 2)
+            {
+                throw new Exception(
+                    $"Expected two conversion rate securities for LTC to ETH, is {conversionSymbols.Count}");
+            }
+
+            if (conversionSymbols[0] != _ltcUsdSymbol)
+            {
+                throw new Exception(
+                    $"Expected first conversion rate security from LTC to ETH to be {_ltcUsdSymbol}, is {conversionSymbols[0]}");
+            }
+
+            if (conversionSymbols[1] != _ethUsdSymbol)
+            {
+                throw new Exception(
+                    $"Expected second conversion rate security from LTC to ETH to be {_ethUsdSymbol}, is {conversionSymbols[1]}");
+            }
+
+            var ltcUsdValue = Securities[_ltcUsdSymbol].GetLastData().Value;
+            var ethUsdValue = Securities[_ethUsdSymbol].GetLastData().Value;
+
+            var expectedConversionRate = ltcUsdValue / ethUsdValue;
+            var actualConversionRate = ltcCash.ConversionRate;
+
+            if (actualConversionRate != expectedConversionRate)
+            {
+                throw new Exception(
+                    $"Expected conversion rate from LTC to ETH to be {expectedConversionRate}, is {actualConversionRate}");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "-137.671"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "Ξ0"},
+            {"Total Accumulated Estimated Alpha Value", "Ξ0"},
+            {"Mean Population Estimated Insight Value", "Ξ0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.Python/TwoLegCurrencyConversionRegressionAlgorithm.py
+++ b/Algorithm.Python/TwoLegCurrencyConversionRegressionAlgorithm.py
@@ -27,9 +27,14 @@ class TwoLegCurrencyConversionRegressionAlgorithm(QCAlgorithm):
         self.SetAccountCurrency("ETH")
         self.SetCash("ETH", 100000)
         self.SetCash("LTC", 100000)
+        self.SetCash("USD", 100000)
 
         self._ethUsdSymbol = self.AddCrypto("ETHUSD", Resolution.Minute).Symbol
         self._ltcUsdSymbol = self.AddCrypto("LTCUSD", Resolution.Minute).Symbol
+
+    def OnData(self, data):
+        if not self.Portfolio.Invested:
+            self.MarketOrder(self._ltcUsdSymbol, 1)
 
     def OnEndOfAlgorithm(self):
         ltcCash = self.Portfolio.CashBook["LTC"]

--- a/Algorithm.Python/TwoLegCurrencyConversionRegressionAlgorithm.py
+++ b/Algorithm.Python/TwoLegCurrencyConversionRegressionAlgorithm.py
@@ -1,0 +1,59 @@
+### QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+### Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+###
+### Licensed under the Apache License, Version 2.0 (the "License");
+### you may not use this file except in compliance with the License.
+### You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+###
+### Unless required by applicable law or agreed to in writing, software
+### distributed under the License is distributed on an "AS IS" BASIS,
+### WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+### See the License for the specific language governing permissions and
+### limitations under the License.
+
+from QuantConnect import *
+from QuantConnect.Algorithm import *
+
+
+### <summary>
+### Regression algorithm which tests that a two leg currency conversion happens correctly
+### </summary>
+class TwoLegCurrencyConversionRegressionAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        self.SetStartDate(2018, 4, 4)
+        self.SetEndDate(2018, 4, 4)
+
+        # GDAX doesn't have LTCETH or ETHLTC, but they do have ETHUSD and LTCUSD to form a path between ETH and LTC
+        self.SetAccountCurrency("ETH")
+        self.SetCash("ETH", 100000)
+        self.SetCash("LTC", 100000)
+
+        self._ethUsdSymbol = self.AddCrypto("ETHUSD", Resolution.Minute).Symbol
+        self._ltcUsdSymbol = self.AddCrypto("LTCUSD", Resolution.Minute).Symbol
+
+    def OnEndOfAlgorithm(self):
+        ltcCash = self.Portfolio.CashBook["LTC"]
+
+        conversionSymbols = [x.Symbol for x in ltcCash.CurrencyConversion.ConversionRateSecurities]
+
+        if len(conversionSymbols) != 2:
+            raise ValueError(
+                f"Expected two conversion rate securities for LTC to ETH, is {len(conversionSymbols)}")
+
+        if conversionSymbols[0] != self._ltcUsdSymbol:
+            raise ValueError(
+                f"Expected first conversion rate security from LTC to ETH to be {self._ltcUsdSymbol}, is {conversionSymbols[0]}")
+
+        if conversionSymbols[1] != self._ethUsdSymbol:
+            raise ValueError(
+                f"Expected second conversion rate security from LTC to ETH to be {self._ethUsdSymbol}, is {conversionSymbols[1]}")
+
+        ltcUsdValue = self.Securities[self._ltcUsdSymbol].GetLastData().Value
+        ethUsdValue = self.Securities[self._ethUsdSymbol].GetLastData().Value
+
+        expectedConversionRate = ltcUsdValue / ethUsdValue
+        actualConversionRate = ltcCash.ConversionRate
+
+        if actualConversionRate != expectedConversionRate:
+            raise ValueError(
+                f"Expected conversion rate from LTC to ETH to be {expectedConversionRate}, is {actualConversionRate}")

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -48,7 +48,9 @@ namespace QuantConnect.Securities
         /// If this cash represents the account currency, then <see cref="QuantConnect.Symbol.Empty"/>
         /// is returned
         /// </summary>
-        [Obsolete("This property has been made obsolete, use the symbols on the securities in CurrencyConversion.ConversionRateSecurities instead. This property only returns the symbol of the first security used to calculate conversion rates, there may be more.")]
+        [JsonIgnore]
+        [Obsolete("This property has been made obsolete, use SecuritySymbols instead.\n" +
+            "This property only returns the symbol of the first security used to calculate conversion rates, there may be more.")]
         public Symbol SecuritySymbol =>
             CurrencyConversion?.ConversionRateSecurities.First().Symbol ?? QuantConnect.Symbol.Empty;
 
@@ -57,8 +59,16 @@ namespace QuantConnect.Securities
         /// If this cash represents the account currency, then null is returned.
         /// </summary>
         [JsonIgnore]
-        [Obsolete("This property has been made obsolete, use CurrencyConversion.ConversionRateSecurities instead. This property only returns the first security used to calculate conversion rates, there may be more.")]
+        [Obsolete("This property has been made obsolete, use CurrencyConversion.ConversionRateSecurities instead.\n" +
+            "This property only returns the first security used to calculate conversion rates, there may be more.")]
         public Security ConversionRateSecurity => CurrencyConversion?.ConversionRateSecurities.First();
+
+        /// <summary>
+        /// Gets the symbols of the securities required to provide conversion rates.
+        /// If this cash represents the account currency, then an empty enumerable is returned.
+        /// </summary>
+        public IEnumerable<Symbol> SecuritySymbols =>
+            CurrencyConversion?.ConversionRateSecurities.Select(x => x.Symbol) ?? new List<Symbol>(0);
 
         /// <summary>
         /// Gets the object that calculates the conversion rate to account currency

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -44,26 +44,6 @@ namespace QuantConnect.Securities
         public event EventHandler Updated;
 
         /// <summary>
-        /// Gets the symbol of the first security required to provide conversion rates.
-        /// If this cash represents the account currency, then <see cref="QuantConnect.Symbol.Empty"/>
-        /// is returned
-        /// </summary>
-        [JsonIgnore]
-        [Obsolete("This property has been made obsolete, use SecuritySymbols instead.\n" +
-            "This property only returns the symbol of the first security used to calculate conversion rates, there may be more.")]
-        public Symbol SecuritySymbol =>
-            CurrencyConversion?.ConversionRateSecurities.First().Symbol ?? QuantConnect.Symbol.Empty;
-
-        /// <summary>
-        /// Gets the first security used to apply conversion rates.
-        /// If this cash represents the account currency, then null is returned.
-        /// </summary>
-        [JsonIgnore]
-        [Obsolete("This property has been made obsolete, use CurrencyConversion.ConversionRateSecurities instead.\n" +
-            "This property only returns the first security used to calculate conversion rates, there may be more.")]
-        public Security ConversionRateSecurity => CurrencyConversion?.ConversionRateSecurities.First();
-
-        /// <summary>
         /// Gets the symbols of the securities required to provide conversion rates.
         /// If this cash represents the account currency, then an empty enumerable is returned.
         /// </summary>

--- a/Common/Securities/CashBook.cs
+++ b/Common/Securities/CashBook.cs
@@ -130,7 +130,10 @@ namespace QuantConnect.Securities
                     defaultResolution);
                 if (subscriptionDataConfig != null)
                 {
-                    addedSubscriptionDataConfigs.Add(subscriptionDataConfig);
+                    foreach (var s in subscriptionDataConfig)
+                    {
+                        addedSubscriptionDataConfigs.Add(s);
+                    }
                 }
             }
             return addedSubscriptionDataConfigs;

--- a/Common/Securities/CashBook.cs
+++ b/Common/Securities/CashBook.cs
@@ -120,7 +120,7 @@ namespace QuantConnect.Securities
             {
                 var cash = kvp.Value;
 
-                var subscriptionDataConfig = cash.EnsureCurrencyDataFeed(
+                var subscriptionDataConfigs = cash.EnsureCurrencyDataFeed(
                     securities,
                     subscriptions,
                     marketMap,
@@ -128,11 +128,11 @@ namespace QuantConnect.Securities
                     securityService,
                     AccountCurrency,
                     defaultResolution);
-                if (subscriptionDataConfig != null)
+                if (subscriptionDataConfigs != null)
                 {
-                    foreach (var s in subscriptionDataConfig)
+                    foreach (var subscriptionDataConfig in subscriptionDataConfigs)
                     {
-                        addedSubscriptionDataConfigs.Add(s);
+                        addedSubscriptionDataConfigs.Add(subscriptionDataConfig);
                     }
                 }
             }

--- a/Common/Securities/Cfd/Cfd.cs
+++ b/Common/Securities/Cfd/Cfd.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using QuantConnect.Data;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.Fills;
@@ -116,6 +117,26 @@ namespace QuantConnect.Securities.Cfd
         public decimal MinimumPriceVariation
         {
             get { return SymbolProperties.MinimumPriceVariation; }
+        }
+
+        /// <summary>
+        /// Decomposes the specified currency pair into a base and quote currency provided as out parameters
+        /// </summary>
+        /// <param name="symbol">The input symbol to be decomposed</param>
+        /// <param name="symbolProperties">The symbol properties for this security</param>
+        /// <param name="baseCurrency">The output base currency</param>
+        /// <param name="quoteCurrency">The output quote currency</param>
+        public static void DecomposeCurrencyPair(Symbol symbol, SymbolProperties symbolProperties, out string baseCurrency, out string quoteCurrency)
+        {
+            quoteCurrency = symbolProperties.QuoteCurrency;
+            if (symbol.Value.EndsWith(quoteCurrency))
+            {
+                baseCurrency = symbol.Value.RemoveFromEnd(quoteCurrency);
+            }
+            else
+            {
+                throw new InvalidOperationException($"Symbol doesn't end with {quoteCurrency}");
+            }
         }
     }
 }

--- a/Common/Securities/CurrencyConversion/ICurrencyConversion.cs
+++ b/Common/Securities/CurrencyConversion/ICurrencyConversion.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace QuantConnect.Securities.CurrencyConversion
+{
+    public interface ICurrencyConversion
+    {
+        string SourceCurrency { get; }
+
+        string DestinationCurrency { get; }
+
+        decimal Update(); // pokes the component so it updates its state, and returns latest conversion
+
+        decimal GetConversion(); // gets the current conversion rate
+
+        IEnumerable<Security> GetConversionRateSecurities();
+    }
+}

--- a/Common/Securities/CurrencyConversion/ICurrencyConversion.cs
+++ b/Common/Securities/CurrencyConversion/ICurrencyConversion.cs
@@ -1,17 +1,52 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
 using System.Collections.Generic;
 
 namespace QuantConnect.Securities.CurrencyConversion
 {
+    /// <summary>
+    /// Represents a type capable of calculating the conversion rate between two currencies
+    /// </summary>
     public interface ICurrencyConversion
     {
+        /// <summary>
+        /// The currency this conversion converts from
+        /// </summary>
         string SourceCurrency { get; }
 
+        /// <summary>
+        /// The currency this conversion converts to
+        /// </summary>
         string DestinationCurrency { get; }
 
-        decimal Update(); // pokes the component so it updates its state, and returns latest conversion
+        /// <summary>
+        /// The current conversion rate between <see cref="SourceCurrency"/> and <see cref="DestinationCurrency"/>
+        /// </summary>
+        decimal ConversionRate { get; }
 
-        decimal GetConversion(); // gets the current conversion rate
+        /// <summary>
+        /// The securities which the conversion rate is based on
+        /// </summary>
+        IEnumerable<Security> ConversionRateSecurities { get; }
 
-        IEnumerable<Security> GetConversionRateSecurities();
+        /// <summary>
+        /// Updates the internal conversion rate based on the latest data, and returns the new conversion rate
+        /// </summary>
+        /// <returns>The new conversion rate</returns>
+        decimal Update();
     }
 }

--- a/Common/Securities/CurrencyConversion/SecurityCurrencyConversion.cs
+++ b/Common/Securities/CurrencyConversion/SecurityCurrencyConversion.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using QuantConnect.Data;
+using QuantConnect;
+using QuantConnect.Util;
+
+namespace QuantConnect.Securities.CurrencyConversion
+{
+    public class SecurityCurrencyConversion : ICurrencyConversion
+    {
+        /// <summary>
+        /// Class that holds Security for conversion and bool, which tells if rate should be inverted (1/rate)
+        /// </summary>
+        public class Step
+        {
+            public readonly Symbol Symbol;
+            public Security RateSecurity { get; private set; }
+            public readonly bool Inverted;
+            public decimal ConversionRate;
+
+            public string PairSymbol => RateSecurity.Symbol.Value;
+
+            public Step(Symbol symbol, Security rateSecurity, bool inverted = false)
+            {
+                this.Symbol = symbol;
+                this.RateSecurity = rateSecurity;
+                this.Inverted = inverted;
+
+                if (RateSecurity != null)
+                {
+                    Update(RateSecurity.GetLastData());
+                }
+            }
+
+            public void Update(BaseData data)
+            {
+                if (data != null && Symbol == data.Symbol)
+                {
+                    var rate = data.Value;
+
+                    if (Inverted)
+                    {
+                        rate = 1 / rate;
+                    }
+
+                    ConversionRate = rate;
+                }
+            }
+
+            public void SetSecurity(Security security)
+            {
+                if (security.Symbol.ID == Symbol.ID)
+                {
+                    RateSecurity = security;
+                }
+            }
+        }
+
+        private decimal _conversionRate = 1m;
+
+        private List<Security> _securities;
+
+        private List<Step> _steps;
+
+        // constructor is private, can't use new on this class
+        private SecurityCurrencyConversion()
+        {
+
+        }
+
+        /// <summary> List of available securities to use for conversion </summary>
+        public IReadOnlyList<Security> Securities { get { return _securities; } }
+
+        public IReadOnlyList<Step> ConversionSteps { get { return _steps;  } }
+
+        public string SourceCurrency { get; private set; }
+
+        public string DestinationCurrency { get; private set; }
+
+        public decimal GetConversion() { return _conversionRate; }
+
+        public decimal Update()
+        {
+            decimal newConversionRate = 0;
+            var stepWithDataFound = false;
+
+            _steps.ForEach(step =>
+            {
+                var lastData = step.RateSecurity.GetLastData();
+                if (lastData == null)
+                {
+                    return;
+                }
+
+                decimal price = lastData.Price;
+
+                if (price != 0m)
+                {
+                    if (!stepWithDataFound)
+                    {
+                        newConversionRate = 1;
+                        stepWithDataFound = true;
+                    }
+
+                    if (step.Inverted)
+                    {
+                        newConversionRate /= price;
+                    }
+                    else
+                    {
+                        newConversionRate *= price;
+                    }
+                }
+            });
+
+            _conversionRate = newConversionRate;
+
+            return _conversionRate;
+        }
+
+        public IEnumerable<Security> GetConversionRateSecurities()
+        {
+            return _steps.Select(step => step.RateSecurity);
+        }
+
+        // linear search for path
+        public static SecurityCurrencyConversion LinearSearch(string sourceCurrency, string destinationCurrency, IEnumerable<Security> existingSecurities, IEnumerable<Symbol> potentialSymbols, Func<Symbol, Security> makeNewSecurity)
+        {
+            var conversion = new SecurityCurrencyConversion();
+
+            conversion._securities = existingSecurities.ToList();
+
+            var symToSecMap = new Dictionary<Symbol, Security>();
+
+            var allSymbols = existingSecurities.Select(sec => sec.Symbol).Concat(potentialSymbols).Where(x => x.SecurityType == SecurityType.Crypto || x.Value.Length == 6);
+
+            // search existing _securities list, and if anything found, calculate if inverted and then return step
+            // 1 leg
+            foreach (var sym in allSymbols)
+            {
+                if (sym.PairContainsCode(sourceCurrency))
+                {
+                    if (sym.CurrencyPairDual(sourceCurrency) == destinationCurrency)
+                    {
+                        bool inverted = sym.ComparePair(sourceCurrency, destinationCurrency) == CurrencyPairUtil.Match.InverseMatch;
+
+
+                        var selection = existingSecurities.FirstOrDefault(s => s.Symbol == sym);
+
+                        if (selection != null)
+                        {
+                            conversion._steps = new List<Step>() { new Step(sym, selection, inverted) };
+                        }
+                        else
+                        {
+                            conversion._steps = new List<Step>() { new Step(sym, makeNewSecurity(sym), inverted) };
+                        }
+
+                        return conversion;
+                    }
+                }
+            }
+
+            // 2 legs
+            foreach (var sym1 in allSymbols)
+            {
+                if (sym1.PairContainsCode(sourceCurrency))
+                {
+                    var midCode = sym1.CurrencyPairDual(sourceCurrency);
+
+                    foreach (var sym2 in allSymbols)
+                    {
+                        if (sym2.PairContainsCode(midCode))
+                        {
+                            if (sym2.CurrencyPairDual(midCode) == destinationCurrency)
+                            {
+                                string baseCode;
+                                string quoteCode;
+
+                                CurrencyPairUtil.DecomposeCurrencyPair(sym1, out baseCode, out quoteCode);
+
+                                var selection = existingSecurities.Where(s => s.Symbol == sym1);
+
+                                // Step 1
+
+                                Step step1;
+
+                                if (selection.Any())
+                                {
+                                    step1 = new Step(sym1, selection.Single(), sourceCurrency == quoteCode);
+                                }
+                                else
+                                {
+                                    step1 = new Step(sym1, makeNewSecurity(sym1), sourceCurrency == quoteCode);
+                                }
+
+                                CurrencyPairUtil.DecomposeCurrencyPair(sym2, out baseCode, out quoteCode);
+
+                                selection = existingSecurities.Where(s => s.Symbol == sym2);
+
+                                // Step 2
+
+                                Step step2;
+
+                                if(selection.Any())
+                                {
+                                    step2 = new Step(sym2, selection.Single(), midCode == quoteCode);
+                                }
+                                else
+                                {
+                                    step2 = new Step(sym2, makeNewSecurity(sym2), midCode == quoteCode);
+                                }
+
+                                conversion._steps = new List<Step>() { step1, step2 };
+
+                                return conversion;
+                            }
+                        }
+                    }
+                }
+            }
+
+            throw new ArgumentException($"No conversion path found in availableSecurities list for sourceCurrency {sourceCurrency} and destinationCurrency {destinationCurrency}");
+        }
+    }
+}

--- a/Common/Securities/CurrencyConversion/SecurityCurrencyConversion.cs
+++ b/Common/Securities/CurrencyConversion/SecurityCurrencyConversion.cs
@@ -146,7 +146,8 @@ namespace QuantConnect.Securities.CurrencyConversion
             Func<Symbol, Security> makeNewSecurity)
         {
             var allSymbols = existingSecurities.Select(sec => sec.Symbol).Concat(potentialSymbols)
-                .Where(CurrencyPairUtil.IsDecomposable);
+                .Where(CurrencyPairUtil.IsDecomposable)
+                .ToList();
 
             var securitiesBySymbol = existingSecurities.Aggregate(new Dictionary<Symbol, Security>(),
                 (mapping, security) =>
@@ -244,12 +245,17 @@ namespace QuantConnect.Securities.CurrencyConversion
         {
             inverted = false;
 
-            if (!symbol.PairContainsCurrency(sourceCurrency))
+            string baseCurrency;
+            string quoteCurrency;
+
+            CurrencyPairUtil.DecomposeCurrencyPair(symbol, out baseCurrency, out quoteCurrency);
+
+            if (!CurrencyPairUtil.PairContainsCurrency(baseCurrency, quoteCurrency, sourceCurrency))
             {
                 return false;
             }
 
-            if (symbol.CurrencyPairDual(sourceCurrency) != destinationCurrency)
+            if (CurrencyPairUtil.CurrencyPairDual(baseCurrency, quoteCurrency, sourceCurrency) != destinationCurrency)
             {
                 return false;
             }

--- a/Common/Securities/CurrencyConversion/SecurityCurrencyConversion.cs
+++ b/Common/Securities/CurrencyConversion/SecurityCurrencyConversion.cs
@@ -166,54 +166,54 @@ namespace QuantConnect.Securities.CurrencyConversion
                 });
 
             // Search for 1 leg conversions
-            foreach (var symbol in allSymbols)
+            foreach (var potentialConversionRateSymbol in allSymbols)
             {
-                if (!symbol.PairContainsCurrency(sourceCurrency))
+                if (!potentialConversionRateSymbol.PairContainsCurrency(sourceCurrency))
                 {
                     continue;
                 }
 
-                if (symbol.CurrencyPairDual(sourceCurrency) != destinationCurrency)
+                if (potentialConversionRateSymbol.CurrencyPairDual(sourceCurrency) != destinationCurrency)
                 {
                     continue;
                 }
 
                 var steps = new List<Step>(1);
 
-                var inverted = symbol.ComparePair(sourceCurrency, destinationCurrency) ==
+                var inverted = potentialConversionRateSymbol.ComparePair(sourceCurrency, destinationCurrency) ==
                     CurrencyPairUtil.Match.InverseMatch;
 
                 Security existingSecurity;
-                if (securitiesBySymbol.TryGetValue(symbol, out existingSecurity))
+                if (securitiesBySymbol.TryGetValue(potentialConversionRateSymbol, out existingSecurity))
                 {
                     steps.Add(new Step(existingSecurity, inverted));
                 }
                 else
                 {
-                    steps.Add(new Step(makeNewSecurity(symbol), inverted));
+                    steps.Add(new Step(makeNewSecurity(potentialConversionRateSymbol), inverted));
                 }
 
                 return new SecurityCurrencyConversion(sourceCurrency, destinationCurrency, steps);
             }
 
             // Search for 2 leg conversions
-            foreach (var symbol1 in allSymbols)
+            foreach (var potentialConversionRateSymbol1 in allSymbols)
             {
-                if (!symbol1.PairContainsCurrency(sourceCurrency))
+                if (!potentialConversionRateSymbol1.PairContainsCurrency(sourceCurrency))
                 {
                     continue;
                 }
 
-                var middleCurrency = symbol1.CurrencyPairDual(sourceCurrency);
+                var middleCurrency = potentialConversionRateSymbol1.CurrencyPairDual(sourceCurrency);
 
-                foreach (var symbol2 in allSymbols)
+                foreach (var potentialConversionRateSymbol2 in allSymbols)
                 {
-                    if (!symbol2.PairContainsCurrency(middleCurrency))
+                    if (!potentialConversionRateSymbol2.PairContainsCurrency(middleCurrency))
                     {
                         continue;
                     }
 
-                    if (symbol2.CurrencyPairDual(middleCurrency) != destinationCurrency)
+                    if (potentialConversionRateSymbol2.CurrencyPairDual(middleCurrency) != destinationCurrency)
                     {
                         continue;
                     }
@@ -223,30 +223,38 @@ namespace QuantConnect.Securities.CurrencyConversion
                     string baseCurrency;
                     string quoteCurrency;
 
-                    CurrencyPairUtil.DecomposeCurrencyPair(symbol1, out baseCurrency, out quoteCurrency);
+                    CurrencyPairUtil.DecomposeCurrencyPair(
+                        potentialConversionRateSymbol1,
+                        out baseCurrency,
+                        out quoteCurrency);
 
                     // Step 1
                     Security existingSecurity1;
-                    if (securitiesBySymbol.TryGetValue(symbol1, out existingSecurity1))
+                    if (securitiesBySymbol.TryGetValue(potentialConversionRateSymbol1, out existingSecurity1))
                     {
                         steps.Add(new Step(existingSecurity1, sourceCurrency == quoteCurrency));
                     }
                     else
                     {
-                        steps.Add(new Step(makeNewSecurity(symbol1), sourceCurrency == quoteCurrency));
+                        steps.Add(
+                            new Step(makeNewSecurity(potentialConversionRateSymbol1), sourceCurrency == quoteCurrency));
                     }
 
-                    CurrencyPairUtil.DecomposeCurrencyPair(symbol2, out baseCurrency, out quoteCurrency);
+                    CurrencyPairUtil.DecomposeCurrencyPair(
+                        potentialConversionRateSymbol2,
+                        out baseCurrency,
+                        out quoteCurrency);
 
                     // Step 2
                     Security existingSecurity2;
-                    if (securitiesBySymbol.TryGetValue(symbol2, out existingSecurity2))
+                    if (securitiesBySymbol.TryGetValue(potentialConversionRateSymbol2, out existingSecurity2))
                     {
                         steps.Add(new Step(existingSecurity2, middleCurrency == quoteCurrency));
                     }
                     else
                     {
-                        steps.Add(new Step(makeNewSecurity(symbol2), middleCurrency == quoteCurrency));
+                        steps.Add(
+                            new Step(makeNewSecurity(potentialConversionRateSymbol2), middleCurrency == quoteCurrency));
                     }
 
                     return new SecurityCurrencyConversion(sourceCurrency, destinationCurrency, steps);

--- a/Common/Securities/CurrencyConversion/SecurityCurrencyConversion.cs
+++ b/Common/Securities/CurrencyConversion/SecurityCurrencyConversion.cs
@@ -180,6 +180,10 @@ namespace QuantConnect.Securities.CurrencyConversion
             foreach (var potentialConversionRateSymbol1 in allSymbols)
             {
                 var middleCurrency = potentialConversionRateSymbol1.CurrencyPairDual(sourceCurrency);
+                if (middleCurrency == null)
+                {
+                    continue;
+                }
 
                 foreach (var potentialConversionRateSymbol2 in allSymbols)
                 {

--- a/Common/Util/CurrencyPairUtil.cs
+++ b/Common/Util/CurrencyPairUtil.cs
@@ -139,8 +139,7 @@ namespace QuantConnect.Util
                 return baseCurrency;
             }
 
-            throw new ArgumentException(
-                $"The known symbol {knownSymbol} isn't contained in currency pair {baseCurrency}{quoteCurrency}.");
+            return null;
         }
 
         /// <summary>
@@ -184,35 +183,6 @@ namespace QuantConnect.Util
             }
 
             return Match.NoMatch;
-        }
-
-        /// <summary>
-        /// Returns whether a currency pair contains a certain currency as base or as quote
-        /// </summary>
-        /// <param name="pair">The currency pair to check the sides of</param>
-        /// <param name="currency">The currency to look for</param>
-        /// <returns>True if currency is the base or quote currency of pair, false if not</returns>
-        public static bool PairContainsCurrency(this Symbol pair, string currency)
-        {
-            string baseCurrency;
-            string quoteCurrency;
-
-            DecomposeCurrencyPair(pair, out baseCurrency, out quoteCurrency);
-
-            return PairContainsCurrency(baseCurrency, quoteCurrency, currency);
-        }
-
-        /// <summary>
-        /// Returns whether a currency pair contains a certain currency as base or as quote
-        /// </summary>
-        /// <param name="baseCurrency">The base currency of the currency pair</param>
-        /// <param name="quoteCurrency">The quote currency of the currency pair</param>
-        /// <param name="currency">The currency to look for</param>
-        /// <returns>True if currency is the base or quote currency of pair, false if not</returns>
-        public static bool PairContainsCurrency(string baseCurrency, string quoteCurrency, string currency)
-        {
-            return baseCurrency.Equals(currency, StringComparison.InvariantCultureIgnoreCase) ||
-                quoteCurrency.Equals(currency, StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/Common/Util/CurrencyPairUtil.cs
+++ b/Common/Util/CurrencyPairUtil.cs
@@ -1,0 +1,161 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Crypto;
+using QuantConnect.Securities.Forex;
+
+namespace QuantConnect.Util
+{
+    public static class CurrencyPairUtil
+    {
+        private static Lazy<SymbolPropertiesDatabase> symbolPropertiesDatabase = new Lazy<SymbolPropertiesDatabase>(SymbolPropertiesDatabase.FromDataFolder);
+
+        /// <summary>
+        /// Decomposes the specified currency pair into a base and quote currency provided as out parameters.
+        /// Requires symbols in Currencies.CurrencySymbols dictionary to make accurate splits, important for crypto-currency symbols.
+        /// </summary>
+        /// <param name="currencyPair">The input currency pair to be decomposed, for example, "EURUSD"</param>
+        /// <param name="baseCurrency">The output base currency</param>
+        /// <param name="quoteCurrency">The output quote currency</param>
+        public static void DecomposeCurrencyPair(Symbol currencyPair, out string baseCurrency, out string quoteCurrency)
+        {
+            if (currencyPair == null)
+            {
+                throw new ArgumentException($"Currency pair must not be null");
+            }
+
+            if (currencyPair.SecurityType == SecurityType.Crypto)
+            {
+                var symbolProperties = symbolPropertiesDatabase.Value.GetSymbolProperties(
+                    currencyPair.ID.Market,
+                    currencyPair,
+                    currencyPair.SecurityType,
+                    "USD");
+                Crypto.DecomposeCurrencyPair(currencyPair, symbolProperties, out baseCurrency, out quoteCurrency);
+            }
+            else
+            {
+                Forex.DecomposeCurrencyPair(currencyPair.Value, out baseCurrency, out quoteCurrency);
+            }
+        }
+
+        /// <summary>
+        /// You have currencyPair AB and one known symbol (A or B). This function returns another one (B or A).
+        /// </summary>
+        /// <param name="currencyPair">Currency pair AB</param>
+        /// <param name="knownSymbol">Known part of the currencyPair (either A or B)</param>
+        /// <returns>Returns other part of currencyPair (either B or A)</returns>
+        public static string CurrencyPairDual(this Symbol currencyPair, string knownSymbol)
+        {
+            string CurrencyA = null;
+            string CurrencyB = null;
+
+            DecomposeCurrencyPair(currencyPair, out CurrencyA, out CurrencyB);
+
+            if (CurrencyA == knownSymbol)
+            {
+                return CurrencyB;
+            }
+            else if (CurrencyB == knownSymbol)
+            {
+                return CurrencyA;
+            }
+            else
+            {
+                throw new ArgumentException($"The knownSymbol {knownSymbol} isn't contained in currencyPair {currencyPair}.");
+            }
+        }
+
+        public enum Match
+        {
+            /// <summary>
+            /// No match was found
+            /// </summary>
+            NoMatch,
+
+            /// <summary>
+            /// Pair was found exact as it is
+            /// </summary>
+            ExactMatch,
+
+            /// <summary>
+            /// Only inverse pair was found
+            /// </summary>
+            InverseMatch
+        }
+
+        public static Match ComparePair(this Symbol pairA, Symbol pairB)
+        {
+            if (pairA == pairB)
+            {
+                return Match.ExactMatch;
+            }
+
+            string baseA;
+            string quoteA;
+
+            DecomposeCurrencyPair(pairA, out baseA, out quoteA);
+
+            string baseB;
+            string quoteB;
+
+            DecomposeCurrencyPair(pairB, out baseB, out quoteB);
+
+            if(baseA == quoteB && baseB == quoteA)
+            {
+                return Match.InverseMatch;
+            }
+
+            return Match.NoMatch;
+        }
+
+        public static Match ComparePair(this Symbol pairA, string baseB, string quoteB)
+        {
+            if (pairA.Value == baseB + quoteB)
+            {
+                return Match.ExactMatch;
+            }
+
+            string baseA;
+            string quoteA;
+
+            DecomposeCurrencyPair(pairA, out baseA, out quoteA);
+
+            if (baseA == quoteB && baseB == quoteA)
+            {
+                return Match.InverseMatch;
+            }
+
+            return Match.NoMatch;
+        }
+
+        public static bool PairContainsCode(this Symbol pair, string code)
+        {
+            string baseCode;
+            string quoteCode;
+
+            DecomposeCurrencyPair(pair, out baseCode, out quoteCode);
+
+            return baseCode == code || quoteCode == code;
+        }
+
+    }
+}

--- a/Common/Util/CurrencyPairUtil.cs
+++ b/Common/Util/CurrencyPairUtil.cs
@@ -112,23 +112,35 @@ namespace QuantConnect.Util
         /// <returns>The other part of currencyPair (either B or A)</returns>
         public static string CurrencyPairDual(this Symbol currencyPair, string knownSymbol)
         {
-            string currencyA;
-            string currencyB;
+            string baseCurrency;
+            string quoteCurrency;
 
-            DecomposeCurrencyPair(currencyPair, out currencyA, out currencyB);
+            DecomposeCurrencyPair(currencyPair, out baseCurrency, out quoteCurrency);
 
-            if (currencyA == knownSymbol)
+            return CurrencyPairDual(baseCurrency, quoteCurrency, knownSymbol);
+        }
+
+        /// <summary>
+        /// You have currencyPair AB and one known symbol (A or B). This function returns the other symbol (B or A).
+        /// </summary>
+        /// <param name="baseCurrency">The base currency of the currency pair</param>
+        /// <param name="quoteCurrency">The quote currency of the currency pair</param>
+        /// <param name="knownSymbol">Known part of the currencyPair (either A or B)</param>
+        /// <returns>The other part of currencyPair (either B or A)</returns>
+        public static string CurrencyPairDual(string baseCurrency, string quoteCurrency, string knownSymbol)
+        {
+            if (baseCurrency == knownSymbol)
             {
-                return currencyB;
+                return quoteCurrency;
             }
 
-            if (currencyB == knownSymbol)
+            if (quoteCurrency == knownSymbol)
             {
-                return currencyA;
+                return baseCurrency;
             }
 
             throw new ArgumentException(
-                $"The known symbol {knownSymbol} isn't contained in currency pair {currencyPair}.");
+                $"The known symbol {knownSymbol} isn't contained in currency pair {baseCurrency}{quoteCurrency}.");
         }
 
         /// <summary>
@@ -166,11 +178,6 @@ namespace QuantConnect.Util
                 return Match.ExactMatch;
             }
 
-            string baseCurrencyA;
-            string quoteCurrencyA;
-
-            DecomposeCurrencyPair(pairA, out baseCurrencyA, out quoteCurrencyA);
-
             if (pairA.Value == quoteCurrencyB + baseCurrencyB)
             {
                 return Match.InverseMatch;
@@ -192,6 +199,18 @@ namespace QuantConnect.Util
 
             DecomposeCurrencyPair(pair, out baseCurrency, out quoteCurrency);
 
+            return PairContainsCurrency(baseCurrency, quoteCurrency, currency);
+        }
+
+        /// <summary>
+        /// Returns whether a currency pair contains a certain currency as base or as quote
+        /// </summary>
+        /// <param name="baseCurrency">The base currency of the currency pair</param>
+        /// <param name="quoteCurrency">The quote currency of the currency pair</param>
+        /// <param name="currency">The currency to look for</param>
+        /// <returns>True if currency is the base or quote currency of pair, false if not</returns>
+        public static bool PairContainsCurrency(string baseCurrency, string quoteCurrency, string currency)
+        {
             return baseCurrency.Equals(currency, StringComparison.InvariantCultureIgnoreCase) ||
                 quoteCurrency.Equals(currency, StringComparison.InvariantCultureIgnoreCase);
         }

--- a/Common/Util/CurrencyPairUtil.cs
+++ b/Common/Util/CurrencyPairUtil.cs
@@ -109,7 +109,7 @@ namespace QuantConnect.Util
         /// </summary>
         /// <param name="currencyPair">Currency pair AB</param>
         /// <param name="knownSymbol">Known part of the currencyPair (either A or B)</param>
-        /// <returns>The other part of currencyPair (either B or A)</returns>
+        /// <returns>The other part of currencyPair (either B or A), or null if known symbol is not part of currencyPair</returns>
         public static string CurrencyPairDual(this Symbol currencyPair, string knownSymbol)
         {
             string baseCurrency;
@@ -126,7 +126,7 @@ namespace QuantConnect.Util
         /// <param name="baseCurrency">The base currency of the currency pair</param>
         /// <param name="quoteCurrency">The quote currency of the currency pair</param>
         /// <param name="knownSymbol">Known part of the currencyPair (either A or B)</param>
-        /// <returns>The other part of currencyPair (either B or A)</returns>
+        /// <returns>The other part of currencyPair (either B or A), or null if known symbol is not part of the currency pair</returns>
         public static string CurrencyPairDual(string baseCurrency, string quoteCurrency, string knownSymbol)
         {
             if (baseCurrency == knownSymbol)

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -295,15 +295,11 @@ namespace QuantConnect.Lean.Engine
                 }
 
                 // poke each cash object to update from the recent security data
-                foreach (var kvp in algorithm.Portfolio.CashBook)
+                foreach (var cash in algorithm.Portfolio.CashBook.Values.Where(x => x.CurrencyConversion != null))
                 {
-                    var cash = kvp.Value;
-                    var updateData = cash.ConversionRateSecurity?.GetLastData();
-                    if (updateData != null)
-                    {
-                        cash.Update(updateData);
-                    }
+                    cash.Update();
                 }
+
                 // security prices got updated
                 algorithm.Portfolio.InvalidateTotalPortfolioValue();
 

--- a/Engine/Setup/BaseSetupHandler.cs
+++ b/Engine/Setup/BaseSetupHandler.cs
@@ -62,7 +62,7 @@ namespace QuantConnect.Lean.Engine.Setup
                 .ToList();
 
             var securitiesToUpdate = cashToUpdate
-                .SelectMany(x => x.CurrencyConversion.GetConversionRateSecurities())
+                .SelectMany(x => x.CurrencyConversion.ConversionRateSecurities)
                 .Distinct()
                 .ToList();
 

--- a/Engine/Setup/BaseSetupHandler.cs
+++ b/Engine/Setup/BaseSetupHandler.cs
@@ -122,8 +122,7 @@ namespace QuantConnect.Lean.Engine.Setup
                     $" Attempting to request daily resolution history to resolve conversion rate");
 
                 var unassignedCashSymbols = unassignedCash
-                    .SelectMany(x => x.CurrencyConversion.GetConversionRateSecurities())
-                    .Select(x => x.Symbol)
+                    .SelectMany(x => x.SecuritySymbols)
                     .ToHashSet();
 
                 var replacementHistoryRequests = new List<HistoryRequest>();

--- a/Engine/Setup/BaseSetupHandler.cs
+++ b/Engine/Setup/BaseSetupHandler.cs
@@ -58,27 +58,32 @@ namespace QuantConnect.Lean.Engine.Setup
 
             // now set conversion rates
             var cashToUpdate = algorithm.Portfolio.CashBook.Values
-                .Where(x => x.ConversionRateSecurity != null && x.ConversionRate == 0)
+                .Where(x => x.CurrencyConversion != null && x.ConversionRate == 0)
+                .ToList();
+
+            var securitiesToUpdate = cashToUpdate
+                .SelectMany(x => x.CurrencyConversion.GetConversionRateSecurities())
+                .Distinct()
                 .ToList();
 
             var historyRequestFactory = new HistoryRequestFactory(algorithm);
             var historyRequests = new List<HistoryRequest>();
-            foreach (var cash in cashToUpdate)
+            foreach (var security in securitiesToUpdate)
             {
                 var configs = algorithm
                     .SubscriptionManager
                     .SubscriptionDataConfigService
-                    .GetSubscriptionDataConfigs(cash.ConversionRateSecurity.Symbol,
+                    .GetSubscriptionDataConfigs(security.Symbol,
                         includeInternalConfigs: true);
 
                 // we need to order and select a specific configuration type
                 // so the conversion rate is deterministic
                 var configToUse = configs.OrderBy(x => x.TickType).First();
-                var hours = cash.ConversionRateSecurity.Exchange.Hours;
+                var hours = security.Exchange.Hours;
 
                 var resolution = configs.GetHighestResolution();
                 var startTime = historyRequestFactory.GetStartTimeAlgoTz(
-                    cash.ConversionRateSecurity.Symbol,
+                    security.Symbol,
                     10,
                     resolution,
                     hours,
@@ -89,7 +94,7 @@ namespace QuantConnect.Lean.Engine.Setup
                     configToUse,
                     startTime,
                     endTime,
-                    cash.ConversionRateSecurity.Exchange.Hours,
+                    security.Exchange.Hours,
                     resolution));
             }
 
@@ -97,26 +102,40 @@ namespace QuantConnect.Lean.Engine.Setup
             var slices = algorithm.HistoryProvider.GetHistory(historyRequests, algorithm.TimeZone);
             slices.PushThrough(data =>
             {
-                foreach (var cash in cashToUpdate
-                    .Where(x => x.ConversionRateSecurity.Symbol == data.Symbol))
+                foreach (var security in securitiesToUpdate.Where(x => x.Symbol == data.Symbol))
                 {
-                    cash.Update(data);
+                    security.SetMarketPrice(data);
                 }
             });
 
+            foreach (var cash in cashToUpdate)
+            {
+                cash.Update();
+            }
+
             // Any remaining unassigned cash will attempt to fall back to a daily resolution history request to resolve
-            var unassignedCash = cashToUpdate.Where(x => x.ConversionRate == 0).Select(x => x.SecuritySymbol).ToList();
+            var unassignedCash = cashToUpdate.Where(x => x.ConversionRate == 0).ToList();
             if (unassignedCash.Any())
             {
-                Log.Error($"Failed to assign conversion rates for the following cash: {string.Join(",", unassignedCash.Select(x => x.Value))}." +
+                Log.Error(
+                    $"Failed to assign conversion rates for the following cash: {string.Join(",", unassignedCash.Select(x => x.Symbol))}." +
                     $" Attempting to request daily resolution history to resolve conversion rate");
 
+                var unassignedCashSymbols = unassignedCash
+                    .SelectMany(x => x.CurrencyConversion.GetConversionRateSecurities())
+                    .Select(x => x.Symbol)
+                    .ToHashSet();
+
                 var replacementHistoryRequests = new List<HistoryRequest>();
-                foreach (var request in historyRequests.Where(x => unassignedCash.Contains(x.Symbol) && x.Resolution < Resolution.Daily))
+                foreach (var request in historyRequests.Where(x =>
+                    unassignedCashSymbols.Contains(x.Symbol) && x.Resolution < Resolution.Daily))
                 {
-                    var newRequest = new HistoryRequest(request.EndTimeUtc.AddDays(-10), request.EndTimeUtc, request.DataType,
-                        request.Symbol, Resolution.Daily, request.ExchangeHours, request.DataTimeZone, request.FillForwardResolution,
-                        request.IncludeExtendedMarketHours, request.IsCustomData, request.DataNormalizationMode, request.TickType);
+                    var newRequest = new HistoryRequest(request.EndTimeUtc.AddDays(-10), request.EndTimeUtc,
+                        request.DataType,
+                        request.Symbol, Resolution.Daily, request.ExchangeHours, request.DataTimeZone,
+                        request.FillForwardResolution,
+                        request.IncludeExtendedMarketHours, request.IsCustomData, request.DataNormalizationMode,
+                        request.TickType);
 
                     replacementHistoryRequests.Add(newRequest);
                 }
@@ -124,12 +143,16 @@ namespace QuantConnect.Lean.Engine.Setup
                 slices = algorithm.HistoryProvider.GetHistory(replacementHistoryRequests, algorithm.TimeZone);
                 slices.PushThrough(data =>
                 {
-                    foreach (var cash in cashToUpdate
-                        .Where(x => x.ConversionRateSecurity.Symbol == data.Symbol))
+                    foreach (var security in securitiesToUpdate.Where(x => x.Symbol == data.Symbol))
                     {
-                        cash.Update(data);
+                        security.SetMarketPrice(data);
                     }
                 });
+
+                foreach (var cash in unassignedCash)
+                {
+                    cash.Update();
+                }
             }
 
             Log.Trace("BaseSetupHandler.SetupCurrencyConversions():" +

--- a/Report/PortfolioLooper/PortfolioLooper.cs
+++ b/Report/PortfolioLooper/PortfolioLooper.cs
@@ -367,10 +367,11 @@ namespace QuantConnect.Report
 
                         foreach (var quoteBar in updateSlice.QuoteBars.Values)
                         {
-                            // We need to ensure that the currency pair we're converting matches our slice symbol
-                            foreach (var cash in Algorithm.Portfolio.CashBook.Values.Where(x => x.ConversionRateSecurity != null && x.ConversionRateSecurity.Symbol == quoteBar.Symbol))
+                            Algorithm.Securities[quoteBar.Symbol].SetMarketPrice(quoteBar);
+
+                            foreach (var cash in Algorithm.Portfolio.CashBook.Values)
                             {
-                                cash.Update(quoteBar);
+                                cash.Update();
                             }
                         }
 

--- a/Tests/Common/Securities/CashBookTests.cs
+++ b/Tests/Common/Securities/CashBookTests.cs
@@ -147,7 +147,7 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
-        public void UpdateEventCalledForCashUpdates()
+        public void UpdateEventCalledForCashUpdatesWhenAccessingConversionRate()
         {
             var cashBook = new CashBook();
             var called = false;
@@ -161,6 +161,7 @@ namespace QuantConnect.Tests.Common.Securities
                 }
             };
             cash.Update();
+            var conversionRate = cash.ConversionRate;
 
             Assert.IsTrue(called);
         }
@@ -260,9 +261,11 @@ namespace QuantConnect.Tests.Common.Securities
                 updatedCalled = updateType == CashBook.UpdateType.Updated;
             };
             cash.Update();
+            var conversionRate = cash.ConversionRate;
             Assert.IsFalse(called);
 
             cash2.Update();
+            var conversionRate2 = cash2.ConversionRate;
             Assert.IsTrue(updatedCalled);
         }
 

--- a/Tests/Common/Securities/CashBookTests.cs
+++ b/Tests/Common/Securities/CashBookTests.cs
@@ -160,7 +160,7 @@ namespace QuantConnect.Tests.Common.Securities
                     called = true;
                 }
             };
-            cash.Update(new Tick { Value = 10 });
+            cash.Update();
 
             Assert.IsTrue(called);
         }
@@ -238,7 +238,7 @@ namespace QuantConnect.Tests.Common.Securities
             {
                 called = true;
             };
-            cash.Update(new Tick { Value = 10 });
+            cash.Update();
 
             Assert.IsFalse(called);
         }
@@ -259,10 +259,10 @@ namespace QuantConnect.Tests.Common.Securities
                 called = true;
                 updatedCalled = updateType == CashBook.UpdateType.Updated;
             };
-            cash.Update(new Tick { Value = 10 });
+            cash.Update();
             Assert.IsFalse(called);
 
-            cash2.Update(new Tick { Value = 10 });
+            cash2.Update();
             Assert.IsTrue(updatedCalled);
         }
 

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -140,11 +140,11 @@ namespace QuantConnect.Tests.Common.Securities
             );
             var usdjpy = new Security(Symbols.USDJPY, SecurityExchangeHours, new Cash("JPY", 0, 0), SymbolProperties.GetDefault("JPY"), ErrorCurrencyConverter.Instance, RegisteredSecurityDataTypesProvider.Null, new SecurityCache());
             var changes = new SecurityChanges(new[] { usdjpy }, Enumerable.Empty<Security>());
-            var addedSecurity = cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, changes, dataManager.SecurityService, cashBook.AccountCurrency);
+            var addedSecurities = cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, changes, dataManager.SecurityService, cashBook.AccountCurrency);
 
             // the security exists in SecurityChanges so it is NOT added to the security manager or subscriptions
             // this security will be added by the algorithm manager
-            Assert.IsNull(addedSecurity);
+            Assert.True(addedSecurities == null || addedSecurities.Count == 0);
         }
 
         [Test]
@@ -297,23 +297,30 @@ namespace QuantConnect.Tests.Common.Securities
                     )
                 }
             };
-            var symbol1 = quoteCash.EnsureCurrencyDataFeed(securities,
-                subscriptions,
-                MarketMap,
-                SecurityChanges.None,
-                dataManager.SecurityService,
-                accountCurrency);
-            Assert.IsNotNull(symbol1);
-            Assert.AreEqual(quoteCurrencySymbol, symbol1.Symbol.Value);
 
-            var symbol2 = baseCash.EnsureCurrencyDataFeed(securities,
+            var configs1 = quoteCash.EnsureCurrencyDataFeed(securities,
                 subscriptions,
                 MarketMap,
                 SecurityChanges.None,
                 dataManager.SecurityService,
                 accountCurrency);
-            Assert.IsNotNull(symbol2);
-            Assert.AreEqual(baseCurrencySymbol, symbol2.Symbol.Value);
+            Assert.AreEqual(1, configs1.Count);
+
+            var config1 = configs1[0];
+            Assert.IsNotNull(config1);
+            Assert.AreEqual(quoteCurrencySymbol, config1.Symbol.Value);
+
+            var configs2 = baseCash.EnsureCurrencyDataFeed(securities,
+                subscriptions,
+                MarketMap,
+                SecurityChanges.None,
+                dataManager.SecurityService,
+                accountCurrency);
+            Assert.AreEqual(1, configs2.Count);
+
+            var config2 = configs2[0];
+            Assert.IsNotNull(config2);
+            Assert.AreEqual(baseCurrencySymbol, config2.Symbol.Value);
         }
 
         public void EnsureInternalCurrencyDataFeedsForNonUsdQuoteCurrencyGetAdded()
@@ -457,24 +464,23 @@ namespace QuantConnect.Tests.Common.Securities
             var dataManager = new DataManagerStub(TimeKeeper);
             subscriptions.SetDataManager(dataManager);
             var securities = new SecurityManager(TimeKeeper);
-            securities.Add(
-                Symbols.USDJPY,
-                new Security(
-                    SecurityExchangeHours,
-                    subscriptions.Add(Symbols.USDJPY, Resolution.Minute, TimeZone, TimeZone),
-                    new Cash(cashBook.AccountCurrency, 0, 1m),
-                    SymbolProperties.GetDefault(cashBook.AccountCurrency),
-                    ErrorCurrencyConverter.Instance,
-                    RegisteredSecurityDataTypesProvider.Null,
-                    new SecurityCache()
-                )
+            var security = new Security(
+                SecurityExchangeHours,
+                subscriptions.Add(Symbols.USDJPY, Resolution.Minute, TimeZone, TimeZone),
+                new Cash(cashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(cashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
             );
+            securities.Add(Symbols.USDJPY, security);
 
             // we need to get subscription index
             cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, SecurityChanges.None, dataManager.SecurityService, cashBook.AccountCurrency);
 
             var last = 120m;
-            cash.Update(new Tick(DateTime.Now, Symbols.USDJPY, last, 119.95m, 120.05m));
+            security.SetMarketPrice(new Tick(DateTime.Now, Symbols.USDJPY, last, 119.95m, 120.05m));
+            cash.Update();
 
             // jpy is inverted, so compare on the inverse
             Assert.AreEqual(1 / last, cash.ConversionRate);
@@ -493,24 +499,23 @@ namespace QuantConnect.Tests.Common.Securities
             var dataManager = new DataManagerStub(TimeKeeper);
             subscriptions.SetDataManager(dataManager);
             var securities = new SecurityManager(TimeKeeper);
-            securities.Add(
-                Symbols.GBPUSD,
-                new Security(
-                    SecurityExchangeHours,
-                    subscriptions.Add(Symbols.GBPUSD, Resolution.Minute, TimeZone, TimeZone),
-                    new Cash(cashBook.AccountCurrency, 0, 1m),
-                    SymbolProperties.GetDefault(cashBook.AccountCurrency),
-                    ErrorCurrencyConverter.Instance,
-                    RegisteredSecurityDataTypesProvider.Null,
-                    new SecurityCache()
-                )
+            var security = new Security(
+                SecurityExchangeHours,
+                subscriptions.Add(Symbols.GBPUSD, Resolution.Minute, TimeZone, TimeZone),
+                new Cash(cashBook.AccountCurrency, 0, 1m),
+                SymbolProperties.GetDefault(cashBook.AccountCurrency),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
             );
+            securities.Add(Symbols.GBPUSD, security);
 
             // we need to get subscription index
             cash.EnsureCurrencyDataFeed(securities, subscriptions, MarketMap, SecurityChanges.None, dataManager.SecurityService, cashBook.AccountCurrency);
 
             var last = 1.5m;
-            cash.Update(new Tick(DateTime.Now, Symbols.GBPUSD, last, last * 1.009m, last * 0.009m));
+            security.SetMarketPrice(new Tick(DateTime.Now, Symbols.GBPUSD, last, last * 1.009m, last * 0.009m));
+            cash.Update();
 
             // jpy is inverted, so compare on the inverse
             Assert.AreEqual(last, cash.ConversionRate);
@@ -535,7 +540,7 @@ namespace QuantConnect.Tests.Common.Securities
             {
                 called = true;
             };
-            cash.Update(new Tick { Value = 10 } );
+            cash.Update();
             Assert.IsTrue(called);
         }
 
@@ -601,7 +606,7 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [TestCaseSource(nameof(cryptoBrokerageStableCoinCases))]
-        public void CryptoStableCoinMappingIsCorrect(IBrokerageModel brokerageModel, string accountCurrency, string stableCoin, bool shouldThrow, Symbol expectedConversionSymbol)
+        public void CryptoStableCoinMappingIsCorrect(IBrokerageModel brokerageModel, string accountCurrency, string stableCoin, bool shouldThrow, Symbol[] expectedConversionSymbols)
         {
             var cashBook = new CashBook() {AccountCurrency = accountCurrency};
             var cash = new Cash(stableCoin, 10m, 1m);
@@ -629,13 +634,20 @@ namespace QuantConnect.Tests.Common.Securities
             }
 
             // Verify the conversion symbol is correct
-            if (expectedConversionSymbol == null)
+            if (expectedConversionSymbols == null)
             {
-                Assert.IsNull(cash.ConversionRateSecurity);
+                Assert.IsNull(cash.CurrencyConversion);
             }
             else
             {
-                Assert.AreEqual(expectedConversionSymbol, cash.ConversionRateSecurity.Symbol);
+                Assert.IsNotNull(cash.CurrencyConversion);
+
+                var actualConversionSymbols = cash.CurrencyConversion
+                                                  .GetConversionRateSecurities()
+                                                  .Select(x => x.Symbol)
+                                                  .ToArray();
+
+                Assert.AreEqual(expectedConversionSymbols, actualConversionSymbols);
             }
         }
 
@@ -646,42 +658,42 @@ namespace QuantConnect.Tests.Common.Securities
 
         // Crypto brokerage model stable coin and account currency cases
         // The last var is expectedConversionSymbol, and is null when we expect there
-        // not to be a conversion security for our tests output
+        // not to be an (indirect) conversion for our tests output
         private static object[] cryptoBrokerageStableCoinCases =
         {
             // *** Bitfinex ***
             // Trades USDC, EURS, and USDT
             // USDC Cases
-            new object[] { new BitfinexBrokerageModel(), Currencies.USD, "USDC", false, Symbol.Create("USDCUSD", SecurityType.Crypto, Market.Bitfinex) },
-            new object[] { new BitfinexBrokerageModel(), Currencies.EUR, "USDC", true, null }, // No USDCEUR, does throw!
-            new object[] { new BitfinexBrokerageModel(), Currencies.GBP, "USDC", true, null }, // No USDCGBP, does throw!
+            new object[] { new BitfinexBrokerageModel(), Currencies.USD, "USDC", false, new[] { Symbol.Create("USDCUSD", SecurityType.Crypto, Market.Bitfinex) } },
+            new object[] { new BitfinexBrokerageModel(), Currencies.EUR, "USDC", false, new[] { Symbol.Create("USDCUSD", SecurityType.Crypto, Market.Bitfinex), Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda) } }, // No USDCEUR, but indirect conversion exists
+            new object[] { new BitfinexBrokerageModel(), Currencies.GBP, "USDC", false, new[] { Symbol.Create("USDCUSD", SecurityType.Crypto, Market.Bitfinex), Symbol.Create("GBPUSD", SecurityType.Forex, Market.Oanda) } }, // No USDCGBP, but indirect conversion exists
 
             // EURS Cases
-            new object[] { new BitfinexBrokerageModel(), Currencies.USD, "EURS", false, Symbol.Create("EURSUSD", SecurityType.Crypto, Market.Bitfinex) },
+            new object[] { new BitfinexBrokerageModel(), Currencies.USD, "EURS", false, new[] { Symbol.Create("EURSUSD", SecurityType.Crypto, Market.Bitfinex) } },
             new object[] { new BitfinexBrokerageModel(), Currencies.EUR, "EURS", false, null }, // No EURSEUR, but does not throw! Conversion 1-1
-            new object[] { new BitfinexBrokerageModel(), Currencies.GBP, "EURS", true, null }, // No EURSGBP, does throw!
+            new object[] { new BitfinexBrokerageModel(), Currencies.GBP, "EURS", false, new[] { Symbol.Create("EURSUSD", SecurityType.Crypto, Market.Bitfinex), Symbol.Create("GBPUSD", SecurityType.Forex, Market.Oanda) } }, // No EURSGBP, but indirect conversion exists
 
             // USDT (Tether) Cases
-            new object[] { new BitfinexBrokerageModel(), Currencies.USD, "USDT", false, Symbol.Create("USDTUSD", SecurityType.Crypto, Market.Bitfinex) },
-            new object[] { new BitfinexBrokerageModel(), Currencies.EUR, "USDT", true, null }, // No USDTEUR, does throw!
-            new object[] { new BitfinexBrokerageModel(), Currencies.GBP, "USDT", true, null }, // No USDTGBP, does throw!
+            new object[] { new BitfinexBrokerageModel(), Currencies.USD, "USDT", false, new[] { Symbol.Create("USDTUSD", SecurityType.Crypto, Market.Bitfinex) } },
+            new object[] { new BitfinexBrokerageModel(), Currencies.EUR, "USDT", false, new[] { Symbol.Create("BTCUSDT", SecurityType.Crypto, Market.Bitfinex), Symbol.Create("BTCEUR", SecurityType.Crypto, Market.Bitfinex) } }, // No USDTEUR, but indirect conversion exists
+            new object[] { new BitfinexBrokerageModel(), Currencies.GBP, "USDT", false, new[] { Symbol.Create("BTCUSDT", SecurityType.Crypto, Market.Bitfinex), Symbol.Create("BTCGBP", SecurityType.Crypto, Market.Bitfinex) } }, // No USDTGBP, but indirect conversion exists
 
             // *** GDAX ***
             // Trades USDC and USDT* (*Not yet trading live, but expected soon)
             // USDC Cases
             new object[] { new GDAXBrokerageModel(), Currencies.USD, "USDC", false, null }, // No USDCUSD, but does not throw! Conversion 1-1
-            new object[] { new GDAXBrokerageModel(), Currencies.EUR, "USDC", false, Symbol.Create("USDCEUR", SecurityType.Crypto, Market.GDAX) },
-            new object[] { new GDAXBrokerageModel(), Currencies.GBP, "USDC", false, Symbol.Create("USDCGBP", SecurityType.Crypto, Market.GDAX) }, 
+            new object[] { new GDAXBrokerageModel(), Currencies.EUR, "USDC", false, new[] { Symbol.Create("USDCEUR", SecurityType.Crypto, Market.GDAX) } },
+            new object[] { new GDAXBrokerageModel(), Currencies.GBP, "USDC", false, new[] { Symbol.Create("USDCGBP", SecurityType.Crypto, Market.GDAX) } },
 
             // *** Binance ***
             // USDC Cases
             new object[] { new BinanceBrokerageModel(), Currencies.USD, "USDC", false, null }, // No USDCUSD, but does not throw! Conversion 1-1
-            new object[] { new BinanceBrokerageModel(), Currencies.EUR, "USDC", true, null }, // No USDCEUR, does throw!
-            new object[] { new BinanceBrokerageModel(), Currencies.GBP, "USDC", true, null }, // No USDCGBP, does throw!
+            new object[] { new BinanceBrokerageModel(), Currencies.EUR, "USDC", false, new[] { Symbol.Create("BNBUSDC", SecurityType.Crypto, Market.Binance), Symbol.Create("BNBEUR", SecurityType.Crypto, Market.Binance) } }, // No USDCEUR, but indirect conversion exists
+            new object[] { new BinanceBrokerageModel(), Currencies.GBP, "USDC", false, new[] { Symbol.Create("BNBUSDC", SecurityType.Crypto, Market.Binance), Symbol.Create("BNBGBP", SecurityType.Crypto, Market.Binance) } }, // No USDCGBP, but indirect conversion exists
 
             // BGBP Cases
-            new object[] { new BinanceBrokerageModel(), Currencies.USD, "BGBP", true, null }, // No BGBPUSD, does throw!
-            new object[] { new BinanceBrokerageModel(), Currencies.EUR, "BGBP", true, null }, // No BGBPEUR, does throw!
+            new object[] { new BinanceBrokerageModel(), Currencies.USD, "BGBP", true, null }, // No BGBPUSD and no indirect conversion, does throw!
+            new object[] { new BinanceBrokerageModel(), Currencies.EUR, "BGBP", true, null }, // No BGBPEUR and no indirect conversion, does throw!
             new object[] { new BinanceBrokerageModel(), Currencies.GBP, "BGBP", false, null }, // No BGBPGBP, but does not throw! Conversion 1-1
 
             new object[] { new OandaBrokerageModel(), Currencies.EUR, "INR", true, null }, // No INREUR, does throw!

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -532,7 +532,7 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
-        public void UpdateEventCalledForUpdateMethod()
+        public void UpdateEventCalledWhenAccessingConversionRateAfterCallingUpdateMethod()
         {
             var called = false;
             var cash = new Cash(Currencies.USD, 1, 1);
@@ -541,6 +541,7 @@ namespace QuantConnect.Tests.Common.Securities
                 called = true;
             };
             cash.Update();
+            var conversionRate = cash.ConversionRate;
             Assert.IsTrue(called);
         }
 

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -643,9 +643,9 @@ namespace QuantConnect.Tests.Common.Securities
                 Assert.IsNotNull(cash.CurrencyConversion);
 
                 var actualConversionSymbols = cash.CurrencyConversion
-                                                  .GetConversionRateSecurities()
-                                                  .Select(x => x.Symbol)
-                                                  .ToArray();
+                    .ConversionRateSecurities
+                    .Select(x => x.Symbol)
+                    .ToArray();
 
                 Assert.AreEqual(expectedConversionSymbols, actualConversionSymbols);
             }

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -697,7 +697,7 @@ namespace QuantConnect.Tests.Common.Securities
             new object[] { new BinanceBrokerageModel(), Currencies.EUR, "BGBP", true, null }, // No BGBPEUR and no indirect conversion, does throw!
             new object[] { new BinanceBrokerageModel(), Currencies.GBP, "BGBP", false, null }, // No BGBPGBP, but does not throw! Conversion 1-1
 
-            new object[] { new OandaBrokerageModel(), Currencies.EUR, "INR", true, null }, // No INREUR, does throw!
+            new object[] { new OandaBrokerageModel(), Currencies.EUR, "INR", false, new[] { Symbol.Create("USDINR", SecurityType.Forex, Market.Oanda), Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda) } }, // No INREUR, but indirect conversion exists
         };
     }
 }

--- a/Tests/Common/Securities/CurrencyConversion/SecurityCurrencyConversionTests.cs
+++ b/Tests/Common/Securities/CurrencyConversion/SecurityCurrencyConversionTests.cs
@@ -232,6 +232,27 @@ namespace QuantConnect.Tests.Common.Securities.CurrencyConversion
         }
 
         [Test]
+        public void UpdateReturnsZeroWhenNoDataForOneOfTwoSymbols()
+        {
+            var existingSecurities = new List<Security>
+            {
+                CreateSecurity(Symbols.ETHBTC),
+                CreateSecurity(Symbols.BTCUSD)
+            };
+
+            var currencyConversion = SecurityCurrencyConversion.LinearSearch(
+                "ETH",
+                "USD",
+                existingSecurities,
+                new List<Symbol>(0),
+                CreateSecurity);
+
+            existingSecurities[0].SetMarketPrice(new Tick { Value = 15m });
+
+            Assert.AreEqual(0m, currencyConversion.Update());
+        }
+
+        [Test]
         public void ConversionRateReturnsLatestConversionRate()
         {
             var existingSecurities = new List<Security> { CreateSecurity(Symbols.BTCUSD) };

--- a/Tests/Common/Securities/CurrencyConversion/SecurityCurrencyConversionTests.cs
+++ b/Tests/Common/Securities/CurrencyConversion/SecurityCurrencyConversionTests.cs
@@ -1,0 +1,364 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Securities;
+using QuantConnect.Securities.CurrencyConversion;
+using QuantConnect.Tests.Engine.DataFeeds;
+
+namespace QuantConnect.Tests.Common.Securities.CurrencyConversion
+{
+    [TestFixture]
+    public class SecurityCurrencyConversionTests
+    {
+        [Test]
+        public void LinearSearchFindsOneLegConversions()
+        {
+            var existingSecurities = new List<Security>(0);
+            var potentialSymbols = new List<Symbol> { Symbols.EURUSD };
+
+            var subscriptions = new SubscriptionManager();
+            var dataManager = new DataManagerStub();
+            subscriptions.SetDataManager(dataManager);
+
+            var createdSecurities = new List<Security>();
+            var makeNewSecurity = new Func<Symbol, Security>(symbol =>
+            {
+                var security = CreateSecurity(symbol);
+                createdSecurities.Add(security);
+                return security;
+            });
+
+            var currencyConversion = SecurityCurrencyConversion.LinearSearch(
+                "EUR",
+                "USD",
+                existingSecurities,
+                potentialSymbols,
+                makeNewSecurity);
+
+            var securities = currencyConversion.ConversionRateSecurities.ToList();
+            Assert.AreEqual(1, securities.Count);
+            Assert.AreEqual(createdSecurities, securities);
+            Assert.AreEqual(Symbols.EURUSD, securities[0].Symbol);
+        }
+
+        [Test]
+        public void LinearSearchFindsTwoLegConversions()
+        {
+            var existingSecurities = new List<Security>(0);
+            var potentialSymbols = new List<Symbol> { Symbols.BTCUSD, Symbols.EURUSD };
+
+            var subscriptions = new SubscriptionManager();
+            var dataManager = new DataManagerStub();
+            subscriptions.SetDataManager(dataManager);
+
+            var createdSecurities = new List<Security>();
+            var makeNewSecurity = new Func<Symbol, Security>(symbol =>
+            {
+                var security = CreateSecurity(symbol);
+                createdSecurities.Add(security);
+                return security;
+            });
+
+            var currencyConversion = SecurityCurrencyConversion.LinearSearch(
+                "BTC",
+                "EUR",
+                existingSecurities,
+                potentialSymbols,
+                makeNewSecurity);
+
+            var securities = currencyConversion.ConversionRateSecurities.ToList();
+            Assert.AreEqual(2, securities.Count);
+            Assert.AreEqual(createdSecurities, securities);
+            Assert.AreEqual(Symbols.BTCUSD, securities[0].Symbol);
+            Assert.AreEqual(Symbols.EURUSD, securities[1].Symbol);
+        }
+
+        [Test]
+        public void LinearSearchPrefersExistingSecuritiesOverNewOnesOneLeg()
+        {
+            var existingSecurities = new List<Security> { CreateSecurity(Symbols.EURUSD) };
+            var potentialSymbols = new List<Symbol> { Symbols.EURUSD };
+
+            var subscriptions = new SubscriptionManager();
+            var dataManager = new DataManagerStub();
+            subscriptions.SetDataManager(dataManager);
+
+            var createdSecurities = new List<Security>();
+            var makeNewSecurity = new Func<Symbol, Security>(symbol =>
+            {
+                var security = CreateSecurity(symbol);
+                createdSecurities.Add(security);
+                return security;
+            });
+
+            var currencyConversion = SecurityCurrencyConversion.LinearSearch(
+                "EUR",
+                "USD",
+                existingSecurities,
+                potentialSymbols,
+                makeNewSecurity);
+
+            var securities = currencyConversion.ConversionRateSecurities.ToList();
+            Assert.AreEqual(1, securities.Count);
+            Assert.AreEqual(0, createdSecurities.Count);
+            Assert.AreEqual(existingSecurities, securities);
+        }
+
+        [Test]
+        public void LinearSearchPrefersExistingSecuritiesOverNewOnesTwoLeg()
+        {
+            var existingSecurities = new List<Security> { CreateSecurity(Symbols.BTCUSD) };
+            var potentialSymbols = new List<Symbol> { Symbols.BTCUSD, Symbols.EURUSD };
+
+            var subscriptions = new SubscriptionManager();
+            var dataManager = new DataManagerStub();
+            subscriptions.SetDataManager(dataManager);
+
+            var createdSecurities = new List<Security>();
+            var makeNewSecurity = new Func<Symbol, Security>(symbol =>
+            {
+                var security = CreateSecurity(symbol);
+                createdSecurities.Add(security);
+                return security;
+            });
+
+            var currencyConversion = SecurityCurrencyConversion.LinearSearch(
+                "BTC",
+                "EUR",
+                existingSecurities,
+                potentialSymbols,
+                makeNewSecurity);
+
+            var securities = currencyConversion.ConversionRateSecurities.ToList();
+            Assert.AreEqual(2, securities.Count);
+            Assert.AreEqual(existingSecurities[0], securities[0]);
+            Assert.AreEqual(createdSecurities[0], securities[1]);
+            Assert.AreEqual(Symbols.EURUSD, securities[1].Symbol);
+        }
+
+        [Test]
+        public void LinearSearchThrowsWhenNoConversionPossible()
+        {
+            var existingSecurities = new List<Security>(0);
+            var potentialSymbols = new List<Symbol> { Symbols.EURGBP };
+
+            Assert.Throws<ArgumentException>(() => SecurityCurrencyConversion.LinearSearch(
+                "EUR",
+                "USD",
+                existingSecurities,
+                potentialSymbols,
+                CreateSecurity));
+        }
+
+        [TestCaseSource(nameof(oneLegCases))]
+        public void UpdateCalculatesNewConversionRateOneLeg(
+            string sourceCurrency,
+            string destinationCurrency,
+            Symbol symbol,
+            decimal expectedRate)
+        {
+            var existingSecurities = new List<Security> { CreateSecurity(symbol) };
+
+            var currencyConversion = SecurityCurrencyConversion.LinearSearch(
+                sourceCurrency,
+                destinationCurrency,
+                existingSecurities,
+                new List<Symbol>(0),
+                CreateSecurity);
+
+            existingSecurities[0].SetMarketPrice(new Tick { Value = 10m });
+
+            Assert.AreEqual(expectedRate, currencyConversion.Update());
+        }
+
+        [TestCaseSource(nameof(twoLegCases))]
+        public void UpdateCalculatesNewConversionRateTwoLeg(
+            string sourceCurrency,
+            string destinationCurrency,
+            Symbol symbol1,
+            Symbol symbol2,
+            decimal expectedRate)
+        {
+            var existingSecurities = new List<Security>
+            {
+                CreateSecurity(symbol1),
+                CreateSecurity(symbol2)
+            };
+
+            var currencyConversion = SecurityCurrencyConversion.LinearSearch(
+                sourceCurrency,
+                destinationCurrency,
+                existingSecurities,
+                new List<Symbol>(0),
+                CreateSecurity);
+
+            existingSecurities[0].SetMarketPrice(new Tick { Value = 15m });
+            existingSecurities[1].SetMarketPrice(new Tick { Value = 25m });
+
+            Assert.AreEqual(expectedRate, currencyConversion.Update());
+        }
+
+        [Test]
+        public void UpdateReturnsZeroWhenNoData()
+        {
+            var existingSecurities = new List<Security> { CreateSecurity(Symbols.BTCUSD) };
+
+            var currencyConversion = SecurityCurrencyConversion.LinearSearch(
+                "BTC",
+                "USD",
+                existingSecurities,
+                new List<Symbol>(0),
+                CreateSecurity);
+
+            Assert.AreEqual(0m, currencyConversion.Update());
+        }
+
+        [Test]
+        public void ConversionRateReturnsLatestConversionRate()
+        {
+            var existingSecurities = new List<Security> { CreateSecurity(Symbols.BTCUSD) };
+
+            var currencyConversion = SecurityCurrencyConversion.LinearSearch(
+                "BTC",
+                "USD",
+                existingSecurities,
+                new List<Symbol>(0),
+                CreateSecurity);
+
+            Assert.AreEqual(0m, currencyConversion.ConversionRate);
+
+            existingSecurities[0].SetMarketPrice(new Tick { Value = 10m });
+            currencyConversion.Update();
+            Assert.AreEqual(10m, currencyConversion.ConversionRate);
+
+            existingSecurities[0].SetMarketPrice(new Tick { Value = 20m });
+            currencyConversion.Update();
+            Assert.AreEqual(20m, currencyConversion.ConversionRate);
+        }
+
+        [Test]
+        public void ConversionRateZeroAtStart()
+        {
+            var existingSecurities = new List<Security>(0);
+            var potentialSymbols = new List<Symbol> { Symbols.EURUSD };
+
+            var currencyConversion = SecurityCurrencyConversion.LinearSearch(
+                "EUR",
+                "USD",
+                existingSecurities,
+                potentialSymbols,
+                CreateSecurity);
+
+            Assert.AreEqual(0, currencyConversion.ConversionRate);
+        }
+
+        [Test]
+        public void SourceCurrencyReturnsCorrectValue()
+        {
+            var existingSecurities = new List<Security>(0);
+            var potentialSymbols = new List<Symbol> { Symbols.EURUSD };
+
+            var currencyConversion = SecurityCurrencyConversion.LinearSearch(
+                "EUR",
+                "USD",
+                existingSecurities,
+                potentialSymbols,
+                CreateSecurity);
+
+            Assert.AreEqual("EUR", currencyConversion.SourceCurrency);
+        }
+
+        [Test]
+        public void DestinationCurrencyReturnsCorrectValue()
+        {
+            var existingSecurities = new List<Security>(0);
+            var potentialSymbols = new List<Symbol> { Symbols.EURUSD };
+
+            var currencyConversion = SecurityCurrencyConversion.LinearSearch(
+                "EUR",
+                "USD",
+                existingSecurities,
+                potentialSymbols,
+                CreateSecurity);
+
+            Assert.AreEqual("USD", currencyConversion.DestinationCurrency);
+        }
+
+        private static Security CreateSecurity(Symbol symbol)
+        {
+            var timezone = TimeZones.NewYork;
+
+            var config = new SubscriptionDataConfig(
+                typeof(TradeBar),
+                symbol,
+                Resolution.Hour,
+                timezone,
+                timezone,
+                true,
+                false,
+                false);
+
+            return new Security(
+                SecurityExchangeHours.AlwaysOpen(timezone),
+                config,
+                new Cash(Currencies.USD, 0, 1),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+        }
+
+        /// <summary>
+        /// One leg Update() test cases.
+        /// sourceCurrency, destinationCurrency, symbol, expectedRate
+        /// expectedRate is the expected rate when the value of symbol is set to 10
+        /// </summary>
+        private static object[] oneLegCases =
+        {
+            // Not inverted
+            new object[] { "BTC", "USD", Symbols.BTCUSD, 10m },
+
+            // Inverted
+            new object[] { "USD", "BTC", Symbols.BTCUSD, 0.1m }
+        };
+
+        /// <summary>
+        /// Two leg Update() test cases:
+        /// sourceCurrency, destinationCurrency, symbol1, symbol2, expectedRate
+        /// expectedRate is the expected rate when the value of symbol1 is set to 15 and the value of symbol2 to 25
+        /// </summary>
+        private static object[] twoLegCases =
+        {
+            // Not inverted
+            new object[] { "ETH", "USD", Symbols.ETHBTC, Symbols.BTCUSD, 15m * 25m },
+
+            // First pair inverted
+            new object[] { "USD", "BTC", Symbols.ETHUSD, Symbols.ETHBTC, (1m / 15m) * 25m },
+
+            // Second pair inverted
+            new object[] { "ETH", "BTC", Symbols.ETHUSD, Symbols.BTCUSD, 15m * (1m / 25m) },
+
+            // Both pairs inverted
+            new object[] { "USD", "ETH", Symbols.BTCUSD, Symbols.ETHBTC, (1m / 15m) * (1m / 25m) }
+        };
+    }
+}

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -242,11 +242,6 @@ namespace QuantConnect.Tests.Common.Securities
                 Assert.AreEqual((double)mchJwb, (double)(mchUsd*usdJwb), 1e-10);
                 //Console.WriteLine("Step: " + i + " -- MCHJWB: " + mchJwb);
 
-
-                jwbCash.Update(new IndicatorDataPoint(MCHJWB, time, mchJwb));
-                usdCash.Update(new IndicatorDataPoint(MCHUSD, time, mchUsd));
-                mchCash.Update(new IndicatorDataPoint(JWBUSD, time, usdJwb));
-
                 var updateData = new Dictionary<Security, BaseData>
                 {
                     {mchJwbSecurity, new IndicatorDataPoint(MCHJWB, time, mchJwb)},
@@ -258,6 +253,10 @@ namespace QuantConnect.Tests.Common.Securities
                 {
                     kvp.Key.SetMarketPrice(kvp.Value);
                 }
+
+                jwbCash.Update();
+                usdCash.Update();
+                mchCash.Update();
 
                 portfolio.ProcessFill(fill);
                 //Console.WriteLine("-----------------------");

--- a/Tests/Common/Util/CurrencyPairUtilTests.cs
+++ b/Tests/Common/Util/CurrencyPairUtilTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -90,8 +90,8 @@ namespace QuantConnect.Tests.Common.Util
         {
             var currencyPair = Symbol.Create("ETHBTC", SecurityType.Crypto, Market.Bitfinex);
 
-            Assert.Throws<ArgumentException>(() => currencyPair.CurrencyPairDual("ZRX"));
-            Assert.Throws<ArgumentException>(() => CurrencyPairUtil.CurrencyPairDual("ETH", "BTC", "ZRX"));
+            Assert.AreEqual(null, currencyPair.CurrencyPairDual("ZRX"));
+            Assert.AreEqual(null, CurrencyPairUtil.CurrencyPairDual("ETH", "BTC", "ZRX"));
         }
 
         [Test]
@@ -103,22 +103,6 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual(CurrencyPairUtil.Match.ExactMatch, ethusd.ComparePair("ETH", "USD"));
             Assert.AreEqual(CurrencyPairUtil.Match.InverseMatch, eurusd.ComparePair("USD", "EUR"));
             Assert.AreEqual(CurrencyPairUtil.Match.NoMatch, ethusd.ComparePair("BTC", "USD"));
-        }
-
-        [TestCase("ETH", true)]
-        [TestCase("USD", true)]
-        [TestCase("Eth", true)]
-        [TestCase("Usd", true)]
-        [TestCase("ZRX", false)]
-        [TestCase("BTC", false)]
-        [TestCase("Zrx", false)]
-        [TestCase("Btc", false)]
-        public void PairContainsCurrencyWorksCorrectly(string currency, bool result)
-        {
-            var ethusd = Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex);
-
-            Assert.AreEqual(result, ethusd.PairContainsCurrency(currency));
-            Assert.AreEqual(result, CurrencyPairUtil.PairContainsCurrency("ETH", "USD", currency));
         }
 
         /// <summary>

--- a/Tests/Common/Util/CurrencyPairUtilTests.cs
+++ b/Tests/Common/Util/CurrencyPairUtilTests.cs
@@ -59,6 +59,8 @@ namespace QuantConnect.Tests.Common.Util
 
             Assert.AreEqual("USD", currencyPair.CurrencyPairDual("EUR"));
             Assert.AreEqual("EUR", currencyPair.CurrencyPairDual("USD"));
+            Assert.AreEqual("USD", CurrencyPairUtil.CurrencyPairDual("EUR", "USD", "EUR"));
+            Assert.AreEqual("EUR", CurrencyPairUtil.CurrencyPairDual("EUR", "USD", "USD"));
         }
 
         [Test]
@@ -68,6 +70,8 @@ namespace QuantConnect.Tests.Common.Util
 
             Assert.AreEqual("XAG", currencyPair.CurrencyPairDual("USD"));
             Assert.AreEqual("USD", currencyPair.CurrencyPairDual("XAG"));
+            Assert.AreEqual("XAG", CurrencyPairUtil.CurrencyPairDual("XAG", "USD", "USD"));
+            Assert.AreEqual("USD", CurrencyPairUtil.CurrencyPairDual("XAG", "USD", "XAG"));
         }
 
         [Test]
@@ -77,6 +81,8 @@ namespace QuantConnect.Tests.Common.Util
 
             Assert.AreEqual("BTC", currencyPair.CurrencyPairDual("ETH"));
             Assert.AreEqual("ETH", currencyPair.CurrencyPairDual("BTC"));
+            Assert.AreEqual("BTC", CurrencyPairUtil.CurrencyPairDual("ETH", "BTC", "ETH"));
+            Assert.AreEqual("ETH", CurrencyPairUtil.CurrencyPairDual("ETH", "BTC", "BTC"));
         }
 
         [Test]
@@ -85,6 +91,7 @@ namespace QuantConnect.Tests.Common.Util
             var currencyPair = Symbol.Create("ETHBTC", SecurityType.Crypto, Market.Bitfinex);
 
             Assert.Throws<ArgumentException>(() => currencyPair.CurrencyPairDual("ZRX"));
+            Assert.Throws<ArgumentException>(() => CurrencyPairUtil.CurrencyPairDual("ETH", "BTC", "ZRX"));
         }
 
         [Test]
@@ -111,6 +118,7 @@ namespace QuantConnect.Tests.Common.Util
             var ethusd = Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex);
 
             Assert.AreEqual(result, ethusd.PairContainsCurrency(currency));
+            Assert.AreEqual(result, CurrencyPairUtil.PairContainsCurrency("ETH", "USD", currency));
         }
 
         /// <summary>

--- a/Tests/Common/Util/CurrencyPairUtilTests.cs
+++ b/Tests/Common/Util/CurrencyPairUtilTests.cs
@@ -1,0 +1,92 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Util;
+namespace QuantConnect.Tests.Common.Util
+{
+    [TestFixture]
+    public class CurrencyPairUtilTests
+    {
+        [Test]
+        public void DecomposeThrowsOnNullSymbol()
+        {
+            Symbol symbol = null;
+            string basec, quotec;
+
+            Assert.Throws<ArgumentException>(() => CurrencyPairUtil.DecomposeCurrencyPair(symbol, out basec, out quotec),
+                                             "Currency pair must not be null");
+        }
+
+        [Test]
+        public void CurrencyPairDualForex()
+        {
+            var currencyPair = Symbol.Create("EURUSD", SecurityType.Forex, Market.FXCM);
+
+            Assert.AreEqual(CurrencyPairUtil.CurrencyPairDual(currencyPair, "EUR"), "USD");
+            Assert.AreEqual(CurrencyPairUtil.CurrencyPairDual(currencyPair, "USD"), "EUR");
+        }
+
+        [Test]
+        public void CurrencyPairDualCrypto()
+        {
+            var currencyPair = Symbol.Create("ETHBTC", SecurityType.Crypto, Market.Bitfinex);
+
+            Assert.AreEqual(CurrencyPairUtil.CurrencyPairDual(currencyPair, "ETH"), "BTC");
+            Assert.AreEqual(CurrencyPairUtil.CurrencyPairDual(currencyPair, "BTC"), "ETH");
+        }
+
+        [Test]
+        public void CurrencyPairDualThrowsOnWrongKnownSymbol()
+        {
+            var currencyPair = Symbol.Create("ETHBTC", SecurityType.Crypto, Market.Bitfinex);
+
+            Assert.Throws<ArgumentException>(() => CurrencyPairUtil.CurrencyPairDual(currencyPair, "ZRX"),
+                                             "The knownSymbol ZRX isn't contained in currencyPair ETHBTC.");
+        }
+
+        [Test]
+        public void ComparePairWorksCorrectly()
+        {
+            var ethusd = Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex);
+            var btcusd = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Bitfinex);
+
+            var eurusd = Symbol.Create("EURUSD", SecurityType.Forex, Market.FXCM);
+            var usdeur = Symbol.Create("USDEUR", SecurityType.Forex, Market.FXCM);
+
+            Assert.AreEqual(ethusd.ComparePair(ethusd), CurrencyPairUtil.Match.ExactMatch);
+            Assert.AreEqual(ethusd.ComparePair("ETH", "USD"), CurrencyPairUtil.Match.ExactMatch);
+
+            Assert.AreEqual(eurusd.ComparePair(usdeur), CurrencyPairUtil.Match.InverseMatch);
+            Assert.AreEqual(eurusd.ComparePair("USD", "EUR"), CurrencyPairUtil.Match.InverseMatch);
+
+            Assert.AreEqual(ethusd.ComparePair(btcusd), CurrencyPairUtil.Match.NoMatch);
+            Assert.AreEqual(ethusd.ComparePair("BTC", "USD"), CurrencyPairUtil.Match.NoMatch);
+        }
+
+        [Test]
+        public void PairContainsCodeWorksCorrectly()
+        {
+            var ethusd = Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex);
+
+            Assert.AreEqual(CurrencyPairUtil.PairContainsCode(ethusd, "ETH"), true);
+            Assert.AreEqual(CurrencyPairUtil.PairContainsCode(ethusd, "USD"), true);
+            Assert.AreEqual(CurrencyPairUtil.PairContainsCode(ethusd, "ZRX"), false);
+            Assert.AreEqual(CurrencyPairUtil.PairContainsCode(ethusd, "BTC"), false);
+        }
+
+    }
+}

--- a/Tests/Common/Util/CurrencyPairUtilTests.cs
+++ b/Tests/Common/Util/CurrencyPairUtilTests.cs
@@ -16,6 +16,7 @@
 using System;
 using NUnit.Framework;
 using QuantConnect.Util;
+
 namespace QuantConnect.Tests.Common.Util
 {
     [TestFixture]
@@ -25,10 +26,10 @@ namespace QuantConnect.Tests.Common.Util
         public void DecomposeThrowsOnNullSymbol()
         {
             Symbol symbol = null;
-            string basec, quotec;
+            string baseCurrency, quoteCurrency;
 
-            Assert.Throws<ArgumentException>(() => CurrencyPairUtil.DecomposeCurrencyPair(symbol, out basec, out quotec),
-                                             "Currency pair must not be null");
+            Assert.Throws<ArgumentException>(
+                () => CurrencyPairUtil.DecomposeCurrencyPair(symbol, out baseCurrency, out quoteCurrency));
         }
 
         [Test]
@@ -36,8 +37,8 @@ namespace QuantConnect.Tests.Common.Util
         {
             var currencyPair = Symbol.Create("EURUSD", SecurityType.Forex, Market.FXCM);
 
-            Assert.AreEqual(CurrencyPairUtil.CurrencyPairDual(currencyPair, "EUR"), "USD");
-            Assert.AreEqual(CurrencyPairUtil.CurrencyPairDual(currencyPair, "USD"), "EUR");
+            Assert.AreEqual("USD", currencyPair.CurrencyPairDual("EUR"));
+            Assert.AreEqual("EUR", currencyPair.CurrencyPairDual("USD"));
         }
 
         [Test]
@@ -45,8 +46,8 @@ namespace QuantConnect.Tests.Common.Util
         {
             var currencyPair = Symbol.Create("ETHBTC", SecurityType.Crypto, Market.Bitfinex);
 
-            Assert.AreEqual(CurrencyPairUtil.CurrencyPairDual(currencyPair, "ETH"), "BTC");
-            Assert.AreEqual(CurrencyPairUtil.CurrencyPairDual(currencyPair, "BTC"), "ETH");
+            Assert.AreEqual("BTC", currencyPair.CurrencyPairDual("ETH"));
+            Assert.AreEqual("ETH", currencyPair.CurrencyPairDual("BTC"));
         }
 
         [Test]
@@ -54,8 +55,7 @@ namespace QuantConnect.Tests.Common.Util
         {
             var currencyPair = Symbol.Create("ETHBTC", SecurityType.Crypto, Market.Bitfinex);
 
-            Assert.Throws<ArgumentException>(() => CurrencyPairUtil.CurrencyPairDual(currencyPair, "ZRX"),
-                                             "The knownSymbol ZRX isn't contained in currencyPair ETHBTC.");
+            Assert.Throws<ArgumentException>(() => currencyPair.CurrencyPairDual("ZRX"));
         }
 
         [Test]
@@ -67,26 +67,25 @@ namespace QuantConnect.Tests.Common.Util
             var eurusd = Symbol.Create("EURUSD", SecurityType.Forex, Market.FXCM);
             var usdeur = Symbol.Create("USDEUR", SecurityType.Forex, Market.FXCM);
 
-            Assert.AreEqual(ethusd.ComparePair(ethusd), CurrencyPairUtil.Match.ExactMatch);
-            Assert.AreEqual(ethusd.ComparePair("ETH", "USD"), CurrencyPairUtil.Match.ExactMatch);
+            Assert.AreEqual(CurrencyPairUtil.Match.ExactMatch, ethusd.ComparePair(ethusd));
+            Assert.AreEqual(CurrencyPairUtil.Match.ExactMatch, ethusd.ComparePair("ETH", "USD"));
 
-            Assert.AreEqual(eurusd.ComparePair(usdeur), CurrencyPairUtil.Match.InverseMatch);
-            Assert.AreEqual(eurusd.ComparePair("USD", "EUR"), CurrencyPairUtil.Match.InverseMatch);
+            Assert.AreEqual(CurrencyPairUtil.Match.InverseMatch, eurusd.ComparePair(usdeur));
+            Assert.AreEqual(CurrencyPairUtil.Match.InverseMatch, eurusd.ComparePair("USD", "EUR"));
 
-            Assert.AreEqual(ethusd.ComparePair(btcusd), CurrencyPairUtil.Match.NoMatch);
-            Assert.AreEqual(ethusd.ComparePair("BTC", "USD"), CurrencyPairUtil.Match.NoMatch);
+            Assert.AreEqual(CurrencyPairUtil.Match.NoMatch, ethusd.ComparePair(btcusd));
+            Assert.AreEqual(CurrencyPairUtil.Match.NoMatch, ethusd.ComparePair("BTC", "USD"));
         }
 
         [Test]
-        public void PairContainsCodeWorksCorrectly()
+        public void PairContainsCurrencyWorksCorrectly()
         {
             var ethusd = Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Bitfinex);
 
-            Assert.AreEqual(CurrencyPairUtil.PairContainsCode(ethusd, "ETH"), true);
-            Assert.AreEqual(CurrencyPairUtil.PairContainsCode(ethusd, "USD"), true);
-            Assert.AreEqual(CurrencyPairUtil.PairContainsCode(ethusd, "ZRX"), false);
-            Assert.AreEqual(CurrencyPairUtil.PairContainsCode(ethusd, "BTC"), false);
+            Assert.IsTrue(ethusd.PairContainsCurrency("ETH"));
+            Assert.IsTrue(ethusd.PairContainsCurrency("USD"));
+            Assert.IsFalse(ethusd.PairContainsCurrency("ZRX"));
+            Assert.IsFalse(ethusd.PairContainsCurrency("BTC"));
         }
-
     }
 }

--- a/Tests/Common/Util/CurrencyPairUtilTests.cs
+++ b/Tests/Common/Util/CurrencyPairUtilTests.cs
@@ -86,7 +86,7 @@ namespace QuantConnect.Tests.Common.Util
         }
 
         [Test]
-        public void CurrencyPairDualThrowsOnWrongKnownSymbol()
+        public void CurrencyPairDualReturnsNullOnWrongKnownSymbol()
         {
             var currencyPair = Symbol.Create("ETHBTC", SecurityType.Crypto, Market.Bitfinex);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR is a continuation of #2146. It includes the currency conversion changes in that PR applied on the current master, with some clean-up and more tests.

This PR changes the conversion rate calculation of `Cash` objects so that it considers 2-leg currency conversions on top of the 1-leg currency conversions that we currently check for. For example, if the account currency is set to ETH and LTC cash is added, the conversion rate from LTC to ETH can now be calculated using a combination of pairs like LTCUSD and ETHUSD, instead of throwing an error for there not being an LTCETH or an ETHLTC security.

`Cash.SecuritySymbol` and `Cash.ConversionRateSecurity` have been made obsolete because it no longer holds true that there is at most one conversion rate security. These properties still return the details of the first conversion rate security if there is one to preserve backwards compatibility. The replacement for these properties is `Cash.CurrencyConversion.ConversionRateSecurities`.

I initially tried rebasing the commits in #2146 on top of the current master, but the 3 year difference caused so many conflicts that I eventually re-applied the changes on the current master by hand instead. Despite the missing Git history, credit for some of the changes in this PR goes to @viliwonka.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #2060

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Makes it possible to use symbols that don't directly map to the account currency.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Maybe? I don't know if the current documentation says anything about the obsoleted properties.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit & regression tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->