### PR TITLE
Fix live ETF universe selection

### DIFF
--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -300,11 +300,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 _customExchange.AddEnumerator(new EnumeratorHandler(config.Symbol, enumerator, enqueueable));
                 enumerator = enqueueable;
             }
-            else if (config.Type == typeof (CoarseFundamental))
+            else if (config.Type == typeof (CoarseFundamental) || config.Type == typeof (ETFConstituentData))
             {
-                Log.Trace($"LiveTradingDataFeed.CreateUniverseSubscription(): Creating coarse universe: {config.Symbol.ID}");
+                Log.Trace($"LiveTradingDataFeed.CreateUniverseSubscription(): Creating {config.Type.Name} universe: {config.Symbol.ID}");
 
-                // Will try to pull coarse data from the data folder every 10min, file with today's date.
+                // Will try to pull data from the data folder every 10min, file with yesterdays date.
                 // If lean is started today it will trigger initial coarse universe selection
                 var factory = new LiveCustomDataSubscriptionEnumeratorFactory(_timeProvider,
                     // we adjust time to the previous tradable date
@@ -320,8 +320,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 var enqueable = new EnqueueableEnumerator<BaseData>();
                 _customExchange.SetDataHandler(config.Symbol, data =>
                 {
-                    var coarseData = data as BaseDataCollection;
-                    enqueable.Enqueue(new BaseDataCollection(coarseData.Time, config.Symbol, coarseData.Data));
+                    enqueable.Enqueue(data);
                     subscription.OnNewDataAvailable();
                 });
                 enumerator = GetConfiguredFrontierAwareEnumerator(enqueable, tzOffsetProvider,

--- a/Tests/Engine/DataFeeds/LiveCoarseUniverseTests.cs
+++ b/Tests/Engine/DataFeeds/LiveCoarseUniverseTests.cs
@@ -39,18 +39,21 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void CoarseUniverseRotatesActiveSecurity()
         {
             var startDate = new DateTime(2014, 3, 24);
-            var endDate = new DateTime(2014, 3, 29);
+            var endDate = new DateTime(2014, 3, 31);
 
             var timeProvider = new ManualTimeProvider(TimeZones.NewYork);
             timeProvider.SetCurrentTime(startDate);
 
             var coarseTimes = new List<DateTime>
             {
+                // coarse files go from the 24th (Monday) to the 28th (Friday)
+                // they are emitted in the next day, excluding saturday
                 new DateTime(2014, 3, 25, 5, 0, 0, 0),
                 new DateTime(2014, 3, 26, 5, 0, 0, 0),
                 new DateTime(2014, 3, 27, 5, 0, 0, 0),
                 new DateTime(2014, 3, 28, 5, 0, 0, 0),
-                new DateTime(2014, 3, 29, 5, 0, 0, 0)
+                // 29th is Saturday
+                new DateTime(2014, 3, 30, 5, 0, 0, 0)
             }.ToHashSet();
 
             var coarseSymbols = new List<Symbol> { Symbols.SPY, Symbols.AAPL, Symbols.MSFT };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- ETF live universe selection will behave the same as Coarse selection.
  Adding unit test
- Remove creation of `BaseDataCollection` which was added at https://github.com/QuantConnect/Lean/pull/4636 due to normalized `Symbol` not matching the `config.Symbol`, not required anymore (should of probably been part of https://github.com/QuantConnect/Lean/pull/5927/files#diff-1ce1e57ed2332bd9b6c8072e8481d4932e41451bc5612212e368b183659cc80dR321).
This uncovered that this new collection `EndTime` == `Time` which is different than the original `BaseDataCollection` where coarse of the 24th end time is midnight of the 25th (and consumed on the 25th), this was causing the unit test `CoarseUniverseRotatesActiveSecurity` to be emitting coarse data (and asserting it) on Saturday when it should come through on Sunday

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
ETF live selection works as expected
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests, live deployments
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
