### PR TITLE
Include DataSource repos in stub generation

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -28,3 +28,5 @@ jobs:
           ./ci_build_stubs.sh -t -g -p
         env:
           PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          ADDITIONAL_STUBS_REPOS: ${{ secrets.ADDITIONAL_STUBS_REPOS }}
+          QC_GIT_TOKEN: ${{ secrets.QC_GIT_TOKEN }}

--- a/ci_build_stubs.sh
+++ b/ci_build_stubs.sh
@@ -18,6 +18,26 @@ STUBS_DIR="$LEAN_BIN_DIR/generated-stubs"
 # If you do this, know that PyPI and TestPyPI require different API tokens
 PYPI_REPO="pypi"
 
+# For our all additional repos we want to include in our stubs
+ADDITIONAL_REPOS_DIR="$LEAN_DIR/ADDITIONAL_STUBS"
+
+# This function essentially loads in additional repo into our Lean directory
+# which will then be included in our generation of stubs
+function prepare_additional_repos {
+    if [ ! -d $ADDITIONAL_REPOS_DIR ]; then
+        mkdir $ADDITIONAL_REPOS_DIR
+    fi
+
+    cd $ADDITIONAL_REPOS_DIR
+    for REPO in ${ADDITIONAL_STUBS_REPOS[@]}; do
+        #Replace github.com with token from environment before checking it out
+        git clone "${repo//github.com/"${QC_GIT_TOKEN}@github.com"}"
+    done
+
+    # Return us back to previous directory
+    cd -
+}
+
 function ensure_repo_up_to_date {
     if [ ! -d $3 ]; then
         git clone $1 $3
@@ -35,6 +55,8 @@ function install_twine {
 function generate_stubs {
     ensure_repo_up_to_date $GENERATOR_REPO $GENERATOR_BRANCH $GENERATOR_DIR
     ensure_repo_up_to_date $RUNTIME_REPO $RUNTIME_BRANCH $RUNTIME_DIR
+
+    prepare_additional_repos
 
     if [ -d $STUBS_DIR ]; then
         rm -rf $STUBS_DIR


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Modify stub generation to include additional repos into the workflow.

This loads additional repos into the Lean dir which gets passed to the generator. See accompanying generator PR QuantConnect/quantconnect-stubs-generator#4 which filters undesired data source repos that we are including.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add DataSource stubs to Python

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the bash script as well as generation of the new stubs

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
