### PR TITLE
Updates KeltnerChannels to Update MiddleBand with EndTime

### DIFF
--- a/Indicators/KeltnerChannels.cs
+++ b/Indicators/KeltnerChannels.cs
@@ -118,7 +118,7 @@ namespace QuantConnect.Indicators
             AverageTrueRange.Update(input);
 
             var typicalPrice = (input.High + input.Low + input.Close)/3m;
-            MiddleBand.Update(input.Time, typicalPrice);
+            MiddleBand.Update(input.EndTime, typicalPrice);
 
             // poke the upper/lower bands, they actually don't use the input, they compute
             // based on the ATR and the middle band

--- a/Tests/Indicators/KeltnerChannelsTests.cs
+++ b/Tests/Indicators/KeltnerChannelsTests.cs
@@ -62,6 +62,20 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
+        public void ComparesTimeStampBetweenKeltnerChannelAndMiddleBand()
+        {
+            TestHelper.TestIndicator(
+                CreateIndicator(),
+                TestFileName,
+                "Middle Band",
+                (ind, expected) => Assert.AreEqual(
+                    ((KeltnerChannels)ind).Current.EndTime,
+                    ((KeltnerChannels)ind).MiddleBand.Current.EndTime
+                )
+            );
+        }
+
+        [Test]
         public override void ResetsProperly()
         {
             var kch = CreateIndicator() as KeltnerChannels;


### PR DESCRIPTION
#### Description
Updates `KeltnerChannels` to update `MiddleBand` with `input.EndTime`.

#### Motivation and Context
Fix indicator.

#### How Has This Been Tested?
```python
qb = QuantBook()
spy = qb.AddEquity("SPY")
keltner = KeltnerChannels(20, 2)
dfKeltner = qb.Indicator(keltner, 'SPY', 100, Resolution.Daily)
dfKeltner.head(30)
````
In master we see a timestamp misalignment:
https://www.dropbox.com/s/hk5qop5j4yw2z9c/master.png?dl=1
https://www.dropbox.com/s/lkcksbpz5gm5sw6/new.png?dl=1

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`