### PR TITLE
Fix FOPs maintenance margin requirements

### DIFF
--- a/Algorithm.CSharp/DelistingFutureOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DelistingFutureOptionRegressionAlgorithm.cs
@@ -123,7 +123,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.117"},
             {"Treynor Ratio", "1.617"},
             {"Total Fees", "$37.00"},
-            {"Estimated Strategy Capacity", "$580000.00"},
+            {"Estimated Strategy Capacity", "$310000000.00"},
             {"Lowest Capacity Asset", "DC V5E8P9SH0U0X"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},

--- a/Algorithm.CSharp/FutureOptionBuySellCallIntradayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionBuySellCallIntradayRegressionAlgorithm.cs
@@ -138,7 +138,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.418"},
             {"Treynor Ratio", "3.493"},
             {"Total Fees", "$14.80"},
-            {"Estimated Strategy Capacity", "$6300000.00"},
+            {"Estimated Strategy Capacity", "$75000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UK0MYO1"},
             {"Fitness Score", "0.017"},
             {"Kelly Criterion Estimate", "0"},

--- a/Algorithm.CSharp/FutureOptionCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallITMExpiryRegressionAlgorithm.cs
@@ -222,7 +222,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.411"},
             {"Treynor Ratio", "-27.616"},
             {"Total Fees", "$7.40"},
-            {"Estimated Strategy Capacity", "$5800000.00"},
+            {"Estimated Strategy Capacity", "$73000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UK0MYO1"},
             {"Fitness Score", "0.008"},
             {"Kelly Criterion Estimate", "0"},

--- a/Algorithm.CSharp/FutureOptionCallITMGreeksExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallITMGreeksExpiryRegressionAlgorithm.cs
@@ -14,13 +14,11 @@
 */
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
-using QuantConnect.Orders;
 using QuantConnect.Securities;
+using System.Collections.Generic;
 using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Algorithm.CSharp
@@ -187,7 +185,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.784"},
             {"Treynor Ratio", "-18.756"},
             {"Total Fees", "$66.60"},
-            {"Estimated Strategy Capacity", "$5300000.00"},
+            {"Estimated Strategy Capacity", "$7500000.00"},
             {"Lowest Capacity Asset", "ES XFH59UK0MYO1"},
             {"Fitness Score", "0.156"},
             {"Kelly Criterion Estimate", "0"},

--- a/Algorithm.CSharp/FutureOptionCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallOTMExpiryRegressionAlgorithm.cs
@@ -197,7 +197,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.408"},
             {"Treynor Ratio", "-27.32"},
             {"Total Fees", "$3.70"},
-            {"Estimated Strategy Capacity", "$5600000.00"},
+            {"Estimated Strategy Capacity", "$71000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UPHGV9G|ES XFH59UK0MYO1"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},

--- a/Algorithm.CSharp/FutureOptionMultipleContractsInDifferentContractMonthsWithSameUnderlyingFutureRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionMultipleContractsInDifferentContractMonthsWithSameUnderlyingFutureRegressionAlgorithm.cs
@@ -122,7 +122,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.043"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$7.40"},
-            {"Estimated Strategy Capacity", "$1700000.00"},
+            {"Estimated Strategy Capacity", "$9800000.00"},
             {"Lowest Capacity Asset", "OG 31BFX0QKBVPGG|GC XE1Y0ZJ8NQ8T"},
             {"Fitness Score", "0.019"},
             {"Kelly Criterion Estimate", "0"},

--- a/Algorithm.CSharp/FutureOptionPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionPutITMExpiryRegressionAlgorithm.cs
@@ -223,7 +223,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.408"},
             {"Treynor Ratio", "-28.523"},
             {"Total Fees", "$7.40"},
-            {"Estimated Strategy Capacity", "$6300000.00"},
+            {"Estimated Strategy Capacity", "$81000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UK0MYO1"},
             {"Fitness Score", "0.008"},
             {"Kelly Criterion Estimate", "0"},

--- a/Algorithm.CSharp/FutureOptionPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionPutOTMExpiryRegressionAlgorithm.cs
@@ -196,7 +196,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.409"},
             {"Treynor Ratio", "-27.056"},
             {"Total Fees", "$3.70"},
-            {"Estimated Strategy Capacity", "$8400000.00"},
+            {"Estimated Strategy Capacity", "$110000000.00"},
             {"Lowest Capacity Asset", "ES 31EL5FBZBMXES|ES XFH59UK0MYO1"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},

--- a/Algorithm.CSharp/FutureOptionShortCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortCallITMExpiryRegressionAlgorithm.cs
@@ -207,7 +207,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.41"},
             {"Treynor Ratio", "-27.331"},
             {"Total Fees", "$7.40"},
-            {"Estimated Strategy Capacity", "$8600000.00"},
+            {"Estimated Strategy Capacity", "$110000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UK0MYO1"},
             {"Fitness Score", "0.02"},
             {"Kelly Criterion Estimate", "0"},

--- a/Algorithm.CSharp/FutureOptionShortCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortCallOTMExpiryRegressionAlgorithm.cs
@@ -190,7 +190,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.406"},
             {"Treynor Ratio", "-28.184"},
             {"Total Fees", "$3.70"},
-            {"Estimated Strategy Capacity", "$3100000.00"},
+            {"Estimated Strategy Capacity", "$40000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UPNF7B8|ES XFH59UK0MYO1"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},

--- a/Algorithm.CSharp/FutureOptionShortPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortPutITMExpiryRegressionAlgorithm.cs
@@ -204,7 +204,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.406"},
             {"Treynor Ratio", "-24.058"},
             {"Total Fees", "$7.40"},
-            {"Estimated Strategy Capacity", "$8700000.00"},
+            {"Estimated Strategy Capacity", "$110000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UK0MYO1"},
             {"Fitness Score", "0.021"},
             {"Kelly Criterion Estimate", "0"},

--- a/Algorithm.CSharp/FutureOptionShortPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortPutOTMExpiryRegressionAlgorithm.cs
@@ -189,7 +189,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.408"},
             {"Treynor Ratio", "-28.646"},
             {"Total Fees", "$3.70"},
-            {"Estimated Strategy Capacity", "$5200000.00"},
+            {"Estimated Strategy Capacity", "$66000000.00"},
             {"Lowest Capacity Asset", "ES 31EL5FAJQ6SBO|ES XFH59UK0MYO1"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -88,6 +88,25 @@ namespace QuantConnect
         public static TimeSpan DelistingMarketCloseOffsetSpan { get; set; } = TimeSpan.FromMinutes(-15);
 
         /// <summary>
+        /// Helper method to create an order request to liquidate a delisted asset
+        /// </summary>
+        public static SubmitOrderRequest CreateDelistedSecurityOrderRequest(this Security security, DateTime utcTime)
+        {
+            var orderType = OrderType.Market;
+            var tag = "Liquidate from delisting";
+            if (security.Type.IsOption())
+            {
+                // tx handler will determine auto exercise/assignment
+                tag = "Option Expired";
+                orderType = OrderType.OptionExercise;
+            }
+
+            // submit an order to liquidate on market close or exercise (for options)
+            return new SubmitOrderRequest(orderType, security.Type, security.Symbol,
+                -security.Holdings.Quantity, 0, 0, utcTime, tag);
+        }
+
+        /// <summary>
         /// Safe multiplies a decimal by 100
         /// </summary>
         /// <param name="value">The decimal to multiply</param>

--- a/Common/Securities/Future/FutureMarginModel.cs
+++ b/Common/Securities/Future/FutureMarginModel.cs
@@ -146,7 +146,7 @@ namespace QuantConnect.Securities.Future
         public override MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
         {
             var security = parameters.Security;
-            if (security?.GetLastData() == null || security.Holdings.HoldingsCost == 0m)
+            if (security?.GetLastData() == null || parameters.Quantity == 0m)
             {
                 return 0m;
             }

--- a/Common/Securities/FutureOption/FuturesOptionsMarginModel.cs
+++ b/Common/Securities/FutureOption/FuturesOptionsMarginModel.cs
@@ -24,7 +24,7 @@ namespace QuantConnect.Securities.Option
     /// </summary>
     public class FuturesOptionsMarginModel : FutureMarginModel
     {
-        private const decimal FixedMarginMultiplier = 1.5m;
+        public const decimal FixedMarginMultiplier = 1.5m;
 
         /// <summary>
         /// Creates an instance of FutureOptionMarginModel
@@ -48,7 +48,7 @@ namespace QuantConnect.Securities.Option
         /// </remarks>
         public override MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
         {
-            return base.GetMaintenanceMargin(parameters.ForUnderlying()) * FixedMarginMultiplier;
+            return base.GetMaintenanceMargin(parameters.ForUnderlying(parameters.Quantity)) * FixedMarginMultiplier;
         }
 
         /// <summary>

--- a/Common/Securities/MaintenanceMarginParameters.cs
+++ b/Common/Securities/MaintenanceMarginParameters.cs
@@ -81,13 +81,8 @@ namespace QuantConnect.Securities
         /// Creates a new instance of the <see cref="MaintenanceMarginParameters"/> class to compute the maintenance margin
         /// required to support the algorithm's current holdings
         /// </summary>
-        public static MaintenanceMarginParameters ForCurrentHoldings(Security security, decimal? quantity = null)
+        public static MaintenanceMarginParameters ForCurrentHoldings(Security security)
         {
-            if (quantity != null)
-            {
-                return ForQuantityAtCurrentPrice(security, quantity.Value);
-            }
-
             return new MaintenanceMarginParameters(security,
                 security.Holdings.Quantity,
                 security.Holdings.HoldingsCost,
@@ -108,7 +103,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Creates a new instance of <see cref="MaintenanceMarginParameters"/> for the security's underlying
         /// </summary>
-        public MaintenanceMarginParameters ForUnderlying()
+        public MaintenanceMarginParameters ForUnderlying(decimal quantity)
         {
             var derivative = Security as IDerivativeSecurity;
             if (derivative == null)
@@ -116,7 +111,7 @@ namespace QuantConnect.Securities
                 throw new InvalidOperationException("ForUnderlying is only invokable for IDerivativeSecurity (Option|Future)");
             }
 
-            return ForCurrentHoldings(derivative.Underlying);
+            return ForQuantityAtCurrentPrice(derivative.Underlying, quantity);
         }
     }
 }

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -1059,18 +1059,8 @@ namespace QuantConnect.Lean.Engine
                     continue;
                 }
 
-                var orderType = OrderType.Market;
-                var tag = "Liquidate from delisting";
-                if (security.Type.IsOption())
-                {
-                    // tx handler will determine auto exercise/assignment
-                    tag = "Option Expired";
-                    orderType = OrderType.OptionExercise;
-                }
-
                 // submit an order to liquidate on market close or exercise (for options)
-                var request = new SubmitOrderRequest(orderType, security.Type, security.Symbol,
-                    -security.Holdings.Quantity, 0, 0, algorithm.UtcTime, tag);
+                var request = security.CreateDelistedSecurityOrderRequest(algorithm.UtcTime);
 
                 delistings.RemoveAt(i);
                 algorithm.Transactions.ProcessRequest(request);

--- a/Tests/Common/Securities/FutureOptionMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/FutureOptionMarginBuyingPowerModelTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -16,10 +16,15 @@
 using System;
 using NUnit.Framework;
 using QuantConnect.Data;
-using QuantConnect.Data.Market;
+using QuantConnect.Orders;
 using QuantConnect.Securities;
+using QuantConnect.Data.Market;
+using QuantConnect.Tests.Engine;
 using QuantConnect.Securities.Future;
 using QuantConnect.Securities.Option;
+using QuantConnect.Tests.Engine.DataFeeds;
+using QuantConnect.Brokerages.Backtesting;
+using QuantConnect.Lean.Engine.TransactionHandlers;
 
 namespace QuantConnect.Tests.Common.Securities
 {
@@ -27,7 +32,7 @@ namespace QuantConnect.Tests.Common.Securities
     public class FutureOptionMarginBuyingPowerModelTests
     {
         [Test]
-        public void MarginForSymbolWithOneLinerHistory()
+        public void MarginWithNoFutureOptionHoldings()
         {
             const decimal price = 1.2345m;
             var time = new DateTime(2020, 10, 14);
@@ -61,9 +66,132 @@ namespace QuantConnect.Tests.Common.Securities
             var futureBuyingPowerModel = new FutureMarginModel(security: optionSecurity.Underlying);
             var futureOptionBuyingPowerModel = new FuturesOptionsMarginModel(futureOption: optionSecurity);
 
+            // we don't hold FOPs!
+            Assert.AreEqual(0m, futureOptionBuyingPowerModel.GetMaintenanceMargin(optionSecurity));
+            Assert.AreNotEqual(0m, futureBuyingPowerModel.GetMaintenanceMargin(optionSecurity.Underlying));
+
+            Assert.AreNotEqual(0m, futureOptionBuyingPowerModel.GetInitialMarginRequirement(optionSecurity, 10));
+            Assert.AreEqual(
+                futureBuyingPowerModel.GetInitialMarginRequirement(optionSecurity.Underlying, 10) *
+                FuturesOptionsMarginModel.FixedMarginMultiplier,
+                futureOptionBuyingPowerModel.GetInitialMarginRequirement(optionSecurity, 10));
+        }
+
+        [Test]
+        public void MarginWithFutureAndFutureOptionHoldings()
+        {
+            const decimal price = 1.2345m;
+            var time = new DateTime(2020, 10, 14);
+            var expDate = new DateTime(2021, 3, 19);
+            var tz = TimeZones.NewYork;
+
+            // For this symbol we dont have any history, but only one date and margins line
+            var ticker = QuantConnect.Securities.Futures.Indices.SP500EMini;
+            var future = Symbol.CreateFuture(ticker, Market.CME, expDate);
+            var symbol = Symbol.CreateOption(future, Market.CME, OptionStyle.American, OptionRight.Call, 2550m,
+                new DateTime(2021, 3, 19));
+
+            var optionSecurity = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(Currencies.USD, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
+            );
+            optionSecurity.Underlying = new Future(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), future, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(Currencies.USD, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
+            );
+            optionSecurity.Underlying.SetMarketPrice(new Tick {Value = price, Time = time});
+            optionSecurity.Holdings.SetHoldings(1.5m, 1);
+            optionSecurity.Underlying.Holdings.SetHoldings(1.5m, 1);
+
+            var futureBuyingPowerModel = new FutureMarginModel(security: optionSecurity.Underlying);
+            var futureOptionBuyingPowerModel = new FuturesOptionsMarginModel(futureOption: optionSecurity);
+
             Assert.AreNotEqual(0m, futureOptionBuyingPowerModel.GetMaintenanceMargin(optionSecurity));
-            Assert.AreEqual(futureBuyingPowerModel.GetMaintenanceMargin(optionSecurity.Underlying) * 1.5m, futureOptionBuyingPowerModel.GetMaintenanceMargin(optionSecurity));
+            Assert.AreEqual(
+                futureBuyingPowerModel.GetMaintenanceMargin(optionSecurity.Underlying) *
+                FuturesOptionsMarginModel.FixedMarginMultiplier,
+                futureOptionBuyingPowerModel.GetMaintenanceMargin(optionSecurity));
+        }
+
+        [Test]
+        public void MarginWithFutureOptionHoldings()
+        {
+            const decimal price = 1.2345m;
+            var time = new DateTime(2020, 10, 14);
+            var expDate = new DateTime(2021, 3, 19);
+            var tz = TimeZones.NewYork;
+
+            // For this symbol we dont have any history, but only one date and margins line
+            var ticker = QuantConnect.Securities.Futures.Indices.SP500EMini;
+            var future = Symbol.CreateFuture(ticker, Market.CME, expDate);
+            var symbol = Symbol.CreateOption(future, Market.CME, OptionStyle.American, OptionRight.Call, 2550m,
+                new DateTime(2021, 3, 19));
+
+            var optionSecurity = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(Currencies.USD, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
+            );
+            optionSecurity.Underlying = new Future(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), future, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(Currencies.USD, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
+            );
+            optionSecurity.Underlying.SetMarketPrice(new Tick { Value = price, Time = time });
+            optionSecurity.Holdings.SetHoldings(1.5m, 1);
+
+            var futureBuyingPowerModel = new FutureMarginModel(security: optionSecurity.Underlying);
+            var futureOptionBuyingPowerModel = new FuturesOptionsMarginModel(futureOption: optionSecurity);
+
+            Assert.AreNotEqual(0m, futureOptionBuyingPowerModel.GetMaintenanceMargin(optionSecurity));
+            Assert.AreEqual(0, futureBuyingPowerModel.GetMaintenanceMargin(optionSecurity.Underlying));
+        }
+
+        [Test]
+        public void OptionExersiceWhenFullyInvested()
+        {
+            var algorithm = new AlgorithmStub();
+            algorithm.SetFinishedWarmingUp();
+            var backtestingTransactionHandler = new BacktestingTransactionHandler();
+            algorithm.Transactions.SetOrderProcessor(backtestingTransactionHandler);
+            backtestingTransactionHandler.Initialize(algorithm, new BacktestingBrokerage(algorithm), new TestResultHandler(packet => { }));
+
+            const decimal price = 2600m;
+            var time = new DateTime(2020, 10, 14);
+            var expDate = new DateTime(2021, 3, 19);
+
+            // For this symbol we dont have any history, but only one date and margins line
+            var ticker = QuantConnect.Securities.Futures.Indices.SP500EMini;
+            var future = Symbol.CreateFuture(ticker, Market.CME, expDate);
+            var symbol = Symbol.CreateOption(future, Market.CME, OptionStyle.American, OptionRight.Call, 2550m,
+                new DateTime(2021, 3, 19));
+
+            var optionSecurity = algorithm.AddOptionContract(symbol);
+            optionSecurity.Underlying = algorithm.AddFutureContract(future);
+
+            optionSecurity.Underlying.SetMarketPrice(new Tick { Value = price, Time = time });
+            optionSecurity.SetMarketPrice(new Tick { Value = 150, Time = time });
+            optionSecurity.Holdings.SetHoldings(1.5m, 10);
+
+            var request = optionSecurity.CreateDelistedSecurityOrderRequest(algorithm.UtcTime);
+
+            var ticket = algorithm.Transactions.AddOrder(request);
+
+            Assert.AreEqual(OrderStatus.Filled, ticket.Status);
         }
     }
 }
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix FOPs maintenance margin requirements since they were relaying on
  the underlyings holdings cost to return 0 in some cases. Updating unit
  tests. Cause the capacity calculation to be increased
- Fix Option exercise order being rejected because of margin not
  available, will now take into account the margin used by the option
  itself. Adding unit test

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


<details>
<summary>Python Algorithm Reproducing Issue</summary>

```python
import pandas as pd
import numpy as np
class FuturesOptionsStrategyAlgorithm(QCAlgorithm):
    def Initialize(self):
        self.SetTimeZone("America/Chicago")
        self.SetStartDate(2016, 10, 25)
        self.SetEndDate(2016, 10, 25)
        self.SetCash(10000)
        futuresInstrument = self.AddFuture('GC', Resolution.Minute)
        futuresInstrument.SetFilter(1, 1000)
    def OnData(self, data):
        if not (self.Time.hour == 9 and self.Time.minute > 30):
            return
        if self.Portfolio.Invested:
            self.Debug(str(self.Time) + '; MarginRemaining after entering: ' + str(self.Portfolio.MarginRemaining))
            self.Quit()
            return
        for chain in data.FutureChains:
            allFuturesContracts = [x for x in chain.Value]
            if len(allFuturesContracts) == 0:
                return None
        allFuturesOptionsChains = []
        for contract in allFuturesContracts:
            allContracts = self.OptionChainProvider.GetOptionContractList(contract.Symbol, self.Time.date())
            allFuturesOptionsChains.extend(allContracts)
        self.Debug(str(self.Time) + '; MarginRemaining before entering: ' + str(self.Portfolio.MarginRemaining))
        for contract in allFuturesOptionsChains:
            if contract.Value.replace(' ', '') == 'OG170126C01400000':
                self.AddOptionContract(contract, Resolution.Minute)
                if self.Securities[contract].AskPrice <= 0 or not data.ContainsKey(contract):
                    return None
                self.Debug(str(self.Time) + '; ' + contract.Value + '; ' + str(self.Securities[contract].AskPrice))
                self.MarketOrder(contract, 10)
```

</details>

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
N/A
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test and all existing tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
