### PR TITLE
Round AverageLoss to Avoid Very Small Numbers

### DIFF
--- a/Indicators/RelativeStrengthIndex.cs
+++ b/Indicators/RelativeStrengthIndex.cs
@@ -13,6 +13,8 @@
  * limitations under the License.
 */
 
+using System;
+
 namespace QuantConnect.Indicators
 {
     /// <summary>
@@ -98,7 +100,8 @@ namespace QuantConnect.Indicators
             var averageLoss = AverageLoss < 0 ? 0 : AverageLoss.Current.Value;
             var averageGain = AverageGain < 0 ? 0 : AverageGain.Current.Value;
 
-            if (averageLoss == 0m)
+            // Round AverageLoss to avoid computing RSI with very small numbers that lead to overflow exception on the division operation below
+            if (Math.Round(averageLoss, 10) == 0m)
             {
                 // all up days is 100
                 return 100m;


### PR DESCRIPTION
#### Description
Round AverageLoss to avoid computing RSI with very small numbers that lead to overflow exception on the division operation below:
```csharp
var rs = averageGain / averageLoss;
```

#### Motivation and Context
Handle mathematical edge case

#### How Has This Been Tested?
User algorithm.
I logged the values of `averageGain`, `averageLoss`, `_previousInput.Value` and `input.Value`:
```
Runtime Error: OverflowException : 80.46975999999999999999999998 0.0000000000000000000000000003 13690.0374 13690.0374
```
to verify that the value of `averageLoss` is very small due to a "rounding" error.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`