### PR TITLE
Add Overload in SecurityTransactionManager Methods to Support Python Functions

### DIFF
--- a/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
+++ b/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
@@ -488,10 +488,10 @@ namespace QuantConnect.Algorithm.CSharp
             }
 
             var filledOrderTickets = Transactions.GetOrderTickets(x => x.Status == OrderStatus.Filled);
-
+            Log("Order ticket types");
             foreach (var ticket in filledOrderTickets)
             {
-                Log($"Ticket symbol: {ticket.Symbol}");
+                Log($"Order ticket type: {ticket.OrderType}");
             }
         }
 

--- a/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
+++ b/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
@@ -509,6 +509,25 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 throw new Exception($"No remaining quantiy to be filled from open orders was expected");
             }
+
+            var defaultOrders = Transactions.GetOrders();
+            var defaultOrderTickets = Transactions.GetOrderTickets();
+            var defaultOpenOrders = Transactions.GetOpenOrders();
+            var defaultOpenOrderTickets = Transactions.GetOpenOrderTickets();
+            var defaultOpenOrdersRemaining = Transactions.GetOpenOrdersRemainingQuantity();
+
+            if (defaultOrders.Count() != 10 || defaultOrderTickets.Count() != 10)
+            {
+                throw new Exception($"There were expected 10 orders and 10 order tickets");
+            }
+            if (defaultOpenOrders.Count != 0 || defaultOpenOrderTickets.Any())
+            {
+                throw new Exception($"No open orders or tickets were expected");
+            }
+            if (defaultOpenOrdersRemaining != 0m)
+            {
+                throw new Exception($"No remaining quantiy to be filled from open orders was expected");
+            }
         }
 
         /// <summary>

--- a/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
+++ b/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
@@ -476,22 +476,25 @@ namespace QuantConnect.Algorithm.CSharp
 
         public override void OnEndOfAlgorithm()
         {
-            var filledOrders = Transactions.GetOrders(x => x.Status == OrderStatus.Filled);
-            var openOrders = Transactions.GetOpenOrders(x => true);
-            if (filledOrders.Count() != 8)
-            {
-                throw new Exception($"There were expected 8 filled orders but there were only {filledOrders.Count()}");
-            }
-            if (openOrders.Count != 0)
-            {
-                throw new Exception($"No open order was expected but there were {openOrders.Count} orders");
-            }
+            Func<OrderTicket, bool> basicOrderTicketFilter = x => x.Symbol == symbol;
 
-            var filledOrderTickets = Transactions.GetOrderTickets(x => x.Status == OrderStatus.Filled);
-            Log("Order ticket types");
-            foreach (var ticket in filledOrderTickets)
+            var filledOrders = Transactions.GetOrders(x => x.Status == OrderStatus.Filled);
+            var orderTickets = Transactions.GetOrderTickets(basicOrderTicketFilter);
+            var openOrders = Transactions.GetOpenOrders(x => x.Symbol == symbol);
+            var openOrderTickets = Transactions.GetOpenOrderTickets(basicOrderTicketFilter);
+            var remainingOpenOrders = Transactions.GetOpenOrdersRemainingQuantity(basicOrderTicketFilter);
+
+            if (filledOrders.Count() != 8 || orderTickets.Count() != 10)
             {
-                Log($"Order ticket type: {ticket.OrderType}");
+                throw new Exception($"There were expected 8 filled orders and 10 order tickets");
+            }
+            if (openOrders.Count != 0 || openOrderTickets.Any())
+            {
+                throw new Exception($"No open orders or tickets were expected");
+            }
+            if (remainingOpenOrders != 0m)
+            {
+                throw new Exception($"No remaining quantiy to be filled from open orders was expected");
             }
         }
 

--- a/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
+++ b/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
@@ -496,6 +496,19 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 throw new Exception($"No remaining quantiy to be filled from open orders was expected");
             }
+
+            var symbolOpenOrders = Transactions.GetOpenOrders(symbol).Count;
+            var symbolOpenOrdersTickets = Transactions.GetOpenOrderTickets(symbol).Count();
+            var symbolOpenOrdersRemainingQuantity = Transactions.GetOpenOrdersRemainingQuantity(symbol);
+
+            if (symbolOpenOrders != 0 || symbolOpenOrdersTickets != 0)
+            {
+                throw new Exception($"No open orders or tickets were expected");
+            }
+            if (symbolOpenOrdersRemainingQuantity != 0)
+            {
+                throw new Exception($"No remaining quantiy to be filled from open orders was expected");
+            }
         }
 
         /// <summary>

--- a/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
+++ b/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;
+using System.Linq;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -471,6 +472,27 @@ namespace QuantConnect.Algorithm.CSharp
         private bool TimeIs(int day, int hour, int minute)
         {
             return Time.Day == day && Time.Hour == hour && Time.Minute == minute;
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            var filledOrders = Transactions.GetOrders(x => x.Status == OrderStatus.Filled);
+            var openOrders = Transactions.GetOpenOrders(x => true);
+            if (filledOrders.Count() != 8)
+            {
+                throw new Exception($"There were expected 8 filled orders but there were only {filledOrders.Count()}");
+            }
+            if (openOrders.Count != 0)
+            {
+                throw new Exception($"No open order was expected but there were {openOrders.Count} orders");
+            }
+
+            var filledOrderTickets = Transactions.GetOrderTickets(x => x.Status == OrderStatus.Filled);
+
+            foreach (var ticket in filledOrderTickets)
+            {
+                Log($"Ticket symbol: {ticket.Symbol}");
+            }
         }
 
         /// <summary>

--- a/Algorithm.Python/OrderTicketDemoAlgorithm.py
+++ b/Algorithm.Python/OrderTicketDemoAlgorithm.py
@@ -353,5 +353,6 @@ class OrderTicketDemoAlgorithm(QCAlgorithm):
         assert(not len(openOrders))
 
         filledOrderTickets = self.Transactions.GetOrderTickets(lambda x: x.Status == OrderStatus.Filled)
+        self.Log("Order ticket types")
         for ticket in filledOrderTickets:
-            self.Log("Ticket symbol: " + str(ticket.Symbol))
+            self.Log("Order ticket type: " + str(ticket.OrderType))

--- a/Algorithm.Python/OrderTicketDemoAlgorithm.py
+++ b/Algorithm.Python/OrderTicketDemoAlgorithm.py
@@ -343,16 +343,19 @@ class OrderTicketDemoAlgorithm(QCAlgorithm):
         return self.Time.day == day and self.Time.hour == hour and self.Time.minute == minute
 
     def OnEndOfAlgorithm(self):
-        filledOrders = self.Transactions.GetOrders(lambda x: x.Status == OrderStatus.Filled)
-        openOrders = self.Transactions.GetOpenOrders(lambda x: True)
+        basicOrderTicketFilter = lambda x: x.Symbol == self.spy;
+
+        filledOrders = self.Transactions.GetOrders(lambda x: x.Status == OrderStatus.Filled);
+        orderTickets = self.Transactions.GetOrderTickets(basicOrderTicketFilter);
+        openOrders = self.Transactions.GetOpenOrders(lambda x: x.Symbol == symbol);
+        openOrderTickets = self.Transactions.GetOpenOrderTickets(basicOrderTicketFilter);
+        remainingOpenOrders = self.Transactions.GetOpenOrdersRemainingQuantity(basicOrderTicketFilter);
 
         # The type returned by self.Transactions.GetOrders() is iterable and not a list
         # that's why we use sum() to get the size of the iterable object type
         filledOrdersSize = sum(1 for order in filledOrders)
-        assert(filledOrdersSize == 8)
-        assert(not len(openOrders))
-
-        filledOrderTickets = self.Transactions.GetOrderTickets(lambda x: x.Status == OrderStatus.Filled)
-        self.Log("Order ticket types")
-        for ticket in filledOrderTickets:
-            self.Log("Order ticket type: " + str(ticket.OrderType))
+        orderTicketsSize = sum(1 for ticket in orderTickets)
+        openOrderTicketsSize = sum(1 for ticket in openOrderTickets)
+        assert(filledOrdersSize == 8 and orderTicketsSize == 10), "There were expected 8 filled orders and 10 order tickets"
+        assert(not (len(openOrders) or openOrderTicketsSize)), "No open orders or tickets were expected"
+        assert(not remainingOpenOrders), "No remaining quantiy to be filled from open orders was expected"

--- a/Algorithm.Python/OrderTicketDemoAlgorithm.py
+++ b/Algorithm.Python/OrderTicketDemoAlgorithm.py
@@ -347,7 +347,7 @@ class OrderTicketDemoAlgorithm(QCAlgorithm):
 
         filledOrders = self.Transactions.GetOrders(lambda x: x.Status == OrderStatus.Filled);
         orderTickets = self.Transactions.GetOrderTickets(basicOrderTicketFilter);
-        openOrders = self.Transactions.GetOpenOrders(lambda x: x.Symbol == symbol);
+        openOrders = self.Transactions.GetOpenOrders(lambda x: x.Symbol == self.spy);
         openOrderTickets = self.Transactions.GetOpenOrderTickets(basicOrderTicketFilter);
         remainingOpenOrders = self.Transactions.GetOpenOrdersRemainingQuantity(basicOrderTicketFilter);
 
@@ -356,6 +356,15 @@ class OrderTicketDemoAlgorithm(QCAlgorithm):
         filledOrdersSize = sum(1 for order in filledOrders)
         orderTicketsSize = sum(1 for ticket in orderTickets)
         openOrderTicketsSize = sum(1 for ticket in openOrderTickets)
+
         assert(filledOrdersSize == 8 and orderTicketsSize == 10), "There were expected 8 filled orders and 10 order tickets"
         assert(not (len(openOrders) or openOrderTicketsSize)), "No open orders or tickets were expected"
         assert(not remainingOpenOrders), "No remaining quantiy to be filled from open orders was expected"
+
+        spyOpenOrders = self.Transactions.GetOpenOrders(self.spy)
+        spyOpenOrderTickets = self.Transactions.GetOpenOrderTickets(self.spy)
+        spyOpenOrderTicketsSize = sum(1 for tickets in spyOpenOrderTickets)
+        spyOpenOrdersRemainingQuantity = self.Transactions.GetOpenOrdersRemainingQuantity(self.spy)
+
+        assert(not (len(spyOpenOrders) or spyOpenOrderTicketsSize)), "No open orders or tickets were expected"
+        assert(not spyOpenOrdersRemainingQuantity), "No remaining quantiy to be filled from open orders was expected"

--- a/Algorithm.Python/OrderTicketDemoAlgorithm.py
+++ b/Algorithm.Python/OrderTicketDemoAlgorithm.py
@@ -341,3 +341,17 @@ class OrderTicketDemoAlgorithm(QCAlgorithm):
 
     def TimeIs(self, day, hour, minute):
         return self.Time.day == day and self.Time.hour == hour and self.Time.minute == minute
+
+    def OnEndOfAlgorithm(self):
+        filledOrders = self.Transactions.GetOrders(lambda x: x.Status == OrderStatus.Filled)
+        openOrders = self.Transactions.GetOpenOrders(lambda x: True)
+
+        # The type returned by self.Transactions.GetOrders() is iterable and not a list
+        # that's why we use sum() to get the size of the iterable object type
+        filledOrdersSize = sum(1 for order in filledOrders)
+        assert(filledOrdersSize == 8)
+        assert(not len(openOrders))
+
+        filledOrderTickets = self.Transactions.GetOrderTickets(lambda x: x.Status == OrderStatus.Filled)
+        for ticket in filledOrderTickets:
+            self.Log("Ticket symbol: " + str(ticket.Symbol))

--- a/Algorithm.Python/OrderTicketDemoAlgorithm.py
+++ b/Algorithm.Python/OrderTicketDemoAlgorithm.py
@@ -368,3 +368,17 @@ class OrderTicketDemoAlgorithm(QCAlgorithm):
 
         assert(not (len(spyOpenOrders) or spyOpenOrderTicketsSize)), "No open orders or tickets were expected"
         assert(not spyOpenOrdersRemainingQuantity), "No remaining quantiy to be filled from open orders was expected"
+
+        defaultOrders = self.Transactions.GetOrders();
+        defaultOrderTickets = self.Transactions.GetOrderTickets();
+        defaultOpenOrders = self.Transactions.GetOpenOrders();
+        defaultOpenOrderTickets = self.Transactions.GetOpenOrderTickets();
+        defaultOpenOrdersRemaining = self.Transactions.GetOpenOrdersRemainingQuantity();
+
+        defaultOrdersSize = sum(1 for order in defaultOrders)
+        defaultOrderTicketsSize = sum(1 for ticket in defaultOrderTickets)
+        defaultOpenOrderTicketsSize = sum(1 for ticket in defaultOpenOrderTickets)
+
+        assert(defaultOrdersSize == 10 and defaultOrderTicketsSize == 10), "There were expected 10 orders and 10 order tickets"
+        assert(not (len(defaultOpenOrders) or defaultOpenOrderTicketsSize)), "No open orders or tickets were expected"
+        assert(not defaultOpenOrdersRemaining), "No remaining quantiy to be filled from open orders was expected"

--- a/Common/Securities/SecurityTransactionManager.cs
+++ b/Common/Securities/SecurityTransactionManager.cs
@@ -179,7 +179,7 @@ namespace QuantConnect.Securities
             }
 
             var cancelledOrders = new List<OrderTicket>();
-            foreach (var ticket in GetOpenOrderTickets(x => true))
+            foreach (var ticket in GetOpenOrderTickets())
             {
                 ticket.Cancel($"Canceled by CancelOpenOrders() at {_algorithm.UtcTime:o}");
                 cancelledOrders.Add(ticket);
@@ -232,11 +232,11 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Gets an enumerable of <see cref="OrderTicket"/> matching the specified <paramref name="filter"/>
         /// </summary>
-        /// <param name="filter">The Pyhton function filter used to find the required order tickets</param>
+        /// <param name="filter">The Python function filter used to find the required order tickets</param>
         /// <returns>An enumerable of <see cref="OrderTicket"/> matching the specified <paramref name="filter"/></returns>
-        public IEnumerable<OrderTicket> GetOrderTickets(PyObject filter = null)
+        public IEnumerable<OrderTicket> GetOrderTickets(PyObject filter)
         {
-            return _orderProcessor.GetOrderTickets(filter.ConvertToDelegate<Func<OrderTicket, bool>>() ?? (x => true));
+            return _orderProcessor.GetOrderTickets(filter.ConvertToDelegate<Func<OrderTicket, bool>>());
         }
 
         /// <summary>
@@ -264,9 +264,9 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <param name="filter">The Python function filter used to find the required order tickets</param>
         /// <returns>An enumerable of opened <see cref="OrderTicket"/> matching the specified <paramref name="filter"/></returns>
-        public IEnumerable<OrderTicket> GetOpenOrderTickets(PyObject filter = null)
+        public IEnumerable<OrderTicket> GetOpenOrderTickets(PyObject filter)
         {
-            return _orderProcessor.GetOpenOrderTickets(filter.ConvertToDelegate<Func<OrderTicket, bool>>() ?? (x => true));
+            return _orderProcessor.GetOpenOrderTickets(filter.ConvertToDelegate<Func<OrderTicket, bool>>());
         }
 
         /// <summary>
@@ -285,7 +285,7 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <param name="filter">Filters the order tickets to be included in the aggregate quantity remaining to be filled</param>
         /// <returns>Total quantity that hasn't been filled yet for all orders that were not filtered</returns>
-        public decimal GetOpenOrdersRemainingQuantity(PyObject filter = null)
+        public decimal GetOpenOrdersRemainingQuantity(PyObject filter)
         {
             return GetOpenOrderTickets(filter)
                 .Aggregate(0m, (d, t) => d + t.Quantity - t.QuantityFilled);
@@ -370,9 +370,9 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <param name="filter">Python function object used to filter the orders</param>
         /// <returns>All filtered open orders this order provider currently holds</returns>
-        public List<Order> GetOpenOrders(PyObject filter = null)
+        public List<Order> GetOpenOrders(PyObject filter)
         {
-             Func<Order, bool> csharpFilter = filter.ConvertToDelegate<Func<Order, bool>>() ?? (x => true);
+             Func<Order, bool> csharpFilter = filter.ConvertToDelegate<Func<Order, bool>>();
             return _orderProcessor.GetOpenOrders(x => csharpFilter(x));
         }
 

--- a/Tests/Common/Securities/SecurityTransactionManagerTests.cs
+++ b/Tests/Common/Securities/SecurityTransactionManagerTests.cs
@@ -72,13 +72,13 @@ namespace QuantConnect.Tests.Common.Securities
                 var orders = algorithm.Transactions.GetOrders(basicOrderFilter.ToPython());
                 var orderTickets = algorithm.Transactions.GetOrderTickets(basicOrderTicketFilter.ToPython());
                 var openOrders = algorithm.Transactions.GetOpenOrders(basicOrderFilter.ToPython());
-                var openOrdersTickets = algorithm.Transactions.GetOpenOrderTickets(basicOrderTicketFilter.ToPython());
+                var openOrderTickets = algorithm.Transactions.GetOpenOrderTickets(basicOrderTicketFilter.ToPython());
                 var openOrdersRemaining = algorithm.Transactions.GetOpenOrdersRemainingQuantity(basicOrderTicketFilter.ToPython());
 
                 Assert.AreEqual(2, orders.Count());
                 Assert.AreEqual(2, orderTickets.Count());
                 Assert.AreEqual(2, openOrders.Count);
-                Assert.AreEqual(2, openOrdersTickets.Count());
+                Assert.AreEqual(2, openOrderTickets.Count());
                 Assert.AreEqual(368, openOrdersRemaining);
 
                 var ibmOpenOrders = algorithm.Transactions.GetOpenOrders(ibm.ToPython()).Count;
@@ -95,7 +95,21 @@ namespace QuantConnect.Tests.Common.Securities
                 Assert.AreEqual(1, spyOpenOrders);
                 Assert.AreEqual(1, spyOpenOrderTickets);
                 Assert.AreEqual(184, spyOpenOrdersRemainingQuantity);
+
+                var defaultOrders = algorithm.Transactions.GetOrders();
+                var defaultOrderTickets = algorithm.Transactions.GetOrderTickets();
+                var defaultOpenOrders = algorithm.Transactions.GetOpenOrders();
+                var defaultOpenOrderTickets = algorithm.Transactions.GetOpenOrderTickets();
+                var defaultOpenOrdersRemaining = algorithm.Transactions.GetOpenOrdersRemainingQuantity();
+
+                Assert.AreEqual(2, defaultOrders.Count());
+                Assert.AreEqual(2, defaultOrderTickets.Count());
+                Assert.AreEqual(2, defaultOpenOrders.Count);
+                Assert.AreEqual(2, defaultOpenOrderTickets.Count());
+                Assert.AreEqual(368, defaultOpenOrdersRemaining);
             }
+
+            transactionHandler.Exit();
         }
     }
 }

--- a/Tests/Common/Securities/SecurityTransactionManagerTests.cs
+++ b/Tests/Common/Securities/SecurityTransactionManagerTests.cs
@@ -1,0 +1,124 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Brokerages.Backtesting;
+using QuantConnect.Tests.Engine;
+using QuantConnect.Algorithm;
+using QuantConnect.Lean.Engine.Results;
+using Python.Runtime;
+using QuantConnect.Logging;
+
+namespace QuantConnect.Tests.Common.Securities
+{
+    [TestFixture]
+    public class SecurityTransactionManagerTests
+    {
+        private static TimeKeeper TimeKeeper
+        {
+            get { return new TimeKeeper(DateTime.Now, new[] { TimeZones.NewYork }); }
+        }
+
+        private static SubscriptionDataConfig CreateTradeBarDataConfig(Symbol symbol)
+        {
+            return new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true);
+        }
+
+        private static readonly SecurityExchangeHours SecurityExchangeHours = SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork);
+
+        private IResultHandler _resultHandler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _resultHandler = new TestResultHandler(Console.WriteLine);
+        }
+
+        [Test]
+        public void WorksProperlyWithPyObjects()
+        {
+            var algorithm = new QCAlgorithm();
+            var securities = new SecurityManager(TimeKeeper);
+            var transactions = new SecurityTransactionManager(null, securities);
+            var transactionHandler = new BacktestingTransactionHandler();
+            var portfolio = new SecurityPortfolioManager(securities, transactions);
+
+            algorithm.Securities = securities;
+            transactionHandler.Initialize(algorithm, new BacktestingBrokerage(algorithm), _resultHandler);
+            transactions.SetOrderProcessor(transactionHandler);
+
+            // Adding cash: strike price times number of shares
+            portfolio.SetCash(192 * 100);
+
+            securities.Add(
+                Symbols.SPY,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(Symbols.SPY),
+                    new Cash(Currencies.USD, 0, 1m),
+                    SymbolProperties.GetDefault(Currencies.USD),
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null,
+                    new SecurityCache()
+                )
+            );
+            securities.Add(
+                Symbols.IBM,
+                new Security(
+                    SecurityExchangeHours,
+                    CreateTradeBarDataConfig(Symbols.IBM),
+                    new Cash(Currencies.USD, 0, 1m),
+                    SymbolProperties.GetDefault(Currencies.USD),
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null,
+                    new SecurityCache()
+                )
+            );
+            securities[Symbols.IBM].Holdings.SetHoldings(1, 1);
+            securities[Symbols.SPY].Holdings.SetHoldings(1, 1);
+
+            var holdings = securities[Symbols.IBM].Holdings.Quantity;
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.Market, SecurityType.Equity, Symbols.IBM, -holdings, 0, 0, securities.UtcTime, ""));
+            transactions.AddOrder(new SubmitOrderRequest(OrderType.Market, SecurityType.Equity, Symbols.SPY, -holdings, 0, 0, securities.UtcTime, ""));
+
+            Func<Order, bool> basicOrderFilter = x => true;
+            Func<OrderTicket, bool> basicOrderTicketFilter = x => true;
+            using (Py.GIL())
+            {
+                var orders = transactions.GetOrders(basicOrderFilter.ToPython());
+                var orderTickets = transactions.GetOrderTickets(basicOrderTicketFilter.ToPython());
+                var openOrders = transactions.GetOpenOrders(basicOrderFilter.ToPython());
+                var openOrdersTickets = transactions.GetOpenOrderTickets(basicOrderTicketFilter.ToPython());
+                var openOrdersRemaining = transactions.GetOpenOrdersRemainingQuantity(basicOrderTicketFilter.ToPython());
+                Assert.AreEqual(2, orders.Count());
+                Assert.AreEqual(2, orderTickets.Count());
+                Assert.AreEqual(0, openOrders.Count);
+                Assert.AreEqual(0, openOrdersTickets.Count());
+                Assert.AreEqual(0, openOrdersRemaining);
+                foreach(var ticket in orderTickets)
+                {
+                    Log.Trace($"Ticket symbol: {ticket.Symbol} - Status: {ticket.Status}");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Add overload in `SecurityTransactionManager` class to support Python functions as parameter in some methods
- Add unit tests and regression tests to ensure the bug is gone
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4514
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this changes python users will be able to pass python functions as parameters to some methods of `SecurityTransactionManager` class
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require changes or updates to documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- In the unit test it was created a QCAlgorithm and submitted two orders for different symbols and then asserted if the number of elements returned by `GetOrderTickets()`, `GetOrders()`, `GetOpenOrders()`, `GetOpenOrderTickets()` and `GetOpenOrdersRemainingQuantity()` methods, using PyObjects filters as parameters, were two.
- It was used the regression test `OrderTicketDemoAlgorithm.cs/py` to check the error was gone. At the end of the algorithm it was asserted if number of filled orders were the expected ones(8 orders) and that there were not open orders still, using `GetOrderTickets()`, `GetOrders()`, `GetOpenOrders()`, `GetOpenOrderTickets()` and `GetOpenOrdersRemainingQuantity()` methods methods with Python functions as parameters.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
