### PR TITLE
Python Stubs Adjustment

### DIFF
--- a/Common/Securities/Option/StrategyMatcher/OptionPosition.cs
+++ b/Common/Securities/Option/StrategyMatcher/OptionPosition.cs
@@ -29,7 +29,7 @@ namespace QuantConnect.Securities.Option.StrategyMatcher
         /// <summary>
         /// Gets a new <see cref="OptionPosition"/> with zero <see cref="Quantity"/>
         /// </summary>
-        public static OptionPosition None(Symbol symbol)
+        public static OptionPosition Empty(Symbol symbol)
             => new OptionPosition(symbol, 0);
 
         /// <summary>

--- a/Tests/Common/Securities/Options/StrategyMatcher/OptionPositionTests.cs
+++ b/Tests/Common/Securities/Options/StrategyMatcher/OptionPositionTests.cs
@@ -148,9 +148,9 @@ namespace QuantConnect.Tests.Common.Securities.Options.StrategyMatcher
         }
 
         [Test]
-        public void None_CreatesOptionPosition_WithZeroQuantity()
+        public void Empty_CreatesOptionPosition_WithZeroQuantity()
         {
-            var none = OptionPosition.None(Symbols.SPY);
+            var none = OptionPosition.Empty(Symbols.SPY);
             Assert.AreEqual(0, none.Quantity);
             Assert.AreEqual(Symbols.SPY, none.Symbol);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


#### Description
<!--- Describe your changes in detail -->

Minor change for clean integration with Python Stubs.
- OptionPosition.None renamed to OptionPosition.Empty

The original name of the function causes issues in stubs as `None` is a reserved word for Python. 

PR is paired with QuantConnect/quantconnect-stubs-generator#5 to resolve CI and PyRight errors on stub generation.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

Very minor breaking change, only used instance was in test. I suppose is possible a user could use it in an algorithm, however I believe it is unlikely.

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
