### PR TITLE
Fixes GetBuyingPowerModel Method of DefaultBrokerageModel

### DIFF
--- a/Algorithm.CSharp/BasicSetAccountCurrencyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicSetAccountCurrencyAlgorithm.cs
@@ -14,6 +14,7 @@
 */
 
 using System.Collections.Generic;
+using QuantConnect.Brokerages;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
 
@@ -33,6 +34,7 @@ namespace QuantConnect.Algorithm.CSharp
         {
             SetStartDate(2018, 04, 04);  //Set Start Date
             SetEndDate(2018, 04, 04);    //Set End Date
+            SetBrokerageModel(BrokerageName.GDAX, AccountType.Cash);
             //Before setting any cash or adding a Security call SetAccountCurrency
             SetAccountCurrency("EUR");
             SetCash(100000);             //Set Strategy Cash
@@ -87,14 +89,14 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$0.00"},
+            {"Total Fees", "$298.35"},
             {"Estimated Strategy Capacity", "$85000.00"},
             {"Lowest Capacity Asset", "BTCEUR XJ"},
             {"Fitness Score", "0.506"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
             {"Sortino Ratio", "79228162514264337593543950335"},
-            {"Return Over Maximum Drawdown", "-14.148"},
+            {"Return Over Maximum Drawdown", "-13.614"},
             {"Portfolio Turnover", "1.073"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
@@ -109,7 +111,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "18dc611407abec4ea47092e71f33f983"}
+            {"OrderListHash", "2ba443899dcccc79dc0f04441f797bf9"}
         };
     }
 }

--- a/Algorithm.CSharp/TwoLegCurrencyConversionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TwoLegCurrencyConversionRegressionAlgorithm.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Brokerages;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
 
@@ -33,6 +34,7 @@ namespace QuantConnect.Algorithm.CSharp
         {
             SetStartDate(2018, 04, 04);
             SetEndDate(2018, 04, 04);
+            SetBrokerageModel(BrokerageName.GDAX, AccountType.Cash);
 
             // GDAX doesn't have LTCETH or ETHLTC, but they do have ETHUSD and LTCUSD to form a path between ETH and LTC
             SetAccountCurrency("ETH");

--- a/Algorithm.CSharp/WarmupConversionRatesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WarmupConversionRatesRegressionAlgorithm.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using QuantConnect.Brokerages;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
 
@@ -32,6 +33,7 @@ namespace QuantConnect.Algorithm.CSharp
         {
             SetStartDate(2018, 4, 5);
             SetEndDate(2018, 4, 5);
+            SetBrokerageModel(BrokerageName.GDAX, AccountType.Cash);
             SetCash(10000);
 
             SetWarmUp(TimeSpan.FromDays(1));
@@ -100,14 +102,14 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$0.00"},
+            {"Total Fees", "$29.84"},
             {"Estimated Strategy Capacity", "$410000.00"},
             {"Lowest Capacity Asset", "LTCUSD XJ"},
             {"Fitness Score", "0.499"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
             {"Sortino Ratio", "79228162514264337593543950335"},
-            {"Return Over Maximum Drawdown", "-315.48"},
+            {"Return Over Maximum Drawdown", "-189.336"},
             {"Portfolio Turnover", "0.999"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
@@ -122,7 +124,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "d38f5aec6a9c4dcf62de7b0dff26117f"}
+            {"OrderListHash", "c764c98687300a2da250436baae2963c"}
         };
     }
 }

--- a/Algorithm.Python/BasicSetAccountCurrencyAlgorithm.py
+++ b/Algorithm.Python/BasicSetAccountCurrencyAlgorithm.py
@@ -22,6 +22,7 @@ class BasicSetAccountCurrencyAlgorithm(QCAlgorithm):
 
         self.SetStartDate(2018, 4, 4)  #Set Start Date
         self.SetEndDate(2018, 4, 4)    #Set End Date
+        self.SetBrokerageModel(BrokerageName.GDAX, AccountType.Cash);
         # Before setting any cash or adding a Security call SetAccountCurrency
         self.SetAccountCurrency("EUR")
         self.SetCash(100000)           #Set Strategy Cash

--- a/Algorithm.Python/TwoLegCurrencyConversionRegressionAlgorithm.py
+++ b/Algorithm.Python/TwoLegCurrencyConversionRegressionAlgorithm.py
@@ -20,7 +20,7 @@ class TwoLegCurrencyConversionRegressionAlgorithm(QCAlgorithm):
     def Initialize(self):
         self.SetStartDate(2018, 4, 4)
         self.SetEndDate(2018, 4, 4)
-
+        self.SetBrokerageModel(BrokerageName.GDAX, AccountType.Cash);
         # GDAX doesn't have LTCETH or ETHLTC, but they do have ETHUSD and LTCUSD to form a path between ETH and LTC
         self.SetAccountCurrency("ETH")
         self.SetCash("ETH", 100000)

--- a/Common/Brokerages/BinanceBrokerageModel.cs
+++ b/Common/Brokerages/BinanceBrokerageModel.cs
@@ -45,20 +45,6 @@ namespace QuantConnect.Brokerages
         }
 
         /// <summary>
-        /// Gets a new buying power model for the security, returning the default model with the security's configured leverage.
-        /// For cash accounts, leverage = 1 is used.
-        /// For standard account margin trading the leverage is 3x, leverage 5x only supported in the master account
-        /// </summary>
-        /// <param name="security">The security to get a buying power model for</param>
-        /// <returns>The buying power model for this brokerage/security</returns>
-        public override IBuyingPowerModel GetBuyingPowerModel(Security security)
-        {
-            return AccountType == AccountType.Cash
-                ? new CashBuyingPowerModel()
-                : new SecurityMarginModel(GetLeverage(security));
-        }
-
-        /// <summary>
         /// Binance global leverage rule
         /// </summary>
         /// <param name="security"></param>

--- a/Common/Brokerages/BitfinexBrokerageModel.cs
+++ b/Common/Brokerages/BitfinexBrokerageModel.cs
@@ -46,20 +46,6 @@ namespace QuantConnect.Brokerages
         }
 
         /// <summary>
-        /// Gets a new buying power model for the security, returning the default model with the security's configured leverage.
-        /// For cash accounts, leverage = 1 is used.
-        /// For margin trading, max leverage = 3.3
-        /// </summary>
-        /// <param name="security">The security to get a buying power model for</param>
-        /// <returns>The buying power model for this brokerage/security</returns>
-        public override IBuyingPowerModel GetBuyingPowerModel(Security security)
-        {
-            return AccountType == AccountType.Cash
-                ? (IBuyingPowerModel)new CashBuyingPowerModel()
-                : new SecurityMarginModel(_maxLeverage);
-        }
-
-        /// <summary>
         /// Bitfinex global leverage rule
         /// </summary>
         /// <param name="security"></param>

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -351,33 +351,16 @@ namespace QuantConnect.Brokerages
         /// <returns>The buying power model for this brokerage/security</returns>
         public virtual IBuyingPowerModel GetBuyingPowerModel(Security security)
         {
-            var leverage = GetLeverage(security);
-            IBuyingPowerModel model;
-
-            switch (security.Type)
+            return security.Type switch
             {
-                case SecurityType.Crypto:
-                    model = new CashBuyingPowerModel();
-                    break;
-                case SecurityType.Forex:
-                case SecurityType.Cfd:
-                    model = new SecurityMarginModel(leverage, RequiredFreeBuyingPowerPercent);
-                    break;
-                case SecurityType.Option:
-                    model = new OptionMarginModel(RequiredFreeBuyingPowerPercent);
-                    break;
-                case SecurityType.FutureOption:
-                    model = new FuturesOptionsMarginModel(RequiredFreeBuyingPowerPercent, (Option)security);
-                    break;
-                case SecurityType.Future:
-                    model = new FutureMarginModel(RequiredFreeBuyingPowerPercent, security);
-                    break;
-                case SecurityType.Index:
-                default:
-                    model = new SecurityMarginModel(leverage, RequiredFreeBuyingPowerPercent);
-                    break;
-            }
-            return model;
+                SecurityType.Future => new FutureMarginModel(RequiredFreeBuyingPowerPercent, security),
+                SecurityType.FutureOption => new FuturesOptionsMarginModel(RequiredFreeBuyingPowerPercent, (Option)security),
+                SecurityType.IndexOption => new OptionMarginModel(RequiredFreeBuyingPowerPercent),
+                SecurityType.Option => new OptionMarginModel(RequiredFreeBuyingPowerPercent),
+                _ => AccountType == AccountType.Cash
+                    ? new CashBuyingPowerModel()
+                    : new SecurityMarginModel(GetLeverage(security), RequiredFreeBuyingPowerPercent)
+            };
         }
 
         /// <summary>

--- a/Common/Brokerages/FTXBrokerageModel.cs
+++ b/Common/Brokerages/FTXBrokerageModel.cs
@@ -48,20 +48,6 @@ namespace QuantConnect.Brokerages
         }
         
         /// <summary>
-        /// Gets a new buying power model for the security, returning the default model with the security's configured leverage.
-        /// For cash accounts, leverage = 1 is used.
-        /// For margin trading, FTX supports up to 20x leverage, default is 3xs 
-        /// </summary>
-        /// <param name="security">The security to get a buying power model for</param>
-        /// <returns>The buying power model for this brokerage/security</returns>
-        public override IBuyingPowerModel GetBuyingPowerModel(Security security)
-        {
-            return AccountType == AccountType.Margin
-                ? new SecurityMarginModel(GetLeverage(security))
-                : new CashBuyingPowerModel();
-        }
-
-        /// <summary>
         /// Gets the brokerage's leverage for the specified security
         /// </summary>
         /// <param name="security">The security's whose leverage we seek</param>

--- a/Common/Brokerages/KrakenBrokerageModel.cs
+++ b/Common/Brokerages/KrakenBrokerageModel.cs
@@ -134,23 +134,6 @@ namespace QuantConnect.Brokerages
         }
 
         /// <summary>
-        /// Gets a new buying power model for the security, returning the default model with the security's configured leverage.
-        /// For cash accounts, leverage = 1 is used.
-        /// For margin trading, max leverage = 5
-        /// </summary>
-        /// <param name="security">The security to get a buying power model for</param>
-        /// <returns>The buying power model for this brokerage/security</returns>
-        public override IBuyingPowerModel GetBuyingPowerModel(Security security)
-        {
-            if (AccountType == AccountType.Margin)
-            {
-                return new SecurityMarginModel(GetLeverage(security));
-            }
-                   
-            return new CashBuyingPowerModel();
-        }
-
-        /// <summary>
         /// Kraken global leverage rule
         /// </summary>
         /// <param name="security"></param>

--- a/Common/Brokerages/SamcoBrokerageModel.cs
+++ b/Common/Brokerages/SamcoBrokerageModel.cs
@@ -142,20 +142,6 @@ namespace QuantConnect.Brokerages
         public override IReadOnlyDictionary<SecurityType, string> DefaultMarkets { get; } = GetDefaultMarkets();
 
         /// <summary>
-        /// Gets a new buying power model for the security, returning the default model with the
-        /// security's configured leverage. For cash accounts, leverage = 1 is used. For margin
-        /// trading, max leverage = 7
-        /// </summary>
-        /// <param name="security">The security to get a buying power model for</param>
-        /// <returns>The buying power model for this brokerage/security</returns>
-        public override IBuyingPowerModel GetBuyingPowerModel(Security security)
-        {
-            return AccountType == AccountType.Cash
-                ? (IBuyingPowerModel)new CashBuyingPowerModel()
-                : new SecurityMarginModel(_maxLeverage);
-        }
-
-        /// <summary>
         /// Samco global leverage rule
         /// </summary>
         /// <param name="security"></param>

--- a/Common/Brokerages/TradierBrokerageModel.cs
+++ b/Common/Brokerages/TradierBrokerageModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -34,7 +34,7 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
         /// </summary>
-        /// <param name="accountType">The type of account to be modelled, defaults to
+        /// <param name="accountType">The type of account to be modeled, defaults to
         /// <see cref="QuantConnect.AccountType.Margin"/></param>
         public TradierBrokerageModel(AccountType accountType = AccountType.Margin)
             : base(accountType)
@@ -102,7 +102,7 @@ namespace QuantConnect.Brokerages
             if (request.Quantity != null && request.Quantity != order.Quantity)
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "UpdateRejected",
-                    "Traider does not support updating order quantities."
+                    "Tradier does not support updating order quantities."
                 );
 
                 return false;

--- a/Common/Brokerages/ZerodhaBrokerageModel.cs
+++ b/Common/Brokerages/ZerodhaBrokerageModel.cs
@@ -136,22 +136,6 @@ namespace QuantConnect.Brokerages
         /// </summary>
         public override IReadOnlyDictionary<SecurityType, string> DefaultMarkets { get; } = GetDefaultMarkets();
 
-
-
-        /// <summary>
-        /// Gets a new buying power model for the security, returning the default model with the security's configured leverage.
-        /// For cash accounts, leverage = 1 is used.
-        /// For margin trading, max leverage = 7
-        /// </summary>
-        /// <param name="security">The security to get a buying power model for</param>
-        /// <returns>The buying power model for this brokerage/security</returns>
-        public override IBuyingPowerModel GetBuyingPowerModel(Security security)
-        {
-            return AccountType == AccountType.Cash
-                ? (IBuyingPowerModel)new CashBuyingPowerModel()
-                : new SecurityMarginModel(_maxLeverage);
-        }
-
         /// <summary>
         /// Zerodha global leverage rule
         /// </summary>

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -1186,6 +1186,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(-3000m, actual);
 
             var btcusd = algo.AddCrypto("BTCUSD", market: Market.GDAX);
+            btcusd.BuyingPowerModel = new CashBuyingPowerModel();
             btcusd.FeeModel = new ConstantFeeModel(0);
             // Set Price to $26
             Update(btcusd, 26);


### PR DESCRIPTION
#### Description
`CashBuyingPowerModel`, which reflected on `AlphaStreamBrokerageModel`, a margin-only brokerage.

It also didn't consider the account type, so `InteractiveBrokersBrokerageModel` was using the margin model even if `AccountType.Cash` was selected.

Removes `GetBuyingPowerModel` method from other Brokerage Models when their cases are covered by `DefaultBrokerageModel`

Fixes some typoes in `TradierBrokerageModel`

Fixes unit and regression tests. For the regression tests, we have explicitly set the brokerage model.

#### Motivation and Context
Bugfix.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit and regression tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`