### PR TITLE
Option Exercise Quantity Fix

### DIFF
--- a/Algorithm.CSharp/OptionExerciseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExerciseRegressionAlgorithm.cs
@@ -1,0 +1,159 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class OptionExerciseRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _equity, _option;
+        private Symbol _contractSymbol;
+        private bool _purchasedUnderlying;
+        private int quantity = 20;
+
+        public override void Initialize()
+        {
+            SetStartDate(2014, 6, 6);
+            SetEndDate(2014, 6, 9);
+            SetCash(1000000);
+
+            _equity = AddEquity("AAPL", Resolution.Minute).Symbol;
+            var option = AddOption("AAPL", Resolution.Minute);
+            _option = option.Symbol;
+
+            option.SetFilter(universe => from symbol in universe
+                                .WeeklysOnly()
+                                .Strikes(-5, +5)
+                                .Expiration(TimeSpan.Zero, TimeSpan.FromDays(29))
+                                         select symbol);
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            Log($"Order Symbol: {orderEvent.Symbol}; Quantity: {orderEvent.Quantity}; Status: {orderEvent.Status}");
+
+            if (orderEvent.Symbol == _equity && orderEvent.Status == OrderStatus.Filled)
+            {
+                _purchasedUnderlying = true;
+            }
+        }
+
+        public override void OnData(Slice data)
+        {
+            if (_contractSymbol != null)
+            {
+                return;
+            }
+
+            // Buy the underlying for our covered put
+            if (data.ContainsKey(_equity) && !_purchasedUnderlying)
+            {
+                MarketOrder(_equity, 100 * quantity);
+            }
+
+            // Buy a contract and exercise it immediately
+            if (_purchasedUnderlying && data.OptionChains.TryGetValue(_option, out OptionChain chain))
+            {
+                var contract = chain
+                    .Where(x => x.Right == OptionRight.Put)
+                    .OrderByDescending(x => x.Strike - data[_equity].Price)
+                    .FirstOrDefault();
+
+                _contractSymbol = contract.Symbol;
+                MarketOrder(_contractSymbol, quantity);
+
+                // Exercise option
+                Log("Quantity before: " + Portfolio[_equity].Quantity);
+                ExerciseOption(_contractSymbol, quantity);
+                Log("Quantity after: " + Portfolio[_equity].Quantity);
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (Portfolio[_equity].Quantity != 0)
+            {
+                throw new Exception("Regression equity holdings should be zero after exercise.");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "3"},
+            {"Average Win", "2.12%"},
+            {"Average Loss", "-2.21%"},
+            {"Compounding Annual Return", "-12.452%"},
+            {"Drawdown", "0.100%"},
+            {"Expectancy", "-0.019"},
+            {"Net Profit", "-0.134%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "50%"},
+            {"Win Rate", "50%"},
+            {"Profit-Loss Ratio", "0.96"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-11.822"},
+            {"Tracking Error", "0.009"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$15.00"},
+            {"Estimated Strategy Capacity", "$420000.00"},
+            {"Lowest Capacity Asset", "AAPL 2ZQA0P58YFYIU|AAPL R735QTJ8XC9X"},
+            {"Fitness Score", "0.5"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "-112.368"},
+            {"Portfolio Turnover", "1.322"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "6cf7690b1df610c3d17bff446aa59ae4"}
+        };
+    }
+}

--- a/Algorithm.CSharp/OptionExerciseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExerciseRegressionAlgorithm.cs
@@ -24,6 +24,9 @@ using QuantConnect.Securities;
 
 namespace QuantConnect.Algorithm.CSharp
 {
+    /// <summary>
+    /// Regression algorithm reproducing issue #5610
+    /// </summary>
     public class OptionExerciseRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private Symbol _equity, _option;
@@ -105,7 +108,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+        public Language[] Languages { get; } = { Language.CSharp };
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Common/Securities/BuyingPowerModel.cs
+++ b/Common/Securities/BuyingPowerModel.cs
@@ -268,7 +268,7 @@ namespace QuantConnect.Securities
                         Time = parameters.Order.Time,
                         LimitPrice = option.StrikePrice,
                         Symbol = underlying.Symbol,
-                        Quantity = option.Symbol.ID.OptionRight == OptionRight.Call ? quantity : -quantity
+                        Quantity = quantity
                     };
 
                     // we continue with this call for underlying


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Fix option exercised quantity in BuyingPowerModel

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5610

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug causing option exercise order quantities to flip sign for put options. This is not needed because the quantity is already determined by option.GetExerciseQuantity() on line 263 of the BuyingPowerModel

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests ran and passing
Additional regression for this issue created. Failing in master, passing in this PR.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
