### PR TITLE
Detect unsupported option style in option price model

### DIFF
--- a/Algorithm.CSharp/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.cs
@@ -108,12 +108,19 @@ namespace QuantConnect.Algorithm.CSharp
                 }
 
                 // Greeks shpould be valid if they were successfuly accessed for supported option style
-                if (_optionStyleIsSupported
-                    && ((contract.Right == OptionRight.Call && (greeks.Delta < 0m || greeks.Delta > 1m || greeks.Rho <= 0m))
-                        || (contract.Right == OptionRight.Put && (greeks.Delta < -1m || greeks.Delta > 0m || greeks.Rho >= 0m))
-                        || greeks.Theta == 0m || greeks.Vega <= 0m || greeks.Gamma <= 0m))
+                if (_optionStyleIsSupported)
                 {
-                    throw new Exception($"Expected greeks to have valid values. Greeks were: Delta: {greeks.Delta}, Rho: {greeks.Rho}, Theta: {greeks.Theta}, Vega: {greeks.Vega}, Gamma: {greeks.Gamma}");
+                    if (greeks.Delta == 0m && greeks.Gamma == 0m && greeks.Theta == 0m && greeks.Vega == 0m && greeks.Rho == 0m)
+                    {
+                        throw new Exception($"Expected greeks to not be zero simultaneously for {contract.Symbol.Value}, an {_option.Style} style option, using {_option?.PriceModel.GetType().Name}, but they were");
+                    }
+
+                    if (((contract.Right == OptionRight.Call && (greeks.Delta < 0m || greeks.Delta > 1m || greeks.Rho < 0m))
+                        || (contract.Right == OptionRight.Put && (greeks.Delta < -1m || greeks.Delta > 0m || greeks.Rho > 0m))
+                        || greeks.Vega < 0m || greeks.Gamma < 0m))
+                    {
+                        throw new Exception($"Expected greeks to have valid values. Greeks were: Delta: {greeks.Delta}, Rho: {greeks.Rho}, Theta: {greeks.Theta}, Vega: {greeks.Vega}, Gamma: {greeks.Gamma}");
+                    }
                 }
             }
         }

--- a/Algorithm.CSharp/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.cs
@@ -29,11 +29,11 @@ namespace QuantConnect.Algorithm.CSharp
     /// </summary>
     public abstract class OptionPriceModelForOptionStylesBaseRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
-        protected OptionStyle _optionStyle = OptionStyle.European;
-        protected bool _optionStyleIsSupported;
-        protected bool _triedGreeksCalculation;
-        protected Option _option;
-        protected IEnumerable<OptionContract> _contracts;
+        private bool _optionStyleIsSupported;
+        private Option _option;
+        private bool _triedGreeksCalculation;
+
+        private IEnumerable<OptionContract> _contracts;
 
         public override void OnData(Slice slice)
         {
@@ -70,6 +70,14 @@ namespace QuantConnect.Algorithm.CSharp
             }
         }
 
+        protected void Init(Option option, bool optionStyleIsSupported)
+        {
+            _option = option;
+            _optionStyleIsSupported = optionStyleIsSupported;
+            _triedGreeksCalculation = false;
+        }
+
+
         public void CheckGreeks()
         {
             if (_contracts == null || !_contracts.Any())
@@ -89,7 +97,7 @@ namespace QuantConnect.Algorithm.CSharp
                     // Greeks should have not been successfully accessed if the option style is not supported
                     if (!_optionStyleIsSupported)
                     {
-                        throw new Exception($"Expected greeks not to be calculated for {contract.Symbol.Value}, an {_optionStyle} style option, using {_option?.PriceModel.GetType().Name}, which does not support them, but they were");
+                        throw new Exception($"Expected greeks not to be calculated for {contract.Symbol.Value}, an {_option.Style} style option, using {_option?.PriceModel.GetType().Name}, which does not support them, but they were");
 
                     }
                 }
@@ -98,7 +106,7 @@ namespace QuantConnect.Algorithm.CSharp
                     // ArgumentException is only expected if the option style is not supported
                     if (_optionStyleIsSupported)
                     {
-                        throw new Exception($"Expected greeks to be calculated for {contract.Symbol.Value}, an {_optionStyle} style option, using {_option?.PriceModel.GetType().Name}, which supports them, but they were not");
+                        throw new Exception($"Expected greeks to be calculated for {contract.Symbol.Value}, an {_option.Style} style option, using {_option?.PriceModel.GetType().Name}, which supports them, but they were not");
                     }
                 }
 

--- a/Algorithm.CSharp/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.cs
@@ -33,7 +33,7 @@ namespace QuantConnect.Algorithm.CSharp
         private Option _option;
         private bool _triedGreeksCalculation;
 
-        private IEnumerable<OptionContract> _contracts;
+        private OptionChain _contracts;
 
         public override void OnData(Slice slice)
         {
@@ -49,8 +49,7 @@ namespace QuantConnect.Algorithm.CSharp
                     continue;
                 }
 
-                var chain = kvp.Value;
-                _contracts = chain.Where(x => x.Right == OptionRight.Call);
+                _contracts = kvp.Value;
             }
         }
 
@@ -111,7 +110,10 @@ namespace QuantConnect.Algorithm.CSharp
                 }
 
                 // Greeks shpould be valid if they were successfuly accessed for supported option style
-                if (_optionStyleIsSupported && (greeks.Delta < 0m || greeks.Delta > 1m || greeks.Theta >= 0m || greeks.Rho <= 0m || greeks.Vega <= 0m))
+                if (_optionStyleIsSupported
+                    && ((contract.Right == OptionRight.Call && (greeks.Delta < 0m || greeks.Delta > 1m || greeks.Rho <= 0m))
+                        || (contract.Right == OptionRight.Put && (greeks.Delta < -1m || greeks.Delta > 0m || greeks.Rho >= 0m))
+                        || greeks.Theta >= 0m || greeks.Vega <= 0m))
                 {
                     throw new Exception($"Expected greeks to have valid values. Greeks were: Gamma: {greeks.Gamma}, Rho: {greeks.Rho}, Delta: {greeks.Delta}, Vega: {greeks.Vega}");
                 }

--- a/Algorithm.CSharp/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using QuantConnect.Interfaces;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities.Option;
@@ -26,7 +27,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// Base regression algorithm excersizing for exercising different style options with option price models that migth
     /// or might not support them. Also, if the option style is supported, greeks are asserted to be accesible and have valid values.
     /// </summary>
-    public abstract class OptionPriceModelForOptionStylesBaseRegressionAlgorithm : QCAlgorithm
+    public abstract class OptionPriceModelForOptionStylesBaseRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         protected OptionStyle _optionStyle = OptionStyle.European;
         protected bool _optionStyleIsSupported;
@@ -108,5 +109,30 @@ namespace QuantConnect.Algorithm.CSharp
                 }
             }
         }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        abstract public long DataPoints { get; }
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        abstract public int AlgorithmHistoryDataPoints { get; }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        abstract public Dictionary<string, string> ExpectedStatistics { get; }
     }
 }

--- a/Algorithm.CSharp/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.cs
@@ -113,9 +113,9 @@ namespace QuantConnect.Algorithm.CSharp
                 if (_optionStyleIsSupported
                     && ((contract.Right == OptionRight.Call && (greeks.Delta < 0m || greeks.Delta > 1m || greeks.Rho <= 0m))
                         || (contract.Right == OptionRight.Put && (greeks.Delta < -1m || greeks.Delta > 0m || greeks.Rho >= 0m))
-                        || greeks.Theta >= 0m || greeks.Vega <= 0m))
+                        || greeks.Theta == 0m || greeks.Vega <= 0m || greeks.Gamma <= 0m))
                 {
-                    throw new Exception($"Expected greeks to have valid values. Greeks were: Gamma: {greeks.Gamma}, Rho: {greeks.Rho}, Delta: {greeks.Delta}, Vega: {greeks.Vega}");
+                    throw new Exception($"Expected greeks to have valid values. Greeks were: Delta: {greeks.Delta}, Rho: {greeks.Rho}, Theta: {greeks.Theta}, Vega: {greeks.Vega}, Gamma: {greeks.Gamma}");
                 }
             }
         }

--- a/Algorithm.CSharp/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.cs
@@ -31,9 +31,8 @@ namespace QuantConnect.Algorithm.CSharp
     {
         private bool _optionStyleIsSupported;
         private Option _option;
+        private bool _checkGreeks;
         private bool _triedGreeksCalculation;
-
-        private OptionChain _contracts;
 
         public override void OnData(Slice slice)
         {
@@ -49,16 +48,13 @@ namespace QuantConnect.Algorithm.CSharp
                     continue;
                 }
 
-                _contracts = kvp.Value;
+                CheckGreeks(kvp.Value);
             }
         }
 
         public override void OnEndOfDay(Symbol symbol)
         {
-            if (!IsWarmingUp)
-            {
-                CheckGreeks();
-            }
+            _checkGreeks = true;
         }
 
         public override void OnEndOfAlgorithm()
@@ -73,20 +69,22 @@ namespace QuantConnect.Algorithm.CSharp
         {
             _option = option;
             _optionStyleIsSupported = optionStyleIsSupported;
+            _checkGreeks = true;
             _triedGreeksCalculation = false;
         }
 
 
-        public void CheckGreeks()
+        public void CheckGreeks(OptionChain contracts)
         {
-            if (_contracts == null || !_contracts.Any())
+            if (!_checkGreeks || !contracts.Any())
             {
                 return;
             }
 
+            _checkGreeks = false;
             _triedGreeksCalculation = true;
 
-            foreach (var contract in _contracts)
+            foreach (var contract in contracts)
             {
                 Greeks greeks = new Greeks();
                 try

--- a/Algorithm.CSharp/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.cs
@@ -1,0 +1,112 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Securities.Option;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Base regression algorithm excersizing for exercising different style options with option price models that migth
+    /// or might not support them. Also, if the option style is supported, greeks are asserted to be accesible and have valid values.
+    /// </summary>
+    public abstract class OptionPriceModelForOptionStylesBaseRegressionAlgorithm : QCAlgorithm
+    {
+        protected OptionStyle _optionStyle = OptionStyle.European;
+        protected bool _optionStyleIsSupported;
+        protected bool _triedGreeksCalculation;
+        protected Option _option;
+        protected IEnumerable<OptionContract> _contracts;
+
+        public override void OnData(Slice slice)
+        {
+            if (IsWarmingUp)
+            {
+                return;
+            }
+
+            foreach (var kvp in slice.OptionChains)
+            {
+                if (kvp.Key != _option?.Symbol)
+                {
+                    continue;
+                }
+
+                var chain = kvp.Value;
+                _contracts = chain.Where(x => x.Right == OptionRight.Call);
+            }
+        }
+
+        public override void OnEndOfDay(Symbol symbol)
+        {
+            if (!IsWarmingUp)
+            {
+                CheckGreeks();
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_triedGreeksCalculation)
+            {
+                throw new Exception("Expected greeks to be accessed");
+            }
+        }
+
+        public void CheckGreeks()
+        {
+            if (_contracts == null || !_contracts.Any())
+            {
+                return;
+            }
+
+            _triedGreeksCalculation = true;
+
+            foreach (var contract in _contracts)
+            {
+                Greeks greeks = new Greeks();
+                try
+                {
+                    greeks = contract.Greeks;
+
+                    // Greeks should have not been successfully accessed if the option style is not supported
+                    if (!_optionStyleIsSupported)
+                    {
+                        throw new Exception($"Expected greeks not to be calculated for {contract.Symbol.Value}, an {_optionStyle} style option, using {_option?.PriceModel.GetType().Name}, which does not support them, but they were");
+
+                    }
+                }
+                catch (ArgumentException)
+                {
+                    // ArgumentException is only expected if the option style is not supported
+                    if (_optionStyleIsSupported)
+                    {
+                        throw new Exception($"Expected greeks to be calculated for {contract.Symbol.Value}, an {_optionStyle} style option, using {_option?.PriceModel.GetType().Name}, which supports them, but they were not");
+                    }
+                }
+
+                // Greeks shpould be valid if they were successfuly accessed for supported option style
+                if (_optionStyleIsSupported && (greeks.Delta < 0m || greeks.Delta > 1m || greeks.Theta >= 0m || greeks.Rho <= 0m || greeks.Vega <= 0m))
+                {
+                    throw new Exception($"Expected greeks to have valid values. Greeks were: Gamma: {greeks.Gamma}, Rho: {greeks.Rho}, Delta: {greeks.Delta}, Vega: {greeks.Vega}");
+                }
+            }
+        }
+    }
+}

--- a/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.cs
@@ -27,14 +27,14 @@ namespace QuantConnect.Algorithm.CSharp
     {
         public override void Initialize()
         {
-            SetStartDate(2015, 12, 24);
-            SetEndDate(2015, 12, 24);
+            SetStartDate(2014, 6, 9);
+            SetEndDate(2014, 6, 9);
 
-            var option = AddOption("GOOG", Resolution.Minute);
+            var option = AddOption("AAPL", Resolution.Minute);
             // BaroneAdesiWhaley model supports American style options
             option.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
 
-            SetWarmup(1, Resolution.Daily);
+            SetWarmup(2, Resolution.Daily);
 
             Init(option, optionStyleIsSupported: true);
         }
@@ -42,7 +42,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 911426;
+        public override long DataPoints => 1781481;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.cs
@@ -13,11 +13,7 @@
  * limitations under the License.
 */
 
-using System;
-using System.Linq;
 using System.Collections.Generic;
-using QuantConnect.Data;
-using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities.Option;
 
@@ -27,7 +23,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// Regression algorithm excersizing an equity covered American style option, using an option price model
     /// that supports American style options and asserting that the option price model is used.
     /// </summary>
-    public class OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm : OptionPriceModelForOptionStylesBaseRegressionAlgorithm, IRegressionAlgorithmDefinition
+    public class OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm : OptionPriceModelForOptionStylesBaseRegressionAlgorithm
     {
         public override void Initialize()
         {
@@ -46,29 +42,19 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
-        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
-        /// </summary>
-        public bool CanRunLocally { get; } = true;
-
-        /// <summary>
-        /// This is used by the regression test system to indicate which languages this algorithm is written in.
-        /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
-
-        /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 911426;
+        public override long DataPoints => 911426;
 
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 0;
+        public override int AlgorithmHistoryDataPoints => 0;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
-        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "0"},
             {"Average Win", "0%"},

--- a/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.cs
@@ -1,0 +1,187 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities.Option;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm excersizing an equity covered American style option, using an option price model that supports American style options and asserting that the option price model is used.
+    /// </summary>
+    public class OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private bool _showGreeks = false;
+        private bool _triedGreeksCalculation = false;
+        private Symbol _spyOptionSymbol;
+
+        public override void Initialize()
+        {
+            SetStartDate(2020, 1, 2);
+            SetEndDate(2020, 1, 14);
+            SetCash(100000);
+
+            var spyIndex = AddEquity("SPY", Resolution.Minute);
+            spyIndex.SetDataNormalizationMode(DataNormalizationMode.Raw);
+            var spyOption = AddOption("SPY", Resolution.Minute);
+            spyOption.SetFilter(-1, 1, TimeSpan.FromDays(45), TimeSpan.FromDays(55));
+            spyOption.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
+            _spyOptionSymbol = spyOption.Symbol;
+
+            SetWarmUp(TimeSpan.FromDays(155));
+
+            _showGreeks = true;
+            _triedGreeksCalculation = false;
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (IsWarmingUp)
+            {
+                return;
+            }
+
+            foreach (var kvp in slice.OptionChains)
+            {
+                if (kvp.Key != _spyOptionSymbol)
+                {
+                    continue;
+                }
+
+                var chain = kvp.Value;
+                var contracts = chain.Where(x => x.Right == OptionRight.Call);
+
+                if (!contracts.Any())
+                {
+                    return;
+                }
+
+                if (_showGreeks)
+                {
+                    _showGreeks = false;
+                    _triedGreeksCalculation = true;
+
+                    foreach (var contract in contracts)
+                    {
+                        Greeks greeks;
+                        try
+                        {
+                            greeks = contract.Greeks;
+                        }
+                        catch (ArgumentException)
+                        {
+                            throw new Exception($"Expected greeks to be calculated for {contract.Symbol.Value}, an American style option, but they were not");
+                        }
+
+                        Log($@"{contract.Symbol.Value},
+                            strike: {contract.Strike},
+                            Gamma: {greeks.Gamma},
+                            Rho: {greeks.Rho},
+                            Delta: {greeks.Delta},
+                            Vega: {greeks.Vega}");
+                    }
+                }
+            }
+        }
+
+        public override void OnEndOfDay(Symbol symbol)
+        {
+            _showGreeks = true;
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_triedGreeksCalculation)
+            {
+                throw new Exception("Expected greeks to be calculated");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        // public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 26311717;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-2.663"},
+            {"Tracking Error", "0.069"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.cs
@@ -30,15 +30,13 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2015, 12, 24);
             SetEndDate(2015, 12, 24);
 
-            _option = AddOption("GOOG", Resolution.Minute);
+            var option = AddOption("GOOG", Resolution.Minute);
             // BaroneAdesiWhaley model supports American style options
-            _option.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
+            option.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
 
             SetWarmup(1, Resolution.Daily);
 
-            _optionStyle = OptionStyle.American;
-            _optionStyleIsSupported = true;
-            _triedGreeksCalculation = false;
+            Init(option, optionStyleIsSupported: true);
         }
 
         /// <summary>

--- a/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.cs
@@ -14,7 +14,6 @@
 */
 
 using System.Collections.Generic;
-using QuantConnect.Interfaces;
 using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Algorithm.CSharp

--- a/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.cs
@@ -24,28 +24,27 @@ using QuantConnect.Securities.Option;
 namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
-    /// Regression algorithm excersizing an equity covered American style option, using an option price model that supports American style options and asserting that the option price model is used.
+    /// Regression algorithm excersizing an equity covered American style option, using an option price model
+    /// that supports American style options and asserting that the option price model is used.
     /// </summary>
     public class OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private bool _showGreeks = false;
         private bool _triedGreeksCalculation = false;
-        private Symbol _spyOptionSymbol;
+        private Symbol _optionSymbol;
 
         public override void Initialize()
         {
-            SetStartDate(2020, 1, 2);
-            SetEndDate(2020, 1, 14);
+            SetStartDate(2015, 12, 23);
+            SetEndDate(2015, 12, 24);
             SetCash(100000);
 
-            var spyIndex = AddEquity("SPY", Resolution.Minute);
-            spyIndex.SetDataNormalizationMode(DataNormalizationMode.Raw);
-            var spyOption = AddOption("SPY", Resolution.Minute);
-            spyOption.SetFilter(-1, 1, TimeSpan.FromDays(45), TimeSpan.FromDays(55));
-            spyOption.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
-            _spyOptionSymbol = spyOption.Symbol;
-
-            SetWarmUp(TimeSpan.FromDays(155));
+            var equity = AddEquity("GOOG", Resolution.Minute);
+            equity.SetDataNormalizationMode(DataNormalizationMode.Raw);
+            var option = AddOption("GOOG", Resolution.Minute);
+            // BaroneAdesiWhaley model supports American style options
+            option.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
+            _optionSymbol = option.Symbol;
 
             _showGreeks = true;
             _triedGreeksCalculation = false;
@@ -60,7 +59,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             foreach (var kvp in slice.OptionChains)
             {
-                if (kvp.Key != _spyOptionSymbol)
+                if (kvp.Key != _optionSymbol)
                 {
                     continue;
                 }
@@ -90,7 +89,7 @@ namespace QuantConnect.Algorithm.CSharp
                             throw new Exception($"Expected greeks to be calculated for {contract.Symbol.Value}, an American style option, but they were not");
                         }
 
-                        Log($@"{contract.Symbol.Value},
+                        Debug($@"{contract.Symbol.Value},
                             strike: {contract.Strike},
                             Gamma: {greeks.Gamma},
                             Rho: {greeks.Rho},
@@ -122,13 +121,12 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        // public Language[] Languages { get; } = { Language.CSharp, Language.Python };
-        public Language[] Languages { get; } = { Language.CSharp };
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 26311717;
+        public long DataPoints => 910617;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -156,8 +154,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "0"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-2.663"},
-            {"Tracking Error", "0.069"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},

--- a/Algorithm.CSharp/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.cs
@@ -24,7 +24,8 @@ using QuantConnect.Securities.Option;
 namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
-    /// Regression algorithm excersizing an equity covered European style option, using an option price model that supports European style options and asserting that the option price model is used.
+    /// Regression algorithm excersizing an index covered European style option, using an option price model
+    /// that supports European style options and asserting that the option price model is used.
     /// </summary>
     public class OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
@@ -35,16 +36,15 @@ namespace QuantConnect.Algorithm.CSharp
         public override void Initialize()
         {
             SetStartDate(2021, 1, 4);
-            SetEndDate(2021, 1, 10);
+            SetEndDate(2021, 1, 4);
             SetCash(100000);
 
             var spxIndex = AddIndex("SPX", Resolution.Minute);
             spxIndex.SetDataNormalizationMode(DataNormalizationMode.Raw);
             var spxOption = AddIndexOption("SPX", Resolution.Minute);
+            // BlackScholes model supports European style options
             spxOption.PriceModel = OptionPriceModels.BlackScholes();
             _spxOptionSymbol = spxOption.Symbol;
-
-            SetWarmUp(10, Resolution.Daily);
 
             _showGreeks = true;
             _triedGreeksCalculation = false;
@@ -89,7 +89,7 @@ namespace QuantConnect.Algorithm.CSharp
                             throw new Exception($"Expected greeks to be calculated for {contract.Symbol.Value}, an European style option, but they were not");
                         }
 
-                        Log($@"{contract.Symbol.Value},
+                        Debug($@"{contract.Symbol.Value},
                             strike: {contract.Strike},
                             Gamma: {greeks.Gamma},
                             Rho: {greeks.Rho},
@@ -121,13 +121,12 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        // public Language[] Languages { get; } = { Language.CSharp, Language.Python };
-        public Language[] Languages { get; } = { Language.CSharp };
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 38359;
+        public long DataPoints => 7118;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -155,8 +154,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "0"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-103.054"},
-            {"Tracking Error", "0.069"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},
@@ -164,8 +163,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "79228162514264337593543950335"},
-            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Sortino Ratio", "0"},
+            {"Return Over Maximum Drawdown", "0"},
             {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},

--- a/Algorithm.CSharp/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.cs
@@ -34,15 +34,13 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2021, 1, 14);
             SetEndDate(2021, 1, 14);
 
-            _option = AddIndexOption("SPX", Resolution.Hour);
+            var option = AddIndexOption("SPX", Resolution.Hour);
             // BlackScholes model supports European style options
-            _option.PriceModel = OptionPriceModels.BlackScholes();
+            option.PriceModel = OptionPriceModels.BlackScholes();
 
             SetWarmup(7, Resolution.Daily);
 
-            _optionStyle = OptionStyle.European;
-            _optionStyleIsSupported = true;
-            _triedGreeksCalculation = false;
+            Init(option, optionStyleIsSupported: true);
         }
 
         /// <summary>

--- a/Algorithm.CSharp/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Algorithm.CSharp
     {
         private bool _showGreeks = false;
         private bool _triedGreeksCalculation = false;
-        private Symbol _spxOptionSymbol;
+        private Symbol _optionSymbol;
 
         public override void Initialize()
         {
@@ -39,12 +39,12 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2021, 1, 4);
             SetCash(100000);
 
-            var spxIndex = AddIndex("SPX", Resolution.Minute);
-            spxIndex.SetDataNormalizationMode(DataNormalizationMode.Raw);
-            var spxOption = AddIndexOption("SPX", Resolution.Minute);
+            var index = AddIndex("SPX", Resolution.Minute);
+            index.SetDataNormalizationMode(DataNormalizationMode.Raw);
+            var indexOption = AddIndexOption("SPX", Resolution.Minute);
             // BlackScholes model supports European style options
-            spxOption.PriceModel = OptionPriceModels.BlackScholes();
-            _spxOptionSymbol = spxOption.Symbol;
+            indexOption.PriceModel = OptionPriceModels.BlackScholes();
+            _optionSymbol = indexOption.Symbol;
 
             _showGreeks = true;
             _triedGreeksCalculation = false;
@@ -59,7 +59,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             foreach (var kvp in slice.OptionChains)
             {
-                if (kvp.Key != _spxOptionSymbol)
+                if (kvp.Key != _optionSymbol)
                 {
                     continue;
                 }

--- a/Algorithm.CSharp/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.cs
@@ -1,0 +1,186 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities.Option;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm excersizing an equity covered European style option, using an option price model that supports European style options and asserting that the option price model is used.
+    /// </summary>
+    public class OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private bool _showGreeks = false;
+        private bool _triedGreeksCalculation = false;
+        private Symbol _spxOptionSymbol;
+
+        public override void Initialize()
+        {
+            SetStartDate(2021, 1, 4);
+            SetEndDate(2021, 1, 10);
+            SetCash(100000);
+
+            var spxIndex = AddIndex("SPX", Resolution.Minute);
+            spxIndex.SetDataNormalizationMode(DataNormalizationMode.Raw);
+            var spxOption = AddIndexOption("SPX", Resolution.Minute);
+            spxOption.PriceModel = OptionPriceModels.BlackScholes();
+            _spxOptionSymbol = spxOption.Symbol;
+
+            SetWarmUp(10, Resolution.Daily);
+
+            _showGreeks = true;
+            _triedGreeksCalculation = false;
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (IsWarmingUp)
+            {
+                return;
+            }
+
+            foreach (var kvp in slice.OptionChains)
+            {
+                if (kvp.Key != _spxOptionSymbol)
+                {
+                    continue;
+                }
+
+                var chain = kvp.Value;
+                var contracts = chain.Where(x => x.Right == OptionRight.Call);
+
+                if (!contracts.Any())
+                {
+                    return;
+                }
+
+                if (_showGreeks)
+                {
+                    _showGreeks = false;
+                    _triedGreeksCalculation = true;
+
+                    foreach (var contract in contracts)
+                    {
+                        Greeks greeks;
+                        try
+                        {
+                            greeks = contract.Greeks;
+                        }
+                        catch (ArgumentException)
+                        {
+                            throw new Exception($"Expected greeks to be calculated for {contract.Symbol.Value}, an European style option, but they were not");
+                        }
+
+                        Log($@"{contract.Symbol.Value},
+                            strike: {contract.Strike},
+                            Gamma: {greeks.Gamma},
+                            Rho: {greeks.Rho},
+                            Delta: {greeks.Delta},
+                            Vega: {greeks.Vega}");
+                    }
+                }
+            }
+        }
+
+        public override void OnEndOfDay(Symbol symbol)
+        {
+            _showGreeks = true;
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_triedGreeksCalculation)
+            {
+                throw new Exception("Expected greeks to be calculated");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        // public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 38359;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-103.054"},
+            {"Tracking Error", "0.069"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// Regression algorithm excersizing an index covered European style option, using an option price model
     /// that supports European style options and asserting that the option price model is used.
     /// </summary>
-    public class OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm : OptionPriceModelForOptionStylesBaseRegressionAlgorithm, IRegressionAlgorithmDefinition
+    public class OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm : OptionPriceModelForOptionStylesBaseRegressionAlgorithm
     {
         public override void Initialize()
         {
@@ -46,29 +46,19 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
-        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
-        /// </summary>
-        public bool CanRunLocally { get; } = true;
-
-        /// <summary>
-        /// This is used by the regression test system to indicate which languages this algorithm is written in.
-        /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
-
-        /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 1406;
+        public override long DataPoints => 1406;
 
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 0;
+        public override int AlgorithmHistoryDataPoints => 0;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
-        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "0"},
             {"Average Win", "0%"},

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.cs
@@ -30,18 +30,20 @@ namespace QuantConnect.Algorithm.CSharp
     {
         private bool _showGreeks = false;
         private bool _triedGreeksCalculation = false;
-        private Symbol _spyOptionSymbol;
+        private Symbol _optionSymbol;
+
         public override void Initialize()
         {
-            SetStartDate(2020, 1, 2);
-            SetEndDate(2020, 1, 14);
+            SetStartDate(2015, 12, 23);
+            SetEndDate(2015, 12, 24);
             SetCash(100000);
 
-            var spyIndex = AddEquity("SPY", Resolution.Minute);
-            spyIndex.SetDataNormalizationMode(DataNormalizationMode.Raw);
-            var spyOption = AddOption("SPY", Resolution.Minute);
-            spyOption.PriceModel = OptionPriceModels.BlackScholes();
-            _spyOptionSymbol = spyOption.Symbol;
+            var equity = AddEquity("GOOG", Resolution.Minute);
+            equity.SetDataNormalizationMode(DataNormalizationMode.Raw);
+            var option = AddOption("GOOG", Resolution.Minute);
+            // BlackSholes model does not support American style options
+            option.PriceModel = OptionPriceModels.BlackScholes();
+            _optionSymbol = option.Symbol;
 
             SetWarmUp(TimeSpan.FromDays(10));
 
@@ -57,7 +59,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             foreach (var kvp in slice.OptionChains)
             {
-                if (kvp.Key != _spyOptionSymbol)
+                if (kvp.Key != _optionSymbol)
                 {
                     continue;
                 }
@@ -81,12 +83,6 @@ namespace QuantConnect.Algorithm.CSharp
                         try
                         {
                             greeks = contract.Greeks;
-                            Log($@"{contract.Symbol.Value},
-                                strike: {contract.Strike},
-                                Gamma: {greeks.Gamma},
-                                Rho: {greeks.Rho},
-                                Delta: {greeks.Delta},
-                                Vega: {greeks.Vega}");
                             throw new Exception($"Expected greeks not to be calculated for {contract.Symbol.Value}, an American style option, using an option price model that does not support them, but they were");
                         }
                         catch (ArgumentException)
@@ -119,13 +115,12 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        // public Language[] Languages { get; } = { Language.CSharp, Language.Python };
-        public Language[] Languages { get; } = { Language.CSharp };
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 26399875;
+        public long DataPoints => 910666;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -153,8 +148,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "0"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-2.663"},
-            {"Tracking Error", "0.069"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.cs
@@ -1,0 +1,184 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities.Option;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm excersizing an equity covered American style option, using an option price model that does not support American style options and asserting that the option price model is not used.
+    /// </summary>
+    public class OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private bool _showGreeks = false;
+        private bool _triedGreeksCalculation = false;
+        private Symbol _spyOptionSymbol;
+        public override void Initialize()
+        {
+            SetStartDate(2020, 1, 2);
+            SetEndDate(2020, 1, 14);
+            SetCash(100000);
+
+            var spyIndex = AddEquity("SPY", Resolution.Minute);
+            spyIndex.SetDataNormalizationMode(DataNormalizationMode.Raw);
+            var spyOption = AddOption("SPY", Resolution.Minute);
+            spyOption.PriceModel = OptionPriceModels.BlackScholes();
+            _spyOptionSymbol = spyOption.Symbol;
+
+            SetWarmUp(TimeSpan.FromDays(10));
+
+            _showGreeks = true;
+            _triedGreeksCalculation = false;
+        }
+        public override void OnData(Slice slice)
+        {
+            if (IsWarmingUp)
+            {
+                return;
+            }
+
+            foreach (var kvp in slice.OptionChains)
+            {
+                if (kvp.Key != _spyOptionSymbol)
+                {
+                    continue;
+                }
+
+                var chain = kvp.Value;
+                var contracts = chain.Where(x => x.Right == OptionRight.Call);
+
+                if (!contracts.Any())
+                {
+                    return;
+                }
+
+                if (_showGreeks)
+                {
+                    _showGreeks = false;
+                    _triedGreeksCalculation = true;
+
+                    foreach (var contract in contracts)
+                    {
+                        Greeks greeks;
+                        try
+                        {
+                            greeks = contract.Greeks;
+                            Log($@"{contract.Symbol.Value},
+                                strike: {contract.Strike},
+                                Gamma: {greeks.Gamma},
+                                Rho: {greeks.Rho},
+                                Delta: {greeks.Delta},
+                                Vega: {greeks.Vega}");
+                            throw new Exception($"Expected greeks not to be calculated for {contract.Symbol.Value}, an American style option, using an option price model that does not support them, but they were");
+                        }
+                        catch (ArgumentException)
+                        {
+                            // Expected
+                        }
+                    }
+                }
+            }
+        }
+
+        public override void OnEndOfDay(Symbol symbol)
+        {
+            _showGreeks = true;
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_triedGreeksCalculation)
+            {
+                throw new Exception("Expected greeks to be calculated");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        // public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 26399875;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-2.663"},
+            {"Tracking Error", "0.069"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.cs
@@ -33,15 +33,13 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2015, 12, 24);
             SetEndDate(2015, 12, 24);
 
-            _option = AddOption("GOOG", Resolution.Minute);
+            var option = AddOption("GOOG", Resolution.Minute);
             // BlackSholes model does not support American style options
-            _option.PriceModel = OptionPriceModels.BlackScholes();
+            option.PriceModel = OptionPriceModels.BlackScholes();
 
             SetWarmup(1, Resolution.Daily);
 
-            _optionStyle = OptionStyle.American;
-            _optionStyleIsSupported = false;
-            _triedGreeksCalculation = false;
+            Init(option, optionStyleIsSupported: false);
         }
 
         /// <summary>

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.cs
@@ -30,14 +30,14 @@ namespace QuantConnect.Algorithm.CSharp
     {
         public override void Initialize()
         {
-            SetStartDate(2015, 12, 24);
-            SetEndDate(2015, 12, 24);
+            SetStartDate(2014, 6, 9);
+            SetEndDate(2014, 6, 9);
 
-            var option = AddOption("GOOG", Resolution.Minute);
+            var option = AddOption("AAPL", Resolution.Minute);
             // BlackSholes model does not support American style options
             option.PriceModel = OptionPriceModels.BlackScholes();
 
-            SetWarmup(1, Resolution.Daily);
+            SetWarmup(2, Resolution.Daily);
 
             Init(option, optionStyleIsSupported: false);
         }
@@ -45,7 +45,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 911426;
+        public override long DataPoints => 1781481;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// <summary>
     /// Regression algorithm excersizing an equity covered American style option, using an option price model that does not support American style options and asserting that the option price model is not used.
     /// </summary>
-    public class OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm : OptionPriceModelForOptionStylesBaseRegressionAlgorithm, IRegressionAlgorithmDefinition
+    public class OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm : OptionPriceModelForOptionStylesBaseRegressionAlgorithm
     {
         public override void Initialize()
         {
@@ -45,29 +45,19 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
-        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
-        /// </summary>
-        public bool CanRunLocally { get; } = true;
-
-        /// <summary>
-        /// This is used by the regression test system to indicate which languages this algorithm is written in.
-        /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
-
-        /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 911426;
+        public override long DataPoints => 911426;
 
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 0;
+        public override int AlgorithmHistoryDataPoints => 0;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
-        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "0"},
             {"Average Win", "0%"},

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.cs
@@ -1,0 +1,186 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities.Option;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm excersizing an equity covered European style option, using an option price model that does not support European style options and asserting that the option price model is not used.
+    /// </summary>
+    public class OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private bool _showGreeks = false;
+        private bool _triedGreeksCalculation = false;
+        private Symbol _spxOptionSymbol;
+
+        public override void Initialize()
+        {
+            SetStartDate(2021, 1, 4);
+            SetEndDate(2021, 1, 10);
+            SetCash(100000);
+
+            var spxIndex = AddIndex("SPX", Resolution.Minute);
+            spxIndex.SetDataNormalizationMode(DataNormalizationMode.Raw);
+            var spxOption = AddIndexOption("SPX", Resolution.Minute);
+            spxOption.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
+            _spxOptionSymbol = spxOption.Symbol;
+
+            SetWarmUp(10, Resolution.Daily);
+
+            _showGreeks = true;
+            _triedGreeksCalculation = false;
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (IsWarmingUp)
+            {
+                return;
+            }
+
+            foreach (var kvp in slice.OptionChains)
+            {
+                if (kvp.Key != _spxOptionSymbol)
+                {
+                    continue;
+                }
+
+                var chain = kvp.Value;
+                var contracts = chain.Where(x => x.Right == OptionRight.Call);
+
+                if (!contracts.Any())
+                {
+                    return;
+                }
+
+                if (_showGreeks)
+                {
+                    _showGreeks = false;
+                    _triedGreeksCalculation = true;
+
+                    foreach (var contract in contracts)
+                    {
+                        Greeks greeks;
+                        try
+                        {
+                            greeks = contract.Greeks;
+                            Log($@"{contract.Symbol.Value},
+                                strike: {contract.Strike},
+                                Gamma: {greeks.Gamma},
+                                Rho: {greeks.Rho},
+                                Delta: {greeks.Delta},
+                                Vega: {greeks.Vega}");
+                            throw new Exception($"Expected greeks not to be calculated for {contract.Symbol.Value}, an European style option, using an option price model that does not support them, but they were");
+                        }
+                        catch (ArgumentException)
+                        {
+                            // Expected
+                        }
+                    }
+                }
+            }
+        }
+
+        public override void OnEndOfDay(Symbol symbol)
+        {
+            _showGreeks = true;
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_triedGreeksCalculation)
+            {
+                throw new Exception("Expected greeks to be calculated");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        // public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 38359;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-103.054"},
+            {"Tracking Error", "0.069"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.cs
@@ -34,15 +34,13 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2021, 1, 14);
             SetEndDate(2021, 1, 14);
 
-            _option = AddIndexOption("SPX", Resolution.Hour);
+            var option = AddIndexOption("SPX", Resolution.Hour);
             // BaroneAdesiWhaley model does not support European style options
-            _option.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
+            option.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
 
             SetWarmup(7, Resolution.Daily);
 
-            _optionStyle = OptionStyle.European;
-            _optionStyleIsSupported = false;
-            _triedGreeksCalculation = false;
+            Init(option, optionStyleIsSupported: false);
         }
 
         /// <summary>

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Algorithm.CSharp
     {
         private bool _showGreeks = false;
         private bool _triedGreeksCalculation = false;
-        private Symbol _spxOptionSymbol;
+        private Symbol _optionSymbol;
 
         public override void Initialize()
         {
@@ -39,12 +39,12 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2021, 1, 4);
             SetCash(100000);
 
-            var spxIndex = AddIndex("SPX", Resolution.Minute);
-            spxIndex.SetDataNormalizationMode(DataNormalizationMode.Raw);
-            var spxOption = AddIndexOption("SPX", Resolution.Minute);
+            var index = AddIndex("SPX", Resolution.Minute);
+            index.SetDataNormalizationMode(DataNormalizationMode.Raw);
+            var indexOption = AddIndexOption("SPX", Resolution.Minute);
             // BaroneAdesiWhaley model does not support European style options
-            spxOption.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
-            _spxOptionSymbol = spxOption.Symbol;
+            indexOption.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
+            _optionSymbol = indexOption.Symbol;
 
             _showGreeks = true;
             _triedGreeksCalculation = false;
@@ -59,7 +59,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             foreach (var kvp in slice.OptionChains)
             {
-                if (kvp.Key != _spxOptionSymbol)
+                if (kvp.Key != _optionSymbol)
                 {
                     continue;
                 }

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.cs
@@ -27,84 +27,22 @@ namespace QuantConnect.Algorithm.CSharp
     /// Regression algorithm excersizing an equity covered European style option, using an option price model
     /// that does not support European style options and asserting that the option price model is not used.
     /// </summary>
-    public class OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    public class OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm : OptionPriceModelForOptionStylesBaseRegressionAlgorithm, IRegressionAlgorithmDefinition
     {
-        private bool _showGreeks = false;
-        private bool _triedGreeksCalculation = false;
-        private Symbol _optionSymbol;
-
         public override void Initialize()
         {
-            SetStartDate(2021, 1, 4);
-            SetEndDate(2021, 1, 4);
-            SetCash(100000);
+            SetStartDate(2021, 1, 14);
+            SetEndDate(2021, 1, 14);
 
-            var index = AddIndex("SPX", Resolution.Minute);
-            index.SetDataNormalizationMode(DataNormalizationMode.Raw);
-            var indexOption = AddIndexOption("SPX", Resolution.Minute);
+            _option = AddIndexOption("SPX", Resolution.Hour);
             // BaroneAdesiWhaley model does not support European style options
-            indexOption.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
-            _optionSymbol = indexOption.Symbol;
+            _option.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
 
-            _showGreeks = true;
+            SetWarmup(7, Resolution.Daily);
+
+            _optionStyle = OptionStyle.European;
+            _optionStyleIsSupported = false;
             _triedGreeksCalculation = false;
-        }
-
-        public override void OnData(Slice slice)
-        {
-            if (IsWarmingUp)
-            {
-                return;
-            }
-
-            foreach (var kvp in slice.OptionChains)
-            {
-                if (kvp.Key != _optionSymbol)
-                {
-                    continue;
-                }
-
-                var chain = kvp.Value;
-                var contracts = chain.Where(x => x.Right == OptionRight.Call);
-
-                if (!contracts.Any())
-                {
-                    return;
-                }
-
-                if (_showGreeks)
-                {
-                    _showGreeks = false;
-                    _triedGreeksCalculation = true;
-
-                    foreach (var contract in contracts)
-                    {
-                        Greeks greeks;
-                        try
-                        {
-                            greeks = contract.Greeks;
-                            throw new Exception($"Expected greeks not to be calculated for {contract.Symbol.Value}, an European style option, using an option price model that does not support them, but they were");
-                        }
-                        catch (ArgumentException)
-                        {
-                            // Expected
-                        }
-                    }
-                }
-            }
-        }
-
-        public override void OnEndOfDay(Symbol symbol)
-        {
-            _showGreeks = true;
-        }
-
-        public override void OnEndOfAlgorithm()
-        {
-            if (!_triedGreeksCalculation)
-            {
-                throw new Exception("Expected greeks to be calculated");
-            }
         }
 
         /// <summary>
@@ -120,7 +58,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 7118;
+        public long DataPoints => 1406;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -157,8 +95,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "0"},
-            {"Return Over Maximum Drawdown", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
             {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.cs
@@ -24,7 +24,8 @@ using QuantConnect.Securities.Option;
 namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
-    /// Regression algorithm excersizing an equity covered European style option, using an option price model that does not support European style options and asserting that the option price model is not used.
+    /// Regression algorithm excersizing an equity covered European style option, using an option price model
+    /// that does not support European style options and asserting that the option price model is not used.
     /// </summary>
     public class OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
@@ -35,16 +36,15 @@ namespace QuantConnect.Algorithm.CSharp
         public override void Initialize()
         {
             SetStartDate(2021, 1, 4);
-            SetEndDate(2021, 1, 10);
+            SetEndDate(2021, 1, 4);
             SetCash(100000);
 
             var spxIndex = AddIndex("SPX", Resolution.Minute);
             spxIndex.SetDataNormalizationMode(DataNormalizationMode.Raw);
             var spxOption = AddIndexOption("SPX", Resolution.Minute);
+            // BaroneAdesiWhaley model does not support European style options
             spxOption.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
             _spxOptionSymbol = spxOption.Symbol;
-
-            SetWarmUp(10, Resolution.Daily);
 
             _showGreeks = true;
             _triedGreeksCalculation = false;
@@ -83,12 +83,6 @@ namespace QuantConnect.Algorithm.CSharp
                         try
                         {
                             greeks = contract.Greeks;
-                            Log($@"{contract.Symbol.Value},
-                                strike: {contract.Strike},
-                                Gamma: {greeks.Gamma},
-                                Rho: {greeks.Rho},
-                                Delta: {greeks.Delta},
-                                Vega: {greeks.Vega}");
                             throw new Exception($"Expected greeks not to be calculated for {contract.Symbol.Value}, an European style option, using an option price model that does not support them, but they were");
                         }
                         catch (ArgumentException)
@@ -121,13 +115,12 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        // public Language[] Languages { get; } = { Language.CSharp, Language.Python };
-        public Language[] Languages { get; } = { Language.CSharp };
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 38359;
+        public long DataPoints => 7118;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -155,8 +148,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "0"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-103.054"},
-            {"Tracking Error", "0.069"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},
@@ -164,8 +157,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "79228162514264337593543950335"},
-            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Sortino Ratio", "0"},
+            {"Return Over Maximum Drawdown", "0"},
             {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// Regression algorithm excersizing an equity covered European style option, using an option price model
     /// that does not support European style options and asserting that the option price model is not used.
     /// </summary>
-    public class OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm : OptionPriceModelForOptionStylesBaseRegressionAlgorithm, IRegressionAlgorithmDefinition
+    public class OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm : OptionPriceModelForOptionStylesBaseRegressionAlgorithm
     {
         public override void Initialize()
         {
@@ -46,29 +46,19 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
-        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
-        /// </summary>
-        public bool CanRunLocally { get; } = true;
-
-        /// <summary>
-        /// This is used by the regression test system to indicate which languages this algorithm is written in.
-        /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
-
-        /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 1406;
+        public override long DataPoints => 1406;
 
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 0;
+        public override int AlgorithmHistoryDataPoints => 0;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
-        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "0"},
             {"Average Win", "0%"},

--- a/Algorithm.Python/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.py
@@ -1,0 +1,68 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Base regression algorithm excersizing for exercising different style options with option price models that migth
+### or might not support them. Also, if the option style is supported, greeks are asserted to be accesible and have valid values.
+### </summary>
+class OptionPriceModelForOptionStylesBaseRegressionAlgorithm(QCAlgorithm):
+    def __init__(self):
+        super().__init__()
+        self._optionStyle = OptionStyle.European
+        self._optionStyleIsSupported = False
+        self._triedGreeksCalculation = False
+        self._option = None
+        self._contracts = None
+
+    def OnData(self, slice):
+        if self.IsWarmingUp: return
+
+        for kvp in slice.OptionChains:
+            if self._option is None or kvp.Key != self._option.Symbol: continue
+
+            chain = kvp.Value
+            self._contracts = [contract for contract in chain if contract.Right == OptionRight.Call]
+
+    def OnEndOfDay(self, symbol):
+        if not self.IsWarmingUp:
+            self.CheckGreeks()
+
+    def OnEndOfAlgorithm(self):
+        if not self._triedGreeksCalculation:
+            raise Exception("Expected greeks to be accessed")
+
+    def CheckGreeks(self):
+        if self._contracts is None or len(self._contracts) == 0: return
+
+        self._triedGreeksCalculation = True
+
+        for contract in self._contracts:
+            greeks = Greeks()
+            try:
+                greeks = contract.Greeks
+
+                # Greeks should have not been successfully accessed if the option style is not supported
+                if not self._optionStyleIsSupported:
+                    raise Exception(f'Expected greeks not to be calculated for {contract.Symbol.Value}, an {self._optionStyle} style option, using {type(self._option.PriceModel).__name__}, which does not support them, but they were')
+            except ArgumentException:
+                # ArgumentException is only expected if the option style is not supported
+                raise Exception(f'Expected greeks to be calculated for {contract.Symbol.Value}, an {self._optionStyle} style option, using {type(self._option.PriceModel).__name__}, which supports them, but they were not')
+
+            # Greeks shpould be valid if they were successfuly accessed for supported option style
+            if self._optionStyleIsSupported and (greeks.Delta < 0 or greeks.Delta > 1 or greeks.Theta >= 0 or greeks.Rho <= 0 or greeks.Vega <= 0):
+                raise Exception(f'Expected greeks to have valid values. Greeks were: Gamma: {greeks.Gamma}, Rho: {greeks.Rho}, Delta: {greeks.Delta}, Vega: {greeks.Vega}')
+
+
+

--- a/Algorithm.Python/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 from AlgorithmImports import *
-from System import Enum
 
 ### <summary>
 ### Base regression algorithm excersizing for exercising different style options with option price models that migth

--- a/Algorithm.Python/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.py
@@ -31,8 +31,7 @@ class OptionPriceModelForOptionStylesBaseRegressionAlgorithm(QCAlgorithm):
         for kvp in slice.OptionChains:
             if self._option is None or kvp.Key != self._option.Symbol: continue
 
-            chain = kvp.Value
-            self._contracts = [contract for contract in chain if contract.Right == OptionRight.Call]
+            self._contracts = [contract for contract in kvp.Value]
 
     def OnEndOfDay(self, symbol):
         if not self.IsWarmingUp:
@@ -65,7 +64,10 @@ class OptionPriceModelForOptionStylesBaseRegressionAlgorithm(QCAlgorithm):
                 raise Exception(f'Expected greeks to be calculated for {contract.Symbol.Value}, an {self._option.Style} style option, using {type(self._option.PriceModel).__name__}, which supports them, but they were not')
 
             # Greeks shpould be valid if they were successfuly accessed for supported option style
-            if self._optionStyleIsSupported and (greeks.Delta < 0 or greeks.Delta > 1 or greeks.Theta >= 0 or greeks.Rho <= 0 or greeks.Vega <= 0):
+            if (self._optionStyleIsSupported
+                and ((contract.Right == OptionRight.Call and (greeks.Delta < 0.0 or greeks.Delta > 1.0 or greeks.Rho <= 0.0))
+                    or (contract.Right == OptionRight.Put and (greeks.Delta < -1.0 or greeks.Delta > 0.0 or greeks.Rho >= 0.0))
+                    or greeks.Theta >= 0.0 or greeks.Vega <= 0.0)):
                 raise Exception(f'Expected greeks to have valid values. Greeks were: Gamma: {greeks.Gamma}, Rho: {greeks.Rho}, Delta: {greeks.Delta}, Vega: {greeks.Vega}')
 
 

--- a/Algorithm.Python/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.py
@@ -20,7 +20,6 @@ from AlgorithmImports import *
 class OptionPriceModelForOptionStylesBaseRegressionAlgorithm(QCAlgorithm):
     def __init__(self):
         super().__init__()
-        self._optionStyle = OptionStyle.European
         self._optionStyleIsSupported = False
         self._triedGreeksCalculation = False
         self._option = None
@@ -43,6 +42,11 @@ class OptionPriceModelForOptionStylesBaseRegressionAlgorithm(QCAlgorithm):
         if not self._triedGreeksCalculation:
             raise Exception("Expected greeks to be accessed")
 
+    def Init(self, option, optionStyleIsSupported):
+        self._option = option
+        self._optionStyleIsSupported = optionStyleIsSupported
+        self._triedGreeksCalculation = False
+
     def CheckGreeks(self):
         if self._contracts is None or len(self._contracts) == 0: return
 
@@ -55,10 +59,10 @@ class OptionPriceModelForOptionStylesBaseRegressionAlgorithm(QCAlgorithm):
 
                 # Greeks should have not been successfully accessed if the option style is not supported
                 if not self._optionStyleIsSupported:
-                    raise Exception(f'Expected greeks not to be calculated for {contract.Symbol.Value}, an {self._optionStyle} style option, using {type(self._option.PriceModel).__name__}, which does not support them, but they were')
+                    raise Exception(f'Expected greeks not to be calculated for {contract.Symbol.Value}, an {self._option.Style} style option, using {type(self._option.PriceModel).__name__}, which does not support them, but they were')
             except ArgumentException:
                 # ArgumentException is only expected if the option style is not supported
-                raise Exception(f'Expected greeks to be calculated for {contract.Symbol.Value}, an {self._optionStyle} style option, using {type(self._option.PriceModel).__name__}, which supports them, but they were not')
+                raise Exception(f'Expected greeks to be calculated for {contract.Symbol.Value}, an {self._option.Style} style option, using {type(self._option.PriceModel).__name__}, which supports them, but they were not')
 
             # Greeks shpould be valid if they were successfuly accessed for supported option style
             if self._optionStyleIsSupported and (greeks.Delta < 0 or greeks.Delta > 1 or greeks.Theta >= 0 or greeks.Rho <= 0 or greeks.Vega <= 0):

--- a/Algorithm.Python/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForOptionStylesBaseRegressionAlgorithm.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 from AlgorithmImports import *
+from System import Enum
 
 ### <summary>
 ### Base regression algorithm excersizing for exercising different style options with option price models that migth
@@ -57,18 +58,20 @@ class OptionPriceModelForOptionStylesBaseRegressionAlgorithm(QCAlgorithm):
                 greeks = contract.Greeks
 
                 # Greeks should have not been successfully accessed if the option style is not supported
+                optionStyleStr = 'American' if self._option.Style == OptionStyle.American else 'European'
                 if not self._optionStyleIsSupported:
-                    raise Exception(f'Expected greeks not to be calculated for {contract.Symbol.Value}, an {self._option.Style} style option, using {type(self._option.PriceModel).__name__}, which does not support them, but they were')
+                    raise Exception(f'Expected greeks not to be calculated for {contract.Symbol.Value}, an {optionStyleStr} style option, using {type(self._option.PriceModel).__name__}, which does not support them, but they were')
             except ArgumentException:
                 # ArgumentException is only expected if the option style is not supported
-                raise Exception(f'Expected greeks to be calculated for {contract.Symbol.Value}, an {self._option.Style} style option, using {type(self._option.PriceModel).__name__}, which supports them, but they were not')
+                if self._optionStyleIsSupported:
+                    raise Exception(f'Expected greeks to be calculated for {contract.Symbol.Value}, an {optionStyleStr} style option, using {type(self._option.PriceModel).__name__}, which supports them, but they were not')
 
             # Greeks shpould be valid if they were successfuly accessed for supported option style
             if (self._optionStyleIsSupported
                 and ((contract.Right == OptionRight.Call and (greeks.Delta < 0.0 or greeks.Delta > 1.0 or greeks.Rho <= 0.0))
                     or (contract.Right == OptionRight.Put and (greeks.Delta < -1.0 or greeks.Delta > 0.0 or greeks.Rho >= 0.0))
-                    or greeks.Theta >= 0.0 or greeks.Vega <= 0.0)):
-                raise Exception(f'Expected greeks to have valid values. Greeks were: Gamma: {greeks.Gamma}, Rho: {greeks.Rho}, Delta: {greeks.Delta}, Vega: {greeks.Vega}')
+                    or greeks.Theta == 0.0 or greeks.Vega <= 0.0 or greeks.Gamma <= 0.0)):
+                raise Exception(f'Expected greeks to have valid values. Greeks were: Delta: {greeks.Delta}, Rho: {greeks.Rho}, Delta: {greeks.Delta}, Vega: {greeks.Vega}, Gamma: {greeks.Gamma}')
 
 
 

--- a/Algorithm.Python/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.py
@@ -1,0 +1,69 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression algorithm excersizing an equity covered American style option, using an option price model
+### that supports American style options and asserting that the option price model is used.
+### </summary>
+class OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        self.SetStartDate(2015, 12, 23)
+        self.SetEndDate(2015, 12, 24)
+        self.SetCash(100000)
+
+        equity = self.AddEquity("GOOG", Resolution.Minute)
+        equity.SetDataNormalizationMode(DataNormalizationMode.Raw)
+        option = self.AddOption("GOOG", Resolution.Minute)
+        # BaroneAdesiWhaley model supports American style options
+        option.PriceModel = OptionPriceModels.BaroneAdesiWhaley()
+        self._optionSymbol = option.Symbol
+
+        self._showGreeks = True
+        self._triedGreeksCalculation = False
+
+    def OnData(self, slice):
+        if self.IsWarmingUp: return
+
+        for kvp in slice.OptionChains:
+            if kvp.Key != self._optionSymbol: continue
+
+            chain = kvp.Value
+            contracts = [contract for contract in chain if contract.Right == OptionRight.Call]
+
+            if len(contracts) == 0: return
+
+            if self._showGreeks:
+                self._showGreeks = False
+                self._triedGreeksCalculation = True
+
+                for contract in contracts:
+                    try:
+                        greeks = contract.Greeks
+                    except ArgumentException:
+                        raise Exception(f'Expected greeks to be calculated for {contract.Symbol.Value}, an American style option, but they were not')
+
+                    self.Debug(f'{contract.Symbol.Value},\n'
+                        f'strike: {contract.Strike},\n'
+                        f'Gamma: {greeks.Gamma},\n'
+                        f'Rho: {greeks.Rho},\n'
+                        f'Delta: {greeks.Delta},\n'
+                        f'Vega: {greeks.Vega}')
+
+    def OnEndOfDay(self, symbol):
+        self._showGreeks = True
+
+    def OnEndOfAlgorithm(self):
+        if not self._triedGreeksCalculation:
+            raise Exception("Expected greeks to be calculated")

--- a/Algorithm.Python/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.py
@@ -23,12 +23,10 @@ class OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm(OptionPriceM
         self.SetStartDate(2015, 12, 24)
         self.SetEndDate(2015, 12, 24)
 
-        self._option = self.AddOption("GOOG", Resolution.Minute)
+        option = self.AddOption("GOOG", Resolution.Minute)
         # BaroneAdesiWhaley model supports American style options
-        self._option.PriceModel = OptionPriceModels.BaroneAdesiWhaley()
+        option.PriceModel = OptionPriceModels.BaroneAdesiWhaley()
 
         self.SetWarmup(1, Resolution.Daily)
 
-        self._optionStyle = OptionStyle.American
-        self._optionStyleIsSupported = True
-        self._triedGreeksCalculation = False
+        self.Init(option, optionStyleIsSupported=True)

--- a/Algorithm.Python/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.py
@@ -20,13 +20,13 @@ from OptionPriceModelForOptionStylesBaseRegressionAlgorithm import OptionPriceMo
 ### </summary>
 class OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm(OptionPriceModelForOptionStylesBaseRegressionAlgorithm):
     def Initialize(self):
-        self.SetStartDate(2015, 12, 24)
-        self.SetEndDate(2015, 12, 24)
+        self.SetStartDate(2014, 6, 9)
+        self.SetEndDate(2014, 6, 9)
 
-        option = self.AddOption("GOOG", Resolution.Minute)
+        option = self.AddOption("AAPL", Resolution.Minute)
         # BaroneAdesiWhaley model supports American style options
         option.PriceModel = OptionPriceModels.BaroneAdesiWhaley()
 
-        self.SetWarmup(1, Resolution.Daily)
+        self.SetWarmup(2, Resolution.Daily)
 
         self.Init(option, optionStyleIsSupported=True)

--- a/Algorithm.Python/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.py
@@ -12,58 +12,23 @@
 # limitations under the License.
 
 from AlgorithmImports import *
+from OptionPriceModelForOptionStylesBaseRegressionAlgorithm import OptionPriceModelForOptionStylesBaseRegressionAlgorithm
 
 ### <summary>
 ### Regression algorithm excersizing an equity covered European style option, using an option price model
 ### that supports European style options and asserting that the option price model is used.
 ### </summary>
-class OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm(QCAlgorithm):
+class OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm(OptionPriceModelForOptionStylesBaseRegressionAlgorithm):
     def Initialize(self):
-        self.SetStartDate(2021, 1, 4)
-        self.SetEndDate(2021, 1, 4)
-        self.SetCash(100000)
+        self.SetStartDate(2021, 1, 14)
+        self.SetEndDate(2021, 1, 14)
 
-        index = self.AddIndex("SPX", Resolution.Minute)
-        index.SetDataNormalizationMode(DataNormalizationMode.Raw)
-        indexOption = self.AddIndexOption("SPX", Resolution.Minute)
+        self._option = self.AddIndexOption("SPX", Resolution.Hour)
         # BlackScholes model supports European style options
-        indexOption.PriceModel = OptionPriceModels.BlackScholes()
-        self._indexOptionSymbol = indexOption.Symbol
+        self._option.PriceModel = OptionPriceModels.BlackScholes()
 
-        self._showGreeks = True
+        self.SetWarmup(7, Resolution.Daily)
+
+        self._optionStyle = OptionStyle.European
+        self._optionStyleIsSupported = True
         self._triedGreeksCalculation = False
-
-    def OnData(self, slice):
-        if self.IsWarmingUp: return
-
-        for kvp in slice.OptionChains:
-            if kvp.Key != self._indexOptionSymbol: continue
-
-            chain = kvp.Value
-            contracts = [contract for contract in chain if contract.Right == OptionRight.Call]
-
-            if len(contracts) == 0: return
-
-            if self._showGreeks:
-                self._showGreeks = False
-                self._triedGreeksCalculation = True
-
-                for contract in contracts:
-                    try:
-                        greeks = contract.Greeks
-                    except ArgumentException:
-                        raise Exception(f'Expected greeks to be calculated for {contract.Symbol.Value}, an European style option, but they were not')
-
-                    self.Debug(f'{contract.Symbol.Value},\n'
-                        f'strike: {contract.Strike},\n'
-                        f'Gamma: {greeks.Gamma},\n'
-                        f'Rho: {greeks.Rho},\n'
-                        f'Delta: {greeks.Delta},\n'
-                        f'Vega: {greeks.Vega}')
-
-    def OnEndOfDay(self, symbol):
-        self._showGreeks = True
-
-    def OnEndOfAlgorithm(self):
-        if not self._triedGreeksCalculation:
-            raise Exception("Expected greeks to be calculated")

--- a/Algorithm.Python/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.py
@@ -23,12 +23,10 @@ class OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm(OptionPriceM
         self.SetStartDate(2021, 1, 14)
         self.SetEndDate(2021, 1, 14)
 
-        self._option = self.AddIndexOption("SPX", Resolution.Hour)
+        option = self.AddIndexOption("SPX", Resolution.Hour)
         # BlackScholes model supports European style options
-        self._option.PriceModel = OptionPriceModels.BlackScholes()
+        option.PriceModel = OptionPriceModels.BlackScholes()
 
         self.SetWarmup(7, Resolution.Daily)
 
-        self._optionStyle = OptionStyle.European
-        self._optionStyleIsSupported = True
-        self._triedGreeksCalculation = False
+        self.Init(option, optionStyleIsSupported=True)

--- a/Algorithm.Python/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.py
@@ -1,0 +1,69 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression algorithm excersizing an equity covered European style option, using an option price model
+### that supports European style options and asserting that the option price model is used.
+### </summary>
+class OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        self.SetStartDate(2021, 1, 4)
+        self.SetEndDate(2021, 1, 4)
+        self.SetCash(100000)
+
+        index = self.AddIndex("SPX", Resolution.Minute)
+        index.SetDataNormalizationMode(DataNormalizationMode.Raw)
+        indexOption = self.AddIndexOption("SPX", Resolution.Minute)
+        # BlackScholes model supports European style options
+        indexOption.PriceModel = OptionPriceModels.BlackScholes()
+        self._indexOptionSymbol = indexOption.Symbol
+
+        self._showGreeks = True
+        self._triedGreeksCalculation = False
+
+    def OnData(self, slice):
+        if self.IsWarmingUp: return
+
+        for kvp in slice.OptionChains:
+            if kvp.Key != self._indexOptionSymbol: continue
+
+            chain = kvp.Value
+            contracts = [contract for contract in chain if contract.Right == OptionRight.Call]
+
+            if len(contracts) == 0: return
+
+            if self._showGreeks:
+                self._showGreeks = False
+                self._triedGreeksCalculation = True
+
+                for contract in contracts:
+                    try:
+                        greeks = contract.Greeks
+                    except ArgumentException:
+                        raise Exception(f'Expected greeks to be calculated for {contract.Symbol.Value}, an European style option, but they were not')
+
+                    self.Debug(f'{contract.Symbol.Value},\n'
+                        f'strike: {contract.Strike},\n'
+                        f'Gamma: {greeks.Gamma},\n'
+                        f'Rho: {greeks.Rho},\n'
+                        f'Delta: {greeks.Delta},\n'
+                        f'Vega: {greeks.Vega}')
+
+    def OnEndOfDay(self, symbol):
+        self._showGreeks = True
+
+    def OnEndOfAlgorithm(self):
+        if not self._triedGreeksCalculation:
+            raise Exception("Expected greeks to be calculated")

--- a/Algorithm.Python/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.py
@@ -12,23 +12,21 @@
 # limitations under the License.
 
 from AlgorithmImports import *
-from datetime import timedelta
+from OptionPriceModelForOptionStylesBaseRegressionAlgorithm import OptionPriceModelForOptionStylesBaseRegressionAlgorithm
 
 ### <summary>
 ### Regression algorithm excersizing an equity covered American style option, using an option price model
 ### that supports American style options and asserting that the option price model is used.
 ### </summary>
-class OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm(QCAlgorithm):
+class OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm(OptionPriceModelForOptionStylesBaseRegressionAlgorithm):
     def Initialize(self):
         self.SetStartDate(2015, 12, 24)
         self.SetEndDate(2015, 12, 24)
 
-        self._option = self.AddOption("GOOG", Resolution.Minute)
+        option = self.AddOption("GOOG", Resolution.Minute)
         # BlackSholes model does not support American style options
-        self._option.PriceModel = OptionPriceModels.BlackScholes()
+        option.PriceModel = OptionPriceModels.BlackScholes()
 
         self.SetWarmup(1, Resolution.Daily)
 
-        self._optionStyle = OptionStyle.American
-        self._optionStyleIsSupported = False
-        self._triedGreeksCalculation = False
+        self.Init(option, optionStyleIsSupported=False)

--- a/Algorithm.Python/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.py
@@ -1,0 +1,67 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+from datetime import timedelta
+
+### <summary>
+### Regression algorithm excersizing an equity covered American style option, using an option price model
+### that supports American style options and asserting that the option price model is used.
+### </summary>
+class OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        self.SetStartDate(2015, 12, 23)
+        self.SetEndDate(2015, 12, 24)
+        self.SetCash(100000)
+
+        index = self.AddEquity("GOOG", Resolution.Minute)
+        index.SetDataNormalizationMode(DataNormalizationMode.Raw)
+        option = self.AddOption("GOOG", Resolution.Minute)
+        # BlackSholes model does not support American style options
+        option.PriceModel = OptionPriceModels.BlackScholes()
+        self._optionSymbol = option.Symbol
+
+        self.SetWarmUp(timedelta(10))
+
+        self._showGreeks = True
+        self._triedGreeksCalculation = False
+
+    def OnData(self, slice):
+        if self.IsWarmingUp: return
+
+        for kvp in slice.OptionChains:
+            if kvp.Key != self._optionSymbol: continue
+
+            chain = kvp.Value
+            contracts = [contract for contract in chain if contract.Right == OptionRight.Call]
+
+            if len(contracts) == 0: return
+
+            if self._showGreeks:
+                self._showGreeks = False
+                self._triedGreeksCalculation = True
+
+                for contract in contracts:
+                    try:
+                        greeks = contract.Greeks
+                        raise Exception(f'Expected greeks not to be calculated for {contract.Symbol.Value}, an American style option, using an option price model that does not support them, but they were');
+                    except ArgumentException:
+                        # Expected
+                        pass
+
+    def OnEndOfDay(self, symbol):
+        self._showGreeks = True
+
+    def OnEndOfAlgorithm(self):
+        if not self._triedGreeksCalculation:
+            raise Exception("Expected greeks to be calculated")

--- a/Algorithm.Python/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.py
@@ -20,13 +20,13 @@ from OptionPriceModelForOptionStylesBaseRegressionAlgorithm import OptionPriceMo
 ### </summary>
 class OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm(OptionPriceModelForOptionStylesBaseRegressionAlgorithm):
     def Initialize(self):
-        self.SetStartDate(2015, 12, 24)
-        self.SetEndDate(2015, 12, 24)
+        self.SetStartDate(2014, 6, 9)
+        self.SetEndDate(2014, 6, 9)
 
-        option = self.AddOption("GOOG", Resolution.Minute)
+        option = self.AddOption("AAPL", Resolution.Minute)
         # BlackSholes model does not support American style options
         option.PriceModel = OptionPriceModels.BlackScholes()
 
-        self.SetWarmup(1, Resolution.Daily)
+        self.SetWarmup(2, Resolution.Daily)
 
         self.Init(option, optionStyleIsSupported=False)

--- a/Algorithm.Python/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.py
@@ -1,0 +1,64 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression algorithm excersizing an equity covered European style option, using an option price model
+### that does not support European style options and asserting that the option price model is not used.
+### </summary>
+class OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        self.SetStartDate(2021, 1, 4)
+        self.SetEndDate(2021, 1, 4)
+        self.SetCash(100000)
+
+        index = self.AddIndex("SPX", Resolution.Minute)
+        index.SetDataNormalizationMode(DataNormalizationMode.Raw)
+        indexOption = self.AddIndexOption("SPX", Resolution.Minute)
+        # BaroneAdesiWhaley model does not support European style options
+        indexOption.PriceModel = OptionPriceModels.BaroneAdesiWhaley()
+        self._indexOptionSymbol = indexOption.Symbol
+
+        self._showGreeks = True
+        self._triedGreeksCalculation = False
+
+    def OnData(self, slice):
+        if self.IsWarmingUp: return
+
+        for kvp in slice.OptionChains:
+            if kvp.Key != self._indexOptionSymbol: continue
+
+            chain = kvp.Value
+            contracts = [contract for contract in chain if contract.Right == OptionRight.Call]
+
+            if len(contracts) == 0: return
+
+            if self._showGreeks:
+                self._showGreeks = False
+                self._triedGreeksCalculation = True
+
+                for contract in contracts:
+                    try:
+                        greeks = contract.Greeks
+                        raise Exception(f'Expected greeks not to be calculated for {contract.Symbol.Value}, an European style option, using an option price model that does not support them, but they were');
+                    except ArgumentException:
+                        # Expected
+                        pass
+
+    def OnEndOfDay(self, symbol):
+        self._showGreeks = True
+
+    def OnEndOfAlgorithm(self):
+        if not self._triedGreeksCalculation:
+            raise Exception("Expected greeks to be calculated")

--- a/Algorithm.Python/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.py
@@ -23,12 +23,10 @@ class OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm(OptionPric
         self.SetStartDate(2021, 1, 14)
         self.SetEndDate(2021, 1, 14)
 
-        self._option = self.AddIndexOption("SPX", Resolution.Hour)
+        option = self.AddIndexOption("SPX", Resolution.Hour)
         # BaroneAdesiWhaley model does not support European style options
-        self._option.PriceModel = OptionPriceModels.BaroneAdesiWhaley()
+        option.PriceModel = OptionPriceModels.BaroneAdesiWhaley()
 
         self.SetWarmup(7, Resolution.Daily)
 
-        self._optionStyle = OptionStyle.European
-        self._optionStyleIsSupported = False
-        self._triedGreeksCalculation = False
+        self.Init(option, optionStyleIsSupported=False)

--- a/Common/Securities/Option/OptionPriceModels.cs
+++ b/Common/Securities/Option/OptionPriceModels.cs
@@ -46,6 +46,7 @@ namespace QuantConnect.Securities.Option
         /// </summary>
         /// <param name="priceEngineName">QL price engine name</param>
         /// <param name="riskFree">The risk free rate</param>
+        /// <param name="allowedOptionStyles">List of option styles supported by the pricing model. It defaults to both American and European option styles</param>
         /// <returns>New option price model instance of specific engine</returns>
         public static IOptionPriceModel Create(string priceEngineName, decimal riskFree, OptionStyle[] allowedOptionStyles = null)
         {
@@ -119,7 +120,7 @@ namespace QuantConnect.Securities.Option
         }
 
         /// <summary>
-        /// Pricing engine for European options using finite-differences.
+        /// Pricing engine for European and American options using finite-differences.
         /// QuantLib reference: http://quantlib.org/reference/class_quant_lib_1_1_f_d_european_engine.html
         /// </summary>
         /// <returns>New option price model instance</returns>
@@ -138,7 +139,7 @@ namespace QuantConnect.Securities.Option
         }
 
         /// <summary>
-        /// Pricing engine for vanilla options using binomial trees. Jarrow-Rudd model.
+        /// Pricing engine for European and American vanilla options using binomial trees. Jarrow-Rudd model.
         /// QuantLib reference: http://quantlib.org/reference/class_quant_lib_1_1_f_d_european_engine.html
         /// </summary>
         /// <returns>New option price model instance</returns>
@@ -153,7 +154,7 @@ namespace QuantConnect.Securities.Option
 
 
         /// <summary>
-        /// Pricing engine for vanilla options using binomial trees. Cox-Ross-Rubinstein(CRR) model.
+        /// Pricing engine for European and American vanilla options using binomial trees. Cox-Ross-Rubinstein(CRR) model.
         /// QuantLib reference: http://quantlib.org/reference/class_quant_lib_1_1_f_d_european_engine.html
         /// </summary>
         /// <returns>New option price model instance</returns>
@@ -167,7 +168,7 @@ namespace QuantConnect.Securities.Option
         }
 
         /// <summary>
-        /// Pricing engine for vanilla options using binomial trees. Additive Equiprobabilities model.
+        /// Pricing engine for European and American vanilla options using binomial trees. Additive Equiprobabilities model.
         /// QuantLib reference: http://quantlib.org/reference/class_quant_lib_1_1_f_d_european_engine.html
         /// </summary>
         /// <returns>New option price model instance</returns>
@@ -181,7 +182,7 @@ namespace QuantConnect.Securities.Option
         }
 
         /// <summary>
-        /// Pricing engine for vanilla options using binomial trees. Trigeorgis model.
+        /// Pricing engine for European and American vanilla options using binomial trees. Trigeorgis model.
         /// QuantLib reference: http://quantlib.org/reference/class_quant_lib_1_1_f_d_european_engine.html
         /// </summary>
         /// <returns>New option price model instance</returns>
@@ -195,7 +196,7 @@ namespace QuantConnect.Securities.Option
         }
 
         /// <summary>
-        /// Pricing engine for vanilla options using binomial trees. Tian model.
+        /// Pricing engine for European and American vanilla options using binomial trees. Tian model.
         /// QuantLib reference: http://quantlib.org/reference/class_quant_lib_1_1_f_d_european_engine.html
         /// </summary>
         /// <returns>New option price model instance</returns>
@@ -209,7 +210,7 @@ namespace QuantConnect.Securities.Option
         }
 
         /// <summary>
-        /// Pricing engine for vanilla options using binomial trees. Leisen-Reimer model.
+        /// Pricing engine for European and American vanilla options using binomial trees. Leisen-Reimer model.
         /// QuantLib reference: http://quantlib.org/reference/class_quant_lib_1_1_f_d_european_engine.html
         /// </summary>
         /// <returns>New option price model instance</returns>
@@ -223,7 +224,7 @@ namespace QuantConnect.Securities.Option
         }
 
         /// <summary>
-        /// Pricing engine for vanilla options using binomial trees. Joshi model.
+        /// Pricing engine for European and American vanilla options using binomial trees. Joshi model.
         /// QuantLib reference: http://quantlib.org/reference/class_quant_lib_1_1_f_d_european_engine.html
         /// </summary>
         /// <returns>New option price model instance</returns>

--- a/Common/Securities/Option/OptionPriceModels.cs
+++ b/Common/Securities/Option/OptionPriceModels.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,10 +27,10 @@ namespace QuantConnect.Securities.Option
     /// Static class contains definitions of major option pricing models that can be used in LEAN
     /// </summary>
     /// <remarks>
-    /// To introduce particular model into algorithm add the following line to the algorithm's Initialize() method: 
-    ///     
+    /// To introduce particular model into algorithm add the following line to the algorithm's Initialize() method:
+    ///
     ///     option.PriceModel = OptionPriceModels.BjerksundStensland(); // Option pricing model of choice
-    /// 
+    ///
     /// </remarks>
     public static class OptionPriceModels
     {
@@ -42,12 +42,12 @@ namespace QuantConnect.Securities.Option
         private const int _timeStepsFD = 100;
 
         /// <summary>
-        /// Creates pricing engine by engine type name. 
+        /// Creates pricing engine by engine type name.
         /// </summary>
         /// <param name="priceEngineName">QL price engine name</param>
         /// <param name="riskFree">The risk free rate</param>
         /// <returns>New option price model instance of specific engine</returns>
-        public static IOptionPriceModel Create(string priceEngineName, decimal riskFree)
+        public static IOptionPriceModel Create(string priceEngineName, decimal riskFree, OptionStyle[] allowedOptionStyles = null)
         {
             var type = AppDomain.CurrentDomain.GetAssemblies()
                 .Where(a => !a.IsDynamic)
@@ -58,11 +58,12 @@ namespace QuantConnect.Securities.Option
             return new QLOptionPriceModel(process => (IPricingEngine)Activator.CreateInstance(type, process),
                 _underlyingVolEstimator,
                 new ConstantQLRiskFreeRateEstimator(riskFree),
-                _dividendYieldEstimator);
+                _dividendYieldEstimator,
+                allowedOptionStyles);
         }
 
         /// <summary>
-        /// Pricing engine for European vanilla options using analytical formula. 
+        /// Pricing engine for European vanilla options using analytical formula.
         /// QuantLib reference: http://quantlib.org/reference/class_quant_lib_1_1_analytic_european_engine.html
         /// </summary>
         /// <returns>New option price model instance</returns>
@@ -71,7 +72,8 @@ namespace QuantConnect.Securities.Option
             return new QLOptionPriceModel(process => new AnalyticEuropeanEngine(process),
                                            _underlyingVolEstimator,
                                            _riskFreeRateEstimator,
-                                           _dividendYieldEstimator);
+                                           _dividendYieldEstimator,
+                                           new[] { OptionStyle.European });
         }
 
         /// <summary>
@@ -84,11 +86,12 @@ namespace QuantConnect.Securities.Option
             return new QLOptionPriceModel(process => new BaroneAdesiWhaleyApproximationEngine(process),
                                            _underlyingVolEstimator,
                                            _riskFreeRateEstimator,
-                                           _dividendYieldEstimator);
+                                           _dividendYieldEstimator,
+                                           new[] { OptionStyle.American });
         }
 
         /// <summary>
-        /// Bjerksund and Stensland pricing engine for American options (1993) 
+        /// Bjerksund and Stensland pricing engine for American options (1993)
         /// QuantLib reference: http://quantlib.org/reference/class_quant_lib_1_1_bjerksund_stensland_approximation_engine.html
         /// </summary>
         /// <returns>New option price model instance</returns>
@@ -97,11 +100,12 @@ namespace QuantConnect.Securities.Option
             return new QLOptionPriceModel(process => new BjerksundStenslandApproximationEngine(process),
                                            _underlyingVolEstimator,
                                            _riskFreeRateEstimator,
-                                           _dividendYieldEstimator);
+                                           _dividendYieldEstimator,
+                                           new[] { OptionStyle.American });
         }
 
         /// <summary>
-        /// Pricing engine for European vanilla options using integral approach. 
+        /// Pricing engine for European vanilla options using integral approach.
         /// QuantLib reference: http://quantlib.org/reference/class_quant_lib_1_1_integral_engine.html
         /// </summary>
         /// <returns>New option price model instance</returns>
@@ -110,11 +114,12 @@ namespace QuantConnect.Securities.Option
             return new QLOptionPriceModel(process => new IntegralEngine(process),
                                            _underlyingVolEstimator,
                                            _riskFreeRateEstimator,
-                                           _dividendYieldEstimator);
+                                           _dividendYieldEstimator,
+                                           new[] { OptionStyle.European });
         }
 
         /// <summary>
-        /// Pricing engine for European options using finite-differences. 
+        /// Pricing engine for European options using finite-differences.
         /// QuantLib reference: http://quantlib.org/reference/class_quant_lib_1_1_f_d_european_engine.html
         /// </summary>
         /// <returns>New option price model instance</returns>
@@ -128,7 +133,8 @@ namespace QuantConnect.Securities.Option
             return new QLOptionPriceModel(pricingEngineFunc,
                                            _underlyingVolEstimator,
                                            _riskFreeRateEstimator,
-                                           _dividendYieldEstimator);
+                                           _dividendYieldEstimator,
+                                           new[] { OptionStyle.American, OptionStyle.European });
         }
 
         /// <summary>
@@ -141,7 +147,8 @@ namespace QuantConnect.Securities.Option
             return new QLOptionPriceModel(process => new BinomialVanillaEngine<JarrowRudd>(process, _timeStepsBinomial),
                                           _underlyingVolEstimator,
                                           _riskFreeRateEstimator,
-                                          _dividendYieldEstimator);
+                                          _dividendYieldEstimator,
+                                           new[] { OptionStyle.American, OptionStyle.European });
         }
 
 
@@ -155,7 +162,8 @@ namespace QuantConnect.Securities.Option
             return new QLOptionPriceModel(process => new BinomialVanillaEngine<CoxRossRubinstein>(process, _timeStepsBinomial),
                                           _underlyingVolEstimator,
                                           _riskFreeRateEstimator,
-                                          _dividendYieldEstimator);
+                                          _dividendYieldEstimator,
+                                           new[] { OptionStyle.American, OptionStyle.European });
         }
 
         /// <summary>
@@ -168,7 +176,8 @@ namespace QuantConnect.Securities.Option
             return new QLOptionPriceModel(process => new BinomialVanillaEngine<AdditiveEQPBinomialTree>(process, _timeStepsBinomial),
                                           _underlyingVolEstimator,
                                           _riskFreeRateEstimator,
-                                          _dividendYieldEstimator);
+                                          _dividendYieldEstimator,
+                                           new[] { OptionStyle.American, OptionStyle.European });
         }
 
         /// <summary>
@@ -181,7 +190,8 @@ namespace QuantConnect.Securities.Option
             return new QLOptionPriceModel(process => new BinomialVanillaEngine<Trigeorgis>(process, _timeStepsBinomial),
                                           _underlyingVolEstimator,
                                           _riskFreeRateEstimator,
-                                          _dividendYieldEstimator);
+                                          _dividendYieldEstimator,
+                                           new[] { OptionStyle.American, OptionStyle.European });
         }
 
         /// <summary>
@@ -194,7 +204,8 @@ namespace QuantConnect.Securities.Option
             return new QLOptionPriceModel(process => new BinomialVanillaEngine<Tian>(process, _timeStepsBinomial),
                                           _underlyingVolEstimator,
                                           _riskFreeRateEstimator,
-                                          _dividendYieldEstimator);
+                                          _dividendYieldEstimator,
+                                           new[] { OptionStyle.American, OptionStyle.European });
         }
 
         /// <summary>
@@ -207,7 +218,8 @@ namespace QuantConnect.Securities.Option
             return new QLOptionPriceModel(process => new BinomialVanillaEngine<LeisenReimer>(process, _timeStepsBinomial),
                                           _underlyingVolEstimator,
                                           _riskFreeRateEstimator,
-                                          _dividendYieldEstimator);
+                                          _dividendYieldEstimator,
+                                           new[] { OptionStyle.American, OptionStyle.European });
         }
 
         /// <summary>
@@ -220,7 +232,8 @@ namespace QuantConnect.Securities.Option
             return new QLOptionPriceModel(process => new BinomialVanillaEngine<Joshi4>(process, _timeStepsBinomial),
                                           _underlyingVolEstimator,
                                           _riskFreeRateEstimator,
-                                          _dividendYieldEstimator);
+                                          _dividendYieldEstimator,
+                                           new[] { OptionStyle.American, OptionStyle.European });
         }
 
     }

--- a/Common/Securities/Option/QLOptionPriceModel.cs
+++ b/Common/Securities/Option/QLOptionPriceModel.cs
@@ -48,9 +48,10 @@ namespace QuantConnect.Securities.Option
         public bool VolatilityEstimatorWarmedUp => _underlyingVolEstimator.IsReady;
 
         /// <summary>
-        /// TODO:
+        /// List of option styles supported by the pricing model.
+        /// By default, both American and European option styles are supported.
         /// </summary>
-        public OptionStyle[] AllowedOptionStyles { get; } = new[] { OptionStyle.European };
+        public OptionStyle[] AllowedOptionStyles { get; } = new[] { OptionStyle.European, OptionStyle.American };
 
         /// <summary>
         /// Method constructs QuantLib option price model with necessary estimators of underlying volatility, risk free rate, and underlying dividend yield
@@ -59,6 +60,7 @@ namespace QuantConnect.Securities.Option
         /// <param name="underlyingVolEstimator">The underlying volatility estimator</param>
         /// <param name="riskFreeRateEstimator">The risk free rate estimator</param>
         /// <param name="dividendYieldEstimator">The underlying dividend yield estimator</param>
+        /// <param name="allowedOptionStyles">List of option styles supported by the pricing model. It defaults to both American and European option styles</param>
         public QLOptionPriceModel(PricingEngineFunc pricingEngineFunc, IQLUnderlyingVolatilityEstimator underlyingVolEstimator, IQLRiskFreeRateEstimator riskFreeRateEstimator, IQLDividendYieldEstimator dividendYieldEstimator, OptionStyle[] allowedOptionStyles = null)
         {
             _pricingEngineFunc = (option, process) => pricingEngineFunc(process);
@@ -78,6 +80,7 @@ namespace QuantConnect.Securities.Option
         /// <param name="underlyingVolEstimator">The underlying volatility estimator</param>
         /// <param name="riskFreeRateEstimator">The risk free rate estimator</param>
         /// <param name="dividendYieldEstimator">The underlying dividend yield estimator</param>
+        /// <param name="allowedOptionStyles">List of option styles supported by the pricing model. It defaults to both American and European option styles</param>
         public QLOptionPriceModel(PricingEngineFuncEx pricingEngineFunc, IQLUnderlyingVolatilityEstimator underlyingVolEstimator, IQLRiskFreeRateEstimator riskFreeRateEstimator, IQLDividendYieldEstimator dividendYieldEstimator, OptionStyle[] allowedOptionStyles = null)
         {
             _pricingEngineFunc = pricingEngineFunc;

--- a/Common/Securities/Option/QLOptionPriceModel.cs
+++ b/Common/Securities/Option/QLOptionPriceModel.cs
@@ -31,6 +31,8 @@ namespace QuantConnect.Securities.Option
     /// </summary>
     public class QLOptionPriceModel : IOptionPriceModel
     {
+        private static readonly OptionStyle[] _defaultAllowedOptionStyles = new[] { OptionStyle.European, OptionStyle.American };
+
         private readonly IQLUnderlyingVolatilityEstimator _underlyingVolEstimator;
         private readonly IQLRiskFreeRateEstimator _riskFreeRateEstimator;
         private readonly IQLDividendYieldEstimator _dividendYieldEstimator;
@@ -51,7 +53,7 @@ namespace QuantConnect.Securities.Option
         /// List of option styles supported by the pricing model.
         /// By default, both American and European option styles are supported.
         /// </summary>
-        public OptionStyle[] AllowedOptionStyles { get; } = new[] { OptionStyle.European, OptionStyle.American };
+        public OptionStyle[] AllowedOptionStyles { get; }
 
         /// <summary>
         /// Method constructs QuantLib option price model with necessary estimators of underlying volatility, risk free rate, and underlying dividend yield
@@ -68,10 +70,7 @@ namespace QuantConnect.Securities.Option
             _riskFreeRateEstimator = riskFreeRateEstimator ?? new ConstantQLRiskFreeRateEstimator();
             _dividendYieldEstimator = dividendYieldEstimator ?? new ConstantQLDividendYieldEstimator();
 
-            if (allowedOptionStyles != null)
-            {
-                AllowedOptionStyles = allowedOptionStyles;
-            }
+            AllowedOptionStyles = allowedOptionStyles ?? _defaultAllowedOptionStyles;
         }
         /// <summary>
         /// Method constructs QuantLib option price model with necessary estimators of underlying volatility, risk free rate, and underlying dividend yield
@@ -107,7 +106,7 @@ namespace QuantConnect.Securities.Option
         {
             if (!AllowedOptionStyles.Contains(contract.Symbol.ID.OptionStyle))
             {
-               throw new ArgumentException($"{contract.Symbol.ID.OptionStyle} style options are not supported by this pricing model");
+               throw new ArgumentException($"{contract.Symbol.ID.OptionStyle} style options are not supported by {this.GetType().Name}");
             }
 
             try

--- a/Tests/Common/Securities/OptionPriceModelTests.cs
+++ b/Tests/Common/Securities/OptionPriceModelTests.cs
@@ -26,6 +26,7 @@ using Moq;
 using QLNet;
 using Cash = QuantConnect.Securities.Cash;
 using Option = QuantConnect.Securities.Option.Option;
+using Log = QuantConnect.Logging.Log;
 
 namespace QuantConnect.Tests.Common
 {
@@ -317,6 +318,22 @@ namespace QuantConnect.Tests.Common
             {
                 Assert.DoesNotThrow(call);
                 Assert.DoesNotThrow(put);
+
+                var results = priceModel.Evaluate(optionCall, null, contractCall);
+                var greeks = results.Greeks;
+
+                Assert.That(greeks.Delta, Is.InRange(0, 1m));
+                Assert.Less(greeks.Theta, 0);
+                Assert.Greater(greeks.Rho, 0m);
+                Assert.Greater(greeks.Vega, 0m);
+
+                results = priceModel.Evaluate(optionPut, null, contractPut);
+                greeks = results.Greeks;
+
+                Assert.That(greeks.Delta, Is.InRange(-1m, 0));
+                Assert.Less(greeks.Theta, 0);
+                Assert.Less(greeks.Rho, 0m);
+                Assert.Greater(greeks.Vega, 0m);
             }
         }
 

--- a/Tests/Common/Securities/OptionPriceModelTests.cs
+++ b/Tests/Common/Securities/OptionPriceModelTests.cs
@@ -41,44 +41,20 @@ namespace QuantConnect.Tests.Common
             const decimal riskFreeRate = 0.01m;
             var tz = TimeZones.NewYork;
             var evaluationDate = new DateTime(2015, 2, 19);
-            var SPY_C_192_Feb19_2016E = Symbol.CreateOption("SPY", Market.USA, OptionStyle.European, OptionRight.Call, 192m, new DateTime(2016, 02, 19));
-            var SPY_P_192_Feb19_2016E = Symbol.CreateOption("SPY", Market.USA, OptionStyle.European, OptionRight.Put, 192m, new DateTime(2016, 02, 19));
+            var spy = Symbols.SPY;
+            var SPY_C_192_Feb19_2016E = GetOptionSymbol(spy, OptionStyle.European, OptionRight.Call);
+            var SPY_P_192_Feb19_2016E = GetOptionSymbol(spy, OptionStyle.European, OptionRight.Put);
 
             // setting up underlying
-            var equity = new Equity(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
-                new Cash(Currencies.USD, 0, 1m),
-                SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
-            equity.SetMarketPrice(new Tick { Value = underlyingPrice });
-            equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
+            var equity = GetEquity(spy, underlyingPrice, underlyingVol, tz);
 
             // setting up European style call option
-            var contractCall = new OptionContract(SPY_C_192_Feb19_2016E, Symbols.SPY) { Time = evaluationDate };
-            var optionCall = new Option(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(typeof(TradeBar), SPY_C_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false),
-                new Cash(Currencies.USD, 0, 1m),
-                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
-            optionCall.Underlying = equity;
+            var contractCall = GetOptionContract(SPY_C_192_Feb19_2016E, spy, evaluationDate);
+            var optionCall = GetOption(SPY_C_192_Feb19_2016E, equity, tz);
 
             // setting up European style put option
-            var contractPut = new OptionContract(SPY_P_192_Feb19_2016E, Symbols.SPY) { Time = evaluationDate };
-            var optionPut = new Option(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(typeof(TradeBar), SPY_P_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false),
-                new Cash(Currencies.USD, 0, 1m),
-                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
-            optionPut.Underlying = equity;
+            var contractPut = GetOptionContract(SPY_P_192_Feb19_2016E, spy, evaluationDate);
+            var optionPut = GetOption(SPY_P_192_Feb19_2016E, equity, tz);
 
             // running evaluation
             var priceModel = OptionPriceModels.BlackScholes();
@@ -103,32 +79,16 @@ namespace QuantConnect.Tests.Common
             const decimal riskFreeRate = 0.01m;
             var tz = TimeZones.NewYork;
             var evaluationDate = new DateTime(2015, 2, 19);
-            var SPY_C_192_Feb19_2016E = Symbol.CreateOption("SPY", Market.USA, OptionStyle.European, OptionRight.Call, 192m, new DateTime(2016, 02, 19));
+            var spy = Symbols.SPY;
+            var SPY_C_192_Feb19_2016E = GetOptionSymbol(spy, OptionStyle.European, OptionRight.Call);
 
             // setting up underlying
-            var equity = new Equity(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
-                new Cash(Currencies.USD, 0, 1m),
-                SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
-            equity.SetMarketPrice(new Tick { Value = underlyingPrice });
-            equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
+            var equity = GetEquity(spy, underlyingPrice, underlyingVol, tz);
 
-            // setting up European style option
-            var contract = new OptionContract(SPY_C_192_Feb19_2016E, Symbols.SPY) { Time = evaluationDate };
-            var optionCall = new Option(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(typeof(TradeBar), SPY_C_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false),
-                new Cash(Currencies.USD, 0, 1m),
-                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
+            // setting up European style call option
+            var contract = GetOptionContract(SPY_C_192_Feb19_2016E, spy, evaluationDate);
+            var optionCall = GetOption(SPY_C_192_Feb19_2016E, equity, tz);
             optionCall.SetMarketPrice(new Tick { Value = price });
-            optionCall.Underlying = equity;
 
             // running evaluation
             var priceModel = OptionPriceModels.BlackScholes();
@@ -151,39 +111,15 @@ namespace QuantConnect.Tests.Common
             const decimal underlyingVol = 0.25m;
             const decimal riskFreeRate = 0.01m;
             var tz = TimeZones.NewYork;
+            var spy = Symbols.SPY;
             var evaluationDate = new DateTime(2015, 2, 19);
+            var SPY_C_192_Feb19_2016E = GetOptionSymbol(spy, OptionStyle.American, OptionRight.Call);
 
-            var equity = new Equity(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
-                new Cash(Currencies.USD, 0, 1m),
-                SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
-            equity.SetMarketPrice(new Tick { Value = underlyingPrice });
-            equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
+            var equity = GetEquity(spy, underlyingPrice, underlyingVol, tz);
 
             var contract = new OptionContract(Symbols.SPY_C_192_Feb19_2016, Symbols.SPY) { Time = evaluationDate };
-            var optionCall = new Option(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(
-                    typeof(TradeBar),
-                    Symbols.SPY_C_192_Feb19_2016,
-                    Resolution.Minute,
-                    tz,
-                    tz,
-                    true,
-                    false,
-                    false
-                ),
-                new Cash(Currencies.USD, 0, 1m),
-                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
+            var optionCall = GetOption(SPY_C_192_Feb19_2016E, equity, tz);
             optionCall.SetMarketPrice(new Tick { Value = price });
-            optionCall.Underlying = equity;
 
             var priceModel = OptionPriceModels.BaroneAdesiWhaley();
             var results = priceModel.Evaluate(optionCall, null, contract);
@@ -209,40 +145,16 @@ namespace QuantConnect.Tests.Common
             const decimal underlyingPrice = 200m;
             const decimal underlyingVol = 0.25m;
             var tz = TimeZones.NewYork;
+            var spy = Symbols.SPY;
             var evaluationDate1 = new DateTime(2015, 2, 19);
             var evaluationDate2 = new DateTime(2015, 2, 20);
+            var SPY_C_192_Feb19_2016E = GetOptionSymbol(spy, OptionStyle.American, OptionRight.Call);
 
-            var equity = new Equity(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
-                new Cash(Currencies.USD, 0, 1m),
-                SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
-            equity.SetMarketPrice(new Tick { Value = underlyingPrice });
-            equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
+            var equity = GetEquity(spy, underlyingPrice, underlyingVol, tz);
 
-            var contract = new OptionContract(Symbols.SPY_C_192_Feb19_2016, Symbols.SPY) { Time = evaluationDate1 };
-            var optionCall = new Option(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(
-                    typeof(TradeBar),
-                    Symbols.SPY_C_192_Feb19_2016,
-                    Resolution.Minute,
-                    tz,
-                    tz,
-                    true,
-                    false,
-                    false
-                ),
-                new Cash(Currencies.USD, 0, 1m),
-                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
+            var contract = GetOptionContract(SPY_C_192_Feb19_2016E, spy, evaluationDate1);
+            var optionCall = GetOption(SPY_C_192_Feb19_2016E, equity, tz);
             optionCall.SetMarketPrice(new Tick { Value = price });
-            optionCall.Underlying = equity;
 
             var priceModel = OptionPriceModels.BaroneAdesiWhaley();
             var results = priceModel.Evaluate(optionCall, null, contract);
@@ -279,38 +191,14 @@ namespace QuantConnect.Tests.Common
             const decimal underlyingVol = 0.15m;
             var tz = TimeZones.NewYork;
             var evaluationDate = new DateTime(2016, 1, 19);
+            var spy = Symbols.SPY;
 
-            var equity = new Equity(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
-                new Cash(Currencies.USD, 0, 1m),
-                SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
-            equity.SetMarketPrice(new Tick { Value = underlyingPrice });
-            equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
+            var equity = GetEquity(spy, underlyingPrice, underlyingVol, tz);
 
-            var contract = new OptionContract(Symbols.SPY_P_192_Feb19_2016, Symbols.SPY) { Time = evaluationDate };
-            var optionPut = new Option(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(
-                    typeof(TradeBar),
-                    Symbols.SPY_P_192_Feb19_2016,
-                    Resolution.Minute,
-                    tz,
-                    tz,
-                    true,
-                    false,
-                    false
-                ),
-                new Cash(Currencies.USD, 0, 1m),
-                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
+            var contract = GetOptionContract(Symbols.SPY_P_192_Feb19_2016, spy, evaluationDate);
+
+            var optionPut = GetOption(Symbols.SPY_P_192_Feb19_2016, equity, tz);
             optionPut.SetMarketPrice(new Tick { Value = price });
-            optionPut.Underlying = equity;
 
             var priceModel = (QLOptionPriceModel)OptionPriceModels.CrankNicolsonFD();
             priceModel.EnableGreekApproximation = false;
@@ -356,44 +244,20 @@ namespace QuantConnect.Tests.Common
             const decimal underlyingVol = 0.15m;
             var tz = TimeZones.NewYork;
             var evaluationDate = new DateTime(2015, 2, 19);
-            var SPY_C_192_Feb19_2016E = Symbol.CreateOption("SPY", Market.USA, OptionStyle.European, OptionRight.Call, 192m, new DateTime(2016, 02, 19));
-            var SPY_P_192_Feb19_2016E = Symbol.CreateOption("SPY", Market.USA, OptionStyle.European, OptionRight.Put, 192m, new DateTime(2016, 02, 19));
+            var spy = Symbols.SPY;
+            var SPY_C_192_Feb19_2016E = GetOptionSymbol(spy, OptionStyle.European, OptionRight.Call);
+            var SPY_P_192_Feb19_2016E = GetOptionSymbol(spy, OptionStyle.European, OptionRight.Put);
 
             // setting up underlying
-            var equity = new Equity(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, tz, tz, true, false, false),
-                new Cash(Currencies.USD, 0, 1m),
-                SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
-            equity.SetMarketPrice(new Tick { Value = underlyingPrice });
-            equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
+            var equity = GetEquity(spy, underlyingPrice, underlyingVol, tz);
 
             // setting up European style call option
-            var contractCall = new OptionContract(SPY_C_192_Feb19_2016E, Symbols.SPY) { Time = evaluationDate };
-            var optionCall = new Option(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(typeof(TradeBar), SPY_C_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false),
-                new Cash(Currencies.USD, 0, 1m),
-                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
-            optionCall.Underlying = equity;
+            var contractCall = GetOptionContract(SPY_C_192_Feb19_2016E, spy, evaluationDate);
+            var optionCall = GetOption(SPY_C_192_Feb19_2016E, equity, tz);
 
             // setting up European style put option
-            var contractPut = new OptionContract(SPY_P_192_Feb19_2016E, Symbols.SPY) { Time = evaluationDate };
-            var optionPut = new Option(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(typeof(TradeBar), SPY_P_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false),
-                new Cash(Currencies.USD, 0, 1m),
-                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
-            optionPut.Underlying = equity;
+            var contractPut = GetOptionContract(SPY_P_192_Feb19_2016E, spy, evaluationDate);
+            var optionPut = GetOption(SPY_P_192_Feb19_2016E, equity, tz);
 
             // running evaluation
             var volatilityModel = new Mock<IQLUnderlyingVolatilityEstimator>();
@@ -425,44 +289,19 @@ namespace QuantConnect.Tests.Common
             var tz = TimeZones.NewYork;
             var evaluationDate = new DateTime(2015, 2, 19);
             var spy = Symbols.SPY;
-            var SPY_C_192_Feb19_2016E = Symbol.CreateOption(spy.Value, Market.USA, optionStyle, OptionRight.Call, 192m, new DateTime(2016, 02, 19));
-            var SPY_P_192_Feb19_2016E = Symbol.CreateOption(spy.Value, Market.USA, optionStyle, OptionRight.Put, 192m, new DateTime(2016, 02, 19));
+            var SPY_C_192_Feb19_2016E = GetOptionSymbol(spy, optionStyle, OptionRight.Call);
+            var SPY_P_192_Feb19_2016E = GetOptionSymbol(spy, optionStyle, OptionRight.Put);
 
             // setting up underlying
-            var equity = new Equity(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(typeof(TradeBar), spy, Resolution.Minute, tz, tz, true, false, false),
-                new Cash(Currencies.USD, 0, 1m),
-                SymbolProperties.GetDefault(Currencies.USD),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
-            equity.SetMarketPrice(new Tick { Value = underlyingPrice });
-            equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
+            var equity = GetEquity(spy, underlyingPrice, underlyingVol, tz);
 
             // setting up European style call option
-            var contractCall = new OptionContract(SPY_C_192_Feb19_2016E, spy) { Time = evaluationDate };
-            var optionCall = new Option(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(typeof(TradeBar), SPY_C_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false),
-                new Cash(Currencies.USD, 0, 1m),
-                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
-            optionCall.Underlying = equity;
+            var contractCall = GetOptionContract(SPY_C_192_Feb19_2016E, spy, evaluationDate);
+            var optionCall = GetOption(SPY_C_192_Feb19_2016E, equity, tz);
 
             // setting up European style put option
-            var contractPut = new OptionContract(SPY_P_192_Feb19_2016E, spy) { Time = evaluationDate };
-            var optionPut = new Option(
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new SubscriptionDataConfig(typeof(TradeBar), SPY_P_192_Feb19_2016E, Resolution.Minute, tz, tz, true, false, false),
-                new Cash(Currencies.USD, 0, 1m),
-                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null
-            );
-            optionPut.Underlying = equity;
+            var contractPut = GetOptionContract(SPY_P_192_Feb19_2016E, spy, evaluationDate);
+            var optionPut = GetOption(SPY_P_192_Feb19_2016E, equity, tz);
 
             // running evaluation
             var priceModel = (IOptionPriceModel)typeof(OptionPriceModels).GetMethod(qlModelName).Invoke(null, new object[]{});
@@ -479,6 +318,47 @@ namespace QuantConnect.Tests.Common
                 Assert.DoesNotThrow(call);
                 Assert.DoesNotThrow(put);
             }
+        }
+
+        private Symbol GetOptionSymbol(Symbol underlying, OptionStyle optionStyle, OptionRight optionRight)
+        {
+            return Symbol.CreateOption(underlying.Value, Market.USA, optionStyle, optionRight, 192m, new DateTime(2016, 02, 19));
+        }
+
+        private Equity GetEquity(Symbol symbol, decimal underlyingPrice, decimal underlyingVol, NodaTime.DateTimeZone tz)
+        {
+            var equity = new Equity(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
+            );
+            equity.SetMarketPrice(new Tick { Value = underlyingPrice });
+            equity.VolatilityModel = new DummyVolatilityModel(underlyingVol);
+
+            return equity;
+        }
+
+        public OptionContract GetOptionContract(Symbol symbol, Symbol underlying, DateTime evaluationDate)
+        {
+            return new OptionContract(symbol, underlying) { Time = evaluationDate };
+        }
+
+        public Option GetOption(Symbol symbol, Equity underlying, NodaTime.DateTimeZone tz)
+        {
+            var option = new Option(
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, tz, tz, true, false, false),
+                new Cash(Currencies.USD, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
+            );
+            option.Underlying = underlying;
+
+            return option;
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description

When using a `QLOptionPriceModel` for an unsupported option style (like `BlackScholes` or `Integral` for an American style option), price estimation and greeks calculation by QLNet fails by throwing an exception. In this case, option price calculation was defaulting to 0 (which lead to greeks having an invalid value of 0) instead of detecting and communicating the issue. Now the unsupported option style is detected and communicated. On the other hand, using `BlackScholes` or `Integral` for European style options does calculate valid greeks.

#### Related Issue

Closes #4520 

#### Motivation and Context

Using `QLOptionPriceModel` for an unsupported option style (like `BlackScholes` or `Integral` for an American style option) was defaulting option price estimation to 0 and by extension assigning 0 to greeks. Ideally, the problem is detected and communicated.

#### Requires Documentation Change

This issue does not require documentation changes.

#### How Has This Been Tested?

- Asserting that option price evaluation (`OptionPriceModel.Evaluate()`) throws for an unsuported option style (like `BlackScholes` for American style options).
- Asserting that option price evaluation (`OptionPriceModel.Evaluate()`) does not throws for a suported option style (like `BlackScholes` for European style options).

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
