### PR TITLE
Pandas Remapper Refactor

### DIFF
--- a/Common/PandasMapper.py
+++ b/Common/PandasMapper.py
@@ -1,0 +1,96 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Lean Pandas Remapper
+Wraps key indexing functions of Pandas to remap keys to SIDs when accessing dataframes.
+Allowing support for indexing of Lean created Indexes with tickers like "SPY", Symbol objs, and SIDs
+
+'''
+
+import pandas as pd
+from pandas.core.indexes.frozen import FrozenList as pdFrozenList
+
+from clr import AddReference
+AddReference("QuantConnect.Common")
+from QuantConnect import *
+
+def mapper(key):
+    '''Maps a Symbol object or a Symbol Ticker (string) to the string representation of
+    Symbol SecurityIdentifier.If cannot map, returns the object
+    '''
+    keyType = type(key)
+    if keyType is Symbol:
+        return str(key.ID)
+    if keyType is str:
+        reserved = ['high', 'low', 'open', 'close']
+        if key in reserved:
+            return key
+        kvp = SymbolCache.TryGetSymbol(key, None)
+        if kvp[0]:
+            return str(kvp[1].ID)
+    if keyType is list:
+        return [mapper(x) for x in key]
+    if keyType is tuple:
+        return tuple([mapper(x) for x in key])
+    if keyType is dict:
+        return { k: mapper(v) for k, v in key.items()}
+    return key
+
+def wrap_function(f):
+    '''Wraps function f with g.
+    Function g converts the args / kwargs to use alternative index keys
+      and then calls original function with the mapped args
+    '''
+    def wrapped_function(*args, **kwargs):
+
+        # Map args & kwargs, if wrapped function fails because key, execute with original
+        # Allows for df, Series, etc indexing for keys like 'SPY' if they exist
+        try:
+            newargs = args
+            newkwargs = kwargs
+
+            if len(args) > 1:
+                newargs = mapper(args)
+            if len(kwargs) > 0:
+                newkwargs = mapper(kwargs)
+
+            result = f(*newargs, **newkwargs)
+            return result
+        except KeyError:
+            pass
+
+        result = f(*args, **kwargs)
+        return result
+
+    wrapped_function.__name__ = f.__name__
+    return wrapped_function
+
+# Wrap all core __getItem__ and loc functions that are shared, yet still throw key errors if index not found
+pd.core.indexing._LocationIndexer.__getitem__ = wrap_function(pd.core.indexing._LocationIndexer.__getitem__)
+pd.core.indexing._ScalarAccessIndexer.__getitem__ = wrap_function(pd.core.indexing._ScalarAccessIndexer.__getitem__)
+pd.core.indexes.base.Index.get_loc = wrap_function(pd.core.indexes.base.Index.get_loc)
+
+# Wrap __contains__ to support Python syntax like 'SPY' in DataFrame 
+pd.core.indexes.base.Index.__contains__ = wrap_function(pd.core.indexes.base.Index.__contains__)
+
+# For older version of pandas we may need to wrap extra functions
+if (int(pd.__version__.split('.')[0]) < 1):
+    pd.core.indexes.base.Index.get_value = wrap_function(pd.core.indexes.base.Index.get_value)
+
+# For compatibility with PandasData.cs usage of this module (Previously wrapped classes)
+FrozenList = pdFrozenList
+Index = pd.Index
+MultiIndex = pd.MultiIndex
+Series = pd.Series
+DataFrame = pd.DataFrame

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -59,86 +59,8 @@ namespace QuantConnect.Python
             {
                 using (Py.GIL())
                 {
-                    // this python Remapper class will work as a proxy and adjust the
-                    // input to its methods using the provided 'mapper' callable object
-                    _pandas = PythonEngine.ModuleFromString("remapper",
-                        @"import pandas as pd
-from pandas.core.indexes.frozen import FrozenList as pdFrozenList
-
-from clr import AddReference
-AddReference(""QuantConnect.Common"")
-from QuantConnect import *
-
-def mapper(key):
-    '''Maps a Symbol object or a Symbol Ticker (string) to the string representation of
-    Symbol SecurityIdentifier.If cannot map, returns the object
-    '''
-    keyType = type(key)
-    if keyType is Symbol:
-        return str(key.ID)
-    if keyType is str:
-        reserved = ['high', 'low', 'open', 'close']
-        if key in reserved:
-            return key
-        kvp = SymbolCache.TryGetSymbol(key, None)
-        if kvp[0]:
-            return str(kvp[1].ID)
-    if keyType is list:
-        return [mapper(x) for x in key]
-    if keyType is tuple:
-        return tuple([mapper(x) for x in key])
-    if keyType is dict:
-        return { k: mapper(v) for k, v in key.items()}
-    return key
-
-def wrap_function(f):
-    '''Wraps function f with g.
-    Function g converts the args / kwargs to use alternative index keys
-      and then calls original function with the mapped args
-    '''
-    def wrapped_function(*args, **kwargs):
-
-        # Map args & kwargs, if wrapped function fails because key, execute with original
-        # Allows for df, Series, etc indexing for keys like 'SPY' if they exist
-        try:
-            newargs = args
-            newkwargs = kwargs
-
-            if len(args) > 1:
-                newargs = mapper(args)
-            if len(kwargs) > 0:
-                newkwargs = mapper(kwargs)
-
-            result = f(*newargs, **newkwargs)
-            return result
-        except KeyError:
-            pass
-
-        result = f(*args, **kwargs)
-        return result
-
-    wrapped_function.__name__ = f.__name__
-    return wrapped_function
-
-# Wrap all core __getItem__ and loc functions that are shared, yet still throw key errors if index not found
-pd.core.indexing._LocationIndexer.__getitem__ = wrap_function(pd.core.indexing._LocationIndexer.__getitem__)
-pd.core.indexing._ScalarAccessIndexer.__getitem__ = wrap_function(pd.core.indexing._ScalarAccessIndexer.__getitem__)
-pd.core.indexes.base.Index.get_loc = wrap_function(pd.core.indexes.base.Index.get_loc)
-
-# Wrap __contains__ to support Python syntax like 'SPY' in DataFrame 
-pd.core.indexes.base.Index.__contains__ = wrap_function(pd.core.indexes.base.Index.__contains__)
-
-# For older version of pandas we may need to wrap extra functions
-if (int(pd.__version__.split('.')[0]) < 1):
-    pd.core.indexes.base.Index.get_value = wrap_function(pd.core.indexes.base.Index.get_value)
-
-# For compabitilty with PandasData.cs usage of this module (Previously wrapped classes)
-FrozenList = pdFrozenList
-Index = pd.Index
-MultiIndex = pd.MultiIndex
-Series = pd.Series
-DataFrame = pd.DataFrame
-");
+                    // Use our PandasMapper class that modifies pandas indexing to support tickers, symbols and SIDs
+                    _pandas = PythonEngine.ImportModule("PandasMapper");
                 }
             }
 

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -63,14 +63,7 @@ namespace QuantConnect.Python
                     // input to its methods using the provided 'mapper' callable object
                     _pandas = PythonEngine.ModuleFromString("remapper",
                         @"import pandas as pd
-from pandas.core.resample import Resampler, DatetimeIndexResampler, PeriodIndexResampler, TimedeltaIndexResampler
-from pandas.core.groupby.generic import DataFrameGroupBy, SeriesGroupBy
 from pandas.core.indexes.frozen import FrozenList as pdFrozenList
-from pandas.core.window import Expanding, EWM, Rolling, Window
-from pandas.core.computation.ops import UndefinedVariableError
-from inspect import getmembers, isfunction, isgenerator
-from functools import partial
-from sys import modules
 
 from clr import AddReference
 AddReference(""QuantConnect.Common"")
@@ -78,7 +71,7 @@ from QuantConnect import *
 
 def mapper(key):
     '''Maps a Symbol object or a Symbol Ticker (string) to the string representation of
-    Symbol SecurityIdentifier. If cannot map, returns the object
+    Symbol SecurityIdentifier.If cannot map, returns the object
     '''
     keyType = type(key)
     if keyType is Symbol:
@@ -95,220 +88,55 @@ def mapper(key):
     if keyType is tuple:
         return tuple([mapper(x) for x in key])
     if keyType is dict:
-        return {k:mapper(v) for k,v in key.items()}
+        return { k: mapper(v) for k, v in key.items()}
     return key
-
-def try_wrap_as_index(obj):
-    '''Tries to wrap object if it is one of pandas' index objects.'''
-
-    objType = type(obj)
-
-    if objType is pd.Index:
-        return True, Index(obj)
-
-    if objType is pd.MultiIndex:
-        result = object.__new__(MultiIndex)
-        result._set_levels(obj.levels, copy=obj.copy, validate=False)
-        result._set_codes(obj.codes, copy=obj.copy, validate=False)
-        result._set_names(obj.names)
-        result.sortorder = obj.sortorder
-        return True, result
-
-    if objType is pdFrozenList:
-        return True, FrozenList(obj)
-
-    return False, obj
-
-def try_wrap_as_pandas(obj):
-    '''Tries to wrap object if it is a pandas' object.'''
-
-    success, obj = try_wrap_as_index(obj)
-    if success:
-        return success, obj
-
-    objType = type(obj)
-
-    if objType is pd.DataFrame:
-        return True, DataFrame(data=obj)
-
-    if objType is pd.Series:
-        return True, Series(data=obj)
-
-    if objType is tuple:
-        anySuccess = False
-        results = list()
-        for item in obj:
-            success, result = try_wrap_as_pandas(item)
-            anySuccess |= success
-            results.append(result)
-        if anySuccess:
-            return True, tuple(results)
-
-    return False, obj
-
-def try_wrap_resampler(obj, self):
-    '''Tries to wrap object if it is a pandas' Resampler object.'''
-
-    if not isinstance(obj, Resampler):
-        return False, obj
-
-    klass = CreateWrapperClass(type(obj))
-    return True, klass(self, groupby=obj.groupby, kind=obj.kind, axis=obj.axis)
 
 def wrap_function(f):
     '''Wraps function f with g.
-    Function g converts the args/kwargs to use alternative index keys
-    and the result of the f function call to the wrapper objects
+    Function g converts the args / kwargs to use alternative index keys
+      and then calls original function with the mapped args
     '''
-    def g(*args, **kwargs):
+    def wrapped_function(*args, **kwargs):
 
-        if len(args) > 1:
-            args = mapper(args)
-        if len(kwargs) > 0:
-            kwargs = mapper(kwargs)
-
+        # Map args & kwargs, if wrapped function fails because key, execute with original
+        # Allows for df, Series, etc indexing for keys like 'SPY' if they exist
         try:
-            result = f(*args, **kwargs)
-        except UndefinedVariableError as e:
-            # query/eval methods needs to look for a scope variable at a higher level
-            # since the wrapper classes are children of pandas classes
-            kwargs['level'] = kwargs.pop('level', 0) + 1
-            result = f(*args, **kwargs)
+            newargs = args
+            newkwargs = kwargs
 
-        success, result = try_wrap_as_pandas(result)
-        if success:
+            if len(args) > 1:
+                newargs = mapper(args)
+            if len(kwargs) > 0:
+                newkwargs = mapper(kwargs)
+
+            result = f(*newargs, **newkwargs)
             return result
+        except KeyError:
+            pass
 
-        success, result = try_wrap_resampler(result, args[0])
-        if success:
-            return result
-
-        if isgenerator(result):
-            return ( (k, try_wrap_as_pandas(v)[1]) for k, v in result)
-
+        result = f(*args, **kwargs)
         return result
 
-    g.__name__ = f.__name__
-    return g
+    wrapped_function.__name__ = f.__name__
+    return wrapped_function
 
-def wrap_special_function(name, cls, fcls, gcls = None):
-    '''Replaces the special function of a given class by g that wraps fcls
-    This is how pandas implements them.
-    gcls represents an alternative for fcls
-    if the keyword argument has 'win_type' key for the Rolling/Window case
-    '''
-    fcls = CreateWrapperClass(fcls)
-    if gcls is not None:
-        gcls = CreateWrapperClass(fcls)
+pd.core.indexing._LocationIndexer.__getitem__ = wrap_function(pd.core.indexing._LocationIndexer.__getitem__)
+pd.core.indexing._ScalarAccessIndexer.__getitem__ = wrap_function(pd.core.indexing._ScalarAccessIndexer.__getitem__)
+pd.core.indexes.base.Index.get_loc = wrap_function(pd.core.indexes.base.Index.get_loc)
+pd.core.indexes.base.Index.__contains__ = wrap_function(pd.core.indexes.base.Index.__contains__)
+pd.core.series.Series.__getitem__ = wrap_function(pd.core.series.Series.__getitem__)
 
-    def g(*args, **kwargs):
-        if kwargs.get('win_type', None):
-            return gcls(*args, **kwargs)
-        return fcls(*args, **kwargs)
-    g.__name__ = name
-    setattr(cls, g.__name__, g)
+# For older version of pandas we may need to wrap extra functions
+if (int(pd.__version__.split('.')[0]) < 1):
+    pd.core.indexes.base.Index.get_value = wrap_function(pd.core.indexes.base.Index.get_value)
 
-def CreateWrapperClass(cls: type):
-    '''Creates wrapper classes.
-    Members of the original class are wrapped to allow alternative index look-up
-    '''
-    # Define a new class
-    klass = type(f'{cls.__name__}', (cls,) + cls.__bases__, dict(cls.__dict__))
-
-    def g(self, name):
-        '''Wrap '__getattribute__' to handle indices
-        Only need to wrap columns, index and levels attributes
-        '''
-        attr = object.__getattribute__(self, name)
-        if name in ['columns', 'index', 'levels']:
-            _, attr = try_wrap_as_index(attr)
-        return attr
-    g.__name__ =  '__getattribute__'
-    g.__qualname__ =  g.__name__
-    setattr(klass, g.__name__, g)
-
-    def wrap_union(f):
-        '''Wraps function f (union) with g.
-        Special case: The union method from index objects needs to
-        receive pandas' index objects to avoid infity recursion.
-        Function g converts the args/kwargs objects to one of pandas index objects
-        and the result of the f function call back to wrapper indexes objects
-        '''
-        def unwrap_index(obj):
-            '''Tries to unwrap object if it is one of this module wrapper's index objects.'''
-            objType = type(obj)
-
-            if objType is Index:
-                return pd.Index(obj)
-
-            if objType is MultiIndex:
-                result = object.__new__(pd.MultiIndex)
-                result._set_levels(obj.levels, copy=obj.copy, validate=False)
-                result._set_codes(obj.codes, copy=obj.copy, validate=False)
-                result._set_names(obj.names)
-                result.sortorder = obj.sortorder
-                return result
-
-            if objType is FrozenList:
-                return pdFrozenList(obj)
-
-            return obj
-
-        def g(*args, **kwargs):
-
-            args = tuple([unwrap_index(x) for x in args])
-            result = f(*args, **kwargs)
-            _, result = try_wrap_as_index(result)
-            return result
-
-        g.__name__ = f.__name__
-        return g
-
-    # We allow the wraopping of slot methods that are not inherited from object
-    # It will include operation methods like __add__ and __contains__
-    allow_list = set(x for x in dir(klass) if x.startswith('__')) - set(dir(object))
-
-    # Wrap class members of the newly created class
-    for name, member in getmembers(klass):
-        if name.startswith('_') and name not in allow_list:
-            continue
-
-        if isfunction(member):
-            if name == 'union':
-                member = wrap_union(member)
-            else:
-                member = wrap_function(member)
-            setattr(klass, name, member)
-
-        elif type(member) is property:
-            if type(member.fget) is partial:
-                func = CreateWrapperClass(member.fget.func)
-                fget = partial(func, name)
-            else:
-                fget = wrap_function(member.fget)
-            member = property(fget, member.fset, member.fdel, member.__doc__)
-            setattr(klass, name, member)
-
-    return klass
-
-FrozenList = CreateWrapperClass(pdFrozenList)
-Index = CreateWrapperClass(pd.Index)
-MultiIndex = CreateWrapperClass(pd.MultiIndex)
-Series = CreateWrapperClass(pd.Series)
-DataFrame = CreateWrapperClass(pd.DataFrame)
-
-wrap_special_function('groupby', Series, SeriesGroupBy)
-wrap_special_function('groupby', DataFrame, DataFrameGroupBy)
-wrap_special_function('ewm', Series, EWM)
-wrap_special_function('ewm', DataFrame, EWM)
-wrap_special_function('expanding', Series, Expanding)
-wrap_special_function('expanding', DataFrame, Expanding)
-wrap_special_function('rolling', Series, Rolling, Window)
-wrap_special_function('rolling', DataFrame, Rolling, Window)
-
-CreateSeries = pd.Series
-
-setattr(modules[__name__], 'concat', wrap_function(pd.concat))");
+# For compabitilty with PandasData.cs usage of this module (Previously wrapped classes)
+FrozenList = pdFrozenList
+Index = pd.Index
+MultiIndex = pd.MultiIndex
+Series = pd.Series
+DataFrame = pd.DataFrame
+");
                 }
             }
 
@@ -561,17 +389,11 @@ setattr(modules[__name__], 'concat', wrap_function(pd.concat))");
                     }
 
                     // Adds pandas.Series value keyed by the column name
-                    // CreateSeries will create an original pandas.Series
-                    // We are not using the wrapper class to avoid unnecessary and expensive
-                    // index wrapping operations when the Series are packed into a DataFrame
-                    pyDict.SetItem(kvp.Key, _pandas.CreateSeries(values, index));
+                    pyDict.SetItem(kvp.Key, _pandas.Series(values, index));
                 }
                 _series.Clear();
 
-                // Create a DataFrame with wrapper class.
-                // This is the starting point. The types of all DataFrame and Series that result from any operation will
-                // be wrapper classes. Index and MultiIndex will be converted when required by index operations such as
-                // stack, unstack, merge, union, etc.
+                // Create the DataFrame
                 return _pandas.DataFrame(pyDict);
             }
         }

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -120,11 +120,13 @@ def wrap_function(f):
     wrapped_function.__name__ = f.__name__
     return wrapped_function
 
+# Wrap all core __getItem__ and loc functions that are shared, yet still throw key errors if index not found
 pd.core.indexing._LocationIndexer.__getitem__ = wrap_function(pd.core.indexing._LocationIndexer.__getitem__)
 pd.core.indexing._ScalarAccessIndexer.__getitem__ = wrap_function(pd.core.indexing._ScalarAccessIndexer.__getitem__)
 pd.core.indexes.base.Index.get_loc = wrap_function(pd.core.indexes.base.Index.get_loc)
+
+# Wrap __contains__ to support Python syntax like 'SPY' in DataFrame 
 pd.core.indexes.base.Index.__contains__ = wrap_function(pd.core.indexes.base.Index.__contains__)
-pd.core.series.Series.__getitem__ = wrap_function(pd.core.series.Series.__getitem__)
 
 # For older version of pandas we may need to wrap extra functions
 if (int(pd.__version__.split('.')[0]) < 1):

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -71,6 +71,9 @@
       <PackagePath></PackagePath>
     </None>
     <Content Include="AlgorithmImports.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="PandasMapper.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -659,11 +659,6 @@ def Test(dataFrame, other, symbol):
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
-            // IX deprecated in newer pandas
-            if(_newerPandas){
-                return;
-            }
-
             using (Py.GIL())
             {
                 dynamic test = PythonEngine.ModuleFromString("testModule",
@@ -671,7 +666,7 @@ def Test(dataFrame, other, symbol):
 import pandas as pd
 def Test(dataFrame, dataFrame2, symbol):
     newDataFrame = pd.concat([dataFrame, dataFrame2])
-    data = newDataFrame['lastprice'].unstack(level=0).ix[-1][{index}]
+    data = newDataFrame['lastprice'].unstack(level=0).iloc[-1][{index}]
     if data is 0:
         raise Exception('Data is zero')").GetAttr("Test");
 
@@ -897,7 +892,7 @@ def Test(dataFrame, symbol):
         [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_ftypes(string index, bool cache = false)
         {
-            // ftypes not supported in newer pandas
+            // ftypes deprecated in newer pandas; use dtypes instead
             if(_newerPandas){
                 return;
             }
@@ -961,7 +956,7 @@ def Test(dataFrame, symbol):
         [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_get_value_index(string index, bool cache = false)
         {
-            // get_value deprecated in new Pandas
+            // get_value deprecated in new Pandas; Syntax also deprecated; Use .at[] or .iat[] instead
             if(_newerPandas){
                 return;
             }
@@ -986,7 +981,7 @@ def Test(dataFrame, symbol):
         [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_get_value_column(string index, bool cache = false)
         {
-            // get_value deprecated in new Pandas
+            // get_value deprecated in new Pandas; use at[] or iat[] instead
             if(_newerPandas){
                 return;
             }
@@ -1143,7 +1138,7 @@ def Test(dataFrame, symbol):
         [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_ix(string index, bool cache = false)
         {
-            // ix not supported in newer pandas
+            // ix deprecated in newer pandas; use loc and iloc instead
             if(_newerPandas){
                 return;
             }
@@ -1168,11 +1163,6 @@ def Test(dataFrame, symbol):
         [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_join(string index, bool cache = false)
         {
-            // ix deprecated in newer pandas
-            if(_newerPandas){
-                return;
-            }
-
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
             using (Py.GIL())
@@ -1181,7 +1171,7 @@ def Test(dataFrame, symbol):
                     $@"
 def Test(dataFrame, dataFrame2, symbol):
     newDataFrame = dataFrame.join(dataFrame2, lsuffix='_')
-    data = newDataFrame['lastprice'].unstack(level=0).ix[-1][{index}]
+    data = newDataFrame['lastprice_'].unstack(level=0).iloc[-1][{index}]
     if data is 0:
         raise Exception('Data is zero')").GetAttr("Test");
 
@@ -1627,7 +1617,7 @@ def Test(dataFrame, symbol):
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
-            // set_value deprecated in newer pandas
+            // set_value deprecated in newer pandas; use .at[] or .iat instead
             if(_newerPandas) {
                 return;
             }
@@ -2396,8 +2386,8 @@ def Test(dataFrame, symbol):
         [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilitySeries_get_value(string index, bool cache = false)
         {
-            // get_value deprecated in new Pandas
-            if(_newerPandas){
+            // get_value deprecated in new Pandas; Use .at[] or .iat[] instead
+            if (_newerPandas){
                 return;
             }
 
@@ -2710,12 +2700,13 @@ def Test(dataFrame, symbol):
         [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilitySeries_set_value(string index, bool cache = false)
         {
-            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
-
-            // set_value deprecated in newer pandas
-            if(_newerPandas) {
+            // set_value deprecated in newer pandas; Use .at[] or .iat[] instead
+            if (_newerPandas)
+            {
                 return;
             }
+
+            if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
             using (Py.GIL())
             {

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -36,11 +36,24 @@ namespace QuantConnect.Tests.Python
     public partial class PandasConverterTests
     {
         private PandasConverter _converter = new PandasConverter();
+        private bool _newerPandas;
+
+        private static bool IsNewerPandas(){
+            bool newPandas;
+            using(Py.GIL()){
+                var pandas = Py.Import("pandas");
+                var local = new PyDict();
+                local["pd"] = pandas;
+                newPandas = PythonEngine.Eval("int(pd.__version__.split('.')[0]) >= 1", locals:local.Handle).As<bool>();
+            }
+            return newPandas;
+        }
 
         [SetUp]
         public void Setup()
         {
             SymbolCache.Clear();
+            _newerPandas = IsNewerPandas();
         }
 
         [TearDown]
@@ -513,6 +526,13 @@ def Test(dataFrame, symbol):
         [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_at(string index, bool cache = false)
         {
+            // Syntax like ({index},) deprecated in newer version of pandas
+            // Same result achievable by .loc[{index}]['lastprice']
+            if (_newerPandas)
+            {
+                return;
+            }
+
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
             using (Py.GIL())
@@ -638,6 +658,11 @@ def Test(dataFrame, other, symbol):
         public void BackwardsCompatibilityDataFrame_concat(string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            // IX deprecated in newer pandas
+            if(_newerPandas){
+                return;
+            }
 
             using (Py.GIL())
             {
@@ -872,6 +897,11 @@ def Test(dataFrame, symbol):
         [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_ftypes(string index, bool cache = false)
         {
+            // ftypes not supported in newer pandas
+            if(_newerPandas){
+                return;
+            }
+
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
             using (Py.GIL())
@@ -931,6 +961,11 @@ def Test(dataFrame, symbol):
         [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_get_value_index(string index, bool cache = false)
         {
+            // get_value deprecated in new Pandas
+            if(_newerPandas){
+                return;
+            }
+
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
             using (Py.GIL())
@@ -951,6 +986,11 @@ def Test(dataFrame, symbol):
         [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_get_value_column(string index, bool cache = false)
         {
+            // get_value deprecated in new Pandas
+            if(_newerPandas){
+                return;
+            }
+            
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
             using (Py.GIL())
@@ -1103,6 +1143,11 @@ def Test(dataFrame, symbol):
         [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_ix(string index, bool cache = false)
         {
+            // ix not supported in newer pandas
+            if(_newerPandas){
+                return;
+            }
+
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
             using (Py.GIL())
@@ -1123,6 +1168,11 @@ def Test(dataFrame, symbol):
         [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilityDataFrame_join(string index, bool cache = false)
         {
+            // ix deprecated in newer pandas
+            if(_newerPandas){
+                return;
+            }
+
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
             using (Py.GIL())
@@ -1576,6 +1626,11 @@ def Test(dataFrame, symbol):
         public void BackwardsCompatibilityDataFrame_set_value(string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            // set_value deprecated in newer pandas
+            if(_newerPandas) {
+                return;
+            }
 
             using (Py.GIL())
             {
@@ -2341,6 +2396,11 @@ def Test(dataFrame, symbol):
         [TestCase("str(symbol.ID)")]
         public void BackwardsCompatibilitySeries_get_value(string index, bool cache = false)
         {
+            // get_value deprecated in new Pandas
+            if(_newerPandas){
+                return;
+            }
+
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
             using (Py.GIL())
@@ -2651,6 +2711,11 @@ def Test(dataFrame, symbol):
         public void BackwardsCompatibilitySeries_set_value(string index, bool cache = false)
         {
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
+
+            // set_value deprecated in newer pandas
+            if(_newerPandas) {
+                return;
+            }
 
             using (Py.GIL())
             {

--- a/Tests/Python/PandasTests/PandasMapperTests.py
+++ b/Tests/Python/PandasTests/PandasMapperTests.py
@@ -1,0 +1,91 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+To test this script directly you will need to import QuantConnect Dlls using clrloader from the appropriate 
+location, the code below shows how to do this. Otherwise you can run it directly from C# in Lean without it.
+
+To run as a solo script, add the following code to your script
+
+Requires:
+clr-loader==0.1.6
+pandas
+
+*********** CODE ***********
+import os
+import sys
+
+# Get to DLL location where we are testing, change as needed
+fileDirectory = os.path.dirname(os.path.abspath(__file__))
+dlldir = "../../bin/Debug"
+dlldir = os.path.join(fileDirectory, dlldir)
+
+# Move us to dll directory and add it to path
+os.chdir(dlldir)
+sys.path.append(dlldir)
+
+# Tell PythonNet to use .dotnet 5
+from pythonnet import set_runtime
+import clr_loader
+set_runtime(clr_loader.get_coreclr(os.path.join(dlldir, "QuantConnect.Lean.Launcher.runtimeconfig.json")))
+
+'''
+
+from clr import AddReference
+AddReference("QuantConnect.Common")
+AddReference("QuantConnect.Tests")
+
+from QuantConnect import *
+from QuantConnect.Python import PandasConverter
+from QuantConnect.Tests import Symbols
+from QuantConnect.Tests.Python import PythonTestingUtils
+
+# Import our mapper which wraps core pandas functions (included in build dir)
+import PandasMapper
+import pandas as pd
+
+# Get some dataframes from Lean to test on
+spy = Symbols.SPY
+aapl = Symbols.AAPL
+SymbolCache.Set("SPY", spy)
+SymbolCache.Set("AAPL", aapl)
+
+pdConverter = PandasConverter()
+
+slices = PythonTestingUtils.GetSlices(spy)
+spydf = pdConverter.GetDataFrame(slices)
+
+slices = PythonTestingUtils.GetSlices(aapl)
+aapldf = pdConverter.GetDataFrame(slices)
+
+
+def Test_Concat(dataFrame, dataFrame2, indexer):
+    newDataFrame = pd.concat([dataFrame, dataFrame2])
+    data = newDataFrame['lastprice'].unstack(level=0).iloc[-1][indexer]
+    if data is 0:
+        raise Exception('Data is zero')
+
+def Test_Join(dataFrame, dataFrame2, indexer):
+    newDataFrame = dataFrame.join(dataFrame2, lsuffix='_')
+    base =  newDataFrame['lastprice_'].unstack(level=0)
+    data = base.iloc[-1][indexer]
+    if data is 0:
+        raise Exception('Data is zero')
+
+Test_Concat(spydf, aapldf, "spy")
+Test_Concat(spydf, aapldf, spy)
+Test_Concat(spydf, aapldf, str(spy.ID))
+
+Test_Join(spydf, aapldf, "spy")
+Test_Join(spydf, aapldf, spy)
+Test_Join(spydf, aapldf, str(spy.ID))

--- a/Tests/Python/PythonTestingUtils.cs
+++ b/Tests/Python/PythonTestingUtils.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+
+namespace QuantConnect.Tests.Python
+{
+    public static class PythonTestingUtils
+    {
+        public static dynamic GetSlices(Symbol symbol)
+        {
+            var slices = Enumerable
+                .Range(0, 100)
+                .Select(
+                    i =>
+                    {
+                        var time = new DateTime(2013, 10, 7).AddMilliseconds(14400000 + i * 10000);
+                        return new Slice(
+                            time,
+                            new List<BaseData> {
+                                new Tick
+                                {
+                                    Time = time,
+                                    Symbol = symbol,
+                                    Value = 167 + i / 10,
+                                    Quantity = 1 + i * 10,
+                                    Exchange = "T"
+                                }
+                            }
+                        );
+                    }
+                );
+            return slices;
+        }
+    }
+}

--- a/Tests/Python/PythonTestingUtils.cs
+++ b/Tests/Python/PythonTestingUtils.cs
@@ -1,3 +1,19 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -118,6 +118,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Python\Indicators\IndicatorExtensionsTests.py" />
+    <Content Include="Python\PandasTests\PandasMapperTests.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="RegressionAlgorithms\Test_AlgorithmPythonWrapper.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Refactor pandas mapper as a part of #5678

Broke this change out into its own PR since it applies to old and new pandas.


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#5678

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Attempting to support newer pandas version > 1 caused a lot of problems with the previous implementation. So I went about finding a new way to do mapping to Symbol ID indexes. 

I was able to do this by directly wrapping internally shared index functions that do the fetching of values. In this wrapping I remap the args and attempt to fetch the index with the new values. If this fails pandas will attempt to fall back to the previous arg request just in case (supports user defined pandas frames with tickers)

#### Performance improvements
Research Indexing
```
Cell 1:
qb = QuantBook()
qb.AddEquity("SPY")
qb.AddEquity("TSLA")
qb.AddEquity("AAPL")
qb.AddEquity("GOOG")
qb.AddEquity("BAC")
qb.AddEquity("CHWY")
qb.AddEquity("BABA")
qb.AddEquity("RKT")
qb.AddForex("EURUSD")
qb.AddCrypto("BTCUSD")

history = qb.History(qb.Securities.Keys, 360, Resolution.Daily)

Cell 2:
%%time
for seq in range(1000):
    for key in qb.Securities.Keys:
        history.loc[key]
        history.loc[key.Value]
        history.loc[str(key.ID)]
```

Results from cell 2 %%time:
```
---------- NEW -----------
Research Indexing
CPU times: user 19.6 s, sys: 84.1 ms, total: 19.7 s
CPU times: user 19.5 s, sys: 156 ms, total: 19.7 s
CPU times: user 19.9 s, sys: 123 ms, total: 20 s
CPU times: user 20.2 s, sys: 79.5 ms, total: 20.2 s
CPU times: user 19.9 s, sys: 123 ms, total: 20 s
CPU times: user 20.1 s, sys: 217 ms, total: 20.3 s

---------- OLD -----------
Research Indexing
CPU times: user 1min 47s, sys: 693 ms, total: 1min 47s
CPU times: user 1min 48s, sys: 834 ms, total: 1min 48s
CPU times: user 1min 49s, sys: 930 ms, total: 1min 50s
CPU times: user 1min 49s, sys: 974 ms, total: 1min 50s
CPU times: user 1min 45s, sys: 958 ms, total: 1min 46s
```

`HistoryRequestBenchmark` Python Algorithm
```
---------- NEW -----------
45.86 seconds at 40k data points per second
40.77 seconds at 45k data points per second
47.54 seconds at 38k data points per second
53.84 seconds at 34k data points per second

---------- OLD -----------
62.89 seconds at 29k data points per second
59.16 seconds at 31k data points per second
68.05 seconds at 27k data points per second
66.98 seconds at 27k data points per second
```

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All regressions and unit tests passing with:
- current pandas (0.25.3)
- pandas 1.15


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
