### PR TITLE
Resolve Currency ConversionRate Backup

### DIFF
--- a/Engine/Setup/BaseSetupHandler.cs
+++ b/Engine/Setup/BaseSetupHandler.cs
@@ -93,6 +93,7 @@ namespace QuantConnect.Lean.Engine.Setup
                     resolution));
             }
 
+            // Attempt to get history for these requests and update cash
             var slices = algorithm.HistoryProvider.GetHistory(historyRequests, algorithm.TimeZone);
             slices.PushThrough(data =>
             {
@@ -102,6 +103,37 @@ namespace QuantConnect.Lean.Engine.Setup
                     cash.Update(data);
                 }
             });
+
+            // Any remaining unassigned cash will attempt to fall back to a daily resolution history request to resolve
+            var unassignedCash = cashToUpdate.Where(x => x.ConversionRate == 0).Select(x => x.SecuritySymbol).ToList();
+            if (unassignedCash.Any())
+            {
+                Log.Error($"Failed to assign conversion rates for the following cash: {string.Join(",", unassignedCash.Select(x => x.Value))}." +
+                    $" Attempting to request daily resolution history to resolve conversion rate");
+
+                var originalRequests = historyRequests.Where(x =>
+                    unassignedCash.Contains(x.Symbol));
+
+                var replacementHistoryRequests = new List<HistoryRequest>();
+                foreach (var request in originalRequests.Where(x => x.Resolution < Resolution.Daily))
+                {
+                    var newRequest = new HistoryRequest(request.EndTimeUtc.AddDays(-10), request.EndTimeUtc, request.DataType,
+                        request.Symbol, Resolution.Daily, request.ExchangeHours, request.DataTimeZone, request.FillForwardResolution,
+                        request.IncludeExtendedMarketHours, request.IsCustomData, request.DataNormalizationMode, request.TickType);
+
+                    replacementHistoryRequests.Add(newRequest);
+                }
+
+                slices = algorithm.HistoryProvider.GetHistory(replacementHistoryRequests, algorithm.TimeZone);
+                slices.PushThrough(data =>
+                {
+                    foreach (var cash in cashToUpdate
+                        .Where(x => x.ConversionRateSecurity.Symbol == data.Symbol))
+                    {
+                        cash.Update(data);
+                    }
+                });
+            }
 
             Log.Trace("BaseSetupHandler.SetupCurrencyConversions():" +
                 $"{Environment.NewLine}{algorithm.Portfolio.CashBook}");

--- a/Engine/Setup/BaseSetupHandler.cs
+++ b/Engine/Setup/BaseSetupHandler.cs
@@ -111,11 +111,8 @@ namespace QuantConnect.Lean.Engine.Setup
                 Log.Error($"Failed to assign conversion rates for the following cash: {string.Join(",", unassignedCash.Select(x => x.Value))}." +
                     $" Attempting to request daily resolution history to resolve conversion rate");
 
-                var originalRequests = historyRequests.Where(x =>
-                    unassignedCash.Contains(x.Symbol));
-
                 var replacementHistoryRequests = new List<HistoryRequest>();
-                foreach (var request in originalRequests.Where(x => x.Resolution < Resolution.Daily))
+                foreach (var request in historyRequests.Where(x => unassignedCash.Contains(x.Symbol) && x.Resolution < Resolution.Daily))
                 {
                     var newRequest = new HistoryRequest(request.EndTimeUtc.AddDays(-10), request.EndTimeUtc, request.DataType,
                         request.Symbol, Resolution.Daily, request.ExchangeHours, request.DataTimeZone, request.FillForwardResolution,

--- a/Tests/Engine/Setup/BaseSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BaseSetupHandlerTests.cs
@@ -1,13 +1,31 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
 using NUnit.Framework;
 using QuantConnect.Data;
+using QuantConnect.Util;
 using QuantConnect.Data.Auxiliary;
+using QuantConnect.Lean.Engine.Setup;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.HistoricalData;
-using QuantConnect.Lean.Engine.Setup;
 
 namespace QuantConnect.Tests.Engine.Setup
 {
-    class BaseSetupHandlerTests
+    [TestFixture]
+    public class BaseSetupHandlerTests
     {
         [Test]
         public void CurrencyConversionRateResolved()
@@ -44,6 +62,8 @@ namespace QuantConnect.Tests.Engine.Setup
             // Assert that our portfolio has some value and that value is bitcoin
             Assert.IsTrue(algorithm.Portfolio.Cash > 0);
             Assert.IsTrue(algorithm.Portfolio.CashBook["BTC"].ValueInAccountCurrency > 0);
+
+            zipCache.DisposeSafely();
         }
     }
 }

--- a/Tests/Engine/Setup/BaseSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BaseSetupHandlerTests.cs
@@ -1,0 +1,49 @@
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Auxiliary;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Lean.Engine.HistoricalData;
+using QuantConnect.Lean.Engine.Setup;
+
+namespace QuantConnect.Tests.Engine.Setup
+{
+    class BaseSetupHandlerTests
+    {
+        [Test]
+        public void CurrencyConversionRateResolved()
+        {
+            // Unit test to prove that in the event that default resolution (minute) history request returns
+            // no data for our currency conversion that BaseSetupHandler will use a daily history request
+            // to determine the the conversion rate if possible.
+
+            // Setup history provider and algorithm
+            var historyProvider = new SubscriptionDataReaderHistoryProvider();
+            var zipCache = new ZipDataCacheProvider(new DefaultDataProvider());
+            historyProvider.Initialize(new HistoryProviderInitializeParameters(
+                null,
+                null,
+                new DefaultDataProvider(),
+                zipCache,
+                new LocalDiskMapFileProvider(),
+                new LocalDiskFactorFileProvider(),
+                null,
+                false,
+                new DataPermissionManager()));
+
+            var algorithm = new BrokerageSetupHandlerTests.TestAlgorithm { UniverseSettings = { Resolution = Resolution.Minute } };
+            algorithm.SetHistoryProvider(historyProvider);
+
+            // Pick a date range where we do NOT have BTCUSD minute data
+            algorithm.SetStartDate(2015, 1, 24);
+            algorithm.SetCash("USD", 0);
+            algorithm.SetCash("BTC", 10);
+
+            // Have BaseSetupHandler resolve the currency conversion
+            BaseSetupHandler.SetupCurrencyConversions(algorithm, algorithm.DataManager.UniverseSelection);
+
+            // Assert that our portfolio has some value and that value is bitcoin
+            Assert.IsTrue(algorithm.Portfolio.Cash > 0);
+            Assert.IsTrue(algorithm.Portfolio.CashBook["BTC"].ValueInAccountCurrency > 0);
+        }
+    }
+}

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -580,7 +580,7 @@ namespace QuantConnect.Tests.Engine.Setup
             };
         }
 
-        private class TestAlgorithm : QCAlgorithm
+        internal class TestAlgorithm : QCAlgorithm
         {
             private readonly Action _beforePostInitializeAction;
 
@@ -602,7 +602,7 @@ namespace QuantConnect.Tests.Engine.Setup
             }
         }
 
-        private LiveNodePacket GetJob()
+        internal static LiveNodePacket GetJob()
         {
             var job = new LiveNodePacket
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
In the event that currency conversion rate can not be determined using a securities assigned resolution attempt to use a daily history request to resolve the conversion rate.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5439

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Gives currency conversion rate a fall back to resolve the conversion rate if the initial history request failed.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All regressions passing
Unit test replicating issue added

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
