### PR TITLE
Fix IB restarts during weekends

### DIFF
--- a/Brokerages/QuantConnect.Brokerages.csproj
+++ b/Brokerages/QuantConnect.Brokerages.csproj
@@ -38,7 +38,7 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
-    <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.57" />
+    <PackageReference Include="QuantConnect.IBAutomater" Version="2.0.60" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION

#### Description
- Moved weekend wait logic for IB restarts from [IBAutomater](https://github.com/QuantConnect/IBAutomater) to `InteractiveBrokersBrokerage`
- Updated IBAutomater to `v2.0.60`

#### Related Issue
- #5900
- #5920
- https://github.com/QuantConnect/IBAutomater/pull/59

#### Motivation and Context
- Occasional IB algorithm termination at the start of the weekend reset period (~11 PM ET)

#### Requires Documentation Change

#### How Has This Been Tested?

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.