### PR TITLE
Adds Warnings to MOO and MOO using Tick Data

### DIFF
--- a/Tests/Common/Orders/Fills/EquityFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/EquityFillModelTests.cs
@@ -764,6 +764,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             fill = model.MarketOnOpenFill(equity, order);
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
             Assert.AreEqual(expected, fill.FillPrice);
+            Assert.IsTrue(fill.Message.Contains("Fill with last Quote data.", StringComparison.InvariantCulture));
         }
 
         [TestCase(Resolution.Minute, 3, 17, 0, 9, 29)]
@@ -1020,6 +1021,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 fill = model.MarketOnCloseFill(equity, order);
                 Assert.AreEqual(order.Quantity, fill.FillQuantity);
                 Assert.AreEqual(expected, fill.FillPrice);
+                Assert.AreEqual("No trade with the OfficialClose or ClosingPrints flag for data that does not include extended market hours. Fill with last Trade data.", fill.Message);
                 return;
             }
 
@@ -1084,7 +1086,9 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 new Tick(time, Symbols.SPY,  "80000001", "P", 100, 0.95m),   // Open but not primary exchange
             }, typeof(Tick));
 
+            fill = model.MarketOnCloseFill(equity, order);
             Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual("No trade with the OfficialClose or ClosingPrints flag within the 1-minute timeout.", fill.Message);
 
             // 2 minutes after the close
             time = reference.AddMinutes(62);
@@ -1101,6 +1105,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             fill = model.MarketOnCloseFill(equity, order);
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
             Assert.AreEqual(expected, fill.FillPrice);
+            Assert.IsTrue(fill.Message.Contains("Fill with last Trade data.", StringComparison.InvariantCulture));
         }
 
         [TestCase(OrderDirection.Buy)]


### PR DESCRIPTION
#### Description
These warnings are meant to let the user know that it was not possible to find ticks marked with the `OfficialOpen`, `OfficialClose`, `OpeningPrints` or `ClosingPrints` flags.

#### Related Issue
Improves #5913

#### Motivation and Context
Improve warnings.

#### How Has This Been Tested?
Improve unit tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`