### PR TITLE
Delisted Warning Time Correction

### DIFF
--- a/Algorithm.CSharp/DelistedIndexOptionDivestedRegression.cs
+++ b/Algorithm.CSharp/DelistedIndexOptionDivestedRegression.cs
@@ -1,0 +1,151 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class DelistedIndexOptionDivestedRegression : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol spx;
+        private Symbol optionSymbol;
+        private DateTime optionExpiry = DateTime.MaxValue;
+        private string ticker;
+        private bool addOption = true;
+
+        public override void Initialize()
+        {
+            SetStartDate(2021, 1, 3);  //Set Start Date
+            SetEndDate(2021, 1, 20);    //Set End Date
+
+            ticker = "SPX";
+            var spxSecurity = AddIndex(ticker, Resolution.Minute);
+            spxSecurity.SetDataNormalizationMode(DataNormalizationMode.Raw);
+            spx = spxSecurity.Symbol;
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (!slice.ContainsKey(spx))
+            {
+                return;
+            }
+
+            if (addOption)
+            {
+                var contracts = OptionChainProvider.GetOptionContractList(spx, Time);
+                contracts = contracts.Where(x =>
+                    x.ID.OptionRight == OptionRight.Put &&
+                    x.ID.Date.Date == new DateTime(2021, 1, 15));
+
+                var option = AddIndexOptionContract(contracts.First(), Resolution.Minute);
+                optionExpiry = option.Expiry;
+                optionSymbol = option.Symbol;
+
+
+                addOption = false;
+            }
+
+            if (slice.ContainsKey(optionSymbol))
+            {
+                if (!Portfolio.Invested)
+                {
+                    SetHoldings(optionSymbol, 0.25);
+                }
+
+                if (optionExpiry < Time.Date)
+                {
+                    throw new Exception($"Received expired contract {optionSymbol} expired: {optionExpiry} current time: {Time}");
+                }
+            }
+
+        }
+        public override void OnEndOfAlgorithm()
+        {
+            foreach (var holding in Portfolio.Values)
+            {
+                Log($"Holding {holding.Symbol.Value}; Invested: {holding.Invested}; Quantity: {holding.Quantity}");
+
+                if (holding.Symbol == optionSymbol && holding.Invested)
+                {
+                    throw new Exception($"Index option {optionSymbol.Value} is still invested after delisting");
+                }
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "2"},
+            {"Average Win", "0%"},
+            {"Average Loss", "-26.40%"},
+            {"Compounding Annual Return", "-99.821%"},
+            {"Drawdown", "45.600%"},
+            {"Expectancy", "-1"},
+            {"Net Profit", "-26.400%"},
+            {"Sharpe Ratio", "-0.557"},
+            {"Probabilistic Sharpe Ratio", "20.162%"},
+            {"Loss Rate", "100%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "-0.564"},
+            {"Beta", "-0.663"},
+            {"Annual Standard Deviation", "1.752"},
+            {"Annual Variance", "3.069"},
+            {"Information Ratio", "-0.906"},
+            {"Tracking Error", "1.763"},
+            {"Treynor Ratio", "1.472"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$1000000.00"},
+            {"Lowest Capacity Asset", "SPX 31KC0UJFONTBI|SPX 31"},
+            {"Fitness Score", "0.005"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "-0.249"},
+            {"Return Over Maximum Drawdown", "-2.699"},
+            {"Portfolio Turnover", "0.016"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "4ae4c1d8e4054c41908fd36e893699a6"}
+        };
+    }
+}

--- a/Engine/DataFeeds/Enumerators/DelistingEventProvider.cs
+++ b/Engine/DataFeeds/Enumerators/DelistingEventProvider.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -76,7 +76,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                     var price = eventArgs.LastBaseData?.Price ?? 0;
                     yield return new Delisting(
                         eventArgs.Symbol,
-                        eventArgs.Date,
+                        DelistingDate.Value.Date,
                         price,
                         DelistingType.Warning);
                 }

--- a/Tests/Engine/DataFeeds/Enumerators/DelistingEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/DelistingEnumeratorTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -64,7 +64,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             Assert.IsNotNull(enumerator.Current as Delisting);
             Assert.AreEqual(MarketDataType.Auxiliary, enumerator.Current.DataType);
             Assert.AreEqual(DelistingType.Warning, (enumerator.Current as Delisting).Type);
-            Assert.AreEqual(DateTime.UtcNow.Date, (enumerator.Current as Delisting).Time.Date);
+            Assert.AreEqual(_config.Symbol.ID.Date, (enumerator.Current as Delisting).Time.Date);
             Assert.AreEqual(7.5, (enumerator.Current as Delisting).Price);
 
             Assert.IsTrue(enumerator.MoveNext());

--- a/Tests/Engine/DataFeeds/Enumerators/DelistingEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/DelistingEnumeratorTests.cs
@@ -15,6 +15,8 @@
 */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -175,6 +177,68 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
 
             Assert.IsFalse(enumerator.MoveNext());
 
+            enumerator.Dispose();
+        }
+
+        [Test]
+        public void EmitsDelistedWarningOnNonTradableDay()
+        {
+            // Unit test to simulate and reproduce #5545
+
+            // Give us two tradable days before and after expiration
+            var tradableDays = new List<DateTime> { new DateTime(2021, 01, 01), new DateTime(2021, 01, 04) };
+
+            // Set expiration as 1/2/21 a Saturday, not included in our tradble days
+            var expiration = new DateTime(2021, 01, 02);
+            var symbol = Symbol.CreateFuture("ASD", Market.USA, expiration);
+            var config = new SubscriptionDataConfig(typeof(TradeBar),
+                symbol,
+                Resolution.Daily,
+                TimeZones.NewYork,
+                TimeZones.NewYork,
+                true,
+                true,
+                false);
+            
+            var eventProvider = new DelistingEventProvider();
+            eventProvider.Initialize(config,
+                null,
+                null,
+                DateTime.UtcNow);
+
+            var tradableDateEvents = tradableDays.Select(day => new NewTradableDateEventArgs(
+                day,
+                new Tick(day, config.Symbol, 10, 5),
+                config.Symbol,
+                null
+            )).GetEnumerator();
+
+            // Pass in the day before expiration should be nothing
+            tradableDateEvents.MoveNext();
+            var enumerator = eventProvider.GetEvents(tradableDateEvents.Current).GetEnumerator();
+            Assert.IsFalse(enumerator.MoveNext());
+
+            // Pass in the following monday, should be both but warning first and still scheduled for saturday
+            tradableDateEvents.MoveNext();
+            enumerator = eventProvider.GetEvents(tradableDateEvents.Current).GetEnumerator();
+
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNotNull(enumerator.Current as Delisting);
+            Assert.AreEqual(MarketDataType.Auxiliary, enumerator.Current.DataType);
+            Assert.AreEqual(DelistingType.Warning, (enumerator.Current as Delisting).Type);
+            Assert.AreEqual(config.Symbol.ID.Date, (enumerator.Current as Delisting).Time.Date);
+            Assert.AreEqual(7.5, (enumerator.Current as Delisting).Price);
+
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNotNull(enumerator.Current as Delisting);
+            Assert.AreEqual(MarketDataType.Auxiliary, enumerator.Current.DataType);
+            Assert.AreEqual(DelistingType.Delisted, (enumerator.Current as Delisting).Type);
+            Assert.AreEqual(config.Symbol.ID.Date.AddDays(1), (enumerator.Current as Delisting).Time.Date);
+            Assert.AreEqual(7.5, (enumerator.Current as Delisting).Price);
+
+            Assert.IsFalse(enumerator.MoveNext());
+
+            tradableDateEvents.Dispose();
             enumerator.Dispose();
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adjust Delisted Warning time to emit on `DelistingDate.Value.Date`
- Update Delisting unit test to reflect this change
- Add regression that mimics the issue, (This one is strange because the expiration in the issue was a saturday triggering the problem, the indexoption data included in our repo does not have a saturday expiration)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5545

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This issue aims to address the problem described in #5545. Some information on this particular case:
- Index Option {SPX   101016P01000000}
- Expires 10/16/2010 ( A Saturday)

Because the delisting provider generates events only on `TradableDay`'s passed to it, we were not generating the delisting events for this contract until the data reached after or on contract expiration day. But because the tradeable days for this option does not include Saturday, we actually didn't get to create the event until the following Monday.

Now when it received this event, it was using the eventarg.date for the warning emit time (Monday), but the delisting emit time was using the `delistingdate.AddDays(1)` (Saturday +1 = Sunday). Meaning that its warning would not occur before the delisting, which would in turn not give the algorithm manager time to liquidate before the delisting occurred. 

With this adjustment I am hard setting the warning emit time to be the `delistingDate.Date` component, which is the day of delisting at 12AM. So that it will be processed (liquidation or assignment) before the delisting occurs, resolving the issue linked above.


#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All regressions passing.
Delisting unit test updated to expect the delisting.date

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
