### PR TITLE
Avoid sending expired symbols to IDQH

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -192,9 +192,15 @@ namespace QuantConnect.Algorithm
                     }
                 }
 
+                var defaultResolutionToUse = UniverseSettings.Resolution;
+                if (_warmupResolution.HasValue)
+                {
+                    defaultResolutionToUse = _warmupResolution.Value;
+                }
+
                 // if the algorithm has no added security, let's take a look at the universes to determine
                 // what the start date should be used. Defaulting to always open
-                result = Time - _warmupBarCount.Value * UniverseSettings.Resolution.ToTimeSpan();
+                result = Time - _warmupBarCount.Value * defaultResolutionToUse.ToTimeSpan();
 
                 foreach (var universe in _pendingUniverseAdditions.Concat(UniverseManager.Values))
                 {

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -3019,18 +3019,21 @@ namespace QuantConnect
         /// <returns></returns>
         public static DateTime GetDelistingDate(this Symbol symbol, MapFile mapFile = null)
         {
+            if (symbol.IsCanonical())
+            {
+                return Time.EndOfTime;
+            }
             switch (symbol.ID.SecurityType)
             {
-                case SecurityType.Future:
-                    return symbol.ID.Date == SecurityIdentifier.DefaultDate ? Time.EndOfTime : symbol.ID.Date;
                 case SecurityType.Option:
                     return OptionSymbol.GetLastDayOfTrading(symbol);
                 case SecurityType.FutureOption:
                     return FutureOptionSymbol.GetLastDayOfTrading(symbol);
+                case SecurityType.Future:
                 case SecurityType.IndexOption:
                     return symbol.ID.Date;
                 default:
-                    return mapFile?.DelistingDate ?? SecurityIdentifier.DefaultDate;
+                    return mapFile?.DelistingDate ?? Time.EndOfTime;
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Avoid sending expired symbols to the IDQH. This can happen during
  warmup period. Adding unit tests
- Fix for warmup start time, will use resolution if given instead of UniverseSettings.Resolution. Adding unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See https://github.com/QuantConnect/Lean/pull/6293
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adding expired symbols to the live IDQH can cause explosions
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests & live deployments
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
