### PR TITLE
Makes sure to create directory for results-destination-folder

### DIFF
--- a/Engine/Initializer.cs
+++ b/Engine/Initializer.cs
@@ -39,7 +39,12 @@ namespace QuantConnect.Lean.Engine
                 #endif
 
                 Log.DebuggingEnabled = Config.GetBool("debug-mode");
-                Log.FilePath = Path.Combine(Config.Get("results-destination-folder"), "log.txt");
+                var destinationDir = Config.Get("results-destination-folder");
+                if (!string.IsNullOrEmpty(destinationDir))
+                {
+                    Directory.CreateDirectory(destinationDir);
+                    Log.FilePath = Path.Combine(destinationDir, "log.txt");
+                }
                 Log.LogHandler = Composer.Instance.GetExportedValueByTypeName<ILogHandler>(Config.Get("log-handler", "CompositeLogHandler"));
 
                 Log.Trace($"Engine.Main(): LEAN ALGORITHMIC TRADING ENGINE v{Globals.Version} Mode: {mode} ({(Environment.Is64BitProcess ? "64" : "32")}bit) Host: {Environment.MachineName}");

--- a/ToolBox/Program.cs
+++ b/ToolBox/Program.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -51,7 +51,12 @@ namespace QuantConnect.ToolBox
         public static void Main(string[] args)
         {
             Log.DebuggingEnabled = Config.GetBool("debug-mode");
-            Log.FilePath = Path.Combine(Config.Get("results-destination-folder"), "log.txt");
+            var destinationDir = Config.Get("results-destination-folder");
+            if (!string.IsNullOrEmpty(destinationDir))
+            {
+                Directory.CreateDirectory(destinationDir);
+                Log.FilePath = Path.Combine(destinationDir, "log.txt");
+            }
             Log.LogHandler = Composer.Instance.GetExportedValueByTypeName<ILogHandler>(Config.Get("log-handler", "CompositeLogHandler"));
 
             var optionsObject = ToolboxArgumentParser.ParseArguments(args);


### PR DESCRIPTION
#### Description
Folder may not be existent on a very first launch, additional logic could be added to create it automatically on start

#### Related Issue
NA

#### Motivation and Context
Improvement of a use of results-destination-folder

#### Requires Documentation Change
NA

#### How Has This Been Tested?
Locally

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
