### PR TITLE
Update Lean Foundation docker files to IBGateway v985

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -52,6 +52,11 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
     [BrokerageFactory(typeof(InteractiveBrokersBrokerageFactory))]
     public sealed class InteractiveBrokersBrokerage : Brokerage, IDataQueueHandler, IDataQueueUniverseProvider
     {
+        /// <summary>
+        /// The default gateway version to use
+        /// </summary>
+        public static string DefaultVersion { get; } = "985";
+
         private readonly IBAutomater.IBAutomater _ibAutomater;
 
         // Existing orders created in TWS can *only* be cancelled/modified when connected with ClientId = 0
@@ -168,22 +173,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         /// <param name="aggregator">consolidate ticks</param>
         /// <param name="mapFileProvider">representing all the map files</param>
         public InteractiveBrokersBrokerage(IAlgorithm algorithm, IOrderProvider orderProvider, ISecurityProvider securityProvider, IDataAggregator aggregator, IMapFileProvider mapFileProvider)
-            : this(
-                algorithm,
-                orderProvider,
-                securityProvider,
-                aggregator,
-                mapFileProvider,
-                Config.Get("ib-account"),
-                Config.Get("ib-host", "LOCALHOST"),
-                Config.GetInt("ib-port", 4001),
-                Config.Get("ib-tws-dir"),
-                Config.Get("ib-version", "974"),
-                Config.Get("ib-user-name"),
-                Config.Get("ib-password"),
-                Config.Get("ib-trading-mode"),
-                Config.GetValue("ib-agent-description", IB.AgentDescription.Individual)
-                )
+            : this(algorithm, orderProvider, securityProvider, aggregator, mapFileProvider, Config.Get("ib-account"))
         {
         }
 
@@ -207,7 +197,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 Config.Get("ib-host", "LOCALHOST"),
                 Config.GetInt("ib-port", 4001),
                 Config.Get("ib-tws-dir"),
-                Config.Get("ib-version", "974"),
+                Config.Get("ib-version", DefaultVersion),
                 Config.Get("ib-user-name"),
                 Config.Get("ib-password"),
                 Config.Get("ib-trading-mode"),

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageFactory.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageFactory.cs
@@ -73,7 +73,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             var port = Config.GetInt("ib-port", 4001);
             var host = Config.Get("ib-host", "127.0.0.1");
             var twsDirectory = Config.Get("ib-tws-dir", "C:\\Jts");
-            var ibVersion = Config.Get("ib-version", "974");
+            var ibVersion = Config.Get("ib-version", InteractiveBrokersBrokerage.DefaultVersion);
 
             var account = Read<string>(job.BrokerageData, "ib-account", errors);
             var userId = Read<string>(job.BrokerageData, "ib-user-name", errors);

--- a/DockerfileLeanFoundation
+++ b/DockerfileLeanFoundation
@@ -28,10 +28,10 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
    && rm -rf /var/lib/apt/lists/*
 
 # Install IB Gateway: Installs to /usr/local/ibgateway
-RUN wget https://cdn.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64.v984.1h.sh && \
-    chmod 777 ibgateway-latest-standalone-linux-x64.v984.1h.sh && \
-    ./ibgateway-latest-standalone-linux-x64.v984.1h.sh -q && \
-    rm ibgateway-latest-standalone-linux-x64.v984.1h.sh
+RUN wget https://cdn.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64.v985.1h.sh && \
+    chmod 777 ibgateway-latest-standalone-linux-x64.v985.1h.sh && \
+    ./ibgateway-latest-standalone-linux-x64.v985.1h.sh -q && \
+    rm ibgateway-latest-standalone-linux-x64.v985.1h.sh
 
 # Install dotnet 5 sdk & runtime
 RUN wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \

--- a/DockerfileLeanFoundationARM
+++ b/DockerfileLeanFoundationARM
@@ -26,12 +26,12 @@ RUN apt-fast install -y git libgtk2.0.0 cmake bzip2 curl unzip wget python3-pip 
 # Install IB Gateway: Installs to /usr/local/ibgateway
 # We update the install script so it doesn't use the bundled JVM
 # The bundled JVM doesn't work on ARM64, so we update it to use the JVM installed in the previous command
-RUN wget https://cdn.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64.v984.1h.sh && \
+RUN wget https://cdn.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64.v985.1h.sh && \
     java_patch_version=$(java -version 2>&1 | head -n 1 | cut -d'_' -f2 | cut -d'"' -f1) && \
-    bbe -e 's|# INSTALL4J_JAVA_HOME_OVERRIDE=|INSTALL4J_JAVA_HOME_OVERRIDE="/usr/lib/jvm/java-1.8.0-openjdk-arm64"|' -e "s|-lt \"152\"|-lt \"$java_patch_version\"|" -e "s|-gt \"152\"|-gt \"$java_patch_version\"|" ibgateway-latest-standalone-linux-x64.v984.1h.sh > ibgateway-stable-standalone-linux-custom-jvm.sh && \
+    bbe -e 's|# INSTALL4J_JAVA_HOME_OVERRIDE=|INSTALL4J_JAVA_HOME_OVERRIDE="/usr/lib/jvm/java-1.8.0-openjdk-arm64"|' -e "s|-lt \"152\"|-lt \"$java_patch_version\"|" -e "s|-gt \"152\"|-gt \"$java_patch_version\"|" ibgateway-latest-standalone-linux-x64.v985.1h.sh > ibgateway-stable-standalone-linux-custom-jvm.sh && \
     chmod 777 ibgateway-stable-standalone-linux-custom-jvm.sh && \
     ./ibgateway-stable-standalone-linux-custom-jvm.sh -q && \
-    rm ibgateway-latest-standalone-linux-x64.v984.1h.sh ibgateway-stable-standalone-linux-custom-jvm.sh
+    rm ibgateway-latest-standalone-linux-x64.v985.1h.sh ibgateway-stable-standalone-linux-custom-jvm.sh
 
 # Install dotnet 5 sdk & runtime
 # The .deb packages don't support ARM, the install script does

--- a/DockerfileLeanFoundationARM
+++ b/DockerfileLeanFoundationARM
@@ -16,7 +16,7 @@ RUN env TZ=UTC
 # Misc tools for running Python.NET and IB inside a headless container.
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test && apt-get update
 RUN add-apt-repository ppa:apt-fast/stable && apt-get update && apt-get -y install apt-fast
-RUN apt-fast install -y git libgtk2.0.0 cmake bzip2 curl unzip wget python3-pip python-opengl zlib1g-dev \
+RUN apt-get update && apt-fast install -y git libgtk2.0.0 cmake bzip2 curl unzip wget python3-pip python-opengl zlib1g-dev \
     xvfb libxrender1 libxtst6 libxi6 libglib2.0-dev libopenmpi-dev libstdc++6 openmpi-bin \
     r-base pandoc libcurl4-openssl-dev \
     openjdk-8-jdk openjdk-8-jre bbe \


### PR DESCRIPTION

#### Description
- Update IBGateway from `v984.1h` to `v985.1h`

#### Related Issue
#5812 

#### Motivation and Context
- Allow IB data feed to receive sizes in Shares instead of lots

#### How Has This Been Tested?
- Local build + algorithm deployment

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.