### PR TITLE
Research BollingerBands Value Error

### DIFF
--- a/Indicators/BollingerBands.cs
+++ b/Indicators/BollingerBands.cs
@@ -139,10 +139,10 @@ namespace QuantConnect.Indicators
             // Update our Indicators
             var value = ComputeNextValue(input);
 
-            // In the case STD = 0, we know that the our PercentB indicator will fail to update.
-            // This is because the denominator will be 0, when this is the case we do not want
-            // the BollingerBands to emit an update because its PercentB property will be stale.
-            return StandardDeviation.Current.Value == 0
+            // If we are ready and STD = 0, we know that the our PercentB indicator will fail to update.
+            // This is because the denominator will be 0. When this is the case we do not want the
+            // BollingerBands to emit an update because its PercentB property will be stale.
+            return IsReady && StandardDeviation.Current.Value == 0
                 ? new IndicatorResult(value, IndicatorStatus.MathError)
                 : new IndicatorResult(value);
         }

--- a/Indicators/BollingerBands.cs
+++ b/Indicators/BollingerBands.cs
@@ -139,9 +139,9 @@ namespace QuantConnect.Indicators
             // Update our Indicators
             var value = ComputeNextValue(input);
 
-            // If we are ready and STD = 0, we know that the our PercentB indicator will fail to update.
-            // This is because the denominator will be 0. When this is the case we do not want the
-            // BollingerBands to emit an update because its PercentB property will be stale.
+            // If the STD = 0, we know that the our PercentB indicator will fail to update. This is
+            // because the denominator will be 0. When this is the case after fully ready we do not
+            // want the BollingerBands to emit an update because its PercentB property will be stale.
             return IsReady && StandardDeviation.Current.Value == 0
                 ? new IndicatorResult(value, IndicatorStatus.MathError)
                 : new IndicatorResult(value);

--- a/Indicators/BollingerBands.cs
+++ b/Indicators/BollingerBands.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -126,6 +126,25 @@ namespace QuantConnect.Indicators
             Price.Update(input);
 
             return input.Value;
+        }
+
+        /// <summary>
+        /// Validate and Compute the next value for this indicator
+        /// </summary>
+        /// <param name="input">Input for this indicator</param>
+        /// <returns><see cref="IndicatorResult"/> of this update</returns>
+        /// <remarks>Override implemented to handle GH issue #4927</remarks>
+        protected override IndicatorResult ValidateAndComputeNextValue(IndicatorDataPoint input)
+        {
+            // Update our Indicators
+            var value = ComputeNextValue(input);
+
+            // In the case STD = 0, we know that the our PercentB indicator will fail to update.
+            // This is because the denominator will be 0, when this is the case we do not want
+            // the BollingerBands to emit an update because its PercentB property will be stale.
+            return StandardDeviation.Current.Value == 0
+                ? new IndicatorResult(value, IndicatorStatus.MathError)
+                : new IndicatorResult(value);
         }
 
         /// <summary>

--- a/Tests/Indicators/BollingerBandsTests.cs
+++ b/Tests/Indicators/BollingerBandsTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -126,6 +126,48 @@ namespace QuantConnect.Tests.Indicators
 
             Assert.AreEqual(1, lowerBandUpdateCount);
             Assert.AreEqual(1, upperBandUpdateCount);
+        }
+
+        [Test]
+        public void DoesNotUpdateWhenStale()
+        {
+            // Unit test for GH Issue #4927
+            var period = 5;
+            var bb = new BollingerBands(period, 2m);
+
+            var lastPercentB = new IndicatorDataPoint();
+            var lastUpdateTime = DateTime.MinValue;
+            bb.Updated += (s, e) =>
+            {
+                if (bb.IsReady && lastPercentB == bb.PercentB.Current)
+                {
+                    throw new ArgumentException("BollingerBand is stale and should not be updating");
+                }
+
+                lastUpdateTime = e.Time;
+                lastPercentB = bb.PercentB.Current;
+            };
+
+            // Push in identical value points for the entire period.
+            for (int i = 0; i < period; i++)
+            {
+                bb.Update(DateTime.Now, 1);
+            }
+
+            // Push in another identical value point, this should not update!
+            var time = DateTime.Now;
+            bb.Update(time, 1);
+
+            // Assert this was not updated
+            Assert.AreNotEqual(time, lastUpdateTime);
+
+            // Push in a new value
+            time = DateTime.Now;
+            bb.Update(time, 2);
+
+            // Assert this did update
+            Assert.AreEqual(time, lastUpdateTime);
+            Assert.AreEqual(lastPercentB, bb.PercentB.Current);
         }
     }
 }

--- a/Tests/Indicators/BollingerBandsTests.cs
+++ b/Tests/Indicators/BollingerBandsTests.cs
@@ -151,18 +151,18 @@ namespace QuantConnect.Tests.Indicators
             // Push in identical value points for the entire period.
             for (int i = 0; i < period; i++)
             {
-                bb.Update(DateTime.Now, 1);
+                bb.Update(DateTime.UtcNow, 1);
             }
 
             // Push in another identical value point, this should not update!
-            var time = DateTime.Now;
+            var time = DateTime.UtcNow;
             bb.Update(time, 1);
 
             // Assert this was not updated
             Assert.AreNotEqual(time, lastUpdateTime);
 
             // Push in a new value
-            time = DateTime.Now;
+            time = DateTime.UtcNow;
             bb.Update(time, 2);
 
             // Assert this did update


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Address an issue with BollingerBands where the indicator continues to emit updates when one of its properties has gone stale because of an arithmetic error.

The error only occurs when the data is continually filled forward (or just no value change) long enough  for the standard deviation to become zero, causing the BB's PercentB to have a 0 in the denominator. When this happens PercentB no longer updates and it's current point remains the same (time and value) while BB continually emits updates.

To address it, I overrode a function that the indicator base uses to determine if a indicator should send updates `ValidateAndComputeNextValue`. Now when we know that the value will be stale (STD == 0) we will not allow BB to emit updates. 

Although it can just remain stale and BB could to continue emit updates in this condition, this can causes issues for those consuming the property values. A specific example would be the issue linked below.

Note: Also in this case where STD == 0 the other properties (mid, lower, upper bands) would all be equal so really the BB is useless and it is fair to say that it doesn't need to be emitting in this case.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4927 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This problem was found in Py research when using our default notebook to run SPY data through a BB indicator. In the case where only local data is available, the SPY data is filled forward after reaching the end of the included data. (As of right now 3/31/21 is the last SPY daily point) 

Once 30 (BB period) tradable days have passed, the BB's STD becomes 0, because each point was the same. (5/12/21 is the date this occurs) At this point BB's PercentB would stop updating, but BB continued to emit as it did not do anything to validate its properties are all valid.

The consumer, `QuantBook.Indicator()`, would fetch all the BB's properties values and store them for a dataframe each update it got pushed from BB. When the PercentB became stale, it still collected this value as a new value and would store it in the list to later be added to the dataframe.

But when it would create the dataframe with its collection of indicator datapoints, the percent B list would contain many instances of the same point with the same timestamp. Then pandas would throw a value error because the index (timestamp) was appearing more than once. 

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All regressions passing

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
