### PR TITLE
Adds Market.HKFE to InteractiveBrokersFeeModel

### DIFF
--- a/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
+++ b/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
@@ -109,7 +109,7 @@ namespace QuantConnect.Orders.Fees
                     if (market == Market.Globex || market == Market.NYMEX
                         || market == Market.CBOT || market == Market.ICE
                         || market == Market.CFE || market == Market.COMEX
-                        || market == Market.CME)
+                        || market == Market.CME || market == Market.HKFE)
                     {
                         // just in case...
                         market = Market.USA;


### PR DESCRIPTION
#### Description
Adds `Market.HKFE` to `InteractiveBrokersFeeModel` in the Futures Options case.

#### Related Issue
N/A

#### Motivation and Context
Unsupported market.

#### How Has This Been Tested?
Live algorithm running in Lean-CLI before and after this fix:
master:
```
2021-12-22 16:22:05 Order Error: id: 1, Error executing margin models: InteractiveBrokersFeeModel(): unexpected future Market hkfe
```
this PR:
```
2021-12-22 17:05:00 Order Error: id: 1, Insufficient buying power to complete order (Value:148738.6760), Reason: Id: 1, Initial Margin: 16953.85, Free Margin: 13347.365
2021-12-22 17:05:00 New Order Event: Time: 12/22/2021 17:05:00 OrderID: 1 EventID: 1 Symbol: HSI30Z21 Status: Invalid Quantity: 1 Message: Order Error: id: 1, Insufficient buying power to complete order (Value:148738.6760), Reason: Id: 1, Initial Margin: 16953.85, Free Margin: 13347.365
```

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`