### PR TITLE
Increase Binance rate limit to 1 message per 250ms

### DIFF
--- a/Brokerages/Binance/BinanceBrokerage.cs
+++ b/Brokerages/Binance/BinanceBrokerage.cs
@@ -41,8 +41,9 @@ namespace QuantConnect.Brokerages.Binance
         private readonly IAlgorithm _algorithm;
         private readonly SymbolPropertiesDatabaseSymbolMapper _symbolMapper = new SymbolPropertiesDatabaseSymbolMapper(Market.Binance);
 
-        // Binance allows 5 messages per second, but RateGate is sometimes off by a few milliseconds, so we use 5 messages per 1.1 seconds instead
-        private readonly RateGate _webSocketRateLimiter = new RateGate(5, TimeSpan.FromSeconds(1.1));
+        // Binance allows 5 messages per second, but we still get rate limited if we send a lot of messages at that rate
+        // By sending 4 messages per second, evenly spaced out, we can keep sending messages without being limited
+        private readonly RateGate _webSocketRateLimiter = new RateGate(1, TimeSpan.FromMilliseconds(250));
         private long _lastRequestId;
 
         private readonly Timer _keepAliveTimer;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Increases the WebSocket rate limit of the Binance brokerage to 1 message per 250ms.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5583.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Makes it possible to subscribe to 150+ symbols when live trading on Binance.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local live trading of the following algorithm on Binance:
```python
from QuantConnect import AccountType, Market, Resolution, SecurityType, Symbol
from QuantConnect.Algorithm import QCAlgorithm
from QuantConnect.Brokerages import BrokerageName
from QuantConnect.Data import Slice


class BinanceMassSubscribeAlgorithm(QCAlgorithm):
    def Initialize(self) -> None:
        self.SetTimeZone("UTC")
        self.SetStartDate(2018, 1, 1)
        self.SetEndDate(2021, 4, 30)

        self.SetAccountCurrency("USDT")
        self.SetCash(100_000)

        self.SetBrokerageModel(BrokerageName.Binance, AccountType.Cash)
        self.SetBenchmark(Symbol.Create("BTCUSDT", SecurityType.Crypto, Market.Binance))

        # 166 tickers with USDT as quote currency that are in our SPD and are currently spot trading on Binance
        self.tickers = ["AAVEUSDT", "ADAUSDT", "AIONUSDT", "ALGOUSDT", "ALPHAUSDT", "ANKRUSDT", "ANTUSDT", "ARDRUSDT",
                        "ARPAUSDT", "ATOMUSDT", "AUDIOUSDT", "AUDUSDT", "AVAXUSDT", "BALUSDT", "BANDUSDT", "BATUSDT",
                        "BCHUSDT", "BEAMUSDT", "BELUSDT", "BLZUSDT", "BNBUSDT", "BNTUSDT", "BTCUSDT", "BTSUSDT",
                        "BTTUSDT", "BUSDUSDT", "BZRXUSDT", "CELRUSDT", "CHRUSDT", "CHZUSDT", "COCOSUSDT", "COMPUSDT",
                        "COSUSDT", "COTIUSDT", "CRVUSDT", "CTSIUSDT", "CTXCUSDT", "CVCUSDT", "DASHUSDT", "DATAUSDT",
                        "DCRUSDT", "DENTUSDT", "DGBUSDT", "DIAUSDT", "DOCKUSDT", "DOGEUSDT", "DOTUSDT", "DREPUSDT",
                        "DUSKUSDT", "EGLDUSDT", "ENJUSDT", "EOSUSDT", "ETCUSDT", "ETHUSDT", "EURUSDT", "FETUSDT",
                        "FILUSDT", "FIOUSDT", "FLMUSDT", "FTMUSDT", "FTTUSDT", "FUNUSDT", "GBPUSDT", "GTOUSDT",
                        "GXSUSDT", "HBARUSDT", "HIVEUSDT", "HNTUSDT", "HOTUSDT", "ICXUSDT", "INJUSDT", "IOSTUSDT",
                        "IOTAUSDT", "IOTXUSDT", "IRISUSDT", "JSTUSDT", "KAVAUSDT", "KEYUSDT", "KMDUSDT", "KNCUSDT",
                        "KSMUSDT", "LINKUSDT", "LRCUSDT", "LSKUSDT", "LTCUSDT", "LTOUSDT", "LUNAUSDT", "MANAUSDT",
                        "MATICUSDT", "MBLUSDT", "MDTUSDT", "MFTUSDT", "MITHUSDT", "MKRUSDT", "MTLUSDT", "NANOUSDT",
                        "NBSUSDT", "NEARUSDT", "NEOUSDT", "NKNUSDT", "NMRUSDT", "NULSUSDT", "OCEANUSDT", "OGNUSDT",
                        "OMGUSDT", "ONEUSDT", "ONGUSDT", "ONTUSDT", "ORNUSDT", "OXTUSDT", "PAXGUSDT", "PAXUSDT",
                        "PERLUSDT", "PNTUSDT", "QTUMUSDT", "RENUSDT", "REPUSDT", "RLCUSDT", "RSRUSDT", "RUNEUSDT",
                        "RVNUSDT", "SANDUSDT", "SCUSDT", "SNXUSDT", "SOLUSDT", "SRMUSDT", "STMXUSDT", "STORJUSDT",
                        "STPTUSDT", "STXUSDT", "SUNUSDT", "SUSHIUSDT", "SXPUSDT", "TCTUSDT", "TFUELUSDT", "THETAUSDT",
                        "TOMOUSDT", "TRBUSDT", "TROYUSDT", "TRXUSDT", "TUSDUSDT", "UMAUSDT", "UNIUSDT", "USDCUSDT",
                        "UTKUSDT", "VETUSDT", "VITEUSDT", "VTHOUSDT", "WANUSDT", "WAVESUSDT", "WINGUSDT", "WINUSDT",
                        "WNXMUSDT", "WRXUSDT", "WTCUSDT", "XLMUSDT", "XMRUSDT", "XRPUSDT", "XTZUSDT", "XVSUSDT",
                        "YFIIUSDT", "YFIUSDT", "ZECUSDT", "ZENUSDT", "ZILUSDT", "ZRXUSDT"]

        for ticker in self.tickers:
            self.AddCrypto(ticker, Resolution.Minute, Market.Binance)

    def OnData(self, data: Slice) -> None:
        tickers_with_data = [ticker for ticker in self.tickers if ticker in data]
        self.Debug(f"{len(tickers_with_data)} tickers with data: {tickers_with_data}")

        tickers_without_data = [ticker for ticker in self.tickers if ticker not in data]
        self.Debug(f"{len(tickers_without_data)} tickers without data: {tickers_without_data}")
```

I have started live trading this algorithm on Binance multiple times with the change in this PR and haven't hit the rate limit once, despite continuously hitting it when live trading this algorithm on Binance using the current master branch.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
