### PR TITLE
BrokerageTransactionHandler - Handle OrderStatus.New in Order Update/Cancel

### DIFF
--- a/Common/Orders/OrderResponse.cs
+++ b/Common/Orders/OrderResponse.cs
@@ -140,7 +140,17 @@ namespace QuantConnect.Orders
         public static OrderResponse InvalidStatus(OrderRequest request, Order order)
         {
             return Error(request, OrderResponseErrorCode.InvalidOrderStatus,
-                Invariant($"Unable to update order with id {request.OrderId} because it already has {order.Status} status")
+                Invariant($"Unable to update order with id {request.OrderId} because it already has {order.Status} status.")
+            );
+        }
+
+        /// <summary>
+        /// Helper method to create an error response due to the "New" order status
+        /// </summary>
+        public static OrderResponse InvalidNewStatus(OrderRequest request, Order order)
+        {
+            return Error(request, OrderResponseErrorCode.InvalidNewOrderStatus,
+                Invariant($"Unable to update or cancel order with id {request.OrderId} and status {order.Status} because the submit confirmation has not been received yet.")
             );
         }
 

--- a/Common/Orders/OrderResponseErrorCode.cs
+++ b/Common/Orders/OrderResponseErrorCode.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -179,5 +179,10 @@ namespace QuantConnect.Orders
         /// The order's quantity exceeds the max shortable quantity set by the brokerage
         /// </summary>
         ExceedsShortableQuantity = -31,
+
+        /// <summary>
+        /// Cannot update/cancel orders with OrderStatus.New
+        /// </summary>
+        InvalidNewOrderStatus = -32
     }
 }


### PR DESCRIPTION

#### Description
- The `BrokerageTransactionHandler` has been updated to reject order updates and cancellations if the order still has a status of `OrderStatus.New` (i.e. the order has just been submitted and the `Submitted` order event has not been received yet)

#### Motivation and Context
- This issue was causing the following error when deploying the test algorithm to IB:
```
Runtime Error: Duplicate order id. Origin: [Id=144] IBPlaceOrder: TSLA (STK TSLA USD Smart NASDAQ  0  )
```

#### How Has This Been Tested?
- Local and cloud testing with the following test algorithm deployed to IB:
``` C#
namespace QuantConnect.Algorithm.CSharp
{
    public class TestDuplicateOrderId : QCAlgorithm
    {
	private bool _done;
		
        public override void Initialize()
        {
            SetBenchmark(t => 0);

            SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage);
            AddEquity("TSLA", Resolution.Second);
        }

        public override void OnData(Slice slice)
        {
            if (IsWarmingUp) return;

            if (!_done)
            {
                LimitOrder("TSLA", 1, 500, "Test");

                var ticket = Transactions.GetOpenOrderTickets(x => x.Tag == "Test").FirstOrDefault();
                if (ticket != null)
                {
                    // Note: Updating an order just submitted in the same time step is not recommended
                    ticket.UpdateLimitPrice(400);

                    _done = true;
                }
            }
        }
    }
}
```

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.