### PR TITLE
Reconcile the Market Open and Close for Futures and Scheduled Events

### DIFF
--- a/Algorithm.CSharp/FutureOptionBuySellCallIntradayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionBuySellCallIntradayRegressionAlgorithm.cs
@@ -141,14 +141,14 @@ namespace QuantConnect.Algorithm.CSharp
             {"Win Rate", "50%"},
             {"Profit-Loss Ratio", "0.71"},
             {"Alpha", "-0.036"},
-            {"Beta", "-0.012"},
+            {"Beta", "-0.013"},
             {"Annual Standard Deviation", "0.08"},
             {"Annual Variance", "0.006"},
             {"Information Ratio", "-0.149"},
             {"Tracking Error", "0.387"},
-            {"Treynor Ratio", "2.943"},
+            {"Treynor Ratio", "2.865"},
             {"Total Fees", "$3.70"},
-            {"Estimated Strategy Capacity", "$280000000.00"},
+            {"Estimated Strategy Capacity", "$140000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UPBIJ7O|ES XFH59UK0MYO1"},
             {"Fitness Score", "0.017"},
             {"Kelly Criterion Estimate", "0"},
@@ -169,7 +169,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "18f8a17034aa12be40581baecca96788"}
+            {"OrderListHash", "1f521247474162d17ff94fbaa654385b"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallITMExpiryRegressionAlgorithm.cs
@@ -225,14 +225,14 @@ namespace QuantConnect.Algorithm.CSharp
             {"Win Rate", "50%"},
             {"Profit-Loss Ratio", "0.17"},
             {"Alpha", "-0.086"},
-            {"Beta", "0.004"},
+            {"Beta", "0.003"},
             {"Annual Standard Deviation", "0.07"},
             {"Annual Variance", "0.005"},
             {"Information Ratio", "-0.283"},
             {"Tracking Error", "0.379"},
-            {"Treynor Ratio", "-23.811"},
+            {"Treynor Ratio", "-25.997"},
             {"Total Fees", "$1.85"},
-            {"Estimated Strategy Capacity", "$270000000.00"},
+            {"Estimated Strategy Capacity", "$140000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UPBIJ7O|ES XFH59UK0MYO1"},
             {"Fitness Score", "0.008"},
             {"Kelly Criterion Estimate", "0"},
@@ -253,7 +253,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "b738fdaf1dae6849884df9e51eb6482b"}
+            {"OrderListHash", "c61ac689d112eab8fde5f2b1f715b7d3"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallOTMExpiryRegressionAlgorithm.cs
@@ -205,9 +205,9 @@ namespace QuantConnect.Algorithm.CSharp
             {"Annual Variance", "0.002"},
             {"Information Ratio", "-0.206"},
             {"Tracking Error", "0.376"},
-            {"Treynor Ratio", "-23.481"},
+            {"Treynor Ratio", "-23.833"},
             {"Total Fees", "$1.85"},
-            {"Estimated Strategy Capacity", "$200000000.00"},
+            {"Estimated Strategy Capacity", "$99000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UPHGV9G|ES XFH59UK0MYO1"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
@@ -228,7 +228,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "cf1c12b839e49456dc2793f0e63c7803"}
+            {"OrderListHash", "498c9958139b70d42ebecc65c4eceeee"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionPutITMExpiryRegressionAlgorithm.cs
@@ -231,9 +231,9 @@ namespace QuantConnect.Algorithm.CSharp
             {"Annual Variance", "0.002"},
             {"Information Ratio", "-0.221"},
             {"Tracking Error", "0.376"},
-            {"Treynor Ratio", "-24.544"},
+            {"Treynor Ratio", "-28.081"},
             {"Total Fees", "$1.85"},
-            {"Estimated Strategy Capacity", "$330000000.00"},
+            {"Estimated Strategy Capacity", "$170000000.00"},
             {"Lowest Capacity Asset", "ES 31EL5FAOOQON8|ES XFH59UK0MYO1"},
             {"Fitness Score", "0.008"},
             {"Kelly Criterion Estimate", "0"},
@@ -254,7 +254,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "99f96f433bc76c31cb25bcd9117a6bf1"}
+            {"OrderListHash", "1d90a4ed7fc218fe364435359358b2d5"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionPutOTMExpiryRegressionAlgorithm.cs
@@ -204,9 +204,9 @@ namespace QuantConnect.Algorithm.CSharp
             {"Annual Variance", "0.004"},
             {"Information Ratio", "-0.243"},
             {"Tracking Error", "0.378"},
-            {"Treynor Ratio", "-23.284"},
+            {"Treynor Ratio", "-23.592"},
             {"Total Fees", "$1.85"},
-            {"Estimated Strategy Capacity", "$360000000.00"},
+            {"Estimated Strategy Capacity", "$180000000.00"},
             {"Lowest Capacity Asset", "ES 31EL5FBZBMXES|ES XFH59UK0MYO1"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
@@ -227,7 +227,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "ec799886c15ac6c4b8fb3d873d7e6b14"}
+            {"OrderListHash", "76a3f4adc886f92b2f996d7e45e77dad"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionShortCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortCallITMExpiryRegressionAlgorithm.cs
@@ -210,14 +210,14 @@ namespace QuantConnect.Algorithm.CSharp
             {"Win Rate", "50%"},
             {"Profit-Loss Ratio", "1.79"},
             {"Alpha", "0.057"},
-            {"Beta", "-0.002"},
+            {"Beta", "-0.003"},
             {"Annual Standard Deviation", "0.053"},
             {"Annual Variance", "0.003"},
             {"Information Ratio", "0.094"},
             {"Tracking Error", "0.379"},
-            {"Treynor Ratio", "-23.276"},
+            {"Treynor Ratio", "-20.601"},
             {"Total Fees", "$1.85"},
-            {"Estimated Strategy Capacity", "$300000000.00"},
+            {"Estimated Strategy Capacity", "$150000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UP5K75W|ES XFH59UK0MYO1"},
             {"Fitness Score", "0.02"},
             {"Kelly Criterion Estimate", "0"},
@@ -238,7 +238,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "8a33f32b29bcc66d4dd779b36df9a010"}
+            {"OrderListHash", "5358f87044d3f8dc5d67cb7362b12cea"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionShortCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortCallOTMExpiryRegressionAlgorithm.cs
@@ -198,9 +198,9 @@ namespace QuantConnect.Algorithm.CSharp
             {"Annual Variance", "0"},
             {"Information Ratio", "0.012"},
             {"Tracking Error", "0.375"},
-            {"Treynor Ratio", "-24.052"},
+            {"Treynor Ratio", "-23.475"},
             {"Total Fees", "$1.85"},
-            {"Estimated Strategy Capacity", "$78000000.00"},
+            {"Estimated Strategy Capacity", "$39000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UPNF7B8|ES XFH59UK0MYO1"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
@@ -221,7 +221,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "8cb012d36057103bf26a897fe5fa54d6"}
+            {"OrderListHash", "3e2637348e4985e9398811e0a9ba62ff"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionShortPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortPutITMExpiryRegressionAlgorithm.cs
@@ -212,9 +212,9 @@ namespace QuantConnect.Algorithm.CSharp
             {"Annual Variance", "0.001"},
             {"Information Ratio", "-0.006"},
             {"Tracking Error", "0.375"},
-            {"Treynor Ratio", "-20.61"},
+            {"Treynor Ratio", "-15.363"},
             {"Total Fees", "$1.85"},
-            {"Estimated Strategy Capacity", "$200000000.00"},
+            {"Estimated Strategy Capacity", "$100000000.00"},
             {"Lowest Capacity Asset", "ES 31EL5FAOUP0P0|ES XFH59UK0MYO1"},
             {"Fitness Score", "0.021"},
             {"Kelly Criterion Estimate", "0"},
@@ -235,7 +235,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "eb37251ad1e32dd348af8a69e1888053"}
+            {"OrderListHash", "e8b27b23cb2bc65318696257af42b82e"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionShortPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortPutOTMExpiryRegressionAlgorithm.cs
@@ -197,9 +197,9 @@ namespace QuantConnect.Algorithm.CSharp
             {"Annual Variance", "0.002"},
             {"Information Ratio", "0.07"},
             {"Tracking Error", "0.377"},
-            {"Treynor Ratio", "-24.401"},
+            {"Treynor Ratio", "-24.023"},
             {"Total Fees", "$1.85"},
-            {"Estimated Strategy Capacity", "$80000000.00"},
+            {"Estimated Strategy Capacity", "$40000000.00"},
             {"Lowest Capacity Asset", "ES 31EL5FAJQ6SBO|ES XFH59UK0MYO1"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
@@ -220,7 +220,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "76ed4eaa5f6ed50aa6134aecfbbe9e29"}
+            {"OrderListHash", "9213af45c30119e0a53c3b57d3c553de"}
         };
     }
 }

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -935,8 +935,20 @@ namespace QuantConnect.Algorithm
                 }
             }
 
-            if (request.OrderType == OrderType.MarketOnClose)
+            if (request.OrderType == OrderType.MarketOnOpen)
             {
+                if (security.Exchange.Hours.IsMarketAlwaysOpen)
+                {
+                    throw new InvalidOperationException($"Market never closes for this symbol {security.Symbol}, can no submit a {nameof(OrderType.MarketOnOpen)} order.");
+                }
+            }
+            else if (request.OrderType == OrderType.MarketOnClose)
+            {
+                if (security.Exchange.Hours.IsMarketAlwaysOpen)
+                {
+                    throw new InvalidOperationException($"Market never closes for this symbol {security.Symbol}, can no submit a {nameof(OrderType.MarketOnClose)} order.");
+                }
+
                 var nextMarketClose = security.Exchange.Hours.GetNextMarketClose(security.LocalTime, false);
 
                 // Enforce MarketOnClose submission buffer

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -478,6 +478,11 @@ namespace QuantConnect.Orders.Fills
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
         public virtual OrderEvent MarketOnOpenFill(Security asset, MarketOnOpenOrder order)
         {
+            if (asset.Exchange.Hours.IsMarketAlwaysOpen)
+            {
+                throw new InvalidOperationException($"Market never closes for this symbol {asset.Symbol}, can no submit a {nameof(OrderType.MarketOnOpen)} order.");
+            }
+
             var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
             var fill = new OrderEvent(order, utcTime, OrderFee.Zero);
 
@@ -534,6 +539,11 @@ namespace QuantConnect.Orders.Fills
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
         public virtual OrderEvent MarketOnCloseFill(Security asset, MarketOnCloseOrder order)
         {
+            if (asset.Exchange.Hours.IsMarketAlwaysOpen)
+            {
+                throw new InvalidOperationException($"Market never closes for this symbol {asset.Symbol}, can no submit a {nameof(OrderType.MarketOnClose)} order.");
+            }
+
             var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
             var fill = new OrderEvent(order, utcTime, OrderFee.Zero);
 

--- a/Common/Scheduling/TimeRules.cs
+++ b/Common/Scheduling/TimeRules.cs
@@ -165,8 +165,9 @@ namespace QuantConnect.Scheduling
             var timeAfterOpen = TimeSpan.FromMinutes(minutesAfterOpen);
             Func<IEnumerable<DateTime>, IEnumerable<DateTime>> applicator = dates =>
                 from date in dates
-                where security.Exchange.DateIsOpen(date)
                 let marketOpen = security.Exchange.Hours.GetNextMarketOpen(date, extendedMarketOpen)
+                // make sure the market open is of this date
+                where security.Exchange.DateIsOpen(date) && marketOpen.Date == date.Date
                 let localEventTime = marketOpen + timeAfterOpen
                 let utcEventTime = localEventTime.ConvertToUtc(security.Exchange.TimeZone)
                 select utcEventTime;
@@ -191,8 +192,9 @@ namespace QuantConnect.Scheduling
             var timeBeforeClose = TimeSpan.FromMinutes(minutesBeforeClose);
             Func<IEnumerable<DateTime>, IEnumerable<DateTime>> applicator = dates =>
                 from date in dates
-                where security.Exchange.DateIsOpen(date)
                 let marketClose = security.Exchange.Hours.GetNextMarketClose(date, extendedMarketClose)
+                // make sure the market open is of this date
+                where security.Exchange.DateIsOpen(date) && marketClose.Date == date.Date
                 let localEventTime = marketClose - timeBeforeClose
                 let utcEventTime = localEventTime.ConvertToUtc(security.Exchange.TimeZone)
                 select utcEventTime;

--- a/Engine/RealTime/ScheduledEventFactory.cs
+++ b/Engine/RealTime/ScheduledEventFactory.cs
@@ -120,15 +120,19 @@ namespace QuantConnect.Lean.Engine.RealTime
                 throw new ArgumentException("Delta must be less than a day", "endOfDayDelta");
             }
 
+            var isMarketAlwaysOpen = security.Exchange.Hours.IsMarketAlwaysOpen;
+
             // define all the times we want this event to be fired, every tradeable day for the securtiy
             // at the delta time before market close expressed in UTC
             var times =
                 // for every date the exchange is open for this security
                 from date in Time.EachTradeableDay(security, start, end)
-                // get the next market close for the specified date
-                let marketClose = security.Exchange.Hours.GetNextMarketClose(date, security.IsExtendedMarketHours)
+                // get the next market close for the specified date if the market closes at some point.
+                // Otherwise, use the given date at midnight
+                let marketClose = isMarketAlwaysOpen ?
+                    date.Date.AddDays(1) : security.Exchange.Hours.GetNextMarketClose(date, security.IsExtendedMarketHours)
                 // define the time of day we want the event to fire before marketclose
-                let eventTime = marketClose.Subtract(endOfDayDelta)
+                let eventTime = isMarketAlwaysOpen ? marketClose : marketClose.Subtract(endOfDayDelta)
                 // convert the event time into UTC
                 let eventUtcTime = eventTime.ConvertToUtc(security.Exchange.TimeZone)
                 // perform filter to verify it's not before the current time

--- a/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
+++ b/Tests/Common/Orders/Fills/BackwardsCompatibilityFillModelsTests.cs
@@ -245,38 +245,61 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             Assert.AreEqual(12345, result.OrderEvent.FillPrice);
         }
 
-        [Test]
-        public void OldBaseFillModel_MarketOnOpenFill()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void OldBaseFillModel_MarketOnOpenFill(bool isMarketAlwaysOpen)
         {
             var model = new TestFillModelInheritBaseClass();
-            _security.SetMarketPrice(new Tick(orderDateTime, _security.Symbol, 88, 88) {TickType = TickType.Trade});
+            var security = SecurityTests.GetSecurity(isMarketAlwaysOpen);
+            var reference = new DateTime(2022, 4, 5, 10, 0, 0);
+            var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
+            var timeKeeper = new TimeKeeper(referenceUtc);
+            security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+            security.SetMarketPrice(new Tick(orderDateTime, security.Symbol, 88, 88) { TickType = TickType.Trade });
 
-            var result = model.Fill(
-                new FillModelParameters(_security,
-                    new MarketOnOpenOrder(_security.Symbol, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config),
-                    Time.OneHour));
+            var args = new FillModelParameters(security, new MarketOnOpenOrder(security.Symbol, 1, orderDateTime),
+                new MockSubscriptionDataConfigProvider(_config), Time.OneHour);
+            if (isMarketAlwaysOpen)
+            {
+                Assert.Throws<InvalidOperationException>(() => model.Fill(args));
+            }
+            else
+            {
+                var result = model.Fill(args);
 
-            Assert.True(model.MarketOnOpenFillWasCalled);
-            Assert.IsNotNull(result);
-            Assert.True(model.GetPricesWasCalled);
-            Assert.AreEqual(12345, result.OrderEvent.FillPrice);
+                Assert.True(model.MarketOnOpenFillWasCalled);
+                Assert.IsNotNull(result);
+                Assert.True(model.GetPricesWasCalled);
+                Assert.AreEqual(12345, result.OrderEvent.FillPrice);
+            }
         }
 
-        [Test]
-        public void OldBaseFillModel_MarketOnCloseFill()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void OldBaseFillModel_MarketOnCloseFill(bool isMarketAlwaysOpen)
         {
             var model = new TestFillModelInheritBaseClass();
-            var result = model.Fill(
-                new FillModelParameters(_security,
-                    new MarketOnCloseOrder(_security.Symbol, 1, orderDateTime),
-                    new MockSubscriptionDataConfigProvider(_config),
-                    Time.OneHour));
+            var security = SecurityTests.GetSecurity(isMarketAlwaysOpen);
+            var reference = new DateTime(2022, 4, 5, 10, 0, 0);
+            var referenceUtc = reference.ConvertToUtc(TimeZones.NewYork);
+            var timeKeeper = new TimeKeeper(referenceUtc);
+            security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
 
-            Assert.True(model.MarketOnCloseFillWasCalled);
-            Assert.IsNotNull(result);
-            Assert.True(model.GetPricesWasCalled);
-            Assert.AreEqual(12345, result.OrderEvent.FillPrice);
+            var args = new FillModelParameters(security, new MarketOnCloseOrder(security.Symbol, 1, orderDateTime),
+                new MockSubscriptionDataConfigProvider(_config), Time.OneHour);
+            if (isMarketAlwaysOpen)
+            {
+                Assert.Throws<InvalidOperationException>(() => model.Fill(args));
+            }
+            else
+            {
+                var result = model.Fill(args);
+
+                Assert.True(model.MarketOnCloseFillWasCalled);
+                Assert.IsNotNull(result);
+                Assert.True(model.GetPricesWasCalled);
+                Assert.AreEqual(12345, result.OrderEvent.FillPrice);
+            }
         }
 
         #endregion

--- a/Tests/Common/Scheduling/TimeRulesTests.cs
+++ b/Tests/Common/Scheduling/TimeRulesTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -109,6 +109,74 @@ namespace QuantConnect.Tests.Common.Scheduling
                 Assert.AreEqual(TimeSpan.FromHours(4 + 5), time.TimeOfDay);
             }
             Assert.AreEqual(1, count);
+        }
+
+        [Test]
+        public void RegularMarketOpenNoDeltaForContinuousSchedules()
+        {
+            var rules = GetFutureTimeRules(TimeZones.Utc);
+            var rule = rules.AfterMarketOpen(Symbols.ES_Future_Chain, 0);
+            var times = rule.CreateUtcEventTimes(new[] {
+                new DateTime(2022, 01, 01),
+                new DateTime(2022, 01, 02),
+                new DateTime(2022, 01, 03),
+                new DateTime(2022, 01, 04),
+                new DateTime(2022, 01, 05),
+                new DateTime(2022, 01, 06),
+                new DateTime(2022, 01, 07),
+                new DateTime(2022, 01, 08),
+                new DateTime(2022, 01, 09)
+            });
+
+            var expectedMarketOpenDates = new[] {
+                new DateTime(2022, 01, 02, 23, 0, 0),
+                new DateTime(2022, 01, 03, 21, 30, 0),
+                new DateTime(2022, 01, 04, 21, 30, 0),
+                new DateTime(2022, 01, 05, 21, 30, 0),
+                new DateTime(2022, 01, 06, 21, 30, 0),
+                new DateTime(2022, 01, 07, 21, 30, 0),
+                new DateTime(2022, 01, 09, 23, 0, 0)
+            };
+            int count = 0;
+            foreach (var time in times)
+            {
+                Assert.AreEqual(expectedMarketOpenDates[count], time);
+                count++;
+            }
+            Assert.AreEqual(7, count);
+        }
+
+        [Test]
+        public void ExtendedMarketCloseNoDeltaForContinuousSchedules()
+        {
+            var rules = GetTimeRules(TimeZones.Utc);
+            var rule = rules.BeforeMarketClose(Symbols.SPY, 0, true);
+            var times = rule.CreateUtcEventTimes(new[] {
+                new DateTime(2022, 01, 01),
+                new DateTime(2022, 01, 02),
+                new DateTime(2022, 01, 03),
+                new DateTime(2022, 01, 04),
+                new DateTime(2022, 01, 05),
+                new DateTime(2022, 01, 06),
+                new DateTime(2022, 01, 07),
+                new DateTime(2022, 01, 08),
+                new DateTime(2022, 01, 09)
+            });
+
+            var expectedMarketOpenDates = new[] {
+                new DateTime(2022, 01, 04, 01, 00, 00),
+                new DateTime(2022, 01, 05, 01, 00, 00),
+                new DateTime(2022, 01, 06, 01, 00, 00),
+                new DateTime(2022, 01, 07, 01, 00, 00),
+                new DateTime(2022, 01, 08, 01, 00, 00)
+            };
+            int count = 0;
+            foreach (var time in times)
+            {
+                Assert.AreEqual(expectedMarketOpenDates[count], time);
+                count++;
+            }
+            Assert.AreEqual(5, count);
         }
 
         [Test]
@@ -239,6 +307,29 @@ namespace QuantConnect.Tests.Common.Scheduling
             var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Daily, marketHourDbEntry.DataTimeZone, securityExchangeHours.TimeZone, true, false, false);
             manager.Add(
                 Symbols.SPY,
+                new Security(
+                    securityExchangeHours,
+                    config,
+                    new Cash(Currencies.USD, 0, 1m),
+                    SymbolProperties.GetDefault(Currencies.USD),
+                    ErrorCurrencyConverter.Instance,
+                    RegisteredSecurityDataTypesProvider.Null,
+                    new SecurityCache()
+                )
+            );
+            var rules = new TimeRules(manager, dateTimeZone);
+            return rules;
+        }
+
+        private static TimeRules GetFutureTimeRules(DateTimeZone dateTimeZone)
+        {
+            var timeKeeper = new TimeKeeper(_utcNow, new List<DateTimeZone>());
+            var manager = new SecurityManager(timeKeeper);
+            var marketHourDbEntry = MarketHoursDatabase.FromDataFolder().GetEntry(Market.CME, "ES", SecurityType.Future);
+            var securityExchangeHours = marketHourDbEntry.ExchangeHours;
+            var config = new SubscriptionDataConfig(typeof(TradeBar), Symbols.ES_Future_Chain, Resolution.Daily, marketHourDbEntry.DataTimeZone, securityExchangeHours.TimeZone, true, false, false);
+            manager.Add(
+                Symbols.ES_Future_Chain,
                 new Security(
                     securityExchangeHours,
                     config,

--- a/Tests/Common/Securities/LocalMarketHoursTests.cs
+++ b/Tests/Common/Securities/LocalMarketHoursTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -15,6 +15,7 @@
 
 using System;
 using NUnit.Framework;
+using System.Globalization;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Common.Securities
@@ -61,6 +62,30 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var marketHours = GetUsEquityWeekDayMarketHours();
             Assert.AreEqual(TimeSpan.FromHours(6.5), marketHours.MarketDuration);
+        }
+
+        [TestCase("1.00:00:00", null, false)]
+        [TestCase(null, "00:00:00", false)]
+
+        [TestCase("1.00:00:00", "00:00:00", true)]
+        [TestCase("0.10:00:00", "10:00:00", false)]
+        [TestCase("0.18:00:00", "00:00:00", false)]
+        [TestCase("1.00:00:00", "00:01:00", false)]
+        [TestCase("1.00:00:00", "10:00:00", false)]
+        public void IsContinuousMarketOpenTests(string previousSegmentEndStr, string nextSegmentStartStr, bool expected)
+        {
+            TimeSpan? previousSegmentEnd = null;
+            TimeSpan? nextSegmentStart = null;
+            if (previousSegmentEndStr != null)
+            {
+                previousSegmentEnd = TimeSpan.ParseExact(previousSegmentEndStr, "d\\.hh\\:mm\\:ss", CultureInfo.InvariantCulture);
+            }
+            if (nextSegmentStartStr != null)
+            {
+                nextSegmentStart = TimeSpan.ParseExact(nextSegmentStartStr, "hh\\:mm\\:ss", CultureInfo.InvariantCulture);
+            }
+
+            Assert.AreEqual(expected, LocalMarketHours.IsContinuousMarketOpen(previousSegmentEnd, nextSegmentStart));
         }
 
         private static LocalMarketHours GetUsEquityWeekDayMarketHours()

--- a/Tests/Common/Securities/Options/OptionSymbolTests.cs
+++ b/Tests/Common/Securities/Options/OptionSymbolTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -54,6 +54,20 @@ namespace QuantConnect.Tests.Common.Securities.Options
                 new DateTime(2019, 9, 20));
 
             Assert.IsFalse(OptionSymbol.IsOptionContractExpired(symbol, new DateTime(2019, 1, 1)));
+        }
+
+        [Test]
+        public void IsOptionContractExpiredReturnsFalseIfTimeOfDayDiffer()
+        {
+            var symbol = Symbol.CreateOption(
+                "BHP",
+                Market.USA,
+                OptionStyle.American,
+                OptionRight.Call,
+                55m,
+                new DateTime(2022, 03, 11));
+
+            Assert.IsFalse(OptionSymbol.IsOptionContractExpired(symbol, new DateTime(2022, 03, 11)));
         }
     }
 }

--- a/Tests/Common/Securities/SecurityTests.cs
+++ b/Tests/Common/Securities/SecurityTests.cs
@@ -292,10 +292,21 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(tradeBars[0].Volume, fromDynamicSecurityData.Volume);
         }
 
-        internal static Security GetSecurity()
+        internal static Security GetSecurity(bool isMarketAlwaysOpen = true)
         {
+            SecurityExchangeHours securityExchangeHours;
+            if (isMarketAlwaysOpen)
+            {
+                securityExchangeHours = SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork);
+            }
+            else
+            {
+                var marketHourDbEntry = MarketHoursDatabase.FromDataFolder().GetEntry(Market.USA, "SPY", SecurityType.Equity);
+                securityExchangeHours = marketHourDbEntry.ExchangeHours;
+            }
+
             return new Security(
-                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                securityExchangeHours,
                 CreateTradeBarConfig(),
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Changes taken from https://github.com/QuantConnect/Lean/pull/6227 credit for @Marinovsky - Rebased + a few more tweaks and added more tests

------------


- Fix bug in GetNextMarketOpen() method. This method didn't consider the cases when the open market time was part of the last market open segment. Also, when some potential market open wasn't accepted it just jumped into the next day but didn't consider the next segment in the day if possible.
- Fix bug in AfterMarketOpen() method. This method processed more than once the same date because applicator didn't consider the date returned by GetNextMarketOpen() and the time period it had advanced.
- Fix wrong regression tests statistics. Debugging the failing regression and unit tests It was found that they were directly relationed with the changes in GetNextMarketOpen() and AfterMarketOpen() and that the previous returned values were wrong.

The following regression tests were also failing for the changes in `AfterMarketOpen()` and `GetNextMarketOpen()`:

```
PR `2020-01-06 16:31:00 1/6/2020 4:31:00 PM - Buy@AfterMarketOpen`
vs
MASTER `2020-01-07 00:01:00 1/7/2020 12:01:00 AM - Buy@AfterMarketOpen`
```

- Algorithm.CSharp/FutureOptionBuySellCallIntradayRegressionAlgorithm.cs
- Algorithm.CSharp/FutureOptionCallITMExpiryRegressionAlgorithm.cs
- Algorithm.CSharp/FutureOptionCallOTMExpiryRegressionAlgorithm.cs
- Algorithm.CSharp/FutureOptionPutITMExpiryRegressionAlgorithm.cs
- Algorithm.CSharp/FutureOptionPutOTMExpiryRegressionAlgorithm.cs
- Algorithm.CSharp/FutureOptionShortCallITMExpiryRegressionAlgorithm.cs
- Algorithm.CSharp/FutureOptionShortCallOTMExpiryRegressionAlgorithm.cs
- Algorithm.CSharp/FutureOptionShortPutITMExpiryRegressionAlgorithm.cs
- Algorithm.CSharp/FutureOptionShortPutOTMExpiryRegressionAlgorithm.cs
Although, the tests above were failing for the changes in `GetNextMarketOpen()` they were also failing because `applicator` function didn't take into account the dates `GetNextMarketOpen()` have already processed looking for the next market open so, if the given date was for example a Thursday at 00:00:00 as `GetNextMarketOpen()` is not inclusive, it jumped into the next day and returned the first segment(at 00:00:00) according to the MHDB. However, as we see for the last tests this date returned by `GetNextOpenMarket()` was wrong, so the date returned by `AfterMarketOpen()` was also wrong. Here we can see an example of the difference between the logs before and after the changes:
BEFORE
![image](https://user-images.githubusercontent.com/47573394/155003006-8eefb583-0b54-4f9a-8344-b36a820fb20e.png)
AFTER
![image](https://user-images.githubusercontent.com/47573394/155003043-b3cb34c1-3470-470f-bbcf-d621f7758502.png)
As you can see for 06/01/2020 00:00:00 the date `AfterMarketOpen()` should return should be 06/01/2020 16:30:00, which is the next segment for that day according to MHDB

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/6189
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Accurately model futures market hours
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
