### PR TITLE
Fixes WarmUpIndicator Overload Inconsistency

### DIFF
--- a/Algorithm.CSharp/SmaCrossUniverseSelectionAlgorithm.cs
+++ b/Algorithm.CSharp/SmaCrossUniverseSelectionAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -63,7 +63,12 @@ namespace QuantConnect.Algorithm.CSharp
                 return (from cf in coarse
                         where cf.HasFundamentalData
                         // grab the SMA instance for this symbol
-                        let avg = averages.GetOrAdd(cf.Symbol, sym => WarmUpIndicator(cf.Symbol, new SimpleMovingAverage(100), Resolution.Daily))
+                        let avg = averages.GetOrAdd(cf.Symbol, sym =>
+                        {
+                            var sma = new SimpleMovingAverage(100);
+                            WarmUpIndicator(cf.Symbol, sma, Resolution.Daily);
+                            return sma;
+                        })
                         // Update returns true when the indicators are ready, so don't accept until they are
                         where avg.Update(cf.EndTime, cf.AdjustedPrice)
                         // only pick symbols who have their price over their 100 day sma

--- a/Algorithm.Python/SmaCrossUniverseSelectionAlgorithm.py
+++ b/Algorithm.Python/SmaCrossUniverseSelectionAlgorithm.py
@@ -63,8 +63,8 @@ class SmaCrossUniverseSelectionAlgorithm(QCAlgorithm):
             symbol = cf.Symbol
             price = cf.AdjustedPrice
             # grab the SMA instance for this symbol
-            avg = self.averages.setdefault(symbol,
-                self.WarmUpIndicator(symbol, SimpleMovingAverage(100), Resolution.Daily))
+            avg = self.averages.setdefault(symbol, SimpleMovingAverage(100))
+            self.WarmUpIndicator(symbol, avg, Resolution.Daily)
             # Update returns true when the indicators are ready, so don't accept until they are
             if avg.Update(cf.EndTime, price):
                value = avg.Current.Value

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -2553,14 +2553,13 @@ namespace QuantConnect.Algorithm
         /// <param name="indicator">The indicator we want to warm up</param>
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
-        /// <returns>The given indicator</returns>
         [DocumentationAttribute(HistoricalData)]
         [DocumentationAttribute(Indicators)]
-        public IndicatorBase<IndicatorDataPoint> WarmUpIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        public void WarmUpIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
         {
             resolution = GetResolution(symbol, resolution);
             var period = resolution.Value.ToTimeSpan();
-            return WarmUpIndicator(symbol, indicator, period, selector);
+            WarmUpIndicator(symbol, indicator, period, selector);
         }
 
         /// <summary>
@@ -2570,16 +2569,15 @@ namespace QuantConnect.Algorithm
         /// <param name="indicator">The indicator we want to warm up</param>
         /// <param name="period">The necessary period to warm up the indicator</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
-        /// <returns>The given indicator</returns>
         [DocumentationAttribute(HistoricalData)]
         [DocumentationAttribute(Indicators)]
-        public IndicatorBase<IndicatorDataPoint> WarmUpIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, TimeSpan period, Func<IBaseData, decimal> selector = null)
+        public void WarmUpIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, TimeSpan period, Func<IBaseData, decimal> selector = null)
         {
             var history = GetIndicatorWarmUpHistory(symbol, indicator, period);
-            if (history == Enumerable.Empty<Slice>()) return indicator;
+            if (history == Enumerable.Empty<Slice>()) return;
 
             // assign default using cast
-            selector = selector ?? (x => x.Value);
+            selector ??= (x => x.Value);
 
             Action<IBaseData> onDataConsolidated = bar =>
             {
@@ -2588,7 +2586,6 @@ namespace QuantConnect.Algorithm
             };
 
             WarmUpIndicatorImpl(symbol, period, onDataConsolidated, history);
-            return indicator;
         }
 
         /// <summary>
@@ -2598,15 +2595,14 @@ namespace QuantConnect.Algorithm
         /// <param name="indicator">The indicator we want to warm up</param>
         /// <param name="resolution">The resolution</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
-        /// <returns>The given indicator</returns>
         [DocumentationAttribute(HistoricalData)]
         [DocumentationAttribute(Indicators)]
-        public IndicatorBase<T> WarmUpIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, Resolution? resolution = null, Func<IBaseData, T> selector = null)
+        public void WarmUpIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, Resolution? resolution = null, Func<IBaseData, T> selector = null)
             where T : class, IBaseData
         {
             resolution = GetResolution(symbol, resolution);
             var period = resolution.Value.ToTimeSpan();
-            return WarmUpIndicator(symbol, indicator, period, selector);
+            WarmUpIndicator(symbol, indicator, period, selector);
         }
 
         /// <summary>
@@ -2616,17 +2612,16 @@ namespace QuantConnect.Algorithm
         /// <param name="indicator">The indicator we want to warm up</param>
         /// <param name="period">The necessary period to warm up the indicator</param>
         /// <param name="selector">Selects a value from the BaseData send into the indicator, if null defaults to a cast (x => (T)x)</param>
-        /// <returns>The given indicator</returns>
         [DocumentationAttribute(HistoricalData)]
         [DocumentationAttribute(Indicators)]
-        public IndicatorBase<T> WarmUpIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, TimeSpan period, Func<IBaseData, T> selector = null)
+        public void WarmUpIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, TimeSpan period, Func<IBaseData, T> selector = null)
             where T : class, IBaseData
         {
             var history = GetIndicatorWarmUpHistory(symbol, indicator, period);
-            if (history == Enumerable.Empty<Slice>()) return indicator;
+            if (history == Enumerable.Empty<Slice>()) return;
 
             // assign default using cast
-            selector = selector ?? (x => (T)x);
+            selector ??= (x => (T)x);
 
             // we expect T type as input
             Action<T> onDataConsolidated = bar =>
@@ -2635,7 +2630,6 @@ namespace QuantConnect.Algorithm
             };
 
             WarmUpIndicatorImpl(symbol, period, onDataConsolidated, history);
-            return indicator;
         }
 
         private IEnumerable<Slice> GetIndicatorWarmUpHistory(Symbol symbol, IIndicator indicator, TimeSpan timeSpan)

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -661,21 +661,18 @@ namespace QuantConnect.Algorithm
         public void WarmUpIndicator(Symbol symbol, PyObject indicator, Resolution? resolution = null, PyObject selector = null)
         {
             // TODO: to be removed when https://github.com/QuantConnect/pythonnet/issues/62 is solved
-            IndicatorBase<IndicatorDataPoint> indicatorDataPoint;
-            IndicatorBase<IBaseDataBar> indicatorDataBar;
-            IndicatorBase<TradeBar> indicatorTradeBar;
 
-            if (indicator.TryConvert(out indicatorDataPoint))
+            if (indicator.TryConvert(out IndicatorBase<IndicatorDataPoint> indicatorDataPoint))
             {
                 WarmUpIndicator(symbol, indicatorDataPoint, resolution, selector?.ConvertToDelegate<Func<IBaseData, decimal>>());
                 return;
             }
-            else if (indicator.TryConvert(out indicatorDataBar))
+            if (indicator.TryConvert(out IndicatorBase<IBaseDataBar> indicatorDataBar))
             {
                 WarmUpIndicator(symbol, indicatorDataBar, resolution, selector?.ConvertToDelegate<Func<IBaseData, IBaseDataBar>>());
                 return;
             }
-            else if (indicator.TryConvert(out indicatorTradeBar))
+            if (indicator.TryConvert(out IndicatorBase<TradeBar> indicatorTradeBar))
             {
                 WarmUpIndicator(symbol, indicatorTradeBar, resolution, selector?.ConvertToDelegate<Func<IBaseData, TradeBar>>());
                 return;


### PR DESCRIPTION
#### Description
`WarmUpIndicator` for Python indicators doesn't return the indicator anymore after #6027. So all overloads should return `void` for consistency.

Fixes `SmaCrossUniverseSelectionAlgorithm` [C# and Py] to follow the new return type.

#### Motivation and Context
API standardization.

#### Requires Documentation Change
It should be included on docs/v2.

#### How Has This Been Tested?
`SmaCrossUniverseSelectionAlgorithm` [C# and Py] executed in QuantConnect Cloud. 
The Python version raised this exception:
```
Runtime Error: AttributeError : &#039;NoneType&#039; object has no attribute &#039;Update&#039;
  at CoarseSmaSelector
``` 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.