### PR TITLE
Adds Missing UpdateTriggerPrice Method

### DIFF
--- a/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
@@ -35,9 +35,9 @@ namespace QuantConnect.Algorithm.CSharp
         // We assert the following occur in FIFO order in OnOrderEvent
         private readonly Queue<string> _expectedEvents = new Queue<string>(new[]
         {
-            "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 144.6434 USD LimitPrice: 144.3551 TriggerPrice: 143.6051 OrderFee: 1 USD",
-            "Time: 10/10/2013 15:57:00 OrderID: 73 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 145.6636 USD LimitPrice: 145.6434 TriggerPrice: 144.8934 OrderFee: 1 USD",
-            "Time: 10/11/2013 15:37:00 OrderID: 74 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 146.7185 USD LimitPrice: 146.6723 TriggerPrice: 145.9223 OrderFee: 1 USD"        });
+            "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 399 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 144.6434 USD LimitPrice: 144.3551 TriggerPrice: 143.61 OrderFee: 1 USD",
+            "Time: 10/10/2013 15:57:00 OrderID: 73 EventID: 156 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 145.6636 USD LimitPrice: 145.6434 TriggerPrice: 144.89 OrderFee: 1 USD",
+            "Time: 10/11/2013 15:37:00 OrderID: 74 EventID: 380 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 146.7185 USD LimitPrice: 146.6723 TriggerPrice: 145.92 OrderFee: 1 USD"        });
 
         /// <summary>
         /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
@@ -89,6 +89,7 @@ namespace QuantConnect.Algorithm.CSharp
 
                 var newQuantity = _request.Quantity - _negative;
                 _request.UpdateQuantity(newQuantity, $"LIT - Quantity: {newQuantity}");
+                _request.UpdateTriggerPrice(_request.Get(OrderField.TriggerPrice).RoundToSignificantDigits(5));
             }
         }
 
@@ -175,7 +176,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "359ac5b8cd73a8e42b7897a883f5f73d"}
+            {"OrderListHash", "5aebd643ee5365f55f10038150b47203"}
         };
     }
 }

--- a/Algorithm.Python/LimitIfTouchedRegressionAlgorithm.py
+++ b/Algorithm.Python/LimitIfTouchedRegressionAlgorithm.py
@@ -22,9 +22,9 @@ from collections import deque
 ### <meta name="tag" content="limit if touched order"/>
 class LimitIfTouchedRegressionAlgorithm(QCAlgorithm):
     _expectedEvents = deque([
-        "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 144.6434 USD LimitPrice: 144.3551 TriggerPrice: 143.6051 OrderFee: 1 USD",
-        "Time: 10/10/2013 15:57:00 OrderID: 73 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 145.6636 USD LimitPrice: 145.6434 TriggerPrice: 144.8934 OrderFee: 1 USD",
-        "Time: 10/11/2013 15:37:00 OrderID: 74 EventID: 11 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 146.7185 USD LimitPrice: 146.6723 TriggerPrice: 145.9223 OrderFee: 1 USD"    ])
+        "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 399 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 144.6434 USD LimitPrice: 144.3551 TriggerPrice: 143.61 OrderFee: 1 USD",
+        "Time: 10/10/2013 15:57:00 OrderID: 73 EventID: 156 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 145.6636 USD LimitPrice: 145.6434 TriggerPrice: 144.89 OrderFee: 1 USD",
+        "Time: 10/11/2013 15:37:00 OrderID: 74 EventID: 380 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 146.7185 USD LimitPrice: 146.6723 TriggerPrice: 145.92 OrderFee: 1 USD"    ])
 
     def Initialize(self):
         self.SetStartDate(2013, 10, 7)
@@ -51,7 +51,8 @@ class LimitIfTouchedRegressionAlgorithm(QCAlgorithm):
                     return
 
                 new_quantity = int(self._request.Quantity - self._negative)
-                self._request.UpdateQuantity(new_quantity, f"LIT - Quantity: {new_quantity}")
+                self._request.UpdateQuantity(new_quantity, f"LIT - Quantity: {new_quantity}")     
+                self._request.UpdateTriggerPrice(Extensions.RoundToSignificantDigits(self._request.Get(OrderField.TriggerPrice), 5));
 
     def OnOrderEvent(self, orderEvent):
         if orderEvent.Status == OrderStatus.Filled:

--- a/Common/Orders/OrderTicket.cs
+++ b/Common/Orders/OrderTicket.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -284,7 +284,7 @@ namespace QuantConnect.Orders
         /// Submits an <see cref="UpdateOrderRequest"/> with the <see cref="SecurityTransactionManager"/> to update
         /// the ticket with tag specified in <paramref name="tag"/>
         /// </summary>
-        /// <param name="tag"></param>
+        /// <param name="tag">The new tag for this order ticket</param>
         /// <returns><see cref="OrderResponse"/> from updating the order</returns>
         public OrderResponse UpdateTag(string tag)
         {
@@ -299,8 +299,8 @@ namespace QuantConnect.Orders
         /// Submits an <see cref="UpdateOrderRequest"/> with the <see cref="SecurityTransactionManager"/> to update
         /// the ticket with quantity specified in <paramref name="quantity"/> and with tag specified in <paramref name="quantity"/>
         /// </summary>
-        /// <param name="quantity"></param>
-        /// <param name="tag"></param>
+        /// <param name="quantity">The new quantity for this order ticket</param>
+        /// <param name="tag">The new tag for this order ticket</param>
         /// <returns><see cref="OrderResponse"/> from updating the order</returns>
         public OrderResponse UpdateQuantity(decimal quantity, string tag = null)
         {
@@ -316,8 +316,8 @@ namespace QuantConnect.Orders
         /// Submits an <see cref="UpdateOrderRequest"/> with the <see cref="SecurityTransactionManager"/> to update
         /// the ticker with limit price specified in <paramref name="limitPrice"/> and with tag specified in <paramref name="tag"/>
         /// </summary>
-        /// <param name="limitPrice"></param>
-        /// <param name="tag"></param>
+        /// <param name="limitPrice">The new limit price for this order ticket</param>
+        /// <param name="tag">The new tag for this order ticket</param>
         /// <returns><see cref="OrderResponse"/> from updating the order</returns>
         public OrderResponse UpdateLimitPrice(decimal limitPrice, string tag = null)
         {
@@ -333,14 +333,31 @@ namespace QuantConnect.Orders
         /// Submits an <see cref="UpdateOrderRequest"/> with the <see cref="SecurityTransactionManager"/> to update
         /// the ticker with stop price specified in <paramref name="stopPrice"/> and with tag specified in <paramref name="tag"/>
         /// </summary>
-        /// <param name="stopPrice"></param>
-        /// <param name="tag"></param>
+        /// <param name="stopPrice">The new stop price  for this order ticket</param>
+        /// <param name="tag">The new tag for this order ticket</param>
         /// <returns><see cref="OrderResponse"/> from updating the order</returns>
         public OrderResponse UpdateStopPrice(decimal stopPrice, string tag = null)
         {
             var fields = new UpdateOrderFields()
             {
                 StopPrice = stopPrice,
+                Tag = tag
+            };
+            return Update(fields);
+        }
+
+        /// <summary>
+        /// Submits an <see cref="UpdateOrderRequest"/> with the <see cref="SecurityTransactionManager"/> to update
+        /// the ticker with trigger price specified in <paramref name="triggerPrice"/> and with tag specified in <paramref name="tag"/>
+        /// </summary>
+        /// <param name="triggerPrice">The new price which, when touched, will trigger the setting of a limit order.</param>
+        /// <param name="tag">The new tag for this order ticket</param>
+        /// <returns><see cref="OrderResponse"/> from updating the order</returns>
+        public OrderResponse UpdateTriggerPrice(decimal triggerPrice, string tag = null)
+        {
+            var fields = new UpdateOrderFields()
+            {
+                TriggerPrice = triggerPrice,
                 Tag = tag
             };
             return Update(fields);


### PR DESCRIPTION
#### Description
Since there is `UpdateStopPrice`, `UpdateLimitPrice`, `UpdateQuantity` and `UpdateTag` method to make it easier to update the `OrderTicket`, we include `UpdateTriggerPrice` to cover the `LimitIfTouched` case.
Also, updated the docs or the arguments for these methods.

Closes https://github.com/QuantConnect/Lean/issues/6295

#### Motivation and Context
Standardization and documentation.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`