### PR TITLE
Make `PandasConverter.GetIndicatorDataFrame` accept Python dictionary

### DIFF
--- a/Common/Python/PandasConverter.cs
+++ b/Common/Python/PandasConverter.cs
@@ -123,36 +123,6 @@ namespace QuantConnect.Python
         }
 
         /// <summary>
-        /// Creates a series from a list of <see cref="IndicatorDataPoint"/> and adds it to the
-        /// <see cref="PyDict"/> as the value of the given <paramref name="key"/>
-        /// </summary>
-        /// <param name="key">Key to insert in the <see cref="PyDict"/></param>
-        /// <param name="points">List of <see cref="IndicatorDataPoint"/> that will make up the resulting series</param>
-        /// <param name="pyDict"><see cref="PyDict"/> where the resulting key-value pair will be inserted into</param>
-        private void AddSeriesToPyDict(string key, List<IndicatorDataPoint> points, PyDict pyDict)
-        {
-            var index = new List<DateTime>();
-            var values = new List<double>();
-
-            foreach (var point in points)
-            {
-                index.Add(point.EndTime);
-                values.Add((double) point.Value);
-            }
-            pyDict.SetItem(key.ToLowerInvariant(), _pandas.Series(values, index));
-        }
-
-        /// <summary>
-        /// Converts a <see cref="PyDict"/> of string to pandas.Series in a pandas.DataFrame
-        /// </summary>
-        /// <param name="pyDict"><see cref="PyDict"/> of string to pandas.Series</param>
-        /// <returns><see cref="PyObject"/> containing a pandas.DataFrame</returns>
-        private PyObject MakeIndicatorDataFrame(PyDict pyDict)
-        {
-            return _pandas.DataFrame(pyDict, columns: pyDict.Keys().Select(x => x.As<string>().ToLowerInvariant()).OrderBy(x => x));
-        }
-
-        /// <summary>
         /// Converts a dictionary with a list of <see cref="IndicatorDataPoint"/> in a pandas.DataFrame
         /// </summary>
         /// <param name="data">Dictionary with a list of <see cref="IndicatorDataPoint"/></param>
@@ -225,6 +195,36 @@ namespace QuantConnect.Python
             return _pandas == null
                 ? "pandas module was not imported."
                 : _pandas.Repr();
+        }
+
+        /// <summary>
+        /// Creates a series from a list of <see cref="IndicatorDataPoint"/> and adds it to the
+        /// <see cref="PyDict"/> as the value of the given <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">Key to insert in the <see cref="PyDict"/></param>
+        /// <param name="points">List of <see cref="IndicatorDataPoint"/> that will make up the resulting series</param>
+        /// <param name="pyDict"><see cref="PyDict"/> where the resulting key-value pair will be inserted into</param>
+        private void AddSeriesToPyDict(string key, List<IndicatorDataPoint> points, PyDict pyDict)
+        {
+            var index = new List<DateTime>();
+            var values = new List<double>();
+
+            foreach (var point in points)
+            {
+                index.Add(point.EndTime);
+                values.Add((double) point.Value);
+            }
+            pyDict.SetItem(key.ToLowerInvariant(), _pandas.Series(values, index));
+        }
+
+        /// <summary>
+        /// Converts a <see cref="PyDict"/> of string to pandas.Series in a pandas.DataFrame
+        /// </summary>
+        /// <param name="pyDict"><see cref="PyDict"/> of string to pandas.Series</param>
+        /// <returns><see cref="PyObject"/> containing a pandas.DataFrame</returns>
+        private PyObject MakeIndicatorDataFrame(PyDict pyDict)
+        {
+            return _pandas.DataFrame(pyDict, columns: pyDict.Keys().Select(x => x.As<string>().ToLowerInvariant()).OrderBy(x => x));
         }
     }
 }

--- a/Common/Python/PandasConverter.cs
+++ b/Common/Python/PandasConverter.cs
@@ -123,10 +123,12 @@ namespace QuantConnect.Python
         }
 
         /// <summary>
-        /// Converts a dictionary with a list of <see cref="IndicatorDataPoint"/> in a pandas.DataFrame
+        /// Creates a series from a list of <see cref="IndicatorDataPoint"/> and adds it to the
+        /// <see cref="PyDict"/> as the value of the given <paramref name="key"/>
         /// </summary>
-        /// <param name="data">Dictionary with a list of <see cref="IndicatorDataPoint"/></param>
-        /// <returns><see cref="PyObject"/> containing a pandas.DataFrame</returns>
+        /// <param name="key">Key to insert in the <see cref="PyDict"/></param>
+        /// <param name="points">List of <see cref="IndicatorDataPoint"/> that will make up the resulting series</param>
+        /// <param name="pyDict"><see cref="PyDict"/> where the resulting key-value pair will be inserted into</param>
         private void AddSeriesToPyDict(string key, List<IndicatorDataPoint> points, PyDict pyDict)
         {
             var index = new List<DateTime>();
@@ -141,9 +143,9 @@ namespace QuantConnect.Python
         }
 
         /// <summary>
-        /// Converts a dictionary with a list of <see cref="IndicatorDataPoint"/> in a pandas.DataFrame
+        /// Converts a <see cref="PyDict"/> of string to pandas.Series in a pandas.DataFrame
         /// </summary>
-        /// <param name="data">Dictionary with a list of <see cref="IndicatorDataPoint"/></param>
+        /// <param name="pyDict"><see cref="PyDict"/> of string to pandas.Series</param>
         /// <returns><see cref="PyObject"/> containing a pandas.DataFrame</returns>
         private PyObject MakeIndicatorDataFrame(PyDict pyDict)
         {
@@ -173,7 +175,7 @@ namespace QuantConnect.Python
         /// <summary>
         /// Converts a dictionary with a list of <see cref="IndicatorDataPoint"/> in a pandas.DataFrame
         /// </summary>
-        /// <param name="data"><see cref="PyObject"/> that should be a dictionary of string to list of <see cref="IndicatorDataPoint"/></param>
+        /// <param name="data"><see cref="PyObject"/> that should be a dictionary (convertible to PyDict) of string to list of <see cref="IndicatorDataPoint"/></param>
         /// <returns><see cref="PyObject"/> containing a pandas.DataFrame</returns>
         public PyObject GetIndicatorDataFrame(PyObject data)
         {

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -3566,8 +3566,8 @@ from QuantConnect.Python import PandasConverter
 from QuantConnect.Indicators import IndicatorDataPoint;
 
 def DataFrameContainsCorrectData():
-    now = datetime(2018, 1, 1)
-    makePoint = lambda i: IndicatorDataPoint(now + timedelta(minutes=i), i)
+    dateTime = datetime(2018, 1, 1)
+    makePoint = lambda i: IndicatorDataPoint(dateTime + timedelta(minutes=i), i)
     indicator1DataPoints = [makePoint(i) for i in range(10)]
     indicator2DataPoints = [makePoint(i) for i in range(5)]
     indicator3DataPoints = []
@@ -3586,7 +3586,7 @@ def DataFrameContainsCorrectData():
         dataFrame.index.tolist() == [point.EndTime for point in indicator1DataPoints] and
         hasData('ind1', indicator1DataPoints) and
         hasData('ind2', indicator2DataPoints) and
-        hasData('ind3', indicator3DataPoints) and
+        hasData('ind3', indicator3DataPoints)
     )
 
 def DataFrameIsEmpty():
@@ -3609,8 +3609,8 @@ def DataFrameIsEmpty():
         {
             using (Py.GIL())
             {
-                var now = new DateTime(2018, 1, 1);
-                Func<int, IndicatorDataPoint> makePoint = i => new IndicatorDataPoint(now.AddMinutes(i), i);
+                var dateTime = new DateTime(2018, 1, 1);
+                Func<int, IndicatorDataPoint> makePoint = i => new IndicatorDataPoint(dateTime.AddMinutes(i), i);
                 var indicator1DataPoints = Enumerable.Range(0, 10).Select(i => makePoint(i)).ToList();
                 var indicator2DataPoints = Enumerable.Range(0, 5).Select(i => makePoint(i)).ToList();
                 var indicator3DataPoints = new List<IndicatorDataPoint>();

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -3566,7 +3566,7 @@ from QuantConnect.Python import PandasConverter
 from QuantConnect.Indicators import IndicatorDataPoint;
 
 def DataFrameContainsCorrectData():
-    now = datetime.now()
+    now = datetime(2018, 1, 1)
     makePoint = lambda i: IndicatorDataPoint(now + timedelta(minutes=i), i)
     indicator1DataPoints = [makePoint(i) for i in range(10)]
     indicator2DataPoints = [makePoint(i) for i in range(5)]
@@ -3579,7 +3579,6 @@ def DataFrameContainsCorrectData():
     }})
 
     hasData = lambda key, data: dataFrame[key].tolist()[:len(data)] == [point.Value for point in data]
-    hasRightIndex = lambda key, data: dataFrame[key].index.tolist()[:len(data)] == [point.EndTime for point in data]
 
     return (
         dataFrame.shape == (10, 3) and
@@ -3588,9 +3587,6 @@ def DataFrameContainsCorrectData():
         hasData('ind1', indicator1DataPoints) and
         hasData('ind2', indicator2DataPoints) and
         hasData('ind3', indicator3DataPoints) and
-        hasRightIndex('ind1', indicator1DataPoints) and
-        hasRightIndex('ind2', indicator2DataPoints) and
-        hasRightIndex('ind3', indicator3DataPoints)
     )
 
 def DataFrameIsEmpty():
@@ -3613,7 +3609,7 @@ def DataFrameIsEmpty():
         {
             using (Py.GIL())
             {
-                var now = DateTime.Now.RoundUp(TimeSpan.FromMinutes(1));
+                var now = new DateTime(2018, 1, 1);
                 Func<int, IndicatorDataPoint> makePoint = i => new IndicatorDataPoint(now.AddMinutes(i), i);
                 var indicator1DataPoints = Enumerable.Range(0, 10).Select(i => makePoint(i)).ToList();
                 var indicator2DataPoints = Enumerable.Range(0, 5).Select(i => makePoint(i)).ToList();

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -3516,7 +3516,6 @@ def Test(dataFrame, symbol):
             {
                 dynamic test = PyModule.FromString("testModule",
                     $@"
-from AlgorithmImports import *
 from QuantConnect.Python import PandasConverter
 from QuantConnect.Indicators import IndicatorDataPoint;
 def Test():
@@ -3534,7 +3533,6 @@ def Test():
             {
                 dynamic tests = PyModule.FromString("testModule",
                     $@"
-from AlgorithmImports import *
 from QuantConnect.Python import PandasConverter
 from QuantConnect.Indicators import IndicatorDataPoint;
 pdConverter = PandasConverter()


### PR DESCRIPTION
#### Description

- `PandasConverter.GetIndicatorDataFrame` now has an overload to accept a Python dictionary.
- Common logic for both overloads was abstracted in private methods.
- Tests were added to assert that the resulting data frames contain the expected data.

#### Related Issue

Closes #6320 

#### Motivation and Context

The original overload accepts a C# `Dictionary`, so in order to use this method in Python one would have to import C#'s `Dictionary`, `List`, `String`, etc. and then create a `Dictionary[String, List[IndicatorDataPoint]]` to pass it to `PandasConverter.GetIndicatorDataFrame`. The new overload allows to pass a Python dictionary (`dict`).

#### Requires Documentation Change

This change does not require updates to documentation

#### How Has This Been Tested?

- Embedded Python modules were used to assert that `PandasConverter.GetIndicatorDataFrame` accepts Python `dict`.
- Embedded Python modules were used to convert a `dict` to `Pandas.DataFrame` and then assert that it contains the correct data (column and row labels, shape, actual data)
- The same as the previous point was done for the original overload to assert that it properly converts a `Dictionary<string, List<IndicatorDataPoint>>` to a `Pandas.DataFrame`.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

