### PR TITLE
Reduce Leverage for Equity to 1 in Alpha Stream Brokerage Model

### DIFF
--- a/Common/Brokerages/AlphaStreamsBrokerageModel.cs
+++ b/Common/Brokerages/AlphaStreamsBrokerageModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -66,22 +66,10 @@ namespace QuantConnect.Brokerages
 
             switch (security.Type)
             {
-                case SecurityType.Equity:
-                    return 2m;
-
                 case SecurityType.Forex:
                 case SecurityType.Cfd:
                     return 10m;
 
-                case SecurityType.Crypto:
-                    return 1m;
-
-                case SecurityType.Base:
-                case SecurityType.Commodity:
-                case SecurityType.Option:
-                case SecurityType.FutureOption:
-                case SecurityType.IndexOption:
-                case SecurityType.Future:
                 default:
                     return 1m;
             }


### PR DESCRIPTION
#### Description
All security type use 1 as leverage but Forex and CFD that are allowed to use 10.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`