### PR TITLE
Bump pythonNet version 2.0.12

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -35,7 +35,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.11" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.12" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Fuzzy" Version="3.6.0" />
     <PackageReference Include="Accord.MachineLearning" Version="3.6.0" />

--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
@@ -51,6 +51,7 @@ class BlackLittermanOptimizationPortfolioConstructionModel(PortfolioConstruction
             risk_free_rate(float): The risk free rate
             delta(float): The risk aversion coeffficient of the market portfolio
             tau(float): The model parameter indicating the uncertainty of the CAPM prior"""
+        super().__init__()
         self.lookback = lookback
         self.period = period
         self.resolution = resolution

--- a/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/EqualWeightingPortfolioConstructionModel.py
@@ -28,6 +28,7 @@ class EqualWeightingPortfolioConstructionModel(PortfolioConstructionModel):
                               The function returns null if unknown, in which case the function will be called again in the
                               next loop. Returning current time will trigger rebalance.
             portfolioBias: Specifies the bias of the portfolio (Short, Long/Short, Long)'''
+        super().__init__()
         self.portfolioBias = portfolioBias
 
         # If the argument is an instance of Resolution or Timedelta

--- a/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModel.py
@@ -39,6 +39,7 @@ class MeanVarianceOptimizationPortfolioConstructionModel(PortfolioConstructionMo
             period(int): The time interval of history price to calculate the weight
             resolution: The resolution of the history price
             optimizer(class): Method used to compute the portfolio weights"""
+        super().__init__()
         self.lookback = lookback
         self.period = period
         self.resolution = resolution

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -30,7 +30,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.11" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.12" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Math" Version="3.6.0" />
     <PackageReference Include="Accord.Statistics" Version="3.6.0" />

--- a/Algorithm.Python/CustomModelsAlgorithm.py
+++ b/Algorithm.Python/CustomModelsAlgorithm.py
@@ -58,6 +58,7 @@ class CustomModelsAlgorithm(QCAlgorithm):
 # If we want to use methods from other models, you need to inherit from one of them
 class CustomFillModel(ImmediateFillModel):
     def __init__(self, algorithm):
+        super().__init__()
         self.algorithm = algorithm
         self.absoluteRemainingByOrderId = {}
         self.random = Random(387510346)
@@ -85,6 +86,7 @@ class CustomFillModel(ImmediateFillModel):
 
 class CustomFeeModel(FeeModel):
     def __init__(self, algorithm):
+        super().__init__()
         self.algorithm = algorithm
 
     def GetOrderFee(self, parameters):
@@ -107,6 +109,7 @@ class CustomSlippageModel:
 
 class CustomBuyingPowerModel(BuyingPowerModel):
     def __init__(self, algorithm):
+        super().__init__()
         self.algorithm = algorithm
 
     def HasSufficientBuyingPowerForOrder(self, parameters):

--- a/Algorithm.Python/CustomWarmUpPeriodIndicatorAlgorithm.py
+++ b/Algorithm.Python/CustomWarmUpPeriodIndicatorAlgorithm.py
@@ -97,6 +97,7 @@ class CustomWarmUpPeriodIndicatorAlgorithm(QCAlgorithm):
 # Represents the traditional simple moving average indicator (SMA) without Warm Up Period parameter defined
 class CSMANotWarmUp(PythonIndicator):
     def __init__(self, name, period):
+        super().__init__()
         self.Name = name
         self.Value = 0
         self.queue = deque(maxlen=period)

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -37,7 +37,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.11" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.12" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Algorithm.Python/RegisterIndicatorRegressionAlgorithm.py
+++ b/Algorithm.Python/RegisterIndicatorRegressionAlgorithm.py
@@ -107,6 +107,7 @@ class RegisterIndicatorRegressionAlgorithm(QCAlgorithm):
 
 class CustomIndicator(PythonIndicator):
     def __init__(self):
+        super().__init__()
         self.Name = "Jose"
         self.Value = 0
 

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -1121,7 +1121,8 @@ namespace QuantConnect.Algorithm
                     // In order to convert it into a C# Dictionary
                     if (PyDict.IsDictType(headers))
                     {
-                        foreach (PyObject pyKey in headers)
+                        using var iterator = headers.GetIterator();
+                        foreach (PyObject pyKey in iterator)
                         {
                             var key = (string)pyKey.AsManagedObject(typeof(string));
                             var value = (string)headers.GetItem(pyKey).AsManagedObject(typeof(string));

--- a/Algorithm/QuantConnect.Algorithm.csproj
+++ b/Algorithm/QuantConnect.Algorithm.csproj
@@ -30,7 +30,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.11" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.12" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -690,7 +690,8 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
 
                     requests.Clear();
 
-                    foreach (PyObject pyRequest in pyRequests.GetIterator())
+                    using var iterator = pyRequests.GetIterator();
+                    foreach (PyObject pyRequest in iterator)
                     {
                         SubmitOrderRequest request;
                         if (TryConvert(pyRequest, out request))

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -634,7 +634,7 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
             // Only throws if there is an error in its implementation body
             catch (PythonException exception)
             {
-                if (!exception.Message.StartsWith("TypeError : OnEndOfDay()"))
+                if (!exception.Message.StartsWith("OnEndOfDay()"))
                 {
                     _baseAlgorithm.SetRunTimeError(exception);
                 }
@@ -662,7 +662,7 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
             // Only throws if there is an error in its implementation body
             catch (PythonException exception)
             {
-                if (!exception.Message.StartsWith("TypeError : OnEndOfDay()"))
+                if (!exception.Message.StartsWith("OnEndOfDay()"))
                 {
                     _baseAlgorithm.SetRunTimeError(exception);
                 }
@@ -690,7 +690,7 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
 
                     requests.Clear();
 
-                    foreach (PyObject pyRequest in pyRequests)
+                    foreach (PyObject pyRequest in pyRequests.GetIterator())
                     {
                         SubmitOrderRequest request;
                         if (TryConvert(pyRequest, out request))

--- a/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
+++ b/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
@@ -29,7 +29,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.11" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.12" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Common/Exceptions/InvalidTokenPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/InvalidTokenPythonExceptionInterpreter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -36,7 +36,6 @@ namespace QuantConnect.Exceptions
         public override bool CanInterpret(Exception exception)
         {
             return base.CanInterpret(exception) &&
-                exception.Message.Contains("SyntaxError") &&
                 exception.Message.Contains("invalid token");
         }
 

--- a/Common/Exceptions/KeyErrorPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/KeyErrorPythonExceptionInterpreter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -37,8 +37,17 @@ namespace QuantConnect.Exceptions
         /// <returns>True if the exception can be interpreted, false otherwise</returns>
         public override bool CanInterpret(Exception exception)
         {
-            return base.CanInterpret(exception) &&
-                exception.Message.Contains("KeyError");
+            var pythonException = exception as PythonException;
+            if (pythonException == null)
+            {
+                return false;
+            }
+
+            using (Py.GIL())
+            {
+                return base.CanInterpret(exception) &&
+                    pythonException.Type.Name.Contains("KeyError", StringComparison.InvariantCultureIgnoreCase);
+            }
         }
         /// <summary>
         /// Interprets the specified exception into a new exception

--- a/Common/Exceptions/NoMethodMatchPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/NoMethodMatchPythonExceptionInterpreter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -37,7 +37,6 @@ namespace QuantConnect.Exceptions
         public override bool CanInterpret(Exception exception)
         {
             return base.CanInterpret(exception) &&
-                exception.Message.Contains("TypeError") &&
                 exception.Message.Contains("No method match");
         }
 

--- a/Common/Exceptions/UnsupportedOperandPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/UnsupportedOperandPythonExceptionInterpreter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -37,7 +37,6 @@ namespace QuantConnect.Exceptions
         public override bool CanInterpret(Exception exception)
         {
             return base.CanInterpret(exception) &&
-                exception.Message.Contains("TypeError") &&
                 exception.Message.Contains("unsupported operand type");
         }
 
@@ -51,7 +50,7 @@ namespace QuantConnect.Exceptions
         {
             var pe = (PythonException)exception;
 
-            var types = pe.Message.Split(':')[2].Trim();
+            var types = pe.Message.Split(':')[1].Trim();
             var message = $"Trying to perform a summation, subtraction, multiplication or division between {types} objects throws a TypeError exception. To prevent the exception, ensure that both values share the same type.";
             message += PythonUtil.PythonExceptionStackParser(pe.StackTrace);
 

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -588,7 +588,7 @@ namespace QuantConnect
             using (Py.GIL())
             {
                 int argCount;
-                var pyArgCount = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var pyArgCount = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from inspect import signature\n" +
                     "def GetArgCount(method):\n" +
                     "   return len(signature(method).parameters)\n"
@@ -2651,7 +2651,7 @@ namespace QuantConnect
                     var name = type.FullName.Substring(0, type.FullName.IndexOf('`'));
                     code = $"import System; delegate = {name}[{code.Substring(1)}](pyObject)";
 
-                    PythonEngine.Exec(code, null, locals.Handle);
+                    PythonEngine.Exec(code, null, locals);
                     result = (T)locals.GetItem("delegate").AsManagedObject(typeof(T));
                     locals.Dispose();
                     return true;
@@ -2816,7 +2816,8 @@ namespace QuantConnect
                     pyObject = new PyList(new[] {pyObject});
                 }
 
-                foreach (PyObject item in pyObject)
+                using var iterator = pyObject.GetIterator();
+                foreach (PyObject item in iterator)
                 {
                     if (PyString.IsStringType(item))
                     {

--- a/Common/Python/MarginCallModelPythonWrapper.cs
+++ b/Common/Python/MarginCallModelPythonWrapper.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -62,7 +62,7 @@ namespace QuantConnect.Python
                 // Since ExecuteMarginCall may return a python list
                 // Need to convert to C# list
                 var tickets = new List<OrderTicket>();
-                var iterator = marginCalls.GetIterator();
+                using var iterator = marginCalls.GetIterator();
                 foreach (PyObject pyObject in iterator)
                 {
                     OrderTicket ticket;
@@ -105,7 +105,8 @@ namespace QuantConnect.Python
                 // Since GetMarginCallOrders may return a python list
                 // Need to convert to C# list
                 var requests = new List<SubmitOrderRequest>();
-                foreach (PyObject pyObject in marginCallOrders)
+                using var iterator = marginCallOrders.GetIterator();
+                foreach (PyObject pyObject in iterator)
                 {
                     SubmitOrderRequest request;
                     if (pyObject.TryConvert(out request))

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -60,7 +60,7 @@ namespace QuantConnect.Python
                 using (Py.GIL())
                 {
                     // Use our PandasMapper class that modifies pandas indexing to support tickers, symbols and SIDs
-                    _pandas = PythonEngine.ImportModule("PandasMapper");
+                    _pandas = Py.Import("PandasMapper");
                 }
             }
 

--- a/Common/Python/PythonSlice.cs
+++ b/Common/Python/PythonSlice.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -32,7 +32,7 @@ namespace QuantConnect.Python
         static PythonSlice()
         {
             // Python Data class: Converts custom data (PythonData) into a python object'''
-            _converter = PythonEngine.ModuleFromString("converter",
+            _converter = PyModule.FromString("converter",
                 "class Data(object):\n" +
                 "    def __init__(self, data):\n" +
                 "        self.data = data\n" +

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -35,7 +35,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.11" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.12" />
     <PackageReference Include="CloneExtensions" Version="1.3.0" />
     <PackageReference Include="fasterflect" Version="3.0.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />

--- a/Common/Util/PythonUtil.cs
+++ b/Common/Util/PythonUtil.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -254,7 +254,7 @@ namespace QuantConnect.Util
         /// <returns>PyObject with a python module</returns>
         private static PyObject GetModule()
         {
-            return PythonEngine.ModuleFromString("x",
+            return PyModule.FromString("x",
                 "from clr import AddReference\n" +
                 "AddReference(\"System\")\n" +
                 "from System import Action, Func\n" +

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -43,7 +43,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.11" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.12" />
     <PackageReference Include="fasterflect" Version="3.0.0" />
     <PackageReference Include="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -32,7 +32,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.11" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.12" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Report/QuantConnect.Report.csproj
+++ b/Report/QuantConnect.Report.csproj
@@ -42,7 +42,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.11" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.12" />
     <PackageReference Include="Deedle" Version="2.1.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">

--- a/Report/ReportElements/ChartReportElement.cs
+++ b/Report/ReportElements/ChartReportElement.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -32,7 +32,7 @@ namespace QuantConnect.Report.ReportElements
 
             using (Py.GIL())
             {
-                dynamic module = PythonEngine.ImportModule("ReportCharts");
+                dynamic module = Py.Import("ReportCharts");
                 var classObj = module.ReportCharts;
 
                 Charting = classObj.Invoke();

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -56,9 +56,10 @@ namespace QuantConnect.Research
             //Determine if we are in a Python Notebook
             try
             {
+                PythonEngine.Initialize();
                 using (Py.GIL())
                 {
-                    var isPython = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                    var isPython = PyModule.FromString(Guid.NewGuid().ToString(),
                         "try:\n" +
                         "   import IPython\n" +
                         "   def IsPythonNotebook():\n" +

--- a/Research/QuantConnect.Research.csproj
+++ b/Research/QuantConnect.Research.csproj
@@ -32,7 +32,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.11" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.12" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -280,7 +280,7 @@ namespace QuantConnect.Tests.Algorithm
             {
                 using (Py.GIL())
                 {
-                    var customDataType = PythonEngine.ModuleFromString("testModule",
+                    var customDataType = PyModule.FromString("testModule",
                         @"
 from AlgorithmImports import *
 from QuantConnect.Tests import *

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -163,7 +163,7 @@ class BadCustomIndicator:
 
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(), code);
+                var module = PyModule.FromString(Guid.NewGuid().ToString(), code);
 
                 var goodIndicator = module.GetAttr("GoodCustomIndicator").Invoke();
                 Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, goodIndicator, Resolution.Minute));
@@ -204,7 +204,7 @@ algo.RegisterIndicator(forex.Symbol, indicator, Resolution.Daily)";
 
             using (Py.GIL())
             {
-                Assert.DoesNotThrow(() => PythonEngine.ModuleFromString("RegistersIndicatorProperlyPythonScript", code));
+                Assert.DoesNotThrow(() => PyModule.FromString("RegistersIndicatorProperlyPythonScript", code));
             }
         }
     }

--- a/Tests/Algorithm/AlgorithmSetBrokerageTests.cs
+++ b/Tests/Algorithm/AlgorithmSetBrokerageTests.cs
@@ -80,7 +80,7 @@ namespace QuantConnect.Tests.Algorithm
         {
             using (Py.GIL())
             {
-                var model = PythonEngine.ModuleFromString("testModule",
+                var model = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 

--- a/Tests/Algorithm/Framework/FrameworkModelsPythonInheritanceTests.cs
+++ b/Tests/Algorithm/Framework/FrameworkModelsPythonInheritanceTests.cs
@@ -43,8 +43,7 @@ class MockUniverseSelectionModel(ManualUniverseSelectionModel):
 
             using (Py.GIL())
             {
-                dynamic pyModel = PythonEngine
-                    .ModuleFromString(Guid.NewGuid().ToString(), code)
+                dynamic pyModel = PyModule.FromString(Guid.NewGuid().ToString(), code)
                     .GetAttr("MockUniverseSelectionModel");
 
                 var model = new UniverseSelectionModelPythonWrapper(pyModel());
@@ -77,8 +76,7 @@ class MockUniverseSelectionModel(FundamentalUniverseSelectionModel):
 
             using (Py.GIL())
             {
-                dynamic pyModel = PythonEngine
-                    .ModuleFromString(Guid.NewGuid().ToString(), code)
+                dynamic pyModel = PyModule.FromString(Guid.NewGuid().ToString(), code)
                     .GetAttr("MockUniverseSelectionModel");
 
                 var model = new UniverseSelectionModelPythonWrapper(pyModel());

--- a/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
@@ -311,7 +311,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                     using (Py.GIL())
                     {
                         var name = nameof(BLOPCM);
-                        var instance = PythonEngine.ModuleFromString(name, GetPythonBLOPCM()).GetAttr(name).Invoke(((int)portfolioBias).ToPython());
+                        var instance = PyModule.FromString(name, GetPythonBLOPCM()).GetAttr(name).Invoke(((int)portfolioBias).ToPython());
                         var model = new PortfolioConstructionModelPythonWrapper(instance);
                         _algorithm.SetPortfolioConstruction(model);
                     }

--- a/Tests/Algorithm/Framework/Portfolio/PortfolioConstructionModelPythonWrapperTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/PortfolioConstructionModelPythonWrapperTests.cs
@@ -36,13 +36,14 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 
             using (Py.GIL())
             {
-                dynamic model = PythonEngine.ModuleFromString(
+                dynamic model = PyModule.FromString(
                     "TestPCM",
                     @"
 from AlgorithmImports import *
 
 class PyPCM(EqualWeightingPortfolioConstructionModel):
     def __init__(self):
+        super().__init__()
         self.CreateTargets_WasCalled = False
         self.OnSecuritiesChanged_WasCalled = False
         self.ShouldCreateTargetForInsight_WasCalled = False
@@ -102,7 +103,7 @@ class PyPCM(EqualWeightingPortfolioConstructionModel):
 
             using (Py.GIL())
             {
-                dynamic model = PythonEngine.ModuleFromString(
+                dynamic model = PyModule.FromString(
                     "TestPCM",
                     @"
 
@@ -113,6 +114,7 @@ from QuantConnect.Algorithm.Framework.Portfolio import *
 
 class PyPCM(EqualWeightingPortfolioConstructionModel):
     def __init__(self):
+        super().__init__()
         self.CreateTargets_WasCalled = False
         self.OnSecuritiesChanged_WasCalled = False
         self.ShouldCreateTargetForInsight_WasCalled = False

--- a/Tests/Algorithm/Framework/Portfolio/PortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/PortfolioConstructionModelTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -40,7 +40,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 constructionModel = new TestPortfolioConstructionModel();
                 using (Py.GIL())
                 {
-                    var func = PythonEngine.ModuleFromString("RebalanceFunc",
+                    var func = PyModule.FromString("RebalanceFunc",
                         @"
 from datetime import timedelta
 
@@ -74,7 +74,7 @@ def RebalanceFunc(time):
                 constructionModel = new TestPortfolioConstructionModel();
                 using (Py.GIL())
                 {
-                    var func = PythonEngine.ModuleFromString("RebalanceFunc",
+                    var func = PyModule.FromString("RebalanceFunc",
                         @"
 from datetime import timedelta
 
@@ -114,7 +114,7 @@ def RebalanceFunc(time):
                 constructionModel = new TestPortfolioConstructionModel();
                 using (Py.GIL())
                 {
-                    var func = PythonEngine.ModuleFromString("RebalanceFunc",
+                    var func = PyModule.FromString("RebalanceFunc",
                         @"
 from datetime import timedelta
 
@@ -148,7 +148,7 @@ def RebalanceFunc(time):
                 constructionModel = new TestPortfolioConstructionModel();
                 using (Py.GIL())
                 {
-                    var func = PythonEngine.ModuleFromString("RebalanceFunc",
+                    var func = PyModule.FromString("RebalanceFunc",
                         @"
 from datetime import timedelta
 
@@ -179,7 +179,7 @@ def RebalanceFunc(time):
                 constructionModel = new TestPortfolioConstructionModel();
                 using (Py.GIL())
                 {
-                    var func = PythonEngine.ModuleFromString(
+                    var func = PyModule.FromString(
                         "RebalanceFunc",
                         @"
 from datetime import timedelta
@@ -223,7 +223,7 @@ def RebalanceFunc():
                 constructionModel = new TestPortfolioConstructionModel();
                 using (Py.GIL())
                 {
-                    var func = PythonEngine.ModuleFromString(
+                    var func = PyModule.FromString(
                         "RebalanceFunc",
                         @"
 from datetime import timedelta
@@ -290,7 +290,7 @@ def RebalanceFunc(time):
                 constructionModel = new TestPortfolioConstructionModel();
                 using (Py.GIL())
                 {
-                    dynamic func = PythonEngine.ModuleFromString("RebalanceFunc",
+                    dynamic func = PyModule.FromString("RebalanceFunc",
                         @"
 import datetime
 
@@ -327,7 +327,7 @@ def RebalanceFunc(dateRules):
                 {
                     if (version == 1)
                     {
-                        dynamic func = PythonEngine.ModuleFromString("RebalanceFunc",
+                        dynamic func = PyModule.FromString("RebalanceFunc",
                             @"
 from System import *
 
@@ -337,7 +337,7 @@ def RebalanceFunc(timeSpan):
                     }
                     else
                     {
-                        dynamic func = PythonEngine.ModuleFromString("RebalanceFunc",
+                        dynamic func = PyModule.FromString("RebalanceFunc",
                             @"
 from datetime import timedelta
 

--- a/Tests/Algorithm/Framework/Portfolio/ReturnsSymbolDataTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/ReturnsSymbolDataTests.cs
@@ -200,8 +200,7 @@ def GetDeterminantFromHistory(history):
 
             using (Py.GIL())
             {
-                dynamic GetDeterminantFromHistory = PythonEngine
-                    .ModuleFromString("GetDeterminantFromHistory", code)
+                dynamic GetDeterminantFromHistory = PyModule.FromString("GetDeterminantFromHistory", code)
                     .GetAttr("GetDeterminantFromHistory");
 
                 dynamic df = new PandasConverter().GetDataFrame(history);

--- a/Tests/Common/Data/CalendarConsolidatorsTests.cs
+++ b/Tests/Common/Data/CalendarConsolidatorsTests.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Tests.Common.Data
 
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(
+                var module = PyModule.FromString(
                     "PythonCalendar",
                     @"
 from AlgorithmImports import *

--- a/Tests/Common/Data/Custom/PythonCustomDataTests.cs
+++ b/Tests/Common/Data/Custom/PythonCustomDataTests.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Tests.Common.Data.Custom
             dynamic instance;
             using (Py.GIL())
             {
-                PyObject test = PythonEngine.ModuleFromString("testModule",
+                PyObject test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -49,7 +49,7 @@ class Test(PythonData):
             dynamic instance;
             using (Py.GIL())
             {
-                PyObject test = PythonEngine.ModuleFromString("testModule",
+                PyObject test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -68,7 +68,7 @@ class Test(PythonData):
             dynamic instance;
             using (Py.GIL())
             {
-                PyObject test = PythonEngine.ModuleFromString("testModule",
+                PyObject test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -87,7 +87,7 @@ class Test(PythonData):
             dynamic instance;
             using (Py.GIL())
             {
-                PyObject test = PythonEngine.ModuleFromString("testModule",
+                PyObject test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 

--- a/Tests/Common/Data/SliceTests.cs
+++ b/Tests/Common/Data/SliceTests.cs
@@ -40,12 +40,12 @@ namespace QuantConnect.Tests.Common.Data
             var tradeBar = new TradeBar { Symbol = Symbols.SPY, Time = now };
             var unlinkedData = new UnlinkedData { Symbol = Symbols.SPY, Time = now };
             var quoteBar = new QuoteBar { Symbol = Symbols.SPY, Time = now };
-            var tick = new Tick(now, Symbols.SPY, 1.1m, 2.1m) {TickType = TickType.Trade};
+            var tick = new Tick(now, Symbols.SPY, 1.1m, 2.1m) { TickType = TickType.Trade };
             var openInterest = new OpenInterest(now, Symbols.SPY, 1);
             var split = new Split(Symbols.SPY, now, 1, 1, SplitType.SplitOccurred);
             var delisting = new Delisting(Symbols.SPY, now, 1, DelistingType.Delisted);
 
-            var slice = new Slice(now, new BaseData[] {quoteBar, tradeBar, unlinkedData, tick, split, delisting, openInterest }, now);
+            var slice = new Slice(now, new BaseData[] { quoteBar, tradeBar, unlinkedData, tick, split, delisting, openInterest }, now);
 
             Assert.AreEqual(slice.Get(typeof(TradeBar))[Symbols.SPY], tradeBar);
             Assert.AreEqual(slice.Get(typeof(UnlinkedData))[Symbols.SPY], unlinkedData);
@@ -345,7 +345,7 @@ namespace QuantConnect.Tests.Common.Data
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                 @"
 from AlgorithmImports import *
 
@@ -368,7 +368,7 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic testModule = PythonEngine.ModuleFromString("testModule",
+                dynamic testModule = PyModule.FromString("testModule",
                     @"
 
 from AlgorithmImports import *
@@ -420,7 +420,7 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -442,7 +442,7 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 from QuantConnect.Tests import *
@@ -465,7 +465,7 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 from QuantConnect.Tests import *
@@ -488,7 +488,7 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -513,7 +513,7 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 from QuantConnect.Tests import *
@@ -540,7 +540,7 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 from QuantConnect.Tests import *
@@ -565,7 +565,7 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 from QuantConnect.Tests import *
@@ -590,7 +590,7 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 from QuantConnect.Data.Custom.IconicTypes import *
@@ -618,7 +618,7 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 from QuantConnect.Data.Custom.IconicTypes import *
@@ -646,7 +646,7 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -693,7 +693,7 @@ def Test(slice):
             var tradeBars = new TradeBars { { Symbols.BTCUSD, tradeBar } };
             var quoteBars = new QuoteBars { { Symbols.BTCUSD, quoteBar } };
 
-            var slice = new Slice(DateTime.Now, new List<BaseData>(){ tradeBar, quoteBar }, tradeBars, quoteBars, null, null, null, null, null, null, null, DateTime.Now);
+            var slice = new Slice(DateTime.Now, new List<BaseData>() { tradeBar, quoteBar }, tradeBars, quoteBars, null, null, null, null, null, null, null, DateTime.Now);
 
             var tradeBarData = slice.Get<TradeBar>();
             Assert.AreEqual(1, tradeBarData.Count);
@@ -721,14 +721,14 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
 def Test(slice):
     slice.clear()").GetAttr("Test");
 
-                Assert.Throws<PythonException>(() => test(GetPythonSlice()), "Slice is read-only: cannot clear the collection");
+                Assert.Throws<InvalidOperationException>(() => test(GetPythonSlice()), "Slice is read-only: cannot clear the collection");
             }
         }
 
@@ -737,14 +737,14 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
 def Test(slice):
     slice.popitem()").GetAttr("Test");
 
-                Assert.Throws<PythonException>(() => test(GetPythonSlice()), "Slice is read-only: cannot pop an item from the collection");
+                Assert.Throws<NotSupportedException>(() => test(GetPythonSlice()), "Slice is read-only: cannot pop an item from the collection");
             }
         }
 
@@ -753,14 +753,14 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
 def Test(slice, symbol):
     slice.pop(symbol)").GetAttr("Test");
 
-                Assert.Throws<PythonException>(() => test(GetPythonSlice(), Symbols.SPY), $"Slice is read-only: cannot pop the value for {Symbols.SPY} from the collection");
+                Assert.Throws<InvalidOperationException>(() => test(GetPythonSlice(), Symbols.SPY), $"Slice is read-only: cannot pop the value for {Symbols.SPY} from the collection");
             }
         }
 
@@ -769,14 +769,14 @@ def Test(slice, symbol):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
 def Test(slice, symbol, default_value):
     slice.pop(symbol, default_value)").GetAttr("Test");
 
-                Assert.Throws<PythonException>(() => test(GetPythonSlice(), Symbols.SPY, null), $"Slice is read-only: cannot pop the value for {Symbols.SPY} from the collection");
+                Assert.Throws<InvalidOperationException>(() => test(GetPythonSlice(), Symbols.SPY, null), $"Slice is read-only: cannot pop the value for {Symbols.SPY} from the collection");
             }
         }
 
@@ -785,7 +785,7 @@ def Test(slice, symbol, default_value):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -793,7 +793,7 @@ def Test(slice, symbol):
     item = { symbol: 1 }
     slice.update(item)").GetAttr("Test");
 
-                Assert.Throws<PythonException>(() => test(GetPythonSlice(), Symbols.SPY), "Slice is read-only: cannot update the collection");
+                Assert.Throws<InvalidOperationException>(() => test(GetPythonSlice(), Symbols.SPY), "Slice is read-only: cannot update the collection");
             }
         }
 
@@ -802,7 +802,7 @@ def Test(slice, symbol):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -822,7 +822,7 @@ def Test(slice, symbol, bar):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 AddReference(""QuantConnect.Tests"")
@@ -846,7 +846,7 @@ def Test(slice, symbol):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 AddReference(""QuantConnect.Tests"")
@@ -975,7 +975,7 @@ def Test(slice, symbol):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 AddReference(""QuantConnect.Tests"")
@@ -999,7 +999,7 @@ def Test(slice, symbol):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -1018,7 +1018,7 @@ def Test(slice, symbol):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -1037,7 +1037,7 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -1059,7 +1059,7 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -1081,7 +1081,7 @@ def Test(slice):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -1100,7 +1100,7 @@ def Test(slice, keys):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -1119,7 +1119,7 @@ def Test(slice, keys, default_value):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -1129,7 +1129,7 @@ def Test(slice, symbol):
                 var pythonSlice = GetPythonSlice();
                 dynamic expected = pythonSlice[Symbols.SPY];
                 PyObject result = null;
-                Assert.DoesNotThrow(() => result = test(GetPythonSlice(), Symbols.SPY ));
+                Assert.DoesNotThrow(() => result = test(GetPythonSlice(), Symbols.SPY));
                 BaseData actual;
                 Assert.IsTrue(result.TryConvert(out actual));
                 Assert.AreEqual(expected.Symbol, actual.Symbol);
@@ -1142,7 +1142,7 @@ def Test(slice, symbol):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -1165,7 +1165,7 @@ def Test(slice, symbol, default_value):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -1181,7 +1181,7 @@ def Test(slice, symbol):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -1204,7 +1204,7 @@ def Test(slice, symbol):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -1230,7 +1230,7 @@ def Test(slice, symbol, default_value):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -1238,7 +1238,7 @@ def Test(slice, symbol):
     return slice.setdefault(symbol)").GetAttr("Test");
 
                 var symbol = Symbols.EURUSD;
-                Assert.Throws<PythonException>(() => test(GetPythonSlice(), symbol),
+                Assert.Throws<KeyNotFoundException>(() => test(GetPythonSlice(), symbol),
                     $"Slice is read-only: cannot set default value to  for {symbol}");
             }
         }

--- a/Tests/Common/Exceptions/InvalidTokenPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/InvalidTokenPythonExceptionInterpreterTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -35,7 +35,7 @@ namespace QuantConnect.Tests.Common.Exceptions
                 try
                 {
                     // importing a module with syntax error 'x = 01' will throw
-                    PythonEngine.ModuleFromString(Guid.NewGuid().ToString(), "x = 01");
+                    PyModule.FromString(Guid.NewGuid().ToString(), "x = 01");
                 }
                 catch (PythonException pythonException)
                 {

--- a/Tests/Common/Notifications/NotificationManagerTests.cs
+++ b/Tests/Common/Notifications/NotificationManagerTests.cs
@@ -21,7 +21,6 @@ using QuantConnect.Notifications;
 
 namespace QuantConnect.Tests.Common.Notifications
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(true)]
     [TestFixture(false)]
     public class NotificationManagerTests
@@ -124,7 +123,7 @@ namespace QuantConnect.Tests.Common.Notifications
             {
                 dynamic function;
                 bool result;
-                var test = PythonEngine.ModuleFromString("testModule",
+                var test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 

--- a/Tests/Common/Orders/Fees/BackwardsCompatibilityFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/BackwardsCompatibilityFeeModelTests.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
                     "class CustomFeeModel:\n" +
                     "   def __init__(self):\n" +
@@ -79,7 +79,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
                     "class CustomFeeModel(FeeModel):\n" +
                     "   def __init__(self):\n" +

--- a/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
+++ b/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
@@ -288,7 +288,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
                     "class CustomFillModel(ImmediateFillModel):\n" +
                     "   def __init__(self):\n" +
@@ -320,7 +320,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
                     "class CustomFillModel(FillModel):\n" +
                     "   def __init__(self):\n" +
@@ -352,7 +352,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
                     "class CustomFillModel(FillModel):\n" +
                     "   def __init__(self):\n" +
@@ -384,7 +384,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
                     "class CustomFillModel(FillModel):\n" +
                     "   def __init__(self):\n" +
@@ -423,7 +423,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
                     "class CustomFillModel(FillModel):\n" +
                     "   def __init__(self):\n" +
@@ -462,7 +462,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
                     "class CustomFillModel(ImmediateFillModel):\n" +
                     "   def __init__(self):\n" +

--- a/Tests/Common/Securities/DynamicSecurityDataTests.cs
+++ b/Tests/Common/Securities/DynamicSecurityDataTests.cs
@@ -153,7 +153,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -179,7 +179,7 @@ def Test(dynamicData):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -203,7 +203,7 @@ def Test(dynamicData):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -227,7 +227,7 @@ def Test(dynamicData):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -254,7 +254,7 @@ def Test(dynamicData):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -279,7 +279,7 @@ def Test(dynamicData):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -304,7 +304,7 @@ def Test(dynamicData):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -329,7 +329,7 @@ def Test(dynamicData):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -350,14 +350,14 @@ def Test(dynamicData):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
 def Test(dynamicData):
     data = dynamicData.Get(TradeBar)").GetAttr("Test");
 
-                Assert.Throws<PythonException>(() => test(securityData));
+                Assert.Throws<KeyNotFoundException>(() => test(securityData));
             }
         }
 
@@ -370,7 +370,7 @@ def Test(dynamicData):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -892,7 +892,7 @@ namespace QuantConnect.Tests.Common.Util
             using (Py.GIL())
             {
                 // Try to convert a python class which inherits from a C# object
-                value = PythonEngine.ModuleFromString("testModule",
+                value = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -941,8 +941,8 @@ class Test(PythonData):
             using (Py.GIL())
             {
                 // Try to convert a python object as a IndicatorBase<TradeBar>
-                var locals = new PyDict();
-                PythonEngine.Exec("class A:\n    pass", null, locals.Handle);
+                using var locals = new PyDict();
+                PythonEngine.Exec("class A:\n    pass", null, locals);
                 var value = locals.GetItem("A").Invoke();
 
                 IndicatorBase<TradeBar> indicatorBaseTradeBar;
@@ -959,7 +959,7 @@ class Test(PythonData):
             using (Py.GIL())
             {
                 // Try to convert a python class which inherits from a C# object
-                value = PythonEngine.ModuleFromString("testModule",
+                value = PyModule.FromString("testModule",
                     @"
 from AlgorithmImports import *
 
@@ -982,8 +982,8 @@ class Test(PythonData):
 
             using (Py.GIL())
             {
-                var locals = new PyDict();
-                PythonEngine.Exec(code, null, locals.Handle);
+                using var locals = new PyDict();
+                PythonEngine.Exec(code, null, locals);
                 var pyObject = locals.GetItem("coarseSelector");
                 pyObject.TryConvertToDelegate(out coarseSelector);
             }
@@ -1009,8 +1009,8 @@ class Test(PythonData):
 
             using (Py.GIL())
             {
-                var locals = new PyDict();
-                PythonEngine.Exec("def raise_number(a): raise ValueError(a)", null, locals.Handle);
+                using var locals = new PyDict();
+                PythonEngine.Exec("def raise_number(a): raise ValueError(a)", null, locals);
                 var pyObject = locals.GetItem("raise_number");
                 pyObject.TryConvertToDelegate(out action);
             }
@@ -1022,7 +1022,7 @@ class Test(PythonData):
             }
             catch (PythonException e)
             {
-                Assert.AreEqual($"ValueError : {2}", e.Message);
+                Assert.AreEqual($"{2}", e.Message);
             }
         }
 
@@ -1033,8 +1033,8 @@ class Test(PythonData):
 
             using (Py.GIL())
             {
-                var locals = new PyDict();
-                PythonEngine.Exec("def raise_number(a, b): raise ValueError(a * b)", null, locals.Handle);
+                using var locals = new PyDict();
+                PythonEngine.Exec("def raise_number(a, b): raise ValueError(a * b)", null, locals);
                 var pyObject = locals.GetItem("raise_number");
                 pyObject.TryConvertToDelegate(out action);
             }
@@ -1046,7 +1046,7 @@ class Test(PythonData):
             }
             catch (PythonException e)
             {
-                Assert.AreEqual("ValueError : 6.0", e.Message);
+                Assert.AreEqual("6.0", e.Message);
             }
         }
 
@@ -1057,8 +1057,8 @@ class Test(PythonData):
 
             using (Py.GIL())
             {
-                var locals = new PyDict();
-                PythonEngine.Exec("def raise_number(a, b): raise ValueError(a * b)", null, locals.Handle);
+                using var locals = new PyDict();
+                PythonEngine.Exec("def raise_number(a, b): raise ValueError(a * b)", null, locals);
                 var pyObject = locals.GetItem("raise_number");
                 Assert.Throws<ArgumentException>(() => pyObject.TryConvertToDelegate(out action));
             }
@@ -1132,7 +1132,7 @@ class Test(PythonData):
         {
             using (Py.GIL())
             {
-                var actualDictionary = PythonEngine.ModuleFromString(
+                var actualDictionary = PyModule.FromString(
                     "PyObjectDictionaryConvertToDictionary_Success",
                     @"
 from datetime import datetime as dt
@@ -1165,7 +1165,7 @@ actualDictionary.update({'IBM': dt(2019,10,5)})
         {
             using (Py.GIL())
             {
-                var pyObject = PythonEngine.ModuleFromString(
+                var pyObject = PyModule.FromString(
                     "PyObjectDictionaryConvertToDictionary_FailNotDictionary",
                     "actualDictionary = list()"
                 ).GetAttr("actualDictionary");
@@ -1179,7 +1179,7 @@ actualDictionary.update({'IBM': dt(2019,10,5)})
         {
             using (Py.GIL())
             {
-                var pyObject = PythonEngine.ModuleFromString(
+                var pyObject = PyModule.FromString(
                     "PyObjectDictionaryConvertToDictionary_FailWrongItemType",
                     @"
 actualDictionary = dict()

--- a/Tests/Indicators/PythonIndicatorNoinheritanceTests.cs
+++ b/Tests/Indicators/PythonIndicatorNoinheritanceTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -33,7 +33,7 @@ namespace QuantConnect.Tests.Indicators
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(
+                var module = PyModule.FromString(
                     Guid.NewGuid().ToString(),
                     @"
 from collections import deque

--- a/Tests/Indicators/PythonIndicatorNoinheritanceTestsLegacy.cs
+++ b/Tests/Indicators/PythonIndicatorNoinheritanceTestsLegacy.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -33,7 +33,7 @@ namespace QuantConnect.Tests.Indicators
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(
+                var module = PyModule.FromString(
                     Guid.NewGuid().ToString(),
                     @"
 from collections import deque

--- a/Tests/Indicators/PythonIndicatorTests.cs
+++ b/Tests/Indicators/PythonIndicatorTests.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Tests.Indicators
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(
+                var module = PyModule.FromString(
                     Guid.NewGuid().ToString(),
                     @"
 from AlgorithmImports import *
@@ -172,7 +172,7 @@ class CustomSimpleMovingAverage(PythonIndicator):
 
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(
+                var module = PyModule.FromString(
                     Guid.NewGuid().ToString(),
                     @"
 from AlgorithmImports import *
@@ -216,7 +216,7 @@ class BadCustomIndicator(PythonIndicator):
             //Setup Python Indicator and Consolidator
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
                     "consolidator = QuoteBarConsolidator(timedelta(days = 5)) \n" +
                     "timeDelta = timedelta(days=2)\n" +
@@ -257,7 +257,7 @@ class BadCustomIndicator(PythonIndicator):
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(
+                var module = PyModule.FromString(
                     Guid.NewGuid().ToString(),
                     @"
 from AlgorithmImports import *
@@ -300,7 +300,7 @@ class CustomSimpleMovingAverage(PythonIndicator):
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(
+                var module = PyModule.FromString(
                     Guid.NewGuid().ToString(),
                     @"
 from AlgorithmImports import *

--- a/Tests/Python/AlgorithmPythonWrapperTests.cs
+++ b/Tests/Python/AlgorithmPythonWrapperTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -155,7 +155,7 @@ namespace QuantConnect.Tests.Python
 
             using (Py.GIL())
             {
-                 PythonEngine.ModuleFromString("Test_AlgorithmPythonWrapper", code);
+                PyModule.FromString("Test_AlgorithmPythonWrapper", code);
                 return new AlgorithmPythonWrapper("Test_AlgorithmPythonWrapper");
             }
         }

--- a/Tests/Python/DataConsolidatorPythonWrapperTests.cs
+++ b/Tests/Python/DataConsolidatorPythonWrapperTests.cs
@@ -30,7 +30,7 @@ namespace QuantConnect.Tests.Python
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
                     "class CustomConsolidator():\n" +
                     "   def __init__(self):\n" +
@@ -72,7 +72,7 @@ namespace QuantConnect.Tests.Python
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
                     "class CustomConsolidator():\n" +
                     "   def __init__(self):\n" +
@@ -103,7 +103,7 @@ namespace QuantConnect.Tests.Python
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
                     "class CustomConsolidator():\n" +
                     "   def __init__(self):\n" +
@@ -128,7 +128,7 @@ namespace QuantConnect.Tests.Python
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
                     "class CustomConsolidator():\n" +
                     "   def __init__(self):\n" +
@@ -189,7 +189,7 @@ namespace QuantConnect.Tests.Python
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
                     "class ImplementingClass():\n" +
                     "   def __init__(self):\n" +
@@ -200,6 +200,7 @@ namespace QuantConnect.Tests.Python
                     "       self.EventCalled = True\n" +
                     "class CustomConsolidator(QuoteBarConsolidator):\n" +
                     "   def __init__(self,span):\n" +
+                    "       super().__init__(span)\n" +
                     "       self.Span = span");
 
                 var implementingClass = module.GetAttr("ImplementingClass").Invoke();

--- a/Tests/Python/MethodOverloadTests.cs
+++ b/Tests/Python/MethodOverloadTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -64,10 +64,10 @@ namespace QuantConnect.Tests.Python
                 Assert.Throws<PythonException>(() => _algorithm.call_plot_throw_test());
 
                 // self.Plot("ERROR", self.Portfolio), where self.Portfolio is IAlgorithm.Portfolio: instance of SecurityPortfolioManager
-                Assert.Throws<PythonException>(() => _algorithm.call_plot_throw_managed_test());
+                Assert.Throws<ArgumentException>(() => _algorithm.call_plot_throw_managed_test());
 
                 // self.Plot("ERROR", self.a), where self.a is an instance of a python object
-                Assert.Throws<PythonException>(() => _algorithm.call_plot_throw_pyobject_test());
+                Assert.Throws<ArgumentException>(() => _algorithm.call_plot_throw_pyobject_test());
             }
         }
     }

--- a/Tests/Python/NamedArgumentsTests.cs
+++ b/Tests/Python/NamedArgumentsTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -34,7 +34,7 @@ namespace QuantConnect.Tests.Python
             using (Py.GIL())
             {
                 // Test function that will used named args in Python -> C#
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "def test(algorithm):\n" +
                     "   aapl = algorithm.AddEquity(ticker='AAPL')\n" +
                     "   return aapl\n"

--- a/Tests/Python/PandasConverterTests.BackwardsCompatibility.cs
+++ b/Tests/Python/PandasConverterTests.BackwardsCompatibility.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Tests.Python
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(df, symbol):
     df = df.lastprice.unstack(level=0){method}").GetAttr("Test");
@@ -51,7 +51,7 @@ def Test(df, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(df, symbol):
     df = df.lastprice.unstack(level=0){method}
@@ -78,7 +78,7 @@ def Test(df, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(df, other, symbol):
     df = df{method}
@@ -100,7 +100,7 @@ def Test(df, other, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(df, symbol):
     series = df.lastprice
@@ -117,7 +117,7 @@ def Test(df, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(df, symbol):
     series = df.lastprice
@@ -145,7 +145,7 @@ def Test(df, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(df, other, symbol):
     series, other = other.lastprice, df.lastprice
@@ -304,7 +304,7 @@ def Test(df, other, symbol):
 
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString("Test",
+                var module = PyModule.FromString("Test",
                     @"import pandas
 from inspect import getmembers, isfunction, signature
 

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -41,13 +41,15 @@ namespace QuantConnect.Tests.Python
         private PandasConverter _converter = new PandasConverter();
         private bool _newerPandas;
 
-        private static bool IsNewerPandas(){
+        private static bool IsNewerPandas()
+        {
             bool newPandas;
-            using(Py.GIL()){
+            using (Py.GIL())
+            {
                 var pandas = Py.Import("pandas");
-                var local = new PyDict();
+                using var local = new PyDict();
                 local["pd"] = pandas;
-                newPandas = PythonEngine.Eval("int(pd.__version__.split('.')[0]) >= 1", locals:local.Handle).As<bool>();
+                newPandas = PythonEngine.Eval("int(pd.__version__.split('.')[0]) >= 1", locals: local).As<bool>();
             }
             return newPandas;
         }
@@ -69,7 +71,7 @@ namespace QuantConnect.Tests.Python
         public void HandlesEnumerableDataType()
         {
             var converter = new PandasConverter();
-            var data = new []
+            var data = new[]
             {
                 new EnumerableData
                 {
@@ -240,7 +242,8 @@ namespace QuantConnect.Tests.Python
             var converter = new PandasConverter();
             var rawBars = Enumerable
                 .Range(0, 10)
-                .Select(i => new NullableValueData {
+                .Select(i => new NullableValueData
+                {
                     Symbol = Symbols.AAPL,
                     EndTime = new DateTime(2020, 1, 1),
                     NullableInt = null,
@@ -298,7 +301,7 @@ namespace QuantConnect.Tests.Python
             using (Py.GIL())
             {
 
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
     $@"
 def Test(dataFrame):
     data = dataFrame.loc['LOW']
@@ -336,7 +339,7 @@ def Test(dataFrame):
             using (Py.GIL())
             {
 
-                var Test = PythonEngine.ModuleFromString("testModule",
+                var Test = PyModule.FromString("testModule",
     $@"
 def Test1(dataFrame):
     # Should not throw, access all LOW ticker data
@@ -373,7 +376,7 @@ def Test4(dataFrame):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.droplevel('symbol')
@@ -392,7 +395,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.add_prefix('price_')['price_lastprice'].unstack(level=0)
@@ -413,7 +416,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.add_suffix('_tick')['lastprice_tick'].unstack(level=0)
@@ -434,7 +437,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, other, symbol):
     data = dataFrame.lastprice.unstack(level=0)
@@ -457,7 +460,7 @@ def Test(dataFrame, other, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import numpy as np
 def Test(dataFrame, symbol):
@@ -479,7 +482,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.unstack(level=0).applymap(lambda x: x*2)
@@ -500,7 +503,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.unstack(level=0).asfreq(freq='30S')
@@ -521,7 +524,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import pandas as pd
 def Test(dataFrame, symbol):
@@ -544,7 +547,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.assign(tmp=lambda x: x.lastprice * 1.1)['tmp'].unstack(level=0)
@@ -565,7 +568,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.unstack(level=0).astype('float16')
@@ -593,7 +596,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.at[({index},), 'lastprice']").GetAttr("Test");
@@ -611,7 +614,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.unstack(level=0).at_time('04:00')
@@ -632,7 +635,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     axes = dataFrame.axes[0]
@@ -652,7 +655,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.unstack(level=0).between_time('02:00', '06:00')
@@ -673,7 +676,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     columns = dataFrame.lastprice.unstack(level=0).columns
@@ -693,7 +696,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import numpy as np
 def Test(dataFrame, other, symbol):
@@ -717,7 +720,7 @@ def Test(dataFrame, other, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import pandas as pd
 def Test(dataFrame, dataFrame2, symbol):
@@ -739,7 +742,7 @@ def Test(dataFrame, dataFrame2, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import numpy as np
 def Test(dataFrame, other, symbol):
@@ -762,7 +765,7 @@ def Test(dataFrame, other, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.drop(columns=['exchange']).lastprice.unstack(level=0)
@@ -783,7 +786,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.droplevel('time').lastprice
@@ -804,7 +807,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import numpy as np
 def Test(dataFrame, symbol):
@@ -826,7 +829,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.eval('tmp=lastprice * 1.1')['tmp'].unstack(level=0)
@@ -847,7 +850,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, other, symbol):
     if not dataFrame.equals(other):
@@ -866,7 +869,7 @@ def Test(dataFrame, other, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.unstack(level=0)
@@ -888,7 +891,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.unstack(level=0)
@@ -910,7 +913,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.explode('lastprice').lastprice.unstack(level=0)
@@ -931,7 +934,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.filter(items=['lastprice']).lastprice.unstack(level=0)
@@ -949,7 +952,8 @@ def Test(dataFrame, symbol):
         public void BackwardsCompatibilityDataFrame_ftypes(string index, bool cache = false)
         {
             // ftypes deprecated in newer pandas; use dtypes instead
-            if(_newerPandas){
+            if (_newerPandas)
+            {
                 return;
             }
 
@@ -957,7 +961,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.unstack(level=0).ftypes
@@ -978,7 +982,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.get({index})
@@ -998,7 +1002,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame['lastprice'][{index}]").GetAttr("Test");
@@ -1013,7 +1017,8 @@ def Test(dataFrame, symbol):
         public void BackwardsCompatibilityDataFrame_get_value_index(string index, bool cache = false)
         {
             // get_value deprecated in new Pandas; Syntax also deprecated; Use .at[] or .iat[] instead
-            if(_newerPandas){
+            if (_newerPandas)
+            {
                 return;
             }
 
@@ -1021,7 +1026,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.get_value(({index},), 'lastprice')
@@ -1038,15 +1043,16 @@ def Test(dataFrame, symbol):
         public void BackwardsCompatibilityDataFrame_get_value_column(string index, bool cache = false)
         {
             // get_value deprecated in new Pandas; use at[] or iat[] instead
-            if(_newerPandas){
+            if (_newerPandas)
+            {
                 return;
             }
-            
+
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.unstack(level=0)
@@ -1068,7 +1074,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import pandas as pd
 def Test(df, other, symbol):
@@ -1091,7 +1097,7 @@ def Test(df, other, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame['lastprice'].unstack(level=0).iloc[-1][{index}]
@@ -1111,7 +1117,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.unstack(level=0)
@@ -1132,7 +1138,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     if {index} not in dataFrame.index.levels[0]:
@@ -1154,7 +1160,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     for index, data in dataFrame.{method}():
@@ -1176,7 +1182,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     for index, data in dataFrame.lastprice.unstack(level=0).iterrows():
@@ -1195,7 +1201,8 @@ def Test(dataFrame, symbol):
         public void BackwardsCompatibilityDataFrame_ix(string index, bool cache = false)
         {
             // ix deprecated in newer pandas; use loc and iloc instead
-            if(_newerPandas){
+            if (_newerPandas)
+            {
                 return;
             }
 
@@ -1203,7 +1210,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame['lastprice'].unstack(level=0).ix[-1][{index}]
@@ -1223,7 +1230,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, dataFrame2, symbol):
     newDataFrame = dataFrame.join(dataFrame2, lsuffix='_')
@@ -1244,7 +1251,7 @@ def Test(dataFrame, dataFrame2, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.loc[{index}]").GetAttr("Test");
@@ -1266,13 +1273,13 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbols):
     data = dataFrame.lastprice.unstack(0)
     data = data.loc[:, {index}]").GetAttr("Test");
 
-                var symbols = new List<Symbol> {Symbols.SPY, Symbols.AAPL};
+                var symbols = new List<Symbol> { Symbols.SPY, Symbols.AAPL };
                 Assert.DoesNotThrow(() => test(GetTestDataFrame(symbols), symbols));
             }
         }
@@ -1286,7 +1293,7 @@ def Test(dataFrame, symbols):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     time = dataFrame.index.get_level_values('time')[0]
@@ -1306,7 +1313,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.loc[{index}]").GetAttr("Test");
@@ -1324,7 +1331,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.loc[{index}].loc['2013-10-07 04:00:00']").GetAttr("Test");
@@ -1342,7 +1349,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.unstack(0)
@@ -1364,7 +1371,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import pandas as pd
 def Test(dataFrame, symbol):
@@ -1388,7 +1395,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, dataFrame2, symbol):
     newDataFrame = dataFrame.merge(dataFrame2, on='symbol', how='outer')
@@ -1412,7 +1419,7 @@ def Test(dataFrame, dataFrame2, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.{method}(3, 'lastprice')
@@ -1433,7 +1440,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import pandas as pd
 def Test(dataFrame, other, symbol):
@@ -1459,7 +1466,7 @@ def Test(dataFrame, other, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.pop('lastprice')
@@ -1480,7 +1487,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.query('lastprice > 100').lastprice.unstack(0)
@@ -1501,7 +1508,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     time = '2011-02-01'
@@ -1523,7 +1530,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, other, symbol):
     data = other.reindex_like(dataFrame)
@@ -1547,7 +1554,7 @@ def Test(dataFrame, other, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.rename({rename})['price'].unstack(0)
@@ -1568,7 +1575,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.reorder_levels(['time', 'symbol']).lastprice.unstack(1)
@@ -1589,7 +1596,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.unstack(0) 
@@ -1611,7 +1618,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.unstack(0).reset_index('time')
@@ -1632,7 +1639,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.rolling(2).sum()
@@ -1654,7 +1661,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.select_dtypes(exclude=['int']).lastprice.unstack(0)
@@ -1674,13 +1681,14 @@ def Test(dataFrame, symbol):
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
 
             // set_value deprecated in newer pandas; use .at[] or .iat instead
-            if(_newerPandas) {
+            if (_newerPandas)
+            {
                 return;
             }
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     idx = dataFrame.first_valid_index()
@@ -1702,7 +1710,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.slice_shift().lastprice.unstack(0)
@@ -1723,7 +1731,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.sort_values(by=['lastprice']).lastprice.unstack(0)
@@ -1744,7 +1752,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.unstack(0).swapaxes('index', 'columns')
@@ -1765,7 +1773,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.swaplevel().lastprice.unstack(1)
@@ -1786,7 +1794,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.take([0, 3]).lastprice.unstack(0)
@@ -1807,7 +1815,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import numpy as np
 def Test(dataFrame, symbol):
@@ -1829,7 +1837,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.T.iloc[0]
@@ -1850,7 +1858,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.transpose().iloc[0]
@@ -1871,7 +1879,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 from datetime import timedelta as d
 def Test(dataFrame, symbol):
@@ -1891,7 +1899,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.tz_localize('UTC', level=1)
@@ -1913,7 +1921,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.unstack(level=0).lastprice[{index}]").GetAttr("Test");
@@ -1931,7 +1939,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     df2 = dataFrame.unstack(level=0)
@@ -1951,7 +1959,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     df2 = dataFrame.lastprice.unstack(level=0)
@@ -1974,7 +1982,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import pandas as pd
 def Test(dataFrame, symbol):
@@ -1997,7 +2005,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     dataFrame = dataFrame.lastprice.unstack(0)
@@ -2019,7 +2027,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.xs({index})").GetAttr("Test");
@@ -2036,7 +2044,7 @@ def Test(dataFrame, symbol):
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import pandas as pd
 from datetime import datetime as dt
@@ -2061,7 +2069,7 @@ def Test(dataFrame, symbol):
             if (cache) SymbolCache.Set("SPY", Symbols.SPY);
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import pandas as pd
 from datetime import datetime as dt
@@ -2087,7 +2095,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, other, symbol):
     data = dataFrame.lastprice
@@ -2110,7 +2118,7 @@ def Test(dataFrame, other, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import numpy as np
 def Test(dataFrame, symbol):
@@ -2132,7 +2140,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice.droplevel(0) 
@@ -2151,7 +2159,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import pandas as pd
 def Test(dataFrame, symbol):
@@ -2172,7 +2180,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.astype('float16')
@@ -2193,7 +2201,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice.droplevel(0) 
@@ -2212,7 +2220,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2231,7 +2239,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice.droplevel(0) 
@@ -2250,7 +2258,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import numpy as np
 def Test(dataFrame, other, symbol):
@@ -2274,7 +2282,7 @@ def Test(dataFrame, other, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2297,7 +2305,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2319,7 +2327,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, other, symbol):
     series = dataFrame.lastprice
@@ -2340,7 +2348,7 @@ def Test(dataFrame, other, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2362,7 +2370,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2384,7 +2392,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2406,7 +2414,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice.droplevel(0) 
@@ -2425,7 +2433,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2443,7 +2451,8 @@ def Test(dataFrame, symbol):
         public void BackwardsCompatibilitySeries_get_value(string index, bool cache = false)
         {
             // get_value deprecated in new Pandas; Use .at[] or .iat[] instead
-            if (_newerPandas){
+            if (_newerPandas)
+            {
                 return;
             }
 
@@ -2451,7 +2460,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2473,7 +2482,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import pandas as pd
 def Test(df, other, symbol):
@@ -2496,7 +2505,7 @@ def Test(df, other, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice.droplevel(0) 
@@ -2517,7 +2526,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2539,7 +2548,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2561,7 +2570,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import pandas as pd
 def Test(dataFrame, other, symbol):
@@ -2587,7 +2596,7 @@ def Test(dataFrame, other, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     data = dataFrame.lastprice.pop({index})
@@ -2607,7 +2616,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, other, symbol):
     series = dataFrame.lastprice
@@ -2630,7 +2639,7 @@ def Test(dataFrame, other, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2652,7 +2661,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2674,7 +2683,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2696,7 +2705,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2715,7 +2724,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2737,7 +2746,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2766,7 +2775,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2789,7 +2798,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2811,7 +2820,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2833,7 +2842,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2855,7 +2864,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2877,7 +2886,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import numpy as np
 def Test(dataFrame, symbol):
@@ -2901,7 +2910,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2923,7 +2932,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2945,7 +2954,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 from datetime import timedelta as d
 def Test(dataFrame, symbol):
@@ -2965,7 +2974,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -2988,7 +2997,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 import pandas as pd
 def Test(dataFrame, symbol):
@@ -3012,7 +3021,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -3034,7 +3043,7 @@ def Test(dataFrame, symbol):
 
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     $@"
 def Test(dataFrame, symbol):
     series = dataFrame.lastprice
@@ -3050,7 +3059,7 @@ def Test(dataFrame, symbol):
         {
             using (Py.GIL())
             {
-                dynamic test = PythonEngine.ModuleFromString("testModule",
+                dynamic test = PyModule.FromString("testModule",
                     @"
 def Test(dataFrame, symbol):
     if 'SPY' not in dataFrame.index.levels[0]:
@@ -3183,10 +3192,10 @@ def Test(dataFrame, symbol):
 
 
         private static Resolution[] ResolutionCases = { Resolution.Tick, Resolution.Minute, Resolution.Second };
-        private static Symbol[] SymbolCases = {Symbols.Fut_SPY_Feb19_2016, Symbols.Fut_SPY_Mar19_2016, Symbols.SPY_C_192_Feb19_2016, Symbols.SPY_P_192_Feb19_2016};
+        private static Symbol[] SymbolCases = { Symbols.Fut_SPY_Feb19_2016, Symbols.Fut_SPY_Mar19_2016, Symbols.SPY_C_192_Feb19_2016, Symbols.SPY_P_192_Feb19_2016 };
 
         [Test]
-        public void HandlesOpenInterestTicks([ValueSource(nameof(ResolutionCases))]Resolution resolution, [ValueSource(nameof(SymbolCases))] Symbol symbol)
+        public void HandlesOpenInterestTicks([ValueSource(nameof(ResolutionCases))] Resolution resolution, [ValueSource(nameof(SymbolCases))] Symbol symbol)
         {
             // Arrange
             var converter = new PandasConverter();
@@ -3541,7 +3550,7 @@ def Test(dataFrame, symbol):
 
         private dynamic GetTestDataFrame(Symbol symbol, int count = 1)
         {
-            return GetTestDataFrame(new[] {symbol}, count);
+            return GetTestDataFrame(new[] { symbol }, count);
         }
 
         private dynamic GetTestDataFrame(IEnumerable<Symbol> symbols, int count = 1)
@@ -3579,7 +3588,7 @@ def Test(dataFrame, symbol):
             public SubTradeBar(TradeBar tradeBar) : base(tradeBar) { }
 
             public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode) =>
-                new SubTradeBar((TradeBar) base.Reader(config, line, date, isLiveMode));
+                new SubTradeBar((TradeBar)base.Reader(config, line, date, isLiveMode));
         }
 
         internal class SubSubTradeBar : SubTradeBar
@@ -3591,7 +3600,7 @@ def Test(dataFrame, symbol):
             public SubSubTradeBar(TradeBar tradeBar) : base(tradeBar) { }
 
             public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode) =>
-                new SubSubTradeBar((TradeBar) base.Reader(config, line, date, isLiveMode));
+                new SubSubTradeBar((TradeBar)base.Reader(config, line, date, isLiveMode));
         }
 
         internal class NullableValueData : BaseData
@@ -3603,7 +3612,7 @@ def Test(dataFrame, symbol):
             public double? NullableColumn { get; set; }
         }
 
-        internal class CustomData: DynamicData
+        internal class CustomData : DynamicData
         {
             private bool _isInitialized;
             private readonly List<string> _propertyNames = new List<string>();
@@ -3637,7 +3646,7 @@ def Test(dataFrame, symbol):
                     var value = csv[i].ToDecimal();
                     data.SetProperty(_propertyNames[i], value);
                 }
-                
+
                 if (!_propertyNames.Contains("Value"))
                 {
                     data.Value = 1;

--- a/Tests/Python/PortfolioCustomModelTests.cs
+++ b/Tests/Python/PortfolioCustomModelTests.cs
@@ -84,7 +84,7 @@ namespace QuantConnect.Tests.Python
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString("CustomMarginCallModel", code);
+                var module = PyModule.FromString("CustomMarginCallModel", code);
                 dynamic CustomMarginCallModel = module.GetAttr("CustomMarginCallModel");
                 return CustomMarginCallModel(portfolio, null);
             }
@@ -127,6 +127,7 @@ from AlgorithmImports import *
 
 class CustomMarginCallModel(DefaultMarginCallModel):
     def __init__(self, portfolio, defaultOrderProperties):
+        super().__init__(portfolio, defaultOrderProperties)
         self.porfolio = portfolio
         self.defaultOrderProperties = defaultOrderProperties
 

--- a/Tests/Python/PythonOptionTests.cs
+++ b/Tests/Python/PythonOptionTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -35,7 +35,7 @@ namespace QuantConnect.Tests.Python
             using (Py.GIL())
             {
                 //Filter function that returns a list of symbols
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "def filter(universe):\n" +
                     "   universe = universe.WeeklysOnly().Expiration(0, 10)\n" +
                     "   return [symbol for symbol in universe\n"+
@@ -60,7 +60,7 @@ namespace QuantConnect.Tests.Python
             using (Py.GIL())
             {
                 //Filter function that returns a OptionFilterUniverse
-                var module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(),
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "def filter(universe):\n" +
                     "   universe = universe.WeeklysOnly().Expiration(0, 5)\n" +
                     "   return universe"

--- a/Tests/Python/PythonPackagesTests.cs
+++ b/Tests/Python/PythonPackagesTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -898,7 +898,7 @@ def RunTest():
         {
             using (Py.GIL())
             {
-                dynamic module = PythonEngine.ModuleFromString(Guid.NewGuid().ToString(), code);
+                dynamic module = PyModule.FromString(Guid.NewGuid().ToString(), code);
                 Assert.DoesNotThrow(() => module.RunTest());
             }
         }

--- a/Tests/Python/PythonWrapperTests.cs
+++ b/Tests/Python/PythonWrapperTests.cs
@@ -30,7 +30,7 @@ namespace QuantConnect.Tests.Python
             {
                 using (Py.GIL())
                 {
-                    var module = PythonEngine.ModuleFromString(nameof(ValidateImplementationOf), MissingMethod1);
+                    var module = PyModule.FromString(nameof(ValidateImplementationOf), MissingMethod1);
                     var model = module.GetAttr("ModelMissingMethod1");
                     Assert.That(() => model.ValidateImplementationOf<IModel>(), Throws
                         .Exception.InstanceOf<NotImplementedException>().With.Message.Contains("Method1"));
@@ -42,7 +42,7 @@ namespace QuantConnect.Tests.Python
             {
                 using (Py.GIL())
                 {
-                    var module = PythonEngine.ModuleFromString(nameof(ValidateImplementationOf), FullyImplemented);
+                    var module = PyModule.FromString(nameof(ValidateImplementationOf), FullyImplemented);
                     var model = module.GetAttr("FullyImplementedModel");
                     Assert.That(() => model.ValidateImplementationOf<IModel>(), Throws.Nothing);
                 }
@@ -53,7 +53,7 @@ namespace QuantConnect.Tests.Python
             {
                 using (Py.GIL())
                 {
-                    var module = PythonEngine.ModuleFromString(nameof(ValidateImplementationOf), DerivedFromCsharp);
+                    var module = PyModule.FromString(nameof(ValidateImplementationOf), DerivedFromCsharp);
                     var model = module.GetAttr("DerivedFromCSharpModel");
                     Assert.That(() => model.ValidateImplementationOf<IModel>(), Throws.Nothing);
                 }

--- a/Tests/Python/SecurityCustomModelTests.cs
+++ b/Tests/Python/SecurityCustomModelTests.cs
@@ -77,7 +77,7 @@ namespace QuantConnect.Tests.Python
         {
             using (Py.GIL())
             {
-                var module = PythonEngine.ModuleFromString("CustomBuyingPowerModel", code);
+                var module = PyModule.FromString("CustomBuyingPowerModel", code);
                 return module.GetAttr("CustomBuyingPowerModel").Invoke();
             }
         }

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.11" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.12" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Math" Version="3.6.0" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />

--- a/Tests/Research/QuantBookFundamentalTests.cs
+++ b/Tests/Research/QuantBookFundamentalTests.cs
@@ -144,7 +144,7 @@ namespace QuantConnect.Tests.Research
             {
                 var testModule = _module.FundamentalHistoryTest();
                 var data = testModule.getFundamentals(input[0], input[1], input[2], input[3]);
-                Assert.IsEmpty(data);
+                Assert.AreEqual(true, (bool)data.empty);
             }
         }
 

--- a/Tests/ResearchRegressionTests.cs
+++ b/Tests/ResearchRegressionTests.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
+using QuantConnect.Logging;
 using QuantConnect.Util;
 using System;
 using System.Collections.Generic;
@@ -228,6 +229,23 @@ namespace QuantConnect.Tests
             {
                 StartInfo = startInfo,
             };
+
+            // real-time stream process output
+            process.OutputDataReceived += (sender, args) =>
+            {
+                if(args.Data != null)
+                {
+                    Log.Debug(args.Data);
+                }
+            };
+            process.ErrorDataReceived += (sender, args) =>
+            {
+                if (args.Data != null)
+                {
+                    Log.Debug(args.Data);
+                }
+            };
+
             process.Start();
             process.BeginErrorReadLine();
             process.BeginOutputReadLine();

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -40,7 +40,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.11" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.12" />
     <PackageReference Include="CoinAPI.WebSocket.V1" Version="1.6.7" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />
     <PackageReference Include="Common.Logging.Core" Version="3.4.1" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Bump pythonNet version 2.0.12
- Updates after pythonNet rebase
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See https://github.com/QuantConnect/pythonnet/pull/64
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Update
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running tests, research.


#### Memory sanity test
Running `CoarseFineFundamentalComboAlgorithm` using `self.__numberOfSymbols = 50;self.__numberOfSymbolsFine = 10`
`Master`
![image](https://user-images.githubusercontent.com/18473240/165858936-e73b44bd-476f-4fa5-acde-d8ec941b30d8.png)

`PR`
![image](https://user-images.githubusercontent.com/18473240/165859093-cd2026b6-13a6-45ef-82df-62d1fe0ba729.png)


#### Performance sanity test:
```
HistoryRequestBenchmark PR
49.38 seconds at 37k data points per second. Processing total of 1,822,036 data points.
48.48 seconds at 38k data points per second. Processing total of 1,822,036 data points.
47.68 seconds at 38k data points per second. Processing total of 1,822,036 data points.
```
```
BasicTemplateBenchmark PR
51.53 seconds at 51k data points per second. Processing total of 2,639,319 data points.
51.72 seconds at 51k data points per second. Processing total of 2,639,319 data points.
50.72 seconds at 52k data points per second. Processing total of 2,639,319 data points.
```
```
BasicTemplateBenchmark MASTER
48.77 seconds at 54k data points per second. Processing total of 2,639,319 data points.
46.56 seconds at 57k data points per second. Processing total of 2,639,319 data points.
47.14 seconds at 56k data points per second. Processing total of 2,639,319 data points.
```
```
HistoryRequestBenchmark MASTER
46.75 seconds at 39k data points per second. Processing total of 1,822,036 data points.
47.13 seconds at 39k data points per second. Processing total of 1,822,036 data points.
48.57 seconds at 38k data points per second. Processing total of 1,822,036 data points.
```
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
