### PR TITLE
Fix bug in ConsumeMultipleMinutes() test

### DIFF
--- a/Common/Scheduling/TimeConsumer.cs
+++ b/Common/Scheduling/TimeConsumer.cs
@@ -44,6 +44,9 @@ namespace QuantConnect.Scheduling
         /// </summary>
         public DateTime? NextTimeRequest { get; set; }
 
+        /// <summary>
+        /// Event to trigger when the timer has already processed this consumer
+        /// </summary>
         public AutoResetEvent? TriggerEvent { get; set; }
     }
 }

--- a/Common/Scheduling/TimeConsumer.cs
+++ b/Common/Scheduling/TimeConsumer.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Threading;
 
 namespace QuantConnect.Scheduling
 {
@@ -42,5 +43,7 @@ namespace QuantConnect.Scheduling
         /// to be <see cref="IsolatorLimitProvider"/>
         /// </summary>
         public DateTime? NextTimeRequest { get; set; }
+
+        public AutoResetEvent? TriggerEvent { get; set; }
     }
 }

--- a/Common/Scheduling/TimeConsumer.cs
+++ b/Common/Scheduling/TimeConsumer.cs
@@ -14,7 +14,6 @@
 */
 
 using System;
-using System.Threading;
 
 namespace QuantConnect.Scheduling
 {
@@ -43,10 +42,5 @@ namespace QuantConnect.Scheduling
         /// to be <see cref="IsolatorLimitProvider"/>
         /// </summary>
         public DateTime? NextTimeRequest { get; set; }
-
-        /// <summary>
-        /// Event to trigger when the timer has already processed this consumer
-        /// </summary>
-        public AutoResetEvent? TriggerEvent { get; set; }
     }
 }

--- a/Common/Scheduling/TimeMonitor.cs
+++ b/Common/Scheduling/TimeMonitor.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -28,6 +28,7 @@ namespace QuantConnect.Scheduling
     {
         private readonly List<TimeConsumer> _timeConsumers;
         private readonly Timer _timer;
+        public AutoResetEvent TimeMonitorEvent;
 
         /// <summary>
         /// Returns the number of time consumers currently being monitored
@@ -49,6 +50,7 @@ namespace QuantConnect.Scheduling
         public TimeMonitor(int monitorIntervalMs = 100)
         {
             _timeConsumers = new List<TimeConsumer>();
+            TimeMonitorEvent = new AutoResetEvent(false);
             _timer = new Timer(state =>
             {
                 lock (_timeConsumers)
@@ -76,6 +78,8 @@ namespace QuantConnect.Scheduling
                                 // pass
                             }
                         }
+
+                        TimeMonitorEvent.Set();
                     }
                 }
             }, null, monitorIntervalMs, monitorIntervalMs);

--- a/Common/Scheduling/TimeMonitor.cs
+++ b/Common/Scheduling/TimeMonitor.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -26,7 +26,7 @@ namespace QuantConnect.Scheduling
     /// </summary>
     public class TimeMonitor : IDisposable
     {
-        private readonly List<TimeConsumer> _timeConsumers;
+        protected readonly List<TimeConsumer> _timeConsumers;
         private readonly Timer _timer;
 
         /// <summary>
@@ -75,6 +75,11 @@ namespace QuantConnect.Scheduling
                             {
                                 // pass
                             }
+                        }
+
+                        if (consumer.TriggerEvent != null)
+                        {
+                            consumer.TriggerEvent.Set();
                         }
                     }
                 }

--- a/Common/Scheduling/TimeMonitor.cs
+++ b/Common/Scheduling/TimeMonitor.cs
@@ -57,33 +57,37 @@ namespace QuantConnect.Scheduling
 
                     foreach (var consumer in _timeConsumers)
                     {
-                        if (consumer.NextTimeRequest == null)
-                        {
-                            // first time, for performance we register this here and not the time consumer
-                            consumer.NextTimeRequest = consumer.TimeProvider.GetUtcNow().AddMinutes(1);
-                        }
-                        else if (consumer.TimeProvider.GetUtcNow() >= consumer.NextTimeRequest)
-                        {
-                            // each minute request additional time from the isolator
-                            consumer.NextTimeRequest = consumer.NextTimeRequest.Value.AddMinutes(1);
-                            try
-                            {
-                                // this will notify the isolator that we've exceed the limits
-                                consumer.IsolatorLimitProvider.RequestAdditionalTime(minutes: 1);
-                            }
-                            catch
-                            {
-                                // pass
-                            }
-                        }
-
-                        if (consumer.TriggerEvent != null)
-                        {
-                            consumer.TriggerEvent.Set();
-                        }
+                        ProcessConsumer(consumer);
                     }
                 }
             }, null, monitorIntervalMs, monitorIntervalMs);
+        }
+
+        /// <summary>
+        /// Process the TimeConsumer object in _timeConsumers list
+        /// </summary>
+        /// <param name="consumer">The TimeConsumer object to be processed</param>
+        protected virtual void ProcessConsumer(TimeConsumer consumer)
+        {
+            if (consumer.NextTimeRequest == null)
+            {
+                // first time, for performance we register this here and not the time consumer
+                consumer.NextTimeRequest = consumer.TimeProvider.GetUtcNow().AddMinutes(1);
+            }
+            else if (consumer.TimeProvider.GetUtcNow() >= consumer.NextTimeRequest)
+            {
+                // each minute request additional time from the isolator
+                consumer.NextTimeRequest = consumer.NextTimeRequest.Value.AddMinutes(1);
+                try
+                {
+                    // this will notify the isolator that we've exceed the limits
+                    consumer.IsolatorLimitProvider.RequestAdditionalTime(minutes: 1);
+                }
+                catch
+                {
+                    // pass
+                }
+            }
         }
 
         /// <summary>

--- a/Common/Scheduling/TimeMonitor.cs
+++ b/Common/Scheduling/TimeMonitor.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -28,7 +28,6 @@ namespace QuantConnect.Scheduling
     {
         private readonly List<TimeConsumer> _timeConsumers;
         private readonly Timer _timer;
-        public AutoResetEvent TimeMonitorEvent;
 
         /// <summary>
         /// Returns the number of time consumers currently being monitored
@@ -50,7 +49,6 @@ namespace QuantConnect.Scheduling
         public TimeMonitor(int monitorIntervalMs = 100)
         {
             _timeConsumers = new List<TimeConsumer>();
-            TimeMonitorEvent = new AutoResetEvent(false);
             _timer = new Timer(state =>
             {
                 lock (_timeConsumers)
@@ -78,8 +76,6 @@ namespace QuantConnect.Scheduling
                                 // pass
                             }
                         }
-
-                        TimeMonitorEvent.Set();
                     }
                 }
             }, null, monitorIntervalMs, monitorIntervalMs);

--- a/Tests/Common/IsolatorLimitResultProviderTests.cs
+++ b/Tests/Common/IsolatorLimitResultProviderTests.cs
@@ -194,6 +194,15 @@ namespace QuantConnect.Tests.Common
         {
             public TimeMonitorTest(int monitorIntervalMs = 100): base(monitorIntervalMs) {}
 
+            protected override void ProcessConsumer(TimeConsumer consumer)
+            {
+                base.ProcessConsumer(consumer);
+                if (consumer.TriggerEvent != null)
+                {
+                    consumer.TriggerEvent.Set();
+                }
+            }
+
             public void RemoveAll()
             {
                 lock (_timeConsumers)

--- a/Tests/Common/IsolatorLimitResultProviderTests.cs
+++ b/Tests/Common/IsolatorLimitResultProviderTests.cs
@@ -118,19 +118,21 @@ namespace QuantConnect.Tests.Common
         }
 
         [Test]
+        [Repeat(1000)]
         public void ConsumesMultipleMinutes()
         {
             var timeProvider = new ManualTimeProvider(new DateTime(2000, 01, 01));
+
             var provider = new FakeIsolatorLimitResultProvider();
             Action code = () =>
             {
                 // lets give the monitor time to register the initial time
-                Thread.Sleep(100);
+                _timeMonitor.TimeMonitorEvent.WaitOne();
                 for (int i = 0; i < 4; i++)
                 {
                     timeProvider.AdvanceSeconds(45);
                     // give the monitoring task time to request more time
-                    Thread.Sleep(100);
+                    _timeMonitor.TimeMonitorEvent.WaitOne();
                 }
             };
 
@@ -140,7 +142,7 @@ namespace QuantConnect.Tests.Common
             Assert.IsTrue(provider.Invocations.TrueForAll(invoc => invoc == 1));
 
             // give time to the monitor to register the time consumer ended
-            Thread.Sleep(50);
+            Thread.Sleep(100);
             Assert.AreEqual(0, _timeMonitor.Count);
         }
 

--- a/Tests/Common/IsolatorLimitResultProviderTests.cs
+++ b/Tests/Common/IsolatorLimitResultProviderTests.cs
@@ -130,7 +130,7 @@ namespace QuantConnect.Tests.Common
                 {
                     timeProvider.AdvanceSeconds(45);
                     // give the monitoring task time to request more time
-                    Thread.Sleep(20);
+                    Thread.Sleep(100);
                 }
             };
 

--- a/Tests/Common/IsolatorLimitResultProviderTests.cs
+++ b/Tests/Common/IsolatorLimitResultProviderTests.cs
@@ -118,21 +118,19 @@ namespace QuantConnect.Tests.Common
         }
 
         [Test]
-        [Repeat(1000)]
         public void ConsumesMultipleMinutes()
         {
             var timeProvider = new ManualTimeProvider(new DateTime(2000, 01, 01));
-
             var provider = new FakeIsolatorLimitResultProvider();
             Action code = () =>
             {
                 // lets give the monitor time to register the initial time
-                _timeMonitor.TimeMonitorEvent.WaitOne();
+                Thread.Sleep(100);
                 for (int i = 0; i < 4; i++)
                 {
                     timeProvider.AdvanceSeconds(45);
                     // give the monitoring task time to request more time
-                    _timeMonitor.TimeMonitorEvent.WaitOne();
+                    Thread.Sleep(100);
                 }
             };
 
@@ -142,7 +140,7 @@ namespace QuantConnect.Tests.Common
             Assert.IsTrue(provider.Invocations.TrueForAll(invoc => invoc == 1));
 
             // give time to the monitor to register the time consumer ended
-            Thread.Sleep(100);
+            Thread.Sleep(50);
             Assert.AreEqual(0, _timeMonitor.Count);
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Sometimes 20ms wasn't enough time for the timer to kick in so the action code advanced faster than the timer and finally there were less invocations than expected
#### Description
<!--- Describe your changes in detail -->
- Fix bug in `IsolatorLimitResultProviderTests.ConsumeMultipleMinutes()`
- Change calls to `Thread.Sleep()` with `autoResetEvent.WaitOne()` in `IsolatorLimitResultProviderTests.cs`
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #6080 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change the test `ConsumeMultipleMinutes()` will only fail when a breaking change related with `IsolatorLimitResultProvider.cs` is done
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require changes or updates to documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`IsolatorLimitResultProviderTests.ConsumeMultipleMinutes()` was ran 500 times giving the timer 15ms to kick in. This test case failed and the same happened when giving less time than 20ms. Then it was used an AutoResetEvent to advance in the action code at the same time as the timer kicked in. `ConsumeMultipleMinutes()` was ran 2000 times and then all the tests in the file were ran.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
