### PR TITLE
Do not emit zero quantity Exercise Order events

### DIFF
--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1171,9 +1171,13 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
                         var quantity = -security.Holdings.Quantity;
 
-                        var exerciseOrder = GenerateOptionExerciseOrder(security, quantity);
+                        // If the quantity is already 0 for Lean and the brokerage there is nothing else todo here
+                        if (quantity != 0)
+                        {
+                            var exerciseOrder = GenerateOptionExerciseOrder(security, quantity);
 
-                        EmitOptionNotificationEvents(security, exerciseOrder);
+                            EmitOptionNotificationEvents(security, exerciseOrder);
+                        }
                     }
                     else
                     {

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -1292,8 +1292,6 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var parameters = new object[] { new OptionNotificationEventArgs(optionSymbol, 0) };
             method.Invoke(transactionHandler, parameters);
 
-            transactionHandler.Exit();
-
             var tickets = algorithm.Transactions.GetOrderTickets().ToList();
             Assert.AreEqual(1, tickets.Count);
 
@@ -1305,6 +1303,14 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
             Assert.AreEqual(expectedUnderlyingPosition, algorithm.Portfolio[equity.Symbol].Quantity);
             Assert.AreEqual(expectedOptionPosition, algorithm.Portfolio[optionSymbol].Quantity);
+
+            // let's push the same event again
+            method.Invoke(transactionHandler, parameters);
+            transactionHandler.Exit();
+
+            // we should not see any new orders or events come through
+            tickets = algorithm.Transactions.GetOrderTickets().ToList();
+            Assert.AreEqual(1, tickets.Count);
         }
 
         // Long Call --> ITM (exercised early - full)
@@ -1367,8 +1373,6 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var parameters = new object[] { new OptionNotificationEventArgs(optionSymbol, expectedOptionPosition) };
             method.Invoke(transactionHandler, parameters);
 
-            transactionHandler.Exit();
-
             var tickets = algorithm.Transactions.GetOrderTickets().ToList();
             Assert.AreEqual(1, tickets.Count);
 
@@ -1380,6 +1384,14 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
             Assert.AreEqual(expectedUnderlyingPosition, algorithm.Portfolio[equity.Symbol].Quantity);
             Assert.AreEqual(expectedOptionPosition, algorithm.Portfolio[optionSymbol].Quantity);
+
+            // let's push the same event again
+            method.Invoke(transactionHandler, parameters);
+            transactionHandler.Exit();
+
+            // we should not see any new orders or events come through
+            tickets = algorithm.Transactions.GetOrderTickets().ToList();
+            Assert.AreEqual(1, tickets.Count);
         }
 
         // Short Call --> ITM (assigned early - full)
@@ -1431,8 +1443,6 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             var parameters = new object[] { new OptionNotificationEventArgs(optionSymbol, expectedOptionPosition) };
             method.Invoke(transactionHandler, parameters);
 
-            transactionHandler.Exit();
-
             var tickets = algorithm.Transactions.GetOrderTickets().ToList();
             Assert.AreEqual(1, tickets.Count);
 
@@ -1444,6 +1454,14 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
 
             Assert.AreEqual(expectedUnderlyingPosition, algorithm.Portfolio[equity.Symbol].Quantity);
             Assert.AreEqual(expectedOptionPosition, algorithm.Portfolio[optionSymbol].Quantity);
+
+            // let's push the same event again
+            method.Invoke(transactionHandler, parameters);
+            transactionHandler.Exit();
+
+            // we should not see any new orders or events come through
+            tickets = algorithm.Transactions.GetOrderTickets().ToList();
+            Assert.AreEqual(1, tickets.Count);
         }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `BrokerateTransactionHandler` will not emit zero quantity Exercise order
  events. Updating unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- IB has been seen to emit portfolio updates with zero quantities multiple times. Was causing Lean to generate 0 quantity exercise events. See https://github.com/QuantConnect/Lean/pull/5880
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
N/A
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests reproducing issue
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
