### PR TITLE
Composite IDQH - Support multiple live data feeds

### DIFF
--- a/Brokerages/Binance/BinanceBrokerage.cs
+++ b/Brokerages/Binance/BinanceBrokerage.cs
@@ -366,7 +366,7 @@ namespace QuantConnect.Brokerages.Binance
         {
             if (!CanSubscribe(dataConfig.Symbol))
             {
-                return Enumerable.Empty<BaseData>().GetEnumerator();
+                return null;
             }
 
             var enumerator = _aggregator.Add(dataConfig, newDataAvailableHandler);

--- a/Brokerages/Bitfinex/BitfinexBrokerage.cs
+++ b/Brokerages/Bitfinex/BitfinexBrokerage.cs
@@ -451,7 +451,7 @@ namespace QuantConnect.Brokerages.Bitfinex
             if (symbol.Value.Contains("UNIVERSE") ||
                 !_symbolMapper.IsKnownLeanSymbol(symbol))
             {
-                return Enumerable.Empty<BaseData>().GetEnumerator();
+                return null;
             }
 
             var enumerator = _aggregator.Add(dataConfig, newDataAvailableHandler);

--- a/Brokerages/GDAX/GDAXDataQueueHandler.cs
+++ b/Brokerages/GDAX/GDAXDataQueueHandler.cs
@@ -62,7 +62,7 @@ namespace QuantConnect.Brokerages.GDAX
         {
             if (!CanSubscribe(dataConfig.Symbol))
             {
-                return Enumerable.Empty<BaseData>().GetEnumerator();
+                return null;
             }
 
             var enumerator = _aggregator.Add(dataConfig, newDataAvailableHandler);

--- a/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
+++ b/Brokerages/InteractiveBrokers/InteractiveBrokersBrokerage.cs
@@ -2532,7 +2532,7 @@ namespace QuantConnect.Brokerages.InteractiveBrokers
         {
             if (!CanSubscribe(dataConfig.Symbol))
             {
-                return Enumerable.Empty<BaseData>().GetEnumerator();
+                return null;
             }
 
             var enumerator = _aggregator.Add(dataConfig, newDataAvailableHandler);

--- a/Brokerages/Oanda/OandaRestApiBase.cs
+++ b/Brokerages/Oanda/OandaRestApiBase.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -367,7 +367,7 @@ namespace QuantConnect.Brokerages.Oanda
         {
             if (!CanSubscribe(dataConfig.Symbol))
             {
-                return Enumerable.Empty<BaseData>().GetEnumerator();
+                return null;
             }
 
             var enumerator = Aggregator.Add(dataConfig, newDataAvailableHandler);

--- a/Brokerages/Tradier/TradierBrokerage.DataQueueHandler.cs
+++ b/Brokerages/Tradier/TradierBrokerage.DataQueueHandler.cs
@@ -94,7 +94,7 @@ namespace QuantConnect.Brokerages.Tradier
 
             if (!CanSubscribe(dataConfig.Symbol))
             {
-                return Enumerable.Empty<BaseData>().GetEnumerator();
+                return null;
             }
 
             var enumerator = _aggregator.Add(dataConfig, newDataAvailableHandler);

--- a/Brokerages/Zerodha/ZerodhaBrokerage.DataQueueHandler.cs
+++ b/Brokerages/Zerodha/ZerodhaBrokerage.DataQueueHandler.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -47,7 +47,7 @@ namespace QuantConnect.Brokerages.Zerodha
             var symbol = dataConfig.Symbol;
             if (!CanSubscribe(symbol))
             {
-                return Enumerable.Empty<BaseData>().GetEnumerator();
+                return null;
             }
 
             var enumerator = _aggregator.Add(dataConfig, newDataAvailableHandler);

--- a/Engine/DataFeeds/CompositeDataQueueHandler.cs
+++ b/Engine/DataFeeds/CompositeDataQueueHandler.cs
@@ -1,0 +1,108 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using Newtonsoft.Json;
+using QuantConnect.Configuration;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Packets;
+using QuantConnect.Util;
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Lean.Engine.DataFeeds
+{
+    /// <summary>
+    /// This data provider will wrap and use multiple data providers internally in the provided order
+    /// </summary>
+    public class CompositeDataQueueHandler : IDataQueueHandler
+    {
+        private readonly List<IDataQueueHandler> _dataHandlers;
+
+        /// <summary>
+        /// Creates a new instance and initialize data providers used
+        /// </summary>
+        public CompositeDataQueueHandler()
+        {
+            _dataHandlers = new List<IDataQueueHandler>();
+
+            var dataProvidersConfig = Config.Get("composite-data-providers");
+            if (!string.IsNullOrEmpty(dataProvidersConfig))
+            {
+                var dataProviders = JsonConvert.DeserializeObject<List<string>>(dataProvidersConfig);
+                foreach (var dataProvider in dataProviders)
+                {
+                    _dataHandlers.Add(Composer.Instance.GetExportedValueByTypeName<IDataQueueHandler>(dataProvider));
+                }
+
+                if (_dataHandlers.Count == 0)
+                {
+                    throw new ArgumentException("CompositeDataProvider(): requires at least 1 valid data provider in 'composite-data-providers'");
+                }
+            }
+            else
+            {
+                throw new ArgumentException("CompositeDataProvider(): requires 'composite-data-providers' to be set with a valid type name");
+            }
+        }
+
+        /// <summary>
+        /// Desktop/Local doesn't support live data from this handler
+        /// </summary>
+        public IEnumerator<BaseData> Subscribe(SubscriptionDataConfig dataConfig, EventHandler newDataAvailableHandler)
+        {
+            for (var i = 0; i < _dataHandlers.Count; i++)
+            {
+                var enumerator = _dataHandlers[i].Subscribe(dataConfig, newDataAvailableHandler);
+
+                if (enumerator != null)
+                {
+                    return enumerator;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Desktop/Local doesn't support live data from this handler
+        /// </summary>
+        public virtual void Unsubscribe(SubscriptionDataConfig dataConfig)
+        {
+            throw new NotImplementedException("QuantConnect.Queues.LiveDataQueue has not implemented live data.");
+        }
+
+        /// <summary>
+        /// Sets the job we're subscribing for
+        /// </summary>
+        /// <param name="job">Job we're subscribing for</param>
+        public void SetJob(LiveNodePacket job)
+        {
+        }
+
+        /// <summary>
+        /// Returns whether the data provider is connected
+        /// </summary>
+        /// <returns>true if the data provider is connected</returns>
+        public bool IsConnected => false;
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Engine/DataFeeds/CompositeDataQueueHandler.cs
+++ b/Engine/DataFeeds/CompositeDataQueueHandler.cs
@@ -57,7 +57,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     return enumerator;
                 }
             }
-            return Enumerable.Empty<BaseData>().GetEnumerator();
+            return null;
         }
 
         /// <summary>

--- a/Engine/DataFeeds/CompositeDataQueueHandler.cs
+++ b/Engine/DataFeeds/CompositeDataQueueHandler.cs
@@ -30,7 +30,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     public class CompositeDataQueueHandler : IDataQueueHandler
     {
         private readonly List<IDataQueueHandler> _dataHandlers = new();
-        private readonly Dictionary<SubscriptionDataConfig, IDataQueueHandler> _dataConfigAndDataHandler;
+        private readonly Dictionary<SubscriptionDataConfig, IDataQueueHandler> _dataConfigAndDataHandler = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CompositeDataQueueHandler"/> class

--- a/Engine/DataFeeds/CompositeDataQueueHandler.cs
+++ b/Engine/DataFeeds/CompositeDataQueueHandler.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using Newtonsoft.Json;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Packets;
@@ -50,7 +51,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             {
                 var enumerator = dataHandler.Subscribe(dataConfig, newDataAvailableHandler);
                 // Check if the enumerator is not empty
-                if (enumerator != null && enumerator.MoveNext())
+                if (enumerator != null)
                 {
                     _dataConfigAndDataHandler.Add(dataConfig, dataHandler);
                     return enumerator;
@@ -75,10 +76,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <param name="job">Job we're subscribing for</param>
         public void SetJob(LiveNodePacket job)
         {
-            var dataHandlerName = job.DataQueueHandler;
-            var dataHandler = Composer.Instance.GetExportedValueByTypeName<IDataQueueHandler>(dataHandlerName);
-            dataHandler.SetJob(job);
-            _dataHandlers.Add(dataHandler);
+            var dataHandlersConfig = job.DataQueueHandler;
+            var dataHandlers = JsonConvert.DeserializeObject<List<string>>(dataHandlersConfig);
+            foreach (var dataHandlerName in dataHandlers)
+            {
+                var dataHandler = Composer.Instance.GetExportedValueByTypeName<IDataQueueHandler>(dataHandlerName);
+                dataHandler.SetJob(job);
+                _dataHandlers.Add(dataHandler);
+            }
         }
 
         /// <summary>

--- a/Tests/Engine/DataFeeds/CompositeDataQueueHandlerTests.cs
+++ b/Tests/Engine/DataFeeds/CompositeDataQueueHandlerTests.cs
@@ -1,0 +1,68 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Packets;
+using QuantConnect.Util;
+using System;
+
+namespace QuantConnect.Tests.Engine.DataFeeds
+{
+    [TestFixture]
+    public class CompositeDataQueueHandlerTests
+    {
+        [Test]
+        public void SetJob()
+        {
+            var dataHanders = Newtonsoft.Json.JsonConvert.SerializeObject(new[] { "FakeDataQueue" });
+            var job = new LiveNodePacket
+            {
+                UserId = 1,
+                ProjectId = 1,
+                DeployId = "1",
+                Brokerage = "ZerodhaBrokerage",
+                DataQueueHandler = dataHanders
+            };
+            var compositeDataQueueHandler = new CompositeDataQueueHandler();
+            compositeDataQueueHandler.SetJob(job);
+            compositeDataQueueHandler.Dispose();
+        }
+
+        [Test]
+        public void Subscribe()
+        {
+            Subscription subscription = null;
+            EventHandler handler = (sender, args) => subscription?.OnNewDataAvailable();
+            var dataConfig = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false, false, TickType.Trade, false);
+            var compositeDataQueueHandler = new CompositeDataQueueHandler();
+            var enumerator = compositeDataQueueHandler.Subscribe(dataConfig, handler);
+            compositeDataQueueHandler.Dispose();
+        }
+
+        [Test]
+        public void Unsubscribe()
+        {
+            var dataConfig = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false, false, TickType.Trade, false);
+            var compositeDataQueueHandler = new CompositeDataQueueHandler();
+            compositeDataQueueHandler.Unsubscribe(dataConfig);
+            compositeDataQueueHandler.Dispose();
+        }
+    }
+}

--- a/Tests/Engine/DataFeeds/CompositeDataQueueHandlerTests.cs
+++ b/Tests/Engine/DataFeeds/CompositeDataQueueHandlerTests.cs
@@ -17,10 +17,8 @@
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
-using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Packets;
-using QuantConnect.Util;
 using System;
 
 namespace QuantConnect.Tests.Engine.DataFeeds
@@ -34,9 +32,6 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var dataHanders = Newtonsoft.Json.JsonConvert.SerializeObject(new[] { "FakeDataQueue" });
             var job = new LiveNodePacket
             {
-                UserId = 1,
-                ProjectId = 1,
-                DeployId = "1",
                 Brokerage = "ZerodhaBrokerage",
                 DataQueueHandler = dataHanders
             };
@@ -46,20 +41,40 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         }
 
         [Test]
-        public void Subscribe()
+        public void SubscribeReturnsNull()
         {
             Subscription subscription = null;
             EventHandler handler = (sender, args) => subscription?.OnNewDataAvailable();
             var dataConfig = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false, false, TickType.Trade, false);
             var compositeDataQueueHandler = new CompositeDataQueueHandler();
             var enumerator = compositeDataQueueHandler.Subscribe(dataConfig, handler);
+            Assert.Null(enumerator);
+            compositeDataQueueHandler.Dispose();
+        }
+
+        [Test]
+        public void SubscribeReturnsNotNull()
+        {
+            var dataHanders = Newtonsoft.Json.JsonConvert.SerializeObject(new[] { "FakeDataQueue" });
+            var job = new LiveNodePacket
+            {
+                Brokerage = "ZerodhaBrokerage",
+                DataQueueHandler = dataHanders
+            };
+            var compositeDataQueueHandler = new CompositeDataQueueHandler();
+            compositeDataQueueHandler.SetJob(job);
+            Subscription subscription = null;
+            EventHandler handler = (sender, args) => subscription?.OnNewDataAvailable();
+            var dataConfig = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false, false, TickType.Trade, false);
+            var enumerator = compositeDataQueueHandler.Subscribe(dataConfig, handler);
+            Assert.NotNull(enumerator);
             compositeDataQueueHandler.Dispose();
         }
 
         [Test]
         public void Unsubscribe()
         {
-            var dataConfig = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false, false, TickType.Trade, false);
+            var dataConfig = new SubscriptionDataConfig(typeof(TradeBar), Symbols.AAPL, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, false, false, TickType.Trade, false);
             var compositeDataQueueHandler = new CompositeDataQueueHandler();
             compositeDataQueueHandler.Unsubscribe(dataConfig);
             compositeDataQueueHandler.Dispose();

--- a/ToolBox/CoinApi/CoinApiDataQueueHandler.cs
+++ b/ToolBox/CoinApi/CoinApiDataQueueHandler.cs
@@ -107,7 +107,7 @@ namespace QuantConnect.ToolBox.CoinApi
         {
             if (!CanSubscribe(dataConfig.Symbol))
             {
-                return Enumerable.Empty<BaseData>().GetEnumerator();
+                return null;
             }
 
             var enumerator = _dataAggregator.Add(dataConfig, newDataAvailableHandler);

--- a/ToolBox/IEX/IEXDataQueueHandler.cs
+++ b/ToolBox/IEX/IEXDataQueueHandler.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -238,9 +238,9 @@ namespace QuantConnect.ToolBox.IEX
                           "is not supported by current implementation of  IEXDataQueueHandler. Sorry. Please try the higher resolution.");
             }
 
-            if (dataConfig.SecurityType != SecurityType.Equity)
+            if (!CanSubscribe(dataConfig.Symbol))
             {
-                return Enumerable.Empty<BaseData>().GetEnumerator();
+                return null;
             }
 
             var enumerator = _aggregator.Add(dataConfig, newDataAvailableHandler);
@@ -255,6 +255,16 @@ namespace QuantConnect.ToolBox.IEX
         /// <param name="job">Job we're subscribing for</param>
         public void SetJob(LiveNodePacket job)
         {
+        }
+
+        /// <summary>
+        /// Checks if this brokerage supports the specified symbol
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <returns>returns true if brokerage supports the specified symbol; otherwise false</returns>
+        private static bool CanSubscribe(Symbol symbol)
+        {
+            return symbol.SecurityType == SecurityType.Equity;
         }
 
         private void Refresh()

--- a/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
+++ b/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -91,7 +91,7 @@ namespace QuantConnect.ToolBox.IQFeed
         {
             if (!CanSubscribe(dataConfig.Symbol))
             {
-                return Enumerable.Empty<BaseData>().GetEnumerator();
+                return null;
             }
 
             var enumerator = _aggregator.Add(dataConfig, newDataAvailableHandler);

--- a/ToolBox/Polygon/PolygonDataQueueHandler.cs
+++ b/ToolBox/Polygon/PolygonDataQueueHandler.cs
@@ -136,7 +136,7 @@ namespace QuantConnect.ToolBox.Polygon
         {
             if (!CanSubscribe(dataConfig.Symbol))
             {
-                return Enumerable.Empty<BaseData>().GetEnumerator();
+                return null;
             }
 
             var enumerator = _dataAggregator.Add(dataConfig, newDataAvailableHandler);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Create an instance of CDQH to wrap IDQH instances for LEAN.
- Make all IDQH instance return `null` if not given a valid subscription `dataConfig`

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#6036

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To support multiple live data feeds. LEAN currently only supports 1 data feed at a time

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running unit tests that has been added to support this feature update

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
