### PR TITLE
Logging improvements

### DIFF
--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -857,7 +857,7 @@ namespace QuantConnect.Api
             // Make sure the link was successfully retrieved
             if (!dataLink.Success)
             {
-                Log.Error($"Api.DownloadData(): Failed to get link for {filePath}. " +
+                Log.Trace($"Api.DownloadData(): Failed to get link for {filePath}. " +
                     $"Errors: {string.Join(',', dataLink.Errors)}");
                 return false;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Two small changes for tomorrow's webinar:
- Applied the changes in #3966 to the `NumericalPrecisionLimited` event to prevent we log those messages many times when using universe selection combined with history requests.
- Turned the ApiDataProvider link errors into trace messages. When using universe selection with alternative data it's sometimes the case that there's no alternative data for non-popular tickers, but there is no way to figure that out without trying to download it, leading to a lot of relatively harmless red messages.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to #3949.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve user experience.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and in the cloud on [this](https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_ca1bd0c0a13808298fbbd71a47aa79ae.html) algorithm.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->