### PR TITLE
Live Internal Subscription Start Time During Warmup

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2094,8 +2094,11 @@ namespace QuantConnect.Algorithm
                 return false;
             }
 
-            // cancel open orders
-            Transactions.CancelOpenOrders(security.Symbol);
+            if (!IsWarmingUp)
+            {
+                // cancel open orders
+                Transactions.CancelOpenOrders(security.Symbol);
+            }
 
             // liquidate if invested
             if (security.Invested)

--- a/Engine/DataFeeds/InternalSubscriptionManager.cs
+++ b/Engine/DataFeeds/InternalSubscriptionManager.cs
@@ -72,7 +72,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     // low resolution subscriptions we will add internal Resolution.Minute subscriptions
                     // if we don't already have this symbol added
                     var config = new SubscriptionDataConfig(request.Configuration, resolution: _resolution, isInternalFeed: true, extendedHours: true, isFilteredSubscription: false);
-                    var internalRequest = new SubscriptionRequest(false, null, request.Security, config, request.StartTimeUtc, request.EndTimeUtc);
+                    var startTimeUtc = request.StartTimeUtc;
+                    if (_algorithm.IsWarmingUp)
+                    {
+                        // during warmup in live trading do not add these internal subscription until the algorithm starts
+                        // these subscription are only added for realtime price in low resolution subscriptions which isn't required for warmup
+                        startTimeUtc = DateTime.UtcNow;
+                    }
+                    var internalRequest = new SubscriptionRequest(false, null, request.Security, config, startTimeUtc, request.EndTimeUtc);
                     if (existing)
                     {
                         _subscriptionRequests[request.Configuration.Symbol].Add(internalRequest);

--- a/Tests/Engine/DataFeeds/InternalSubscriptionManagerTests.cs
+++ b/Tests/Engine/DataFeeds/InternalSubscriptionManagerTests.cs
@@ -60,13 +60,18 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         }
 
         [TestCaseSource(nameof(DataTypeTestCases))]
-        public void CreatesSubscriptions(SubscriptionRequest subscriptionRequest, bool liveMode, bool expectNewSubscription)
+        public void CreatesSubscriptions(SubscriptionRequest subscriptionRequest, bool liveMode, bool expectNewSubscription, bool isWarmup)
         {
             _algorithm.SetLiveMode(liveMode);
+            if (isWarmup)
+            {
+                _algorithm.SetWarmUp(10, Resolution.Daily);
+            }
+            _algorithm.PostInitialize();
 
             var added = false;
             var start = DateTime.UtcNow;
-            var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            using var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(15));
             foreach (var timeSlice in _synchronizer.StreamData(tokenSource.Token))
             {
                 if (!added)
@@ -84,6 +89,12 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
                     if (expectNewSubscription)
                     {
+                        var utcStartTime = _dataManager.DataFeedSubscriptions
+                            .Where(subscription => subscription.Configuration.IsInternalFeed && subscription.Configuration.Symbol == Symbols.BTCUSD)
+                            .Select(subscription => subscription.UtcStartTime)
+                            .First();
+                        Assert.Greater(utcStartTime.Ticks, start.Ticks);
+
                         // let's wait for a data point
                         if (timeSlice.DataPointCount > 0)
                         {
@@ -110,18 +121,23 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         }
 
         [TestCaseSource(nameof(DataTypeTestCases))]
-        public void RemoveSubscriptions(SubscriptionRequest subscriptionRequest, bool liveMode, bool expectNewSubscription)
+        public void RemoveSubscriptions(SubscriptionRequest subscriptionRequest, bool liveMode, bool expectNewSubscription, bool isWarmup)
         {
-            _algorithm.SetLiveMode(liveMode);
             if (!expectNewSubscription)
             {
                 // we only test cases where we expect an internal subscription
                 return;
             }
+            _algorithm.SetLiveMode(liveMode);
+            if (isWarmup)
+            {
+                _algorithm.SetWarmUp(10, Resolution.Daily);
+            }
+            _algorithm.PostInitialize();
             var added = false;
             var shouldRemoved = false;
             var count = 0;
-            var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            using var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(15));
             foreach (var timeSlice in _synchronizer.StreamData(tokenSource.Token))
             {
                 if (!added)
@@ -163,15 +179,16 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             dataQueueTest.ManualTimeProvider.SetCurrentTimeUtc(new DateTime(2020, 09, 03, 10, 0, 0));
             TearDown();
             var liveSynchronizer = new TestableLiveSynchronizer(dataQueueTest.ManualTimeProvider);
-            var dataAggregator = new TestAggregationManager(dataQueueTest.ManualTimeProvider);
+            using var dataAggregator = new TestAggregationManager(dataQueueTest.ManualTimeProvider);
             SetupImpl(dataQueueTest, liveSynchronizer, dataAggregator);
 
             _algorithm.SetDateTime(dataQueueTest.ManualTimeProvider.GetUtcNow());
             _algorithm.SetLiveMode(true);
+            _algorithm.PostInitialize();
             var added = false;
             var first = true;
             var internalDataCount = 0;
-            var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             foreach (var timeSlice in _synchronizer.StreamData(tokenSource.Token))
             {
                 dataQueueTest.ManualTimeProvider.AdvanceSeconds(60);
@@ -230,11 +247,12 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void UniverseSelectionAddAndRemove()
         {
             _algorithm.SetLiveMode(true);
+            _algorithm.PostInitialize();
             _algorithm.UniverseSettings.Resolution = Resolution.Hour;
             _algorithm.UniverseSettings.MinimumTimeInUniverse = TimeSpan.Zero;
             var added = false;
-            var manualEvent = new ManualResetEvent(false);
-            var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            using var manualEvent = new ManualResetEvent(false);
+            using var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(15));
             foreach (var timeSlice in _synchronizer.StreamData(tokenSource.Token))
             {
                 if (!added)
@@ -285,18 +303,21 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             {
                 var result = new List<TestCaseData>();
                 var config = GetConfig(Symbols.BTCUSD, Resolution.Second);
-                result.Add(new TestCaseData(new SubscriptionRequest(false, null, CreateSecurity(config), config, DateTime.UtcNow, DateTime.UtcNow), true, false));
+                result.Add(new TestCaseData(new SubscriptionRequest(false, null, CreateSecurity(config), config, DateTime.UtcNow, DateTime.UtcNow), true, false, false));
 
                 config = GetConfig(Symbols.BTCUSD, Resolution.Minute);
-                result.Add(new TestCaseData(new SubscriptionRequest(false, null, CreateSecurity(config), config, DateTime.UtcNow, DateTime.UtcNow), true, false));
+                result.Add(new TestCaseData(new SubscriptionRequest(false, null, CreateSecurity(config), config, DateTime.UtcNow, DateTime.UtcNow), true, false, false));
 
                 config = GetConfig(Symbols.BTCUSD, Resolution.Hour);
-                result.Add(new TestCaseData(new SubscriptionRequest(false, null, CreateSecurity(config), config, DateTime.UtcNow, DateTime.UtcNow), true, true));
+                result.Add(new TestCaseData(new SubscriptionRequest(false, null, CreateSecurity(config), config, DateTime.UtcNow, DateTime.UtcNow), true, true, false));
 
                 config = GetConfig(Symbols.BTCUSD, Resolution.Daily);
-                result.Add(new TestCaseData(new SubscriptionRequest(false, null, CreateSecurity(config), config, DateTime.UtcNow, DateTime.UtcNow), true, true));
+                result.Add(new TestCaseData(new SubscriptionRequest(false, null, CreateSecurity(config), config, DateTime.UtcNow, DateTime.UtcNow), true, true, false));
 
-                result.Add(new TestCaseData(new SubscriptionRequest(false, null, CreateSecurity(config), config, DateTime.UtcNow, DateTime.UtcNow), false, false));
+                config = GetConfig(Symbols.BTCUSD, Resolution.Daily);
+                result.Add(new TestCaseData(new SubscriptionRequest(false, null, CreateSecurity(config), config, DateTime.UtcNow, DateTime.UtcNow), true, true, true));
+
+                result.Add(new TestCaseData(new SubscriptionRequest(false, null, CreateSecurity(config), config, DateTime.UtcNow, DateTime.UtcNow), false, false, false));
 
                 return result.ToArray();
             }
@@ -331,7 +352,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             _dataFeed = new TestableLiveTradingDataFeed(dataQueueHandler ?? new FakeDataQueue(dataAggregator ?? new AggregationManager()));
             _algorithm = new AlgorithmStub(createDataManager: false);
             _synchronizer = synchronizer ?? new LiveSynchronizer();
-
+            _algorithm.SetStartDate(new DateTime(2022, 04, 13));
 
             var registeredTypesProvider = new RegisteredSecurityDataTypesProvider();
             var securityService = new SecurityService(_algorithm.Portfolio.CashBook,
@@ -364,13 +385,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 new DataChannelProvider());
             _algorithm.SubscriptionManager.SetDataManager(_dataManager);
             _algorithm.Securities.SetSecurityService(securityService);
-            _algorithm.SetFinishedWarmingUp();
             var backtestingTransactionHandler = new BacktestingTransactionHandler();
             backtestingTransactionHandler.Initialize(_algorithm, new PaperBrokerage(_algorithm, new LiveNodePacket()), _resultHandler);
             _algorithm.Transactions.SetOrderProcessor(backtestingTransactionHandler);
-
-            _algorithm.SetDateTime(new DateTime(2022, 04, 13));
-            _algorithm.PostInitialize();
         }
         private class TestAggregationManager : AggregationManager
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Live Trading internal subscription start time will be after warmup.
  Adding unit tests reproducing issue.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
During live trading, these internal subscriptions are added to provide real time data, but during warmup we have no need for them
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests, live trading
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
