### PR TITLE
Add support for IBGateway v985

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -3432,5 +3432,6 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         {
             1100, 1101, 1102, 2103, 2104, 2105, 2106, 2107, 2108, 2119, 2157, 2158, 10197
         };
+
     }
 }

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -71,6 +71,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         private readonly ISecurityProvider _securityProvider;
         private readonly IDataAggregator _aggregator;
         private readonly IB.InteractiveBrokersClient _client;
+        private readonly int _ibVersion;
         private readonly string _agentDescription;
         private readonly EventBasedDataQueueHandlerSubscriptionManager _subscriptionManager;
 
@@ -259,6 +260,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             _account = account;
             _host = host;
             _port = port;
+            _ibVersion = Convert.ToInt32(ibVersion, CultureInfo.InvariantCulture);
             _agentDescription = agentDescription;
 
             _symbolMapper = new InteractiveBrokersSymbolMapper(mapFileProvider);
@@ -2736,12 +2738,13 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <summary>
         /// Modifies the quantity received from IB based on the security type
         /// </summary>
-        public static int AdjustQuantity(SecurityType type, int size)
+        public int AdjustQuantity(SecurityType type, int size)
         {
             switch (type)
             {
                 case SecurityType.Equity:
-                    return size * 100;
+                    // Effective in TWS version 985 and later, for US stocks the bid, ask, and last size quotes are shown in shares (not in lots).
+                    return _ibVersion < 985 ? size * 100 : size;
                 default:
                     return size;
             }

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapper.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersSymbolMapper.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -198,8 +198,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
                 return Symbol.Create(brokerageSymbol, securityType, market);
             }
-            catch (Exception)
+            catch (Exception exception)
             {
+                Log.Error(exception, "Error in GetLeanSymbol");
                 throw new ArgumentException($"Invalid symbol: {brokerageSymbol}, security type: {securityType}, market: {market}.");
             }
         }

--- a/Brokerages/QuantConnect.Brokerages.csproj
+++ b/Brokerages/QuantConnect.Brokerages.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
-    <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.43" />
+    <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.44" />
     <PackageReference Include="RestSharp" Version="106.6.10" />
     <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />


### PR DESCRIPTION

#### Description
- Effective in TWS version 985 and later, for US stocks the bid, ask, and last size quotes are shown in shares (not in lots).
- Updated IBAutomater to `v2.0.44`: https://github.com/QuantConnect/IBAutomater/pull/51
- Added missing error log in IB symbol mapper

#### Motivation and Context
- Fixes incorrect IB data feed sizes (trades and quotes) with high price stocks (e.g. `BRK.A`, `AMZN`) when upgrading IBGateway to `v985`

#### How Has This Been Tested?
- Tested locally with `v984` and `v985`
- Tested in the cloud with `v984`

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.