### PR TITLE
Update Tick.cs Time parsing

### DIFF
--- a/Common/Data/Market/Tick.cs
+++ b/Common/Data/Market/Tick.cs
@@ -495,9 +495,9 @@ namespace QuantConnect.Data.Market
                         var index = 0;
                         TickType = config.TickType;
                         var csv = line.ToCsv(TickType == TickType.Trade ? 6 : 8);
-                        Time = date.Date.AddMilliseconds(csv[index++].ToInt64()).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
+                        Time = date.Date.AddMilliseconds((double)csv[0].ToDecimal()).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
 
-                        if (TickType == TickType.Trade)
+                            if (TickType == TickType.Trade)
                         {
                             Value = csv[index++].ToDecimal() / scaleFactor;
                             Quantity = csv[index++].ToDecimal();

--- a/Common/Data/Market/Tick.cs
+++ b/Common/Data/Market/Tick.cs
@@ -495,9 +495,9 @@ namespace QuantConnect.Data.Market
                         var index = 0;
                         TickType = config.TickType;
                         var csv = line.ToCsv(TickType == TickType.Trade ? 6 : 8);
-                        Time = date.Date.AddMilliseconds((double)csv[0].ToDecimal()).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
+                        Time = date.Date.AddMilliseconds((double)csv[index++].ToDecimal()).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
 
-                            if (TickType == TickType.Trade)
+                        if (TickType == TickType.Trade)
                         {
                             Value = csv[index++].ToDecimal() / scaleFactor;
                             Quantity = csv[index++].ToDecimal();

--- a/Common/Data/Market/Tick.cs
+++ b/Common/Data/Market/Tick.cs
@@ -321,7 +321,7 @@ namespace QuantConnect.Data.Market
             var csv = line.Split(',');
             DataType = MarketDataType.Tick;
             Symbol = symbol;
-            Time = baseDate.Date.AddMilliseconds(csv[0].ToInt32());
+            Time = baseDate.Date.AddTicks(Convert.ToInt64(10000 * csv[0].ToDecimal()));
             Value = csv[1].ToDecimal() / GetScaleFactor(symbol);
             TickType = TickType.Trade;
             Quantity = csv[2].ToDecimal();
@@ -351,7 +351,7 @@ namespace QuantConnect.Data.Market
                     case SecurityType.Equity:
                         {
                             TickType = config.TickType;
-                            Time = date.Date.AddMilliseconds((double)reader.GetDecimal()).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
+                            Time = date.Date.AddTicks(Convert.ToInt64(10000 * reader.GetDecimal())).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
 
                             bool pastLineEnd;
                             if (TickType == TickType.Trade)
@@ -392,7 +392,7 @@ namespace QuantConnect.Data.Market
                     case SecurityType.Cfd:
                         {
                             TickType = TickType.Quote;
-                            Time = date.Date.AddMilliseconds((double) reader.GetDecimal())
+                            Time = date.Date.AddTicks(Convert.ToInt64(10000 * reader.GetDecimal()))
                                 .ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
                             BidPrice = reader.GetDecimal();
                             AskPrice = reader.GetDecimal();
@@ -408,7 +408,7 @@ namespace QuantConnect.Data.Market
 
                             if (TickType == TickType.Trade)
                             {
-                                Time = date.Date.AddMilliseconds((double)reader.GetDecimal())
+                                Time = date.Date.AddTicks(Convert.ToInt64(10000 * reader.GetDecimal()))
                                     .ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
                                 Value = reader.GetDecimal();
                                 Quantity = reader.GetDecimal(out var endOfLine);
@@ -417,7 +417,7 @@ namespace QuantConnect.Data.Market
 
                             if (TickType == TickType.Quote)
                             {
-                                Time = date.Date.AddMilliseconds((double)reader.GetDecimal())
+                                Time = date.Date.AddTicks(Convert.ToInt64(10000 * reader.GetDecimal()))
                                     .ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
                                 BidPrice = reader.GetDecimal();
                                 BidSize = reader.GetDecimal();
@@ -435,7 +435,7 @@ namespace QuantConnect.Data.Market
                     case SecurityType.IndexOption:
                         {
                             TickType = config.TickType;
-                            Time = date.Date.AddMilliseconds((double)reader.GetDecimal())
+                            Time = date.Date.AddTicks(Convert.ToInt64(10000 * reader.GetDecimal()))
                                 .ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
 
                             if (TickType == TickType.Trade)
@@ -495,7 +495,7 @@ namespace QuantConnect.Data.Market
                         var index = 0;
                         TickType = config.TickType;
                         var csv = line.ToCsv(TickType == TickType.Trade ? 6 : 8);
-                        Time = date.Date.AddMilliseconds((double)csv[index++].ToDecimal()).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
+                        Time = date.Date.AddTicks(Convert.ToInt64(10000 * csv[index++].ToDecimal())).ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
 
                         if (TickType == TickType.Trade)
                         {
@@ -554,7 +554,7 @@ namespace QuantConnect.Data.Market
                         if (TickType == TickType.Trade)
                         {
                             var csv = line.ToCsv(3);
-                            Time = date.Date.AddMilliseconds((double)csv[0].ToDecimal())
+                            Time = date.Date.AddTicks(Convert.ToInt64(10000 * csv[0].ToDecimal()))
                                 .ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
                             Value = csv[1].ToDecimal();
                             Quantity = csv[2].ToDecimal();
@@ -564,7 +564,7 @@ namespace QuantConnect.Data.Market
                         if (TickType == TickType.Quote)
                         {
                             var csv = line.ToCsv(6);
-                            Time = date.Date.AddMilliseconds((double)csv[0].ToDecimal())
+                            Time = date.Date.AddTicks(Convert.ToInt64(10000 * csv[0].ToDecimal()))
                                 .ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
                             BidPrice = csv[1].ToDecimal();
                             BidSize = csv[2].ToDecimal();
@@ -583,7 +583,7 @@ namespace QuantConnect.Data.Market
                     {
                         var csv = line.ToCsv(7);
                         TickType = config.TickType;
-                        Time = date.Date.AddMilliseconds(csv[0].ToInt64())
+                        Time = date.Date.AddTicks(Convert.ToInt64(10000 * csv[0].ToDecimal()))
                             .ConvertTo(config.DataTimeZone, config.ExchangeTimeZone);
 
                         if (TickType == TickType.Trade)

--- a/Tests/Common/Data/Market/TickTests.cs
+++ b/Tests/Common/Data/Market/TickTests.cs
@@ -18,8 +18,9 @@ using System.IO;
 using System.Text;
 using NUnit.Framework;
 using QuantConnect.Data;
-using QuantConnect.Data.Market;
+using System.Globalization;
 using QuantConnect.Securities;
+using QuantConnect.Data.Market;
 
 namespace QuantConnect.Tests.Common.Data.Market
 {
@@ -44,11 +45,11 @@ namespace QuantConnect.Tests.Common.Data.Market
             Assert.AreEqual(false, tick.Suspicious);
         }
 
-        [Test]
-        public void ConstructsFromLineWithDecimalTimestamp()
+        [TestCase("18000677.3,3669.12,0.0040077,3669.13,3.40618718", "18000677.3", "3669.12", "0.0040077", "3669.13", "3.40618718")]
+        [TestCase("18000677.3111,3669.12,0.0040077,3669.13,3.40618718", "18000677.3111", "3669.12", "0.0040077", "3669.13", "3.40618718")]
+        public void ConstructsFromLineWithDecimalTimestamp(string line, string milliseconds, string bidPrice,
+            string bidSize, string askPrice, string askSize)
         {
-            const string line = "18000677.3,3669.12,0.0040077,3669.13,3.40618718";
-
             var config = new SubscriptionDataConfig(
                 typeof(Tick), Symbols.BTCUSD, Resolution.Tick, TimeZones.Utc, TimeZones.Utc,
                 false, false, false, false, TickType.Quote);
@@ -57,11 +58,11 @@ namespace QuantConnect.Tests.Common.Data.Market
             var tick = new Tick(config, line, baseDate);
 
             var ms = (tick.Time - baseDate).TotalMilliseconds;
-            Assert.AreEqual(18000677, ms);
-            Assert.AreEqual(3669.12, tick.BidPrice);
-            Assert.AreEqual(0.0040077, tick.BidSize);
-            Assert.AreEqual(3669.13, tick.AskPrice);
-            Assert.AreEqual(3.40618718, tick.AskSize);
+            Assert.AreEqual( decimal.Parse(milliseconds, CultureInfo.InvariantCulture), ms);
+            Assert.AreEqual(decimal.Parse(bidPrice, CultureInfo.InvariantCulture), tick.BidPrice);
+            Assert.AreEqual(decimal.Parse(bidSize, CultureInfo.InvariantCulture), tick.BidSize);
+            Assert.AreEqual(decimal.Parse(askPrice, CultureInfo.InvariantCulture), tick.AskPrice);
+            Assert.AreEqual(decimal.Parse(askSize, CultureInfo.InvariantCulture), tick.AskSize);
         }
 
         [Test]

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -1336,16 +1336,18 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var emittedTradeBars = false;
 
-            ConsumeBridge(feed, TimeSpan.FromSeconds(1), true, ts =>
+            ConsumeBridge(feed, TimeSpan.FromSeconds(3), true, ts =>
             {
                 if (ts.Slice.HasData)
                 {
                     if (ts.Slice.Bars.ContainsKey(symbol))
                     {
                         emittedTradeBars = true;
+                        // we got what we wanted shortcut unit test
+                        _manualTimeProvider.SetCurrentTimeUtc(Time.EndOfTime);
                     }
                 }
-            });
+            }, endDate: _startDate.AddDays(1));
 
             Assert.IsTrue(emittedTradeBars);
         }


### PR DESCRIPTION
Changes the parsing for Tick resolution data from integer to decimal, allowing for a more accurate time conversion.

#### Description
Changes timestamp conversion from integer to decimal.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/6274

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes the issue of pushing multiple ticks together at the same time in backtests when they should be separate, causing for inaccurate timing of trades.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Through the given tests in the LEAN engine

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why --> Simple modification to the code, does not require any extensive testing.
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
