### PR TITLE
CompositeDataQueueHandler handles duplicate configs

### DIFF
--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Data
     /// </summary>
     public class SubscriptionDataConfig : IEquatable<SubscriptionDataConfig>
     {
+        private readonly bool _mappedConfig;
         private readonly SecurityIdentifier _sid;
 
         /// <summary>
@@ -204,7 +205,8 @@ namespace QuantConnect.Data
             bool isFilteredSubscription = true,
             DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted,
             DataMappingMode dataMappingMode = DataMappingMode.OpenInterest,
-            uint contractDepthOffset = 0)
+            uint contractDepthOffset = 0,
+            bool mappedConfig = false)
         {
             if (objectType == null) throw new ArgumentNullException(nameof(objectType));
             if (symbol == null) throw new ArgumentNullException(nameof(symbol));
@@ -221,6 +223,7 @@ namespace QuantConnect.Data
             IsInternalFeed = isInternalFeed;
             IsCustomData = isCustom;
             DataTimeZone = dataTimeZone;
+            _mappedConfig = mappedConfig;
             DataMappingMode = dataMappingMode;
             ExchangeTimeZone = exchangeTimeZone;
             ContractDepthOffset = contractDepthOffset;
@@ -275,6 +278,8 @@ namespace QuantConnect.Data
         /// <param name="dataMappingMode">The contract mapping mode to use for the security</param>
         /// <param name="contractDepthOffset">The continuous contract desired offset from the current front month.
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
+        /// <param name="mappedConfig">True if this is created as a mapped config. This is useful for continuous contract at live trading
+        /// where we subscribe to the mapped symbol but want to preserve uniqueness</param>
         public SubscriptionDataConfig(SubscriptionDataConfig config,
             Type objectType = null,
             Symbol symbol = null,
@@ -289,7 +294,8 @@ namespace QuantConnect.Data
             bool? isFilteredSubscription = null,
             DataNormalizationMode? dataNormalizationMode = null,
             DataMappingMode? dataMappingMode = null,
-            uint? contractDepthOffset = null)
+            uint? contractDepthOffset = null,
+            bool? mappedConfig = null)
             : this(
             objectType ?? config.Type,
             symbol ?? config.Symbol,
@@ -304,7 +310,8 @@ namespace QuantConnect.Data
             isFilteredSubscription ?? config.IsFilteredSubscription,
             dataNormalizationMode ?? config.DataNormalizationMode,
             dataMappingMode ?? config.DataMappingMode,
-            contractDepthOffset ?? config.ContractDepthOffset
+            contractDepthOffset ?? config.ContractDepthOffset,
+            mappedConfig ?? false
             )
         {
             PriceScaleFactor = config.PriceScaleFactor;
@@ -334,7 +341,8 @@ namespace QuantConnect.Data
                 && DataMappingMode == other.DataMappingMode
                 && ExchangeTimeZone.Equals(other.ExchangeTimeZone)
                 && ContractDepthOffset == other.ContractDepthOffset
-                && IsFilteredSubscription == other.IsFilteredSubscription;
+                && IsFilteredSubscription == other.IsFilteredSubscription
+                && _mappedConfig == other._mappedConfig;
         }
 
         /// <summary>
@@ -375,6 +383,7 @@ namespace QuantConnect.Data
                 hashCode = (hashCode*397) ^ ExchangeTimeZone.Id.GetHashCode();// timezone hash is expensive, use id instead
                 hashCode = (hashCode*397) ^ ContractDepthOffset.GetHashCode();
                 hashCode = (hashCode*397) ^ IsFilteredSubscription.GetHashCode();
+                hashCode = (hashCode*397) ^ _mappedConfig.GetHashCode();
                 return hashCode;
             }
         }

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -2944,13 +2944,15 @@ namespace QuantConnect
         /// Helper method to determine symbol for a live subscription
         /// </summary>
         /// <remarks>Useful for continuous futures where we subscribe to the underlying</remarks>
-        public static Symbol GetLiveSubscriptionSymbol(this Symbol symbol)
+        public static bool TryGetLiveSubscriptionSymbol(this Symbol symbol, out Symbol mapped)
         {
+            mapped = null;
             if (symbol.SecurityType == SecurityType.Future && symbol.IsCanonical() && symbol.HasUnderlying)
             {
-                return symbol.Underlying;
+                mapped = symbol.Underlying;
+                return true;
             }
-            return symbol;
+            return false;
         }
 
         /// <summary>

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -3022,6 +3022,35 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Helper method to unsubscribe a given configuration, handling any required mapping
+        /// </summary>
+        public static void UnSubscribe(this IDataQueueHandler dataQueueHandler, SubscriptionDataConfig dataConfig)
+        {
+            if (dataConfig.Symbol.TryGetLiveSubscriptionSymbol(out var mappedSymbol))
+            {
+                dataConfig = new SubscriptionDataConfig(dataConfig, symbol: mappedSymbol, mappedConfig: true);
+            }
+            dataQueueHandler.Unsubscribe(dataConfig);
+        }
+
+        /// <summary>
+        /// Helper method to subscribe a given configuration, handling any required mapping
+        /// </summary>
+        public static IEnumerator<BaseData> Subscribe(this IDataQueueHandler dataQueueHandler,
+            SubscriptionDataConfig dataConfig,
+            EventHandler newDataAvailableHandler,
+            out SubscriptionDataConfig subscribedConfig)
+        {
+            subscribedConfig = dataConfig;
+            if (dataConfig.Symbol.TryGetLiveSubscriptionSymbol(out var mappedSymbol))
+            {
+                subscribedConfig = new SubscriptionDataConfig(dataConfig, symbol: mappedSymbol, mappedConfig: true);
+            }
+            var enumerator = dataQueueHandler.Subscribe(subscribedConfig, newDataAvailableHandler);
+            return enumerator ?? Enumerable.Empty<BaseData>().GetEnumerator();
+        }
+
+        /// <summary>
         /// Helper method to stream read lines from a file
         /// </summary>
         /// <param name="dataProvider">The data provider to use</param>

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -3024,7 +3024,7 @@ namespace QuantConnect
         /// <summary>
         /// Helper method to unsubscribe a given configuration, handling any required mapping
         /// </summary>
-        public static void UnSubscribe(this IDataQueueHandler dataQueueHandler, SubscriptionDataConfig dataConfig)
+        public static void UnsubscribeWithMapping(this IDataQueueHandler dataQueueHandler, SubscriptionDataConfig dataConfig)
         {
             if (dataConfig.Symbol.TryGetLiveSubscriptionSymbol(out var mappedSymbol))
             {
@@ -3036,7 +3036,7 @@ namespace QuantConnect
         /// <summary>
         /// Helper method to subscribe a given configuration, handling any required mapping
         /// </summary>
-        public static IEnumerator<BaseData> Subscribe(this IDataQueueHandler dataQueueHandler,
+        public static IEnumerator<BaseData> SubscribeWithMapping(this IDataQueueHandler dataQueueHandler,
             SubscriptionDataConfig dataConfig,
             EventHandler newDataAvailableHandler,
             out SubscriptionDataConfig subscribedConfig)

--- a/Engine/DataFeeds/Enumerators/LiveSubscriptionEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/LiveSubscriptionEnumerator.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         public LiveSubscriptionEnumerator(SubscriptionDataConfig dataConfig, IDataQueueHandler dataQueueHandler, EventHandler handler)
         {
             _requestedSymbol = dataConfig.Symbol;
-            _underlyingEnumerator = dataQueueHandler.Subscribe(dataConfig, handler, out _currentConfig);
+            _underlyingEnumerator = dataQueueHandler.SubscribeWithMapping(dataConfig, handler, out _currentConfig);
 
             // for any mapping event we will re subscribe
             dataConfig.NewSymbol += (_, _) =>
@@ -53,7 +53,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                 _previousEnumerator = _underlyingEnumerator;
 
                 var oldSymbol = _currentConfig.Symbol;
-                _underlyingEnumerator = dataQueueHandler.Subscribe(dataConfig, handler, out _currentConfig);
+                _underlyingEnumerator = dataQueueHandler.SubscribeWithMapping(dataConfig, handler, out _currentConfig);
 
                 Log.Trace($"LiveSubscriptionEnumerator({_requestedSymbol}): " +
                     $"resubscribing old: '{oldSymbol.Value}' new '{_currentConfig.Symbol.Value}'");

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -141,11 +141,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
             else
             {
-                _dataQueueHandler.Unsubscribe(subscription.Configuration);
+                _dataQueueHandler.UnSubscribe(subscription.Configuration);
                 if (subscription.Configuration.SecurityType == SecurityType.Equity && !subscription.Configuration.IsInternalFeed)
                 {
-                    _dataQueueHandler.Unsubscribe(new SubscriptionDataConfig(subscription.Configuration, typeof(Dividend)));
-                    _dataQueueHandler.Unsubscribe(new SubscriptionDataConfig(subscription.Configuration, typeof(Split)));
+                    _dataQueueHandler.UnSubscribe(new SubscriptionDataConfig(subscription.Configuration, typeof(Dividend)));
+                    _dataQueueHandler.UnSubscribe(new SubscriptionDataConfig(subscription.Configuration, typeof(Split)));
                 }
             }
         }
@@ -166,13 +166,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         }
 
         /// <summary>
-        /// Gets the <see cref="IDataQueueHandler"/> to use by default <see cref="CompositeDataQueueHandler"/>
+        /// Gets the <see cref="IDataQueueHandler"/> to use by default <see cref="DataQueueHandlerManager"/>
         /// </summary>
         /// <remarks>Useful for testing</remarks>
         /// <returns>The loaded <see cref="IDataQueueHandler"/></returns>
         protected virtual IDataQueueHandler GetDataQueueHandler()
         {
-            return new CompositeDataQueueHandler();
+            return new DataQueueHandlerManager();
         }
 
         /// <summary>
@@ -409,7 +409,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
         private IDataQueueUniverseProvider GetUniverseProvider(SecurityType securityType)
         {
-            if (_dataQueueHandler is not IDataQueueUniverseProvider or CompositeDataQueueHandler { HasUniverseProvider: false })
+            if (_dataQueueHandler is not IDataQueueUniverseProvider or DataQueueHandlerManager { HasUniverseProvider: false })
             {
                 throw new NotSupportedException($"The DataQueueHandler does not support {securityType}.");
             }

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -141,11 +141,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
             else
             {
-                _dataQueueHandler.UnSubscribe(subscription.Configuration);
+                _dataQueueHandler.UnsubscribeWithMapping(subscription.Configuration);
                 if (subscription.Configuration.SecurityType == SecurityType.Equity && !subscription.Configuration.IsInternalFeed)
                 {
-                    _dataQueueHandler.UnSubscribe(new SubscriptionDataConfig(subscription.Configuration, typeof(Dividend)));
-                    _dataQueueHandler.UnSubscribe(new SubscriptionDataConfig(subscription.Configuration, typeof(Split)));
+                    _dataQueueHandler.UnsubscribeWithMapping(new SubscriptionDataConfig(subscription.Configuration, typeof(Dividend)));
+                    _dataQueueHandler.UnsubscribeWithMapping(new SubscriptionDataConfig(subscription.Configuration, typeof(Split)));
                 }
             }
         }

--- a/Tests/Common/Securities/SubscriptionDataConfigTests.cs
+++ b/Tests/Common/Securities/SubscriptionDataConfigTests.cs
@@ -67,5 +67,25 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreNotEqual(configA, configB);
             Assert.AreNotEqual(configA.GetHashCode(), configB.GetHashCode());
         }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void EqualityMapped(bool mapped)
+        {
+            var configA = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork,
+                TimeZones.NewYork, false, false, false);
+            var configB = new SubscriptionDataConfig(configA, mappedConfig: mapped);
+
+            if (mapped)
+            {
+                Assert.AreNotEqual(configA, configB);
+                Assert.AreNotEqual(configA.GetHashCode(), configB.GetHashCode());
+            }
+            else
+            {
+                Assert.AreEqual(configA, configB);
+                Assert.AreEqual(configA.GetHashCode(), configB.GetHashCode());
+            }
+        }
     }
 }

--- a/Tests/Engine/DataFeeds/DataQueueHandlerManagerTests.cs
+++ b/Tests/Engine/DataFeeds/DataQueueHandlerManagerTests.cs
@@ -156,10 +156,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             Assert.AreEqual(2, TestDataHandler.SubscribeCounter);
 
-            compositeDataQueueHandler.UnSubscribe(firstUnsubscribe);
+            compositeDataQueueHandler.UnsubscribeWithMapping(firstUnsubscribe);
             Assert.AreEqual(1, TestDataHandler.UnsubscribeCounter);
 
-            compositeDataQueueHandler.UnSubscribe(secondUnsubscribe);
+            compositeDataQueueHandler.UnsubscribeWithMapping(secondUnsubscribe);
             Assert.AreEqual(2, TestDataHandler.UnsubscribeCounter);
 
             enumerator.Dispose();

--- a/Tests/Engine/DataFeeds/Enumerators/LiveSubscriptionEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/LiveSubscriptionEnumeratorTests.cs
@@ -21,6 +21,7 @@ using QuantConnect.Packets;
 using QuantConnect.Interfaces;
 using QuantConnect.Data.Market;
 using System.Collections.Generic;
+using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Enumerators;
 
 namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
@@ -48,7 +49,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
                 MappedSymbol = Symbols.Fut_SPY_Feb19_2016.ID.ToString()
             };
 
-            var data = new LiveSubscriptionEnumerator(config, dataQueue, (_, _) => {});
+            var compositeDataQueueHandler = new TestCompositeDataQueueHandler();
+            compositeDataQueueHandler.ExposedDataHandlers.Add(dataQueue);
+            var data = new LiveSubscriptionEnumerator(config, compositeDataQueueHandler, (_, _) => {});
 
             Assert.IsTrue(data.MoveNext());
             Assert.AreEqual(1, (data.Current as Tick).AskPrice);
@@ -71,7 +74,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             Assert.AreEqual(1, dataQueue.DataPerSymbol.Count);
 
             data.Dispose();
-            dataQueue.Dispose();
+            compositeDataQueueHandler.Dispose();
         }
 
         private class TestDataQueueHandler : IDataQueueHandler
@@ -98,6 +101,11 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             public void Dispose()
             {
             }
+        }
+
+        private class TestCompositeDataQueueHandler : CompositeDataQueueHandler
+        {
+            public List<IDataQueueHandler> ExposedDataHandlers => DataHandlers;
         }
     }
 }

--- a/Tests/Engine/DataFeeds/Enumerators/LiveSubscriptionEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/LiveSubscriptionEnumeratorTests.cs
@@ -49,7 +49,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
                 MappedSymbol = Symbols.Fut_SPY_Feb19_2016.ID.ToString()
             };
 
-            var compositeDataQueueHandler = new TestCompositeDataQueueHandler();
+            var compositeDataQueueHandler = new TestDataQueueHandlerManager();
             compositeDataQueueHandler.ExposedDataHandlers.Add(dataQueue);
             var data = new LiveSubscriptionEnumerator(config, compositeDataQueueHandler, (_, _) => {});
 
@@ -103,7 +103,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             }
         }
 
-        private class TestCompositeDataQueueHandler : CompositeDataQueueHandler
+        private class TestDataQueueHandlerManager : DataQueueHandlerManager
         {
             public List<IDataQueueHandler> ExposedDataHandlers => DataHandlers;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `LiveSubscriptionEnumerator` will not long perform any symbol mapping
  but will just trigger a new subscription call when remapped.
- `CompositeDHQ` will handling symbol mapping and keep track of these
  mapped configs to trigger unsubscribe accordengly. Adding unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`2021-12-07T00:45:47.2230557Z ERROR:: LiveTradingDataFeed.CreateDataSubscription():  System.ArgumentException: An item with the same key has already been added. Key: ES17Z21,#0,ES17Z21,Minute,QuoteBar,Quote,BackwardsRatio,OpenInterest`
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests reproducing issue, live deployments local/cloud
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
