### PR TITLE
Properly handle pending CancelOrderRequests during backtesting

### DIFF
--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -268,6 +268,12 @@ namespace QuantConnect.Brokerages.Backtesting
                         _pending.TryRemove(order.Id, out order);
                         continue;
                     }
+                    
+                    if (order.Status == OrderStatus.CancelPending)
+                    {
+                        // the pending CancelOrderRequest will be handled during the next transaction handler run
+                        continue;
+                    }
 
                     // all order fills are processed on the next bar (except for market orders)
                     if (order.Time == Algorithm.UtcTime && order.Type != OrderType.Market && order.Type != OrderType.OptionExercise)

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -268,12 +268,6 @@ namespace QuantConnect.Brokerages.Backtesting
                         _pending.TryRemove(order.Id, out order);
                         continue;
                     }
-                    
-                    if (order.Status == OrderStatus.CancelPending)
-                    {
-                        // the pending CancelOrderRequest will be handled during the next transaction handler run
-                        continue;
-                    }
 
                     // all order fills are processed on the next bar (except for market orders)
                     if (order.Time == Algorithm.UtcTime && order.Type != OrderType.Market && order.Type != OrderType.OptionExercise)
@@ -403,6 +397,11 @@ namespace QuantConnect.Brokerages.Backtesting
                             Log.Error(err);
                             Algorithm.Error($"Order Error: id: {order.Id}, Transaction model failed to fill for order type: {order.Type} with error: {err.Message}");
                         }
+                    }
+                    else if (order.Status == OrderStatus.CancelPending)
+                    {
+                        // the pending CancelOrderRequest will be handled during the next transaction handler run
+                        continue;
                     }
                     else
                     {


### PR DESCRIPTION
To avoid unneccessary "Insufficient buying power to complete order" errors showing up as Invalid orders during backtesting we need to skip further processing of pending CancelOrderRequests in the BacktestingBrokerage and instead let them be properly removed during the next transaction handler run.

#### Description
When trading leveraged positions that utilize virtually all available margin while employing opposing StopMarket and Limit orders, it often happens that when either order is triggered due to price movements, the remaining order will be cancelled to ensure there are no lingering positions. However, when backtesting we currently fail to detect the pending cancel order in time, so the order request undergoes a validation check for sufficient buying power, which it fails. The order is then marked as Invalid. This can be avoided simply by skipping further processing as the next transaction handler run will process the pending cancel request and swiftly remove the order from the queue, thus ensuring that no errors occur.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
See above.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
1. First you need to create a routine that automatically cancels all open orders when a fill happens that does not match the Buy MarketOrder in (2) :

`public override void OnOrderEvent(OrderEvent orderEvent)
{
    if (!orderEvent.Status.IsFill())
    {
        return;
    }
    if (orderEvent.OrderId != BuyMarketTicket.OrderId)
    {
        Transactions.CancelOpenOrders(orderEvent.Symbol);
    }
}`

2. Create a Buy MarketOrder that uses up virtually all available margin (save the ticket in the BuyMarketTicket variable)
3. Create a Sell StopMarketOrder on the above quantity at a level where it will NOT be filled
4. Create a Sell LimitOrder on the above quantity at a level where it will be filled
5. Wait for Sell LimitOrder to fill
6. The routine from (1) is triggered and the Sell StopMarketOrder is now pending cancel
7. The Sell StopMarketOrder is (incorrectly) validated for sufficient buying power before it could be removed from the pending order queue
8. The Sell StopMarketOrder status changes to Invalid

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
