### PR TITLE
Fixes filtering of CoinAPI raw data in CoinApiDataConverter

### DIFF
--- a/ToolBox/CoinApiDataConverter/CoinApiDataConverter.cs
+++ b/ToolBox/CoinApiDataConverter/CoinApiDataConverter.cs
@@ -89,11 +89,14 @@ namespace QuantConnect.ToolBox.CoinApiDataConverter
                     "quotes",
                     _processingDate.ToStringInvariant(DateFormat.EightCharacter)));
 
+            // Distinct by tick type and first two parts of the raw file name, separated by '-'.
+            // This prevents us from double processing the same ticker twice, in case we're given
+            // two raw data files for the same symbol. Related: https://github.com/QuantConnect/Lean/pull/3262 
             var fileToProcess = tradesFolder.EnumerateFiles("*.gz")
                 .Concat(quotesFolder.EnumerateFiles("*.gz"))
                 .Where(f => f.Name.Contains("SPOT"))
                 .Where(f => f.Name.Split('_').Length == 4)
-                .DistinctBy(x => x.Directory.Parent.Name + x.Name.Split('-')[0]);
+                .DistinctBy(x => x.Directory.Parent.Name + string.Join("-", x.Name.Split('-').Take(2)));
 
             Parallel.ForEach(fileToProcess,(file, loopState) =>
                 {

--- a/ToolBox/CoinApiDataConverter/CoinApiDataConverter.cs
+++ b/ToolBox/CoinApiDataConverter/CoinApiDataConverter.cs
@@ -91,20 +91,20 @@ namespace QuantConnect.ToolBox.CoinApiDataConverter
 
             // Distinct by tick type and first two parts of the raw file name, separated by '-'.
             // This prevents us from double processing the same ticker twice, in case we're given
-            // two raw data files for the same symbol. Related: https://github.com/QuantConnect/Lean/pull/3262 
+            // two raw data files for the same symbol. Related: https://github.com/QuantConnect/Lean/pull/3262
+            var apiDataReader = new CoinApiDataReader(symbolMapper);
             var fileToProcess = tradesFolder.EnumerateFiles("*.gz")
                 .Concat(quotesFolder.EnumerateFiles("*.gz"))
                 .Where(f => f.Name.Contains("SPOT"))
                 .Where(f => f.Name.Split('_').Length == 4)
-                .DistinctBy(x => x.Directory.Parent.Name + string.Join("-", x.Name.Split('-').Take(2)))
-                .DistinctBy(x => new CoinApiDataReader(symbolMapper).GetCoinApiEntryData(x, _processingDate).Symbol);
+                .DistinctBy(x => x.Directory.Parent.Name + apiDataReader.GetCoinApiEntryData(x, _processingDate).Symbol.ID);
 
             Parallel.ForEach(fileToProcess,(file, loopState) =>
                 {
                     Log.Trace($"CoinApiDataConverter(): Starting data conversion from source file: {file.Name}...");
                     try
                     {
-                        ProcessEntry(new CoinApiDataReader(symbolMapper), file);
+                        ProcessEntry(apiDataReader, file);
                     }
                     catch (Exception e)
                     {

--- a/ToolBox/CoinApiDataConverter/CoinApiDataConverter.cs
+++ b/ToolBox/CoinApiDataConverter/CoinApiDataConverter.cs
@@ -96,7 +96,8 @@ namespace QuantConnect.ToolBox.CoinApiDataConverter
                 .Concat(quotesFolder.EnumerateFiles("*.gz"))
                 .Where(f => f.Name.Contains("SPOT"))
                 .Where(f => f.Name.Split('_').Length == 4)
-                .DistinctBy(x => x.Directory.Parent.Name + string.Join("-", x.Name.Split('-').Take(2)));
+                .DistinctBy(x => x.Directory.Parent.Name + string.Join("-", x.Name.Split('-').Take(2)))
+                .DistinctBy(x => new CoinApiDataReader(symbolMapper).GetCoinApiEntryData(x, _processingDate).Symbol);
 
             Parallel.ForEach(fileToProcess,(file, loopState) =>
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Previously, we selected only a single piece of raw data by the ID of that symbol. However, some IDs are duplicated and used for different Symbols, which left some data unprocessed.

The second change is to de-duplicate based on the Symbol we resolve. The reason we do this is because there can be some raw data files that resolve to the same Symbol, but share the same ID and ticker, though it's formatted differently. Example:

```
AI_DBTC
AID_BTC
```

This ensures that no race condition occurs when we start writing data for this ticker to the disk.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to #3262
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improves correctness, stability
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested duplicate ID case by reprocessing crypto data that was previously missing.
Tested processing for AIDBTC symbol on 2018-04-05 and CFIBTC on 2018-05-01, both previously failing cases after first DistinctBy change
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
