### PR TITLE
Add support for array history-provider values to QuantBook

### DIFF
--- a/Engine/HistoricalData/HistoryProviderManager.cs
+++ b/Engine/HistoricalData/HistoryProviderManager.cs
@@ -68,10 +68,10 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             }
             _initialized = true;
 
-            var dataProvidersList = parameters.Job.HistoryProvider.DeserializeList();
+            var dataProvidersList = parameters.Job?.HistoryProvider.DeserializeList() ?? new List<string>();
             if (dataProvidersList.IsNullOrEmpty())
             {
-                dataProvidersList.Add(Config.Get("history-provider", "SubscriptionDataReaderHistoryProvider"));
+                dataProvidersList.AddRange(Config.Get("history-provider", "SubscriptionDataReaderHistoryProvider").DeserializeList());
             }
 
             foreach (var historyProviderName in dataProvidersList)

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -23,6 +23,7 @@ using QuantConnect.Indicators;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine;
 using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Future;
 using QuantConnect.Securities.Option;
@@ -172,7 +173,7 @@ namespace QuantConnect.Research
                         algorithmHandlers.DataPermissionsManager));
 
                 var mapFileProvider = algorithmHandlers.MapFileProvider;
-                HistoryProvider = composer.GetExportedValueByTypeName<IHistoryProvider>(Config.Get("history-provider", "SubscriptionDataReaderHistoryProvider"));
+                HistoryProvider = new HistoryProviderManager();
                 HistoryProvider.Initialize(
                     new HistoryProviderInitializeParameters(
                         null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR makes QuantBook support array values for `history-provider` properties in `config.json`. These were introduced in #6187, which updated `config.json` so that all `history-provider` properties are now arrays of strings instead of strings, and updated the Engine to support this new format. However, the QuantBook class was not updated to support these arrays of strings, causing the composer to throw an error because there is no type named "[\n"QuantConnect.Lean.Engine.HistoricalData.SubscriptionDataReaderHistoryProvider"\n]". This PR fixes that.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #6218.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes a bug.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running backtests and creating QuantBook instances locally using the CLI with custom Docker images, with both string values and array of strings values for `environments.backtesting.history-provider`.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->