### PR TITLE
Option selection speed improvements

### DIFF
--- a/Algorithm.CSharp/AddRemoveOptionUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddRemoveOptionUniverseRegressionAlgorithm.cs
@@ -40,8 +40,8 @@ namespace QuantConnect.Algorithm.CSharp
         private int _expectedContractIndex;
         private readonly List<Symbol> _expectedContracts = new List<Symbol>
         {
-            SymbolRepresentation.ParseOptionTickerOSI("GOOG  151224P00750000"),
             SymbolRepresentation.ParseOptionTickerOSI("GOOG  151224P00747500"),
+            SymbolRepresentation.ParseOptionTickerOSI("GOOG  151224P00750000"),
             SymbolRepresentation.ParseOptionTickerOSI("GOOG  151224P00752500")
         };
 
@@ -109,6 +109,11 @@ namespace QuantConnect.Algorithm.CSharp
                 var googOptionChain = AddOption(UnderlyingTicker);
                 googOptionChain.SetFilter(u =>
                 {
+                    // we added the universe at 10, the universe selection data should not be from before
+                    if (u.Underlying.EndTime.Hour < 10)
+                    {
+                        throw new Exception($"Unexpected underlying data point {u.Underlying.EndTime} {u.Underlying}");
+                    }
                     // find first put above market price
                     return u.IncludeWeeklys()
                         .Strikes(+1, +1)
@@ -231,7 +236,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Treynor Ratio", "0"},
             {"Total Fees", "$6.00"},
             {"Estimated Strategy Capacity", "$2000.00"},
-            {"Lowest Capacity Asset", "GOOCV 305RBQ2BZBZT2|GOOCV VP83T1ZUHROL"},
+            {"Lowest Capacity Asset", "GOOCV 305RBR0BSWIX2|GOOCV VP83T1ZUHROL"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
@@ -251,7 +256,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "1e7b3e90918777b9dbf46353a96f3329"}
+            {"OrderListHash", "550a99c482106defd8ba15f48183768e"}
         };
     }
 }

--- a/Common/Data/DiskDataCacheProvider.cs
+++ b/Common/Data/DiskDataCacheProvider.cs
@@ -16,9 +16,11 @@
 
 using System.IO;
 using Ionic.Zip;
-using QuantConnect.Interfaces;
-using QuantConnect.Logging;
+using System.Linq;
 using QuantConnect.Util;
+using QuantConnect.Logging;
+using QuantConnect.Interfaces;
+using System.Collections.Generic;
 
 namespace QuantConnect.Data
 {
@@ -91,6 +93,15 @@ namespace QuantConnect.Data
         {
             LeanData.ParseKey(key, out var filePath, out var entryName);
             Compression.ZipCreateAppendData(filePath, entryName, data, true);
+        }
+
+        /// <summary>
+        /// Returns a list of zip entries in a provided zip file
+        /// </summary>
+        public List<string> GetZipEntries(string zipFile)
+        {
+            using var stream = new FileStream(zipFile, FileMode.Open, FileAccess.Read);
+            return Compression.GetZipEntryFileNames(stream).ToList();
         }
 
         /// <summary>

--- a/Common/Interfaces/IDataCacheProvider.cs
+++ b/Common/Interfaces/IDataCacheProvider.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.IO;
+using System.Collections.Generic;
 
 namespace QuantConnect.Interfaces
 {
@@ -42,5 +43,10 @@ namespace QuantConnect.Interfaces
         /// <param name="key">The source of the data, used as a key to retrieve data in the cache</param>
         /// <param name="data">The data to cache as a byte array</param>
         void Store(string key, byte[] data);
+
+        /// <summary>
+        /// Returns a list of zip entries in a provided zip file
+        /// </summary>
+        List<string> GetZipEntries(string zipFile);
     }
 }

--- a/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactory.cs
@@ -31,6 +31,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
     {
         private readonly Func<SubscriptionRequest, IEnumerable<DateTime>> _tradableDaysProvider;
         private readonly IMapFileProvider _mapFileProvider;
+        private readonly IDataCacheProvider _dataCacheProvider;
         private readonly bool _isLiveMode;
 
         /// <summary>
@@ -38,13 +39,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// </summary>
         /// <param name="isLiveMode">True for live mode, false otherwise</param>
         /// <param name="mapFileProvider">Used for resolving the correct map files</param>
-        /// <param name="factorFileProvider">Used for getting factor files</param>
-        /// <param name="tradableDaysProvider">Function used to provide the tradable dates to be enumerator.
-        /// Specify null to default to <see cref="SubscriptionRequest.TradableDays"/></param>
-        public BaseDataSubscriptionEnumeratorFactory(bool isLiveMode, IMapFileProvider mapFileProvider, IFactorFileProvider factorFileProvider, Func<SubscriptionRequest, IEnumerable<DateTime>> tradableDaysProvider = null)
+        /// <param name="dataCacheProvider">The cache provider instance to use</param>
+        public BaseDataSubscriptionEnumeratorFactory(bool isLiveMode, IMapFileProvider mapFileProvider, IDataCacheProvider dataCacheProvider)
+            : this(isLiveMode, dataCacheProvider)
         {
-            _isLiveMode = isLiveMode;
-            _tradableDaysProvider = tradableDaysProvider ?? (request => request.TradableDays);
             _mapFileProvider = mapFileProvider;
         }
 
@@ -52,12 +50,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// Initializes a new instance of the <see cref="BaseDataSubscriptionEnumeratorFactory"/> class
         /// </summary>
         /// <param name="isLiveMode">True for live mode, false otherwise</param>
-        /// <param name="tradableDaysProvider">Function used to provide the tradable dates to be enumerator.
-        /// Specify null to default to <see cref="SubscriptionRequest.TradableDays"/></param>
-        public BaseDataSubscriptionEnumeratorFactory(bool isLiveMode, Func<SubscriptionRequest, IEnumerable<DateTime>> tradableDaysProvider = null)
+        /// <param name="dataCacheProvider">The cache provider instance to use</param>
+        public BaseDataSubscriptionEnumeratorFactory(bool isLiveMode, IDataCacheProvider dataCacheProvider)
         {
             _isLiveMode = isLiveMode;
-            _tradableDaysProvider = tradableDaysProvider ?? (request => request.TradableDays);
+            _dataCacheProvider = dataCacheProvider;
+            _tradableDaysProvider = (request => request.TradableDays);
         }
 
         /// <summary>
@@ -73,28 +71,19 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             // It has the added benefit of caching any zip files that we request from the filesystem, and reading
             // files contained within the zip file, which the SingleEntryDataCacheProvider does not support.
             var sourceFactory = request.Configuration.GetBaseDataInstance();
-            using (var dataCacheProvider = new ZipDataCacheProvider(dataProvider))
+            foreach (var date in _tradableDaysProvider(request))
             {
-                foreach (var date in _tradableDaysProvider(request))
+                if (sourceFactory.RequiresMapping() && _mapFileProvider != null)
                 {
-                    if (sourceFactory.RequiresMapping() && _mapFileProvider != null)
-                    {
-                        request.Configuration.MappedSymbol = GetMappedSymbol(request.Configuration, date);
-                    }
+                    request.Configuration.MappedSymbol = GetMappedSymbol(request.Configuration, date);
+                }
 
-                    var source = sourceFactory.GetSource(request.Configuration, date, _isLiveMode);
-                    var factory = SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, request.Configuration, date, _isLiveMode, sourceFactory, dataProvider);
-                    var entriesForDate = factory.Read(source);
-                    foreach (var entry in entriesForDate)
-                    {
-                        // Fix for Daily/Hour options cases when reading in all equity data from daily/hourly file
-                        if (entry.Time.Date != date)
-                        {
-                            continue;
-                        }
-
-                        yield return entry;
-                    }
+                var source = sourceFactory.GetSource(request.Configuration, date, _isLiveMode);
+                var factory = SubscriptionDataSourceReader.ForSource(source, _dataCacheProvider, request.Configuration, date, _isLiveMode, sourceFactory, dataProvider);
+                var entriesForDate = factory.Read(source);
+                foreach (var entry in entriesForDate)
+                {
+                    yield return entry;
                 }
             }
         }

--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         private readonly bool _isLiveMode;
         private readonly IResultHandler _resultHandler;
         private readonly IFactorFileProvider _factorFileProvider;
-        private readonly ZipDataCacheProvider _zipDataCacheProvider;
+        private readonly IDataCacheProvider _dataCacheProvider;
         private readonly ConcurrentDictionary<Symbol, string> _numericalPrecisionLimitedWarnings;
         private readonly int _numericalPrecisionLimitedWarningsMaxCount = 10;
         private readonly ConcurrentDictionary<Symbol, string> _startDateLimitedWarnings;
@@ -50,14 +50,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <param name="resultHandler">The result handler for the algorithm</param>
         /// <param name="mapFileProvider">The map file provider</param>
         /// <param name="factorFileProvider">The factor file provider</param>
-        /// <param name="dataProvider">Provider used to get data when it is not present on disk</param>
+        /// <param name="cacheProvider">Provider used to get data when it is not present on disk</param>
         /// <param name="tradableDaysProvider">Function used to provide the tradable dates to be enumerator.
         /// Specify null to default to <see cref="SubscriptionRequest.TradableDays"/></param>
         /// <param name="enablePriceScaling">Applies price factor</param>
         public SubscriptionDataReaderSubscriptionEnumeratorFactory(IResultHandler resultHandler,
             IMapFileProvider mapFileProvider,
             IFactorFileProvider factorFileProvider,
-            IDataProvider dataProvider,
+            IDataCacheProvider cacheProvider,
             Func<SubscriptionRequest, IEnumerable<DateTime>> tradableDaysProvider = null,
             bool enablePriceScaling = true
             )
@@ -65,7 +65,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             _resultHandler = resultHandler;
             _mapFileProvider = mapFileProvider;
             _factorFileProvider = factorFileProvider;
-            _zipDataCacheProvider = new ZipDataCacheProvider(dataProvider, isDataEphemeral: false);
+            _dataCacheProvider = cacheProvider;
             _numericalPrecisionLimitedWarnings = new ConcurrentDictionary<Symbol, string>();
             _startDateLimitedWarnings = new ConcurrentDictionary<Symbol, string>();
             _isLiveMode = false;
@@ -88,7 +88,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 _factorFileProvider,
                 _tradableDaysProvider(request),
                 _isLiveMode,
-                 _zipDataCacheProvider,
+                _dataCacheProvider,
                 dataProvider
                 );
 
@@ -159,8 +159,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
 
                 _resultHandler.DebugMessage(message);
             }
-
-            _zipDataCacheProvider?.DisposeSafely();
         }
     }
 }

--- a/Engine/DataFeeds/Enumerators/FilterEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/FilterEnumerator.cs
@@ -1,0 +1,84 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
+{
+    /// <summary>
+    /// Enumerator that allow applying a filtering function
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class FilterEnumerator<T> : IEnumerator<T>
+    {
+        private readonly IEnumerator<T> _enumerator;
+        private readonly Func<T, bool> _filter;
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        /// <param name="enumerator">The underlying enumerator to filter on</param>
+        /// <param name="filter">The filter to apply</param>
+        public FilterEnumerator(IEnumerator<T> enumerator, Func<T, bool> filter)
+        {
+            _enumerator = enumerator;
+            _filter = filter;
+        }
+
+        #region Implementation of IDisposable
+
+        public void Dispose()
+        {
+            _enumerator.Dispose();
+        }
+
+        #endregion
+
+        #region Implementation of IEnumerator
+
+        public bool MoveNext()
+        {
+            // run the enumerator until it passes the specified filter
+            while (_enumerator.MoveNext())
+            {
+                if (_filter(_enumerator.Current))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public void Reset()
+        {
+            _enumerator.Reset();
+        }
+
+        public T Current
+        {
+            get { return _enumerator.Current; }
+        }
+
+        object IEnumerator.Current
+        {
+            get { return _enumerator.Current; }
+        }
+
+        #endregion
+    }
+}

--- a/Engine/DataFeeds/SingleEntryDataCacheProvider.cs
+++ b/Engine/DataFeeds/SingleEntryDataCacheProvider.cs
@@ -14,11 +14,14 @@
  *
 */
 
+using System;
 using System.IO;
 using Ionic.Zip;
-using QuantConnect.Interfaces;
-using QuantConnect.Logging;
+using System.Linq;
 using QuantConnect.Util;
+using QuantConnect.Logging;
+using QuantConnect.Interfaces;
+using System.Collections.Generic;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
@@ -87,6 +90,22 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         public void Store(string key, byte[] data)
         {
             //
+        }
+
+        /// <summary>
+        /// Returns a list of zip entries in a provided zip file
+        /// </summary>
+        public List<string> GetZipEntries(string zipFile)
+        {
+            var stream = _dataProvider.Fetch(zipFile);
+            if (stream == null)
+            {
+                throw new ArgumentException($"Failed to create source stream {zipFile}");
+            }
+            var entryNames = Compression.GetZipEntryFileNames(stream).ToList();
+            stream.DisposeSafely();
+
+            return entryNames;
         }
 
         /// <summary>

--- a/Engine/DataFeeds/SubscriptionDataSourceReader.cs
+++ b/Engine/DataFeeds/SubscriptionDataSourceReader.cs
@@ -55,7 +55,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     break;
 
                 case FileFormat.ZipEntryName:
-                    reader = new ZipEntryNameSubscriptionDataSourceReader(dataProvider, config, date, isLiveMode);
+                    reader = new ZipEntryNameSubscriptionDataSourceReader(dataCacheProvider, config, date, isLiveMode);
                     break;
 
                 case FileFormat.Index:

--- a/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
+++ b/Engine/HistoricalData/SubscriptionDataReaderHistoryProvider.cs
@@ -15,11 +15,9 @@
 */
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using NodaTime;
 using QuantConnect.Data;
-using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
@@ -191,59 +189,6 @@ namespace QuantConnect.Lean.Engine.HistoricalData
         protected virtual IEnumerator<BaseData> GetIntradayDataEnumerator(IEnumerator<BaseData> rawData, HistoryRequest request)
         {
             return null;
-        }
-
-        private class FilterEnumerator<T> : IEnumerator<T>
-        {
-            private readonly IEnumerator<T> _enumerator;
-            private readonly Func<T, bool> _filter;
-
-            public FilterEnumerator(IEnumerator<T> enumerator, Func<T, bool> filter)
-            {
-                _enumerator = enumerator;
-                _filter = filter;
-            }
-
-            #region Implementation of IDisposable
-
-            public void Dispose()
-            {
-                _enumerator.Dispose();
-            }
-
-            #endregion
-
-            #region Implementation of IEnumerator
-
-            public bool MoveNext()
-            {
-                // run the enumerator until it passes the specified filter
-                while (_enumerator.MoveNext())
-                {
-                    if (_filter(_enumerator.Current))
-                    {
-                        return true;
-                    }
-                }
-                return false;
-            }
-
-            public void Reset()
-            {
-                _enumerator.Reset();
-            }
-
-            public T Current
-            {
-                get { return _enumerator.Current; }
-            }
-
-            object IEnumerator.Current
-            {
-                get { return _enumerator.Current; }
-            }
-
-            #endregion
         }
     }
 }

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/BaseDataSubscriptionEnumeratorFactoryTests.cs
@@ -47,7 +47,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             );
 
             var fileProvider = TestGlobals.DataProvider;
-            var factory = new BaseDataSubscriptionEnumeratorFactory(false, TestGlobals.MapFileProvider, TestGlobals.FactorFileProvider);
+            using var cache = new ZipDataCacheProvider(fileProvider);
+            var factory = new BaseDataSubscriptionEnumeratorFactory(false, TestGlobals.MapFileProvider, cache);
 
             GC.Collect();
             var ramUsageBeforeLoop = OS.TotalPhysicalMemoryUsed;

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactoryTests.cs
@@ -71,7 +71,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             );
 
             var dataProvider = TestGlobals.DataProvider;
-            var enumeratorFactory = new BaseDataSubscriptionEnumeratorFactory(false, TestGlobals.MapFileProvider, TestGlobals.FactorFileProvider);
+            using var cache = new ZipDataCacheProvider(dataProvider);
+            var enumeratorFactory = new BaseDataSubscriptionEnumeratorFactory(false, TestGlobals.MapFileProvider, cache);
             var fillForwardResolution = Ref.CreateReadOnly(() => Resolution.Minute.ToTimeSpan());
             Func<SubscriptionRequest, IEnumerator<BaseData>> underlyingEnumeratorFunc = (req) =>
                 {

--- a/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
@@ -95,7 +95,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             algorithm.PostInitialize();
 
             var resultHandler = new BacktestingResultHandler();
-            var factory = new SubscriptionDataReaderSubscriptionEnumeratorFactory(resultHandler, TestGlobals.MapFileProvider, TestGlobals.FactorFileProvider, TestGlobals.DataProvider, enablePriceScaling: false);
+            using var cache = new ZipDataCacheProvider(TestGlobals.DataProvider);
+            var factory = new SubscriptionDataReaderSubscriptionEnumeratorFactory(resultHandler, TestGlobals.MapFileProvider, TestGlobals.FactorFileProvider, cache, enablePriceScaling: false);
 
             var universe = algorithm.UniverseManager.Single().Value;
             var security = algorithm.Securities.Single().Value;
@@ -139,9 +140,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             algorithm.Initialize();
             algorithm.PostInitialize();
 
-            var dataProvider = new DefaultDataProvider();
             var resultHandler = new TestResultHandler();
-            var factory = new SubscriptionDataReaderSubscriptionEnumeratorFactory(resultHandler, TestGlobals.MapFileProvider, TestGlobals.FactorFileProvider, TestGlobals.DataProvider, enablePriceScaling: false);
+            using var cache = new ZipDataCacheProvider(TestGlobals.DataProvider);
+            var factory = new SubscriptionDataReaderSubscriptionEnumeratorFactory(resultHandler, TestGlobals.MapFileProvider, TestGlobals.FactorFileProvider, cache, enablePriceScaling: false);
 
             var universe = algorithm.UniverseManager.Single().Value;
             var security = algorithm.AddEquity("AAA", Resolution.Daily);
@@ -149,7 +150,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             // start date is before the first date in the map file
             var subscriptionRequest = new SubscriptionRequest(false, universe, security, securityConfig, new DateTime(2001, 12, 1),
                 new DateTime(2016, 11, 1));
-            var enumerator = factory.CreateEnumerator(subscriptionRequest, dataProvider);
+            var enumerator = factory.CreateEnumerator(subscriptionRequest, TestGlobals.DataProvider);
             // should initialize the data source reader
             enumerator.MoveNext();
 

--- a/Tests/Engine/DataFeeds/IndexSubscriptionDataSourceReaderTests.cs
+++ b/Tests/Engine/DataFeeds/IndexSubscriptionDataSourceReaderTests.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
@@ -130,6 +131,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             }
             public void Store(string key, byte[] data)
             {
+            }
+            public List<string> GetZipEntries(string zipFile)
+            {
+                throw new NotImplementedException();
             }
             public void Dispose()
             {

--- a/Tests/Engine/DataFeeds/SubscriptionDataReaderTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionDataReaderTests.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 using QuantConnect.Data;
@@ -79,7 +80,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             public void Dispose()
             {
             }
-
+            public List<string> GetZipEntries(string zipFile)
+            {
+                throw new NotImplementedException();
+            }
             public bool IsDataEphemeral => true;
             public Stream Fetch(string key)
             {

--- a/Tests/Engine/DataFeeds/TextSubscriptionDataSourceReaderTests.cs
+++ b/Tests/Engine/DataFeeds/TextSubscriptionDataSourceReaderTests.cs
@@ -376,6 +376,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             public string Data { set; get; }
             public bool IsDataEphemeral { set; get; }
 
+            public List<string> GetZipEntries(string zipFile)
+            {
+                throw new NotImplementedException();
+            }
             public Stream Fetch(string key)
             {
                 var stream = new MemoryStream();

--- a/Tests/Engine/DataFeeds/ZipEntryNameSubscriptionFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/ZipEntryNameSubscriptionFactoryTests.cs
@@ -33,7 +33,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var source = Path.Combine("TestData", "20151224_quote_american.zip");
             var config = new SubscriptionDataConfig(typeof (ZipEntryName), Symbol.Create("XLRE", SecurityType.Option, Market.USA), Resolution.Tick,
                 TimeZones.NewYork, TimeZones.NewYork, false, false, false);
-            var factory = new ZipEntryNameSubscriptionDataSourceReader(TestGlobals.DataProvider, config, time, false);
+            using var cacheProvider = new ZipDataCacheProvider(TestGlobals.DataProvider);
+            var factory = new ZipEntryNameSubscriptionDataSourceReader(cacheProvider, config, time, false);
             var expected = new[]
             {
                 Symbol.CreateOption("XLRE", Market.USA, OptionStyle.American, OptionRight.Call, 21m, new DateTime(2016, 08, 19)),

--- a/Tests/ToolBox/LeanDataReaderTests.cs
+++ b/Tests/ToolBox/LeanDataReaderTests.cs
@@ -179,7 +179,8 @@ namespace QuantConnect.Tests.ToolBox
             //load future chain first
             var config = new SubscriptionDataConfig(typeof(ZipEntryName), baseFuture, res,
                                                     TimeZones.NewYork, TimeZones.NewYork, false, false, false, false, tickType);
-            var factory = new ZipEntryNameSubscriptionDataSourceReader(TestGlobals.DataProvider, config, date, false);
+            using var cacheProvider = new ZipDataCacheProvider(TestGlobals.DataProvider);
+            var factory = new ZipEntryNameSubscriptionDataSourceReader(cacheProvider, config, date, false);
 
             var result = factory.Read(new SubscriptionDataSource(filePath, SubscriptionTransportMedium.LocalFile, FileFormat.ZipEntryName))
                           .Select(s => s.Symbol).ToList();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Allow caching zip entry names if possible for a performance improvement,
  Specially for daily and hourly futures and options.
- For option universe subscription request, non option data stack will not use `BaseDataSubscriptionEnumeratorFactory` but the normal data stack. Enables caching in some cases and minor bug fixes

#### PERFORMANCE

- Running on cloud B8-16

```csharp
    public class BasicTemplateOptionsDailyAlgorithm : QCAlgorithm
    {
        public override void Initialize()
        {
            SetStartDate(2020, 1, 1);
            SetEndDate(2020, 6, 1);

            UniverseSettings.Resolution = Resolution.Daily;
            Schedule.On(Schedule.DateRules.EveryDay(), Schedule.TimeRules.Noon, (_, _) =>
            {
                Plot("RAM", "RAM", (int)OS.ApplicationMemoryUsed);
            });
            AddUniverse(CoarseSelectionFunction);
        }

        public static IEnumerable<Symbol> CoarseSelectionFunction(IEnumerable<CoarseFundamental> coarse)
        {
            var sortedByDollarVolume = coarse.OrderByDescending(x => x.DollarVolume);
            var top = sortedByDollarVolume.Take(4);
            return top.Select(x => x.Symbol);
        }
        public override void OnSecuritiesChanged(SecurityChanges changes)
        {
            foreach (var security in changes.AddedSecurities)
            {
            	if(security.Symbol.SecurityType == SecurityType.Equity)
            	{
	                var option = AddOption(security.Symbol, Resolution.Daily);
	            	option.SetFilter(x =>
	            	{
	            		return x.CallsOnly().Strikes(0, 1).Expiration(0, 10);
	            	});
            	}
            }
        }
    }
```

#### MASTER

78.97 seconds at 285k data points per second. Processing total of 22,468,025 data points.
80.36 seconds at 280k data points per second. Processing total of 22,468,025 data points.
77.92 seconds at 288k data points per second. Processing total of 22,468,025 data points.

![image](https://user-images.githubusercontent.com/18473240/148557250-2b3b53d8-5096-49ae-b652-cd9c4a4fd080.png)

![image](https://user-images.githubusercontent.com/18473240/148556819-3f5842da-5f7b-453f-991e-6d0a6fdfc69e.png)

#### PR

29.45 seconds at 765k data points per second. Processing total of 22,518,355 data points.
28.84 seconds at 781k data points per second. Processing total of 22,518,355 data points.
31.11 seconds at 724k data points per second. Processing total of 22,518,355 data points.

![image](https://user-images.githubusercontent.com/18473240/148557971-4694caac-96d7-4fb6-a83a-6e7b581b3ca1.png)


![image](https://user-images.githubusercontent.com/18473240/148556856-676a252d-8e52-42d8-9f5b-9a63077b4f52.png)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Speed improvements
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Cloud backtesting
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
