### PR TITLE
Fixes OverflowException in FuturesOptionsMarginModel

### DIFF
--- a/Common/Securities/FutureOption/FuturesOptionsMarginModel.cs
+++ b/Common/Securities/FutureOption/FuturesOptionsMarginModel.cs
@@ -152,7 +152,7 @@ namespace QuantConnect.Securities.Option
                 return (int) maximumValue;
             }
 
-            return (int) (maximumValue / (1 + denominator.SafeDecimalCast()));
+            return (int) (maximumValue / (1 + denominator).SafeDecimalCast());
         }
     }
 }

--- a/Tests/Common/Securities/FutureOptionMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/FutureOptionMarginBuyingPowerModelTests.cs
@@ -241,6 +241,7 @@ namespace QuantConnect.Tests.Common.Securities
         [TestCase(87, 3700, OptionRight.Call, PositionSide.Long, 59375)]
         [TestCase(108.5, 1000, OptionRight.Call, PositionSide.Long, 59375)]
         [TestCase(125, 570, OptionRight.Call, PositionSide.Long, 59375)]
+        [TestCase(1000, 0, OptionRight.Call, PositionSide.Long, 59375)]
 
         // Long Call maintenance
         [TestCase(10, 56000, OptionRight.Call, PositionSide.Long, 47500)]
@@ -252,6 +253,7 @@ namespace QuantConnect.Tests.Common.Securities
         [TestCase(87, 3600, OptionRight.Call, PositionSide.Long, 47500)]
         [TestCase(108.5, 1000, OptionRight.Call, PositionSide.Long, 47500)]
         [TestCase(125, 540, OptionRight.Call, PositionSide.Long, 47500)]
+        [TestCase(1000, 0, OptionRight.Call, PositionSide.Long, 47500)]
 
         // Short Call initial
         [TestCase(10, 59400, OptionRight.Call, PositionSide.Short, 59375)]
@@ -263,6 +265,7 @@ namespace QuantConnect.Tests.Common.Securities
         [TestCase(87, 28960, OptionRight.Call, PositionSide.Short, 59375)]
         [TestCase(108.5, 11373, OptionRight.Call, PositionSide.Short, 59375)]
         [TestCase(125, 3900, OptionRight.Call, PositionSide.Short, 59375)]
+        [TestCase(1000, 0, OptionRight.Call, PositionSide.Short, 59375)]
 
         // Long Put initial
         [TestCase(10, 45, OptionRight.Put, PositionSide.Long, 59375)]


### PR DESCRIPTION
#### Description
Fixes `OverflowException` in `FuturesOptionsMarginModel` by changing the order that we add `1` to the denominator variable in the `GetMarginRequirement`: we first add it to the `double` variable before we cast it to `decimal` to avoid `decimal.maxValue + 1` exception. 

#### Related Issue
Closes #5624

#### Motivation and Context
Bug fix.

#### How Has This Been Tested?
An algorithm in QuantConnect.com that exposed thee bug.
Unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`