### PR TITLE
Charge correct fees for Coinbase Pro stable pairs

### DIFF
--- a/Common/Currencies.cs
+++ b/Common/Currencies.cs
@@ -116,6 +116,9 @@ namespace QuantConnect
             {"USDT", "USDT"}
         };
 
+        /// <summary>
+        /// Commonly StableCoins quote currencies
+        /// </summary>
         private static readonly string[] _stableCoinsCurrencies = new string[] 
         { 
             USD,
@@ -123,12 +126,26 @@ namespace QuantConnect
             IDR,
             CHF
         };
-        
+
+        /// <summary>
+        /// Define some StableCoins that don't have direct pairs for base currencies in our SPDB in GDAX market
+        /// This is because some CryptoExchanges do not define direct pairs with the stablecoins they offer.
+        ///
+        /// We use this to allow setting cash amounts for these stablecoins without needing a conversion
+        /// security.
+        /// </summary>
         private static readonly Dictionary<string, int> _stableCoinsGDAX = new Dictionary<string, int> 
         {
             { "USDC", 0 }
         };
 
+        /// <summary>
+        /// Define some StableCoins that don't have direct pairs for base currencies in our SPDB in Binance market
+        /// This is because some CryptoExchanges do not define direct pairs with the stablecoins they offer.
+        ///
+        /// We use this to allow setting cash amounts for these stablecoins without needing a conversion
+        /// security.
+        /// </summary>
         private static readonly Dictionary<string, int> _stableCoinsBinance = new Dictionary<string, int>
         {
             { "USDC", 0 },
@@ -142,12 +159,22 @@ namespace QuantConnect
             { "IDRT", 2}
         };
 
+        /// <summary>
+        /// Define some StableCoins that don't have direct pairs for base currencies in our SPDB in Bitfinex market
+        /// This is because some CryptoExchanges do not define direct pairs with the stablecoins they offer.
+        ///
+        /// We use this to allow setting cash amounts for these stablecoins without needing a conversion
+        /// security.
+        /// </summary>
         private static readonly Dictionary<string, int> _stableCoinsBitfinex = new Dictionary<string, int>
         {
             { "EURS", 1 },
             { "XCHF", 3 }
         };
 
+        /// <summary>
+        /// Dictionary to save StableCoins in different Markets
+        /// </summary>
         private static readonly Dictionary<string, Dictionary<string, int>> _stableCoinsMarkets = new Dictionary<string, Dictionary<string, int>>
         {
             { Market.Binance , _stableCoinsBinance},
@@ -156,44 +183,31 @@ namespace QuantConnect
         };
 
         /// <summary>
-        /// Define some StableCoins that don't have direct pairs for base currencies in our SPDB
-        /// This is because some CryptoExchanges do not define direct pairs with the stablecoins they offer.
-        ///
-        /// We use this to allow setting cash amounts for these stablecoins without needing a conversion
-        /// security.
+        /// Checks whether or not certain symbol is a StableCoin between a given market
         /// </summary>
-        public static HashSet<Symbol> StableCoinsWithoutPairs = new HashSet<Symbol>
-        {
-            // Binance StableCoins Missing 1-1 Pairs
-            Symbol.Create("USDCUSD", SecurityType.Crypto, Market.Binance), // USD -> USDC
-            Symbol.Create("USDTUSD", SecurityType.Crypto, Market.Binance), // USD -> USDT
-            Symbol.Create("USDPUSD", SecurityType.Crypto, Market.Binance), // USD -> USDP
-            Symbol.Create("BUSDUSD", SecurityType.Crypto, Market.Binance), // USD -> BUSD
-            Symbol.Create("USTUSD", SecurityType.Crypto, Market.Binance), // USD -> UST
-            Symbol.Create("TUSDUSD", SecurityType.Crypto, Market.Binance), // USD -> TUSD
-            Symbol.Create("DAIUSD", SecurityType.Crypto, Market.Binance), // USD -> DAI
-            Symbol.Create("SUSDUSD", SecurityType.Crypto, Market.Binance), // USD -> SUSD
-            Symbol.Create("IDRTIDR", SecurityType.Crypto, Market.Binance), // IDR -> IDRT
-
-            // Coinbase StableCoins Missing 1-1 Pairs
-            Symbol.Create("USDCUSD", SecurityType.Crypto, Market.GDAX), // USD -> USDC
-
-            // Bitfinex StableCoins Missing 1-1 Pairs
-            Symbol.Create("EURSEUR", SecurityType.Crypto, Market.Bitfinex), // EUR -> EURS
-            Symbol.Create("XCHFCHF", SecurityType.Crypto, Market.Bitfinex), // CHF -> XCHF
-        };
-
-        public static bool IsStableCoin(string symbol, string market)
+        /// <param name="symbol">The symbol from which we want to know if it's a StableCoin</param>
+        /// <param name="market">The market in which we want to search for that StaleCoin</param>
+        /// <param name="quoteCurrency">If the symbol was indeed a StableCoin and this parameter is
+        /// defined, it will check if the quote currency associated with the StableCoin is the
+        /// same as the given in the parameters. Otherwise, it will just check whether or not the 
+        /// given symbol is a StableCoin</param>
+        /// <returns></returns>
+        public static bool IsStableCoin(string symbol, string market, string quoteCurrency = null)
         {
             try
             {
-                var value = _stableCoinsMarkets[market][symbol];
-                return true;
+                var index = _stableCoinsMarkets[market][symbol];
+                if (quoteCurrency == null || quoteCurrency == _stableCoinsCurrencies[index])
+                {
+                    return true;
+                }
             }
             catch
             {
                 return false;
             }
+
+            return false;
         }
 
         /// <summary>

--- a/Common/Currencies.cs
+++ b/Common/Currencies.cs
@@ -43,9 +43,19 @@ namespace QuantConnect
         public const string INR = "INR";
 
         /// <summary>
+        /// IDR (Indonesian rupiah) currency string
+        /// </summary>
+        public const string IDR = "IDR";
+
+        /// <summary>
         /// CNH (Chinese Yuan Renminbi) currency string
         /// </summary>
         public const string CNH = "CNH";
+
+        /// <summary>
+        /// CHF (Swiss Franc) currency string
+        /// </summary>
+        public const string CHF = "CHF";
 
         /// <summary>
         /// HKD (Hong Kong dollar) currency string
@@ -106,6 +116,45 @@ namespace QuantConnect
             {"USDT", "USDT"}
         };
 
+        private static readonly string[] _stableCoinsCurrencies = new string[] 
+        { 
+            USD,
+            EUR,
+            IDR,
+            CHF
+        };
+        
+        private static readonly Dictionary<string, int> _stableCoinsGDAX = new Dictionary<string, int> 
+        {
+            { "USDC", 0 }
+        };
+
+        private static readonly Dictionary<string, int> _stableCoinsBinance = new Dictionary<string, int>
+        {
+            { "USDC", 0 },
+            { "USDT", 0 },
+            { "USDP", 0 },
+            { "BUSD", 0 },
+            { "UST", 0 },
+            { "TUSD", 0 },
+            { "DAI", 0 },
+            { "SUSD", 0},
+            { "IDRT", 2}
+        };
+
+        private static readonly Dictionary<string, int> _stableCoinsBitfinex = new Dictionary<string, int>
+        {
+            { "EURS", 1 },
+            { "XCHF", 3 }
+        };
+
+        private static readonly Dictionary<string, Dictionary<string, int>> _stableCoinsMarkets = new Dictionary<string, Dictionary<string, int>>
+        {
+            { Market.Binance , _stableCoinsBinance},
+            { Market.Bitfinex , _stableCoinsBitfinex},
+            { Market.GDAX , _stableCoinsGDAX},
+        };
+
         /// <summary>
         /// Define some StableCoins that don't have direct pairs for base currencies in our SPDB
         /// This is because some CryptoExchanges do not define direct pairs with the stablecoins they offer.
@@ -132,7 +181,20 @@ namespace QuantConnect
             // Bitfinex StableCoins Missing 1-1 Pairs
             Symbol.Create("EURSEUR", SecurityType.Crypto, Market.Bitfinex), // EUR -> EURS
             Symbol.Create("XCHFCHF", SecurityType.Crypto, Market.Bitfinex), // CHF -> XCHF
-        };  
+        };
+
+        public static bool IsStableCoin(string symbol, string market)
+        {
+            try
+            {
+                var value = _stableCoinsMarkets[market][symbol];
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
 
         /// <summary>
         /// Gets the currency symbol for the specified currency code

--- a/Common/Orders/Fees/GDAXFeeModel.cs
+++ b/Common/Orders/Fees/GDAXFeeModel.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using QuantConnect.Util;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Orders.Fees
@@ -37,7 +38,22 @@ namespace QuantConnect.Orders.Fees
             // marketable limit orders are considered takers
             var isMaker = order.Type == OrderType.Limit && !order.IsMarketable;
 
-            var feePercentage = GetFeePercentage(order.Time, isMaker);
+            // Check if the current symbol is a StableCoin
+            var isStableCoin = false;
+            var quoteCurrency = security.QuoteCurrency.Symbol;
+            foreach (var pair in Currencies.StableCoinsWithoutPairs)
+            {
+                if (CurrencyPairUtil.TryDecomposeCurrencyPair(pair, out var pairBaseCurrency, out var pairQuoteCurrency))
+                {
+                    if ((pairBaseCurrency == quoteCurrency) && (pair.ID.Market == security.Symbol.ID.Market))
+                    {
+                        isStableCoin = true;
+                        break;
+                    }
+                }
+            }
+
+            var feePercentage = GetFeePercentage(order.Time, isMaker, isStableCoin);
 
             // get order value in quote currency, then apply maker/taker fee factor
             var unitPrice = order.Direction == OrderDirection.Buy ? security.AskPrice : security.BidPrice;
@@ -55,15 +71,18 @@ namespace QuantConnect.Orders.Fees
         /// </summary>
         /// <param name="utcTime">The date/time requested (UTC)</param>
         /// <param name="isMaker">true if the maker percentage fee is requested, false otherwise</param>
+        /// <param name="isStableCoin">true if the order security symbol is a StableCoin, false otherwise</param>
         /// <returns>The fee percentage effective at the requested date</returns>
-        public static decimal GetFeePercentage(DateTime utcTime, bool isMaker)
+        public static decimal GetFeePercentage(DateTime utcTime, bool isMaker, bool isStableCoin)
         {
             // Tier 1 fees
             // https://pro.coinbase.com/orders/fees
             // https://blog.coinbase.com/coinbase-pro-market-structure-update-fbd9d49f43d7
             // https://blog.coinbase.com/updates-to-coinbase-pro-fee-structure-b3d9ee586108
+            if (isStableCoin)
+                return isMaker ? 0m : 0.001m;
 
-            if (utcTime < new DateTime(2019, 3, 23, 1, 30, 0))
+            else if (utcTime < new DateTime(2019, 3, 23, 1, 30, 0))
                 return isMaker ? 0m : 0.003m;
                 
             else if (utcTime < new DateTime(2019, 10, 8, 0, 30, 0))

--- a/Common/Orders/Fees/GDAXFeeModel.cs
+++ b/Common/Orders/Fees/GDAXFeeModel.cs
@@ -39,19 +39,8 @@ namespace QuantConnect.Orders.Fees
             var isMaker = order.Type == OrderType.Limit && !order.IsMarketable;
 
             // Check if the current symbol is a StableCoin
-            var isStableCoin = false;
             var quoteCurrency = security.QuoteCurrency.Symbol;
-            foreach (var pair in Currencies.StableCoinsWithoutPairs)
-            {
-                if (CurrencyPairUtil.TryDecomposeCurrencyPair(pair, out var pairBaseCurrency, out var pairQuoteCurrency))
-                {
-                    if ((pairBaseCurrency == quoteCurrency) && (pair.ID.Market == security.Symbol.ID.Market))
-                    {
-                        isStableCoin = true;
-                        break;
-                    }
-                }
-            }
+            var isStableCoin = Currencies.IsStableCoin(quoteCurrency, security.Symbol.ID.Market);
 
             var feePercentage = GetFeePercentage(order.Time, isMaker, isStableCoin);
 

--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -246,8 +246,8 @@ namespace QuantConnect.Securities
             // Check out the StableCoinsWithoutPairs static var for those that are missing their 1-1 conversion pairs
             if (marketMap.TryGetValue(SecurityType.Crypto, out var market)
                 && 
-                (Currencies.StableCoinsWithoutPairs.Contains(QuantConnect.Symbol.Create(Symbol + accountCurrency, SecurityType.Crypto, market))
-                || Currencies.StableCoinsWithoutPairs.Contains(QuantConnect.Symbol.Create(accountCurrency + Symbol, SecurityType.Crypto, market))))
+                (Currencies.IsStableCoin(Symbol, market, accountCurrency)
+                || Currencies.IsStableCoin(accountCurrency, market, Symbol)))
             {
                 CurrencyConversion = null;
                 ConversionRate = 1.0m;

--- a/Common/Util/CurrencyPairUtil.cs
+++ b/Common/Util/CurrencyPairUtil.cs
@@ -211,8 +211,8 @@ namespace QuantConnect.Util
 
                 foreach(var pair in potentialStableCoins)
                 {
-                    if (Currencies.StableCoinsWithoutPairs.Contains(Symbol.Create(currencies[pair[0]] + currencies[pair[1]], SecurityType.Crypto, pairA.ID.Market))
-                        || Currencies.StableCoinsWithoutPairs.Contains(Symbol.Create(currencies[pair[1]] + currencies[pair[0]], SecurityType.Crypto, pairA.ID.Market)))
+                    if (Currencies.IsStableCoin(currencies[pair[0]], pairA.ID.Market, currencies[pair[1]])
+                        || Currencies.IsStableCoin(currencies[pair[1]], pairA.ID.Market, currencies[pair[0]]))
                     {
                         // If there's a stablecoin between them, assign to currency in pair A the value
                         // of the currency in pair B 

--- a/Tests/Common/Orders/Fees/GDAXFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/GDAXFeeModelTests.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
     {
         private Crypto _btcusd;
         private Crypto _btceur;
+        private Crypto _btcusdc;
         private readonly IFeeModel _feeModel = new GDAXFeeModel();
 
         [SetUp]
@@ -54,6 +55,16 @@ namespace QuantConnect.Tests.Common.Orders.Fees
                 RegisteredSecurityDataTypesProvider.Null
             );
             _btceur.SetMarketPrice(new Tick(DateTime.UtcNow, _btceur.Symbol, 100, 100));
+
+            _btcusdc = new Crypto(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new Cash("USDC", 0, 10),
+                new SubscriptionDataConfig(typeof(TradeBar), Symbol.Create("BTCUSDC", SecurityType.Crypto, Market.GDAX), Resolution.Minute, tz, tz, true, false, false),
+                new SymbolProperties("BTCUSDC", "USDC", 1, 0.01m, 0.00000001m, string.Empty),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
+            );
+            _btcusdc.SetMarketPrice(new Tick(DateTime.UtcNow, _btcusdc.Symbol, 100, 100));
         }
 
         [Test]
@@ -86,6 +97,22 @@ namespace QuantConnect.Tests.Common.Orders.Fees
             Assert.AreEqual("EUR", fee.Value.Currency);
             // 100 (price) * 0.003 (taker fee)
             Assert.AreEqual(0.3m, fee.Value.Amount);
+        }
+
+        [Test]
+        public void ReturnsExpectedFeeWithStableCoins()
+        {
+            var time = new DateTime(2019, 2, 1);
+            var fee = _feeModel.GetOrderFee(
+                new OrderFeeParameters(
+                    _btcusdc,
+                    new MarketOrder(_btcusdc.Symbol, 1, time)
+                )
+            );
+
+            Assert.AreEqual("USDC", fee.Value.Currency);
+            // 100 (price) * 0.003 (taker fee)
+            Assert.AreEqual(0.1m, fee.Value.Amount);
         }
 
         [TestCase(2019, 2, 1, 0, 0, 0, 0.3)]

--- a/Tests/Common/Orders/Fees/GDAXFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/GDAXFeeModelTests.cs
@@ -111,7 +111,7 @@ namespace QuantConnect.Tests.Common.Orders.Fees
             );
 
             Assert.AreEqual("USDC", fee.Value.Currency);
-            // 100 (price) * 0.003 (taker fee)
+            // 100 (price) * 0.001 (taker fee)
             Assert.AreEqual(0.1m, fee.Value.Amount);
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix bug in `GDAXFeeModel.cs` which charged incorrect amount of fees for stable pairs
- Remove `StableCoinsWithoutPairs` in`Currencies.cs` in order to use a more efficient implementation. In this one, we can know whether or not a symbol is a StableCoin in constant time. Also, if it's indeed a StableCoin we can know the quote currency associated with in constant time
- Add unit test to make sure everything is working as expected
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #6183
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change users will have the correct fee charges when using Coinbase pro stable pairs in their algorithms
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require changes in documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- There was created an `OrderFeeParameters` using a stable pair in Coinbase pro, and then, after calling for `GetOrderFee()`, there was asserted the fees returned 0.1% taker fee 
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
