### PR TITLE
Get Best Effort Price For Fill Price

### DIFF
--- a/Algorithm.CSharp/AddOptionContractExpiresRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddOptionContractExpiresRegressionAlgorithm.cs
@@ -160,7 +160,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "486118a60d78f74811fe8d927c2c6b43"}
+            {"OrderListHash", "b006bb7864c0b2f1a6552fb2aa7f03b8"}
         };
     }
 }

--- a/Algorithm.CSharp/CustomBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomBenchmarkRegressionAlgorithm.cs
@@ -117,7 +117,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "9ce7252112d0ad7be0704297f7d48a88"}
+            {"OrderListHash", "b7b8e83e4456e143c2c4c11fa31a1cf2"}
         };
     }
 }

--- a/Algorithm.CSharp/CustomBuyingPowerModelAlgorithm.cs
+++ b/Algorithm.CSharp/CustomBuyingPowerModelAlgorithm.cs
@@ -138,7 +138,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "3df007afa8125770e8f1a49263af90a2"}
+            {"OrderListHash", "eba70a03119f2e8fe526d1092fbc36d0"}
         };
     }
 }

--- a/Algorithm.CSharp/DelistingEventsAlgorithm.cs
+++ b/Algorithm.CSharp/DelistingEventsAlgorithm.cs
@@ -181,7 +181,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "61f4d3c109fc4b6b9eb14d2e4eec4843"}
+            {"OrderListHash", "e357cfa77fd5e5b974c68d550fa66490"}
         };
     }
 }

--- a/Algorithm.CSharp/HourResolutionMappingEventRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HourResolutionMappingEventRegressionAlgorithm.cs
@@ -127,7 +127,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "8d5c6263fbdfa4b2338fc725e27b93e9"}
+            {"OrderListHash", "4bf8a2d15c6c6ac98e55d7c6ea10f54e"}
         };
     }
 }

--- a/Algorithm.CSharp/HourReverseSplitRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HourReverseSplitRegressionAlgorithm.cs
@@ -105,7 +105,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "4014a968be616942fad8aff7c37104bc"}
+            {"OrderListHash", "d22c476870c3d52698c94a055b90ed6e"}
         };
     }
 }

--- a/Algorithm.CSharp/HourSplitRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HourSplitRegressionAlgorithm.cs
@@ -149,7 +149,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "fb41809f0365b2c06d0ff9d8e40a4775"}
+            {"OrderListHash", "f6ee7a06dc920d5fdabc4bccb84c90df"}
         };
     }
 }

--- a/Algorithm.CSharp/InceptionDateSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/InceptionDateSelectionRegressionAlgorithm.cs
@@ -137,7 +137,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "b2d634cb245e439e68aedc264ad37809"}
+            {"OrderListHash", "818346776a934bcaabb2752b31f8b092"}
         };
     }
 }

--- a/Algorithm.CSharp/MappedBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MappedBenchmarkRegressionAlgorithm.cs
@@ -104,7 +104,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "88a9d602347e5fee24345674d9d25100"}
+            {"OrderListHash", "d5466a4f274a65313a1f58c78d3cfd00"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionEquityStrategyMatcherRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionEquityStrategyMatcherRegressionAlgorithm.cs
@@ -152,7 +152,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "63d0336c6fd05ac54aaec6a4af623f05"}
+            {"OrderListHash", "16316e5491987b323d8c9f0ff87b20ee"}
         };
     }
 }

--- a/Algorithm.CSharp/RegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionAlgorithm.cs
@@ -126,7 +126,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "121beea4033002e611c01dad24956f88"}
+            {"OrderListHash", "b500cbcfb4acc2e3b07a6ee1b7f41d1a"}
         };
     }
 }

--- a/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
@@ -237,7 +237,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "55.0223%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "6ff35299f0d258c459255e76beb4e427"}
+            {"OrderListHash", "18209554e81f4169a66cd32f9c50462b"}
         };
     }
 }

--- a/Algorithm.CSharp/UniverseSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UniverseSelectionRegressionAlgorithm.cs
@@ -213,7 +213,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "698d53191e2d76ec4171026a68f4b73d"}
+            {"OrderListHash", "bbc9f982183f74b34be4529acaa33fe8"}
         };
     }
 }

--- a/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
@@ -235,7 +235,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "8d76366ca3ee70abc907723b4583d56e"}
+            {"OrderListHash", "308c3da05b4bd6f294158736c998ef36"}
         };
     }
 }

--- a/Algorithm.CSharp/WeeklyUniverseSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WeeklyUniverseSelectionRegressionAlgorithm.cs
@@ -139,7 +139,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "8e9ea215681a3faf227b9908a7235884"}
+            {"OrderListHash", "c585658b51441b4600ec32166af3754c"}
         };
     }
 }

--- a/Algorithm.CSharp/ZeroedBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ZeroedBenchmarkRegressionAlgorithm.cs
@@ -114,7 +114,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "184d77b052ceb9b340c3154aea460b34"}
+            {"OrderListHash", "f409be3a7c63d9c1394c2e6c005a15ee"}
         };
 
         internal class TestBrokerageModel : DefaultBrokerageModel


### PR DESCRIPTION
#### Description
`EquityFillModel` will use Trade Tick or TradeBar data if there is no L1 data available leading to filling to stale price.

#### Related Issue
Closes #5850

#### Motivation and Context
Improve fill model.

#### How Has This Been Tested?
New unit tests

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. 
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`