### PR TITLE
GetLastKnownPrices python data

### DIFF
--- a/Algorithm.CSharp/BasicTemplateFuturesDailyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesDailyAlgorithm.cs
@@ -154,7 +154,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "157cdc340dd50771ffa85dcdff49ad13"}
+            {"OrderListHash", "09b2f274fa2385597a803e58b784f675"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateFuturesDailyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesDailyAlgorithm.cs
@@ -77,7 +77,7 @@ namespace QuantConnect.Algorithm.CSharp
                     ).FirstOrDefault();
 
                     // if found, trade it
-                    if (contract != null)
+                    if (contract != null && IsMarketOpen(contract.Symbol))
                     {
                         _contractSymbol = contract.Symbol;
                         MarketOrder(_contractSymbol, 1);

--- a/Algorithm.CSharp/BasicTemplateFuturesHourlyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesHourlyAlgorithm.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "ea387eaed0d3c57afc51494800df160e"}
+            {"OrderListHash", "87d2b127c9859cad9d2c65ac9d76deb5"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateOptionsDailyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsDailyAlgorithm.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Algorithm.CSharp
                     var contractsByExpiration = chain.Where(x => x.Expiry != Time.Date).OrderBy(x => x.Expiry);
                     var contract = contractsByExpiration.FirstOrDefault();
 
-                    if (contract != null)
+                    if (contract != null && IsMarketOpen(contract.Symbol))
                     {
                         // if found, trade it
                         MarketOrder(contract.Symbol, 1);

--- a/Algorithm.CSharp/BasicTemplateOptionsHourlyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsHourlyAlgorithm.cs
@@ -76,7 +76,7 @@ namespace QuantConnect.Algorithm.CSharp
                         .ThenByDescending(x => x.Right)
                         .FirstOrDefault();
 
-                    if (atmContract != null)
+                    if (atmContract != null && IsMarketOpen(atmContract.Symbol))
                     {
                         // if found, trade it
                         MarketOrder(atmContract.Symbol, 1);

--- a/Algorithm.CSharp/CustomDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataRegressionAlgorithm.cs
@@ -18,7 +18,9 @@ using System.Collections.Generic;
 using System.Globalization;
 using Newtonsoft.Json;
 using QuantConnect.Data;
+using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -31,12 +33,14 @@ namespace QuantConnect.Algorithm.CSharp
     /// <meta name="tag" content="regression test" />
     public class CustomDataRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
+        private bool _warmedUpChecked = false;
+
         /// <summary>
         /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
         /// </summary>
         public override void Initialize()
         {
-            SetStartDate(2011, 9, 13);
+            SetStartDate(2011, 9, 14);
             SetEndDate(2015, 12, 01);
 
             //Set the cash for the strategy:
@@ -45,6 +49,9 @@ namespace QuantConnect.Algorithm.CSharp
             //Define the symbol and "type" of our generic data:
             var resolution = LiveMode ? Resolution.Second : Resolution.Daily;
             AddData<Bitcoin>("BTC", resolution);
+
+            var seeder = new FuncSecuritySeeder(GetLastKnownPrices);
+            SetSecurityInitializer(security => seeder.SeedSecurity(security));
         }
 
         /// <summary>
@@ -66,6 +73,30 @@ namespace QuantConnect.Algorithm.CSharp
             }
         }
 
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            changes.FilterCustomSecurities = false;
+            foreach (var addedSecurity in changes.AddedSecurities)
+            {
+                if (addedSecurity.Symbol.Value == "BTC")
+                {
+                    _warmedUpChecked = true;
+                }
+                if (!addedSecurity.HasData)
+                {
+                    throw new Exception($"Security {addedSecurity.Symbol} was not warmed up!");
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_warmedUpChecked)
+            {
+                throw new Exception($"Security was not warmed up!");
+            }
+        }
+
         /// <summary>
         /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
         /// </summary>
@@ -84,30 +115,30 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "1"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "157.497%"},
+            {"Compounding Annual Return", "157.655%"},
             {"Drawdown", "84.800%"},
             {"Expectancy", "0"},
             {"Net Profit", "5319.007%"},
-            {"Sharpe Ratio", "2.086"},
-            {"Probabilistic Sharpe Ratio", "69.456%"},
+            {"Sharpe Ratio", "2.123"},
+            {"Probabilistic Sharpe Ratio", "70.581%"},
             {"Loss Rate", "0%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "1.747"},
-            {"Beta", "0.047"},
+            {"Alpha", "1.776"},
+            {"Beta", "0.059"},
             {"Annual Standard Deviation", "0.84"},
             {"Annual Variance", "0.706"},
-            {"Information Ratio", "1.922"},
-            {"Tracking Error", "0.848"},
-            {"Treynor Ratio", "37.473"},
+            {"Information Ratio", "1.962"},
+            {"Tracking Error", "0.847"},
+            {"Treynor Ratio", "30.455"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "BTC.Bitcoin 2S"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "2.269"},
-            {"Return Over Maximum Drawdown", "1.858"},
+            {"Sortino Ratio", "2.271"},
+            {"Return Over Maximum Drawdown", "1.86"},
             {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},

--- a/Algorithm.Python/BasicTemplateFuturesDailyAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesDailyAlgorithm.py
@@ -50,6 +50,7 @@ class BasicTemplateFuturesDailyAlgorithm(QCAlgorithm):
                 front = sorted(contracts, key = lambda x: x.Expiry, reverse=True)[0]
 
                 self.contractSymbol = front.Symbol
-                self.MarketOrder(front.Symbol , 1)
+                if self.IsMarketOpen(self.contractSymbol):
+                    self.MarketOrder(front.Symbol , 1)
         else:
             self.Liquidate()

--- a/Algorithm.Python/BasicTemplateFuturesHourlyAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFuturesHourlyAlgorithm.py
@@ -50,6 +50,7 @@ class BasicTemplateFuturesHourlyAlgorithm(QCAlgorithm):
                 front = sorted(contracts, key = lambda x: x.Expiry, reverse=True)[0]
 
                 self.contractSymbol = front.Symbol
-                self.MarketOrder(front.Symbol , 1)
+                if self.IsMarketOpen(self.contractSymbol):
+                    self.MarketOrder(front.Symbol , 1)
         else:
             self.Liquidate()

--- a/Algorithm.Python/BasicTemplateOptionsDailyAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsDailyAlgorithm.py
@@ -51,7 +51,7 @@ class BasicTemplateOptionsDailyAlgorithm(QCAlgorithm):
         contracts = sorted(chain, key = lambda x: x.Expiry)
 
         # if found, trade it
-        if len(contracts) == 0: return
+        if len(contracts) == 0 or not self.IsMarketOpen(contracts[0].Symbol): return
         symbol = contracts[0].Symbol
         self.MarketOrder(symbol, 1)
 

--- a/Algorithm.Python/BasicTemplateOptionsHourlyAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateOptionsHourlyAlgorithm.py
@@ -57,7 +57,7 @@ class BasicTemplateOptionsHourlyAlgorithm(QCAlgorithm):
             key = lambda x: x.Right, reverse=True)
 
         # if found, trade it
-        if len(contracts) == 0: return
+        if len(contracts) == 0 or not self.IsMarketOpen(contracts[0].Symbol): return
         symbol = contracts[0].Symbol
         self.MarketOrder(symbol, 1)
         self.MarketOnCloseOrder(symbol, -1)

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using QuantConnect.Securities.Option;
 using static QuantConnect.StringExtensions;
 using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data;
 
 namespace QuantConnect.Algorithm
 {
@@ -1269,13 +1270,11 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(SecuritiesAndPortfolio)]
         public bool IsMarketOpen(Symbol symbol)
         {
-            var exchangeHours = MarketHoursDatabase
-                .FromDataFolder()
-                .GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
-
-            var time = UtcTime.ConvertFromUtc(exchangeHours.TimeZone);
-
-            return exchangeHours.IsOpen(time, false);
+            if (Securities.TryGetValue(symbol, out var security))
+            {
+                return security.IsMarketOpen(false);
+            }
+            return symbol.IsMarketOpen(UtcTime, false);
         }
 
         private SubmitOrderRequest CreateSubmitOrderRequest(OrderType orderType, Security security, decimal quantity, string tag, IOrderProperties properties, decimal stopPrice = 0m, decimal limitPrice = 0m,  decimal triggerPrice = 0m)

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -22,7 +22,6 @@ using System.Collections.Generic;
 using QuantConnect.Securities.Option;
 using static QuantConnect.StringExtensions;
 using QuantConnect.Algorithm.Framework.Portfolio;
-using QuantConnect.Data;
 
 namespace QuantConnect.Algorithm
 {

--- a/Common/Data/Slice.cs
+++ b/Common/Data/Slice.cs
@@ -340,7 +340,7 @@ namespace QuantConnect.Data
                 var requestedOpenInterest = type == typeof(OpenInterest);
                 if (type == typeof(Tick) || requestedOpenInterest)
                 {
-                    var dataDictionaryCache = GenericDataDictionary.Get(type);
+                    var dataDictionaryCache = GenericDataDictionary.Get(type, isPythonData: false);
                     dictionary = Activator.CreateInstance(dataDictionaryCache.GenericType);
 
                     foreach (var data in instance.Ticks)
@@ -390,15 +390,23 @@ namespace QuantConnect.Data
                 }
                 else
                 {
-                    if (type.IsAssignableTo(typeof(PythonData)))
-                    {
-                        type = typeof(PythonData);
-                    }
+                    var isPythonData = type.IsAssignableTo(typeof(PythonData));
 
-                    var dataDictionaryCache = GenericDataDictionary.Get(type);
+                    var dataDictionaryCache = GenericDataDictionary.Get(type, isPythonData);
                     dictionary = Activator.CreateInstance(dataDictionaryCache.GenericType);
 
-                    foreach (var data in instance._data.Value.Values.Select(x => x.Custom).Where(o => o != null && o.GetType() == type))
+                    foreach (var data in instance._data.Value.Values.Select(x => x.Custom).Where(o =>
+                             {
+                                 if (o == null)
+                                 {
+                                     return false;
+                                 }
+                                 if (isPythonData && o is PythonData data)
+                                 {
+                                     return data.IsOfType(type);
+                                 }
+                                 return o.GetType() == type;
+                             }))
                     {
                         dataDictionaryCache.MethodInfo.Invoke(dictionary, new object[] { data.Symbol, data });
                     }
@@ -658,15 +666,22 @@ namespace QuantConnect.Data
             /// <summary>
             /// Provides a <see cref="GenericDataDictionary"/> instance for a given <see cref="Type"/>
             /// </summary>
-            /// <param name="type"></param>
+            /// <param name="type">The requested data type</param>
+            /// <param name="isPythonData">True if data is of <see cref="PythonData"/> type</param>
             /// <returns>A new instance or retrieved from the cache</returns>
-            public static GenericDataDictionary Get(Type type)
+            public static GenericDataDictionary Get(Type type, bool isPythonData)
             {
                 GenericDataDictionary dataDictionaryCache;
                 if (!_genericCache.TryGetValue(type, out dataDictionaryCache))
                 {
-                    var generic = typeof(DataDictionary<>).MakeGenericType(type);
-                    var method = generic.GetMethod("Add", new[] { typeof(Symbol), type });
+                    var dictionaryType = type;
+                    if (isPythonData)
+                    {
+                        // let's create a python data dictionary because the data itself will be a PythonData type in C#
+                        dictionaryType = typeof(PythonData);
+                    }
+                    var generic = typeof(DataDictionary<>).MakeGenericType(dictionaryType);
+                    var method = generic.GetMethod("Add", new[] { typeof(Symbol), dictionaryType });
                     _genericCache[type] = dataDictionaryCache = new GenericDataDictionary(generic, method);
                 }
 

--- a/Common/Data/Slice.cs
+++ b/Common/Data/Slice.cs
@@ -390,6 +390,11 @@ namespace QuantConnect.Data
                 }
                 else
                 {
+                    if (type.IsAssignableTo(typeof(PythonData)))
+                    {
+                        type = typeof(PythonData);
+                    }
+
                     var dataDictionaryCache = GenericDataDictionary.Get(type);
                     dictionary = Activator.CreateInstance(dataDictionaryCache.GenericType);
 

--- a/Common/ExtendedDictionary.cs
+++ b/Common/ExtendedDictionary.cs
@@ -19,16 +19,13 @@ using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Interfaces;
 using System.Collections;
-using System.Dynamic;
-using System.Reflection;
-using Fasterflect;
 
 namespace QuantConnect
 {
     /// <summary>
     /// Provides a base class for types holding instances keyed by <see cref="Symbol"/>
     /// </summary>
-    public abstract class ExtendedDictionary<T> : DynamicObject, IExtendedDictionary<Symbol, T>
+    public abstract class ExtendedDictionary<T> : IExtendedDictionary<Symbol, T>
     {
         /// <summary>
         /// Removes all items from the <see cref="T:System.Collections.Generic.ICollection`1"/>.
@@ -349,25 +346,6 @@ namespace QuantConnect
         public PyList values()
         {
             return GetValues.ToPyList();
-        }
-
-        public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object? result)
-        {
-            result = this[(Symbol)indexes[0]];
-            return true;
-        }
-
-        public override bool TryInvokeMember(InvokeMemberBinder binder, object?[]? args, out object? result)
-        {
-            var members = GetType().GetMethod(binder.Name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
-
-            if (members != null)
-            {
-                result = members.Invoke(this, args);
-                return true;
-            }
-
-            return base.TryInvokeMember(binder, args, out result);
         }
     }
 }

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -790,17 +790,7 @@ namespace QuantConnect.Orders.Fills
         /// </summary>
         protected static bool IsExchangeOpen(Security asset, bool isExtendedMarketHours)
         {
-            if (!asset.Exchange.DateTimeIsOpen(asset.LocalTime))
-            {
-                // if we're not open at the current time exactly, check the bar size, this handle large sized bars (hours/days)
-                var currentBar = asset.GetLastData();
-                if (asset.LocalTime.Date != currentBar.EndTime.Date
-                    || !asset.Exchange.IsOpenDuringBar(currentBar.Time, currentBar.EndTime, isExtendedMarketHours))
-                {
-                    return false;
-                }
-            }
-            return true;
+            return asset.IsMarketOpen(isExtendedMarketHours);
         }
     }
 }

--- a/Common/Python/PythonData.cs
+++ b/Common/Python/PythonData.cs
@@ -26,6 +26,7 @@ namespace QuantConnect.Python
     /// </summary>
     public class PythonData : DynamicData
     {
+        private readonly string _pythonTypeName;
         private readonly dynamic _pythonData;
         private readonly dynamic _defaultResolution;
         private readonly dynamic _supportedResolutions;
@@ -54,6 +55,7 @@ namespace QuantConnect.Python
                 _isSparseData = pythonData.GetPythonMethod("IsSparseData");
                 _defaultResolution = pythonData.GetPythonMethod("DefaultResolution");
                 _supportedResolutions = pythonData.GetPythonMethod("SupportedResolutions");
+                _pythonTypeName = pythonData.GetPythonType().GetAssemblyName().Name;
             }
         }
 
@@ -86,7 +88,11 @@ namespace QuantConnect.Python
             using (Py.GIL())
             {
                 var data = _pythonData.Reader(config, line, date, isLiveMode);
-                return (data as PyObject).GetAndDispose<BaseData>();
+                var result = (data as PyObject).GetAndDispose<BaseData>();
+
+                (result as PythonData)?.SetProperty("__typename", _pythonTypeName);
+
+                return result;
             }
         }
 
@@ -173,6 +179,20 @@ namespace QuantConnect.Python
             {
                 SetProperty(index, value is double ? value.ConvertInvariant<decimal>() : value);
             }
+        }
+
+        /// <summary>
+        /// Helper method to determine if the current instance is of the provided type
+        /// </summary>
+        /// <param name="type">Target type to check against</param>
+        /// <returns>True if this instance is of the provided type</returns>
+        public bool IsOfType(Type type)
+        {
+            if (HasProperty("__typename"))
+            {
+                return (string)GetProperty("__typename") == type.FullName;
+            }
+            return GetType() == type;
         }
     }
 }

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -15,11 +15,14 @@
 
 using System;
 using NodaTime;
+using System.IO;
 using System.Linq;
+using Python.Runtime;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Util;
 using QuantConnect.Algorithm;
+using QuantConnect.Securities;
 using QuantConnect.Interfaces;
 using QuantConnect.Data.Market;
 using System.Collections.Generic;
@@ -27,7 +30,6 @@ using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Tests.Engine.DataFeeds;
 using QuantConnect.Data.Custom.AlphaStreams;
 using QuantConnect.Lean.Engine.HistoricalData;
-using QuantConnect.Securities;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Tests.Algorithm
@@ -262,6 +264,58 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(1, lastKnownPrices.Count(data => data.GetType() == typeof(QuoteBar)));
         }
 
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void GetLastKnownPricesCustomData(Language language)
+        {
+            var algorithm = GetAlgorithm(new DateTime(2013, 10, 8));
+
+            Symbol symbol;
+            if (language == Language.CSharp)
+            {
+                symbol = algorithm.AddData<CustomData>("SPY").Symbol;
+            }
+            else
+            {
+                using (Py.GIL())
+                {
+                    var customDataType = PythonEngine.ModuleFromString("testModule",
+                        @"
+from AlgorithmImports import *
+from QuantConnect.Tests import *
+
+class Test(PythonData):
+    def GetSource(self, config, date, isLiveMode):
+        fileName = LeanData.GenerateZipFileName(Symbols.SPY, date, config.Resolution, config.TickType)
+        source = f'{Globals.DataFolder}equity/usa/minute/spy/{fileName}'
+        return SubscriptionDataSource(source, SubscriptionTransportMedium.LocalFile, FileFormat.Csv)
+
+    def Reader(self, config, line, date, isLiveMode):
+
+        result = Test()
+        result.DataType = MarketDataType.Base
+        result.Symbol = config.Symbol
+        result.Time = date
+        result.Value = 1
+
+        return result
+        ").GetAttr("Test");
+                    symbol = algorithm.AddData(customDataType, "SPY").Symbol;
+                }
+            }
+
+            var lastKnownPrices = algorithm.GetLastKnownPrices(symbol).ToList();
+            Assert.AreEqual(1, lastKnownPrices.Count);
+            if (language == Language.CSharp)
+            {
+                Assert.AreEqual(1, lastKnownPrices.Count(data => data.GetType() == typeof(CustomData)));
+            }
+            else
+            {
+                Assert.AreEqual(1, lastKnownPrices.Count(data => data.GetType() == typeof(PyObject)));
+            }
+        }
+
         [Test]
         public void GetLastKnownPriceEquity()
         {
@@ -426,6 +480,28 @@ namespace QuantConnect.Tests.Algorithm
                 var endTime = requests.Max(x => x.EndTimeUtc.ConvertFromUtc(x.DataTimeZone));
 
                 return Slices.Where(x => x.Time >= startTime && x.Time <= endTime).ToList();
+            }
+        }
+
+        private class CustomData : TradeBar
+        {
+            public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
+            {
+                var source = Path.Combine(Globals.DataFolder, "equity", "usa", config.Resolution.ToString().ToLower(),
+                    Symbols.SPY.Value.ToLowerInvariant(), LeanData.GenerateZipFileName(Symbols.SPY, date, config.Resolution, config.TickType));
+                return new SubscriptionDataSource(source, SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
+            }
+            public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
+            {
+                var baseData = base.Reader(new SubscriptionDataConfig(config, symbol: Symbols.SPY), line, date, isLiveMode);
+
+                return new CustomData
+                {
+                    DataType = MarketDataType.Base,
+                    Symbol = config.Symbol,
+                    Time = baseData.EndTime,
+                    Value = baseData.Price
+                };
             }
         }
     }

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -30,6 +30,7 @@ using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Tests.Engine.DataFeeds;
 using QuantConnect.Data.Custom.AlphaStreams;
 using QuantConnect.Lean.Engine.HistoricalData;
+using QuantConnect.Python;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Tests.Algorithm
@@ -292,10 +293,12 @@ class Test(PythonData):
 
     def Reader(self, config, line, date, isLiveMode):
 
+        data = line.split(',')
+
         result = Test()
         result.DataType = MarketDataType.Base
         result.Symbol = config.Symbol
-        result.Time = date
+        result.Time = date + timedelta(milliseconds=int(data[0]))
         result.Value = 1
 
         return result
@@ -312,7 +315,7 @@ class Test(PythonData):
             }
             else
             {
-                Assert.AreEqual(1, lastKnownPrices.Count(data => data.GetType() == typeof(PyObject)));
+                Assert.AreEqual(1, lastKnownPrices.Count(data => data.GetType() == typeof(PythonData)));
             }
         }
 

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -21,6 +21,7 @@ using Python.Runtime;
 using NUnit.Framework;
 using QuantConnect.Data;
 using QuantConnect.Util;
+using QuantConnect.Python;
 using QuantConnect.Algorithm;
 using QuantConnect.Securities;
 using QuantConnect.Interfaces;
@@ -30,7 +31,6 @@ using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Tests.Engine.DataFeeds;
 using QuantConnect.Data.Custom.AlphaStreams;
 using QuantConnect.Lean.Engine.HistoricalData;
-using QuantConnect.Python;
 using HistoryRequest = QuantConnect.Data.HistoryRequest;
 
 namespace QuantConnect.Tests.Algorithm
@@ -486,7 +486,7 @@ class Test(PythonData):
             }
         }
 
-        private class CustomData : TradeBar
+        public class CustomData : TradeBar
         {
             public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- `QCAlgorithm.IsMarketOpen` will work correctly when used with daily and hourly
  resolution. Adding tests
- `slice.Get` will work correctly with python custom data. Adding tests
- Fix for python custom data types causing binding runtime exceptions due to being defined private. Adding tests
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/6185
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Perfection
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
