### PR TITLE
Change Binance Benchmark to BTCUSDC

### DIFF
--- a/Common/Brokerages/BinanceBrokerageModel.cs
+++ b/Common/Brokerages/BinanceBrokerageModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -74,7 +74,7 @@ namespace QuantConnect.Brokerages
         /// <returns>The benchmark for this brokerage</returns>
         public override IBenchmark GetBenchmark(SecurityManager securities)
         {
-            var symbol = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Binance);
+            var symbol = Symbol.Create("BTCUSDC", SecurityType.Crypto, Market.Binance);
             return SecurityBenchmark.CreateInstance(securities, symbol);
         }
 


### PR DESCRIPTION
#### Description
`BTCUSD` is not supported by Binance (see Symbol Properties Dabase)

#### Motivation and Context
Bug fix and improve Brokerage modeling.

#### How Has This Been Tested?
The following algorithm raises an exception on master, and passes with this change
```python
class BinanceAlgorithm(QCAlgorithm):
    def Initialize(self):
        self.SetBrokerageModel(BrokerageName.Binance, AccountType.Cash)
```
#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`