### PR TITLE
Add localization for CSV export delimiters in CoarseUniverseGeneratorProgram (#6228)

### DIFF
--- a/ToolBox/CoarseUniverseGenerator/CoarseUniverseGeneratorProgram.cs
+++ b/ToolBox/CoarseUniverseGenerator/CoarseUniverseGeneratorProgram.cs
@@ -262,12 +262,10 @@ namespace QuantConnect.ToolBox.CoarseUniverseGenerator
             var dollarVolume = Math.Truncate(tradeBar.Close * tradeBar.Volume);
             var priceFactor = factorFileRow?.PriceFactor.Normalize() ?? 1m;
             var splitFactor = factorFileRow?.SplitFactor.Normalize() ?? 1m;
-            bool hasFundamentalData = CheckFundamentalData(date, sidContext.MapFile, fineAvailableDates, fineFundamentalFolder);
+            var hasFundamentalData = CheckFundamentalData(date, sidContext.MapFile, fineAvailableDates, fineFundamentalFolder);
 
-            // Get the delimiter used by the current local culture
-            var delimiter = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
             // sid,symbol,close,volume,dollar volume,has fundamental data,price factor,split factor
-            var coarseFileLine = $"{sidContext.SID}{delimiter}{ticker.ToUpperInvariant()}{delimiter}{tradeBar.Close.Normalize()}{delimiter}{tradeBar.Volume.Normalize()}{delimiter}{Math.Truncate(dollarVolume)}{delimiter}{hasFundamentalData}{delimiter}{priceFactor}{delimiter}{splitFactor}";
+            var coarseFileLine = $"{sidContext.SID},{ticker.ToUpperInvariant()},{tradeBar.Close.Normalize().ToStringInvariant()},{tradeBar.Volume.Normalize().ToStringInvariant()},{Math.Truncate(dollarVolume)},{hasFundamentalData},{priceFactor.ToStringInvariant()},{splitFactor.ToStringInvariant()}";
             return coarseFileLine;
         }
 

--- a/ToolBox/CoarseUniverseGenerator/CoarseUniverseGeneratorProgram.cs
+++ b/ToolBox/CoarseUniverseGenerator/CoarseUniverseGeneratorProgram.cs
@@ -264,8 +264,10 @@ namespace QuantConnect.ToolBox.CoarseUniverseGenerator
             var splitFactor = factorFileRow?.SplitFactor.Normalize() ?? 1m;
             bool hasFundamentalData = CheckFundamentalData(date, sidContext.MapFile, fineAvailableDates, fineFundamentalFolder);
 
+            // Get the delimiter used by the current local culture
+            var delimiter = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
             // sid,symbol,close,volume,dollar volume,has fundamental data,price factor,split factor
-            var coarseFileLine = $"{sidContext.SID},{ticker.ToUpperInvariant()},{tradeBar.Close.Normalize()},{tradeBar.Volume.Normalize()},{Math.Truncate(dollarVolume)},{hasFundamentalData},{priceFactor},{splitFactor}";
+            var coarseFileLine = $"{sidContext.SID}{delimiter}{ticker.ToUpperInvariant()}{delimiter}{tradeBar.Close.Normalize()}{delimiter}{tradeBar.Volume.Normalize()}{delimiter}{Math.Truncate(dollarVolume)}{delimiter}{hasFundamentalData}{delimiter}{priceFactor}{delimiter}{splitFactor}";
             return coarseFileLine;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

- Previously, CSV delimiters were hard-coded as comma characters. 
- In some locales, numeric values use commas instead of dots (such as 99,5 instead of 99.5). This presents an issue with CSV parsing when both delimiter and decimal characters are commas.
- This fix uses the delimiter specified by the user's locale, instead of a hard-coded comma. (in most locales where a comma is used in numbers, a semicolon will be used as the delimiter).

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #6228
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, user-generated CSV files will have the correctly localized item delimiter.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require updates to documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Use OS: Windows 11 w/ PL Localization
2. Run `ToolBox / CoarseUniverseGenerator / CoarseUniverseGeneratorProgram.cs`
3. Coarse CSV files now use the proper delimiter
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
Not required
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
