### PR TITLE
Add ValueAreaVolumePercentage Parameter

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -1033,14 +1033,15 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">The symbol whose VP we want</param>
         /// <param name="period">The period of the VP</param>
+        /// <param name="valueAreaVolumePercentage">The percentage of volume contained in the value area</param>
         /// <param name="priceRangeRoundOff">How many digits you want to round and the precision. i.e 0.01 round to two digits exactly.</param>
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Volume Profile indicator for the given parameters</returns>
-        public VolumeProfile VP(Symbol symbol, int period = 2, decimal priceRangeRoundOff = 0.05m, Resolution resolution = Resolution.Daily, Func<IBaseData, TradeBar> selector = null)
+        public VolumeProfile VP(Symbol symbol, int period = 2, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m, Resolution resolution = Resolution.Daily, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, $"VP({period})", resolution);
-            var marketProfile = new VolumeProfile(name, period, priceRangeRoundOff);
+            var marketProfile = new VolumeProfile(name, period, valueAreaVolumePercentage, priceRangeRoundOff);
             RegisterIndicator(symbol, marketProfile, resolution, selector);
 
             if (EnableAutomaticIndicatorWarmUp)

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -1058,14 +1058,15 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">The symbol whose TP we want</param>
         /// <param name="period">The period of the TP</param>
+        /// <param name="valueAreaVolumePercentage">The percentage of volume contained in the value area</param>
         /// <param name="priceRangeRoundOff">How many digits you want to round and the precision. i.e 0.01 round to two digits exactly.</param>
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
         /// <returns>The Time Profile indicator for the given parameters</returns>
-        public TimeProfile TP(Symbol symbol, int period = 2, decimal priceRangeRoundOff = 0.05m, Resolution resolution = Resolution.Daily, Func<IBaseData, TradeBar> selector = null)
+        public TimeProfile TP(Symbol symbol, int period = 2, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m, Resolution resolution = Resolution.Daily, Func<IBaseData, TradeBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, $"TP({period})", resolution);
-            var marketProfile = new TimeProfile(name, period, priceRangeRoundOff);
+            var marketProfile = new TimeProfile(name, period, valueAreaVolumePercentage, priceRangeRoundOff);
             RegisterIndicator(symbol, marketProfile, resolution, selector);
 
             if (EnableAutomaticIndicatorWarmUp)

--- a/Indicators/MarketProfile.cs
+++ b/Indicators/MarketProfile.cs
@@ -44,6 +44,11 @@ namespace QuantConnect.Indicators
         private readonly int _period;
 
         /// <summary>
+        /// Percentage of total volume contained in the ValueArea
+        /// </summary>
+        private readonly decimal _valueAreaVolumePercentage;
+
+        /// <summary>
         /// The range of roundoff to the prices. i.e two decimal places, three decimal places
         /// </summary>
         private readonly decimal _priceRangeRoundOff;
@@ -134,9 +139,10 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="name">The name of this indicator</param>
         /// <param name="period">The period of this indicator</param>
+        /// <param name="valueAreaVolumePercentage">The percentage of volume contained in the value area</param>
         /// <param name="priceRangeRoundOff">How many digits you want to round and the precision.
         /// i.e 0.01 round to two digits exactly. 0.05 by default.</param>
-        protected MarketProfile(string name, int period, decimal priceRangeRoundOff = 0.05m)
+        protected MarketProfile(string name, int period, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m)
             : base(name)
         {
             // Check roundoff is positive
@@ -145,6 +151,7 @@ namespace QuantConnect.Indicators
                 throw new ArgumentException("Must be strictly bigger than zero.", nameof(priceRangeRoundOff));
             }
 
+            _valueAreaVolumePercentage = valueAreaVolumePercentage;
             _oldDataPoints = new RollingWindow<Tuple<decimal, decimal>>(period);
             _volumePerPrice = new SortedList<decimal, decimal>();
             _totalVolume = new Sum(name + "_Sum", period);
@@ -256,7 +263,7 @@ namespace QuantConnect.Indicators
         private void CalculateValueArea()
         {
             // First ValueArea estimation
-            ValueAreaVolume = _totalVolume.Current.Value * 0.70m;
+            ValueAreaVolume = _totalVolume.Current.Value * _valueAreaVolumePercentage;
 
             var currentVolume = POCVolume;
 

--- a/Indicators/TimeProfile.cs
+++ b/Indicators/TimeProfile.cs
@@ -36,10 +36,11 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="name">The name of this indicator</param>
         /// <param name="period">The period of this indicator</param>
+        /// <param name="valueAreaVolumePercentage">The percentage of volume contained in the value area</param>
         /// <param name="priceRangeRoundOff">How many digits you want to round and the precision.
         /// i.e 0.01 round to two digits exactly.</param>
-        public TimeProfile(string name, int period, decimal priceRangeRoundOff = 0.05m)
-            : base(name, period, priceRangeRoundOff)
+        public TimeProfile(string name, int period, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m)
+            : base(name, period, valueAreaVolumePercentage, priceRangeRoundOff)
         { }
 
         /// <summary>

--- a/Indicators/VolumeProfile.cs
+++ b/Indicators/VolumeProfile.cs
@@ -36,10 +36,11 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="name">The name of this indicator</param>
         /// <param name="period">The period of this indicator</param>
+        /// <param name="valueAreaVolumePercentage">The percentage of volume contained in the value area</param>
         /// <param name="priceRangeRoundOff">How many digits you want to round and the precision.
         /// i.e 0.01 round to two digits exactly.</param>
-        public VolumeProfile(string name, int period, decimal priceRangeRoundOff = 0.05m)
-            : base(name, period, priceRangeRoundOff)
+        public VolumeProfile(string name, int period, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m)
+            : base(name, period, valueAreaVolumePercentage, priceRangeRoundOff)
         { }
 
         /// <summary>


### PR DESCRIPTION
Remove hard coding of parameter and set it to optional parameter for the user. The parameter determines the amount of total volume contained in the ValueArea (hardcoded as 0.70m currently but changed to parameter `valueAreaVolumePercentage`). 

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This change will remove a hard coded parameter found in the MarketProfile indicator and allow it to be used as an optional parameter in the MarketProfile and VolumeProfile indicators.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Attached issue: https://github.com/QuantConnect/Lean/issues/5907

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removal of hard coded parameter for more in-depth testing capabilities.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Additional parameter added to the documentation.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
