### PR TITLE
Set WarmUpPeriod value in MarketProfile constructor

### DIFF
--- a/Indicators/MarketProfile.cs
+++ b/Indicators/MarketProfile.cs
@@ -39,11 +39,6 @@ namespace QuantConnect.Indicators
     public abstract class MarketProfile : TradeBarIndicator, IIndicatorWarmUpPeriodProvider
     {
         /// <summary>
-        /// Period of the indicator
-        /// </summary>
-        private readonly int _period;
-
-        /// <summary>
         /// Percentage of total volume contained in the ValueArea
         /// </summary>
         private readonly decimal _valueAreaVolumePercentage;
@@ -132,7 +127,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Required period, in data points, for the indicator to be ready and fully initialized.
         /// </summary>
-        public int WarmUpPeriod => _period;
+        public int WarmUpPeriod { get; private set; }
 
         /// <summary>
         /// Creates a new MarkProfile indicator with the specified period
@@ -151,6 +146,7 @@ namespace QuantConnect.Indicators
                 throw new ArgumentException("Must be strictly bigger than zero.", nameof(priceRangeRoundOff));
             }
 
+            WarmUpPeriod = period;
             _valueAreaVolumePercentage = valueAreaVolumePercentage;
             _oldDataPoints = new RollingWindow<Tuple<decimal, decimal>>(period);
             _volumePerPrice = new SortedList<decimal, decimal>();

--- a/Tests/Indicators/TimeProfileTests.cs
+++ b/Tests/Indicators/TimeProfileTests.cs
@@ -124,12 +124,14 @@ namespace QuantConnect.Tests.Indicators
         public override void WarmsUpProperly()
         {
             var tp = new TimeProfile(20);
-            var time = new DateTime(2020, 8, 1);
+            var reference = new DateTime(2000, 1, 1);
             var period = ((IIndicatorWarmUpPeriodProvider)tp).WarmUpPeriod;
 
+            // Check TimeProfile indicator assigns properly a WarmUpPeriod
+            Assert.AreEqual(20, period);
             for (var i = 0; i < period; i++)
             {
-                tp.Update(time.AddDays(i), i);
+                tp.Update(new TradeBar() { Symbol = Symbols.AAPL, Low = 1, High = 2, Volume = 100, Time = reference.AddDays(1 + i) });
                 Assert.AreEqual(i == period - 1, tp.IsReady);
             }
         }

--- a/Tests/Indicators/VolumeProfileTests.cs
+++ b/Tests/Indicators/VolumeProfileTests.cs
@@ -124,12 +124,14 @@ namespace QuantConnect.Tests.Indicators
         public override void WarmsUpProperly()
         {
             var vp = new VolumeProfile(20);
-            var time = new DateTime(2020, 8, 1);
+            var reference = new DateTime(2000, 1, 1);
             var period = ((IIndicatorWarmUpPeriodProvider)vp).WarmUpPeriod;
 
+            // Check VolumeProfile indicator assigns properly a WarmUpPeriod
+            Assert.AreEqual(20, period);
             for (var i = 0; i < period; i++)
             {
-                vp.Update(time.AddDays(i), i);
+                vp.Update(new TradeBar() { Symbol = Symbols.AAPL, Low = 1, High = 2, Volume = 100, Time = reference.AddDays(1 + i) });
                 Assert.AreEqual(i == period - 1, vp.IsReady);
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Remove unnecessary attribute `_period` in MarketProfile
- Set the value of WarmUpPeriod to the period in MarketProfile constructor
- Fix unit test to check VolumeProfile and TimeProfile indicators are being warmed up properly and their WarmUpPeriod parameter isn't zero

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #6028 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change `VolumeProfile` and `TimeProfile` indicators will be able to be warmed up
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require changes in the documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- There was created a `VolumeProfile` indicator and after get its `WarmUpPeriod` parameter it was asserted this was different from zero and that it was ready when the number of samples were bigger than the WarmUpPeriod parameter. The same was made with a `TimeProfile` indicator
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
