### PR TITLE
IB Brokerage - fix for futures contracts priced in cents

### DIFF
--- a/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageAdditionalTests.cs
+++ b/Tests/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerageAdditionalTests.cs
@@ -210,6 +210,9 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
         {
             get
             {
+                var futureSymbolUsingCents = Symbols.CreateFutureSymbol("LE", new DateTime(2021, 12, 31));
+                var futureOptionSymbolUsingCents = Symbols.CreateFutureOptionSymbol(futureSymbolUsingCents, OptionRight.Call, 1.23m, new DateTime(2021, 12, 3));
+
                 var futureSymbol = Symbol.CreateFuture("NQ", Market.CME, new DateTime(2021, 9, 17));
                 var optionSymbol = Symbol.CreateOption("AAPL", Market.USA, OptionStyle.American, OptionRight.Call, 145, new DateTime(2021, 8, 20));
 
@@ -222,6 +225,13 @@ namespace QuantConnect.Tests.Brokerages.InteractiveBrokers
                     // 30 min RTH + 30 min ETH
                     new TestCaseData(Symbols.SPY, Resolution.Second, TimeZones.NewYork, TimeZones.NewYork,
                         new DateTime(2021, 8, 6, 10, 0, 0), TimeSpan.FromHours(1), true, 3600),
+
+                    // daily
+                    new TestCaseData(futureSymbolUsingCents, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork,
+                        new DateTime(2021, 9, 20, 0, 0, 0), TimeSpan.FromDays(10), true, 6),
+                    // hourly
+                    new TestCaseData(futureOptionSymbolUsingCents, Resolution.Hour, TimeZones.NewYork, TimeZones.NewYork,
+                        new DateTime(2021, 9, 20, 0, 0, 0), TimeSpan.FromDays(10), true, 11),
 
                     // 60 min
                     new TestCaseData(futureSymbol, Resolution.Second, TimeZones.NewYork, TimeZones.Utc,

--- a/Tests/Symbols.cs
+++ b/Tests/Symbols.cs
@@ -148,6 +148,10 @@ namespace QuantConnect.Tests
             }
             return Symbol.CreateFuture(symbol, market, expiry);
         }
+        internal static Symbol CreateFutureOptionSymbol(Symbol underlying, OptionRight right, decimal strike, DateTime expiry)
+        {
+            return Symbol.CreateOption(underlying, underlying.ID.Market, OptionStyle.American, right, strike, expiry);
+        }
 
         private static Symbol CreateCfdSymbol(string symbol, string market)
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Several futures contracts (e.g. ZC, ZS, KE) are priced in cents on the exchange, rather than USD.  IB Api publishes tick prices in cents and expects to receive order limit prices etc in cents, but the Lean InteractiveBrokersBrokerage assumes prices are in USD.  This change uses the IB ContractDetails.PriceMagnifier field to apply conversion of prices passing between Lean and IB so that within Lean all prices are USD, and the correct cent prices are sent to the brokerage.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5238 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fix is required for correct handling of cent-priced futures contracts in live trading via IB Brokerage

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No changes required

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running an algo against IB Brokerage that subscribes to a number of cent-based and dollar-based contracts, places Limit, Market, StopLimitOrder, StopMarketOrder, LimitIfTouchedOrder, restarting with and without existing holdings, and restarting with open orders on the exchange.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

Unit testing in progress 
<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
