### PR TITLE
Send invalid orderEvent for non shortable asset

### DIFF
--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.Api
         public virtual void Initialize(int userId, string token, string dataFolder)
         {
             ApiConnection = new ApiConnection(userId, token);
-            _dataFolder = dataFolder;
+            _dataFolder = dataFolder.Replace("\\", "/", StringComparison.InvariantCulture);
 
             //Allow proper decoding of orders from the API.
             JsonConvert.DefaultSettings = () => new JsonSerializerSettings
@@ -1197,15 +1197,17 @@ namespace QuantConnect.Api
                 return null;
             }
 
+            // Normalize windows paths to linux format
+            filePath = filePath.Replace("\\", "/", StringComparison.InvariantCulture);
+
             // First remove data root directory from path for request if included
             if (filePath.StartsWith(_dataFolder, StringComparison.InvariantCulture))
             {
                 filePath = filePath.Substring(_dataFolder.Length);
             }
 
-            // Normalize windows paths to linux format
-            // Also trim '/' from start, this can cause issues for _dataFolders without final directory separator in the config
-            filePath = filePath.Replace("\\", "/", StringComparison.InvariantCulture).TrimStart('/');
+            // Trim '/' from start, this can cause issues for _dataFolders without final directory separator in the config
+            filePath = filePath.TrimStart('/');
             return filePath;
         }
     }

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -275,6 +275,11 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 ticket.SetOrder(order);
                 _completeOrderTickets.TryAdd(ticket.OrderId, ticket);
                 _completeOrders.TryAdd(order.Id, order);
+
+                HandleOrderEvent(new OrderEvent(order,
+                    _algorithm.UtcTime,
+                    OrderFee.Zero,
+                    orderTag));
             }
             return ticket;
         }

--- a/Tests/Api/ApiTests.cs
+++ b/Tests/Api/ApiTests.cs
@@ -13,9 +13,10 @@
  * limitations under the License.
 */
 
+using System;
+using System.IO;
 using NUnit.Framework;
 using QuantConnect.Api;
-using System.IO;
 
 namespace QuantConnect.Tests.API
 {
@@ -23,13 +24,13 @@ namespace QuantConnect.Tests.API
     /// API Object tests
     /// Tests APIs ability to connect to Web API
     /// </summary>
-    [TestFixture, Explicit("Requires configured api access")]
+    [TestFixture]
     public class ApiTest : ApiTestBase
     {
         /// <summary>
         /// Test successfully authenticating with the ApiConnection using valid credentials.
         /// </summary>
-        [Test]
+        [Test, Explicit("Requires configured api access")]
         public void ApiConnectionWillAuthenticate_ValidCredentials_Successfully()
         {
             var connection = new ApiConnection(TestAccount, TestToken);
@@ -39,7 +40,7 @@ namespace QuantConnect.Tests.API
         /// <summary>
         /// Test successfully authenticating with the API using valid credentials.
         /// </summary>
-        [Test]
+        [Test, Explicit("Requires configured api access")]
         public void ApiWillAuthenticate_ValidCredentials_Successfully()
         {
             var api = new Api.Api();
@@ -68,20 +69,23 @@ namespace QuantConnect.Tests.API
             Assert.IsFalse(api.Connected);
         }
 
-        [TestCase("C:\\Data")]
-        [TestCase("C:\\Data\\")]
-        [TestCase("C:/Data/")]
-        [TestCase("C:/Data")]
-        public void FormattingPathForDataRequestsAreCorrect(string dataFolder)
+        [TestCase("C:\\Data", "forex/oanda/daily/eurusd.zip")]
+        [TestCase("C:\\Data\\", "forex/oanda/daily/eurusd.zip")]
+        [TestCase("C:/Data/", "forex/oanda/daily/eurusd.zip")]
+        [TestCase("C:/Data", "forex/oanda/daily/eurusd.zip")]
+        [TestCase("C:/Data", "forex\\oanda\\daily\\eurusd.zip")]
+        [TestCase("C:/Data/", "forex\\oanda\\daily\\eurusd.zip")]
+        [TestCase("C:\\Data\\", "forex\\oanda\\daily\\eurusd.zip")]
+        [TestCase("C:\\Data", "forex\\oanda\\daily\\eurusd.zip")]
+        public void FormattingPathForDataRequestsAreCorrect(string dataFolder, string dataToDownload)
         {
             var api = new Api.Api();
             api.Initialize(TestAccount, TestToken, dataFolder);
 
-            var dataToDownload = "forex/oanda/daily/eurusd.zip";
             var path = Path.Combine(dataFolder, dataToDownload);
 
             var result = api.FormatPathForDataRequest(path);
-            Assert.AreEqual(dataToDownload, result);
+            Assert.AreEqual(dataToDownload.Replace("\\", "/", StringComparison.InvariantCulture), result);
         }
     }
 }

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -1136,6 +1136,32 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             Assert.AreEqual(10, TestIncrementalOrderIdAlgorithm.OrderEventIds.Count);
         }
 
+        [Test]
+        public void InvalidOrderEventDueToNonShortableAsset()
+        {
+            // Initializes the transaction handler
+            var transactionHandler = new TestBrokerageTransactionHandler();
+            var broker = new TestBroker(_algorithm, false);
+            _algorithm.SetBrokerageModel(new TestShortableBrokerageModel());
+            transactionHandler.Initialize(_algorithm, broker, new BacktestingResultHandler());
+
+            var security = _algorithm.Securities[_symbol];
+            var price = 1.12m;
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, price, price, price));
+            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, -1000, 0, 1.11m, DateTime.UtcNow, "");
+
+            // Mock the the order processor
+            var orderProcessorMock = new Mock<IOrderProcessor>();
+            orderProcessorMock.Setup(m => m.GetOrderTicket(It.IsAny<int>())).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
+            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
+
+            var orderTicket = transactionHandler.Process(orderRequest);
+            transactionHandler.HandleOrderRequest(orderRequest);
+            Assert.AreEqual(orderTicket.Status, OrderStatus.Invalid);
+            Assert.AreEqual(_algorithm.OrderEvents.Count, 1);
+            Assert.AreEqual(_algorithm.OrderEvents.Count(orderEvent => orderEvent.Status == OrderStatus.Invalid), 1);
+        }
+
         internal class TestIncrementalOrderIdAlgorithm : OrderTicketDemoAlgorithm
         {
             public static readonly Dictionary<int, int> OrderEventIds = new Dictionary<int, int>();
@@ -1250,6 +1276,25 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             public new void RoundOrderPrices(Order order, Security security)
             {
                 base.RoundOrderPrices(order, security);
+            }
+        }
+        private class TestNonShortableProvider : IShortableProvider
+        {
+            public Dictionary<Symbol, long> AllShortableSymbols(DateTime localTime)
+            {
+                return new Dictionary<Symbol, long>();
+            }
+            public long? ShortableQuantity(Symbol symbol, DateTime localTime)
+            {
+                return 0;
+            }
+        }
+
+        private class TestShortableBrokerageModel : DefaultBrokerageModel
+        {
+            public TestShortableBrokerageModel()
+            {
+                ShortableProvider = new TestNonShortableProvider();
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- TransactionHandler will see invalid OrderEvent for an order which
  tries to short an non shortable asset. Adding unit test, updating
  regression algorithm.
- Fix Api data price path normalization, found while testing with
shortable provider. Adding unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/5762
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
User experience
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
