### PR TITLE
Scheduled Events for Start/End Week/Month Fix

### DIFF
--- a/Common/Scheduling/DateRules.cs
+++ b/Common/Scheduling/DateRules.cs
@@ -411,8 +411,12 @@ namespace QuantConnect.Scheduling
 
             // Iterate all days between the beginning of "start" week, through end of "end" week.
             // Necessary to ensure we schedule events in the week we start and end. 
-            var beginningOfStartWeek = start.AddDays(-(int)start.DayOfWeek + 1); // +1, Monday is our start of week so offset
-            var endOfEndWeek = end.AddDays(7 - (end.DayOfWeek == DayOfWeek.Sunday ? 7 : (int)end.DayOfWeek)); // Sunday is our end of week so substitute its value as 7
+            // Also if we have a sunday for start/end we need to adjust for it being the front of the week when we want it as the end of the week.
+            var startAdjustment = start.DayOfWeek == DayOfWeek.Sunday ? -7 : 0;
+            var beginningOfStartWeek = start.AddDays(-(int)start.DayOfWeek + 1 + startAdjustment); // Date - DayOfWeek + 1
+
+            var endAdjustment = end.DayOfWeek == DayOfWeek.Sunday ? -7 : 0;
+            var endOfEndWeek = end.AddDays(-(int)end.DayOfWeek + 7 + endAdjustment); // Date - DayOfWeek + 7 
 
             // Determine the schedule for each week in this range
             foreach (var date in Time.EachDay(beginningOfStartWeek, endOfEndWeek).Where(x => x.DayOfWeek == weeklyBaseDay))

--- a/Common/Scheduling/DateRules.cs
+++ b/Common/Scheduling/DateRules.cs
@@ -356,8 +356,7 @@ namespace QuantConnect.Scheduling
             }
 
             // Iterate all days between the beginning of "start" month, through end of "end" month.
-            // Necessary to ensure we schedule events in the month we start and end. Will still filter
-            // out dates outside of start - end
+            // Necessary to ensure we schedule events in the month we start and end.
             var beginningOfStartMonth = new DateTime(start.Year, start.Month, 1);
             var endOfEndMonth = new DateTime(end.Year, end.Month, DateTime.DaysInMonth(end.Year, end.Month));
 
@@ -410,8 +409,13 @@ namespace QuantConnect.Scheduling
                 weeklyBoundaryDay = searchForward ? weeklySchedule.Last().DayOfWeek : weeklySchedule.First().DayOfWeek;
             }
 
+            // Iterate all days between the beginning of "start" week, through end of "end" week.
+            // Necessary to ensure we schedule events in the week we start and end. 
+            var beginningOfStartWeek = start.AddDays(-(int)start.DayOfWeek + 1); // +1, Monday is our start of week so offset
+            var endOfEndWeek = end.AddDays(7 - (end.DayOfWeek == DayOfWeek.Sunday ? 7 : (int)end.DayOfWeek)); // Sunday is our end of week so substitute its value as 7
+
             // Determine the schedule for each week in this range
-            foreach (var date in Time.EachDay(start, end).Where(x => x.DayOfWeek == weeklyBaseDay))
+            foreach (var date in Time.EachDay(beginningOfStartWeek, endOfEndWeek).Where(x => x.DayOfWeek == weeklyBaseDay))
             {
                 var boundary = date.AddDays(weeklyBoundaryDay - weeklyBaseDay);
                 var scheduledDay = GetScheduledDay(securitySchedule, date, offset, searchForward, boundary);

--- a/Common/Scheduling/DateRules.cs
+++ b/Common/Scheduling/DateRules.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -355,7 +355,13 @@ namespace QuantConnect.Scheduling
                 securitySchedule = SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork);
             }
 
-            foreach (var date in Time.EachDay(start, end))
+            // Iterate all days between the beginning of "start" month, through end of "end" month.
+            // Necessary to ensure we schedule events in the month we start and end. Will still filter
+            // out dates outside of start - end
+            var beginningOfStartMonth = new DateTime(start.Year, start.Month, 1);
+            var endOfEndMonth = new DateTime(end.Year, end.Month, DateTime.DaysInMonth(end.Year, end.Month));
+
+            foreach (var date in Time.EachDay(beginningOfStartMonth, endOfEndMonth))
             {
                 var daysInMonth = DateTime.DaysInMonth(date.Year, date.Month);
 

--- a/Tests/Common/Scheduling/DateRulesTests.cs
+++ b/Tests/Common/Scheduling/DateRulesTests.cs
@@ -129,7 +129,7 @@ namespace QuantConnect.Tests.Common.Scheduling
         [TestCase(12, true)]      // After 11th
         [TestCase(16, true)]
         [TestCase(20, true)]
-        public void StartOfMonthStartDateOffset(int startingDateDay, bool expectNone)
+        public void StartOfMonthSameMonthSchedule(int startingDateDay, bool expectNone)
         {
             // Reproduces issue #5678, Assert that even though start is not first of month,
             // we still schedule for that month.
@@ -249,7 +249,7 @@ namespace QuantConnect.Tests.Common.Scheduling
         [TestCase(21, false)]      // After 21th
         [TestCase(25, false)]
         [TestCase(30, false)]
-        public void EndOfMonthEndDateOffset(int endingDateDay, bool expectNone)
+        public void EndOfMonthSameMonthSchedule(int endingDateDay, bool expectNone)
         {
             // Related to issue #5678, Assert that even though end date is not end of month,
             // we still schedule for that month.
@@ -400,7 +400,7 @@ namespace QuantConnect.Tests.Common.Scheduling
         [TestCase(7, true)]     // Start after the 6th
         [TestCase(8, true)]
         [TestCase(9, true)]
-        public void StartOfWeekStartDateOffset(int startingDateDay, bool expectNone)
+        public void StartOfWeekSameWeekSchedule(int startingDateDay, bool expectNone)
         {
             // Related to issue #5678, Assert that even though starting date may not be
             // not monday we still schedule for that week.
@@ -521,7 +521,7 @@ namespace QuantConnect.Tests.Common.Scheduling
         [TestCase(7, false)]     
         [TestCase(8, false)]
         [TestCase(9, false)]
-        public void EndOfWeekEndDateOffset(int endDateDay, bool expectNone)
+        public void EndOfWeekSameWeekSchedule(int endDateDay, bool expectNone)
         {
             // Related to issue #5678, Assert that even though starting date may not be
             // not monday we still schedule for that week.

--- a/Tests/Common/Scheduling/DateRulesTests.cs
+++ b/Tests/Common/Scheduling/DateRulesTests.cs
@@ -347,7 +347,9 @@ namespace QuantConnect.Tests.Common.Scheduling
                 Assert.AreEqual(expectedDayOfWeek, date.DayOfWeek);
             }
 
-            Assert.AreEqual(52, count);
+            // There are 53 saturday and sundays in 2000, otherwise we expect only 52
+            int expected = expectedDayOfWeek == DayOfWeek.Saturday || expectedDayOfWeek == DayOfWeek.Sunday ? 53 : 52;
+            Assert.AreEqual(expected, count);
         }
 
         [TestCase(Symbols.SymbolsKey.SPY, new[] { 3, 10, 18, 24, 31 })]
@@ -388,6 +390,35 @@ namespace QuantConnect.Tests.Common.Scheduling
             foreach (var pair in datesAndExpectedDays)
             {
                 Assert.AreEqual(pair.expectedDay, pair.date.Day);
+            }
+        }
+
+        [TestCase(3, false)]    // Start before the 6th
+        [TestCase(4, false)]    
+        [TestCase(5, false)]
+        [TestCase(6, false)]
+        [TestCase(7, true)]     // Start after the 6th
+        [TestCase(8, true)]
+        [TestCase(9, true)]
+        public void StartOfWeekStartDateOffset(int startingDateDay, bool expectNone)
+        {
+            // Related to issue #5678, Assert that even though starting date may not be
+            // not monday we still schedule for that week.
+
+            // For this test and the EndOfWeek counterpart we will use the week of
+            // 1/3/2000 Monday to 1/9/2000 Sunday; with our variable date applied.
+            var startingDate = new DateTime(2000, 1, startingDateDay);
+            var endingDate = new DateTime(2000, 1, 9);
+
+            var rules = GetDateRules();
+            var rule = rules.WeekStart(3); // 1/6/2000
+            var dates = rule.GetDates(startingDate, endingDate);
+
+            Assert.AreEqual(expectNone, dates.IsNullOrEmpty());
+
+            if (!expectNone)
+            {
+                Assert.AreEqual(new DateTime(2000, 1, 6), dates.First());
             }
         }
 
@@ -480,6 +511,35 @@ namespace QuantConnect.Tests.Common.Scheduling
             foreach (var pair in datesAndExpectedDays)
             {
                 Assert.AreEqual(pair.expectedDay, pair.date.Day);
+            }
+        }
+
+        [TestCase(3, true)]     // End before the 6th
+        [TestCase(4, true)]
+        [TestCase(5, true)]
+        [TestCase(6, false)]    // End after the 6th
+        [TestCase(7, false)]     
+        [TestCase(8, false)]
+        [TestCase(9, false)]
+        public void EndOfWeekEndDateOffset(int endDateDay, bool expectNone)
+        {
+            // Related to issue #5678, Assert that even though starting date may not be
+            // not monday we still schedule for that week.
+
+            // For this test and the EndOfWeek counterpart we will use the week of
+            // 1/3/2000 Monday to 1/9/2000 Sunday; with our variable date applied.
+            var startingDate = new DateTime(2000, 1, 3);
+            var endingDate = new DateTime(2000, 1, endDateDay);
+
+            var rules = GetDateRules();
+            var rule = rules.WeekEnd(1); // 1/6/2000 (For weekEnd, Friday is the base day)
+            var dates = rule.GetDates(startingDate, endingDate);
+
+            Assert.AreEqual(expectNone, dates.IsNullOrEmpty());
+
+            if (!expectNone)
+            {
+                Assert.AreEqual(new DateTime(2000, 1, 6), dates.First());
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Fix issues resolving scheduled events in the same week or month as start/end of date range.

Solved the issue by iterating from the beginning of the start month/week to the end of the end month/week, this ensures we can schedule for the same month/week our start and end dates are in. We still filter out events that are before our start and after our end dates.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5678 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Nasty bug leaving out the start/end week/month in scheduled events. See issue above.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests that reproduces the issue and asserts it fix.

Also adjusted one test that was broken from this change, but for the right reason. Turns out there are 53 Saturday and Sundays in 2000, and the first of them (1st & 2nd) were being missed due to this bug.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
