### PR TITLE
Update IBGateway install path

### DIFF
--- a/DockerfileLeanFoundation
+++ b/DockerfileLeanFoundation
@@ -27,10 +27,11 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
    && apt-fast clean && apt-get remove -y apt-fast && apt-get clean && apt-get autoclean && apt-get autoremove --purge -y \
    && rm -rf /var/lib/apt/lists/*
 
-# Install IB Gateway: Installs to /usr/local/ibgateway
-RUN wget https://cdn.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64.v985.1j.sh && \
+# Install IB Gateway: Installs to /root/ibgateway
+RUN mkdir -p /root/ibgateway && \
+    wget https://cdn.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64.v985.1j.sh && \
     chmod 777 ibgateway-latest-standalone-linux-x64.v985.1j.sh && \
-    ./ibgateway-latest-standalone-linux-x64.v985.1j.sh -q && \
+    ./ibgateway-latest-standalone-linux-x64.v985.1j.sh -q -dir /root/ibgateway && \
     rm ibgateway-latest-standalone-linux-x64.v985.1j.sh
 
 # Install dotnet 5 sdk & runtime

--- a/DockerfileLeanFoundationARM
+++ b/DockerfileLeanFoundationARM
@@ -23,14 +23,15 @@ RUN apt-get update && apt-fast install -y git libgtk2.0.0 cmake bzip2 curl unzip
     && apt-fast clean && apt-get remove -y apt-fast && apt-get clean && apt-get autoclean && apt-get autoremove --purge -y \
     && rm -rf /var/lib/apt/lists/*
 
-# Install IB Gateway: Installs to /usr/local/ibgateway
+# Install IB Gateway: Installs to /root/ibgateway
 # We update the install script so it doesn't use the bundled JVM
 # The bundled JVM doesn't work on ARM64, so we update it to use the JVM installed in the previous command
-RUN wget https://cdn.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64.v985.1j.sh && \
+RUN mkdir -p /root/ibgateway && \
+    wget https://cdn.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64.v985.1j.sh && \
     java_patch_version=$(java -version 2>&1 | head -n 1 | cut -d'_' -f2 | cut -d'"' -f1) && \
     bbe -e 's|# INSTALL4J_JAVA_HOME_OVERRIDE=|INSTALL4J_JAVA_HOME_OVERRIDE="/usr/lib/jvm/java-1.8.0-openjdk-arm64"|' -e "s|-lt \"152\"|-lt \"$java_patch_version\"|" -e "s|-gt \"152\"|-gt \"$java_patch_version\"|" ibgateway-latest-standalone-linux-x64.v985.1j.sh > ibgateway-stable-standalone-linux-custom-jvm.sh && \
     chmod 777 ibgateway-stable-standalone-linux-custom-jvm.sh && \
-    ./ibgateway-stable-standalone-linux-custom-jvm.sh -q && \
+    ./ibgateway-stable-standalone-linux-custom-jvm.sh -q -dir /root/ibgateway && \
     rm ibgateway-latest-standalone-linux-x64.v985.1j.sh ibgateway-stable-standalone-linux-custom-jvm.sh
 
 # Install dotnet 5 sdk & runtime


### PR DESCRIPTION

#### Description
- The installation path of IBGateway in the LeanFoundation docker files has been updated

#### Motivation and Context
- Local Lean users are unable to deploy to Interactive Brokers because of IBAutomater timeout

#### How Has This Been Tested?
- Local testing in Windows and Linux/Docker

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.