### PR TITLE
Composite Indicator Fixes

### DIFF
--- a/Algorithm.CSharp/BasicTemplateIntrinioEconomicData.cs
+++ b/Algorithm.CSharp/BasicTemplateIntrinioEconomicData.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Algorithm.CSharp
         private readonly Identity _brent = new Identity("Brent");
         private readonly Identity _wti = new Identity("WTI");
 
-        private CompositeIndicator<IndicatorDataPoint> _spread;
+        private CompositeIndicator _spread;
 
         private ExponentialMovingAverage _emaWti;
 

--- a/Common/Indicators/IIndicator.cs
+++ b/Common/Indicators/IIndicator.cs
@@ -23,7 +23,7 @@ namespace QuantConnect.Indicators
     /// Represents an indicator that can receive data updates and emit events when the value of
     /// the indicator has changed.
     /// </summary>
-    public interface IIndicator<T> : IComparable<IIndicator<T>>, IComparable, IIndicator
+    public interface IIndicator<T> : IComparable<IIndicator<T>>, IIndicator
         where T : IBaseData
     {
     }
@@ -32,7 +32,7 @@ namespace QuantConnect.Indicators
     /// Represents an indicator that can receive data updates and emit events when the value of
     /// the indicator has changed.
     /// </summary>
-    public interface IIndicator
+    public interface IIndicator : IComparable
     {
         /// <summary>
         /// Event handler that fires after this indicator is updated

--- a/Indicators/CompositeIndicator.cs
+++ b/Indicators/CompositeIndicator.cs
@@ -24,8 +24,7 @@ namespace QuantConnect.Indicators
     /// such that the output of each will be sent to a user specified function.
     /// </summary>
     /// <remarks>
-    /// This implementation maintains backward compatibility for single type composite indicators.
-    /// After discovering minor differences in the types of the left and right indicators we realized we need to have a two type solution
+    /// This implementation maintains backward compatibility for generic type composite indicators.
     /// </remarks>
     /// <typeparam name="T">The type of data input into this indicator</typeparam>
     public class CompositeIndicator<T> : CompositeIndicator
@@ -39,7 +38,7 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator for the 'composer'</param>
         /// <param name="right">The right indidcator for the 'composoer'</param>
         /// <param name="composer">Function used to compose the left and right indicators</param>
-        public CompositeIndicator(string name, IndicatorBase<T> left, IndicatorBase<T> right, CompositeIndicator.IndicatorComposer composer)
+        public CompositeIndicator(string name, IndicatorBase left, IndicatorBase right, CompositeIndicator.IndicatorComposer composer)
             : base(name, left, right, composer)
         {
         }
@@ -51,7 +50,7 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator for the 'composer'</param>
         /// <param name="right">The right indidcator for the 'composoer'</param>
         /// <param name="composer">Function used to compose the left and right indicators</param>
-        public CompositeIndicator(IndicatorBase<T> left, IndicatorBase<T> right, CompositeIndicator.IndicatorComposer composer)
+        public CompositeIndicator(IndicatorBase left, IndicatorBase right, CompositeIndicator.IndicatorComposer composer)
             : this($"COMPOSE({left.Name},{right.Name})", left, right, composer)
         { }
     }
@@ -65,8 +64,6 @@ namespace QuantConnect.Indicators
     /// will have its values automatically updated each time a new piece of data is received from both
     /// the left and right indicators.
     /// </remarks>
-    /// <typeparam name="T">The type of data input into this indicator on the left side</typeparam>
-    /// <typeparam name="K">The type of data input into this indicator on the right side</typeparam>
     public class CompositeIndicator : IndicatorBase<IndicatorDataPoint>
     {
         /// <summary>

--- a/Indicators/CompositeIndicator.cs
+++ b/Indicators/CompositeIndicator.cs
@@ -14,47 +14,9 @@
 */
 
 using System;
-using QuantConnect.Data;
 
 namespace QuantConnect.Indicators
 {
-
-    /// <summary>
-    /// This indicator is capable of wiring up two separate indicators into a single indicator
-    /// such that the output of each will be sent to a user specified function.
-    /// </summary>
-    /// <remarks>
-    /// This implementation maintains backward compatibility for generic type composite indicators.
-    /// </remarks>
-    /// <typeparam name="T">The type of data input into this indicator</typeparam>
-    public class CompositeIndicator<T> : CompositeIndicator
-        where T : IBaseData
-    {
-        /// <summary>
-        /// Creates a new CompositeIndicator capable of taking the output from the left and right indicators
-        /// and producing a new value via the composer delegate specified
-        /// </summary>
-        /// <param name="name">The name of this indicator</param>
-        /// <param name="left">The left indicator for the 'composer'</param>
-        /// <param name="right">The right indidcator for the 'composoer'</param>
-        /// <param name="composer">Function used to compose the left and right indicators</param>
-        public CompositeIndicator(string name, IndicatorBase left, IndicatorBase right, CompositeIndicator.IndicatorComposer composer)
-            : base(name, left, right, composer)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new CompositeIndicator capable of taking the output from the left and right indicators
-        /// and producing a new value via the composer delegate specified
-        /// </summary>
-        /// <param name="left">The left indicator for the 'composer'</param>
-        /// <param name="right">The right indidcator for the 'composoer'</param>
-        /// <param name="composer">Function used to compose the left and right indicators</param>
-        public CompositeIndicator(IndicatorBase left, IndicatorBase right, CompositeIndicator.IndicatorComposer composer)
-            : this($"COMPOSE({left.Name},{right.Name})", left, right, composer)
-        { }
-    }
-
     /// <summary>
     /// This indicator is capable of wiring up two separate indicators into a single indicator
     /// such that the output of each will be sent to a user specified function.

--- a/Indicators/CompositeIndicator.cs
+++ b/Indicators/CompositeIndicator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -76,11 +76,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         public static implicit operator CompositeIndicator<T>(CompositeIndicator<T,K> indicator)
         {
-            var converted = (CompositeIndicator<T>)indicator;
-            if (converted == null){
-                throw new ArgumentException(" Cannot convert");
-            }
-
+            var converted = indicator as CompositeIndicator<T>;
             return converted;
         }
 

--- a/Indicators/CompositeIndicator.cs
+++ b/Indicators/CompositeIndicator.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Indicators
     /// After discovering minor differences in the types of the left and right indicators we realized we need to have a two type solution
     /// </remarks>
     /// <typeparam name="T">The type of data input into this indicator</typeparam>
-    public class CompositeIndicator<T> : CompositeIndicator<T,T>
+    public class CompositeIndicator<T> : CompositeIndicator
         where T : IBaseData
     {
         /// <summary>
@@ -39,7 +39,7 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator for the 'composer'</param>
         /// <param name="right">The right indidcator for the 'composoer'</param>
         /// <param name="composer">Function used to compose the left and right indicators</param>
-        public CompositeIndicator(string name, IndicatorBase<T> left, IndicatorBase<T> right, IndicatorComposer composer)
+        public CompositeIndicator(string name, IndicatorBase<T> left, IndicatorBase<T> right, CompositeIndicator.IndicatorComposer composer)
             : base(name, left, right, composer)
         {
         }
@@ -51,7 +51,7 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator for the 'composer'</param>
         /// <param name="right">The right indidcator for the 'composoer'</param>
         /// <param name="composer">Function used to compose the left and right indicators</param>
-        public CompositeIndicator(IndicatorBase<T> left, IndicatorBase<T> right, IndicatorComposer composer)
+        public CompositeIndicator(IndicatorBase<T> left, IndicatorBase<T> right, CompositeIndicator.IndicatorComposer composer)
             : this($"COMPOSE({left.Name},{right.Name})", left, right, composer)
         { }
     }
@@ -67,19 +67,8 @@ namespace QuantConnect.Indicators
     /// </remarks>
     /// <typeparam name="T">The type of data input into this indicator on the left side</typeparam>
     /// <typeparam name="K">The type of data input into this indicator on the right side</typeparam>
-    public class CompositeIndicator<T, K> : IndicatorBase<IndicatorDataPoint>
-        where T : IBaseData
-        where K : IBaseData
+    public class CompositeIndicator : IndicatorBase<IndicatorDataPoint>
     {
-        /// <summary>
-        /// Implicitly convert this T,K converter to a T composite indicator. Works safely when T,K are the same
-        /// </summary>
-        public static implicit operator CompositeIndicator<T>(CompositeIndicator<T,K> indicator)
-        {
-            var converted = indicator as CompositeIndicator<T>;
-            return converted;
-        }
-
         /// <summary>
         /// Delegate type used to compose the output of two indicators into a new value.
         /// </summary>
@@ -90,7 +79,7 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="right">The right indicator</param>
         /// <returns>And indicator result representing the composition of the two indicators</returns>
-        public delegate IndicatorResult IndicatorComposer(IndicatorBase<T> left, IndicatorBase<K> right);
+        public delegate IndicatorResult IndicatorComposer(IndicatorBase left, IndicatorBase right);
 
         /// <summary>function used to compose the individual indicators</summary>
         private readonly IndicatorComposer _composer;
@@ -98,12 +87,12 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Gets the 'left' indicator for the delegate
         /// </summary>
-        public IndicatorBase<T> Left { get; private set; }
+        public IndicatorBase Left { get; private set; }
 
         /// <summary>
         /// Gets the 'right' indicator for the delegate
         /// </summary>
-        public IndicatorBase<K> Right { get; private set; }
+        public IndicatorBase Right { get; private set; }
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
@@ -130,7 +119,7 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator for the 'composer'</param>
         /// <param name="right">The right indidcator for the 'composoer'</param>
         /// <param name="composer">Function used to compose the left and right indicators</param>
-        public CompositeIndicator(string name, IndicatorBase<T> left, IndicatorBase<K> right, IndicatorComposer composer)
+        public CompositeIndicator(string name, IndicatorBase left, IndicatorBase right, IndicatorComposer composer)
             : base(name)
         {
             _composer = composer;
@@ -146,7 +135,7 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator for the 'composer'</param>
         /// <param name="right">The right indidcator for the 'composoer'</param>
         /// <param name="composer">Function used to compose the left and right indicators</param>
-        public CompositeIndicator(IndicatorBase<T> left, IndicatorBase<K> right, IndicatorComposer composer)
+        public CompositeIndicator(IndicatorBase left, IndicatorBase right, IndicatorComposer composer)
             : this($"COMPOSE({left.Name},{right.Name})", left, right, composer)
         { }
 
@@ -169,7 +158,7 @@ namespace QuantConnect.Indicators
         /// </remarks>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(IndicatorDataPoint input)
+        protected override decimal ComputeNextValue(IndicatorDataPoint _)
         {
             // this should never actually be invoked
             return _composer.Invoke(Left, Right).Value;

--- a/Indicators/ConstantIndicator.cs
+++ b/Indicators/ConstantIndicator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *

--- a/Indicators/IndicatorBase.Operators.cs
+++ b/Indicators/IndicatorBase.Operators.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  * 
@@ -16,22 +16,22 @@
 namespace QuantConnect.Indicators
 {
 
-    public abstract partial class IndicatorBase<T>
+    public abstract partial class IndicatorBase
     {
         /// <summary>
         /// Returns the current value of this instance
         /// </summary>
         /// <param name="instance">The indicator instance</param>
         /// <returns>The current value of the indicator</returns>
-        public static implicit operator decimal(IndicatorBase<T> instance)
+        public static implicit operator decimal(IndicatorBase instance)
         {
-            return instance.Current;
+            return instance.Current.Value;
         }
 
         /// <summary>
         /// Determines if the indicator's current value is greater than the specified value
         /// </summary>
-        public static bool operator >(IndicatorBase<T> left, double right)
+        public static bool operator >(IndicatorBase left, double right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value > (decimal)right;
@@ -40,7 +40,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is less than the specified value
         /// </summary>
-        public static bool operator <(IndicatorBase<T> left, double right)
+        public static bool operator <(IndicatorBase left, double right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value < (decimal)right;
@@ -49,7 +49,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is greater than the indicator's current value
         /// </summary>
-        public static bool operator >(double left, IndicatorBase<T> right)
+        public static bool operator >(double left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return (decimal)left > right.Current.Value;
@@ -58,7 +58,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is less than the indicator's current value
         /// </summary>
-        public static bool operator <(double left, IndicatorBase<T> right)
+        public static bool operator <(double left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return (decimal)left < right.Current.Value;
@@ -67,7 +67,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is greater than or equal to the specified value
         /// </summary>
-        public static bool operator >=(IndicatorBase<T> left, double right)
+        public static bool operator >=(IndicatorBase left, double right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value >= (decimal)right;
@@ -76,7 +76,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is less than or equal to the specified value
         /// </summary>
-        public static bool operator <=(IndicatorBase<T> left, double right)
+        public static bool operator <=(IndicatorBase left, double right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value <= (decimal)right;
@@ -85,7 +85,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is greater than or equal to the indicator's current value
         /// </summary>
-        public static bool operator >=(double left, IndicatorBase<T> right)
+        public static bool operator >=(double left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return (decimal)left >= right.Current.Value;
@@ -94,7 +94,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is less than or equal to the indicator's current value
         /// </summary>
-        public static bool operator <=(double left, IndicatorBase<T> right)
+        public static bool operator <=(double left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return (decimal)left <= right.Current.Value;
@@ -103,7 +103,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is equal to the specified value
         /// </summary>
-        public static bool operator ==(IndicatorBase<T> left, double right)
+        public static bool operator ==(IndicatorBase left, double right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value == (decimal)right;
@@ -112,7 +112,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is not equal to the specified value
         /// </summary>
-        public static bool operator !=(IndicatorBase<T> left, double right)
+        public static bool operator !=(IndicatorBase left, double right)
         {
             if (ReferenceEquals(left, null)) return true;
             return left.Current.Value != (decimal)right;
@@ -121,7 +121,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is equal to the indicator's current value
         /// </summary>
-        public static bool operator ==(double left, IndicatorBase<T> right)
+        public static bool operator ==(double left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return (decimal)left == right.Current.Value;
@@ -130,7 +130,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is not equal to the indicator's current value
         /// </summary>
-        public static bool operator !=(double left, IndicatorBase<T> right)
+        public static bool operator !=(double left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return true;
             return (decimal)left != right.Current.Value;
@@ -139,7 +139,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is greater than the specified value
         /// </summary>
-        public static bool operator >(IndicatorBase<T> left, float right)
+        public static bool operator >(IndicatorBase left, float right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value > (decimal)right;
@@ -148,7 +148,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is less than the specified value
         /// </summary>
-        public static bool operator <(IndicatorBase<T> left, float right)
+        public static bool operator <(IndicatorBase left, float right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value < (decimal)right;
@@ -157,7 +157,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is greater than the indicator's current value
         /// </summary>
-        public static bool operator >(float left, IndicatorBase<T> right)
+        public static bool operator >(float left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return (decimal)left > right.Current.Value;
@@ -166,7 +166,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is less than the indicator's current value
         /// </summary>
-        public static bool operator <(float left, IndicatorBase<T> right)
+        public static bool operator <(float left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return (decimal)left < right.Current.Value;
@@ -175,7 +175,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is greater than or equal to the specified value
         /// </summary>
-        public static bool operator >=(IndicatorBase<T> left, float right)
+        public static bool operator >=(IndicatorBase left, float right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value >= (decimal)right;
@@ -184,7 +184,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is less than or equal to the specified value
         /// </summary>
-        public static bool operator <=(IndicatorBase<T> left, float right)
+        public static bool operator <=(IndicatorBase left, float right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value <= (decimal)right;
@@ -193,7 +193,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is greater than or equal to the indicator's current value
         /// </summary>
-        public static bool operator >=(float left, IndicatorBase<T> right)
+        public static bool operator >=(float left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return (decimal)left >= right.Current.Value;
@@ -202,7 +202,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is less than or equal to the indicator's current value
         /// </summary>
-        public static bool operator <=(float left, IndicatorBase<T> right)
+        public static bool operator <=(float left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return (decimal)left <= right.Current.Value;
@@ -211,7 +211,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is equal to the specified value
         /// </summary>
-        public static bool operator ==(IndicatorBase<T> left, float right)
+        public static bool operator ==(IndicatorBase left, float right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value == (decimal)right;
@@ -220,7 +220,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is not equal to the specified value
         /// </summary>
-        public static bool operator !=(IndicatorBase<T> left, float right)
+        public static bool operator !=(IndicatorBase left, float right)
         {
             if (ReferenceEquals(left, null)) return true;
             return left.Current.Value != (decimal)right;
@@ -229,7 +229,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is equal to the indicator's current value
         /// </summary>
-        public static bool operator ==(float left, IndicatorBase<T> right)
+        public static bool operator ==(float left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return (decimal)left == right.Current.Value;
@@ -238,7 +238,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is not equal to the indicator's current value
         /// </summary>
-        public static bool operator !=(float left, IndicatorBase<T> right)
+        public static bool operator !=(float left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return true;
             return (decimal)left != right.Current.Value;
@@ -246,7 +246,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is greater than the specified value
         /// </summary>
-        public static bool operator >(IndicatorBase<T> left, int right)
+        public static bool operator >(IndicatorBase left, int right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value > right;
@@ -255,7 +255,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is less than the specified value
         /// </summary>
-        public static bool operator <(IndicatorBase<T> left, int right)
+        public static bool operator <(IndicatorBase left, int right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value < right;
@@ -264,7 +264,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is greater than the indicator's current value
         /// </summary>
-        public static bool operator >(int left, IndicatorBase<T> right)
+        public static bool operator >(int left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return left > right.Current.Value;
@@ -273,7 +273,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is less than the indicator's current value
         /// </summary>
-        public static bool operator <(int left, IndicatorBase<T> right)
+        public static bool operator <(int left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return left < right.Current.Value;
@@ -282,7 +282,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is greater than or equal to the specified value
         /// </summary>
-        public static bool operator >=(IndicatorBase<T> left, int right)
+        public static bool operator >=(IndicatorBase left, int right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value >= right;
@@ -291,7 +291,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is less than or equal to the specified value
         /// </summary>
-        public static bool operator <=(IndicatorBase<T> left, int right)
+        public static bool operator <=(IndicatorBase left, int right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value <= right;
@@ -300,7 +300,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is greater than or equal to the indicator's current value
         /// </summary>
-        public static bool operator >=(int left, IndicatorBase<T> right)
+        public static bool operator >=(int left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return left >= right.Current.Value;
@@ -309,7 +309,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is less than or equal to the indicator's current value
         /// </summary>
-        public static bool operator <=(int left, IndicatorBase<T> right)
+        public static bool operator <=(int left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return left <= right.Current.Value;
@@ -318,7 +318,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is equal to the specified value
         /// </summary>
-        public static bool operator ==(IndicatorBase<T> left, int right)
+        public static bool operator ==(IndicatorBase left, int right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value == right;
@@ -327,7 +327,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is not equal to the specified value
         /// </summary>
-        public static bool operator !=(IndicatorBase<T> left, int right)
+        public static bool operator !=(IndicatorBase left, int right)
         {
             if (ReferenceEquals(left, null)) return true;
             return left.Current.Value != right;
@@ -336,7 +336,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is equal to the indicator's current value
         /// </summary>
-        public static bool operator ==(int left, IndicatorBase<T> right)
+        public static bool operator ==(int left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return left == right.Current.Value;
@@ -345,7 +345,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is not equal to the indicator's current value
         /// </summary>
-        public static bool operator !=(int left, IndicatorBase<T> right)
+        public static bool operator !=(int left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return true;
             return left != right.Current.Value;
@@ -353,7 +353,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is greater than the specified value
         /// </summary>
-        public static bool operator >(IndicatorBase<T> left, long right)
+        public static bool operator >(IndicatorBase left, long right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value > right;
@@ -362,7 +362,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is less than the specified value
         /// </summary>
-        public static bool operator <(IndicatorBase<T> left, long right)
+        public static bool operator <(IndicatorBase left, long right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value < right;
@@ -371,7 +371,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is greater than the indicator's current value
         /// </summary>
-        public static bool operator >(long left, IndicatorBase<T> right)
+        public static bool operator >(long left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return left > right.Current.Value;
@@ -380,7 +380,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is less than the indicator's current value
         /// </summary>
-        public static bool operator <(long left, IndicatorBase<T> right)
+        public static bool operator <(long left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return left < right.Current.Value;
@@ -389,7 +389,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is greater than or equal to the specified value
         /// </summary>
-        public static bool operator >=(IndicatorBase<T> left, long right)
+        public static bool operator >=(IndicatorBase left, long right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value >= right;
@@ -398,7 +398,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is less than or equal to the specified value
         /// </summary>
-        public static bool operator <=(IndicatorBase<T> left, long right)
+        public static bool operator <=(IndicatorBase left, long right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value <= right;
@@ -407,7 +407,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is greater than or equal to the indicator's current value
         /// </summary>
-        public static bool operator >=(long left, IndicatorBase<T> right)
+        public static bool operator >=(long left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return left >= right.Current.Value;
@@ -416,7 +416,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is less than or equal to the indicator's current value
         /// </summary>
-        public static bool operator <=(long left, IndicatorBase<T> right)
+        public static bool operator <=(long left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return left <= right.Current.Value;
@@ -425,7 +425,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is equal to the specified value
         /// </summary>
-        public static bool operator ==(IndicatorBase<T> left, long right)
+        public static bool operator ==(IndicatorBase left, long right)
         {
             if (ReferenceEquals(left, null)) return false;
             return left.Current.Value == right;
@@ -434,7 +434,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the indicator's current value is not equal to the specified value
         /// </summary>
-        public static bool operator !=(IndicatorBase<T> left, long right)
+        public static bool operator !=(IndicatorBase left, long right)
         {
             if (ReferenceEquals(left, null)) return true;
             return left.Current.Value != right;
@@ -443,7 +443,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is equal to the indicator's current value
         /// </summary>
-        public static bool operator ==(long left, IndicatorBase<T> right)
+        public static bool operator ==(long left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return false;
             return left == right.Current.Value;
@@ -452,7 +452,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Determines if the specified value is not equal to the indicator's current value
         /// </summary>
-        public static bool operator !=(long left, IndicatorBase<T> right)
+        public static bool operator !=(long left, IndicatorBase right)
         {
             if (ReferenceEquals(right, null)) return true;
             return left != right.Current.Value;

--- a/Indicators/IndicatorBase.Operators.cs
+++ b/Indicators/IndicatorBase.Operators.cs
@@ -15,7 +15,6 @@
 
 namespace QuantConnect.Indicators
 {
-
     public abstract partial class IndicatorBase
     {
         /// <summary>

--- a/Indicators/IndicatorBase.cs
+++ b/Indicators/IndicatorBase.cs
@@ -52,6 +52,9 @@ namespace QuantConnect.Indicators
         /// </summary>
         public event IndicatorUpdatedHandler Updated;
 
+        /// <summary>
+        /// Resets this indicator to its initial state
+        /// </summary>
         public abstract void Reset();
 
         /// <summary>

--- a/Indicators/IndicatorBase.cs
+++ b/Indicators/IndicatorBase.cs
@@ -108,59 +108,6 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
-        /// Determines whether the specified object is equal to the current object.
-        /// </summary>
-        /// <returns>
-        /// true if the specified object  is equal to the current object; otherwise, false.
-        /// </returns>
-        /// <param name="obj">The object to compare with the current object. </param>
-        public override bool Equals(object obj)
-        {
-            // this implementation acts as a liason to prevent inconsistency between the operators
-            // == and != against primitive types. the core impl for equals between two indicators
-            // is still reference equality, however, when comparing value types (floats/int, ect..)
-            // we'll use value type semantics on Current.Value
-            // because of this, we shouldn't need to override GetHashCode as well since we're still
-            // solely relying on reference semantics (think hashset/dictionary impls)
-
-            if (ReferenceEquals(obj, null)) return false;
-            var type = obj.GetType();
-
-            while (type != null && type != typeof(object))
-            {
-
-                // TODO: Not sure about this
-                var cur = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
-                if (typeof(IndicatorBase<>) == cur)
-                {
-                    return ReferenceEquals(this, obj);
-                }
-                type = type.BaseType;
-            }
-
-            try
-            {
-                // the obj is not an indicator, so let's check for value types, try converting to decimal
-                var converted = obj.ConvertInvariant<decimal>();
-                return Current.Value == converted;
-            }
-            catch (InvalidCastException)
-            {
-                // conversion failed, return false
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Get Hash Code for this Object
-        /// </summary>
-        /// <returns>Integer Hash Code</returns>
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
-
-        /// <summary>
         /// Compares the current object with another object of the same type.
         /// </summary>
         /// <returns>
@@ -313,6 +260,57 @@ namespace QuantConnect.Indicators
         {
             // default implementation always returns IndicatorStatus.Success
             return new IndicatorResult(ComputeNextValue(input));
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <returns>
+        /// true if the specified object  is equal to the current object; otherwise, false.
+        /// </returns>
+        /// <param name="obj">The object to compare with the current object. </param>
+        public override bool Equals(object obj)
+        {
+            // this implementation acts as a liason to prevent inconsistency between the operators
+            // == and != against primitive types. the core impl for equals between two indicators
+            // is still reference equality, however, when comparing value types (floats/int, ect..)
+            // we'll use value type semantics on Current.Value
+            // because of this, we shouldn't need to override GetHashCode as well since we're still
+            // solely relying on reference semantics (think hashset/dictionary impls)
+
+            if (ReferenceEquals(obj, null)) return false;
+            var type = obj.GetType();
+
+            while (type != null && type != typeof(object))
+            {
+                var cur = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
+                if (typeof(IndicatorBase<>) == cur)
+                {
+                    return ReferenceEquals(this, obj);
+                }
+                type = type.BaseType;
+            }
+
+            try
+            {
+                // the obj is not an indicator, so let's check for value types, try converting to decimal
+                var converted = obj.ConvertInvariant<decimal>();
+                return Current.Value == converted;
+            }
+            catch (InvalidCastException)
+            {
+                // conversion failed, return false
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Get Hash Code for this Object
+        /// </summary>
+        /// <returns>Integer Hash Code</returns>
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
         }
     }
 }

--- a/Indicators/IndicatorBase.cs
+++ b/Indicators/IndicatorBase.cs
@@ -21,7 +21,10 @@ using QuantConnect.Logging;
 
 namespace QuantConnect.Indicators
 {
-    public abstract class IndicatorBase
+    /// <summary>
+    /// Abstract Indicator base, meant to contain non-generic fields of indicator base to support non-typed inputs
+    /// </summary>
+    public abstract partial class IndicatorBase : IIndicator
     {
         /// <summary>
         /// Gets the current state of this indicator. If the state has not been updated
@@ -33,6 +36,11 @@ namespace QuantConnect.Indicators
         /// Gets a name for this indicator
         /// </summary>
         public string Name { get; protected set; }
+
+        /// <summary>
+        /// Gets the number of samples processed by this indicator
+        /// </summary>
+        public long Samples { get; internal set; }
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
@@ -47,6 +55,24 @@ namespace QuantConnect.Indicators
         public abstract void Reset();
 
         /// <summary>
+        /// Initializes a new instance of the Indicator class.
+        /// </summary>
+        protected IndicatorBase()
+        {
+            Current = new IndicatorDataPoint(DateTime.MinValue, 0m);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Indicator class using the specified name.
+        /// </summary>
+        /// <param name="name">The name of this indicator</param>
+        protected IndicatorBase(string name)
+        {
+            Name = name;
+            Current = new IndicatorDataPoint(DateTime.MinValue, 0m);
+        }
+
+        /// <summary>
         /// Event invocator for the Updated event
         /// </summary>
         /// <param name="consolidated">This is the new piece of data produced by this indicator</param>
@@ -55,7 +81,121 @@ namespace QuantConnect.Indicators
             Updated?.Invoke(this, consolidated);
         }
 
-        // TODO: other non generic methods?
+        /// <summary>
+        /// Updates the state of this indicator with the given value and returns true
+        /// if this indicator is ready, false otherwise
+        /// </summary>
+        /// <param name="input">The value to use to update this indicator</param>
+        /// <returns>True if this indicator is ready, false otherwise</returns>
+        public abstract bool Update(IBaseData input);
+
+        /// <summary>
+        /// ToString Overload for Indicator Base
+        /// </summary>
+        /// <returns>String representation of the indicator</returns>
+        public override string ToString()
+        {
+            return Current.Value.ToStringInvariant("#######0.0####");
+        }
+
+        /// <summary>
+        /// Provides a more detailed string of this indicator in the form of {Name} - {Value}
+        /// </summary>
+        /// <returns>A detailed string of this indicator's current state</returns>
+        public string ToDetailedString()
+        {
+            return $"{Name} - {this}";
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <returns>
+        /// true if the specified object  is equal to the current object; otherwise, false.
+        /// </returns>
+        /// <param name="obj">The object to compare with the current object. </param>
+        public override bool Equals(object obj)
+        {
+            // this implementation acts as a liason to prevent inconsistency between the operators
+            // == and != against primitive types. the core impl for equals between two indicators
+            // is still reference equality, however, when comparing value types (floats/int, ect..)
+            // we'll use value type semantics on Current.Value
+            // because of this, we shouldn't need to override GetHashCode as well since we're still
+            // solely relying on reference semantics (think hashset/dictionary impls)
+
+            if (ReferenceEquals(obj, null)) return false;
+            var type = obj.GetType();
+
+            while (type != null && type != typeof(object))
+            {
+
+                // TODO: Not sure about this
+                var cur = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
+                if (typeof(IndicatorBase<>) == cur)
+                {
+                    return ReferenceEquals(this, obj);
+                }
+                type = type.BaseType;
+            }
+
+            try
+            {
+                // the obj is not an indicator, so let's check for value types, try converting to decimal
+                var converted = obj.ConvertInvariant<decimal>();
+                return Current.Value == converted;
+            }
+            catch (InvalidCastException)
+            {
+                // conversion failed, return false
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Get Hash Code for this Object
+        /// </summary>
+        /// <returns>Integer Hash Code</returns>
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        /// <summary>
+        /// Compares the current object with another object of the same type.
+        /// </summary>
+        /// <returns>
+        /// A value that indicates the relative order of the objects being compared. The return value has the following meanings: Value Meaning Less than zero This object is less than the <paramref name="other"/> parameter.Zero This object is equal to <paramref name="other"/>. Greater than zero This object is greater than <paramref name="other"/>.
+        /// </returns>
+        /// <param name="other">An object to compare with this object.</param>
+        public int CompareTo(IIndicator other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                // everything is greater than null via MSDN
+                return 1;
+            }
+
+            return Current.CompareTo(other.Current);
+        }
+
+        /// <summary>
+        /// Compares the current instance with another object of the same type and returns an integer that indicates whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object.
+        /// </summary>
+        /// <returns>
+        /// A value that indicates the relative order of the objects being compared. The return value has these meanings: Value Meaning Less than zero This instance precedes <paramref name="obj"/> in the sort order. Zero This instance occurs in the same position in the sort order as <paramref name="obj"/>. Greater than zero This instance follows <paramref name="obj"/> in the sort order.
+        /// </returns>
+        /// <param name="obj">An object to compare with this instance. </param><exception cref="T:System.ArgumentException"><paramref name="obj"/> is not the same type as this instance. </exception><filterpriority>2</filterpriority>
+        public int CompareTo(object obj)
+        {
+            var other = obj as IndicatorBase;
+            if (other == null)
+            {
+                throw new ArgumentException("Object must be of type " + GetType().GetBetterTypeName());
+            }
+
+            return CompareTo(other);
+        }
+
     }
 
     /// <summary>
@@ -63,9 +203,10 @@ namespace QuantConnect.Indicators
     /// </summary>
     /// <typeparam name="T">The type of data input into this indicator</typeparam>
     [DebuggerDisplay("{ToDetailedString()}")]
-    public abstract partial class IndicatorBase<T> : IndicatorBase, IIndicator<T>
+    public abstract class IndicatorBase<T> : IndicatorBase
         where T : IBaseData
     {
+
         /// <summary>the most recent input that was given to this indicator</summary>
         private Dictionary<SecurityIdentifier, T> _previousInput = new Dictionary<SecurityIdentifier, T>();
 
@@ -78,10 +219,6 @@ namespace QuantConnect.Indicators
             Name = name;
             Current = new IndicatorDataPoint(DateTime.MinValue, 0m);
         }
-        /// <summary>
-        /// Gets the number of samples processed by this indicator
-        /// </summary>
-        public long Samples { get; private set; }
 
         /// <summary>
         /// Updates the state of this indicator with the given value and returns true
@@ -89,7 +226,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The value to use to update this indicator</param>
         /// <returns>True if this indicator is ready, false otherwise</returns>
-        public bool Update(IBaseData input)
+        public override bool Update(IBaseData input)
         {
             T _previousSymbolInput = default(T);
             if (_previousInput.TryGetValue(input.Symbol.ID, out _previousSymbolInput) && input.EndTime < _previousSymbolInput.EndTime)
@@ -157,111 +294,6 @@ namespace QuantConnect.Indicators
             Samples = 0;
             _previousInput.Clear();
             Current = new IndicatorDataPoint(DateTime.MinValue, default(decimal));
-        }
-
-        /// <summary>
-        /// Compares the current object with another object of the same type.
-        /// </summary>
-        /// <returns>
-        /// A value that indicates the relative order of the objects being compared. The return value has the following meanings: Value Meaning Less than zero This object is less than the <paramref name="other"/> parameter.Zero This object is equal to <paramref name="other"/>. Greater than zero This object is greater than <paramref name="other"/>.
-        /// </returns>
-        /// <param name="other">An object to compare with this object.</param>
-        public int CompareTo(IIndicator<T> other)
-        {
-            if (ReferenceEquals(other, null))
-            {
-                // everything is greater than null via MSDN
-                return 1;
-            }
-
-            return Current.CompareTo(other.Current);
-        }
-
-        /// <summary>
-        /// Compares the current instance with another object of the same type and returns an integer that indicates whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object.
-        /// </summary>
-        /// <returns>
-        /// A value that indicates the relative order of the objects being compared. The return value has these meanings: Value Meaning Less than zero This instance precedes <paramref name="obj"/> in the sort order. Zero This instance occurs in the same position in the sort order as <paramref name="obj"/>. Greater than zero This instance follows <paramref name="obj"/> in the sort order.
-        /// </returns>
-        /// <param name="obj">An object to compare with this instance. </param><exception cref="T:System.ArgumentException"><paramref name="obj"/> is not the same type as this instance. </exception><filterpriority>2</filterpriority>
-        public int CompareTo(object obj)
-        {
-            var other = obj as IndicatorBase<T>;
-            if (other == null)
-            {
-                throw new ArgumentException("Object must be of type " + GetType().GetBetterTypeName());
-            }
-
-            return CompareTo(other);
-        }
-
-        /// <summary>
-        /// Determines whether the specified object is equal to the current object.
-        /// </summary>
-        /// <returns>
-        /// true if the specified object  is equal to the current object; otherwise, false.
-        /// </returns>
-        /// <param name="obj">The object to compare with the current object. </param>
-        public override bool Equals(object obj)
-        {
-            // this implementation acts as a liason to prevent inconsistency between the operators
-            // == and != against primitive types. the core impl for equals between two indicators
-            // is still reference equality, however, when comparing value types (floats/int, ect..)
-            // we'll use value type semantics on Current.Value
-            // because of this, we shouldn't need to override GetHashCode as well since we're still
-            // solely relying on reference semantics (think hashset/dictionary impls)
-
-            if (ReferenceEquals(obj, null)) return false;
-            var type = obj.GetType();
-
-            while (type != null && type != typeof(object))
-            {
-                var cur = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
-                if (typeof(IndicatorBase<>) == cur)
-                {
-                    return ReferenceEquals(this, obj);
-                }
-                type = type.BaseType;
-            }
-
-            try
-            {
-                // the obj is not an indicator, so let's check for value types, try converting to decimal
-                var converted = obj.ConvertInvariant<decimal>();
-                return Current.Value == converted;
-            }
-            catch (InvalidCastException)
-            {
-                // conversion failed, return false
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Get Hash Code for this Object
-        /// </summary>
-        /// <returns>Integer Hash Code</returns>
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
-
-        /// <summary>
-        /// ToString Overload for Indicator Base
-        /// </summary>
-        /// <returns>String representation of the indicator</returns>
-        public override string ToString()
-        {
-            return Current.Value.ToStringInvariant("#######0.0####");
-        }
-
-        /// <summary>
-        /// Provides a more detailed string of this indicator in the form of {Name} - {Value}
-        /// </summary>
-        /// <returns>A detailed string of this indicator's current state</returns>
-        public string ToDetailedString()
-        {
-            return $"{Name} - {this}";
         }
 
         /// <summary>

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -70,7 +70,7 @@ namespace QuantConnect.Indicators
         /// <param name="weight">Indicator that provides the average weights</param>
         /// <param name="period">Average period</param>
         /// <returns>Indicator that results of the average of first by weights given by second</returns>
-        public static CompositeIndicator<IndicatorDataPoint, IndicatorDataPoint> WeightedBy<T, TWeight>(this IndicatorBase<T> value, TWeight weight, int period)
+        public static CompositeIndicator WeightedBy<T, TWeight>(this IndicatorBase<T> value, TWeight weight, int period)
             where T : IBaseData
             where TWeight : IndicatorBase<IndicatorDataPoint>
         {
@@ -110,10 +110,9 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="constant">The addend</param>
         /// <returns>The sum of the left and right indicators</returns>
-        public static CompositeIndicator<T, T> Plus<T>(this IndicatorBase<T> left, decimal constant)
-            where T : IBaseData
+        public static CompositeIndicator Plus(this IndicatorBase left, decimal constant)
         {
-            var constantIndicator = new ConstantIndicator<T>(constant.ToString(CultureInfo.InvariantCulture), constant);
+            var constantIndicator = new ConstantIndicator<IBaseData>(constant.ToString(CultureInfo.InvariantCulture), constant);
             return left.Plus(constantIndicator);
         }
 
@@ -126,11 +125,9 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="right">The right indicator</param>
         /// <returns>The sum of the left and right indicators</returns>
-        public static CompositeIndicator<T, K> Plus<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right)
-            where T : IBaseData
-            where K : IBaseData
+        public static CompositeIndicator Plus(this IndicatorBase left, IndicatorBase right)
         {
-            return new CompositeIndicator<T, K>(left, right, (l, r) => l.Current.Value + r.Current.Value);
+            return new (left, right, (l, r) => l.Current.Value + r.Current.Value);
         }
 
         /// <summary>
@@ -143,11 +140,9 @@ namespace QuantConnect.Indicators
         /// <param name="right">The right indicator</param>
         /// <param name="name">The name of this indicator</param>
         /// <returns>The sum of the left and right indicators</returns>
-        public static CompositeIndicator<T, K> Plus<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right, string name)
-            where T : IBaseData
-            where K : IBaseData
+        public static CompositeIndicator Plus(this IndicatorBase left, IndicatorBase right, string name)
         {
-            return new CompositeIndicator<T, K>(name, left, right, (l, r) => l.Current.Value + r.Current.Value);
+            return new (name, left, right, (l, r) => l.Current.Value + r.Current.Value);
         }
 
         /// <summary>
@@ -159,10 +154,9 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="constant">The subtrahend</param>
         /// <returns>The difference of the left and right indicators</returns>
-        public static CompositeIndicator<T, T> Minus<T>(this IndicatorBase<T> left, decimal constant)
-            where T : IBaseData
+        public static CompositeIndicator Minus(this IndicatorBase left, decimal constant)
         {
-            var constantIndicator = new ConstantIndicator<T>(constant.ToString(CultureInfo.InvariantCulture), constant);
+            var constantIndicator = new ConstantIndicator<IBaseData>(constant.ToString(CultureInfo.InvariantCulture), constant);
             return left.Minus(constantIndicator);
         }
 
@@ -175,11 +169,9 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="right">The right indicator</param>
         /// <returns>The difference of the left and right indicators</returns>
-        public static CompositeIndicator<T, K> Minus<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right)
-            where T : IBaseData
-            where K : IBaseData
+        public static CompositeIndicator Minus(this IndicatorBase left, IndicatorBase right)
         {
-            return new CompositeIndicator<T, K>(left, right, (l, r) => l.Current.Value - r.Current.Value);
+            return new (left, right, (l, r) => l.Current.Value - r.Current.Value);
         }
 
         /// <summary>
@@ -192,11 +184,9 @@ namespace QuantConnect.Indicators
         /// <param name="right">The right indicator</param>
         /// <param name="name">The name of this indicator</param>
         /// <returns>The difference of the left and right indicators</returns>
-        public static CompositeIndicator<T, K> Minus<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right, string name)
-            where T : IBaseData
-            where K : IBaseData
+        public static CompositeIndicator Minus(this IndicatorBase left, IndicatorBase right, string name)
         {
-            return new CompositeIndicator<T, K>(name, left, right, (l, r) => l.Current.Value - r.Current.Value);
+            return new (name, left, right, (l, r) => l.Current.Value - r.Current.Value);
         }
 
         /// <summary>
@@ -208,10 +198,9 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="constant">The constant value denominator</param>
         /// <returns>The ratio of the left to the right indicator</returns>
-        public static CompositeIndicator<T, T> Over<T>(this IndicatorBase<T> left, decimal constant)
-            where T : IBaseData
+        public static CompositeIndicator Over(this IndicatorBase left, decimal constant)
         {
-            var constantIndicator = new ConstantIndicator<T>(constant.ToString(CultureInfo.InvariantCulture), constant);
+            var constantIndicator = new ConstantIndicator<IndicatorDataPoint>(constant.ToString(CultureInfo.InvariantCulture), constant);
             return left.Over(constantIndicator);
         }
 
@@ -224,11 +213,9 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="right">The right indicator</param>
         /// <returns>The ratio of the left to the right indicator</returns>
-        public static CompositeIndicator<T, K> Over<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right)
-            where T : IBaseData
-            where K : IBaseData
+        public static CompositeIndicator Over(this IndicatorBase left, IndicatorBase right)
         {
-            return new CompositeIndicator<T, K>(left, right, (l, r) => r.Current.Value == 0m ? new IndicatorResult(0m, IndicatorStatus.MathError) : new IndicatorResult(l.Current.Value / r.Current.Value));
+            return new (left, right, (l, r) => r.Current.Value == 0m ? new IndicatorResult(0m, IndicatorStatus.MathError) : new IndicatorResult(l.Current.Value / r.Current.Value));
         }
 
         /// <summary>
@@ -241,11 +228,9 @@ namespace QuantConnect.Indicators
         /// <param name="right">The right indicator</param>
         /// <param name="name">The name of this indicator</param>
         /// <returns>The ratio of the left to the right indicator</returns>
-        public static CompositeIndicator<T, K> Over<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right, string name)
-            where T : IBaseData
-            where K : IBaseData
+        public static CompositeIndicator Over(this IndicatorBase left, IndicatorBase right, string name)
         {
-            return new CompositeIndicator<T, K>(name, left, right, (l, r) => r.Current.Value == 0m ? new IndicatorResult(0m, IndicatorStatus.MathError) : new IndicatorResult(l.Current.Value / r.Current.Value));
+            return new (name, left, right, (l, r) => r.Current.Value == 0m ? new IndicatorResult(0m, IndicatorStatus.MathError) : new IndicatorResult(l.Current.Value / r.Current.Value));
         }
 
         /// <summary>
@@ -257,10 +242,9 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="constant">The constant value to multiple by</param>
         /// <returns>The product of the left to the right indicators</returns>
-        public static CompositeIndicator<T, T> Times<T>(this IndicatorBase<T> left, decimal constant)
-            where T : IBaseData
+        public static CompositeIndicator Times(this IndicatorBase left, decimal constant)
         {
-            var constantIndicator = new ConstantIndicator<T>(constant.ToString(CultureInfo.InvariantCulture), constant);
+            var constantIndicator = new ConstantIndicator<IndicatorDataPoint>(constant.ToString(CultureInfo.InvariantCulture), constant);
             return left.Times(constantIndicator);
         }
 
@@ -273,11 +257,9 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="right">The right indicator</param>
         /// <returns>The product of the left to the right indicators</returns>
-        public static CompositeIndicator<T, K> Times<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right)
-            where T : IBaseData
-            where K : IBaseData
+        public static CompositeIndicator Times(this IndicatorBase left, IndicatorBase right)
         {
-            return new CompositeIndicator<T, K>(left, right, (l, r) => l.Current.Value * r.Current.Value);
+            return new (left, right, (l, r) => l.Current.Value * r.Current.Value);
         }
 
         /// <summary>
@@ -290,11 +272,9 @@ namespace QuantConnect.Indicators
         /// <param name="right">The right indicator</param>
         /// <param name="name">The name of this indicator</param>
         /// <returns>The product of the left to the right indicators</returns>
-        public static CompositeIndicator<T, K> Times<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right, string name)
-            where T : IBaseData
-            where K : IBaseData
+        public static CompositeIndicator Times(this IndicatorBase left, IndicatorBase right, string name)
         {
-            return new CompositeIndicator<T, K>(name, left, right, (l, r) => l.Current.Value * r.Current.Value);
+            return new (name, left, right, (l, r) => l.Current.Value * r.Current.Value);
         }
 
         /// <summary>Creates a new ExponentialMovingAverage indicator with the specified period and smoothingFactor from the left indicator
@@ -373,7 +353,7 @@ namespace QuantConnect.Indicators
         /// <param name="period">Average period</param>
         /// <returns>Indicator that results of the average of first by weights given by second</returns>
         // ReSharper disable once UnusedMember.Global
-        public static CompositeIndicator<IndicatorDataPoint, IndicatorDataPoint> WeightedBy(PyObject value, PyObject weight, int period)
+        public static CompositeIndicator WeightedBy(PyObject value, PyObject weight, int period)
         {
             dynamic indicator1 = value.SafeAsManagedObject();
             dynamic indicator2 = weight.SafeAsManagedObject();

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Indicators
         /// <param name="weight">Indicator that provides the average weights</param>
         /// <param name="period">Average period</param>
         /// <returns>Indicator that results of the average of first by weights given by second</returns>
-        public static CompositeIndicator<IndicatorDataPoint> WeightedBy<T, TWeight>(this IndicatorBase<T> value, TWeight weight, int period)
+        public static CompositeIndicator<IndicatorDataPoint, IndicatorDataPoint> WeightedBy<T, TWeight>(this IndicatorBase<T> value, TWeight weight, int period)
             where T : IBaseData
             where TWeight : IndicatorBase<IndicatorDataPoint>
         {
@@ -110,7 +110,7 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="constant">The addend</param>
         /// <returns>The sum of the left and right indicators</returns>
-        public static CompositeIndicator<T> Plus<T>(this IndicatorBase<T> left, decimal constant)
+        public static CompositeIndicator<T, T> Plus<T>(this IndicatorBase<T> left, decimal constant)
             where T : IBaseData
         {
             var constantIndicator = new ConstantIndicator<T>(constant.ToString(CultureInfo.InvariantCulture), constant);
@@ -126,10 +126,11 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="right">The right indicator</param>
         /// <returns>The sum of the left and right indicators</returns>
-        public static CompositeIndicator<T> Plus<T>(this IndicatorBase<T> left, IndicatorBase<T> right)
+        public static CompositeIndicator<T, K> Plus<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right)
             where T : IBaseData
+            where K : IBaseData
         {
-            return new CompositeIndicator<T>(left, right, (l, r) => l.Current.Value + r.Current.Value);
+            return new CompositeIndicator<T, K>(left, right, (l, r) => l.Current.Value + r.Current.Value);
         }
 
         /// <summary>
@@ -142,10 +143,11 @@ namespace QuantConnect.Indicators
         /// <param name="right">The right indicator</param>
         /// <param name="name">The name of this indicator</param>
         /// <returns>The sum of the left and right indicators</returns>
-        public static CompositeIndicator<T> Plus<T>(this IndicatorBase<T> left, IndicatorBase<T> right, string name)
+        public static CompositeIndicator<T, K> Plus<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right, string name)
             where T : IBaseData
+            where K : IBaseData
         {
-            return new CompositeIndicator<T>(name, left, right, (l, r) => l.Current.Value + r.Current.Value);
+            return new CompositeIndicator<T, K>(name, left, right, (l, r) => l.Current.Value + r.Current.Value);
         }
 
         /// <summary>
@@ -157,7 +159,7 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="constant">The subtrahend</param>
         /// <returns>The difference of the left and right indicators</returns>
-        public static CompositeIndicator<T> Minus<T>(this IndicatorBase<T> left, decimal constant)
+        public static CompositeIndicator<T, T> Minus<T>(this IndicatorBase<T> left, decimal constant)
             where T : IBaseData
         {
             var constantIndicator = new ConstantIndicator<T>(constant.ToString(CultureInfo.InvariantCulture), constant);
@@ -173,10 +175,11 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="right">The right indicator</param>
         /// <returns>The difference of the left and right indicators</returns>
-        public static CompositeIndicator<T> Minus<T>(this IndicatorBase<T> left, IndicatorBase<T> right)
+        public static CompositeIndicator<T, K> Minus<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right)
             where T : IBaseData
+            where K : IBaseData
         {
-            return new CompositeIndicator<T>(left, right, (l, r) => l.Current.Value - r.Current.Value);
+            return new CompositeIndicator<T, K>(left, right, (l, r) => l.Current.Value - r.Current.Value);
         }
 
         /// <summary>
@@ -189,10 +192,11 @@ namespace QuantConnect.Indicators
         /// <param name="right">The right indicator</param>
         /// <param name="name">The name of this indicator</param>
         /// <returns>The difference of the left and right indicators</returns>
-        public static CompositeIndicator<T> Minus<T>(this IndicatorBase<T> left, IndicatorBase<T> right, string name)
+        public static CompositeIndicator<T, K> Minus<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right, string name)
             where T : IBaseData
+            where K : IBaseData
         {
-            return new CompositeIndicator<T>(name, left, right, (l, r) => l.Current.Value - r.Current.Value);
+            return new CompositeIndicator<T, K>(name, left, right, (l, r) => l.Current.Value - r.Current.Value);
         }
 
         /// <summary>
@@ -204,7 +208,7 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="constant">The constant value denominator</param>
         /// <returns>The ratio of the left to the right indicator</returns>
-        public static CompositeIndicator<T> Over<T>(this IndicatorBase<T> left, decimal constant)
+        public static CompositeIndicator<T, T> Over<T>(this IndicatorBase<T> left, decimal constant)
             where T : IBaseData
         {
             var constantIndicator = new ConstantIndicator<T>(constant.ToString(CultureInfo.InvariantCulture), constant);
@@ -220,10 +224,11 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="right">The right indicator</param>
         /// <returns>The ratio of the left to the right indicator</returns>
-        public static CompositeIndicator<T> Over<T>(this IndicatorBase<T> left, IndicatorBase<T> right)
+        public static CompositeIndicator<T, K> Over<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right)
             where T : IBaseData
+            where K : IBaseData
         {
-            return new CompositeIndicator<T>(left, right, (l, r) => r.Current.Value == 0m ? new IndicatorResult(0m, IndicatorStatus.MathError) : new IndicatorResult(l.Current.Value / r.Current.Value));
+            return new CompositeIndicator<T, K>(left, right, (l, r) => r.Current.Value == 0m ? new IndicatorResult(0m, IndicatorStatus.MathError) : new IndicatorResult(l.Current.Value / r.Current.Value));
         }
 
         /// <summary>
@@ -236,10 +241,11 @@ namespace QuantConnect.Indicators
         /// <param name="right">The right indicator</param>
         /// <param name="name">The name of this indicator</param>
         /// <returns>The ratio of the left to the right indicator</returns>
-        public static CompositeIndicator<T> Over<T>(this IndicatorBase<T> left, IndicatorBase<T> right, string name)
+        public static CompositeIndicator<T, K> Over<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right, string name)
             where T : IBaseData
+            where K : IBaseData
         {
-            return new CompositeIndicator<T>(name, left, right, (l, r) => r.Current.Value == 0m ? new IndicatorResult(0m, IndicatorStatus.MathError) : new IndicatorResult(l.Current.Value / r.Current.Value));
+            return new CompositeIndicator<T, K>(name, left, right, (l, r) => r.Current.Value == 0m ? new IndicatorResult(0m, IndicatorStatus.MathError) : new IndicatorResult(l.Current.Value / r.Current.Value));
         }
 
         /// <summary>
@@ -251,7 +257,7 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="constant">The constant value to multiple by</param>
         /// <returns>The product of the left to the right indicators</returns>
-        public static CompositeIndicator<T> Times<T>(this IndicatorBase<T> left, decimal constant)
+        public static CompositeIndicator<T, T> Times<T>(this IndicatorBase<T> left, decimal constant)
             where T : IBaseData
         {
             var constantIndicator = new ConstantIndicator<T>(constant.ToString(CultureInfo.InvariantCulture), constant);
@@ -267,10 +273,11 @@ namespace QuantConnect.Indicators
         /// <param name="left">The left indicator</param>
         /// <param name="right">The right indicator</param>
         /// <returns>The product of the left to the right indicators</returns>
-        public static CompositeIndicator<T> Times<T>(this IndicatorBase<T> left, IndicatorBase<T> right)
+        public static CompositeIndicator<T, K> Times<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right)
             where T : IBaseData
+            where K : IBaseData
         {
-            return new CompositeIndicator<T>(left, right, (l, r) => l.Current.Value * r.Current.Value);
+            return new CompositeIndicator<T, K>(left, right, (l, r) => l.Current.Value * r.Current.Value);
         }
 
         /// <summary>
@@ -283,10 +290,11 @@ namespace QuantConnect.Indicators
         /// <param name="right">The right indicator</param>
         /// <param name="name">The name of this indicator</param>
         /// <returns>The product of the left to the right indicators</returns>
-        public static CompositeIndicator<T> Times<T>(this IndicatorBase<T> left, IndicatorBase<T> right, string name)
+        public static CompositeIndicator<T, K> Times<T, K>(this IndicatorBase<T> left, IndicatorBase<K> right, string name)
             where T : IBaseData
+            where K : IBaseData
         {
-            return new CompositeIndicator<T>(name, left, right, (l, r) => l.Current.Value * r.Current.Value);
+            return new CompositeIndicator<T, K>(name, left, right, (l, r) => l.Current.Value * r.Current.Value);
         }
 
         /// <summary>Creates a new ExponentialMovingAverage indicator with the specified period and smoothingFactor from the left indicator
@@ -365,7 +373,7 @@ namespace QuantConnect.Indicators
         /// <param name="period">Average period</param>
         /// <returns>Indicator that results of the average of first by weights given by second</returns>
         // ReSharper disable once UnusedMember.Global
-        public static CompositeIndicator<IndicatorDataPoint> WeightedBy(PyObject value, PyObject weight, int period)
+        public static CompositeIndicator<IndicatorDataPoint, IndicatorDataPoint> WeightedBy(PyObject value, PyObject weight, int period)
         {
             dynamic indicator1 = value.SafeAsManagedObject();
             dynamic indicator2 = weight.SafeAsManagedObject();
@@ -425,7 +433,7 @@ namespace QuantConnect.Indicators
             return SMA(indicator, period, waitForFirstToReady);
         }
 
-        /// <summary>
+                /// <summary>
         /// Creates a new CompositeIndicator such that the result will be the ratio of the left to the constant
         /// </summary>
         /// <remarks>

--- a/Indicators/SharpeRatio.cs
+++ b/Indicators/SharpeRatio.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Indicator to store the calculation of the sharpe ratio
         /// </summary>
-        private readonly CompositeIndicator<IndicatorDataPoint> _sharpeRatio;
+        private readonly CompositeIndicator _sharpeRatio;
 
         /// <summary>
         /// Required period, in data points, for the indicator to be ready and fully initialized.

--- a/Indicators/SharpeRatio.cs
+++ b/Indicators/SharpeRatio.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Indicator to store the calculation of the sharpe ratio
         /// </summary>
-        private readonly CompositeIndicator<IndicatorDataPoint, IndicatorDataPoint> _sharpeRatio;
+        private readonly CompositeIndicator<IndicatorDataPoint> _sharpeRatio;
 
         /// <summary>
         /// Required period, in data points, for the indicator to be ready and fully initialized.

--- a/Indicators/SharpeRatio.cs
+++ b/Indicators/SharpeRatio.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Indicator to store the calculation of the sharpe ratio
         /// </summary>
-        private readonly CompositeIndicator<IndicatorDataPoint> _sharpeRatio;
+        private readonly CompositeIndicator<IndicatorDataPoint, IndicatorDataPoint> _sharpeRatio;
 
         /// <summary>
         /// Required period, in data points, for the indicator to be ready and fully initialized.

--- a/Indicators/VolumeWeightedAveragePriceIndicator.cs
+++ b/Indicators/VolumeWeightedAveragePriceIndicator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -31,7 +31,7 @@ namespace QuantConnect.Indicators
         private readonly int _period;
         private readonly Identity _price;
         private readonly Identity _volume;
-        private CompositeIndicator<IndicatorDataPoint> _vwap;
+        private CompositeIndicator<IndicatorDataPoint, IndicatorDataPoint> _vwap;
 
         /// <summary>
         /// Initializes a new instance of the VWAP class with the default name and period

--- a/Indicators/VolumeWeightedAveragePriceIndicator.cs
+++ b/Indicators/VolumeWeightedAveragePriceIndicator.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Indicators
         private readonly int _period;
         private readonly Identity _price;
         private readonly Identity _volume;
-        private CompositeIndicator<IndicatorDataPoint> _vwap;
+        private CompositeIndicator _vwap;
 
         /// <summary>
         /// Initializes a new instance of the VWAP class with the default name and period

--- a/Indicators/VolumeWeightedAveragePriceIndicator.cs
+++ b/Indicators/VolumeWeightedAveragePriceIndicator.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Indicators
         private readonly int _period;
         private readonly Identity _price;
         private readonly Identity _volume;
-        private CompositeIndicator<IndicatorDataPoint, IndicatorDataPoint> _vwap;
+        private CompositeIndicator<IndicatorDataPoint> _vwap;
 
         /// <summary>
         /// Initializes a new instance of the VWAP class with the default name and period

--- a/Tests/Indicators/CompositeIndicatorTests.cs
+++ b/Tests/Indicators/CompositeIndicatorTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  * 
@@ -27,7 +27,7 @@ namespace QuantConnect.Tests.Indicators
         {
             var left = new Delay(1);
             var right = new Delay(2);
-            var composite = new CompositeIndicator<IndicatorDataPoint>(left, right, (l, r) => l.Current.Value + r.Current.Value);
+            var composite = new CompositeIndicator(left, right, (l, r) => l.Current.Value + r.Current.Value);
 
             left.Update(DateTime.Today.AddSeconds(0), 1m);
             right.Update(DateTime.Today.AddSeconds(0), 1m);
@@ -59,7 +59,7 @@ namespace QuantConnect.Tests.Indicators
         {
             var left = new Identity("left");
             var right = new Identity("right");
-            var composite = new CompositeIndicator<IndicatorDataPoint>(left, right, (l, r) =>
+            var composite = new CompositeIndicator(left, right, (l, r) =>
             {
                 Assert.AreEqual(left, l);
                 Assert.AreEqual(right, r);
@@ -75,7 +75,7 @@ namespace QuantConnect.Tests.Indicators
         public void ResetsProperly() {
             var left = new Maximum("left", 2);
             var right = new Minimum("right", 2);
-            var composite = new CompositeIndicator<IndicatorDataPoint>(left, right, (l, r) => l.Current.Value + r.Current.Value);
+            var composite = new CompositeIndicator(left, right, (l, r) => l.Current.Value + r.Current.Value);
 
             left.Update(DateTime.Today, 1m);
             right.Update(DateTime.Today,-1m);

--- a/Tests/Indicators/IndicatorExtensionsTests.cs
+++ b/Tests/Indicators/IndicatorExtensionsTests.cs
@@ -442,10 +442,7 @@ namespace QuantConnect.Tests.Indicators
             {
                 foreach (var method in methods)
                 {
-                    Console.WriteLine(method);
                     var newCase = new TestCaseData(combo, method);
-
-                    Console.WriteLine(newCase);
                     cases.Add(newCase);
                 }
             }
@@ -695,6 +692,11 @@ namespace QuantConnect.Tests.Indicators
                 Current = new IndicatorDataPoint(DateTime.MinValue, value);
                 OnUpdated(Current);
             }
+
+            protected override decimal ComputeNextValue(T input)
+            {
+                return input.Value;
+            }
         }
 
         private class TestTradeBarIndicator : TestIndicator<TradeBar>
@@ -710,11 +712,6 @@ namespace QuantConnect.Tests.Indicators
                 {
                     return true;
                 }
-            }
-
-            protected override decimal ComputeNextValue(TradeBar input)
-            {
-                return input.Value;
             }
         }
 
@@ -732,11 +729,6 @@ namespace QuantConnect.Tests.Indicators
                     return true;
                 }
             }
-
-            protected override decimal ComputeNextValue(QuoteBar input)
-            {
-                return input.Value;
-            }
         }
 
         private class TestBaseDataIndicator : TestIndicator<BaseData>
@@ -753,11 +745,6 @@ namespace QuantConnect.Tests.Indicators
                     return true;
                 }
             }
-
-            protected override decimal ComputeNextValue(BaseData input)
-            {
-                return input.Value;
-            }
         }
 
         private class TestIndicatorDataPointIndicator : TestIndicator<IndicatorDataPoint>
@@ -773,11 +760,6 @@ namespace QuantConnect.Tests.Indicators
                 {
                     return true;
                 }
-            }
-
-            protected override decimal ComputeNextValue(IndicatorDataPoint input)
-            {
-                return input.Value;
             }
         }
     }

--- a/Tests/Indicators/IndicatorExtensionsTests.cs
+++ b/Tests/Indicators/IndicatorExtensionsTests.cs
@@ -421,10 +421,10 @@ namespace QuantConnect.Tests.Indicators
             // Define our indicators to test on
             var testIndicators = new IIndicator[]
             {
-                new TestBaseDataIndicator("BD"),
-                new TestQuoteBarIndicator("QB"),
-                new TestTradeBarIndicator("TB"),
-                new TestIndicatorDataPointIndicator("IDP")
+                new TestIndicator<BaseData>("BD"),
+                new TestIndicator<QuoteBar>("QB"),
+                new TestIndicator<TradeBar>("TB"),
+                new TestIndicator<IndicatorDataPoint>("IDP")
             };
 
             // Methods defined in CompositeTestRunner
@@ -678,13 +678,21 @@ namespace QuantConnect.Tests.Indicators
             }
         }
 
-        private abstract class TestIndicator<T> : IndicatorBase<T>
+        private class TestIndicator<T> : IndicatorBase<T>
             where T : IBaseData
         {
-            protected TestIndicator(string name)
+            public TestIndicator(string name)
                 : base(name)
             {
 
+            }
+
+            public override bool IsReady
+            {
+                get
+                {
+                    return true;
+                }
             }
 
             public void UpdateValue(int value)
@@ -696,70 +704,6 @@ namespace QuantConnect.Tests.Indicators
             protected override decimal ComputeNextValue(T input)
             {
                 return input.Value;
-            }
-        }
-
-        private class TestTradeBarIndicator : TestIndicator<TradeBar>
-        {
-            public TestTradeBarIndicator(string name)
-                : base(name)
-            {
-            }
-
-            public override bool IsReady
-            {
-                get
-                {
-                    return true;
-                }
-            }
-        }
-
-        private class TestQuoteBarIndicator : TestIndicator<QuoteBar>
-        {
-            public TestQuoteBarIndicator(string name)
-                : base(name)
-            {
-            }
-
-            public override bool IsReady
-            {
-                get
-                {
-                    return true;
-                }
-            }
-        }
-
-        private class TestBaseDataIndicator : TestIndicator<BaseData>
-        {
-            public TestBaseDataIndicator(string name)
-                : base(name)
-            {
-            }
-
-            public override bool IsReady
-            {
-                get
-                {
-                    return true;
-                }
-            }
-        }
-
-        private class TestIndicatorDataPointIndicator : TestIndicator<IndicatorDataPoint>
-        {
-            public TestIndicatorDataPointIndicator(string name)
-                : base(name)
-            {
-            }
-
-            public override bool IsReady
-            {
-                get
-                {
-                    return true;
-                }
             }
         }
     }

--- a/Tests/Indicators/IndicatorTests.cs
+++ b/Tests/Indicators/IndicatorTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -256,7 +256,7 @@ namespace QuantConnect.Tests.Indicators
         {
             var methodName = "op_" + @operator;
             var method =
-                typeof (IndicatorBase<IndicatorDataPoint>).GetMethods(BindingFlags.Static | BindingFlags.Public)
+                typeof (IndicatorBase).GetMethods(BindingFlags.Static | BindingFlags.Public)
                 .SingleOrDefault(x => x.Name == methodName && x.GetParameters()[argIndex].ParameterType == typeof(T));
 
             if (method == null)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Indicator stack refactor to support composite indicators of different input types.


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1602
Closes #5811 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Because of the implementation of indicators all indicators required a input type assigned to the base generic. This is nice for supporting various inputs but not always required. It also causes issues when trying to merge two indicators in a composite indicator because they require generic types. When they are not the same Lean would silently convert one indicator to a decimal value causing undesirable behavior.


#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All regressions and unit test passed.

Addition of a test suite for C# and Python indicators to prove the composite indicators of various input types (Generic) can create composites successfully and their values are created. This set of tests is all red in master and all green in this branch.

The test suite is a little complicated but does generate 96 cases (48 for C#, 48 for Py). The one thing that may be nice to improve upon is the the way I generate the cases and how the methods are currently stored and matched as strings.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
