### PR TITLE
Filter Bitfinex currencies in Derivatives wallet

### DIFF
--- a/Brokerages/Bitfinex/BitfinexBrokerage.Utility.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Utility.cs
@@ -114,8 +114,9 @@ namespace QuantConnect.Brokerages.Bitfinex
         private Func<Wallet, bool> WalletFilter(AccountType accountType)
         {
             return wallet =>
-                wallet.Type.Equals("exchange") && accountType == AccountType.Cash ||
-                wallet.Type.Equals("margin") && accountType == AccountType.Margin;
+                !wallet.Currency.EndsWith("F0") &&
+                (wallet.Type.Equals("exchange") && accountType == AccountType.Cash ||
+                    wallet.Type.Equals("margin") && accountType == AccountType.Margin);
         }
 
         /// <summary>


### PR DESCRIPTION

#### Description
- Updates `BitfinexBrokerage.GetCashBalance()` to filter out funds in the Derivatives wallet

#### Motivation and Context
- Unable to deploy algorithms to Bitfinex when `USDT` balances are present both in the Margin wallet and the Derivatives wallet

#### How Has This Been Tested?
- Deposited funds in both wallets and was able to deploy after the fix

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.