### PR TITLE
fixed problems with testcasesource

### DIFF
--- a/Tests/Algorithm/AlgorithmSetHoldingsTests.cs
+++ b/Tests/Algorithm/AlgorithmSetHoldingsTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -95,7 +95,7 @@ namespace QuantConnect.Tests.Algorithm
             }
         }
 
-        private static TestCaseData[] TestParameters
+        private static IEnumerable<object[]> TestParameters
         {
             get
             {
@@ -117,17 +117,21 @@ namespace QuantConnect.Tests.Algorithm
                 Permuter<object>.Permute(data, permutations);
 
                 var ret = permutations
-                    .Where(row => (Position)row[0] != (Position)row[1])     // initialPosition != finalPosition
-                    .Select(row => new TestCaseData(row).SetName(string.Join("_", row)))
-                    .ToArray();
+                    .Where(row => (Position)row[0] != (Position)row[1]);     // initialPosition != finalPosition
 
                 return ret;
             }
         }
 
         [Test, TestCaseSource(nameof(TestParameters))]
-        public void Run(Position initialPosition, Position finalPosition, FeeType feeType, PriceMovement priceMovement, int leverage)
+        public void Run(object[] parameters)
         {
+            Position initialPosition = (Position)parameters[0];
+            Position finalPosition = (Position)parameters[1];
+            FeeType feeType = (FeeType)parameters[2];
+            PriceMovement priceMovement = (PriceMovement)parameters[3];
+            int leverage = (int)parameters[4];
+
             //Console.WriteLine("----------");
             //Console.WriteLine("PARAMETERS");
             //Console.WriteLine("Initial position: " + initialPosition);
@@ -241,7 +245,12 @@ namespace QuantConnect.Tests.Algorithm
         {
             security.SetMarketPrice(new TradeBar
             {
-                Time = DateTime.Now, Symbol = security.Symbol, Open = price, High = price, Low = price, Close = price
+                Time = DateTime.Now,
+                Symbol = security.Symbol,
+                Open = price,
+                High = price,
+                Low = price,
+                Close = price
             });
         }
     }

--- a/Tests/Common/Securities/Options/StrategyMatcher/OptionStrategyLegPredicateTests.cs
+++ b/Tests/Common/Securities/Options/StrategyMatcher/OptionStrategyLegPredicateTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -60,10 +60,10 @@ namespace QuantConnect.Tests.Common.Securities.Options.StrategyMatcher
             );
 
             var position = new OptionPosition(Put[95m], 1);
-            var positiveSet = new List<OptionPosition> {new OptionPosition(Put[100m], 1)};
+            var positiveSet = new List<OptionPosition> { new OptionPosition(Put[100m], 1) };
             Assert.IsTrue(predicate.Matches(positiveSet, position));
 
-            var negativeSet = new List<OptionPosition> {new OptionPosition(Put[90m], 1)};
+            var negativeSet = new List<OptionPosition> { new OptionPosition(Put[90m], 1) };
             Assert.IsFalse(predicate.Matches(negativeSet, position));
         }
 
@@ -115,7 +115,7 @@ namespace QuantConnect.Tests.Common.Securities.Options.StrategyMatcher
             Assert.IsTrue(filtered.All(p => p.Right == OptionRight.Call));
         }
 
-        public static TestCaseData[] TestCases
+        public static IEnumerable<TestCase> TestCases
         {
             get
             {
@@ -172,8 +172,7 @@ namespace QuantConnect.Tests.Common.Securities.Options.StrategyMatcher
                             .WithTarget(PredicateTargetValue.Expiration, legs => legs[0].Expiration)
                             .ExpectMatch(),
                     }
-                    .Select(x => new TestCaseData(x.WithDefaults()).SetName(x.Name))
-                    .ToArray();
+                    .Select(x => x.WithDefaults());
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
There seems to be a breaking change with the nunit test case source between versions or usage of the extensions in visual studio. The current documentation says no extensions should be used and only nuget should be used to pull down the nuget package. This experience is based on that.

#### Related Issue
#5721

#### Motivation and Context
We should be able to run all tests from the test explorer in visual studio to make sure there are no tests failing. I currently cannot do that without fixing the problem with the test case source.

#### Requires Documentation Change
No

#### How Has This Been Tested?
In visual studio, I can run all tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
