### PR TITLE
Fix Futures SymbolRepresentation disambiguation of ticker with limited year information

### DIFF
--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -141,9 +141,11 @@ namespace QuantConnect
         /// Helper method to parse and generate a future symbol from a given user friendly representation
         /// </summary>
         /// <param name="ticker">The future ticker, for example 'ESZ1'</param>
+        /// <param name="futureYear">Clarifies the year for the current future</param>
         /// <returns>The future symbol or null if failed</returns>
-        public static Symbol ParseFutureSymbol(string ticker)
+        public static Symbol ParseFutureSymbol(string ticker, int? futureYear = null)
         {
+            var disambiguatedFutureYear = futureYear ?? TodayUtc.Year;
             var parsed = ParseFutureTicker(ticker);
             if (parsed == null)
             {
@@ -153,7 +155,7 @@ namespace QuantConnect
             var underlying = parsed.Underlying;
             var expirationYearShort = parsed.ExpirationYearShort;
             var expirationMonth = parsed.ExpirationMonth;
-            var expirationYear = GetExpirationYear(expirationYearShort);
+            var expirationYear = GetExpirationYear(expirationYearShort, disambiguatedFutureYear);
 
             if (!SymbolPropertiesDatabase.FromDataFolder().TryGetMarket(underlying, SecurityType.Future, out var market))
             {
@@ -439,10 +441,10 @@ namespace QuantConnect
 
         private static IReadOnlyDictionary<int, string> _futuresMonthLookup = _futuresMonthCodeLookup.ToDictionary(kv => kv.Value, kv => kv.Key);
 
-        private static int GetExpirationYear(int year)
+        private static int GetExpirationYear(int year, int futureYear)
         {
             var baseNum = 2000;
-            while (baseNum + year < TodayUtc.Year)
+            while (baseNum + year < futureYear)
             {
                 baseNum += 10;
             }

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -180,5 +180,13 @@ namespace QuantConnect.Tests.Common
 
             Assert.AreEqual(expectedValue, result);
         }
+
+        [TestCase("VXZ2")]
+        public void GenerateFutureSymbolFromTickerMissingDecadeInfo(string ticker)
+        {
+            var result = SymbolRepresentation.ParseFutureSymbol(ticker, 2012);
+
+            Assert.AreEqual(new DateTime(2012, 12, 19), result.ID.Date.Date);
+        }
     }
 }

--- a/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesConverter.cs
+++ b/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesConverter.cs
@@ -122,6 +122,12 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
                         {
                             var tick = reader.Current as Tick;
 
+                            if (tick.Symbol.ID.Symbol == "VX" && (
+                                tick.BidPrice >= 998m || tick.AskPrice >= 998m))
+                            {
+                                // Invalid value for VX futures. Invalid prices in raw data are 998/999
+                                continue;
+                            }
                             //Add or create the consolidator-flush mechanism for symbol:
                             List<List<AlgoSeekFuturesProcessor>> symbolProcessors;
                             if (!processors.TryGetValue(tick.Symbol, out symbolProcessors))

--- a/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesReader.cs
+++ b/ToolBox/AlgoSeekFuturesConverter/AlgoSeekFuturesReader.cs
@@ -168,17 +168,17 @@ namespace QuantConnect.ToolBox.AlgoSeekFuturesConverter
                     return null;
                 }
 
-                var symbol = SymbolRepresentation.ParseFutureSymbol(ticker);
+                // ignoring time zones completely -- this is all in the 'data-time-zone'
+                var timeString = csv[_columnTimestamp];
+                var time = DateTime.ParseExact(timeString, "yyyyMMddHHmmssFFF", CultureInfo.InvariantCulture);
+
+                var symbol = SymbolRepresentation.ParseFutureSymbol(ticker, time.Year);
 
                 if (symbol == null || !_symbolMultipliers.ContainsKey(symbol.ID.Symbol) ||
                     _symbolFilter != null && !_symbolFilter.Contains(symbol.ID.Symbol, StringComparer.InvariantCultureIgnoreCase))
                 {
                     return null;
                 }
-
-                // ignoring time zones completely -- this is all in the 'data-time-zone'
-                var timeString = csv[_columnTimestamp];
-                var time = DateTime.ParseExact(timeString, "yyyyMMddHHmmssFFF", CultureInfo.InvariantCulture);
 
                 // detecting tick type (trade or quote)
                 TickType tickType;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Fixes issue where a ticker with limited information about its year (e.g. VXZ0 -> VX 2010-12, was previously returned as VXZ0 -> VX 2020-12) was unable to be disambiguated because we were using the current year as the year of the future contract in question.

Also fixes an issue with VX futures price data having bad 998/999 quote price values

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes https://www.quantconnect.com/forum/discussion/10432/vix-vx19z12-minute-the-issue-starts-from-nov-7th-2012-01-38-pm-and-continues-until-nov-7th-2012-01-38-pm/p1
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix bad VX values, fix futures processing and adds support for future year disambiguation when processing a ticker with limited contract month information
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test, reprocessed data
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
