### PR TITLE
Update BinanceBrokerage to handle more than 512 symbols

### DIFF
--- a/Brokerages/Binance/BinanceBrokerage.cs
+++ b/Brokerages/Binance/BinanceBrokerage.cs
@@ -419,7 +419,7 @@ namespace QuantConnect.Brokerages.Binance
         /// </summary>
         /// <param name="webSocket">The websocket instance</param>
         /// <param name="symbol">The symbol to subscribe</param>
-        private void Subscribe(IWebSocket webSocket, Symbol symbol)
+        private bool Subscribe(IWebSocket webSocket, Symbol symbol)
         {
             Send(webSocket,
                 new
@@ -433,6 +433,8 @@ namespace QuantConnect.Brokerages.Binance
                     id = GetNextRequestId()
                 }
             );
+
+            return true;
         }
 
         /// <summary>
@@ -440,7 +442,7 @@ namespace QuantConnect.Brokerages.Binance
         /// </summary>
         /// <param name="webSocket">The websocket instance</param>
         /// <param name="symbol">The symbol to unsubscribe</param>
-        private void Unsubscribe(IWebSocket webSocket, Symbol symbol)
+        private bool Unsubscribe(IWebSocket webSocket, Symbol symbol)
         {
             Send(webSocket,
                 new
@@ -454,6 +456,8 @@ namespace QuantConnect.Brokerages.Binance
                     id = GetNextRequestId()
                 }
             );
+
+            return true;
         }
 
         private void Send(IWebSocket webSocket, object obj)

--- a/Brokerages/Binance/BinanceBrokerage.cs
+++ b/Brokerages/Binance/BinanceBrokerage.cs
@@ -81,8 +81,8 @@ namespace QuantConnect.Brokerages.Binance
                 maximumWebSocketConnections,
                 symbolWeights,
                 () => new BinanceWebSocketWrapper(null),
-                (ws, s, _) => Subscribe(ws, s),
-                (ws, s, _) => Unsubscribe(ws, s),
+                Subscribe,
+                Unsubscribe,
                 _messageHandler);
 
             SubscriptionManager = subscriptionManager;

--- a/Brokerages/Binance/BinanceBrokerage.cs
+++ b/Brokerages/Binance/BinanceBrokerage.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Brokerages.Binance
             _job = job;
             _algorithm = algorithm;
             _aggregator = aggregator;
-            _messageHandler = new BrokerageConcurrentMessageHandler<WebSocketMessage>(OnMessageImpl);
+            _messageHandler = new BrokerageConcurrentMessageHandler<WebSocketMessage>(OnUserMessage);
 
             var maximumWebSocketConnections = Config.GetInt("binance-maximum-websocket-connections");
             var symbolWeights = maximumWebSocketConnections > 0 ? FetchSymbolWeights() : null;
@@ -83,7 +83,7 @@ namespace QuantConnect.Brokerages.Binance
                 () => new BinanceWebSocketWrapper(null),
                 Subscribe,
                 Unsubscribe,
-                _messageHandler);
+                OnDataMessage);
 
             SubscriptionManager = subscriptionManager;
 

--- a/Brokerages/Binance/BinanceRestApiClient.cs
+++ b/Brokerages/Binance/BinanceRestApiClient.cs
@@ -361,19 +361,17 @@ namespace QuantConnect.Brokerages.Binance
         /// </summary>
         public void StopSession()
         {
-            if (string.IsNullOrEmpty(SessionId))
+            if (!string.IsNullOrEmpty(SessionId))
             {
-                throw new Exception("BinanceBrokerage:UserStream. listenKey wasn't allocated or has been refused.");
+                var request = new RestRequest(UserDataStreamEndpoint, Method.DELETE);
+                request.AddHeader(KeyHeader, ApiKey);
+                request.AddParameter(
+                    "application/x-www-form-urlencoded",
+                    Encoding.UTF8.GetBytes($"listenKey={SessionId}"),
+                    ParameterType.RequestBody
+                );
+                ExecuteRestRequest(request);
             }
-
-            var request = new RestRequest(UserDataStreamEndpoint, Method.DELETE);
-            request.AddHeader(KeyHeader, ApiKey);
-            request.AddParameter(
-                "application/x-www-form-urlencoded",
-                Encoding.UTF8.GetBytes($"listenKey={SessionId}"),
-                ParameterType.RequestBody
-            );
-            ExecuteRestRequest(request);
         }
 
         /// <summary>

--- a/Brokerages/Binance/BinanceRestApiClient.cs
+++ b/Brokerages/Binance/BinanceRestApiClient.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -317,12 +317,18 @@ namespace QuantConnect.Brokerages.Binance
                 var klines = JsonConvert.DeserializeObject<object[][]>(response.Content)
                     .Select(entries => new Messages.Kline(entries))
                     .ToList();
-
-                startMs = klines.Last().OpenTime + resolutionInMs;
-
-                foreach (var kline in klines)
+                if (klines.Count > 0)
                 {
-                    yield return kline;
+                    startMs = klines.Last().OpenTime + resolutionInMs;
+
+                    foreach (var kline in klines)
+                    {
+                        yield return kline;
+                    }
+                }
+                else
+                {
+                    startMs += resolutionInMs;
                 }
             }
         }

--- a/Brokerages/BrokerageMultiWebSocketEntry.cs
+++ b/Brokerages/BrokerageMultiWebSocketEntry.cs
@@ -14,6 +14,7 @@
  */
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace QuantConnect.Brokerages
 {
@@ -73,7 +74,7 @@ namespace QuantConnect.Brokerages
             {
                 lock (_locker)
                 {
-                    return _symbols.AsReadOnly();
+                    return _symbols.ToList();
                 }
             }
         }

--- a/Brokerages/BrokerageMultiWebSocketEntry.cs
+++ b/Brokerages/BrokerageMultiWebSocketEntry.cs
@@ -1,0 +1,100 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+
+namespace QuantConnect.Brokerages
+{
+    /// <summary>
+    /// Helper class for <see cref="BrokerageMultiWebSocketSubscriptionManager"/>
+    /// </summary>
+    public class BrokerageMultiWebSocketEntry
+    {
+        private readonly Dictionary<Symbol, int> _symbolWeights;
+        private readonly List<Symbol> _symbols;
+
+        /// <summary>
+        /// Gets the web socket instance
+        /// </summary>
+        public IWebSocket WebSocket { get; }
+
+        /// <summary>
+        /// Gets the sum of symbol weights for this web socket
+        /// </summary>
+        public int TotalWeight { get; private set; }
+
+        /// <summary>
+        /// Gets the number of symbols subscribed
+        /// </summary>
+        public int SymbolCount => _symbols.Count;
+
+        /// <summary>
+        /// Returns whether the symbol is subscribed
+        /// </summary>
+        /// <param name="symbol"></param>
+        /// <returns></returns>
+        public bool Contains(Symbol symbol) => _symbols.Contains(symbol);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BrokerageMultiWebSocketEntry"/> class
+        /// </summary>
+        /// <param name="symbolWeights">A dictionary of symbol weights</param>
+        /// <param name="webSocket">The web socket instance</param>
+        public BrokerageMultiWebSocketEntry(Dictionary<Symbol, int> symbolWeights, IWebSocket webSocket)
+        {
+            _symbolWeights = symbolWeights;
+            _symbols = new List<Symbol>();
+
+            WebSocket = webSocket;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BrokerageMultiWebSocketEntry"/> class
+        /// </summary>
+        /// <param name="webSocket">The web socket instance</param>
+        public BrokerageMultiWebSocketEntry(IWebSocket webSocket)
+            : this(null, webSocket)
+        {
+        }
+
+        /// <summary>
+        /// Adds a symbol to the entry
+        /// </summary>
+        /// <param name="symbol">The symbol to add</param>
+        public void AddSymbol(Symbol symbol)
+        {
+            _symbols.Add(symbol);
+
+            if (_symbolWeights != null && _symbolWeights.TryGetValue(symbol, out var weight))
+            {
+                TotalWeight += weight;
+            }
+        }
+
+        /// <summary>
+        /// Removes a symbol from the entry
+        /// </summary>
+        /// <param name="symbol">The symbol to remove</param>
+        public void RemoveSymbol(Symbol symbol)
+        {
+            _symbols.Remove(symbol);
+
+            if (_symbolWeights != null && _symbolWeights.TryGetValue(symbol, out var weight))
+            {
+                TotalWeight -= weight;
+            }
+        }
+    }
+}

--- a/Brokerages/BrokerageMultiWebSocketEntry.cs
+++ b/Brokerages/BrokerageMultiWebSocketEntry.cs
@@ -48,6 +48,12 @@ namespace QuantConnect.Brokerages
         public bool Contains(Symbol symbol) => _symbols.Contains(symbol);
 
         /// <summary>
+        /// Returns the list of subscribed symbols
+        /// </summary>
+        /// <returns></returns>
+        public IReadOnlyCollection<Symbol> Symbols => _symbols;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="BrokerageMultiWebSocketEntry"/> class
         /// </summary>
         /// <param name="symbolWeights">A dictionary of symbol weights</param>

--- a/Brokerages/BrokerageMultiWebSocketSubscriptionManager.cs
+++ b/Brokerages/BrokerageMultiWebSocketSubscriptionManager.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Brokerages
         private readonly Func<WebSocketClientWrapper> _webSocketFactory;
         private readonly Func<IWebSocket, Symbol, bool> _subscribeFunc;
         private readonly Func<IWebSocket, Symbol, bool> _unsubscribeFunc;
-        private readonly BrokerageConcurrentMessageHandler<WebSocketMessage> _messageHandler;
+        private readonly Action<WebSocketMessage> _messageHandler;
         private readonly RateGate _connectionRateLimiter;
 
         private const int ConnectionTimeout = 30000;
@@ -63,7 +63,7 @@ namespace QuantConnect.Brokerages
             Func<WebSocketClientWrapper> webSocketFactory,
             Func<IWebSocket, Symbol, bool> subscribeFunc,
             Func<IWebSocket, Symbol, bool> unsubscribeFunc,
-            BrokerageConcurrentMessageHandler<WebSocketMessage> messageHandler,
+            Action<WebSocketMessage> messageHandler,
             RateGate connectionRateLimiter = null)
         {
             _webSocketUrl = webSocketUrl;
@@ -196,7 +196,7 @@ namespace QuantConnect.Brokerages
         private void Connect(IWebSocket webSocket)
         {
             webSocket.Initialize(_webSocketUrl);
-            webSocket.Message += (s, e) => _messageHandler.HandleNewMessage(e);
+            webSocket.Message += (s, e) => _messageHandler(e);
 
             var connectedEvent = new ManualResetEvent(false);
             EventHandler onOpenAction = (_, _) =>

--- a/Brokerages/BrokerageMultiWebSocketSubscriptionManager.cs
+++ b/Brokerages/BrokerageMultiWebSocketSubscriptionManager.cs
@@ -175,7 +175,7 @@ namespace QuantConnect.Brokerages
 
                 entry.AddSymbol(symbol);
 
-                Log.Trace($"BrokerageMultiWebSocketSubscriptionManager.GetWeightedWebSocketForSymbol(): added symbol: {symbol} to websocket: {entry.WebSocket.GetHashCode()} - Count: {entry.SymbolCount}");
+                Log.Trace($"BrokerageMultiWebSocketSubscriptionManager.GetWebSocketForSymbol(): added symbol: {symbol} to websocket: {entry.WebSocket.GetHashCode()} - Count: {entry.SymbolCount}");
 
                 return entry.WebSocket;
             }

--- a/Brokerages/BrokerageMultiWebSocketSubscriptionManager.cs
+++ b/Brokerages/BrokerageMultiWebSocketSubscriptionManager.cs
@@ -1,0 +1,262 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using QuantConnect.Data;
+using QuantConnect.Logging;
+using QuantConnect.Util;
+
+namespace QuantConnect.Brokerages
+{
+    /// <summary>
+    /// Handles brokerage data subscriptions with multiple websocket connections, with optional symbol weighting
+    /// </summary>
+    public class BrokerageMultiWebSocketSubscriptionManager : EventBasedDataQueueHandlerSubscriptionManager
+    {
+        private readonly string _webSocketUrl;
+        private readonly int _maximumSymbolsPerWebSocket;
+        private readonly int _maximumWebSocketConnections;
+        private readonly Func<WebSocketClientWrapper> _webSocketFactory;
+        private readonly Action<IWebSocket, Symbol, TickType> _subscribeFunc;
+        private readonly Action<IWebSocket, Symbol, TickType> _unsubscribeFunc;
+        private readonly BrokerageConcurrentMessageHandler<WebSocketMessage> _messageHandler;
+
+        private const int ConnectionTimeout = 30000;
+
+        private readonly object _locker = new();
+        private readonly List<BrokerageMultiWebSocketEntry> _webSocketEntries = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BrokerageMultiWebSocketSubscriptionManager"/> class
+        /// </summary>
+        /// <param name="webSocketUrl">The URL for websocket connections</param>
+        /// <param name="maximumSymbolsPerWebSocket">The maximum number of symbols per websocket connection</param>
+        /// <param name="maximumWebSocketConnections">The maximum number of websocket connections allowed (if zero, symbol weighting is disabled)</param>
+        /// <param name="symbolWeights">A dictionary for the symbol weights</param>
+        /// <param name="webSocketFactory">A function which returns a new websocket instance</param>
+        /// <param name="subscribeFunc">A function which subscribes a symbol</param>
+        /// <param name="unsubscribeFunc">A function which unsubscribes a symbol</param>
+        /// <param name="messageHandler">The websocket message handler</param>
+        public BrokerageMultiWebSocketSubscriptionManager(
+            string webSocketUrl,
+            int maximumSymbolsPerWebSocket,
+            int maximumWebSocketConnections,
+            Dictionary<Symbol, int> symbolWeights,
+            Func<WebSocketClientWrapper> webSocketFactory,
+            Action<IWebSocket, Symbol, TickType> subscribeFunc,
+            Action<IWebSocket, Symbol, TickType> unsubscribeFunc,
+            BrokerageConcurrentMessageHandler<WebSocketMessage> messageHandler)
+        {
+            _webSocketUrl = webSocketUrl;
+            _maximumSymbolsPerWebSocket = maximumSymbolsPerWebSocket;
+            _maximumWebSocketConnections = maximumWebSocketConnections;
+            _webSocketFactory = webSocketFactory;
+            _subscribeFunc = subscribeFunc;
+            _unsubscribeFunc = unsubscribeFunc;
+            _messageHandler = messageHandler;
+
+            if (_maximumWebSocketConnections > 0)
+            {
+                // symbol weighting enabled, create all websocket instances
+                for (var i = 0; i < _maximumWebSocketConnections; i++)
+                {
+                    _webSocketEntries.Add(new BrokerageMultiWebSocketEntry(symbolWeights, _webSocketFactory()));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Subscribes to the symbols
+        /// </summary>
+        /// <param name="symbols">Symbols to subscribe</param>
+        /// <param name="tickType">Type of tick data</param>
+        protected override bool Subscribe(IEnumerable<Symbol> symbols, TickType tickType)
+        {
+            Log.Trace($"BrokerageMultiWebSocketSubscriptionManager.Subscribe(): {string.Join(",", symbols.Select(x => x.Value))}");
+
+            foreach (var symbol in symbols)
+            {
+                var webSocket = _maximumWebSocketConnections > 0
+                    ? GetWeightedWebSocketForSymbol(symbol)
+                    : GetAvailableWebSocketForSymbol(symbol);
+
+                _subscribeFunc(webSocket, symbol, tickType);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Unsubscribes from the symbols
+        /// </summary>
+        /// <param name="symbols">Symbols to subscribe</param>
+        /// <param name="tickType">Type of tick data</param>
+        protected override bool Unsubscribe(IEnumerable<Symbol> symbols, TickType tickType)
+        {
+            Log.Trace($"BrokerageMultiWebSocketSubscriptionManager.Unsubscribe(): {string.Join(",", symbols.Select(x => x.Value))}");
+
+            foreach (var symbol in symbols)
+            {
+                var entry = GetWebSocketEntryBySymbol(symbol);
+                if (entry != null)
+                {
+                    entry.RemoveSymbol(symbol);
+
+                    _unsubscribeFunc(entry.WebSocket, symbol, tickType);
+                }
+            }
+
+            return true;
+        }
+
+        private BrokerageMultiWebSocketEntry GetWebSocketEntryBySymbol(Symbol symbol)
+        {
+            lock (_locker)
+            {
+                foreach (var entry in _webSocketEntries.Where(entry => entry.Contains(symbol)))
+                {
+                    return entry;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Adds a symbol to one of the predefined websocket connections using symbol weighting.
+        /// If all websocket connections are maxed out, an exception is thrown
+        /// </summary>
+        private IWebSocket GetWeightedWebSocketForSymbol(Symbol symbol)
+        {
+            // use any unused websocket first
+            BrokerageMultiWebSocketEntry entryUnused;
+            lock (_locker)
+            {
+                entryUnused = _webSocketEntries.FirstOrDefault(x => !x.WebSocket.IsOpen);
+            }
+
+            if (entryUnused != null)
+            {
+                var webSocket = entryUnused.WebSocket;
+                Connect(webSocket);
+
+                entryUnused.AddSymbol(symbol);
+
+                Log.Trace($"BrokerageMultiWebSocketSubscriptionManager.GetWeightedWebSocketForSymbol(): added symbol: {symbol} to websocket: {entryUnused.WebSocket.GetHashCode()} - Count: {entryUnused.SymbolCount}");
+
+                return webSocket;
+            }
+
+            lock (_locker)
+            {
+                if (_webSocketEntries.All(x => x.SymbolCount >= _maximumSymbolsPerWebSocket))
+                {
+                    throw new NotSupportedException($"Maximum symbol count reached for the current configuration [MaxSymbolsPerWebSocket={_maximumSymbolsPerWebSocket}, MaxWebSocketConnections:{_maximumWebSocketConnections}]");
+                }
+
+                // sort by weight ascending, taking into account the symbol limit per websocket
+                _webSocketEntries.Sort((x, y) =>
+                    x.SymbolCount >= _maximumSymbolsPerWebSocket
+                    ? 1
+                    : y.SymbolCount >= _maximumSymbolsPerWebSocket
+                        ? -1
+                        : Math.Sign(x.TotalWeight - y.TotalWeight));
+
+                var entry = _webSocketEntries.First();
+                entry.AddSymbol(symbol);
+
+                Log.Trace($"BrokerageMultiWebSocketSubscriptionManager.GetWeightedWebSocketForSymbol(): added symbol: {symbol} to websocket: {entry.WebSocket.GetHashCode()} - Count: {entry.SymbolCount}");
+
+                return entry.WebSocket;
+            }
+        }
+
+        /// <summary>
+        /// Adds a symbol to an existing connection if the maximum limit is not reached,
+        /// otherwise creates a new websocket instance and adds the symbol to it
+        /// </summary>
+        private IWebSocket GetAvailableWebSocketForSymbol(Symbol symbol)
+        {
+            lock (_locker)
+            {
+                foreach (var entry in _webSocketEntries.Where(entry => entry.SymbolCount < _maximumSymbolsPerWebSocket))
+                {
+                    // free slot available, add to existing
+                    entry.AddSymbol(symbol);
+
+                    return entry.WebSocket;
+                }
+            }
+
+            // symbol limit reached on all, create new websocket instance
+            var webSocket = _webSocketFactory();
+
+            lock (_locker)
+            {
+                var entry = new BrokerageMultiWebSocketEntry(webSocket);
+                entry.AddSymbol(symbol);
+
+                _webSocketEntries.Add(entry);
+            }
+
+            Connect(webSocket);
+
+            int connections;
+            lock (_locker)
+            {
+                connections = _webSocketEntries.Count;
+            }
+
+            Log.Trace("BrokerageMultiWebSocketSubscriptionManager.GetAvailableWebSocketForSymbol(): New websocket added: " +
+                $"Hashcode: {webSocket.GetHashCode()}, " +
+                $"WebSocket connections: {connections}");
+
+            return webSocket;
+        }
+
+        private void Connect(IWebSocket webSocket)
+        {
+            webSocket.Initialize(_webSocketUrl);
+            webSocket.Message += (s, e) => _messageHandler.HandleNewMessage(e);
+
+            var connectedEvent = new ManualResetEvent(false);
+            EventHandler onOpenAction = (_, _) =>
+            {
+                connectedEvent.Set();
+            };
+
+            webSocket.Open += onOpenAction;
+
+            try
+            {
+                webSocket.Connect();
+
+                if (!connectedEvent.WaitOne(ConnectionTimeout))
+                {
+                    throw new Exception("BrokerageMultiWebSocketSubscriptionManager.Connect(): WebSocket connection timeout.");
+                }
+            }
+            finally
+            {
+                webSocket.Open -= onOpenAction;
+
+                connectedEvent.DisposeSafely();
+            }
+        }
+    }
+}

--- a/Brokerages/WebSocketClientWrapper.cs
+++ b/Brokerages/WebSocketClientWrapper.cs
@@ -95,7 +95,7 @@ namespace QuantConnect.Brokerages
 
                             Log.Trace($"WebSocketClientWrapper connection task ended: {_url}");
                         },
-                        _cts.Token);
+                        _cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
                     var count = 0;
                     do

--- a/Brokerages/WebSocketClientWrapper.cs
+++ b/Brokerages/WebSocketClientWrapper.cs
@@ -215,7 +215,7 @@ namespace QuantConnect.Brokerages
                 catch (WebSocketException ex)
                 {
                     OnError(new WebSocketError(ex.Message, ex));
-                    Thread.Sleep(2000);
+                    connectionCts.Token.WaitHandle.WaitOne(2000);
                 }
                 catch (Exception ex)
                 {

--- a/Brokerages/WebSocketClientWrapper.cs
+++ b/Brokerages/WebSocketClientWrapper.cs
@@ -212,6 +212,11 @@ namespace QuantConnect.Brokerages
                     }
                 }
                 catch (OperationCanceledException) { }
+                catch (WebSocketException ex)
+                {
+                    OnError(new WebSocketError(ex.Message, ex));
+                    Thread.Sleep(2000);
+                }
                 catch (Exception ex)
                 {
                     OnError(new WebSocketError(ex.Message, ex));

--- a/Brokerages/WebSocketClientWrapper.cs
+++ b/Brokerages/WebSocketClientWrapper.cs
@@ -136,7 +136,10 @@ namespace QuantConnect.Brokerages
                 _cts = null;
             }
 
-            OnClose(new WebSocketCloseData(0, string.Empty, true));
+            if (_client != null)
+            {
+                OnClose(new WebSocketCloseData(0, string.Empty, true));
+            }
         }
 
         /// <summary>

--- a/Brokerages/WebSocketClientWrapper.cs
+++ b/Brokerages/WebSocketClientWrapper.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -208,7 +208,7 @@ namespace QuantConnect.Brokerages
                         }
 
                         var message = Encoding.UTF8.GetString(messageData.Data);
-                        OnMessage(new WebSocketMessage(message));
+                        OnMessage(new WebSocketMessage(this, message));
                     }
                 }
                 catch (OperationCanceledException) { }

--- a/Brokerages/WebSocketMessage.cs
+++ b/Brokerages/WebSocketMessage.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -21,6 +21,11 @@ namespace QuantConnect.Brokerages
     public class WebSocketMessage
     {
         /// <summary>
+        /// Gets the sender websocket instance
+        /// </summary>
+        public IWebSocket WebSocket { get; }
+
+        /// <summary>
         /// Gets the raw message data as text
         /// </summary>
         public string Message { get; }
@@ -28,9 +33,11 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="WebSocketMessage"/> class
         /// </summary>
+        /// <param name="webSocket">The sender websocket instance</param>
         /// <param name="message">The message</param>
-        public WebSocketMessage(string message)
+        public WebSocketMessage(IWebSocket webSocket, string message)
         {
+            WebSocket = webSocket;
             Message = message;
         }
     }

--- a/Tests/Brokerages/GDAX/GDAXTestHelpers.cs
+++ b/Tests/Brokerages/GDAX/GDAXTestHelpers.cs
@@ -55,7 +55,7 @@ namespace QuantConnect.Tests.Brokerages.GDAX
 
         public static WebSocketMessage GetArgs(string json)
         {
-            return new WebSocketMessage(json);
+            return new WebSocketMessage(null, json);
         }
     }
 }


### PR DESCRIPTION
#### Description
- The `BinanceBrokerage` has been updated to use the new `BrokerageMultiWebSocketSubscriptionManager` to handle more than `512` symbols (Binance only supports `1024` subscriptions per single websocket connection).
- The `BrokerageMultiWebSocketSubscriptionManager` can be configured to distribute symbols on multiple connections based on the 24h trade count, using the `"binance-maximum-websocket-connections"` config setting (defaults to zero, where no symbol weighting is performed and additional websocket connections are created as needed).

Closes #5794 

#### Motivation and Context
- Allow `BinanceBrokerage` to support more than `512` subscribed symbols

#### How Has This Been Tested?
- Tested locally, subscribing all `1503` symbols available (both with and without symbol weighting)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.