### PR TITLE
Pandas Mapper Recursion Bug Fix

### DIFF
--- a/Common/PandasMapper.py
+++ b/Common/PandasMapper.py
@@ -49,22 +49,10 @@ def mapper(key):
 
 def wrap_keyerror_function(f):
     '''Wraps function f with wrapped_function, used for functions that throw KeyError when not found.
-    wrapped_function calls the original with standard args, if they recieve a KeyError we go ahead and
-    convert the args / kwargs to use alternative index keys and then call the function again. 
-    If this fails we know neither the original or mapped key function exists and throw the error.
-
-    The order is important because some of the shared functions will call this multiple times in a call stack,
-    keep original first to reduce branch off if original args are working or already mapped.
+    wrapped_function converts the args / kwargs to use alternative index keys and then calls the function. 
+    If this fails we fall back to the original key and try it as well, if they both fail we throw our error.
     '''
     def wrapped_function(*args, **kwargs):
-
-        # Execute original
-        # Allows for df, Series, etc indexing for keys like 'SPY' if they exist
-        try:
-            return f(*args, **kwargs)
-        except KeyError as originalError:
-            oError = originalError
-
         # Map args & kwargs and execute function
         try:
             newargs = args
@@ -76,9 +64,16 @@ def wrap_keyerror_function(f):
                 newkwargs = mapper(kwargs)
 
             return f(*newargs, **newkwargs)
-        except KeyError as mappedError:
-            raise KeyError(f"No key found for either mapped or original key. Mapped Error: {mappedError}; Original Error: {oError}")
+        except KeyError as e:
+            mKey = [arg for arg in newargs if isinstance(arg, str)]
 
+        # Execute original
+        # Allows for df, Series, etc indexing for keys like 'SPY' if they exist
+        try:
+            return f(*args, **kwargs)
+        except KeyError as e:
+            oKey = [arg for arg in args if isinstance(arg, str)]
+            raise KeyError(f"No key found for either mapped or original key. Mapped Key: {mKey}; Original Key: {oKey}")
 
     wrapped_function.__name__ = f.__name__
     return wrapped_function

--- a/Common/PandasMapper.py
+++ b/Common/PandasMapper.py
@@ -47,15 +47,25 @@ def mapper(key):
         return { k: mapper(v) for k, v in key.items()}
     return key
 
-def wrap_function(f):
-    '''Wraps function f with g.
-    Function g converts the args / kwargs to use alternative index keys
-      and then calls original function with the mapped args
+def wrap_keyerror_function(f):
+    '''Wraps function f with wrapped_function, used for functions that throw KeyError when not found.
+    wrapped_function calls the original with standard args, if they recieve a KeyError we go ahead and
+    convert the args / kwargs to use alternative index keys and then call the function again. 
+    If this fails we know neither the original or mapped key function exists and throw the error.
+
+    The order is important because some of the shared functions will call this multiple times in a call stack,
+    keep original first to reduce branch off if original args are working or already mapped.
     '''
     def wrapped_function(*args, **kwargs):
 
-        # Map args & kwargs, if wrapped function fails because key, execute with original
+        # Execute original
         # Allows for df, Series, etc indexing for keys like 'SPY' if they exist
+        try:
+            return f(*args, **kwargs)
+        except KeyError as originalError:
+            oError = originalError
+
+        # Map args & kwargs and execute function
         try:
             newargs = args
             newkwargs = kwargs
@@ -65,32 +75,57 @@ def wrap_function(f):
             if len(kwargs) > 0:
                 newkwargs = mapper(kwargs)
 
-            result = f(*newargs, **newkwargs)
-            return result
-        except KeyError:
-            pass
+            return f(*newargs, **newkwargs)
+        except KeyError as mappedError:
+            raise KeyError(f"No key found for either mapped or original key. Mapped Error: {mappedError}; Original Error: {oError}")
 
-        result = f(*args, **kwargs)
-        return result
 
     wrapped_function.__name__ = f.__name__
     return wrapped_function
 
+def wrap_bool_function(f):
+    '''Wraps function f with wrapped_function, used for functions that reply true/false if key is found.
+    wrapped_function attempts with the original args, if its false, it converts the args / kwargs to use
+    alternative index keys and then attempts with the mapped args.
+    '''
+    def wrapped_function(*args, **kwargs):
+
+        # Try the original args; if true just return true
+        originalResult = f(*args, **kwargs)
+        if originalResult:
+            return originalResult
+
+        # Try our mapped args; return this result regardless
+        newargs = args
+        newkwargs = kwargs
+
+        if len(args) > 1:
+            newargs = mapper(args)
+        if len(kwargs) > 0:
+            newkwargs = mapper(kwargs)
+
+        return f(*newargs, **newkwargs)
+
+    wrapped_function.__name__ = f.__name__
+    return wrapped_function
+
+
 # Wrap all core indexing functions that are shared, yet still throw key errors if index not found
-pd.core.indexing._LocationIndexer.__getitem__ = wrap_function(pd.core.indexing._LocationIndexer.__getitem__)
-pd.core.indexing._ScalarAccessIndexer.__getitem__ = wrap_function(pd.core.indexing._ScalarAccessIndexer.__getitem__)
-pd.core.indexes.base.Index.get_loc = wrap_function(pd.core.indexes.base.Index.get_loc)
+pd.core.indexing._LocationIndexer.__getitem__ = wrap_keyerror_function(pd.core.indexing._LocationIndexer.__getitem__)
+pd.core.indexing._ScalarAccessIndexer.__getitem__ = wrap_keyerror_function(pd.core.indexing._ScalarAccessIndexer.__getitem__)
+pd.core.indexes.base.Index.get_loc = wrap_keyerror_function(pd.core.indexes.base.Index.get_loc)
 
 # Wrap our DF _getitem__ as well, even though most pathways go through the above functions
 # There are cases like indexing with an array that need to be mapped earlier to stop KeyError from arising 
-pd.core.frame.DataFrame.__getitem__ = wrap_function(pd.core.frame.DataFrame.__getitem__)
-
-# Wrap __contains__ to support Python syntax like 'SPY' in DataFrame 
-pd.core.indexes.base.Index.__contains__ = wrap_function(pd.core.indexes.base.Index.__contains__)
+pd.core.frame.DataFrame.__getitem__ = wrap_keyerror_function(pd.core.frame.DataFrame.__getitem__)
 
 # For older version of pandas we may need to wrap extra functions
 if (int(pd.__version__.split('.')[0]) < 1):
-    pd.core.indexes.base.Index.get_value = wrap_function(pd.core.indexes.base.Index.get_value)
+    pd.core.indexes.base.Index.get_value = wrap_keyerror_function(pd.core.indexes.base.Index.get_value)
+
+# Special cases where we need to wrap a function that won't throw a keyerror when not found but instead returns true or false
+# Wrap __contains__ to support Python syntax like 'SPY' in DataFrame 
+pd.core.indexes.base.Index.__contains__ = wrap_bool_function(pd.core.indexes.base.Index.__contains__)
 
 # For compatibility with PandasData.cs usage of this module (Previously wrapped classes)
 FrozenList = pdFrozenList

--- a/Tests/Python/PandasIndexingTests.cs
+++ b/Tests/Python/PandasIndexingTests.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Tests.Python
         }
 
         [Test]
-        public void TestIndexingDataFrameWithList()
+        public void IndexingDataFrameWithList()
         {
             using (Py.GIL())
             {
@@ -49,7 +49,7 @@ namespace QuantConnect.Tests.Python
         }
 
         [Test]
-        public void TestContainsUserMappedTickers()
+        public void ContainsUserMappedTickers()
         {
             using (Py.GIL())
             { 
@@ -61,7 +61,7 @@ namespace QuantConnect.Tests.Python
         }
 
         [Test]
-        public void TestExpectedException()
+        public void ExpectedException()
         {
             using (Py.GIL())
             {

--- a/Tests/Python/PandasIndexingTests.cs
+++ b/Tests/Python/PandasIndexingTests.cs
@@ -14,16 +14,19 @@
  *
 */
 
+using System;
 using NUnit.Framework;
 using Python.Runtime;
 
 namespace QuantConnect.Tests.Python
 {
     [TestFixture]
-    class PandasIndexingTests
+    // TODO: Rename to PandasPythonTests, dedicate class to python tests under ./PandasTests directory
+    public class PandasIndexingTests
     {
         private dynamic _module;
         private dynamic _pandasIndexingTests;
+        private dynamic _pandasDataFrameTests;
 
         [SetUp]
         public void Setup()
@@ -32,6 +35,7 @@ namespace QuantConnect.Tests.Python
             {
                 _module = Py.Import("PandasIndexingTests");
                 _pandasIndexingTests = _module.PandasIndexingTests();
+                _pandasDataFrameTests = _module.PandasDataFrameTests();
             }
         }
 
@@ -41,6 +45,30 @@ namespace QuantConnect.Tests.Python
             using (Py.GIL())
             {
                 Assert.DoesNotThrow((() => _pandasIndexingTests.test_indexing_dataframe_with_list()));
+            }
+        }
+
+        [Test]
+        public void TestContainsUserMappedTickers()
+        {
+            using (Py.GIL())
+            { 
+                PyObject result = _pandasDataFrameTests.test_contains_user_mapped_ticker();
+                var test = result.As<bool>();
+
+                Assert.IsTrue(test);
+            }
+        }
+
+        [Test]
+        public void TestExpectedException()
+        {
+            using (Py.GIL())
+            {
+                PyObject result = _pandasDataFrameTests.test_expected_exception();
+                var exception = result.As<string>();
+
+                Assert.IsTrue(exception.Contains("No key found for either mapped or original key. Mapped Key: ['AAPL R735QTJ8XC9X']; Original Key: ['aapl']", StringComparison.InvariantCulture));
             }
         }
     }

--- a/Tests/Python/PandasTests/PandasIndexingTests.py
+++ b/Tests/Python/PandasTests/PandasIndexingTests.py
@@ -11,15 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from clr import AddReference
-AddReference("System")
-AddReference("QuantConnect.Research")
-AddReference("QuantConnect.Tests")
-
-from QuantConnect.Tests import Symbols
-from QuantConnect.Tests.Python import PythonTestingUtils
-
 from AlgorithmImports import *
+from QuantConnect.Tests import *
+from QuantConnect.Tests.Python import *
 
 # TODO: Rename to PandasResearchTests and keep this class for QB related tests; rename py module to PandasTests
 class PandasIndexingTests():
@@ -50,7 +44,6 @@ class PandasDataFrameTests():
 
         # Create our dataframes
         self.spydf = pdConverter.GetDataFrame(PythonTestingUtils.GetSlices(self.spy))
-        self.aapldf = pdConverter.GetDataFrame(PythonTestingUtils.GetSlices(self.aapl))
 
     def test_contains_user_mapped_ticker(self):
         # Create a new DF that has a plain ticker, test that our mapper doesn't break


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Pandas mapper indexing would sometimes recurse infinitely before crashing. After reproducing the issue it became clear that it was caused by wrapping our base `__contains__` method with the same wrapper as our indexers.

Since the __contains__ returns true or false it does not throw a KeyError like the index functions, leading to conditions under which an underlying dataframe could contain values like "SPY" but because its mapped as "SPY ******" before checking it would return false, causing different pathways to be followed, (I.E. `DataFrame.__getitem__`, failing to `key in self.columns`, causing a infinite recurse until crash)

The solution was to make a special wrapper for functions like __contains__ that checks both the original and mapped keys and returns if either are true, or false if both fail.

This is a better way to break up the Pandas mapper when we consider the index functions we wrapped all share the same KeyError behavior and __contains__ does not.

I also tacked on a more informative error for our wrapper_keyerror_function that prints the keys it attempted.

Note: I added a few to-dos to further cleanup our testing framework I created for pandas. I opt-ed for this implementation because it is much simpler to test it directly with a debugger in Python.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Read description

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests passing, added additional unit tests that are red -> green

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
