### PR TITLE
Wicked Renko Consolidator Fix

### DIFF
--- a/Common/Data/Consolidators/WickedRenkoConsolidator.cs
+++ b/Common/Data/Consolidators/WickedRenkoConsolidator.cs
@@ -137,6 +137,10 @@ namespace QuantConnect.Data.Consolidators
             {
                 _firstTick = false;
 
+                // Round our first rate to the same length as BarSize
+                var decimalPlaces = BitConverter.GetBytes(decimal.GetBits(BarSize)[3])[2];
+                rate = Math.Round(rate, decimalPlaces);
+
                 OpenOn = data.Time;
                 CloseOn = data.Time;
                 OpenRate = rate;

--- a/Tests/Common/Data/WickedRenkoConsolidatorTests.cs
+++ b/Tests/Common/Data/WickedRenkoConsolidatorTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  * 
@@ -581,6 +581,77 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(openRenko.High, 8.0);
             Assert.AreEqual(openRenko.Low, 7.9);
             Assert.AreEqual(openRenko.Close, 7.9);
+        }
+
+        [Test]
+        public void ConsistentRenkos()
+        {
+            // Reproduce issue #5479
+            // Test Renko bar consistency amongst three consolidators starting at different times
+
+            var time = new DateTime(2016, 1, 1);
+            var testValues = new List<decimal>
+            {
+                1.38687m, 1.38688m, 1.38687m, 1.38686m, 1.38685m, 1.38683m, 
+                1.38682m, 1.38682m, 1.38684m, 1.38682m, 1.38682m, 1.38680m, 
+                1.38681m, 1.38686m, 1.38688m, 1.38688m, 1.38690m, 1.38690m,
+                1.38691m, 1.38692m, 1.38694m, 1.38695m, 1.38697m, 1.38697m,
+                1.38700m, 1.38699m, 1.38699m, 1.38699m, 1.38698m, 1.38699m, 
+                1.38697m, 1.38698m, 1.38698m, 1.38697m, 1.38698m, 1.38698m,
+                1.38697m, 1.38697m, 1.38700m, 1.38702m, 1.38701m, 1.38699m,
+                1.38697m, 1.38698m, 1.38696m, 1.38698m, 1.38697m, 1.38695m,
+                1.38695m, 1.38696m, 1.38693m, 1.38692m, 1.38693m, 1.38693m,
+                1.38692m, 1.38693m, 1.38692m, 1.38690m, 1.38686m, 1.38685m,
+                1.38687m, 1.38686m, 1.38686m, 1.38686m, 1.38686m, 1.38685m,
+                1.38684m, 1.38678m, 1.38679m, 1.38680m, 1.38680m, 1.38681m,
+                1.38685m, 1.38685m, 1.38683m, 1.38682m, 1.38682m, 1.38683m,
+                1.38682m, 1.38683m, 1.38682m, 1.38681m, 1.38680m, 1.38681m,
+                1.38681m, 1.38681m, 1.38682m, 1.38680m, 1.38679m, 1.38678m,
+                1.38675m, 1.38678m, 1.38678m, 1.38678m, 1.38682m, 1.38681m,
+                1.38682m, 1.38680m, 1.38682m, 1.38683m, 1.38685m, 1.38683m,
+                1.38683m, 1.38684m, 1.38683m, 1.38683m, 1.38684m, 1.38685m,
+                1.38684m, 1.38683m, 1.38686m, 1.38685m, 1.38685m, 1.38684m,
+                1.38685m, 1.38682m, 1.38684m, 1.38683m, 1.38682m, 1.38683m,
+                1.38685m, 1.38685m, 1.38685m, 1.38683m, 1.38685m, 1.38684m,
+                1.38686m, 1.38693m, 1.38695m, 1.38693m, 1.38694m, 1.38693m,
+                1.38692m, 1.38693m, 1.38695m, 1.38697m, 1.38698m, 1.38695m,
+                1.38696m
+            };
+
+
+            var consolidator1 = new WickedRenkoConsolidator(0.0001m);
+            var consolidator2 = new WickedRenkoConsolidator(0.0001m);
+            var consolidator3 = new WickedRenkoConsolidator(0.0001m);
+
+            // Update each of our consolidators starting at different indexes of test values
+            for (int i = 0; i < testValues.Count; i++)
+            {
+                var data = new IndicatorDataPoint(time.AddSeconds(i), testValues[i]);
+                consolidator1.Update(data);
+
+                if (i > 10)
+                {
+                    consolidator2.Update(data);
+                }
+
+                if (i > 20)
+                {
+                    consolidator3.Update(data);
+                }
+            }
+
+            // Assert that consolidator 2 and 3 price is the same as 1. Even though they started at different
+            // indexes they should be the same
+            var bar1 = consolidator1.Consolidated as RenkoBar;
+            var bar2 = consolidator2.Consolidated as RenkoBar;
+            var bar3 = consolidator3.Consolidated as RenkoBar;
+
+            Assert.AreEqual(bar1.Close, bar2.Close);
+            Assert.AreEqual(bar1.Close, bar3.Close);
+
+            consolidator1.Dispose();
+            consolidator2.Dispose();
+            consolidator3.Dispose();
         }
 
         private class TestWickedRenkoConsolidator : WickedRenkoConsolidator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Round the first value passed to the Renko consolidator to the same length as the BarSize.

This corrects the issue where renko value varied based on start date. 


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5479 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Reference issue above

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All regressions passing ✔️ 

Using the following algo 
```cs
    public class TestAlgo : QCAlgorithm
    {
        private DateTime testTime1 = new DateTime(2014, 5, 5, 0, 2, 0);
        private DateTime testTime2 = new DateTime(2014, 5, 6, 0, 2, 0);
        private RenkoBar currentBar = null;

        public override void Initialize()
        {
            SetStartDate(2014, 5, 2);  //Set Start Date
            SetEndDate(2014, 5, 8);    //Set End Date
            SetCash(10000000);

            var forex = AddForex("EURUSD", Resolution.Second);
            var renko = new WickedRenkoConsolidator(0.0001m);
            renko.DataConsolidated += OnDataRenko;
            SubscriptionManager.AddConsolidator(forex.Symbol, renko);
        }

        public void OnDataRenko(object sender, RenkoBar renko)
        {
            currentBar = renko;
        }

        public override void OnData(Slice slice)
        {
            if (Time == testTime1 || Time == testTime2)
            {
                Log($"{Time} : {currentBar.Close}");
            }
        }
    }
```

Before changes:
```
20210522 00:00:33.265 TRACE:: Log: 1.38709
20210522 00:00:34.268 TRACE:: Log: 1.38719
20210522 00:00:34.761 TRACE:: Log: 1.38729
20210522 00:00:35.175 TRACE:: Log: 1.38709
20210522 00:00:35.625 TRACE:: Log: 1.38699
20210522 00:00:36.090 TRACE:: Log: 1.38719
20210522 00:00:36.489 TRACE:: Log: 1.38729
20210522 00:00:36.922 TRACE:: Log: 1.38739
20210522 00:00:37.441 TRACE:: Log: 1.38719
20210522 00:00:38.016 TRACE:: Log: 1.38709
20210522 00:00:38.457 TRACE:: Log: 1.38699
```

After changes:
```
20210522 00:13:22.100 TRACE:: Log: 1.3871
20210522 00:13:22.100 TRACE:: Log: 1.3872
20210522 00:13:22.101 TRACE:: Log: 1.3873
20210522 00:13:22.101 TRACE:: Log: 1.3871
20210522 00:13:22.101 TRACE:: Log: 1.3870
20210522 00:13:22.101 TRACE:: Log: 1.3872
20210522 00:13:22.102 TRACE:: Log: 1.3873
20210522 00:13:22.102 TRACE:: Log: 1.3874
20210522 00:13:22.102 TRACE:: Log: 1.3872
20210522 00:13:22.103 TRACE:: Log: 1.3871
20210522 00:13:22.103 TRACE:: Log: 1.3870
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
