### PR TITLE
Add missing IBGateway dependency library

### DIFF
--- a/DockerfileLeanFoundation
+++ b/DockerfileLeanFoundation
@@ -280,3 +280,6 @@ ENV PYTHONNET_PYDLL="/opt/miniconda3/lib/libpython3.6m.so"
 
 # List all packages
 RUN conda list
+
+# Add IBGateway v984 dependency library
+RUN apt-get install -y libgtk2.0.0

--- a/DockerfileLeanFoundationARM
+++ b/DockerfileLeanFoundationARM
@@ -203,3 +203,6 @@ ENV PYTHONNET_PYDLL="/opt/miniforge3/lib/libpython3.6m.so"
 
 # List all packages
 RUN conda list
+
+# Add IBGateway v984 dependency library
+RUN apt-get install -y libgtk2.0.0


### PR DESCRIPTION

#### Description
- Added a missing library used by IBGateway v984

#### Related Issue
#5686 

#### Motivation and Context
- After the #5686 update, local Lean users were seeing the following Java errors:
 
![image](https://user-images.githubusercontent.com/7236689/123112765-496eef80-d43e-11eb-8105-7e8979b5aa68.png)


#### Requires Documentation Change
No.

#### How Has This Been Tested?
- tested with local Lean

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.