### PR TITLE
Align universe security and configuration TZ

### DIFF
--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -584,12 +584,12 @@ namespace QuantConnect.Algorithm
                         // since universe selection proper is never invoked on this type of universe
                         var uconfig = new SubscriptionDataConfig(subscription, symbol: universeSymbol, isInternalFeed: true, fillForward: false);
 
-                        if (security.Type == SecurityType.Base)
-                        {
-                            // set entry in market hours database for the universe subscription to match the custom data
-                            var symbolString = MarketHoursDatabase.GetDatabaseSymbolKey(uconfig.Symbol);
-                            MarketHoursDatabase.SetEntry(uconfig.Market, symbolString, uconfig.SecurityType, security.Exchange.Hours, uconfig.DataTimeZone);
-                        }
+                        // this is the universe symbol, has no real entry in the mhdb, will default to market
+                        // and security type which can be different than the provided config so let's make sure
+                        // the config and the security use the same exchange time zone
+                        // set entry in market hours database for the universe subscription to match the config based on the added security
+                        var symbolString = MarketHoursDatabase.GetDatabaseSymbolKey(uconfig.Symbol);
+                        MarketHoursDatabase.SetEntry(uconfig.Market, symbolString, uconfig.SecurityType, security.Exchange.Hours, uconfig.DataTimeZone);
 
                         universe = new UserDefinedUniverse(uconfig,
                             new UniverseSettings(

--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NodaTime;
 using QuantConnect.Algorithm.Selection;
 using QuantConnect.Data;
 using QuantConnect.Data.Fundamental;
@@ -582,14 +583,15 @@ namespace QuantConnect.Algorithm
                     {
                         // create a new universe, these subscription settings don't currently get used
                         // since universe selection proper is never invoked on this type of universe
-                        var uconfig = new SubscriptionDataConfig(subscription, symbol: universeSymbol, isInternalFeed: true, fillForward: false);
+                        var uconfig = new SubscriptionDataConfig(subscription, symbol: universeSymbol, isInternalFeed: true, fillForward: false,
+                            exchangeTimeZone: DateTimeZone.Utc,
+                            dataTimeZone: DateTimeZone.Utc);
 
-                        // this is the universe symbol, has no real entry in the mhdb, will default to market
-                        // and security type which can be different than the provided config so let's make sure
-                        // the config and the security use the same exchange time zone
-                        // set entry in market hours database for the universe subscription to match the config based on the added security
+                        // this is the universe symbol, has no real entry in the mhdb, will default to market and security type
+                        // set entry in market hours database for the universe subscription to match the config
                         var symbolString = MarketHoursDatabase.GetDatabaseSymbolKey(uconfig.Symbol);
-                        MarketHoursDatabase.SetEntry(uconfig.Market, symbolString, uconfig.SecurityType, security.Exchange.Hours, uconfig.DataTimeZone);
+                        MarketHoursDatabase.SetEntry(uconfig.Market, symbolString, uconfig.SecurityType,
+                            SecurityExchangeHours.AlwaysOpen(uconfig.ExchangeTimeZone), uconfig.DataTimeZone);
 
                         universe = new UserDefinedUniverse(uconfig,
                             new UniverseSettings(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Make sure universe security and configuration tz are aligned always.
  Adding unit test reproducing issue

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Exposed by changes at https://github.com/QuantConnect/Lean/pull/6076/files LTDF
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In some cases the TZ of the universe security and it's subscription configuration would not be aligned
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests, live deployment
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
