### PR TITLE
Address some format issues for data request paths

### DIFF
--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -856,7 +856,11 @@ namespace QuantConnect.Api
 
             // Make sure the link was successfully retrieved
             if (!dataLink.Success)
+            {
+                Log.Error($"Api.DownloadData(): Failed to get link for {filePath}. \r\n" +
+                    $"Errors: {string.Join(',', dataLink.Errors)}");
                 return false;
+            }
 
             // Make sure the directory exist before writing
             var directory = Path.GetDirectoryName(filePath);
@@ -1187,15 +1191,21 @@ namespace QuantConnect.Api
         /// <returns>Normalized path</returns>
         public string FormatPathForDataRequest(string filePath)
         {
-            // Normalize windows paths to linux format
-            filePath = filePath.Replace("\\", "/", StringComparison.InvariantCulture);
+            if (filePath == null)
+            {
+                Log.Error("Api.FormatPathForDataRequest(): Cannot format null string");
+                return null;
+            }
 
-            // Remove data root directory from path for request if included
+            // First remove data root directory from path for request if included
             if (filePath.StartsWith(_dataFolder, StringComparison.InvariantCulture))
             {
                 filePath = filePath.Substring(_dataFolder.Length);
             }
 
+            // Normalize windows paths to linux format
+            // Also trim '/' from start, this can cause issues for _dataFolders without final directory separator in the config
+            filePath = filePath.Replace("\\", "/", StringComparison.InvariantCulture).TrimStart('/');
             return filePath;
         }
     }

--- a/Tests/Api/ApiTests.cs
+++ b/Tests/Api/ApiTests.cs
@@ -15,6 +15,7 @@
 
 using NUnit.Framework;
 using QuantConnect.Api;
+using System.IO;
 
 namespace QuantConnect.Tests.API
 {
@@ -65,6 +66,22 @@ namespace QuantConnect.Tests.API
             var api = new Api.Api();
             api.Initialize(TestAccount, "", DataFolder);
             Assert.IsFalse(api.Connected);
+        }
+
+        [TestCase("C:\\Data")]
+        [TestCase("C:\\Data\\")]
+        [TestCase("C:/Data/")]
+        [TestCase("C:/Data")]
+        public void FormattingPathForDataRequestsAreCorrect(string dataFolder)
+        {
+            var api = new Api.Api();
+            api.Initialize(TestAccount, TestToken, dataFolder);
+
+            var dataToDownload = "forex/oanda/daily/eurusd.zip";
+            var path = Path.Combine(dataFolder, dataToDownload);
+
+            var result = api.FormatPathForDataRequest(path);
+            Assert.AreEqual(dataToDownload, result);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Address bugs found with certain paths:
- DataFolder is in Windows path format : need to remove _dataFolder string first before converting to linux format.
- DataFolder does not have final slash, ex: C:/Data instead of C:/Data/ , causes prices to not get matched and request to fail. Now we trim that slash off during the formatting.

Add logging of error in Api.DownloadData for data link failures including error from web api.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Minor adjustments for the new data downloading feature 

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Api data tests are all still passing.
Addition of new test reproducing formatting issue.


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
