### PR TITLE
Add autorestart for Binance data connections

### DIFF
--- a/Brokerages/Binance/BinanceBrokerage.cs
+++ b/Brokerages/Binance/BinanceBrokerage.cs
@@ -83,7 +83,8 @@ namespace QuantConnect.Brokerages.Binance
                 () => new BinanceWebSocketWrapper(null),
                 Subscribe,
                 Unsubscribe,
-                OnDataMessage);
+                OnDataMessage,
+                new TimeSpan(23, 45, 0));
 
             SubscriptionManager = subscriptionManager;
 

--- a/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.Messaging.cs
@@ -103,6 +103,7 @@ namespace QuantConnect.Brokerages.Bitfinex
                 Subscribe,
                 Unsubscribe,
                 OnDataMessage,
+                TimeSpan.Zero,
                 _connectionRateLimiter);
 
             _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();


### PR DESCRIPTION

#### Description
- Binance websocket connections for data subscriptions are now auto-restarted before the max limit of 24 hours.

#### Motivation and Context
- Binance websocket connections have a maximum duration of 24 hours.

#### How Has This Been Tested?
- Local testing

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.