### PR TITLE
Fix for adding continuous future and future contract at the same time

### DIFF
--- a/Algorithm.CSharp/AddFutureContractWithContinuousRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddFutureContractWithContinuousRegressionAlgorithm.cs
@@ -1,0 +1,159 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Orders;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+using System.Collections.Generic;
+using QuantConnect.Securities.Future;
+using QuantConnect.Data.UniverseSelection;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Continuous Futures Regression algorithm. Asserting and showcasing the behavior of adding a continuous future
+    /// and a future contract at the same time
+    /// </summary>
+    public class AddFutureContractWithContinuousRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _currentMappedSymbol;
+        private Future _continuousContract;
+        private Future _futureContract;
+        private bool _ended;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 6);
+            SetEndDate(2013, 10, 10);
+
+            _continuousContract = AddFuture(Futures.Indices.SP500EMini,
+                dataNormalizationMode: DataNormalizationMode.BackwardsRatio,
+                dataMappingMode: DataMappingMode.LastTradingDay,
+                contractDepthOffset: 0
+            );
+
+            _futureContract = AddFutureContract(FutureChainProvider.GetFutureContractList(_continuousContract.Symbol, Time).First());
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (_ended)
+            {
+                throw new Exception($"Algorithm should of ended!");
+            }
+            if (data.Keys.Count > 2)
+            {
+                throw new Exception($"Getting data for more than 2 symbols! {string.Join(",", data.Keys.Select(symbol => symbol))}");
+            }
+            if (UniverseManager.Count != 3)
+            {
+                throw new Exception($"Expecting 3 universes (chain, continuous and user defined) but have {UniverseManager.Count}");
+            }
+
+            if (!Portfolio.Invested)
+            {
+                Buy(_futureContract.Symbol, 1);
+                Buy(_continuousContract.Mapped, 1);
+
+                RemoveSecurity(_futureContract.Symbol);
+                RemoveSecurity(_continuousContract.Symbol);
+
+                _ended = true;
+            }
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            if (orderEvent.Status == OrderStatus.Filled)
+            {
+                Log($"{orderEvent}");
+            }
+        }
+
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            Debug($"{Time}-{changes}");
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "3"},
+            {"Average Win", "0%"},
+            {"Average Loss", "-0.03%"},
+            {"Compounding Annual Return", "-2.503%"},
+            {"Drawdown", "0.000%"},
+            {"Expectancy", "-1"},
+            {"Net Profit", "-0.032%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "100%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-0.678"},
+            {"Tracking Error", "0.243"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$7.40"},
+            {"Estimated Strategy Capacity", "$2100000.00"},
+            {"Lowest Capacity Asset", "ES VMKLFZIH2MTD"},
+            {"Fitness Score", "0.419"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "-81.557"},
+            {"Portfolio Turnover", "0.837"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "68775c18eb40c1bde212653faec4016e"}
+        };
+    }
+}

--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -593,7 +593,7 @@ namespace QuantConnect.Algorithm
             else
             {
                 // should never happen, someone would need to add a non-user defined universe with this symbol
-                throw new Exception("Expected universe with symbol '" + universeSymbol.Value + "' to be of type UserDefinedUniverse.");
+                throw new Exception($"Expected universe with symbol '{universeSymbol.Value}' to be of type {nameof(UserDefinedUniverse)} but was {universe.GetType().Name}.");
             }
 
             return security;

--- a/Common/Data/UniverseSelection/ContinuousContractUniverse.cs
+++ b/Common/Data/UniverseSelection/ContinuousContractUniverse.cs
@@ -133,5 +133,16 @@ namespace QuantConnect.Data.UniverseSelection
                 // in live trading we delay selection so that we make sure auxiliary data is ready
                 .Select(time => _liveMode ? time.Add(Time.LiveAuxiliaryDataOffset) : time);
         }
+
+        /// <summary>
+        /// Creates a continuous universe symbol
+        /// </summary>
+        /// <param name="symbol">The associated symbol</param>
+        /// <returns>A symbol for a continuous universe of the specified symbol</returns>
+        public static Symbol CreateSymbol(Symbol symbol)
+        {
+            var ticker = $"qc-universe-continuous-{symbol.ID.Market.ToLowerInvariant()}-{symbol.SecurityType}-{symbol.ID.Symbol}";
+            return UniverseExtensions.CreateSymbol(symbol.SecurityType, symbol.ID.Market, ticker);
+        }
     }
 }

--- a/Common/Data/UniverseSelection/UniverseExtensions.cs
+++ b/Common/Data/UniverseSelection/UniverseExtensions.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Linq;
 
 namespace QuantConnect.Data.UniverseSelection
@@ -71,6 +72,69 @@ namespace QuantConnect.Data.UniverseSelection
                 clone.Data = clone.Data.Where(d => first.ContainsMember(d.Symbol)).ToList();
                 return second.SelectSymbols(utcTime, clone);
             });
+        }
+
+        /// <summary>
+        /// Creates a universe symbol
+        /// </summary>
+        /// <param name="securityType">The security</param>
+        /// <param name="market">The market</param>
+        /// <param name="ticker">The Universe ticker</param>
+        /// <returns>A symbol for user defined universe of the specified security type and market</returns>
+        public static Symbol CreateSymbol(SecurityType securityType, string market, string ticker)
+        {
+            SecurityIdentifier sid;
+            switch (securityType)
+            {
+                case SecurityType.Base:
+                    sid = SecurityIdentifier.GenerateBase(null, ticker, market);
+                    break;
+
+                case SecurityType.Equity:
+                    sid = SecurityIdentifier.GenerateEquity(SecurityIdentifier.DefaultDate, ticker, market);
+                    break;
+
+                case SecurityType.Option:
+                    var underlying = SecurityIdentifier.GenerateEquity(SecurityIdentifier.DefaultDate, ticker, market);
+                    sid = SecurityIdentifier.GenerateOption(SecurityIdentifier.DefaultDate, underlying, market, 0, 0, 0);
+                    break;
+
+                case SecurityType.FutureOption:
+                    var underlyingFuture = SecurityIdentifier.GenerateFuture(SecurityIdentifier.DefaultDate, ticker, market);
+                    sid = SecurityIdentifier.GenerateOption(SecurityIdentifier.DefaultDate, underlyingFuture, market, 0, 0, 0);
+                    break;
+
+                case SecurityType.IndexOption:
+                    var underlyingIndex = SecurityIdentifier.GenerateIndex(ticker, market);
+                    sid = SecurityIdentifier.GenerateOption(SecurityIdentifier.DefaultDate, underlyingIndex, market, 0, 0, OptionStyle.European);
+                    break;
+
+                case SecurityType.Forex:
+                    sid = SecurityIdentifier.GenerateForex(ticker, market);
+                    break;
+
+                case SecurityType.Cfd:
+                    sid = SecurityIdentifier.GenerateCfd(ticker, market);
+                    break;
+
+                case SecurityType.Index:
+                    sid = SecurityIdentifier.GenerateIndex(ticker, market);
+                    break;
+
+                case SecurityType.Future:
+                    sid = SecurityIdentifier.GenerateFuture(SecurityIdentifier.DefaultDate, ticker, market);
+                    break;
+
+                case SecurityType.Crypto:
+                    sid = SecurityIdentifier.GenerateCrypto(ticker, market);
+                    break;
+
+                case SecurityType.Commodity:
+                default:
+                    throw new NotImplementedException($"The specified security type is not implemented yet: {securityType}");
+            }
+
+            return new Symbol(sid, ticker);
         }
     }
 }

--- a/Common/Data/UniverseSelection/UserDefinedUniverse.cs
+++ b/Common/Data/UniverseSelection/UserDefinedUniverse.cs
@@ -110,58 +110,7 @@ namespace QuantConnect.Data.UniverseSelection
         public static Symbol CreateSymbol(SecurityType securityType, string market)
         {
             var ticker = $"qc-universe-userdefined-{market.ToLowerInvariant()}-{securityType}";
-            SecurityIdentifier sid;
-            switch (securityType)
-            {
-                case SecurityType.Base:
-                    sid = SecurityIdentifier.GenerateBase(null, ticker, market);
-                    break;
-
-                case SecurityType.Equity:
-                    sid = SecurityIdentifier.GenerateEquity(SecurityIdentifier.DefaultDate, ticker, market);
-                    break;
-
-                case SecurityType.Option:
-                    var underlying = SecurityIdentifier.GenerateEquity(SecurityIdentifier.DefaultDate, ticker, market);
-                    sid = SecurityIdentifier.GenerateOption(SecurityIdentifier.DefaultDate, underlying, market, 0, 0, 0);
-                    break;
-
-                case SecurityType.FutureOption:
-                    var underlyingFuture = SecurityIdentifier.GenerateFuture(SecurityIdentifier.DefaultDate, ticker, market);
-                    sid = SecurityIdentifier.GenerateOption(SecurityIdentifier.DefaultDate, underlyingFuture, market, 0, 0, 0);
-                    break;
-
-                case SecurityType.IndexOption:
-                    var underlyingIndex = SecurityIdentifier.GenerateIndex(ticker, market);
-                    sid = SecurityIdentifier.GenerateOption(SecurityIdentifier.DefaultDate, underlyingIndex, market, 0, 0, OptionStyle.European);
-                    break;
-
-                case SecurityType.Forex:
-                    sid = SecurityIdentifier.GenerateForex(ticker, market);
-                    break;
-
-                case SecurityType.Cfd:
-                    sid = SecurityIdentifier.GenerateCfd(ticker, market);
-                    break;
-
-                case SecurityType.Index:
-                    sid = SecurityIdentifier.GenerateIndex(ticker, market);
-                    break;
-
-                case SecurityType.Future:
-                    sid = SecurityIdentifier.GenerateFuture(SecurityIdentifier.DefaultDate, ticker, market);
-                    break;
-
-                case SecurityType.Crypto:
-                    sid = SecurityIdentifier.GenerateCrypto(ticker, market);
-                    break;
-
-                case SecurityType.Commodity:
-                default:
-                    throw new NotImplementedException($"The specified security type is not implemented yet: {securityType}");
-            }
-
-            return new Symbol(sid, ticker);
+            return UniverseExtensions.CreateSymbol(securityType, market, ticker);
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix for adding continuous future and manually adding contract at the
  same time. Continuous future was using the user defined universe
  symbol and caused clashes. Adding regression test reproducing the issue.
- Adjust security removal to handle removing continuous universes too. Covered by added regression test

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
```
2021-12-01T21:56:58.6531043Z TRACE:: BrokerageSetupHandler.Setup(): Has existing holding: NQ17Z21: 8 @ $15366.76549375 - Market: $15872 - Conversion: 
2021-12-01T21:56:58.6546918Z TRACE:: BrokerageSetupHandler.Setup(): Adding unrequested security: NQ17Z21
2021-12-01T21:56:58.6692432Z ERROR:: BrokerageSetupHandler.LoadExistingHoldingsAndOrders():  System.Exception: Expected universe with symbol '/QC-UNIVERSE-USERDEFINED-CME-FUTURE' to be of type UserDefinedUniverse.
   at QuantConnect.Algorithm.QCAlgorithm.AddToUserDefinedUniverse(Security security, List`1 configurations) in /LeanCloud/CI.Builder/bin/Debug/src/QuantConnect/Lean/Algorithm/QCAlgorithm.Universe.cs:line 596
   at QuantConnect.Algorithm.QCAlgorithm.AddSecurity(Symbol symbol, Nullable`1 resolution, Boolean fillDataForward, Decimal leverage, Boolean extendedMarketHours, Nullable`1 dataMappingMode, Nullable`1 dataNormalizationMode, Int32 contractDepthOffset) in /LeanCloud/CI.Builder/bin/Debug/src/QuantConnect/Lean/Algorithm/QCAlgorithm.cs:line 1577
   at QuantConnect.Algorithm.QCAlgorithm.AddFutureContract(Symbol symbol, Nullable`1 resolution, Boolean fillDataForward, Decimal leverage) in /LeanCloud/CI.Builder/bin/Debug/src/QuantConnect/Lean/Algorithm/QCAlgorithm.cs:line 1703
   at QuantConnect.AlgorithmFactory.Python.Wrappers.AlgorithmPythonWrapper.AddFutureContract(Symbol symbol, Nullable`1 resolution, Boolean fillDataForward, Decimal leverage) in /LeanCloud/CI.Builder/bin/Debug/src/QuantConnect/Lean/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs:line 458
   at QuantConnect.Lean.Engine.Setup.BrokerageSetupHandler.AddUnrequestedSecurity(IAlgorithm algorithm, Symbol symbol) in /LeanCloud/CI.Builder/bin/Debug/src/QuantConnect/Lean/Engine/Setup/BrokerageSetupHandler.cs:line 495
   at QuantConnect.Lean.Engine.Setup.BrokerageSetupHandler.LoadExistingHoldingsAndOrders(IBrokerage brokerage, IAlgorithm algorithm, SetupHandlerParameters parameters) in /LeanCloud/CI.Builder/bin/Debug/src/QuantConnect/Lean/Engine/Setup/BrokerageSetupHandler.cs:line 429
```
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Being able to add a future contract manually along side a continuous contract
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
