### PR TITLE
Fix KrakenDownloader error on invalid pair format (#5703)

### DIFF
--- a/ToolBox/KrakenDataDownloader/KrakenDataDownloader.cs
+++ b/ToolBox/KrakenDataDownloader/KrakenDataDownloader.cs
@@ -68,7 +68,14 @@ namespace QuantConnect.ToolBox.KrakenDownloader
                     throw new Exception("Error in Kraken API: " + result.error[0]);
                 }
 
-                data = result.result[symbol.Value].ToObject<List<List<string>>>();
+                if (result.result.ContainsKey(symbol.Value))
+                {
+                    data = result.result[symbol.Value].ToObject<List<List<string>>>();
+                }
+                else
+                {
+                    throw new NotSupportedException("Asset pair was not found in the response. Make sure you use the correct model (XBTUSD -> XXBTZUSD).");
+                }
 
                 foreach (var i in data)
                 {


### PR DESCRIPTION
#### Expected Behavior
KrakenDownloader (KDL) successfully running the following command or throwing *unknown brokerage symbol*
```sh
pwd  # .../Lean/ToolBox/bin/Release
dotnet QuantConnect.ToolBox.dll --app=KDL --from-date=20000101-00:00:00 --tickers=XRPEUR --resolution=Tick
```

#### Actual Behavior
Getting the following error:
```sh
dotnet QuantConnect.ToolBox.dll --app=KDL --from-date=20000101-00:00:00 --tickers=XRPEUR --resolution=Tick
20210624 14:48:21.187 TRACE:: Config.GetValue(): debug-mode - Using default value: False
20210624 14:48:21.194 TRACE:: Config.Get(): Configuration key not found. Key: results-destination-folder - Using default value: 
20210624 14:48:21.194 TRACE:: Config.Get(): Configuration key not found. Key: plugin-directory - Using default value: 
20210624 14:48:21.197 TRACE:: Config.Get(): Configuration key not found. Key: composer-dll-directory - Using default value: /Users/antoinedray/Projects/Lean/ToolBox/bin/Release/
20210624 14:48:21.243 TRACE:: Config.Get(): Configuration key not found. Key: log-handler - Using default value: CompositeLogHandler
20210624 14:48:21.282 TRACE:: Config.Get(): Configuration key not found. Key: data-directory - Using default value: ../../../Data
20210624 14:48:21.284 TRACE:: Config.Get(): Configuration key not found. Key: map-file-provider - Using default value: LocalDiskMapFileProvider
20210624 14:48:21.861 ERROR:: KrakenDownloaderProgram.KrakenDownloader():  Microsoft.CSharp.RuntimeBinder.RuntimeBinderException: Cannot perform runtime binding on a null reference
   at CallSite.Target(Closure , CallSite , Object )
   at System.Dynamic.UpdateDelegates.UpdateAndExecute1[T0,TRet](CallSite site, T0 arg0)
   at QuantConnect.ToolBox.KrakenDownloader.KrakenDataDownloader.Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)+MoveNext() in .../Lean/ToolBox/KrakenDataDownloader/KrakenDataDownloader.cs:line 71
   at QuantConnect.ToolBox.LeanDataWriter.WriteMinuteOrSecondOrTick(IEnumerable`1 source) in .../Lean/ToolBox/LeanDataWriter.cs:line 361
   at QuantConnect.ToolBox.KrakenDownloader.KrakenDownloaderProgram.KrakenDownloader(IList`1 tickers, String resolution, DateTime startDate, DateTime endDate) in .../Lean/ToolBox/KrakenDataDownloader/KrakenDownloaderProgram.cs:line 56
```

#### Potential Solution
The Kraken allow queries from pairs of format XBTUSD and XXBTZUSD but it will only return data with the XXBTZUSD causing errors when XBTUSD ticker is specified.
This commit adds a more meaningful error when KDL is called with XBTUSD format.

#### Reproducing the Problem
```sh
git clone https://github.com/QuantConnect/Lean.git
# open solution in Visual Studio Mac and build QuantConnect.ToolBox > Release > Default
cd Lean/ToolBox/bin/Release
dotnet QuantConnect.ToolBox.dll --app=KDL --from-date=20000101-00:00:00 --tickers=XRPEUR --resolution=Tick
```

#### System Information
macOS Big Sur Version 11.4
  Model Name:	iMac Pro
  Model Identifier:	iMacPro1,1
  Processor Name:	8-Core Intel Xeon W
  Processor Speed:	3.2 GHz
  Number of Processors:	1
  Total Number of Cores:	8
  L2 Cache (per Core):	1 MB
  L3 Cache:	11 MB
  Hyper-Threading Technology:	Enabled
  Memory:	32 GB

Closes https://github.com/QuantConnect/Lean/issues/5703
#### Checklist
- [x] I have completely filled out this template
- [x] I have confirmed that this issue exists on the current `master` branch
- [x] I have confirmed that this is not a duplicate issue by searching [issues](https://github.com/QuantConnect/Lean/issues)
- [x] I have provided detailed steps to reproduce the issue