### PR TITLE
Bug: Config.TryGetValue returns true if key is not found

### DIFF
--- a/Algorithm.CSharp/ParameterizedAlgorithm.cs
+++ b/Algorithm.CSharp/ParameterizedAlgorithm.cs
@@ -28,9 +28,9 @@ namespace QuantConnect.Algorithm.CSharp
     /// <meta name="tag" content="using quantconnect" />
     public class ParameterizedAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
-        // we place attributes on top of our fields or properties that should receive
+        // We place attributes on top of our fields or properties that should receive
         // their values from the job. The values 100 and 200 are just default values that
-        // or only used if the parameters do not exist
+        // are only used if the parameters do not exist.
         [Parameter("ema-fast")]
         public int FastPeriod = 100;
 

--- a/Configuration/Config.cs
+++ b/Configuration/Config.cs
@@ -298,8 +298,8 @@ namespace QuantConnect.Configuration
         /// </summary>
         /// <typeparam name="T">The desired output type</typeparam>
         /// <param name="key">The configuration key</param>
-        /// <param name="value">The output value</param>
-        /// <returns>True on successful parse, false when output value is default(T)</returns>
+        /// <param name="value">The output value. If the key is found and parsed successfully, it will be the parsed value, else default(T).</param>
+        /// <returns>True on successful parse or if they key is not found. False only when key is found but fails to parse.</returns>
         public static bool TryGetValue<T>(string key, out T value)
         {
             return TryGetValue(key, default(T), out value);
@@ -312,8 +312,8 @@ namespace QuantConnect.Configuration
         /// <typeparam name="T">The desired output type</typeparam>
         /// <param name="key">The configuration key</param>
         /// <param name="defaultValue">The default value to use on key not found or unsuccessful parse</param>
-        /// <param name="value">The output value</param>
-        /// <returns>True on successful parse, false when output value is defaultValue</returns>
+        /// <param name="value">The output value. If the key is found and parsed successfully, it will be the parsed value, else defaultValue.</param>
+        /// <returns>True on successful parse or if they key is not found and using defaultValue. False only when key is found but fails to parse.</returns>
         public static bool TryGetValue<T>(string key, T defaultValue, out T value)
         {
             try

--- a/Configuration/Config.cs
+++ b/Configuration/Config.cs
@@ -318,12 +318,8 @@ namespace QuantConnect.Configuration
         {
             try
             {
-                // will throw if the key exists but can't parse.
-                // it won't throw if key is not found
                 value = GetValue(key, defaultValue);
-
-                var keyExists = GetToken(key) != null;
-                return keyExists;
+                return true;
             }
             catch
             {

--- a/Configuration/Config.cs
+++ b/Configuration/Config.cs
@@ -318,8 +318,12 @@ namespace QuantConnect.Configuration
         {
             try
             {
+                // will throw if the key exists but can't parse.
+                // it won't throw if key is not found
                 value = GetValue(key, defaultValue);
-                return true;
+
+                var keyExists = GetToken(key) != null;
+                return keyExists;
             }
             catch
             {


### PR DESCRIPTION
Unlike the method's documentation, [`Config.TryGetValue`](https://github.com/QuantConnect/Lean/blob/3d3733c0fb5a167669e99bb4cc74470c8c3f22c7/Configuration/Config.cs#L295-L329) will actually return true if `key` is not found and using `defaultValue`. It will only return false if `key` is found and fails to parse. This pull request fixes it to return false if key is not found. `value` is still set to `defaultValue`.