### PR TITLE
Fixes LeanDataWriter minute/second/tick writing for uncompressed data greater than 2GB in memory

### DIFF
--- a/ToolBox/LeanDataWriter.cs
+++ b/ToolBox/LeanDataWriter.cs
@@ -354,7 +354,7 @@ namespace QuantConnect.ToolBox
         /// <remarks>This function overwrites existing data files</remarks>
         private void WriteMinuteOrSecondOrTick(IEnumerable<BaseData> source)
         {
-            var sb = new StringBuilder();
+            var lines = new List<string>();
             var lastTime = new DateTime();
 
             // Loop through all the data and write to file as we go
@@ -368,21 +368,21 @@ namespace QuantConnect.ToolBox
                 {
                     // Write and clear the file contents
                     var outputFile = GetZipOutputFileName(_dataDirectory, lastTime);
-                    WriteFile(outputFile, sb.ToString(), lastTime);
-                    sb.Clear();
+                    WriteFile(outputFile, lines, lastTime);
+                    lines.Clear();
                 }
 
                 lastTime = data.Time;
 
                 // Build the line and append it to the file
-                sb.Append(LeanData.GenerateLine(data, _securityType, _resolution) + Environment.NewLine);
+                lines.Add(LeanData.GenerateLine(data, _securityType, _resolution));
             }
 
             // Write the last file
-            if (sb.Length > 0)
+            if (lines.Count > 0)
             {
                 var outputFile = GetZipOutputFileName(_dataDirectory, lastTime);
-                WriteFile(outputFile, sb.ToString(), lastTime);
+                WriteFile(outputFile, lines, lastTime);
             }
         }
 
@@ -393,7 +393,7 @@ namespace QuantConnect.ToolBox
         /// <remarks>This function performs a merge (insert/append/overwrite) with the existing Lean zip file</remarks>
         private void WriteDailyOrHour(IEnumerable<BaseData> source)
         {
-            var sb = new StringBuilder();
+            var lines = new List<string>();
             var lastTime = new DateTime();
 
             // Determine file path
@@ -422,13 +422,13 @@ namespace QuantConnect.ToolBox
             foreach (var kvp in rows)
             {
                 // Build the line and append it to the file
-                sb.Append(kvp.Value + Environment.NewLine);
+                lines.Add(kvp.Value);
             }
 
             // Write the file contents
-            if (sb.Length > 0)
+            if (lines.Count > 0)
             {
-                WriteFile(outputFile, sb.ToString(), lastTime);
+                WriteFile(outputFile, lines, lastTime);
             }
         }
 
@@ -467,11 +467,10 @@ namespace QuantConnect.ToolBox
         /// <param name="filePath">The full path to the new file</param>
         /// <param name="data">The data to write as a string</param>
         /// <param name="date">The date the data represents</param>
-        private void WriteFile(string filePath, string data, DateTime date)
+        private void WriteFile(string filePath, IEnumerable<string> data, DateTime date)
         {
             var tempFilePath = filePath + ".tmp";
 
-            data = data.TrimEnd();
             if (File.Exists(filePath) && !_appendToZips)
             {
                 File.Delete(filePath);
@@ -484,13 +483,13 @@ namespace QuantConnect.ToolBox
             if (_appendToZips)
             {
                 var entryName = LeanData.GenerateZipEntryName(_symbol, date, _resolution, _tickType);
-                Compression.ZipCreateAppendData(filePath, entryName, data, true);
+                Compression.ZipCreateAppendData(filePath, entryName, string.Join(Environment.NewLine, data), true);
                 Log.Trace("LeanDataWriter.Write(): Appended: " + filePath);
             }
             else
             {
                 // Write out this data string to a zip file
-                Compression.Zip(data, tempFilePath, LeanData.GenerateZipEntryName(_symbol, date, _resolution, _tickType));
+                Compression.ZipData(tempFilePath, LeanData.GenerateZipEntryName(_symbol, date, _resolution, _tickType), data);
 
                 // Move temp file to the final destination with the appropriate name
                 File.Move(tempFilePath, filePath);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
LeanDataWriter would crash when writing massive amounts of data (>2GB string object). This PR fixes that by fragmenting strings on a line-by-line basis and writing them to ZIP in that way
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5618 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allow writing of large data files, particularly tick data
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Crypto reprocessing ran, backtest ran, cloud processing testing
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
