### PR TITLE
Change Default Market of CFD to OANDA

### DIFF
--- a/Algorithm.CSharp/CfdTimeZonesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CfdTimeZonesRegressionAlgorithm.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2019, 2, 21);
             SetCash("EUR", 100000);
 
-            _symbol = AddCfd("DE30EUR", Resolution.Minute, Market.Oanda).Symbol;
+            _symbol = AddCfd("DE30EUR").Symbol;
 
             SetBenchmark(_symbol);
         }

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -49,7 +49,7 @@ namespace QuantConnect.Brokerages
             {SecurityType.Future, Market.CME},
             {SecurityType.FutureOption, Market.CME},
             {SecurityType.Forex, Market.Oanda},
-            {SecurityType.Cfd, Market.FXCM},
+            {SecurityType.Cfd, Market.Oanda},
             {SecurityType.Crypto, Market.GDAX},
             {SecurityType.Index, Market.USA},
             {SecurityType.IndexOption, Market.USA}

--- a/Tests/Common/Brokerages/FxcmBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/FxcmBrokerageModelTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -81,6 +81,7 @@ namespace QuantConnect.Tests.Common.Brokerages
 
         private static TestCaseData[] GetOrderTestData()
         {
+            var de30EUR = Symbol.Create("DE30EUR", SecurityType.Cfd, Market.FXCM); ;
             return new[]
             {
                 // invalid security type
@@ -94,59 +95,59 @@ namespace QuantConnect.Tests.Common.Brokerages
 
                 // invalid lot size
                 new TestCaseData(OrderType.Market, _eurUsd, 1m, 0m, 0m, false),
-                new TestCaseData(OrderType.Market, Symbols.DE30EUR, 0.5m, 0m, 0m, false),
+                new TestCaseData(OrderType.Market, de30EUR, 0.5m, 0m, 0m, false),
 
                 // valid lot size
                 new TestCaseData(OrderType.Market, _eurUsd, 1000m, 0m, 0m, true),
-                new TestCaseData(OrderType.Market, Symbols.DE30EUR, 1m, 0m, 0m, true),
+                new TestCaseData(OrderType.Market, de30EUR, 1m, 0m, 0m, true),
 
                 // invalid limit buy price
                 new TestCaseData(OrderType.Limit, _eurUsd, 1000m, 0m, 1.0001m, false),
                 new TestCaseData(OrderType.Limit, _eurUsd, 1000m, 0m, 0.4999m, false),
-                new TestCaseData(OrderType.Limit, Symbols.DE30EUR, 1m, 0m, 10000.1m, false),
-                new TestCaseData(OrderType.Limit, Symbols.DE30EUR, 1m, 0m, 4999m, false),
+                new TestCaseData(OrderType.Limit, de30EUR, 1m, 0m, 10000.1m, false),
+                new TestCaseData(OrderType.Limit, de30EUR, 1m, 0m, 4999m, false),
 
                 // valid limit buy price
                 new TestCaseData(OrderType.Limit, _eurUsd, 1000m, 0m, 1m, true),
                 new TestCaseData(OrderType.Limit, _eurUsd, 1000m, 0m, 0.5m, true),
-                new TestCaseData(OrderType.Limit, Symbols.DE30EUR, 1m, 0m, 10000m, true),
-                new TestCaseData(OrderType.Limit, Symbols.DE30EUR, 1m, 0m, 5000m, true),
+                new TestCaseData(OrderType.Limit, de30EUR, 1m, 0m, 10000m, true),
+                new TestCaseData(OrderType.Limit, de30EUR, 1m, 0m, 5000m, true),
 
                 // invalid limit sell price
                 new TestCaseData(OrderType.Limit, _eurUsd, -1000m, 0m, 0.9999m, false),
                 new TestCaseData(OrderType.Limit, _eurUsd, -1000m, 0m, 1.5001m, false),
-                new TestCaseData(OrderType.Limit, Symbols.DE30EUR, -1m, 0m, 9999.9m, false),
-                new TestCaseData(OrderType.Limit, Symbols.DE30EUR, -1m, 0m, 15000.1m, false),
+                new TestCaseData(OrderType.Limit, de30EUR, -1m, 0m, 9999.9m, false),
+                new TestCaseData(OrderType.Limit, de30EUR, -1m, 0m, 15000.1m, false),
 
                 // valid limit sell price
                 new TestCaseData(OrderType.Limit, _eurUsd, -1000m, 0m, 1m, true),
                 new TestCaseData(OrderType.Limit, _eurUsd, -1000m, 0m, 1.5m, true),
-                new TestCaseData(OrderType.Limit, Symbols.DE30EUR, -1m, 0m, 10000m, true),
-                new TestCaseData(OrderType.Limit, Symbols.DE30EUR, -1m, 0m, 15000m, true),
+                new TestCaseData(OrderType.Limit, de30EUR, -1m, 0m, 10000m, true),
+                new TestCaseData(OrderType.Limit, de30EUR, -1m, 0m, 15000m, true),
 
                 // invalid stop buy price
                 new TestCaseData(OrderType.StopMarket, _eurUsd, 1000m, 0.9999m, 0m, false),
                 new TestCaseData(OrderType.StopMarket, _eurUsd, 1000m, 1.5001m, 0m, false),
-                new TestCaseData(OrderType.StopMarket, Symbols.DE30EUR, 1m, 9999.9m, 0m, false),
-                new TestCaseData(OrderType.StopMarket, Symbols.DE30EUR, 1m, 15000.1m, 0m, false),
+                new TestCaseData(OrderType.StopMarket, de30EUR, 1m, 9999.9m, 0m, false),
+                new TestCaseData(OrderType.StopMarket, de30EUR, 1m, 15000.1m, 0m, false),
 
                 // valid stop buy price
                 new TestCaseData(OrderType.StopMarket, _eurUsd, 1000m, 1m, 0m, true),
                 new TestCaseData(OrderType.StopMarket, _eurUsd, 1000m, 1.5m, 0m, true),
-                new TestCaseData(OrderType.StopMarket, Symbols.DE30EUR, 1m, 10000m, 0m, true),
-                new TestCaseData(OrderType.StopMarket, Symbols.DE30EUR, 1m, 15000m, 0m, true),
+                new TestCaseData(OrderType.StopMarket, de30EUR, 1m, 10000m, 0m, true),
+                new TestCaseData(OrderType.StopMarket, de30EUR, 1m, 15000m, 0m, true),
 
                 // invalid stop sell price
                 new TestCaseData(OrderType.StopMarket, _eurUsd, -1000m, 1.0001m, 0m, false),
                 new TestCaseData(OrderType.StopMarket, _eurUsd, -1000m, 0.4999m, 0m, false),
-                new TestCaseData(OrderType.StopMarket, Symbols.DE30EUR, -1m, 10000.1m, 0m, false),
-                new TestCaseData(OrderType.StopMarket, Symbols.DE30EUR, -1m, 4999m, 0m, false),
+                new TestCaseData(OrderType.StopMarket, de30EUR, -1m, 10000.1m, 0m, false),
+                new TestCaseData(OrderType.StopMarket, de30EUR, -1m, 4999m, 0m, false),
 
                 // valid stop sell price
                 new TestCaseData(OrderType.StopMarket, _eurUsd, -1000m, 1m, 0m, true),
                 new TestCaseData(OrderType.StopMarket, _eurUsd, -1000m, 0.5m, 0m, true),
-                new TestCaseData(OrderType.StopMarket, Symbols.DE30EUR, -1m, 10000m, 0m, true),
-                new TestCaseData(OrderType.StopMarket, Symbols.DE30EUR, -1m, 5000m, 0m, true)
+                new TestCaseData(OrderType.StopMarket, de30EUR, -1m, 10000m, 0m, true),
+                new TestCaseData(OrderType.StopMarket, de30EUR, -1m, 5000m, 0m, true)
             };
         }
     }

--- a/Tests/Common/Util/LeanDataTests.cs
+++ b/Tests/Common/Util/LeanDataTests.cs
@@ -564,11 +564,11 @@ namespace QuantConnect.Tests.Common.Util
                 new LeanDataTestParameters(Symbols.EURUSD, date, Resolution.Daily, TickType.Quote, "eurusd.zip", "eurusd.csv", "forex/oanda/daily"),
 
                 // cfd
-                new LeanDataTestParameters(Symbols.DE10YBEUR, date, Resolution.Tick, TickType.Quote, "20160217_quote.zip", "20160217_de10ybeur_tick_quote.csv", "cfd/fxcm/tick/de10ybeur"),
-                new LeanDataTestParameters(Symbols.DE10YBEUR, date, Resolution.Second, TickType.Quote, "20160217_quote.zip", "20160217_de10ybeur_second_quote.csv", "cfd/fxcm/second/de10ybeur"),
-                new LeanDataTestParameters(Symbols.DE10YBEUR, date, Resolution.Minute, TickType.Quote, "20160217_quote.zip", "20160217_de10ybeur_minute_quote.csv", "cfd/fxcm/minute/de10ybeur"),
-                new LeanDataTestParameters(Symbols.DE10YBEUR, date, Resolution.Hour, TickType.Quote, "de10ybeur.zip", "de10ybeur.csv", "cfd/fxcm/hour"),
-                new LeanDataTestParameters(Symbols.DE10YBEUR, date, Resolution.Daily, TickType.Quote, "de10ybeur.zip", "de10ybeur.csv", "cfd/fxcm/daily"),
+                new LeanDataTestParameters(Symbols.DE10YBEUR, date, Resolution.Tick, TickType.Quote, "20160217_quote.zip", "20160217_de10ybeur_tick_quote.csv", "cfd/oanda/tick/de10ybeur"),
+                new LeanDataTestParameters(Symbols.DE10YBEUR, date, Resolution.Second, TickType.Quote, "20160217_quote.zip", "20160217_de10ybeur_second_quote.csv", "cfd/oanda/second/de10ybeur"),
+                new LeanDataTestParameters(Symbols.DE10YBEUR, date, Resolution.Minute, TickType.Quote, "20160217_quote.zip", "20160217_de10ybeur_minute_quote.csv", "cfd/oanda/minute/de10ybeur"),
+                new LeanDataTestParameters(Symbols.DE10YBEUR, date, Resolution.Hour, TickType.Quote, "de10ybeur.zip", "de10ybeur.csv", "cfd/oanda/hour"),
+                new LeanDataTestParameters(Symbols.DE10YBEUR, date, Resolution.Daily, TickType.Quote, "de10ybeur.zip", "de10ybeur.csv", "cfd/oanda/daily"),
 
                 // Crypto - trades
                 new LeanDataTestParameters(Symbols.BTCUSD, date, Resolution.Tick, TickType.Trade, "20160217_trade.zip", "20160217_btcusd_tick_trade.csv", "crypto/gdax/tick/btcusd"),

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -659,7 +659,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Symbol symbol = null;
             if (securityType == SecurityType.Cfd)
             {
-                symbol = _algorithm.AddCfd(ticker, market: Market.Oanda).Symbol;
+                symbol = _algorithm.AddCfd(ticker).Symbol;
             }
             else if (securityType == SecurityType.Equity)
             {
@@ -1499,14 +1499,14 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             new TestCaseData(Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda), Resolution.Tick, 1, 25, 0, 0, 0, 0, false, _instances[typeof(BaseData)]),
 
             // CFD - FXCM
-            new TestCaseData(Symbols.DE30EUR, Resolution.Hour, 1, 0, 0, 14, 0, 0, false, _instances[typeof(BaseData)]),
-            new TestCaseData(Symbols.DE30EUR, Resolution.Minute, 1, 0, 0, 1 * 60, 0, 0, false, _instances[typeof(BaseData)]),
-            new TestCaseData(Symbols.DE30EUR, Resolution.Tick, 1, 14, 0, 0, 0, 0, false, _instances[typeof(BaseData)]),
+            new TestCaseData(Symbol.Create("DE30EUR", SecurityType.Cfd, Market.FXCM), Resolution.Hour, 1, 0, 0, 14, 0, 0, false, _instances[typeof(BaseData)]),
+            new TestCaseData(Symbol.Create("DE30EUR", SecurityType.Cfd, Market.FXCM), Resolution.Minute, 1, 0, 0, 1 * 60, 0, 0, false, _instances[typeof(BaseData)]),
+            new TestCaseData(Symbol.Create("DE30EUR", SecurityType.Cfd, Market.FXCM), Resolution.Tick, 1, 14, 0, 0, 0, 0, false, _instances[typeof(BaseData)]),
 
             // CFD - Oanda
-            new TestCaseData(Symbol.Create("DE30EUR", SecurityType.Cfd, Market.Oanda), Resolution.Hour, 1, 0, 0, 21, 0, 0, false, _instances[typeof(BaseData)]),
-            new TestCaseData(Symbol.Create("DE30EUR", SecurityType.Cfd, Market.Oanda), Resolution.Minute, 1, 0, 0, 1 * 60, 0, 0, false, _instances[typeof(BaseData)]),
-            new TestCaseData(Symbol.Create("DE30EUR", SecurityType.Cfd, Market.Oanda), Resolution.Tick, 1, 21, 0, 0, 0, 0, false, _instances[typeof(BaseData)]),
+            new TestCaseData(Symbols.DE30EUR, Resolution.Hour, 1, 0, 0, 21, 0, 0, false, _instances[typeof(BaseData)]),
+            new TestCaseData(Symbols.DE30EUR, Resolution.Minute, 1, 0, 0, 1 * 60, 0, 0, false, _instances[typeof(BaseData)]),
+            new TestCaseData(Symbols.DE30EUR, Resolution.Tick, 1, 21, 0, 0, 0, 0, false, _instances[typeof(BaseData)]),
 
             // Crypto
             new TestCaseData(Symbols.BTCUSD, Resolution.Hour, 1, 0, 24, 24, 0, 0, false, _instances[typeof(BaseData)]),

--- a/Tests/Symbols.cs
+++ b/Tests/Symbols.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -52,10 +52,10 @@ namespace QuantConnect.Tests
         public static readonly Symbol BTCEUR = CreateCryptoSymbol("BTCEUR");
         public static readonly Symbol ETHBTC = CreateCryptoSymbol("ETHBTC");
 
-        public static readonly Symbol DE10YBEUR = CreateCfdSymbol("DE10YBEUR", Market.FXCM);
-        public static readonly Symbol DE30EUR = CreateCfdSymbol("DE30EUR", Market.FXCM);
-        public static readonly Symbol XAGUSD = CreateCfdSymbol("XAGUSD", Market.FXCM);
-        public static readonly Symbol XAUUSD = CreateCfdSymbol("XAUUSD", Market.FXCM);
+        public static readonly Symbol DE10YBEUR = CreateCfdSymbol("DE10YBEUR", Market.Oanda);
+        public static readonly Symbol DE30EUR = CreateCfdSymbol("DE30EUR", Market.Oanda);
+        public static readonly Symbol XAGUSD = CreateCfdSymbol("XAGUSD", Market.Oanda);
+        public static readonly Symbol XAUUSD = CreateCfdSymbol("XAUUSD", Market.Oanda);
 
         public static readonly Symbol SPY_Option_Chain = CreateOptionsCanonicalSymbol("SPY");
         public static readonly Symbol SPY_C_192_Feb19_2016 = CreateOptionSymbol("SPY", OptionRight.Call, 192m, new DateTime(2016, 02, 19));


### PR DESCRIPTION
#### Description
Change Default Market of CFD to OANDA

#### Motivation and Context
OANDA is QuantConnect's only provider of CFD. The default Market is FXCM that has been deprecated by didn't have CFD data years before the deprecation.

#### Requires Documentation Change
N/A, just stop using `Market.Oanda`, since it's the default.

#### How Has This Been Tested?
Changing the unit tests. There is also a regression test, `CfdTimeZonesRegressionAlgorithm.cs` that fails before the change. 

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`