### PR TITLE
Pandas Mapper Performance Refactor

### DIFF
--- a/Common/PandasMapper.py
+++ b/Common/PandasMapper.py
@@ -64,6 +64,7 @@ def wrap_keyerror_function(f):
         try:
             return f(*args, **kwargs)
         except (KeyError, TypeError) as e:
+            error = e
             oKey = [arg for arg in args if isinstance(arg, str)]
 
         # Map args & kwargs and execute function
@@ -75,6 +76,10 @@ def wrap_keyerror_function(f):
                 newargs = mapper(args)
             if len(kwargs) > 0:
                 newkwargs = mapper(kwargs)
+
+            # Compare our args, if these are the same we know it will throw, so don't waste time executing again
+            if(str(args) == str(newargs) and str(kwargs) == str(newkwargs)):
+                raise error
 
             return f(*newargs, **newkwargs)
         except KeyError as e:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
A minor refactor to reduce extra branching and unnecessary mapping. First always executes the original args before mapping, this helps reduce the cases where we are mapping twice for nothing. Second, if original fails and we do map, check that the args have changed in mapping. If they haven't then there is no reason to execute again, because we already have that error from the original path.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

One thing I noticed in our mapper that could cause slow down and might be worth addressing is that sometimes in a call stack our wrapper may be called twice, this leads to an array of possible paths that aren't very efficient:
- Args are mapped in first call, in second call mapped again, call goes through because mapped key is valid (Not bad, but wasteful to attempt to map twice)
- Args are mapped in first call, in second call they are mapped again, but call doesn't not go through because valid key is original, throwing key error. Taking us back to second call to execute unmapped args, where original args == mapped args (Wastefully executing twice on something we already know is bad and going to fail). Then kicking us back up to first call, where we opt for the truely original args, until we get back down to a new second call that maps it, likely fails, and then goes back to the true original that was passed to it

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
After testing it appears this actually reduces performance on our most practical case of indexing tickers. So we will be closing this PR.

Test Code Cells:
```
Cell 1:
qb = QuantBook()
qb.AddEquity("SPY")
qb.AddEquity("TSLA")
qb.AddEquity("AAPL")
qb.AddEquity("GOOG")
qb.AddEquity("BAC")
qb.AddEquity("CHWY")
qb.AddEquity("BABA")
qb.AddEquity("RKT")
qb.AddForex("EURUSD")
qb.AddCrypto("BTCUSD")

history = qb.History(qb.Securities.Keys, 360, Resolution.Daily)

Cell 2:
%%time
for seq in range(1000):
    for key in qb.Securities.Keys:
        history.loc[key]
        history.loc[key.Value]
        history.loc[str(key.ID)]

Cell 3:
%%time 
customValue = "txt"
history.at[customValue, 'x'] = 10

for seq in range(10000):
    history.loc[customValue]
```


Results:


-- Updated version
```
Notebook Indexing Tickers
user 24.1 s, sys: 126 ms, total: 24.2 s
user 24.2 s, sys: 153 ms, total: 24.3 s
user 24.1 s, sys: 138 ms, total: 24.3 s
user 25.2 s, sys: 123 ms, total: 25.3 s
user 24.6 s, sys: 315 ms, total: 24.9 s
user 24 s, sys: 176 ms, total: 24.2 s
user 24 s, sys: 12.9 ms, total: 24 s

Notebook Indexing Custom
user 4.95 s, sys: 28.4 ms, total: 4.98 s
user 5.04 s, sys: 0 ns, total: 5.04 s
user 5.14 s, sys: 401 µs, total: 5.14 s

HistoryRequestBenchmark Algorithm
41.71 seconds at 47k data points per second
41.66 seconds at 47k data points per second
42.43 seconds at 46k data points per second

```


-- Master version
```
Notebook Indexing Tickers
user 19.5 s, sys: 138 ms, total: 19.6 s
user 19.4 s, sys: 94.8 ms, total: 19.5 s
user 18.5 s, sys: 85.7 ms, total: 18.6 s
user 18.3 s, sys: 0 ns, total: 18.3 s
user 18.5 s, sys: 0 ns, total: 18.5 s

Notebook Indexing Custom
user 5.77 s, sys: 23.1 ms, total: 5.8 s
user 5.87 s, sys: 0 ns, total: 5.87 s
user 5.75 s, sys: 0 ns, total: 5.75 s
user 5.89 s, sys: 0 ns, total: 5.89 s

HistoryRequestBenchmark Algorithm
41.15 seconds at 47k data points per second
42.25 seconds at 46k data points per second
44.33 seconds at 44k data points per second
```




#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
