### PR TITLE
Fix backtest aborting when calling `self.Error()` in `Initialize()`

### DIFF
--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -231,7 +231,7 @@ namespace QuantConnect.Lean.Engine
                     AlgorithmHandlers.Alphas.OnAfterAlgorithmInitialized(algorithm);
 
                     //If there are any reasons it failed, pass these back to the IDE.
-                    if (!initializeComplete || algorithm.ErrorMessages.Count > 0 || AlgorithmHandlers.Setup.Errors.Count > 0)
+                    if (!initializeComplete || AlgorithmHandlers.Setup.Errors.Count > 0)
                     {
                         initializeComplete = false;
                         //Get all the error messages: internal in algorithm and external in setup handler.

--- a/Tests/Engine/AlgorithmLogTests.cs
+++ b/Tests/Engine/AlgorithmLogTests.cs
@@ -1,0 +1,71 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Algorithm.CSharp;
+
+namespace QuantConnect.Tests.Engine
+{
+    [TestFixture]
+    public class AlgorithmLogTests
+    {
+        [TestCase(typeof(TestAlgorithmWithErrorLogOnInit))]
+        [TestCase(typeof(TestAlgorithmWithDebugLogOnInit))]
+        [TestCase(typeof(TestAlgorithmWithLogOnInit))]
+        public void AlgorithmCompletesWhenCallingErroLogOnInit(Type algorithmType)
+        {
+            var parameters = new RegressionTests.AlgorithmStatisticsTestParameters("QuantConnect.Tests.Engine.AlgorithmLogTests+" + algorithmType.Name,
+                Activator.CreateInstance<BasicTemplateDailyAlgorithm>().ExpectedStatistics,
+                Language.CSharp,
+                AlgorithmStatus.Completed);
+
+            AlgorithmRunner.RunLocalBacktest(parameters.Algorithm,
+                parameters.Statistics,
+                parameters.AlphaStatistics,
+                parameters.Language,
+                parameters.ExpectedFinalStatus,
+                algorithmLocation: "QuantConnect.Tests.dll");
+        }
+
+        public class TestAlgorithmWithErrorLogOnInit : BasicTemplateDailyAlgorithm
+        {
+            public override void Initialize()
+            {
+                base.Initialize();
+                Error("Error in Initialize");
+            }
+        }
+
+        public class TestAlgorithmWithDebugLogOnInit : BasicTemplateDailyAlgorithm
+        {
+            public override void Initialize()
+            {
+                base.Initialize();
+                Debug("Error in Initialize");
+            }
+        }
+
+        public class TestAlgorithmWithLogOnInit : BasicTemplateDailyAlgorithm
+        {
+            public override void Initialize()
+            {
+                base.Initialize();
+                Log("Error in Initialize");
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Description

Calling `self.Error("<msg>")`  in `Initialize()` was causing backtest to abort. Now it continues the algorithm backtest.

#### Related Issue

Closes #6371 

#### Motivation and Context

Calling `self.Error("<msg>")`  in `Initialize()` was causing backtest to abort, but doing so outside (for instance, in `onData()`) works fine . Now it continues the algorithm backtest after `Log()`, `Error()` or `Debug()` are called inside `Initialize()`

#### Requires Documentation Change

This change does not require documentation change

#### How Has This Been Tested?

Backtests are being run for algorithms that call `Log()`, `Error()` and `Debug()` in `Initialize()` and it is being asserted that the final state of the algorithm is `Completed`.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
