### PR TITLE
Warm up EmaCrossAlphaModel indicators

### DIFF
--- a/Algorithm.CSharp/CompositeAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/CompositeAlphaModelFrameworkAlgorithm.cs
@@ -74,47 +74,47 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 56;
+        public int AlgorithmHistoryDataPoints => 208;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "7"},
-            {"Average Win", "0.01%"},
-            {"Average Loss", "-0.40%"},
-            {"Compounding Annual Return", "1143.086%"},
+            {"Total Trades", "18"},
+            {"Average Win", "0.00%"},
+            {"Average Loss", "-0.02%"},
+            {"Compounding Annual Return", "88.032%"},
             {"Drawdown", "1.800%"},
-            {"Expectancy", "-0.319"},
-            {"Net Profit", "3.275%"},
-            {"Sharpe Ratio", "23.495"},
-            {"Probabilistic Sharpe Ratio", "80.494%"},
-            {"Loss Rate", "33%"},
-            {"Win Rate", "67%"},
-            {"Profit-Loss Ratio", "0.02"},
-            {"Alpha", "4.366"},
-            {"Beta", "1.255"},
-            {"Annual Standard Deviation", "0.292"},
-            {"Annual Variance", "0.085"},
-            {"Information Ratio", "47.955"},
-            {"Tracking Error", "0.102"},
-            {"Treynor Ratio", "5.461"},
-            {"Total Fees", "$71.37"},
-            {"Estimated Strategy Capacity", "$3500000.00"},
+            {"Expectancy", "-0.679"},
+            {"Net Profit", "0.811%"},
+            {"Sharpe Ratio", "5.833"},
+            {"Probabilistic Sharpe Ratio", "65.782%"},
+            {"Loss Rate", "73%"},
+            {"Win Rate", "27%"},
+            {"Profit-Loss Ratio", "0.18"},
+            {"Alpha", "-0.473"},
+            {"Beta", "0.725"},
+            {"Annual Standard Deviation", "0.165"},
+            {"Annual Variance", "0.027"},
+            {"Information Ratio", "-14.297"},
+            {"Tracking Error", "0.071"},
+            {"Treynor Ratio", "1.331"},
+            {"Total Fees", "$31.70"},
+            {"Estimated Strategy Capacity", "$5900000.00"},
             {"Lowest Capacity Asset", "AIG R735QTJ8XC9X"},
             {"Fitness Score", "0.501"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "148.07"},
-            {"Return Over Maximum Drawdown", "1487.238"},
-            {"Portfolio Turnover", "0.501"},
-            {"Total Insights Generated", "2"},
+            {"Sortino Ratio", "13.543"},
+            {"Return Over Maximum Drawdown", "75.664"},
+            {"Portfolio Turnover", "0.505"},
+            {"Total Insights Generated", "6"},
             {"Total Insights Closed", "0"},
             {"Total Insights Analysis Completed", "0"},
-            {"Long Insight Count", "2"},
-            {"Short Insight Count", "0"},
-            {"Long/Short Ratio", "100%"},
+            {"Long Insight Count", "5"},
+            {"Short Insight Count", "1"},
+            {"Long/Short Ratio", "500%"},
             {"Estimated Monthly Alpha Value", "$0"},
             {"Total Accumulated Estimated Alpha Value", "$0"},
             {"Mean Population Estimated Insight Value", "$0"},
@@ -122,7 +122,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "5a171f804d47cd27f84aaef791da8594"}
+            {"OrderListHash", "f25344c69f9b9476ae5a834616a65c82"}
         };
     }
 }

--- a/Algorithm.Framework/Alphas/EmaCrossAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/EmaCrossAlphaModel.cs
@@ -163,8 +163,6 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 Fast = new ExponentialMovingAverage(security.Symbol, fastPeriod, ExponentialMovingAverage.SmoothingFactorDefault(fastPeriod));
                 Slow = new ExponentialMovingAverage(security.Symbol, slowPeriod, ExponentialMovingAverage.SmoothingFactorDefault(slowPeriod));
 
-                algorithm.RegisterIndicator(Security.Symbol, Fast, FastConsolidator);
-                algorithm.RegisterIndicator(Security.Symbol, Slow, SlowConsolidator);
                 algorithm.RegisterIndicator(security.Symbol, Fast, FastConsolidator);
                 algorithm.RegisterIndicator(security.Symbol, Slow, SlowConsolidator);
 

--- a/Algorithm.Framework/Alphas/EmaCrossAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/EmaCrossAlphaModel.cs
@@ -117,7 +117,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 SymbolData data;
                 if (_symbolDataBySymbol.TryGetValue(removed.Symbol, out data))
                 {
-                    // clean up our consolidator
+                    // clean up our consolidators
                     algorithm.SubscriptionManager.RemoveConsolidator(data.Security.Symbol, data.FastConsolidator);
                     algorithm.SubscriptionManager.RemoveConsolidator(data.Security.Symbol, data.SlowConsolidator);
                     _symbolDataBySymbol.Remove(removed.Symbol);
@@ -165,6 +165,8 @@ namespace QuantConnect.Algorithm.Framework.Alphas
 
                 algorithm.RegisterIndicator(Security.Symbol, Fast, FastConsolidator);
                 algorithm.RegisterIndicator(Security.Symbol, Slow, SlowConsolidator);
+                algorithm.RegisterIndicator(security.Symbol, Fast, FastConsolidator);
+                algorithm.RegisterIndicator(security.Symbol, Slow, SlowConsolidator);
 
                 algorithm.WarmUpIndicator(security.Symbol, Fast, resolution);
                 algorithm.WarmUpIndicator(security.Symbol, Slow, resolution);

--- a/Algorithm.Framework/Alphas/EmaCrossAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/EmaCrossAlphaModel.cs
@@ -30,7 +30,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         private readonly int _slowPeriod;
         private readonly Resolution _resolution;
         private readonly int _predictionInterval;
-        private readonly Dictionary<Symbol, SymbolData> _symbolDataBySymbol;
+        protected readonly Dictionary<Symbol, SymbolData> _symbolDataBySymbol;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EmaCrossAlphaModel"/> class
@@ -104,6 +104,8 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                     // create fast/slow EMAs
                     var fast = algorithm.EMA(added.Symbol, _fastPeriod, _resolution);
                     var slow = algorithm.EMA(added.Symbol, _slowPeriod, _resolution);
+                    algorithm.WarmUpIndicator(added.Symbol, fast, _resolution);
+                    algorithm.WarmUpIndicator(added.Symbol, slow, _resolution);
                     _symbolDataBySymbol[added.Symbol] = new SymbolData
                     {
                         Security = added,
@@ -123,7 +125,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <summary>
         /// Contains data specific to a symbol required by this model
         /// </summary>
-        private class SymbolData
+        public class SymbolData
         {
             public Security Security { get; set; }
             public Symbol Symbol => Security.Symbol;

--- a/Algorithm.Framework/Alphas/EmaCrossAlphaModel.py
+++ b/Algorithm.Framework/Alphas/EmaCrossAlphaModel.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 from AlgorithmImports import *
-from AlgorithmImports import ExponentialMovingAverage
 
 class EmaCrossAlphaModel(AlphaModel):
     '''Alpha model that uses an EMA cross to create insights'''

--- a/Algorithm.Framework/Alphas/EmaCrossAlphaModel.py
+++ b/Algorithm.Framework/Alphas/EmaCrossAlphaModel.py
@@ -77,8 +77,7 @@ class EmaCrossAlphaModel(AlphaModel):
             data = self.symbolDataBySymbol.pop(removed.Symbol, None)
             if data is not None:
                 # clean up our consolidators
-                algorithm.SubscriptionManager.RemoveConsolidator(removed.Symbol, data.FastConsolidator)
-                algorithm.SubscriptionManager.RemoveConsolidator(removed.Symbol, data.SlowConsolidator)
+                data.RemoveConsolidators()
 
 
 class SymbolData:
@@ -86,6 +85,7 @@ class SymbolData:
     def __init__(self, security, fastPeriod, slowPeriod, algorithm, resolution):
         self.Security = security
         self.Symbol = security.Symbol
+        self.algorithm = algorithm
 
         self.FastConsolidator = algorithm.ResolveConsolidator(security.Symbol, resolution)
         self.SlowConsolidator = algorithm.ResolveConsolidator(security.Symbol, resolution)
@@ -106,6 +106,10 @@ class SymbolData:
         # True if the fast is above the slow, otherwise false.
         # This is used to prevent emitting the same signal repeatedly
         self.FastIsOverSlow = False
+        
+    def RemoveConsolidators(self):
+        self.algorithm.SubscriptionManager.RemoveConsolidator(self.Security.Symbol, self.FastConsolidator)
+        self.algorithm.SubscriptionManager.RemoveConsolidator(self.Security.Symbol, self.SlowConsolidator)
 
     @property
     def SlowIsOverFast(self):

--- a/Algorithm.Framework/Alphas/EmaCrossAlphaModel.py
+++ b/Algorithm.Framework/Alphas/EmaCrossAlphaModel.py
@@ -70,6 +70,8 @@ class EmaCrossAlphaModel(AlphaModel):
                 symbolData = SymbolData(added)
                 symbolData.Fast = algorithm.EMA(added.Symbol, self.fastPeriod, self.resolution)
                 symbolData.Slow = algorithm.EMA(added.Symbol, self.slowPeriod, self.resolution)
+                algorithm.WarmUpIndicator(added.Symbol, symbolData.Fast, self.resolution)
+                algorithm.WarmUpIndicator(added.Symbol, symbolData.Slow, self.resolution)
                 self.symbolDataBySymbol[added.Symbol] = symbolData
             else:
                 # a security that was already initialized was re-added, reset the indicators

--- a/Algorithm.Framework/Alphas/EmaCrossAlphaModel.py
+++ b/Algorithm.Framework/Alphas/EmaCrossAlphaModel.py
@@ -1,4 +1,4 @@
-﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
 # Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 from AlgorithmImports import *
+from AlgorithmImports import ExponentialMovingAverage
 
 class EmaCrossAlphaModel(AlphaModel):
     '''Alpha model that uses an EMA cross to create insights'''
@@ -66,26 +67,42 @@ class EmaCrossAlphaModel(AlphaModel):
         for added in changes.AddedSecurities:
             symbolData = self.symbolDataBySymbol.get(added.Symbol)
             if symbolData is None:
-                # create fast/slow EMAs
-                symbolData = SymbolData(added)
-                symbolData.Fast = algorithm.EMA(added.Symbol, self.fastPeriod, self.resolution)
-                symbolData.Slow = algorithm.EMA(added.Symbol, self.slowPeriod, self.resolution)
-                algorithm.WarmUpIndicator(added.Symbol, symbolData.Fast, self.resolution)
-                algorithm.WarmUpIndicator(added.Symbol, symbolData.Slow, self.resolution)
+                symbolData = SymbolData(added, self.fastPeriod, self.slowPeriod, algorithm, self.resolution)
                 self.symbolDataBySymbol[added.Symbol] = symbolData
             else:
                 # a security that was already initialized was re-added, reset the indicators
                 symbolData.Fast.Reset()
                 symbolData.Slow.Reset()
 
+        for removed in changes.RemovedSecurities:
+            data = self.symbolDataBySymbol.pop(removed.Symbol, None)
+            if data is not None:
+                # clean up our consolidators
+                algorithm.SubscriptionManager.RemoveConsolidator(removed.Symbol, data.FastConsolidator)
+                algorithm.SubscriptionManager.RemoveConsolidator(removed.Symbol, data.SlowConsolidator)
+
 
 class SymbolData:
     '''Contains data specific to a symbol required by this model'''
-    def __init__(self, security):
+    def __init__(self, security, fastPeriod, slowPeriod, algorithm, resolution):
         self.Security = security
         self.Symbol = security.Symbol
-        self.Fast = None
-        self.Slow = None
+
+        self.FastConsolidator = algorithm.ResolveConsolidator(security.Symbol, resolution)
+        self.SlowConsolidator = algorithm.ResolveConsolidator(security.Symbol, resolution)
+
+        algorithm.SubscriptionManager.AddConsolidator(security.Symbol, self.FastConsolidator)
+        algorithm.SubscriptionManager.AddConsolidator(security.Symbol, self.SlowConsolidator)
+
+        # create fast/slow EMAs
+        self.Fast = ExponentialMovingAverage(security.Symbol, fastPeriod, ExponentialMovingAverage.SmoothingFactorDefault(fastPeriod))
+        self.Slow = ExponentialMovingAverage(security.Symbol, slowPeriod, ExponentialMovingAverage.SmoothingFactorDefault(slowPeriod))
+
+        algorithm.RegisterIndicator(security.Symbol, self.Fast, self.FastConsolidator);
+        algorithm.RegisterIndicator(security.Symbol, self.Slow, self.SlowConsolidator);
+
+        algorithm.WarmUpIndicator(security.Symbol, self.Fast, resolution);
+        algorithm.WarmUpIndicator(security.Symbol, self.Slow, resolution);
 
         # True if the fast is above the slow, otherwise false.
         # This is used to prevent emitting the same signal repeatedly

--- a/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
@@ -207,7 +207,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
                 Assert.Ignore($"Ignore {GetType().Name}: Could not create {language} model.");
             }
 
-            var changes = SecurityChangesTests.CreateNonInternal(RemovedSecurities, AddedSecurities);
+            var changes = SecurityChangesTests.CreateNonInternal(AddedSecurities, AddedSecurities);
 
             Assert.DoesNotThrow(() => model.OnSecuritiesChanged(Algorithm, changes));
         }

--- a/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
@@ -30,6 +30,7 @@ using QuantConnect.Algorithm;
 using QuantConnect.Python;
 using QuantConnect.Tests.Common.Data.UniverseSelection;
 using QuantConnect.Tests.Engine.DataFeeds;
+using QuantConnect.Util;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 {
@@ -207,7 +208,11 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
                 Assert.Ignore($"Ignore {GetType().Name}: Could not create {language} model.");
             }
 
-            var changes = SecurityChangesTests.CreateNonInternal(AddedSecurities, AddedSecurities);
+            var removedSecurities = Algorithm.Securities.Values;
+
+            // We have to add some security if we then want to remove it, that's why we cannot use here
+            // RemovedSecurities, because it doesn't contain any security
+            var changes = SecurityChangesTests.CreateNonInternal(removedSecurities, AddedSecurities);
 
             Assert.DoesNotThrow(() => model.OnSecuritiesChanged(Algorithm, changes));
         }

--- a/Tests/Algorithm/Framework/Alphas/EmaCrossAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/EmaCrossAlphaModelTests.cs
@@ -57,7 +57,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         }
 
         [Test]
-        public void TestEmaCrossAlphaModelWarmsUpProperly()
+        public void WarmsUpProperly()
         {
             SetUpHistoryProvider();
 
@@ -98,7 +98,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         }
 
         [Test]
-        public void PythonEmaCrossAlphaModelWarmsUpProperly()
+        public void PythonVersionWarmsUpProperly()
         {
             using (Py.GIL())
             {

--- a/Tests/Algorithm/Framework/Alphas/EmaCrossAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/EmaCrossAlphaModelTests.cs
@@ -18,6 +18,10 @@ using Python.Runtime;
 using QuantConnect.Algorithm.Framework.Alphas;
 using System;
 using System.Collections.Generic;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Util;
+using QuantConnect.Tests.Common.Data.UniverseSelection;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 {
@@ -50,6 +54,88 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         protected override string GetExpectedModelName(IAlphaModel model)
         {
             return $"{nameof(EmaCrossAlphaModel)}(12,26,Daily)";
+        }
+
+        [Test]
+        public void TestEmaCrossAlphaModelWarmsUpProperly()
+        {
+            SetUpHistoryProvider();
+
+            Algorithm.SetStartDate(2013, 10, 08);
+            Algorithm.SetUniverseSelection(new ManualUniverseSelectionModel());
+
+            // Create a EmaCrossAlphaModel for the test
+            var model = new TestEmaCrossAlphaModel();
+
+            // Set the alpha model
+            Algorithm.SetAlpha(model);
+            Algorithm.SetUniverseSelection(new ManualUniverseSelectionModel());
+
+            var changes = SecurityChangesTests.CreateNonInternal(AddedSecurities, RemovedSecurities);
+            Algorithm.OnFrameworkSecuritiesChanged(changes);
+
+            // Get the dictionary of macd indicators
+            var symbolData = model.GetSymbolData();
+
+            // Check the symbolData dictionary is not empty
+            Assert.NotZero(symbolData.Count);
+
+            // Check all EmaCross indicators from the alpha are ready and have at least
+            // one datapoint
+            foreach (var item in symbolData)
+            {
+                var fast = item.Value.Fast;
+                var slow = item.Value.Slow;
+
+                Assert.IsTrue(fast.IsReady);
+                Assert.NotZero(fast.Samples);
+
+                Assert.IsTrue(slow.IsReady);
+                Assert.NotZero(slow.Samples);
+            }
+
+            ZipCacheProvider.DisposeSafely();
+        }
+
+        [Test]
+        public void PythonEmaCrossAlphaModelWarmsUpProperly()
+        {
+            using (Py.GIL())
+            {
+                SetUpHistoryProvider();
+                Algorithm.SetStartDate(2013, 10, 08);
+                Algorithm.SetUniverseSelection(new ManualUniverseSelectionModel());
+
+                // Create and set alpha model
+                dynamic model = Py.Import("EmaCrossAlphaModel").GetAttr("EmaCrossAlphaModel");
+                var instance = model();
+                Algorithm.SetAlpha(instance);
+
+                var changes = SecurityChangesTests.CreateNonInternal(AddedSecurities, RemovedSecurities);
+                Algorithm.OnFrameworkSecuritiesChanged(changes);
+
+                // Get the dictionary of ema cross indicators
+                var symbolData = instance.symbolDataBySymbol;
+
+                // Check the dictionary is not empty
+                Assert.NotZero(symbolData.Length());
+
+                // Check all Ema Cross indicators from the alpha are ready and have at least
+                // one datapoint
+                foreach (var item in symbolData)
+                {
+                    var fast = symbolData[item].Fast;
+                    var slow = symbolData[item].Slow;
+
+                    Assert.IsTrue(fast.IsReady.IsTrue());
+                    Assert.NotZero(((PyObject)fast.Samples).GetAndDispose<int>());
+
+                    Assert.IsTrue(slow.IsReady.IsTrue());
+                    Assert.NotZero(((PyObject)slow.Samples).GetAndDispose<int>());
+                }
+
+                ZipCacheProvider.DisposeSafely();
+            }
         }
     }
 }

--- a/Tests/Algorithm/Framework/Alphas/TestEmaCrossAlphaModel.cs
+++ b/Tests/Algorithm/Framework/Alphas/TestEmaCrossAlphaModel.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         /// <returns>_symbolDataBySymbol dictionary from EmaCrossAlphaModel</returns>
         public Dictionary<Symbol, SymbolData> GetSymbolData()
         {
-            return _symbolDataBySymbol;
+            return SymbolDataBySymbol;
         }
     }
 }

--- a/Tests/Algorithm/Framework/Alphas/TestEmaCrossAlphaModel.cs
+++ b/Tests/Algorithm/Framework/Alphas/TestEmaCrossAlphaModel.cs
@@ -1,0 +1,32 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Algorithm.Framework.Alphas;
+using System.Collections.Generic;
+
+namespace QuantConnect.Tests.Algorithm.Framework.Alphas
+{
+    class TestEmaCrossAlphaModel : EmaCrossAlphaModel
+    {
+        /// <summary>
+        /// Get the _symbolDataBySymbol dictionary from EmaCrossAlphaModel
+        /// </summary>
+        /// <returns>_symbolDataBySymbol dictionary from EmaCrossAlphaModel</returns>
+        public Dictionary<Symbol, SymbolData> GetSymbolData()
+        {
+            return _symbolDataBySymbol;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Warm up `EmaCrossAlphaModel.cs` and `EmaCrossAlphaModel.py` indicators
- Add unit tests to check the behavior is the expected one
- Fix regression test `CompositeAlphaModelFrameworkAlgorithm.cs`. It turns out the period from the start and end date was less than the default period given to the indicators in the EmeCrossAlphaModel, then those indicators were never ready so `Update()` method never returned an insight. Then, when the indicators of EmaCrossAlpha model were warmed up, the statistics of the regression algorithm changed.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #6167
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change users will be able to use default EmaCrossAlphaModel even when the period of time between the start and end date is less than the period of time of the fast or slow EMA indicators
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require an update to documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There was created EmaCrossAlpha models in C# and Python and then asserted their indicators were already warmed up when changes are done
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
