### PR TITLE
IB brokerage - Update option positions at contract expiration

### DIFF
--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -50,6 +50,11 @@ namespace QuantConnect.Brokerages
         public event EventHandler<OrderEvent> OptionPositionAssigned;
 
         /// <summary>
+        /// Event that fires each time an option position has expired
+        /// </summary>
+        public event EventHandler<OptionPositionExpiredEventArgs> OptionPositionExpired;
+
+        /// <summary>
         /// Event that fires each time a user's brokerage account is changed
         /// </summary>
         public event EventHandler<AccountEvent> AccountChanged;
@@ -150,6 +155,24 @@ namespace QuantConnect.Brokerages
                 Log.Debug("Brokerage.OptionPositionAssigned(): " + e);
 
                 OptionPositionAssigned?.Invoke(this, e);
+            }
+            catch (Exception err)
+            {
+                Log.Error(err);
+            }
+        }
+
+        /// <summary>
+        /// Event invocator for the OptionPositionExpired event
+        /// </summary>
+        /// <param name="e">The OrderEvent</param>
+        protected virtual void OnOptionPositionExpired(OptionPositionExpiredEventArgs e)
+        {
+            try
+            {
+                Log.Debug("Brokerage.OnOptionPositionExpired(): " + e);
+
+                OptionPositionExpired?.Invoke(this, e);
             }
             catch (Exception err)
             {

--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -50,9 +50,9 @@ namespace QuantConnect.Brokerages
         public event EventHandler<OrderEvent> OptionPositionAssigned;
 
         /// <summary>
-        /// Event that fires each time an option position has expired
+        /// Event that fires each time an option position has changed
         /// </summary>
-        public event EventHandler<OptionPositionExpiredEventArgs> OptionPositionExpired;
+        public event EventHandler<OptionNotificationEventArgs> OptionNotification;
 
         /// <summary>
         /// Event that fires each time a user's brokerage account is changed
@@ -163,16 +163,16 @@ namespace QuantConnect.Brokerages
         }
 
         /// <summary>
-        /// Event invocator for the OptionPositionExpired event
+        /// Event invocator for the OptionNotification event
         /// </summary>
-        /// <param name="e">The OrderEvent</param>
-        protected virtual void OnOptionPositionExpired(OptionPositionExpiredEventArgs e)
+        /// <param name="e">The OptionNotification event arguments</param>
+        protected virtual void OnOptionNotification(OptionNotificationEventArgs e)
         {
             try
             {
-                Log.Debug("Brokerage.OnOptionPositionExpired(): " + e);
+                Log.Debug("Brokerage.OnOptionNotification(): " + e);
 
-                OptionPositionExpired?.Invoke(this, e);
+                OptionNotification?.Invoke(this, e);
             }
             catch (Exception err)
             {

--- a/Brokerages/InteractiveBrokers/Client/UpdatePortfolioEventArgs.cs
+++ b/Brokerages/InteractiveBrokers/Client/UpdatePortfolioEventArgs.cs
@@ -79,5 +79,14 @@ namespace QuantConnect.Brokerages.InteractiveBrokers.Client
             RealisedPnl = realisedPnl;
             AccountName = accountName;
         }
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            return $"Contract: {Contract}, ConId: {Contract.ConId}, Position: {Position}, MarketPrice: {MarketPrice}, MarketValue: {MarketValue}, AverageCost: {AverageCost}, UnrealisedPnl: {UnrealisedPnl}, RealisedPnl: {RealisedPnl}, AccountName: {AccountName}";
+        }
     }
 }

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1751,16 +1751,12 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
             {
                 Log.Trace($"InteractiveBrokersBrokerage.HandlePortfolioUpdates(): {e}");
 
-                // clear positions for expired option contracts
-                if (e.Contract.SecType is IB.SecurityType.Option or IB.SecurityType.FutureOption &&
-                    e.Position == 0)
+                // notify the transaction handler about all option position updates
+                if (e.Contract.SecType is IB.SecurityType.Option or IB.SecurityType.FutureOption)
                 {
                     var symbol = MapSymbol(e.Contract);
 
-                    if (OptionSymbol.IsOptionContractExpired(symbol, DateTime.UtcNow))
-                    {
-                        OnOptionPositionExpired(new OptionPositionExpiredEventArgs(symbol));
-                    }
+                    OnOptionNotification(new OptionNotificationEventArgs(symbol, e.Position));
                 }
 
                 _accountHoldingsResetEvent.Reset();

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -1757,13 +1757,9 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
                 {
                     var symbol = MapSymbol(e.Contract);
 
-                    if (OptionSymbol.IsOptionContractExpired(symbol, DateTime.UtcNow) &&
-                        _algorithm.Securities.TryGetValue(symbol, out var security))
+                    if (OptionSymbol.IsOptionContractExpired(symbol, DateTime.UtcNow))
                     {
-                        Log.Trace("InteractiveBrokersBrokerage.HandlePortfolioUpdates(): clearing position for expired option holding: " +
-                            $"Symbol: {symbol.Value}, Quantity: {security.Holdings.Quantity}");
-
-                        security.Holdings.SetHoldings(0, 0);
+                        OnOptionPositionExpired(new OptionPositionExpiredEventArgs(symbol));
                     }
                 }
 

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -998,7 +998,8 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
 
             if (order.Type == OrderType.OptionExercise)
             {
-                _client.ClientSocket.exerciseOptions(ibOrderId, contract, 1, decimal.ToInt32(order.Quantity), _account, 0);
+                // IB API requires exerciseQuantity to be positive
+                _client.ClientSocket.exerciseOptions(ibOrderId, contract, 1, decimal.ToInt32(order.AbsoluteQuantity), _account, 0);
             }
             else
             {

--- a/Common/Brokerages/OptionNotificationEventArgs.cs
+++ b/Common/Brokerages/OptionNotificationEventArgs.cs
@@ -19,22 +19,29 @@ using QuantConnect.Interfaces;
 namespace QuantConnect.Brokerages
 {
     /// <summary>
-    /// Event arguments class for the <see cref="IBrokerage.OptionPositionExpired"/> event
+    /// Event arguments class for the <see cref="IBrokerage.OptionNotification"/> event
     /// </summary>
-    public sealed class OptionPositionExpiredEventArgs : EventArgs
+    public sealed class OptionNotificationEventArgs : EventArgs
     {
         /// <summary>
-        /// Gets the expired option symbol
+        /// Gets the option symbol which has received a notification
         /// </summary>
         public Symbol Symbol { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="OptionPositionExpiredEventArgs"/> class
+        /// Gets the new option position (positive for long, zero for flat, negative for short)
+        /// </summary>
+        public decimal Position { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OptionNotificationEventArgs"/> class
         /// </summary>
         /// <param name="symbol">The symbol</param>
-        public OptionPositionExpiredEventArgs(Symbol symbol)
+        /// <param name="position">The new option position</param>
+        public OptionNotificationEventArgs(Symbol symbol, decimal position)
         {
             Symbol = symbol;
+            Position = position;
         }
     }
 }

--- a/Common/Brokerages/OptionPositionExpiredEventArgs.cs
+++ b/Common/Brokerages/OptionPositionExpiredEventArgs.cs
@@ -1,0 +1,40 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Brokerages
+{
+    /// <summary>
+    /// Event arguments class for the <see cref="IBrokerage.OptionPositionExpired"/> event
+    /// </summary>
+    public sealed class OptionPositionExpiredEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the expired option symbol
+        /// </summary>
+        public Symbol Symbol { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OptionPositionExpiredEventArgs"/> class
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        public OptionPositionExpiredEventArgs(Symbol symbol)
+        {
+            Symbol = symbol;
+        }
+    }
+}

--- a/Common/Interfaces/IBrokerage.cs
+++ b/Common/Interfaces/IBrokerage.cs
@@ -39,6 +39,11 @@ namespace QuantConnect.Interfaces
         event EventHandler<OrderEvent> OptionPositionAssigned;
 
         /// <summary>
+        /// Event that fires each time an option position has expired
+        /// </summary>
+        event EventHandler<OptionPositionExpiredEventArgs> OptionPositionExpired;
+
+        /// <summary>
         /// Event that fires each time a user's brokerage account is changed
         /// </summary>
         event EventHandler<AccountEvent> AccountChanged;

--- a/Common/Interfaces/IBrokerage.cs
+++ b/Common/Interfaces/IBrokerage.cs
@@ -39,9 +39,9 @@ namespace QuantConnect.Interfaces
         event EventHandler<OrderEvent> OptionPositionAssigned;
 
         /// <summary>
-        /// Event that fires each time an option position has expired
+        /// Event that fires each time an option position has changed
         /// </summary>
-        event EventHandler<OptionPositionExpiredEventArgs> OptionPositionExpired;
+        event EventHandler<OptionNotificationEventArgs> OptionNotification;
 
         /// <summary>
         /// Event that fires each time a user's brokerage account is changed

--- a/Common/Securities/Option/OptionSymbol.cs
+++ b/Common/Securities/Option/OptionSymbol.cs
@@ -103,9 +103,7 @@ namespace QuantConnect.Securities.Option
         /// <returns>True if the option contract is expired at the specified time, false otherwise</returns>
         public static bool IsOptionContractExpired(Symbol symbol, DateTime currentTimeUtc)
         {
-            if (symbol.SecurityType != SecurityType.Option &&
-                symbol.SecurityType != SecurityType.FutureOption &&
-                symbol.SecurityType != SecurityType.IndexOption)
+            if (!symbol.SecurityType.IsOption())
             {
                 return false;
             }

--- a/Common/Securities/Option/OptionSymbol.cs
+++ b/Common/Securities/Option/OptionSymbol.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -103,7 +103,9 @@ namespace QuantConnect.Securities.Option
         /// <returns>True if the option contract is expired at the specified time, false otherwise</returns>
         public static bool IsOptionContractExpired(Symbol symbol, DateTime currentTimeUtc)
         {
-            if (symbol.SecurityType != SecurityType.Option)
+            if (symbol.SecurityType != SecurityType.Option &&
+                symbol.SecurityType != SecurityType.FutureOption &&
+                symbol.SecurityType != SecurityType.IndexOption)
             {
                 return false;
             }

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1150,7 +1150,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                 var quantity = -security.Holdings.Quantity;
 
                 // generate new order and ticket for the expired option
-                var order = new OptionExerciseOrder(e.Symbol, quantity, DateTime.UtcNow)
+                var order = new OptionExerciseOrder(e.Symbol, quantity, CurrentTimeUtc)
                 {
                     Id = _algorithm.Transactions.GetIncrementOrderId()
                 };
@@ -1163,7 +1163,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
                 // generate the order events reusing the option exercise model
                 var option = (Option)security;
-                var orderEvents = option.OptionExerciseModel.OptionExercise(option, order).ToList();
+                var orderEvents = option.OptionExerciseModel.OptionExercise(option, order);
 
                 foreach (var orderEvent in orderEvents)
                 {

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1159,6 +1159,12 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
                         EmitOptionNotificationEvents(security, exerciseOrder);
                     }
+                    else
+                    {
+                        Log.Error("BrokerageTransactionHandler.HandleOptionNotification(): " +
+                            $"unexpected position ({e.Position} instead of zero) " +
+                            $"for expired option contract: {e.Symbol.Value}");
+                    }
                 }
                 else
                 {

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1199,7 +1199,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
         private OptionExerciseOrder GenerateOptionExerciseOrder(Security security, decimal quantity)
         {
-            // generate new execercise order and ticket for the option
+            // generate new exercise order and ticket for the option
             var order = new OptionExerciseOrder(security.Symbol, quantity, CurrentTimeUtc)
             {
                 Id = _algorithm.Transactions.GetIncrementOrderId()

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -167,9 +167,9 @@
   // Required for IEX history requests
   "iex-cloud-api-key": "",
 
-  // Required for market data from Coin API 
+  // Required for market data from Coin API
   "coinapi-api-key": "",
-  "coinapi-product": "free", // free, startup, streamer, professional, enterprise 
+  "coinapi-product": "free", // free, startup, streamer, professional, enterprise
 
   // Required for streaming Polygon.io data
   // To get your access token go to https://polygon.io

--- a/Tests/Algorithm/AlgorithmLiveTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmLiveTradingTests.cs
@@ -76,7 +76,7 @@ namespace QuantConnect.Tests.Algorithm
 #pragma warning disable 0067 // NullBrokerage doesn't use any of these so we will just ignore them
             public event EventHandler<OrderEvent> OrderStatusChanged;
             public event EventHandler<OrderEvent> OptionPositionAssigned;
-            public event EventHandler<OptionPositionExpiredEventArgs> OptionPositionExpired;
+            public event EventHandler<OptionNotificationEventArgs> OptionNotification;
             public event EventHandler<AccountEvent> AccountChanged;
             public event EventHandler<BrokerageMessageEvent> Message;
 #pragma warning restore 0067

--- a/Tests/Algorithm/AlgorithmLiveTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmLiveTradingTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -76,6 +76,7 @@ namespace QuantConnect.Tests.Algorithm
 #pragma warning disable 0067 // NullBrokerage doesn't use any of these so we will just ignore them
             public event EventHandler<OrderEvent> OrderStatusChanged;
             public event EventHandler<OrderEvent> OptionPositionAssigned;
+            public event EventHandler<OptionPositionExpiredEventArgs> OptionPositionExpired;
             public event EventHandler<AccountEvent> AccountChanged;
             public event EventHandler<BrokerageMessageEvent> Message;
 #pragma warning restore 0067

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -1285,10 +1285,10 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
             algorithm.Transactions.SetOrderProcessor(transactionHandler);
 
-            var method = transactionHandler.GetType().GetMethod("HandleOptionPositionExpired", BindingFlags.NonPublic | BindingFlags.Instance);
+            var method = transactionHandler.GetType().GetMethod("HandleOptionNotification", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.IsNotNull(method);
 
-            var parameters = new object[] { new OptionPositionExpiredEventArgs(optionSymbol) };
+            var parameters = new object[] { new OptionNotificationEventArgs(optionSymbol, 0) };
             method.Invoke(transactionHandler, parameters);
 
             transactionHandler.Exit();


### PR DESCRIPTION

#### Description
- Fixes an issue where at option expiration LEAN positions were not set to zero.

#### Motivation and Context
- Option positions remaining non-zero after expiration.

#### How Has This Been Tested?
> Pending live testing at next weekly option expiration on Friday

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.