### PR TITLE
Solve bug when plotting Python indicators

### DIFF
--- a/Algorithm/QCAlgorithm.Plotting.cs
+++ b/Algorithm/QCAlgorithm.Plotting.cs
@@ -41,6 +41,11 @@ namespace QuantConnect.Algorithm
             { "Alpha Asset Breakdown", new List<string>() }
         };
 
+        public bool ContainsChart(string key)
+        {
+            return _charts.ContainsKey(key);
+        }
+
         /// <summary>
         /// Access to the runtime statistics property. User provided statistics.
         /// </summary>

--- a/Algorithm/QCAlgorithm.Plotting.cs
+++ b/Algorithm/QCAlgorithm.Plotting.cs
@@ -243,7 +243,7 @@ namespace QuantConnect.Algorithm
         /// Plots the value of each indicator on the chart
         /// </summary>
         /// <param name="chart">The chart's name</param>
-        /// <param name="indicators">The indicatorsto plot</param>
+        /// <param name="indicators">The indicators to plot</param>
         /// <seealso cref="Plot(string,string,decimal)"/>
         [DocumentationAttribute(Charting)]
         public void Plot(string chart, params IndicatorBase[] indicators)

--- a/Algorithm/QCAlgorithm.Plotting.cs
+++ b/Algorithm/QCAlgorithm.Plotting.cs
@@ -246,8 +246,7 @@ namespace QuantConnect.Algorithm
         /// <param name="indicators">The indicatorsto plot</param>
         /// <seealso cref="Plot(string,string,decimal)"/>
         [DocumentationAttribute(Charting)]
-        public void Plot<T>(string chart, params IndicatorBase<T>[] indicators)
-            where T : IBaseData
+        public void Plot(string chart, params IndicatorBase[] indicators)
         {
             foreach (var indicator in indicators)
             {

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -694,9 +694,8 @@ namespace QuantConnect.Algorithm
             {
                 try
                 {
-                    var value = (((dynamic)pyObject).Current.Value as PyObject).GetAndDispose<decimal>();
-                    var name = (((dynamic)pyObject).Name as PyObject).GetAndDispose<string>();
-                    Plot(series, name, value);
+                    var indicator = (((dynamic)pyObject) as PyObject).GetAndDispose<IndicatorBase>();
+                    Plot(series, indicator);
                 }
                 catch
                 {

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -695,7 +695,8 @@ namespace QuantConnect.Algorithm
                 try
                 {
                     var value = (((dynamic)pyObject).Current.Value as PyObject).GetAndDispose<decimal>();
-                    Plot(series, value);
+                    var name = (((dynamic)pyObject).Name as PyObject).GetAndDispose<string>();
+                    Plot(series, name, value);
                 }
                 catch
                 {

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -131,10 +131,8 @@ namespace QuantConnect.Tests.Algorithm
                 {
                     throw new NotSupportedException($"RegistersIndicatorProperlyPython(): Unsupported indicator data type: {indicatorTest.GetType()}");
                 }
-
                 Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
-                Assert.DoesNotThrow(() => _algorithm.Plot("TestIndicatorPlot", indicator));
-                Assert.IsTrue(_algorithm.ContainsChart("TestIndicatorPlot"));
+                Assert.DoesNotThrow(() => _algorithm.Plot(_spy.Value, indicator));
 
                 expected++;
 
@@ -143,6 +141,15 @@ namespace QuantConnect.Tests.Algorithm
                     .Consolidators.Count;
                 Assert.AreEqual(expected, actual);
             }
+        }
+
+        [Test]
+        public void PlotPythonIndicatorCorrectly()
+        {
+            var indicatorTest = Activator.CreateInstance(_indicatorTestsTypes.First());
+            PyObject indicator = (indicatorTest as CommonIndicatorTests<IndicatorDataPoint>).GetIndicatorAsPyObject();
+            Assert.DoesNotThrow(() => _algorithm.Plot("TestIndicatorPlot", indicator));
+            Assert.IsTrue(_algorithm.ContainsChart("TestIndicatorPlot"));
         }
 
         [Test]

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -132,7 +132,7 @@ namespace QuantConnect.Tests.Algorithm
                     throw new NotSupportedException($"RegistersIndicatorProperlyPython(): Unsupported indicator data type: {indicatorTest.GetType()}");
                 }
                 Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
-                Assert.DoesNotThrow(() => _algorithm.Plot(_spy.Value, indicator))
+                Assert.DoesNotThrow(() => _algorithm.Plot(_spy.Value, indicator));
                 expected++;
 
                 var actual = _algorithm.SubscriptionManager.Subscriptions

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -144,12 +144,33 @@ namespace QuantConnect.Tests.Algorithm
         }
 
         [Test]
-        public void PlotPythonIndicatorCorrectly()
+        public void PlotPythonIndicatorInSeparateChart()
         {
-            var indicatorTest = Activator.CreateInstance(_indicatorTestsTypes.First());
-            PyObject indicator = (indicatorTest as CommonIndicatorTests<IndicatorDataPoint>).GetIndicatorAsPyObject();
-            Assert.DoesNotThrow(() => _algorithm.Plot("TestIndicatorPlot", indicator));
-            Assert.IsTrue(_algorithm.ContainsChart("TestIndicatorPlot"));
+            PyObject indicator;
+
+            foreach (var type in _indicatorTestsTypes)
+            {
+                var indicatorTest = Activator.CreateInstance(type);
+                if (indicatorTest is CommonIndicatorTests<IndicatorDataPoint>)
+                {
+                    indicator = (indicatorTest as CommonIndicatorTests<IndicatorDataPoint>).GetIndicatorAsPyObject();
+                }
+                else if (indicatorTest is CommonIndicatorTests<IBaseDataBar>)
+                {
+                    indicator = (indicatorTest as CommonIndicatorTests<IBaseDataBar>).GetIndicatorAsPyObject();
+                }
+                else if (indicatorTest is CommonIndicatorTests<TradeBar>)
+                {
+                    indicator = (indicatorTest as CommonIndicatorTests<TradeBar>).GetIndicatorAsPyObject();
+                }
+                else
+                {
+                    throw new NotSupportedException($"RegistersIndicatorProperlyPython(): Unsupported indicator data type: {indicatorTest.GetType()}");
+                }
+
+                Assert.DoesNotThrow(() => _algorithm.Plot($"TestIndicatorPlot-{type.Name}", indicator));
+                Assert.IsTrue(_algorithm.ContainsChart($"TestIndicatorPlot-{type.Name}"));
+            }
         }
 
         [Test]

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -131,8 +131,11 @@ namespace QuantConnect.Tests.Algorithm
                 {
                     throw new NotSupportedException($"RegistersIndicatorProperlyPython(): Unsupported indicator data type: {indicatorTest.GetType()}");
                 }
+
                 Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
-                Assert.DoesNotThrow(() => _algorithm.Plot(_spy.Value, indicator));
+                Assert.DoesNotThrow(() => _algorithm.Plot("TestIndicatorPlot", indicator));
+                Assert.IsTrue(_algorithm.ContainsChart("TestIndicatorPlot"));
+
                 expected++;
 
                 var actual = _algorithm.SubscriptionManager.Subscriptions

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -132,8 +132,7 @@ namespace QuantConnect.Tests.Algorithm
                     throw new NotSupportedException($"RegistersIndicatorProperlyPython(): Unsupported indicator data type: {indicatorTest.GetType()}");
                 }
                 Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_spy, indicator, Resolution.Minute));
-                Assert.DoesNotThrow(() => _algorithm.Plot(_spy.Value, indicator));
-
+                Assert.DoesNotThrow(() => _algorithm.Plot(_spy.Value, indicator))
                 expected++;
 
                 var actual = _algorithm.SubscriptionManager.Subscriptions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When the `QCAlgorithm.Python.Plot()` was called it sent in a decimal value in the second argument to `QCAlgorithm.Plottting.Plot()` so it used the constructor which plots the chart in **Strategy Equity** plot by default instead of plot the chart its own plot
#### Description
<!--- Describe your changes in detail -->
- Solve bug in `QCAlgorithm.Python.Plot()`
- Add unit test to cover the changes
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#6319 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change users will be able to plot an indicator in its own chart
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require updates to documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There has been created different PyObject indicators and after call for the plot method, asserted there was indeed a chart with the name given to the Plot method
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
