### PR TITLE
Fix IB history requests

### DIFF
--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2270,10 +2270,13 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 case Resolution.Tick:
                 case Resolution.Second:
                     return IB.BarSize.OneSecond;
+
                 case Resolution.Minute:
                     return IB.BarSize.OneMinute;
+
                 case Resolution.Hour:
                     return IB.BarSize.OneHour;
+
                 case Resolution.Daily:
                 default:
                     return IB.BarSize.OneDay;
@@ -2291,11 +2294,14 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             {
                 case Resolution.Tick:
                 case Resolution.Second:
-                    return "60 S";
+                    return "1800 S";
+
                 case Resolution.Minute:
                     return "1 D";
+
                 case Resolution.Hour:
                     return "1 M";
+
                 case Resolution.Daily:
                 default:
                     return "1 Y";
@@ -3116,7 +3122,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             var dataDownloading = new AutoResetEvent(false);
             var dataDownloaded = new AutoResetEvent(false);
 
-            var useRegularTradingHours = Convert.ToInt32(!request.IncludeExtendedMarketHours);
+            var useRegularTradingHours = request.Symbol.SecurityType == SecurityType.Equity
+                ? Convert.ToInt32(!request.IncludeExtendedMarketHours)
+                : 0;
 
             // making multiple requests if needed in order to download the history
             while (endTime >= startTime)
@@ -3209,7 +3217,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 history.InsertRange(0, filteredPiece);
 
                 // moving endTime to the new position to proceed with next request (if needed)
-                endTime = filteredPiece.First().Time;
+                endTime = filteredPiece.First().Time.ConvertToUtc(exchangeTimeZone);
             }
 
             return history;

--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -21,11 +21,11 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using IBApi;
+using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Brokerages.InteractiveBrokers;
 using QuantConnect.Data;
-using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Market;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Logging;
@@ -39,6 +39,12 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
     public class InteractiveBrokersBrokerageAdditionalTests
     {
         private readonly List<Order> _orders = new List<Order>();
+
+        [SetUp]
+        public void Setup()
+        {
+            Log.LogHandler = new NUnitLogHandler();
+        }
 
         [Test(Description = "Requires an existing IB connection with the same user credentials.")]
         public void ThrowsWhenExistingSessionDetected()
@@ -153,6 +159,86 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
                 Assert.AreEqual(0, history.Count);
 
                 Assert.IsFalse(hasError);
+            }
+        }
+
+        [Test, TestCaseSource(nameof(GetHistoryData))]
+        public void GetHistory(
+            Symbol symbol,
+            Resolution resolution,
+            DateTimeZone exchangeTimeZone,
+            DateTimeZone dataTimeZone,
+            DateTime endTimeInExchangeTimeZone,
+            TimeSpan historyTimeSpan,
+            bool includeExtendedMarketHours,
+            int expectedCount)
+        {
+            using var brokerage = GetBrokerage();
+            Assert.IsTrue(brokerage.IsConnected);
+
+            var request = new HistoryRequest(
+                endTimeInExchangeTimeZone.ConvertToUtc(exchangeTimeZone).Subtract(historyTimeSpan),
+                endTimeInExchangeTimeZone.ConvertToUtc(exchangeTimeZone),
+                typeof(TradeBar),
+                symbol,
+                resolution,
+                SecurityExchangeHours.AlwaysOpen(exchangeTimeZone),
+                dataTimeZone,
+                null,
+                includeExtendedMarketHours,
+                false,
+                DataNormalizationMode.Raw,
+                TickType.Trade);
+
+            var history = brokerage.GetHistory(request).ToList();
+
+            // check if data points are in chronological order
+            var previousEndTime = DateTime.MinValue;
+            foreach (var bar in history)
+            {
+                Assert.IsTrue(bar.EndTime > previousEndTime);
+
+                previousEndTime = bar.EndTime;
+            }
+
+            Log.Trace($"History count: {history.Count}");
+
+            Assert.AreEqual(expectedCount, history.Count);
+        }
+
+        private static TestCaseData[] GetHistoryData
+        {
+            get
+            {
+                var futureSymbol = Symbol.CreateFuture("NQ", Market.CME, new DateTime(2021, 9, 17));
+                var optionSymbol = Symbol.CreateOption("AAPL", Market.USA, OptionStyle.American, OptionRight.Call, 145, new DateTime(2021, 8, 20));
+
+                return new[]
+                {
+                    // 30 min RTH today + 60 min RTH yesterday
+                    new TestCaseData(Symbols.SPY, Resolution.Second, TimeZones.NewYork, TimeZones.NewYork,
+                        new DateTime(2021, 8, 6, 10, 0, 0), TimeSpan.FromHours(19), false, 5400),
+
+                    // 30 min RTH + 30 min ETH
+                    new TestCaseData(Symbols.SPY, Resolution.Second, TimeZones.NewYork, TimeZones.NewYork,
+                        new DateTime(2021, 8, 6, 10, 0, 0), TimeSpan.FromHours(1), true, 3600),
+
+                    // 60 min
+                    new TestCaseData(futureSymbol, Resolution.Second, TimeZones.NewYork, TimeZones.Utc,
+                        new DateTime(2021, 8, 6, 10, 0, 0), TimeSpan.FromHours(1), false, 3600),
+
+                    // 60 min - RTH flag ignored, no ETH market hours
+                    new TestCaseData(futureSymbol, Resolution.Second, TimeZones.NewYork, TimeZones.Utc,
+                        new DateTime(2021, 8, 6, 10, 0, 0), TimeSpan.FromHours(1), true, 3600),
+
+                    // 30 min today + 60 min yesterday
+                    new TestCaseData(optionSymbol, Resolution.Second, TimeZones.NewYork, TimeZones.NewYork,
+                        new DateTime(2021, 8, 6, 10, 0, 0), TimeSpan.FromHours(19), false, 5400),
+
+                    // 30 min today + 60 min yesterday - RTH flag ignored, no ETH market hours
+                    new TestCaseData(optionSymbol, Resolution.Second, TimeZones.NewYork, TimeZones.NewYork,
+                        new DateTime(2021, 8, 6, 10, 0, 0), TimeSpan.FromHours(19), true, 5400)
+                };
             }
         }
 


### PR DESCRIPTION

#### Description
- Fix time zone bug causing incomplete results
- Use RegularTradingHours flag only for equities
- Second resolution data is now requested in 30 minute chunks (instead of 1 minute):
https://interactivebrokers.github.io/tws-api/historical_limitations.html

#### Motivation and Context
- Missing or incomplete history results

#### How Has This Been Tested?
- Local testing with multiple resolutions and asset types.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.