### PR TITLE
Bitfinex Fee Model Fix

### DIFF
--- a/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -397,7 +397,10 @@ namespace QuantConnect.Brokerages.Bitfinex
                 var fillQuantity = update.ExecAmount;
                 var direction = fillQuantity < 0 ? OrderDirection.Sell : OrderDirection.Buy;
                 var updTime = Time.UnixMillisecondTimeStampToDateTime(update.MtsCreate);
-                var orderFee = new OrderFee(new CashAmount(Math.Abs(update.Fee), GetLeanCurrency(update.FeeCurrency)));
+
+                // Round our fee by the lot size on this security
+                var properties = _symbolPropertiesDatabase.GetSymbolProperties(Market.Bitfinex, symbol, SecurityType.Crypto, order.PriceCurrency);
+                var orderFee = new OrderFee(new CashAmount(Math.Abs(update.Fee % properties.LotSize), GetLeanCurrency(update.FeeCurrency)));
 
                 var status = OrderStatus.Filled;
                 if (fillQuantity != order.Quantity)

--- a/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
@@ -398,9 +398,10 @@ namespace QuantConnect.Brokerages.Bitfinex
                 var direction = fillQuantity < 0 ? OrderDirection.Sell : OrderDirection.Buy;
                 var updTime = Time.UnixMillisecondTimeStampToDateTime(update.MtsCreate);
 
-                // Round our fee by the lot size on this security
+                // Round off our fee by the lot size on this security
                 var properties = _symbolPropertiesDatabase.GetSymbolProperties(Market.Bitfinex, symbol, SecurityType.Crypto, order.PriceCurrency);
-                var orderFee = new OrderFee(new CashAmount(Math.Abs(update.Fee % properties.LotSize), GetLeanCurrency(update.FeeCurrency)));
+                var fee = update.Fee - (update.Fee % properties.LotSize);
+                var orderFee = new OrderFee(new CashAmount(Math.Abs(fee), GetLeanCurrency(update.FeeCurrency)));
 
                 var status = OrderStatus.Filled;
                 if (fillQuantity != order.Quantity)

--- a/Common/Data/Consolidators/WickedRenkoConsolidator.cs
+++ b/Common/Data/Consolidators/WickedRenkoConsolidator.cs
@@ -138,7 +138,7 @@ namespace QuantConnect.Data.Consolidators
                 _firstTick = false;
 
                 // Round our first rate to the same length as BarSize
-                var decimalPlaces = BitConverter.GetBytes(decimal.GetBits(BarSize)[3])[2];
+                var decimalPlaces = BarSize.GetDecimalPlaces();
                 rate = Math.Round(rate, decimalPlaces);
 
                 OpenOn = data.Time;

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -3093,5 +3093,15 @@ namespace QuantConnect
                 return hashCode;
             }
         }
+
+        /// <summary>
+        /// Get the number of decimal places for the given decimal
+        /// </summary>
+        /// <param name="number">Number to determine number of decimal places for</param>
+        /// <returns>Number of decimal places</returns>
+        public static int GetDecimalPlaces(this decimal number)
+        {
+            return BitConverter.GetBytes(decimal.GetBits(number)[3])[2];
+        }
     }
 }

--- a/Common/Orders/Fees/BitfinexFeeModel.cs
+++ b/Common/Orders/Fees/BitfinexFeeModel.cs
@@ -69,9 +69,9 @@ namespace QuantConnect.Orders.Fees
 
             unitPrice *= security.SymbolProperties.ContractMultiplier;
 
-            // Determine fee and round to lot size decimal places
-            var decimalPlaces = security.SymbolProperties.LotSize.GetDecimalPlaces();
-            var fee = Math.Round(unitPrice * order.AbsoluteQuantity * feePercentage, decimalPlaces);
+            // Determine fee and round decimal places to lotsize
+            var fee = unitPrice * order.AbsoluteQuantity * feePercentage;
+            fee -= fee % security.SymbolProperties.LotSize;
             return new OrderFee(new CashAmount(
                 fee,
                 security.QuoteCurrency.Symbol));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Create `GetDecimalPlaces()` extension method for decimals
- Adjust Bitfinex fee model to round fee to lot size
- Adjust and add unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5561

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Incorrect modeling of Bitfinex fees which causes issues with order fill sizes. The fee should be rounded to lot size decimal length always. I verified this behavior in bitfinex by using a practice account.

Using BTC (Lot size `0.00000001`) Taker orders (0.2% fee)
Case 1:
- Order 0.00024444 
- Fee = Order * 0.002 = 0.00000048888 -> Rounded to lot size = 0.00000049
![image](https://user-images.githubusercontent.com/41277998/119577483-96907080-bd6f-11eb-9867-0cfad02c43ec.png)

Case 2:
- Order 0.00021111 
- Fee = Order * 0.002 = 0.00000042222 -> Rounded to lot size = 0.00000042
![image](https://user-images.githubusercontent.com/41277998/119577528-aa3bd700-bd6f-11eb-80f3-40ae680ae74f.png)


#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All regressions passing,
Created a unit test to assert rounding behavior is as expected.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
