### PR TITLE
Add tick type to data downloader get (price data) call in order for a…

### DIFF
--- a/Common/DataDownloaderGetParameters.cs
+++ b/Common/DataDownloaderGetParameters.cs
@@ -1,3 +1,18 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Common/DataDownloaderGetParameters.cs
+++ b/Common/DataDownloaderGetParameters.cs
@@ -14,10 +14,6 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace QuantConnect
 {
@@ -58,7 +54,7 @@ namespace QuantConnect
         /// <param name="resolution">Resolution of the data request</param>
         /// <param name="startUtc">Start time of the data in UTC</param>
         /// <param name="endUtc">End time of the data in UTC</param>
-        /// <param name="tickType">[Optional] The type of tick to get. Defaults to <see cref="TickType.Trade"/></param>
+        /// <param name="tickType">[Optional] The type of tick to get. Defaults to <see cref="QuantConnect.TickType.Trade"/></param>
         public DataDownloaderGetParameters(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType? tickType = null)
         {
             Symbol = symbol;
@@ -67,6 +63,5 @@ namespace QuantConnect
             EndUtc = endUtc;
             TickType = tickType ?? TickType.Trade;
         }
-
     }
 }

--- a/Common/DataDownloaderGetParameters.cs
+++ b/Common/DataDownloaderGetParameters.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuantConnect
+{
+    /// <summary>
+    /// Model class for passing in parameters for historical data
+    /// </summary>
+    public class DataDownloaderGetParameters
+    {
+        /// <summary>
+        /// Symbol for the data we're looking for.
+        /// </summary>
+        public Symbol Symbol { get; set; }
+
+        /// <summary>
+        /// Resolution of the data request
+        /// </summary>
+        public Resolution Resolution { get; set; }
+
+        /// <summary>
+        /// Start time of the data in UTC
+        /// </summary>
+        public DateTime StartUtc { get; set; }
+
+        /// <summary>
+        /// End time of the data in UTC
+        /// </summary>
+        public DateTime EndUtc { get; set; }
+
+        /// <summary>
+        /// The type of tick to get
+        /// </summary>
+        public TickType TickType { get; set; }
+
+        /// <summary>
+        /// Initialize model class for passing in parameters for historical data
+        /// </summary>
+        /// <param name="symbol">Symbol for the data we're looking for.</param>
+        /// <param name="resolution">Resolution of the data request</param>
+        /// <param name="startUtc">Start time of the data in UTC</param>
+        /// <param name="endUtc">End time of the data in UTC</param>
+        /// <param name="tickType">[Optional] The type of tick to get. Defaults to <see cref="TickType.Trade"/></param>
+        public DataDownloaderGetParameters(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType? tickType = null)
+        {
+            Symbol = symbol;
+            Resolution = resolution;
+            StartUtc = startUtc;
+            EndUtc = endUtc;
+            TickType = tickType ?? TickType.Trade;
+        }
+
+    }
+}

--- a/Common/IDataDownloader.cs
+++ b/Common/IDataDownloader.cs
@@ -31,7 +31,8 @@ namespace QuantConnect
         /// <param name="resolution">Resolution of the data request</param>
         /// <param name="startUtc">Start time of the data in UTC</param>
         /// <param name="endUtc">End time of the data in UTC</param>
+        /// <param name="tickType">The type of tick to get</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc);
+        IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType);
     }
 }

--- a/Common/IDataDownloader.cs
+++ b/Common/IDataDownloader.cs
@@ -27,12 +27,8 @@ namespace QuantConnect
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Resolution of the data request</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
-        /// <param name="tickType">The type of tick to get</param>
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType);
+        IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters);
     }
 }

--- a/Engine/DataFeeds/DownloaderDataProvider.cs
+++ b/Engine/DataFeeds/DownloaderDataProvider.cs
@@ -87,7 +87,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     var writer = new LeanDataWriter(resolution, symbol, Globals.DataFolder, tickType);
                     try
                     {
-                        var data = _dataDownloader.Get(symbol, resolution, startTimeUtc, endTimeUtc)
+                        var data = _dataDownloader.Get(symbol, resolution, startTimeUtc, endTimeUtc, tickType)
                             .Where(baseData => symbol.SecurityType == SecurityType.Base || baseData.GetType() == dataType)
                             // for canonical symbols, downloader will return data for all of the chain
                             .GroupBy(baseData => baseData.Symbol);

--- a/Engine/DataFeeds/DownloaderDataProvider.cs
+++ b/Engine/DataFeeds/DownloaderDataProvider.cs
@@ -87,7 +87,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     var writer = new LeanDataWriter(resolution, symbol, Globals.DataFolder, tickType);
                     try
                     {
-                        var data = _dataDownloader.Get(symbol, resolution, startTimeUtc, endTimeUtc, tickType)
+                        var getParams = new DataDownloaderGetParameters(symbol, resolution, startTimeUtc, endTimeUtc, tickType);
+
+                        var data = _dataDownloader.Get(getParams)
                             .Where(baseData => symbol.SecurityType == SecurityType.Base || baseData.GetType() == dataType)
                             // for canonical symbols, downloader will return data for all of the chain
                             .GroupBy(baseData => baseData.Symbol);

--- a/Tests/Common/Util/YahooDataDownloaderTests.cs
+++ b/Tests/Common/Util/YahooDataDownloaderTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  * 
@@ -37,7 +37,7 @@ namespace QuantConnect.Tests.Common.Util
         [Test]
         public void GetMethod_ShouldReturn_Successfully()
         {
-            var yahooData = _yahooDataDownloader.Get(_symbol, Resolution.Daily, new DateTime(2017,1,1), DateTime.Now);
+            var yahooData = _yahooDataDownloader.Get(_symbol, Resolution.Daily, new DateTime(2017,1,1), DateTime.Now, TickType.Trade);
             Assert.IsTrue(yahooData.Any());
         }
 
@@ -45,7 +45,7 @@ namespace QuantConnect.Tests.Common.Util
         public void GetMethod_WithNormalDates_ShouldReturnCorrectHistoricalData()
         {
             //Arrange
-            var yahooData = _yahooDataDownloader.Get(_symbol, Resolution.Daily, new DateTime(2017,2,1), new DateTime(2017,2,2));
+            var yahooData = _yahooDataDownloader.Get(_symbol, Resolution.Daily, new DateTime(2017,2,1), new DateTime(2017,2,2), TickType.Trade);
 
             //Assert
             Assert.AreEqual(yahooData.ElementAt(0).Value, 128.75);
@@ -56,7 +56,7 @@ namespace QuantConnect.Tests.Common.Util
         {
             Assert.Throws<ArgumentException>(() =>
             {
-                _yahooDataDownloader.Get(_symbol, Resolution.Minute, new DateTime(2017, 2, 1), new DateTime(2017, 2, 2));
+                _yahooDataDownloader.Get(_symbol, Resolution.Minute, new DateTime(2017, 2, 1), new DateTime(2017, 2, 2), TickType.Trade);
             });
         }
 
@@ -65,7 +65,7 @@ namespace QuantConnect.Tests.Common.Util
         {
             Assert.Throws<ArgumentException>(() =>
             {
-                _yahooDataDownloader.Get(_symbol, Resolution.Daily, new DateTime(2017, 2, 2), new DateTime(2017, 2, 1));
+                _yahooDataDownloader.Get(_symbol, Resolution.Daily, new DateTime(2017, 2, 2), new DateTime(2017, 2, 1), TickType.Trade);
             });
         }
 
@@ -74,7 +74,7 @@ namespace QuantConnect.Tests.Common.Util
         {
             Assert.Throws<NotSupportedException>(() =>
             {
-                _yahooDataDownloader.Get(new Symbol(SecurityIdentifier.GenerateForex("EURUSD", "USA"), "EURUSD"), Resolution.Daily, new DateTime(2017, 2, 1), new DateTime(2017, 2, 2));
+                _yahooDataDownloader.Get(new Symbol(SecurityIdentifier.GenerateForex("EURUSD", "USA"), "EURUSD"), Resolution.Daily, new DateTime(2017, 2, 1), new DateTime(2017, 2, 2), TickType.Trade);
             });
         }
 

--- a/Tests/Common/Util/YahooDataDownloaderTests.cs
+++ b/Tests/Common/Util/YahooDataDownloaderTests.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Tests.Common.Util
         [Test]
         public void GetMethod_ShouldReturn_Successfully()
         {
-            var yahooData = _yahooDataDownloader.Get(_symbol, Resolution.Daily, new DateTime(2017,1,1), DateTime.Now, TickType.Trade);
+            var yahooData = _yahooDataDownloader.Get(new DataDownloaderGetParameters(_symbol, Resolution.Daily, new DateTime(2017,1,1), DateTime.Now));
             Assert.IsTrue(yahooData.Any());
         }
 
@@ -45,7 +45,7 @@ namespace QuantConnect.Tests.Common.Util
         public void GetMethod_WithNormalDates_ShouldReturnCorrectHistoricalData()
         {
             //Arrange
-            var yahooData = _yahooDataDownloader.Get(_symbol, Resolution.Daily, new DateTime(2017,2,1), new DateTime(2017,2,2), TickType.Trade);
+            var yahooData = _yahooDataDownloader.Get(new DataDownloaderGetParameters(_symbol, Resolution.Daily, new DateTime(2017,2,1), new DateTime(2017,2,2)));
 
             //Assert
             Assert.AreEqual(yahooData.ElementAt(0).Value, 128.75);
@@ -56,7 +56,7 @@ namespace QuantConnect.Tests.Common.Util
         {
             Assert.Throws<ArgumentException>(() =>
             {
-                _yahooDataDownloader.Get(_symbol, Resolution.Minute, new DateTime(2017, 2, 1), new DateTime(2017, 2, 2), TickType.Trade);
+                _yahooDataDownloader.Get(new DataDownloaderGetParameters(_symbol, Resolution.Minute, new DateTime(2017, 2, 1), new DateTime(2017, 2, 2)));
             });
         }
 
@@ -65,7 +65,7 @@ namespace QuantConnect.Tests.Common.Util
         {
             Assert.Throws<ArgumentException>(() =>
             {
-                _yahooDataDownloader.Get(_symbol, Resolution.Daily, new DateTime(2017, 2, 2), new DateTime(2017, 2, 1), TickType.Trade);
+                _yahooDataDownloader.Get(new DataDownloaderGetParameters(_symbol, Resolution.Daily, new DateTime(2017, 2, 2), new DateTime(2017, 2, 1)));
             });
         }
 
@@ -74,7 +74,7 @@ namespace QuantConnect.Tests.Common.Util
         {
             Assert.Throws<NotSupportedException>(() =>
             {
-                _yahooDataDownloader.Get(new Symbol(SecurityIdentifier.GenerateForex("EURUSD", "USA"), "EURUSD"), Resolution.Daily, new DateTime(2017, 2, 1), new DateTime(2017, 2, 2), TickType.Trade);
+                _yahooDataDownloader.Get(new DataDownloaderGetParameters(new Symbol(SecurityIdentifier.GenerateForex("EURUSD", "USA"), "EURUSD"), Resolution.Daily, new DateTime(2017, 2, 1), new DateTime(2017, 2, 2)));
             });
         }
 

--- a/Tests/ToolBox/AlphaVantageDownloader/AlphaVantageDataDownloaderTests.cs
+++ b/Tests/ToolBox/AlphaVantageDownloader/AlphaVantageDataDownloaderTests.cs
@@ -78,7 +78,7 @@ namespace QuantConnect.Tests.ToolBox.AlphaVantageDownloader
                 })
                 .Verifiable();
 
-            var result = _downloader.Get(symbol, resolution, start, end, TickType.Trade);
+            var result = _downloader.Get(new DataDownloaderGetParameters(symbol, resolution, start, end));
 
             _avClient.Verify();
             var requestUrl = BuildUrl(request);
@@ -120,7 +120,7 @@ namespace QuantConnect.Tests.ToolBox.AlphaVantageDownloader
                 })
                 .Verifiable();
 
-            var result = _downloader.Get(symbol, resolution, start, end, TickType.Trade);
+            var result = _downloader.Get(new DataDownloaderGetParameters(symbol, resolution, start, end));
 
             _avClient.Verify();
             var requestUrl = BuildUrl(request);
@@ -173,7 +173,7 @@ namespace QuantConnect.Tests.ToolBox.AlphaVantageDownloader
                 })
                 .Verifiable();
 
-            var result = _downloader.Get(symbol, resolution, start, end, TickType.Trade).ToList();
+            var result = _downloader.Get(new DataDownloaderGetParameters(symbol, resolution, start, end)).ToList();
 
             _avClient.Verify();
             Assert.AreEqual(2, requestUrls.Count);
@@ -197,7 +197,7 @@ namespace QuantConnect.Tests.ToolBox.AlphaVantageDownloader
             var start = DateTime.UtcNow.AddMonths(-2);
             var end = DateTime.UtcNow;
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => _downloader.Get(symbol, resolution, start, end, TickType.Trade).ToList());
+            Assert.Throws<ArgumentOutOfRangeException>(() => _downloader.Get(new DataDownloaderGetParameters(symbol, resolution, start, end)).ToList());
         }
 
         [TestCase(Resolution.Minute)]
@@ -218,7 +218,7 @@ namespace QuantConnect.Tests.ToolBox.AlphaVantageDownloader
                 })
                 .Verifiable();
 
-            Assert.Throws<FormatException>(() => _downloader.Get(symbol, resolution, start, end, TickType.Trade).ToList());
+            Assert.Throws<FormatException>(() => _downloader.Get(new DataDownloaderGetParameters(symbol, resolution, start, end)).ToList());
         }
 
         [Test]
@@ -230,7 +230,7 @@ namespace QuantConnect.Tests.ToolBox.AlphaVantageDownloader
             var start = DateTime.UtcNow.AddYears(-2).AddDays(-1);
             var end = DateTime.UtcNow;
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => _downloader.Get(symbol, resolution, start, end, TickType.Trade).ToList());
+            Assert.Throws<ArgumentOutOfRangeException>(() => _downloader.Get(new DataDownloaderGetParameters(symbol, resolution, start, end)).ToList());
         }
 
         [Test]

--- a/Tests/ToolBox/AlphaVantageDownloader/AlphaVantageDataDownloaderTests.cs
+++ b/Tests/ToolBox/AlphaVantageDownloader/AlphaVantageDataDownloaderTests.cs
@@ -78,7 +78,7 @@ namespace QuantConnect.Tests.ToolBox.AlphaVantageDownloader
                 })
                 .Verifiable();
 
-            var result = _downloader.Get(symbol, resolution, start, end);
+            var result = _downloader.Get(symbol, resolution, start, end, TickType.Trade);
 
             _avClient.Verify();
             var requestUrl = BuildUrl(request);
@@ -120,7 +120,7 @@ namespace QuantConnect.Tests.ToolBox.AlphaVantageDownloader
                 })
                 .Verifiable();
 
-            var result = _downloader.Get(symbol, resolution, start, end);
+            var result = _downloader.Get(symbol, resolution, start, end, TickType.Trade);
 
             _avClient.Verify();
             var requestUrl = BuildUrl(request);
@@ -173,7 +173,7 @@ namespace QuantConnect.Tests.ToolBox.AlphaVantageDownloader
                 })
                 .Verifiable();
 
-            var result = _downloader.Get(symbol, resolution, start, end).ToList();
+            var result = _downloader.Get(symbol, resolution, start, end, TickType.Trade).ToList();
 
             _avClient.Verify();
             Assert.AreEqual(2, requestUrls.Count);
@@ -197,7 +197,7 @@ namespace QuantConnect.Tests.ToolBox.AlphaVantageDownloader
             var start = DateTime.UtcNow.AddMonths(-2);
             var end = DateTime.UtcNow;
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => _downloader.Get(symbol, resolution, start, end).ToList());
+            Assert.Throws<ArgumentOutOfRangeException>(() => _downloader.Get(symbol, resolution, start, end, TickType.Trade).ToList());
         }
 
         [TestCase(Resolution.Minute)]
@@ -218,7 +218,7 @@ namespace QuantConnect.Tests.ToolBox.AlphaVantageDownloader
                 })
                 .Verifiable();
 
-            Assert.Throws<FormatException>(() => _downloader.Get(symbol, resolution, start, end).ToList());
+            Assert.Throws<FormatException>(() => _downloader.Get(symbol, resolution, start, end, TickType.Trade).ToList());
         }
 
         [Test]
@@ -230,7 +230,7 @@ namespace QuantConnect.Tests.ToolBox.AlphaVantageDownloader
             var start = DateTime.UtcNow.AddYears(-2).AddDays(-1);
             var end = DateTime.UtcNow;
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => _downloader.Get(symbol, resolution, start, end).ToList());
+            Assert.Throws<ArgumentOutOfRangeException>(() => _downloader.Get(symbol, resolution, start, end, TickType.Trade).ToList());
         }
 
         [Test]

--- a/ToolBox/AlphaVantageDownloader/AlphaVantageDataDownloader.cs
+++ b/ToolBox/AlphaVantageDownloader/AlphaVantageDataDownloader.cs
@@ -69,8 +69,11 @@ namespace QuantConnect.ToolBox.AlphaVantageDownloader
         /// <param name="startUtc">Start time</param>
         /// <param name="endUtc">End time</param>
         /// <returns></returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
         {
+            if (tickType != TickType.Trade)
+                return Enumerable.Empty<BaseData>();
+
             var request = new RestRequest("query", DataFormat.Json);
             request.AddParameter("symbol", symbol.Value);
             request.AddParameter("datatype", "csv");

--- a/ToolBox/AlphaVantageDownloader/AlphaVantageDataDownloader.cs
+++ b/ToolBox/AlphaVantageDownloader/AlphaVantageDataDownloader.cs
@@ -68,14 +68,16 @@ namespace QuantConnect.ToolBox.AlphaVantageDownloader
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
-            Symbol symbol = dataDownloaderGetParameters.Symbol;
-            Resolution resolution = dataDownloaderGetParameters.Resolution;
-            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
-            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
-            TickType tickType = dataDownloaderGetParameters.TickType;
+            var symbol = dataDownloaderGetParameters.Symbol;
+            var resolution = dataDownloaderGetParameters.Resolution;
+            var startUtc = dataDownloaderGetParameters.StartUtc;
+            var endUtc = dataDownloaderGetParameters.EndUtc;
+            var tickType = dataDownloaderGetParameters.TickType;
 
             if (tickType != TickType.Trade)
+            {
                 return Enumerable.Empty<BaseData>();
+            }
 
             var request = new RestRequest("query", DataFormat.Json);
             request.AddParameter("symbol", symbol.Value);

--- a/ToolBox/AlphaVantageDownloader/AlphaVantageDataDownloader.cs
+++ b/ToolBox/AlphaVantageDownloader/AlphaVantageDataDownloader.cs
@@ -62,15 +62,18 @@ namespace QuantConnect.ToolBox.AlphaVantageDownloader
         }
 
         /// <summary>
-        /// Get data from API
+        /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol to download</param>
-        /// <param name="resolution">Resolution to download</param>
-        /// <param name="startUtc">Start time</param>
-        /// <param name="endUtc">End time</param>
-        /// <returns></returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
+        /// <returns>Enumerable of base data for this symbol</returns>
+        public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
+            Symbol symbol = dataDownloaderGetParameters.Symbol;
+            Resolution resolution = dataDownloaderGetParameters.Resolution;
+            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
+            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
+            TickType tickType = dataDownloaderGetParameters.TickType;
+
             if (tickType != TickType.Trade)
                 return Enumerable.Empty<BaseData>();
 

--- a/ToolBox/AlphaVantageDownloader/AlphaVantageDownloaderProgram.cs
+++ b/ToolBox/AlphaVantageDownloader/AlphaVantageDownloaderProgram.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.ToolBox.AlphaVantageDownloader
                     {
                         // Download the data
                         var symbol = Symbol.Create(ticker, SecurityType.Equity, Market.USA);
-                        var data = downloader.Get(symbol, castResolution, startDate, endDate, TickType.Trade);
+                        var data = downloader.Get(new DataDownloaderGetParameters(symbol, castResolution, startDate, endDate));
 
                         // Save the data
                         var writer = new LeanDataWriter(castResolution, symbol, Globals.DataFolder);

--- a/ToolBox/AlphaVantageDownloader/AlphaVantageDownloaderProgram.cs
+++ b/ToolBox/AlphaVantageDownloader/AlphaVantageDownloaderProgram.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.ToolBox.AlphaVantageDownloader
                     {
                         // Download the data
                         var symbol = Symbol.Create(ticker, SecurityType.Equity, Market.USA);
-                        var data = downloader.Get(symbol, castResolution, startDate, endDate);
+                        var data = downloader.Get(symbol, castResolution, startDate, endDate, TickType.Trade);
 
                         // Save the data
                         var writer = new LeanDataWriter(castResolution, symbol, Globals.DataFolder);

--- a/ToolBox/BinanceDownloader/BinanceDataDownloader.cs
+++ b/ToolBox/BinanceDownloader/BinanceDataDownloader.cs
@@ -53,8 +53,11 @@ namespace QuantConnect.ToolBox.BinanceDownloader
         /// <param name="startUtc">Start time of the data in UTC</param>
         /// <param name="endUtc">End time of the data in UTC</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
         {
+            if (tickType != TickType.Trade)
+                return Enumerable.Empty<BaseData>();
+
             if (resolution == Resolution.Tick || resolution == Resolution.Second)
             {
                 throw new ArgumentException($"Resolution not available: {resolution}");

--- a/ToolBox/BinanceDownloader/BinanceDataDownloader.cs
+++ b/ToolBox/BinanceDownloader/BinanceDataDownloader.cs
@@ -48,13 +48,16 @@ namespace QuantConnect.ToolBox.BinanceDownloader
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Resolution of the data request</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
+        public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
+            Symbol symbol = dataDownloaderGetParameters.Symbol;
+            Resolution resolution = dataDownloaderGetParameters.Resolution;
+            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
+            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
+            TickType tickType = dataDownloaderGetParameters.TickType;
+
             if (tickType != TickType.Trade)
                 return Enumerable.Empty<BaseData>();
 

--- a/ToolBox/BinanceDownloader/BinanceDataDownloader.cs
+++ b/ToolBox/BinanceDownloader/BinanceDataDownloader.cs
@@ -52,14 +52,16 @@ namespace QuantConnect.ToolBox.BinanceDownloader
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
-            Symbol symbol = dataDownloaderGetParameters.Symbol;
-            Resolution resolution = dataDownloaderGetParameters.Resolution;
-            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
-            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
-            TickType tickType = dataDownloaderGetParameters.TickType;
+            var symbol = dataDownloaderGetParameters.Symbol;
+            var resolution = dataDownloaderGetParameters.Resolution;
+            var startUtc = dataDownloaderGetParameters.StartUtc;
+            var endUtc = dataDownloaderGetParameters.EndUtc;
+            var tickType = dataDownloaderGetParameters.TickType;
 
             if (tickType != TickType.Trade)
+            {
                 return Enumerable.Empty<BaseData>();
+            }
 
             if (resolution == Resolution.Tick || resolution == Resolution.Second)
             {

--- a/ToolBox/BinanceDownloader/BinanceDownloaderProgram.cs
+++ b/ToolBox/BinanceDownloader/BinanceDownloaderProgram.cs
@@ -53,7 +53,7 @@ namespace QuantConnect.ToolBox.BinanceDownloader
                         // Download the data
                         var startDate = fromDate;
                         var symbol = downloader.GetSymbol(ticker);
-                        var data = downloader.Get(symbol, castResolution, fromDate, toDate, TickType.Trade);
+                        var data = downloader.Get(new DataDownloaderGetParameters(symbol, castResolution, fromDate, toDate));
                         var bars = data.Cast<TradeBar>().ToList();
 
                         // Save the data (single resolution)

--- a/ToolBox/BinanceDownloader/BinanceDownloaderProgram.cs
+++ b/ToolBox/BinanceDownloader/BinanceDownloaderProgram.cs
@@ -51,7 +51,6 @@ namespace QuantConnect.ToolBox.BinanceDownloader
                     foreach (var ticker in tickers)
                     {
                         // Download the data
-                        var startDate = fromDate;
                         var symbol = downloader.GetSymbol(ticker);
                         var data = downloader.Get(new DataDownloaderGetParameters(symbol, castResolution, fromDate, toDate));
                         var bars = data.Cast<TradeBar>().ToList();

--- a/ToolBox/BinanceDownloader/BinanceDownloaderProgram.cs
+++ b/ToolBox/BinanceDownloader/BinanceDownloaderProgram.cs
@@ -53,7 +53,7 @@ namespace QuantConnect.ToolBox.BinanceDownloader
                         // Download the data
                         var startDate = fromDate;
                         var symbol = downloader.GetSymbol(ticker);
-                        var data = downloader.Get(symbol, castResolution, fromDate, toDate);
+                        var data = downloader.Get(symbol, castResolution, fromDate, toDate, TickType.Trade);
                         var bars = data.Cast<TradeBar>().ToList();
 
                         // Save the data (single resolution)

--- a/ToolBox/BitfinexDownloader/BitfinexDataDownloader.cs
+++ b/ToolBox/BitfinexDownloader/BitfinexDataDownloader.cs
@@ -46,13 +46,16 @@ namespace QuantConnect.ToolBox.BitfinexDownloader
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Resolution of the data request</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
+        public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
+            Symbol symbol = dataDownloaderGetParameters.Symbol;
+            Resolution resolution = dataDownloaderGetParameters.Resolution;
+            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
+            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
+            TickType tickType = dataDownloaderGetParameters.TickType;
+
             if (tickType != TickType.Quote)
                 return Enumerable.Empty<BaseData>();
 

--- a/ToolBox/BitfinexDownloader/BitfinexDataDownloader.cs
+++ b/ToolBox/BitfinexDownloader/BitfinexDataDownloader.cs
@@ -51,8 +51,11 @@ namespace QuantConnect.ToolBox.BitfinexDownloader
         /// <param name="startUtc">Start time of the data in UTC</param>
         /// <param name="endUtc">End time of the data in UTC</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
         {
+            if (tickType != TickType.Quote)
+                return Enumerable.Empty<BaseData>();
+
             if (resolution == Resolution.Tick || resolution == Resolution.Second)
                 throw new ArgumentException($"Resolution not available: {resolution}");
 

--- a/ToolBox/BitfinexDownloader/BitfinexDataDownloader.cs
+++ b/ToolBox/BitfinexDownloader/BitfinexDataDownloader.cs
@@ -50,14 +50,16 @@ namespace QuantConnect.ToolBox.BitfinexDownloader
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
-            Symbol symbol = dataDownloaderGetParameters.Symbol;
-            Resolution resolution = dataDownloaderGetParameters.Resolution;
-            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
-            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
-            TickType tickType = dataDownloaderGetParameters.TickType;
+            var symbol = dataDownloaderGetParameters.Symbol;
+            var resolution = dataDownloaderGetParameters.Resolution;
+            var startUtc = dataDownloaderGetParameters.StartUtc;
+            var endUtc = dataDownloaderGetParameters.EndUtc;
+            var tickType = dataDownloaderGetParameters.TickType;
 
-            if (tickType != TickType.Quote)
+            if (tickType != TickType.Trade)
+            {
                 return Enumerable.Empty<BaseData>();
+            }
 
             if (resolution == Resolution.Tick || resolution == Resolution.Second)
                 throw new ArgumentException($"Resolution not available: {resolution}");
@@ -80,7 +82,7 @@ namespace QuantConnect.ToolBox.BitfinexDownloader
                 false,
                 false,
                 DataNormalizationMode.Adjusted,
-                TickType.Quote);
+                TickType.Trade);
 
             var data = _brokerage.GetHistory(historyRequest);
 

--- a/ToolBox/BitfinexDownloader/BitfinexDownloaderProgram.cs
+++ b/ToolBox/BitfinexDownloader/BitfinexDownloaderProgram.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.ToolBox.BitfinexDownloader
                         var symbol = downloader.GetSymbol(ticker);
                         foreach (var castResolution in resolutions)
                         {
-                            var data = downloader.Get(symbol, castResolution, fromDate, toDate);
+                            var data = downloader.Get(symbol, castResolution, fromDate, toDate, TickType.Trade);
 
                             // Save the data (single resolution)
                             var writer = new LeanDataWriter(castResolution, symbol, dataDirectory);

--- a/ToolBox/BitfinexDownloader/BitfinexDownloaderProgram.cs
+++ b/ToolBox/BitfinexDownloader/BitfinexDownloaderProgram.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.ToolBox.BitfinexDownloader
                         var symbol = downloader.GetSymbol(ticker);
                         foreach (var castResolution in resolutions)
                         {
-                            var data = downloader.Get(symbol, castResolution, fromDate, toDate, TickType.Trade);
+                            var data = downloader.Get(new DataDownloaderGetParameters(symbol, castResolution, fromDate, toDate));
 
                             // Save the data (single resolution)
                             var writer = new LeanDataWriter(castResolution, symbol, dataDirectory);

--- a/ToolBox/CryptoiqDownloader/CryptoiqDownloader.cs
+++ b/ToolBox/CryptoiqDownloader/CryptoiqDownloader.cs
@@ -46,15 +46,16 @@ namespace QuantConnect.ToolBox.CryptoiqDownloader
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
-            Symbol symbol = dataDownloaderGetParameters.Symbol;
-            Resolution resolution = dataDownloaderGetParameters.Resolution;
-            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
-            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
-            TickType tickType = dataDownloaderGetParameters.TickType;
+            var symbol = dataDownloaderGetParameters.Symbol;
+            var resolution = dataDownloaderGetParameters.Resolution;
+            var startUtc = dataDownloaderGetParameters.StartUtc;
+            var endUtc = dataDownloaderGetParameters.EndUtc;
+            var tickType = dataDownloaderGetParameters.TickType;
 
             if (tickType != TickType.Quote)
+            {
                 yield break;
-
+            }
             if (resolution != Resolution.Tick)
             {
                 throw new ArgumentException("Only tick data is currently supported.");

--- a/ToolBox/CryptoiqDownloader/CryptoiqDownloader.cs
+++ b/ToolBox/CryptoiqDownloader/CryptoiqDownloader.cs
@@ -42,13 +42,16 @@ namespace QuantConnect.ToolBox.CryptoiqDownloader
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Only Tick is currently supported</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
+        public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
+            Symbol symbol = dataDownloaderGetParameters.Symbol;
+            Resolution resolution = dataDownloaderGetParameters.Resolution;
+            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
+            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
+            TickType tickType = dataDownloaderGetParameters.TickType;
+
             if (tickType != TickType.Quote)
                 yield break;
 

--- a/ToolBox/CryptoiqDownloader/CryptoiqDownloader.cs
+++ b/ToolBox/CryptoiqDownloader/CryptoiqDownloader.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -47,8 +47,11 @@ namespace QuantConnect.ToolBox.CryptoiqDownloader
         /// <param name="startUtc">Start time of the data in UTC</param>
         /// <param name="endUtc">End time of the data in UTC</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
         {
+            if (tickType != TickType.Quote)
+                yield break;
+
             if (resolution != Resolution.Tick)
             {
                 throw new ArgumentException("Only tick data is currently supported.");

--- a/ToolBox/CryptoiqDownloader/CryptoiqDownloaderProgram.cs
+++ b/ToolBox/CryptoiqDownloader/CryptoiqDownloaderProgram.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.ToolBox.CryptoiqDownloader
                 {
                     // Download the data
                     var symbolObject = Symbol.Create(ticker, SecurityType.Crypto, market);
-                    var data = downloader.Get(symbolObject, Resolution.Tick, startDate, endDate);
+                    var data = downloader.Get(symbolObject, Resolution.Tick, startDate, endDate, TickType.Quote);
 
                     // Save the data
                     var writer = new LeanDataWriter(Resolution.Tick, symbolObject, dataDirectory, TickType.Quote);

--- a/ToolBox/CryptoiqDownloader/CryptoiqDownloaderProgram.cs
+++ b/ToolBox/CryptoiqDownloader/CryptoiqDownloaderProgram.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.ToolBox.CryptoiqDownloader
                 {
                     // Download the data
                     var symbolObject = Symbol.Create(ticker, SecurityType.Crypto, market);
-                    var data = downloader.Get(symbolObject, Resolution.Tick, startDate, endDate, TickType.Quote);
+                    var data = downloader.Get(new DataDownloaderGetParameters(symbolObject, Resolution.Tick, startDate, endDate, TickType.Quote));
 
                     // Save the data
                     var writer = new LeanDataWriter(Resolution.Tick, symbolObject, dataDirectory, TickType.Quote);

--- a/ToolBox/DukascopyDownloader/DukascopyDataDownloader.cs
+++ b/ToolBox/DukascopyDownloader/DukascopyDataDownloader.cs
@@ -56,13 +56,16 @@ namespace QuantConnect.ToolBox.DukascopyDownloader
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Resolution of the data request</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
+        public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
+            Symbol symbol = dataDownloaderGetParameters.Symbol;
+            Resolution resolution = dataDownloaderGetParameters.Resolution;
+            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
+            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
+            TickType tickType = dataDownloaderGetParameters.TickType;
+
             if (tickType != TickType.Quote)
                 yield break;
 

--- a/ToolBox/DukascopyDownloader/DukascopyDataDownloader.cs
+++ b/ToolBox/DukascopyDownloader/DukascopyDataDownloader.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -61,8 +61,11 @@ namespace QuantConnect.ToolBox.DukascopyDownloader
         /// <param name="startUtc">Start time of the data in UTC</param>
         /// <param name="endUtc">End time of the data in UTC</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
         {
+            if (tickType != TickType.Quote)
+                yield break;
+
             if (!_symbolMapper.IsKnownLeanSymbol(symbol))
                 throw new ArgumentException("Invalid symbol requested: " + symbol.Value);
 

--- a/ToolBox/DukascopyDownloader/DukascopyDataDownloader.cs
+++ b/ToolBox/DukascopyDownloader/DukascopyDataDownloader.cs
@@ -60,14 +60,16 @@ namespace QuantConnect.ToolBox.DukascopyDownloader
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
-            Symbol symbol = dataDownloaderGetParameters.Symbol;
-            Resolution resolution = dataDownloaderGetParameters.Resolution;
-            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
-            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
-            TickType tickType = dataDownloaderGetParameters.TickType;
+            var symbol = dataDownloaderGetParameters.Symbol;
+            var resolution = dataDownloaderGetParameters.Resolution;
+            var startUtc = dataDownloaderGetParameters.StartUtc;
+            var endUtc = dataDownloaderGetParameters.EndUtc;
+            var tickType = dataDownloaderGetParameters.TickType;
 
             if (tickType != TickType.Quote)
+            {
                 yield break;
+            }
 
             if (!_symbolMapper.IsKnownLeanSymbol(symbol))
                 throw new ArgumentException("Invalid symbol requested: " + symbol.Value);

--- a/ToolBox/DukascopyDownloader/DukascopyDownloaderProgram.cs
+++ b/ToolBox/DukascopyDownloader/DukascopyDownloaderProgram.cs
@@ -61,7 +61,7 @@ namespace QuantConnect.ToolBox.DukascopyDownloader
                 {
                     var securityType = downloader.GetSecurityType(ticker);
                     var symbolObject = Symbol.Create(ticker, securityType, Market.Dukascopy);
-                    var data = downloader.Get(symbolObject, castResolution, startDate, endDate);
+                    var data = downloader.Get(symbolObject, castResolution, startDate, endDate, TickType.Quote);
 
                     if (allResolutions)
                     {

--- a/ToolBox/DukascopyDownloader/DukascopyDownloaderProgram.cs
+++ b/ToolBox/DukascopyDownloader/DukascopyDownloaderProgram.cs
@@ -61,7 +61,7 @@ namespace QuantConnect.ToolBox.DukascopyDownloader
                 {
                     var securityType = downloader.GetSecurityType(ticker);
                     var symbolObject = Symbol.Create(ticker, securityType, Market.Dukascopy);
-                    var data = downloader.Get(symbolObject, castResolution, startDate, endDate, TickType.Quote);
+                    var data = downloader.Get(new DataDownloaderGetParameters(symbolObject, castResolution, startDate, endDate, TickType.Quote));
 
                     if (allResolutions)
                     {

--- a/ToolBox/GDAXDownloader/GDAXDownloader.cs
+++ b/ToolBox/GDAXDownloader/GDAXDownloader.cs
@@ -43,14 +43,16 @@ namespace QuantConnect.ToolBox.GDAXDownloader
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
-            Symbol symbol = dataDownloaderGetParameters.Symbol;
-            Resolution resolution = dataDownloaderGetParameters.Resolution;
-            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
-            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
-            TickType tickType = dataDownloaderGetParameters.TickType;
+            var symbol = dataDownloaderGetParameters.Symbol;
+            var resolution = dataDownloaderGetParameters.Resolution;
+            var startUtc = dataDownloaderGetParameters.StartUtc;
+            var endUtc = dataDownloaderGetParameters.EndUtc;
+            var tickType = dataDownloaderGetParameters.TickType;
 
             if (tickType != TickType.Trade)
+            {
                 return Enumerable.Empty<BaseData>();
+            }
 
             // get symbol mapper for GDAX
             var mapper = new SymbolPropertiesDatabaseSymbolMapper(Market.GDAX);

--- a/ToolBox/GDAXDownloader/GDAXDownloader.cs
+++ b/ToolBox/GDAXDownloader/GDAXDownloader.cs
@@ -37,15 +37,18 @@ namespace QuantConnect.ToolBox.GDAXDownloader
         const int MaxRequestsPerSecond = 2;
 
         /// <summary>
-        /// Get historical data enumerable for a single symbol, type and resolution given this start and end times(in UTC).
+        /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Only Tick is currently supported</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
+        public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
+            Symbol symbol = dataDownloaderGetParameters.Symbol;
+            Resolution resolution = dataDownloaderGetParameters.Resolution;
+            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
+            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
+            TickType tickType = dataDownloaderGetParameters.TickType;
+
             if (tickType != TickType.Trade)
                 return Enumerable.Empty<BaseData>();
 

--- a/ToolBox/GDAXDownloader/GDAXDownloader.cs
+++ b/ToolBox/GDAXDownloader/GDAXDownloader.cs
@@ -44,8 +44,11 @@ namespace QuantConnect.ToolBox.GDAXDownloader
         /// <param name="startUtc">Start time of the data in UTC</param>
         /// <param name="endUtc">End time of the data in UTC</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
         {
+            if (tickType != TickType.Trade)
+                return Enumerable.Empty<BaseData>();
+
             // get symbol mapper for GDAX
             var mapper = new SymbolPropertiesDatabaseSymbolMapper(Market.GDAX);
             var brokerageTicker = mapper.GetBrokerageSymbol(symbol);

--- a/ToolBox/GDAXDownloader/GDAXDownloaderProgram.cs
+++ b/ToolBox/GDAXDownloader/GDAXDownloaderProgram.cs
@@ -53,7 +53,7 @@ namespace QuantConnect.ToolBox.GDAXDownloader
                 {
                     // Download the data
                     var symbolObject = Symbol.Create(ticker, SecurityType.Crypto, market);
-                    var data = downloader.Get(symbolObject, castResolution, fromDate, toDate, TickType.Trade);
+                    var data = downloader.Get(new DataDownloaderGetParameters(symbolObject, castResolution, fromDate, toDate));
 
                     // Save the data
                     var writer = new LeanDataWriter(castResolution, symbolObject, dataDirectory, TickType.Trade);

--- a/ToolBox/GDAXDownloader/GDAXDownloaderProgram.cs
+++ b/ToolBox/GDAXDownloader/GDAXDownloaderProgram.cs
@@ -53,7 +53,7 @@ namespace QuantConnect.ToolBox.GDAXDownloader
                 {
                     // Download the data
                     var symbolObject = Symbol.Create(ticker, SecurityType.Crypto, market);
-                    var data = downloader.Get(symbolObject, castResolution, fromDate, toDate);
+                    var data = downloader.Get(symbolObject, castResolution, fromDate, toDate, TickType.Trade);
 
                     // Save the data
                     var writer = new LeanDataWriter(castResolution, symbolObject, dataDirectory, TickType.Trade);

--- a/ToolBox/IBDownloader/IBDataDownloader.cs
+++ b/ToolBox/IBDownloader/IBDataDownloader.cs
@@ -54,14 +54,16 @@ namespace QuantConnect.ToolBox.IBDownloader
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
-            Symbol symbol = dataDownloaderGetParameters.Symbol;
-            Resolution resolution = dataDownloaderGetParameters.Resolution;
-            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
-            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
-            TickType tickType = dataDownloaderGetParameters.TickType;
+            var symbol = dataDownloaderGetParameters.Symbol;
+            var resolution = dataDownloaderGetParameters.Resolution;
+            var startUtc = dataDownloaderGetParameters.StartUtc;
+            var endUtc = dataDownloaderGetParameters.EndUtc;
+            var tickType = dataDownloaderGetParameters.TickType;
 
             if (tickType != TickType.Quote)
+            {
                 yield break;
+            }
 
             if (resolution == Resolution.Tick)
             {

--- a/ToolBox/IBDownloader/IBDataDownloader.cs
+++ b/ToolBox/IBDownloader/IBDataDownloader.cs
@@ -55,8 +55,11 @@ namespace QuantConnect.ToolBox.IBDownloader
         /// <param name="startUtc">Start time of the data in UTC</param>
         /// <param name="endUtc">End time of the data in UTC</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
         {
+            if (tickType != TickType.Quote)
+                yield break;
+
             if (resolution == Resolution.Tick)
             {
                 throw new NotSupportedException("Resolution not available: " + resolution);

--- a/ToolBox/IBDownloader/IBDataDownloader.cs
+++ b/ToolBox/IBDownloader/IBDataDownloader.cs
@@ -50,13 +50,16 @@ namespace QuantConnect.ToolBox.IBDownloader
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Resolution of the data request</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
+        public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
+            Symbol symbol = dataDownloaderGetParameters.Symbol;
+            Resolution resolution = dataDownloaderGetParameters.Resolution;
+            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
+            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
+            TickType tickType = dataDownloaderGetParameters.TickType;
+
             if (tickType != TickType.Quote)
                 yield break;
 

--- a/ToolBox/IBDownloader/IBDownloaderProgram.cs
+++ b/ToolBox/IBDownloader/IBDownloaderProgram.cs
@@ -86,7 +86,7 @@ namespace QuantConnect.ToolBox.IBDownloader
 
                         while (startDate < auxEndDate)
                         {
-                            var data = downloader.Get(symbol, castResolution, startDate, auxEndDate);
+                            var data = downloader.Get(symbol, castResolution, startDate, auxEndDate, TickType.Quote);
                             var bars = data.Cast<QuoteBar>().ToList();
 
                             if (allResolutions)

--- a/ToolBox/IBDownloader/IBDownloaderProgram.cs
+++ b/ToolBox/IBDownloader/IBDownloaderProgram.cs
@@ -86,7 +86,7 @@ namespace QuantConnect.ToolBox.IBDownloader
 
                         while (startDate < auxEndDate)
                         {
-                            var data = downloader.Get(symbol, castResolution, startDate, auxEndDate, TickType.Quote);
+                            var data = downloader.Get(new DataDownloaderGetParameters(symbol, castResolution, startDate, auxEndDate, TickType.Quote));
                             var bars = data.Cast<QuoteBar>().ToList();
 
                             if (allResolutions)

--- a/ToolBox/IEX/IEXDataDownloader.cs
+++ b/ToolBox/IEX/IEXDataDownloader.cs
@@ -38,13 +38,16 @@ namespace QuantConnect.ToolBox.IEX
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Resolution of the data request</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
+        public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
+            Symbol symbol = dataDownloaderGetParameters.Symbol;
+            Resolution resolution = dataDownloaderGetParameters.Resolution;
+            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
+            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
+            TickType tickType = dataDownloaderGetParameters.TickType;
+
             if (tickType != TickType.Trade)
                 yield break;
 

--- a/ToolBox/IEX/IEXDataDownloader.cs
+++ b/ToolBox/IEX/IEXDataDownloader.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -43,8 +43,11 @@ namespace QuantConnect.ToolBox.IEX
         /// <param name="startUtc">Start time of the data in UTC</param>
         /// <param name="endUtc">End time of the data in UTC</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
         {
+            if (tickType != TickType.Trade)
+                yield break;
+
             if (!(resolution == Resolution.Daily || resolution == Resolution.Minute))
                 throw new NotSupportedException("Resolution not available: " + resolution);
 

--- a/ToolBox/IEX/IEXDataDownloader.cs
+++ b/ToolBox/IEX/IEXDataDownloader.cs
@@ -42,14 +42,16 @@ namespace QuantConnect.ToolBox.IEX
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
-            Symbol symbol = dataDownloaderGetParameters.Symbol;
-            Resolution resolution = dataDownloaderGetParameters.Resolution;
-            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
-            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
-            TickType tickType = dataDownloaderGetParameters.TickType;
+            var symbol = dataDownloaderGetParameters.Symbol;
+            var resolution = dataDownloaderGetParameters.Resolution;
+            var startUtc = dataDownloaderGetParameters.StartUtc;
+            var endUtc = dataDownloaderGetParameters.EndUtc;
+            var tickType = dataDownloaderGetParameters.TickType;
 
             if (tickType != TickType.Trade)
+            {
                 yield break;
+            }
 
             if (!(resolution == Resolution.Daily || resolution == Resolution.Minute))
                 throw new NotSupportedException("Resolution not available: " + resolution);

--- a/ToolBox/IEX/IEXDownloaderProgram.cs
+++ b/ToolBox/IEX/IEXDownloaderProgram.cs
@@ -58,7 +58,7 @@ namespace QuantConnect.ToolBox.IEX
                     {
                         // Download the data
                         var symbolObject = Symbol.Create(ticker, securityType, market);
-                        var data = downloader.Get(symbolObject, castResolution, startDate, endDate).ToArray();
+                        var data = downloader.Get(symbolObject, castResolution, startDate, endDate, TickType.Trade).ToArray();
 
                         if (data.Length == 0)
                         {

--- a/ToolBox/IEX/IEXDownloaderProgram.cs
+++ b/ToolBox/IEX/IEXDownloaderProgram.cs
@@ -58,7 +58,7 @@ namespace QuantConnect.ToolBox.IEX
                     {
                         // Download the data
                         var symbolObject = Symbol.Create(ticker, securityType, market);
-                        var data = downloader.Get(symbolObject, castResolution, startDate, endDate, TickType.Trade).ToArray();
+                        var data = downloader.Get(new DataDownloaderGetParameters(symbolObject, castResolution, startDate, endDate)).ToArray();
 
                         if (data.Length == 0)
                         {

--- a/ToolBox/IQFeedDownloader/IQFeedDataDownloader.cs
+++ b/ToolBox/IQFeedDownloader/IQFeedDataDownloader.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
@@ -22,18 +23,6 @@ namespace QuantConnect.ToolBox.IQFeedDownloader
         public IQFeedDataDownloader(IQFeedFileHistoryProvider fileHistoryProvider)
         {
             _fileHistoryProvider = fileHistoryProvider;
-            _tickType = TickType.Trade;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IQFeedDataDownloader"/> class
-        /// </summary>
-        /// <param name="fileHistoryProvider"></param>
-        /// <param name="tickType"></param>
-        public IQFeedDataDownloader(IQFeedFileHistoryProvider fileHistoryProvider, TickType tickType)
-        {
-            _fileHistoryProvider = fileHistoryProvider;
-            _tickType = tickType;
         }
 
         /// <summary>
@@ -44,8 +33,11 @@ namespace QuantConnect.ToolBox.IQFeedDownloader
         /// <param name="startUtc">Start time of the data in UTC</param>
         /// <param name="endUtc">End time of the data in UTC</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
         {
+            if (tickType == TickType.OpenInterest)
+                return Enumerable.Empty<BaseData>();
+
             if (symbol.ID.SecurityType != SecurityType.Equity)
                 throw new NotSupportedException("SecurityType not available: " + symbol.ID.SecurityType);
 
@@ -67,7 +59,7 @@ namespace QuantConnect.ToolBox.IQFeedDownloader
                     true,
                     false,
                     DataNormalizationMode.Adjusted,
-                    _tickType));
+                    tickType));
         }
     }
 }

--- a/ToolBox/IQFeedDownloader/IQFeedDataDownloader.cs
+++ b/ToolBox/IQFeedDownloader/IQFeedDataDownloader.cs
@@ -32,14 +32,16 @@ namespace QuantConnect.ToolBox.IQFeedDownloader
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
-            Symbol symbol = dataDownloaderGetParameters.Symbol;
-            Resolution resolution = dataDownloaderGetParameters.Resolution;
-            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
-            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
-            TickType tickType = dataDownloaderGetParameters.TickType;
+            var symbol = dataDownloaderGetParameters.Symbol;
+            var resolution = dataDownloaderGetParameters.Resolution;
+            var startUtc = dataDownloaderGetParameters.StartUtc;
+            var endUtc = dataDownloaderGetParameters.EndUtc;
+            var tickType = dataDownloaderGetParameters.TickType;
 
             if (tickType == TickType.OpenInterest)
+            {
                 return Enumerable.Empty<BaseData>();
+            }
 
             if (symbol.ID.SecurityType != SecurityType.Equity)
                 throw new NotSupportedException("SecurityType not available: " + symbol.ID.SecurityType);

--- a/ToolBox/IQFeedDownloader/IQFeedDataDownloader.cs
+++ b/ToolBox/IQFeedDownloader/IQFeedDataDownloader.cs
@@ -28,13 +28,16 @@ namespace QuantConnect.ToolBox.IQFeedDownloader
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Resolution of the data request</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
+        public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
+            Symbol symbol = dataDownloaderGetParameters.Symbol;
+            Resolution resolution = dataDownloaderGetParameters.Resolution;
+            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
+            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
+            TickType tickType = dataDownloaderGetParameters.TickType;
+
             if (tickType == TickType.OpenInterest)
                 return Enumerable.Empty<BaseData>();
 

--- a/ToolBox/IQFeedDownloader/IQFeedDownloaderProgram.cs
+++ b/ToolBox/IQFeedDownloader/IQFeedDownloaderProgram.cs
@@ -85,7 +85,7 @@ namespace QuantConnect.ToolBox.IQFeedDownloader
                  {
                      // Download the data
                      var symbol = Symbol.Create(request.Ticker, SecurityType.Equity, market);
-                     var data = downloader.Get(symbol, request.Resolution, startDate, endDate, TickType.Trade);
+                     var data = downloader.Get(new DataDownloaderGetParameters(symbol, request.Resolution, startDate, endDate));
 
                      // Write the data
                      var writer = new LeanDataWriter(request.Resolution, symbol, dataDirectory);
@@ -93,7 +93,7 @@ namespace QuantConnect.ToolBox.IQFeedDownloader
 
                      if (request.Resolution == Resolution.Tick)
                      {
-                         var quotes = quoteDownloader.Get(symbol, request.Resolution, startDate, endDate, TickType.Quote);
+                         var quotes = quoteDownloader.Get(new DataDownloaderGetParameters(symbol, request.Resolution, startDate, endDate, TickType.Quote));
                          var quoteWriter = new LeanDataWriter(request.Resolution, symbol, dataDirectory, TickType.Quote);
                          quoteWriter.Write(quotes);
                      }

--- a/ToolBox/IQFeedDownloader/IQFeedDownloaderProgram.cs
+++ b/ToolBox/IQFeedDownloader/IQFeedDownloaderProgram.cs
@@ -75,7 +75,7 @@ namespace QuantConnect.ToolBox.IQFeedDownloader
                 var universeProvider = new IQFeedDataQueueUniverseProvider();
                 var historyProvider = new IQFeedFileHistoryProvider(lookupClient, universeProvider, MarketHoursDatabase.FromDataFolder());
                 var downloader = new IQFeedDataDownloader(historyProvider);
-                var quoteDownloader = new IQFeedDataDownloader(historyProvider, TickType.Quote);
+                var quoteDownloader = new IQFeedDataDownloader(historyProvider);
 
                 var resolutions = allResolution ? new List<Resolution> { Resolution.Tick, Resolution.Second, Resolution.Minute, Resolution.Hour, Resolution.Daily } : new List<Resolution> { castResolution };
                 var requests = resolutions.SelectMany(r => tickers.Select(t => new { Ticker = t, Resolution = r })).ToList();
@@ -85,7 +85,7 @@ namespace QuantConnect.ToolBox.IQFeedDownloader
                  {
                      // Download the data
                      var symbol = Symbol.Create(request.Ticker, SecurityType.Equity, market);
-                     var data = downloader.Get(symbol, request.Resolution, startDate, endDate);
+                     var data = downloader.Get(symbol, request.Resolution, startDate, endDate, TickType.Trade);
 
                      // Write the data
                      var writer = new LeanDataWriter(request.Resolution, symbol, dataDirectory);
@@ -93,7 +93,7 @@ namespace QuantConnect.ToolBox.IQFeedDownloader
 
                      if (request.Resolution == Resolution.Tick)
                      {
-                         var quotes = quoteDownloader.Get(symbol, request.Resolution, startDate, endDate);
+                         var quotes = quoteDownloader.Get(symbol, request.Resolution, startDate, endDate, TickType.Quote);
                          var quoteWriter = new LeanDataWriter(request.Resolution, symbol, dataDirectory, TickType.Quote);
                          quoteWriter.Write(quotes);
                      }

--- a/ToolBox/KrakenDataDownloader/KrakenDataDownloader.cs
+++ b/ToolBox/KrakenDataDownloader/KrakenDataDownloader.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2017 QuantConnect Corporation.
  *
@@ -39,8 +39,11 @@ namespace QuantConnect.ToolBox.KrakenDownloader
         /// <param name="startUtc">Start time of the data in UTC</param>
         /// <param name="endUtc">End time of the data in UTC</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
         {
+            if (tickType != TickType.Trade)
+                yield break;
+
             if (endUtc < startUtc)
             {
                 throw new ArgumentException("The end date must be greater or equal than the start date.");

--- a/ToolBox/KrakenDataDownloader/KrakenDataDownloader.cs
+++ b/ToolBox/KrakenDataDownloader/KrakenDataDownloader.cs
@@ -32,15 +32,18 @@ namespace QuantConnect.ToolBox.KrakenDownloader
         private const string UrlPrototype = @"https://api.kraken.com/0/public/Trades?pair={0}&since={1}";
 
         /// <summary>
-        /// Get historical data enumerable for a trading pair, type and resolution given this start and end time (in UTC).
+        /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Resolution of the data request</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
+        public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
+            Symbol symbol = dataDownloaderGetParameters.Symbol;
+            Resolution resolution = dataDownloaderGetParameters.Resolution;
+            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
+            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
+            TickType tickType = dataDownloaderGetParameters.TickType;
+
             if (tickType != TickType.Trade)
                 yield break;
 

--- a/ToolBox/KrakenDataDownloader/KrakenDataDownloader.cs
+++ b/ToolBox/KrakenDataDownloader/KrakenDataDownloader.cs
@@ -38,14 +38,16 @@ namespace QuantConnect.ToolBox.KrakenDownloader
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
-            Symbol symbol = dataDownloaderGetParameters.Symbol;
-            Resolution resolution = dataDownloaderGetParameters.Resolution;
-            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
-            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
-            TickType tickType = dataDownloaderGetParameters.TickType;
+            var symbol = dataDownloaderGetParameters.Symbol;
+            var resolution = dataDownloaderGetParameters.Resolution;
+            var startUtc = dataDownloaderGetParameters.StartUtc;
+            var endUtc = dataDownloaderGetParameters.EndUtc;
+            var tickType = dataDownloaderGetParameters.TickType;
 
             if (tickType != TickType.Trade)
+            {
                 yield break;
+            }
 
             if (endUtc < startUtc)
             {

--- a/ToolBox/KrakenDataDownloader/KrakenDownloaderProgram.cs
+++ b/ToolBox/KrakenDataDownloader/KrakenDownloaderProgram.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.ToolBox.KrakenDownloader
                 {
                     // Download data
                     var pairObject = Symbol.Create(pair, SecurityType.Crypto, Market.Kraken);
-                    var data = downloader.Get(pairObject, castResolution, startDate, endDate);
+                    var data = downloader.Get(pairObject, castResolution, startDate, endDate, TickType.Trade);
 
                     // Write data
                     var writer = new LeanDataWriter(castResolution, pairObject, dataDirectory);

--- a/ToolBox/KrakenDataDownloader/KrakenDownloaderProgram.cs
+++ b/ToolBox/KrakenDataDownloader/KrakenDownloaderProgram.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.ToolBox.KrakenDownloader
                 {
                     // Download data
                     var pairObject = Symbol.Create(pair, SecurityType.Crypto, Market.Kraken);
-                    var data = downloader.Get(pairObject, castResolution, startDate, endDate, TickType.Trade);
+                    var data = downloader.Get(new DataDownloaderGetParameters(pairObject, castResolution, startDate, endDate));
 
                     // Write data
                     var writer = new LeanDataWriter(castResolution, pairObject, dataDirectory);

--- a/ToolBox/OandaDownloader/OandaDataDownloader.cs
+++ b/ToolBox/OandaDownloader/OandaDataDownloader.cs
@@ -70,13 +70,16 @@ namespace QuantConnect.ToolBox.OandaDownloader
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Resolution of the data request</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
+        public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
+            Symbol symbol = dataDownloaderGetParameters.Symbol;
+            Resolution resolution = dataDownloaderGetParameters.Resolution;
+            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
+            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
+            TickType tickType = dataDownloaderGetParameters.TickType;
+
             if (tickType != TickType.Quote)
                 yield break;
 

--- a/ToolBox/OandaDownloader/OandaDataDownloader.cs
+++ b/ToolBox/OandaDownloader/OandaDataDownloader.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -75,8 +75,11 @@ namespace QuantConnect.ToolBox.OandaDownloader
         /// <param name="startUtc">Start time of the data in UTC</param>
         /// <param name="endUtc">End time of the data in UTC</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
         {
+            if (tickType != TickType.Quote)
+                yield break;
+
             if (!_symbolMapper.IsKnownLeanSymbol(symbol))
                 throw new ArgumentException("Invalid symbol requested: " + symbol.Value);
 

--- a/ToolBox/OandaDownloader/OandaDataDownloader.cs
+++ b/ToolBox/OandaDownloader/OandaDataDownloader.cs
@@ -74,14 +74,16 @@ namespace QuantConnect.ToolBox.OandaDownloader
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
-            Symbol symbol = dataDownloaderGetParameters.Symbol;
-            Resolution resolution = dataDownloaderGetParameters.Resolution;
-            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
-            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
-            TickType tickType = dataDownloaderGetParameters.TickType;
+            var symbol = dataDownloaderGetParameters.Symbol;
+            var resolution = dataDownloaderGetParameters.Resolution;
+            var startUtc = dataDownloaderGetParameters.StartUtc;
+            var endUtc = dataDownloaderGetParameters.EndUtc;
+            var tickType = dataDownloaderGetParameters.TickType;
 
             if (tickType != TickType.Quote)
+            {
                 yield break;
+            }
 
             if (!_symbolMapper.IsKnownLeanSymbol(symbol))
                 throw new ArgumentException("Invalid symbol requested: " + symbol.Value);

--- a/ToolBox/OandaDownloader/OandaDownloaderProgram.cs
+++ b/ToolBox/OandaDownloader/OandaDownloaderProgram.cs
@@ -66,7 +66,7 @@ namespace QuantConnect.ToolBox.OandaDownloader
                     var securityType = downloader.GetSecurityType(ticker);
                     var symbol = Symbol.Create(ticker, securityType, market);
 
-                    var data = downloader.Get(symbol, castResolution, startDate, endDate);
+                    var data = downloader.Get(symbol, castResolution, startDate, endDate, TickType.Quote);
 
                     if (allResolutions)
                     {

--- a/ToolBox/OandaDownloader/OandaDownloaderProgram.cs
+++ b/ToolBox/OandaDownloader/OandaDownloaderProgram.cs
@@ -66,7 +66,7 @@ namespace QuantConnect.ToolBox.OandaDownloader
                     var securityType = downloader.GetSecurityType(ticker);
                     var symbol = Symbol.Create(ticker, securityType, market);
 
-                    var data = downloader.Get(symbol, castResolution, startDate, endDate, TickType.Quote);
+                    var data = downloader.Get(new DataDownloaderGetParameters(symbol, castResolution, startDate, endDate, TickType.Quote));
 
                     if (allResolutions)
                     {

--- a/ToolBox/Polygon/PolygonDataDownloader.cs
+++ b/ToolBox/Polygon/PolygonDataDownloader.cs
@@ -35,11 +35,11 @@ namespace QuantConnect.ToolBox.Polygon
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
-            Symbol symbol = dataDownloaderGetParameters.Symbol;
-            Resolution resolution = dataDownloaderGetParameters.Resolution;
-            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
-            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
-            TickType tickType = dataDownloaderGetParameters.TickType;
+            var symbol = dataDownloaderGetParameters.Symbol;
+            var resolution = dataDownloaderGetParameters.Resolution;
+            var startUtc = dataDownloaderGetParameters.StartUtc;
+            var endUtc = dataDownloaderGetParameters.EndUtc;
+            var tickType = dataDownloaderGetParameters.TickType;
 
             if (symbol.SecurityType != SecurityType.Equity &&
                 symbol.SecurityType != SecurityType.Forex && 

--- a/ToolBox/Polygon/PolygonDataDownloader.cs
+++ b/ToolBox/Polygon/PolygonDataDownloader.cs
@@ -31,14 +31,16 @@ namespace QuantConnect.ToolBox.Polygon
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Resolution of the data request</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
-        /// <param name="tickType">The tick type (Trade or Quote)</param>
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
+        public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
+            Symbol symbol = dataDownloaderGetParameters.Symbol;
+            Resolution resolution = dataDownloaderGetParameters.Resolution;
+            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
+            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
+            TickType tickType = dataDownloaderGetParameters.TickType;
+
             if (symbol.SecurityType != SecurityType.Equity &&
                 symbol.SecurityType != SecurityType.Forex && 
                 symbol.SecurityType != SecurityType.Crypto)

--- a/ToolBox/Polygon/PolygonDataDownloader.cs
+++ b/ToolBox/Polygon/PolygonDataDownloader.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -27,19 +27,6 @@ namespace QuantConnect.ToolBox.Polygon
     public class PolygonDataDownloader : IDataDownloader, IDisposable
     {
         private readonly PolygonDataQueueHandler _historyProvider = new PolygonDataQueueHandler(false);
-
-        /// <summary>
-        /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
-        /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Resolution of the data request</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
-        /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
-        {
-            return Get(symbol, resolution, startUtc, endUtc, TickType.Trade);
-        }
 
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).

--- a/ToolBox/Polygon/PolygonDownloaderProgram.cs
+++ b/ToolBox/Polygon/PolygonDownloaderProgram.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -72,7 +72,7 @@ namespace QuantConnect.ToolBox.Polygon
                         foreach (var tickType in tickTypes)
                         {
                             // Download the data
-                            var data = downloader.Get(symbol, resolution, startDate, endDate, tickType)
+                            var data = downloader.Get(new DataDownloaderGetParameters(symbol, resolution, startDate, endDate, tickType))
                                 .Select(x =>
                                     {
                                         x.Time = x.Time.ConvertTo(exchangeTimeZone, dataTimeZone);

--- a/ToolBox/QuandlBitfinexDownloader/QuandlBitfinexDownloader.cs
+++ b/ToolBox/QuandlBitfinexDownloader/QuandlBitfinexDownloader.cs
@@ -39,15 +39,18 @@ namespace QuantConnect.ToolBox.QuandlBitfinexDownloader
         }
 
         /// <summary>
-        /// Get historical data enumerable for Bitfinex from Quandl
+        /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Only Daily is supported</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
+        public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
+            Symbol symbol = dataDownloaderGetParameters.Symbol;
+            Resolution resolution = dataDownloaderGetParameters.Resolution;
+            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
+            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
+            TickType tickType = dataDownloaderGetParameters.TickType;
+
             if (tickType != TickType.Trade)
                 yield break;
 

--- a/ToolBox/QuandlBitfinexDownloader/QuandlBitfinexDownloader.cs
+++ b/ToolBox/QuandlBitfinexDownloader/QuandlBitfinexDownloader.cs
@@ -39,20 +39,22 @@ namespace QuantConnect.ToolBox.QuandlBitfinexDownloader
         }
 
         /// <summary>
-        /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
+        /// Get historical data enumerable for Bitfinex from Quandl
         /// </summary>
         /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
-            Symbol symbol = dataDownloaderGetParameters.Symbol;
-            Resolution resolution = dataDownloaderGetParameters.Resolution;
-            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
-            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
-            TickType tickType = dataDownloaderGetParameters.TickType;
+            var symbol = dataDownloaderGetParameters.Symbol;
+            var resolution = dataDownloaderGetParameters.Resolution;
+            var startUtc = dataDownloaderGetParameters.StartUtc;
+            var endUtc = dataDownloaderGetParameters.EndUtc;
+            var tickType = dataDownloaderGetParameters.TickType;
 
             if (tickType != TickType.Trade)
+            {
                 yield break;
+            }
 
             if (resolution != Resolution.Daily)
             {

--- a/ToolBox/QuandlBitfinexDownloader/QuandlBitfinexDownloader.cs
+++ b/ToolBox/QuandlBitfinexDownloader/QuandlBitfinexDownloader.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -46,8 +46,11 @@ namespace QuantConnect.ToolBox.QuandlBitfinexDownloader
         /// <param name="startUtc">Start time of the data in UTC</param>
         /// <param name="endUtc">End time of the data in UTC</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
         {
+            if (tickType != TickType.Trade)
+                yield break;
+
             if (resolution != Resolution.Daily)
             {
                 throw new ArgumentException("Only daily data is currently supported.");

--- a/ToolBox/QuandlBitfinexDownloader/QuandlBitfinexDownloaderProgram.cs
+++ b/ToolBox/QuandlBitfinexDownloader/QuandlBitfinexDownloaderProgram.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.ToolBox.QuandlBitfinexDownloader
 
                 // Download the data
                 var symbol = Symbol.Create("BTCUSD", SecurityType.Forex, market);
-                var data = downloader.Get(symbol, Resolution.Daily, fromDate, DateTime.UtcNow, TickType.Trade);
+                var data = downloader.Get(new DataDownloaderGetParameters(symbol, Resolution.Daily, fromDate, DateTime.UtcNow));
 
                 // Save the data
                 var writer = new LeanDataWriter(Resolution.Daily, symbol, dataDirectory, TickType.Trade);

--- a/ToolBox/QuandlBitfinexDownloader/QuandlBitfinexDownloaderProgram.cs
+++ b/ToolBox/QuandlBitfinexDownloader/QuandlBitfinexDownloaderProgram.cs
@@ -44,10 +44,10 @@ namespace QuantConnect.ToolBox.QuandlBitfinexDownloader
 
                 // Download the data
                 var symbol = Symbol.Create("BTCUSD", SecurityType.Forex, market);
-                var data = downloader.Get(symbol, Resolution.Daily, fromDate, DateTime.UtcNow);
+                var data = downloader.Get(symbol, Resolution.Daily, fromDate, DateTime.UtcNow, TickType.Trade);
 
                 // Save the data
-                var writer = new LeanDataWriter(Resolution.Daily, symbol, dataDirectory, TickType.Quote);
+                var writer = new LeanDataWriter(Resolution.Daily, symbol, dataDirectory, TickType.Trade);
                 writer.Write(data);
             }
             catch (Exception err)

--- a/ToolBox/YahooDownloader/YahooDataDownloader.cs
+++ b/ToolBox/YahooDownloader/YahooDataDownloader.cs
@@ -32,14 +32,16 @@ namespace QuantConnect.ToolBox.YahooDownloader
         /// <returns>Enumerable of base data for this symbol</returns>
         public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
-            Symbol symbol = dataDownloaderGetParameters.Symbol;
-            Resolution resolution = dataDownloaderGetParameters.Resolution;
-            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
-            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
-            TickType tickType = dataDownloaderGetParameters.TickType;
+            var symbol = dataDownloaderGetParameters.Symbol;
+            var resolution = dataDownloaderGetParameters.Resolution;
+            var startUtc = dataDownloaderGetParameters.StartUtc;
+            var endUtc = dataDownloaderGetParameters.EndUtc;
+            var tickType = dataDownloaderGetParameters.TickType;
 
             if (tickType != TickType.Trade)
+            {
                 return Enumerable.Empty<BaseData>();
+            }
 
             if (resolution != Resolution.Daily)
             {

--- a/ToolBox/YahooDownloader/YahooDataDownloader.cs
+++ b/ToolBox/YahooDownloader/YahooDataDownloader.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -33,8 +33,11 @@ namespace QuantConnect.ToolBox.YahooDownloader
         /// <param name="startUtc">Start time of the data in UTC</param>
         /// <param name="endUtc">End time of the data in UTC</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc)
+        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
         {
+            if (tickType != TickType.Trade)
+                return Enumerable.Empty<BaseData>();
+
             if (resolution != Resolution.Daily)
             {
                 throw new ArgumentException("The YahooDataDownloader can only download daily data.");

--- a/ToolBox/YahooDownloader/YahooDataDownloader.cs
+++ b/ToolBox/YahooDownloader/YahooDataDownloader.cs
@@ -28,13 +28,16 @@ namespace QuantConnect.ToolBox.YahooDownloader
         /// <summary>
         /// Get historical data enumerable for a single symbol, type and resolution given this start and end time (in UTC).
         /// </summary>
-        /// <param name="symbol">Symbol for the data we're looking for.</param>
-        /// <param name="resolution">Resolution of the data request</param>
-        /// <param name="startUtc">Start time of the data in UTC</param>
-        /// <param name="endUtc">End time of the data in UTC</param>
+        /// <param name="dataDownloaderGetParameters">model class for passing in parameters for historical data</param>
         /// <returns>Enumerable of base data for this symbol</returns>
-        public IEnumerable<BaseData> Get(Symbol symbol, Resolution resolution, DateTime startUtc, DateTime endUtc, TickType tickType)
+        public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
         {
+            Symbol symbol = dataDownloaderGetParameters.Symbol;
+            Resolution resolution = dataDownloaderGetParameters.Resolution;
+            DateTime startUtc = dataDownloaderGetParameters.StartUtc;
+            DateTime endUtc = dataDownloaderGetParameters.EndUtc;
+            TickType tickType = dataDownloaderGetParameters.TickType;
+
             if (tickType != TickType.Trade)
                 return Enumerable.Empty<BaseData>();
 

--- a/ToolBox/YahooDownloader/YahooDownloaderProgram.cs
+++ b/ToolBox/YahooDownloader/YahooDownloaderProgram.cs
@@ -52,7 +52,7 @@ namespace QuantConnect.ToolBox.YahooDownloader
                 {
                     // Download the data
                     var symbolObject = Symbol.Create(ticker, SecurityType.Equity, market);
-                    var data = downloader.Get(symbolObject, castResolution, startDate, endDate, TickType.Trade);
+                    var data = downloader.Get(new DataDownloaderGetParameters(symbolObject, castResolution, startDate, endDate));
 
                     // Save the data
                     var writer = new LeanDataWriter(castResolution, symbolObject, dataDirectory);

--- a/ToolBox/YahooDownloader/YahooDownloaderProgram.cs
+++ b/ToolBox/YahooDownloader/YahooDownloaderProgram.cs
@@ -52,7 +52,7 @@ namespace QuantConnect.ToolBox.YahooDownloader
                 {
                     // Download the data
                     var symbolObject = Symbol.Create(ticker, SecurityType.Equity, market);
-                    var data = downloader.Get(symbolObject, castResolution, startDate, endDate);
+                    var data = downloader.Get(symbolObject, castResolution, startDate, endDate, TickType.Trade);
 
                     // Save the data
                     var writer = new LeanDataWriter(castResolution, symbolObject, dataDirectory);


### PR DESCRIPTION
…pi's with rate limits to handle not making an api call at all.


<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Add tick type to data downloader get call so that api limits are not incremented when data does not match type that lean is requesting

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#6056 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Reduces rate limits being hit

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and integration tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
