### PR TITLE
Fix greeks all being zero on expiration date

### DIFF
--- a/Algorithm.CSharp/OptionExpiryDateTodayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExpiryDateTodayRegressionAlgorithm.cs
@@ -48,7 +48,6 @@ namespace QuantConnect.Algorithm.CSharp
             SetWarmUp(TimeSpan.FromDays(3));
 
             _triedGreeksCalculation = false;
-            QLNet.Settings.includeReferenceDateEvents = true;
         }
 
         public override void OnData(Slice slice)

--- a/Algorithm.CSharp/OptionExpiryDateTodayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExpiryDateTodayRegressionAlgorithm.cs
@@ -1,0 +1,162 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities.Option;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class OptionExpiryDateTodayRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _optionSymbol;
+        private bool _triedGreeksCalculation;
+
+        public override void Initialize() {
+            SetStartDate(2014, 06, 9);
+            SetEndDate(2014, 06, 20);
+
+            var option = AddOption("AAPL");
+            _optionSymbol = option.Symbol;
+            option.SetFilter((universeFilter) =>
+            {
+                return universeFilter.IncludeWeeklys().CallsOnly().Strikes(-1, 1).Expiration(0, 10);
+            });
+            option.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
+            SetWarmUp(TimeSpan.FromDays(4));
+
+            _triedGreeksCalculation = false;
+            QLNet.Settings.includeReferenceDateEvents = true;
+        }
+
+        public override void OnData(Slice slice) {
+            if (IsWarmingUp || Portfolio.Invested) {
+                return;
+            }
+
+            foreach (var kvp in slice.OptionChains) {
+                if (kvp.Key != _optionSymbol) {
+                    continue;
+                }
+
+                var chain = kvp.Value;
+                // Find the call options expiring today
+                var contracts = chain
+                    .Where(contract => contract.Expiry.Date == Time.Date.AddDays(1) && contract.Strike < chain.Underlying.Price)
+                    .OrderByDescending(x => x.Strike)
+                    .ToList();
+
+                if (contracts.Count == 0) {
+                    return;
+                }
+
+                _triedGreeksCalculation = true;
+
+                foreach (var contract in contracts)
+                {
+                    var greeks = contract.Greeks;
+                    if (greeks.Delta == 0m && greeks.Gamma == 0m && greeks.Theta == 0m && greeks.Vega == 0m && greeks.Rho == 0m)
+                    {
+                        throw new Exception($"Expected greeks to not be zero simultaneously for {contract.Symbol}");
+                    }
+
+                    Log($"[{Time}] [{contract.Expiry}] delta {contract.Greeks.Delta}, gamma {contract.Greeks.Gamma}, theta {contract.Greeks.Theta}, vega {contract.Greeks.Vega}, rho {contract.Greeks.Rho}");
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm() {
+            if (!_triedGreeksCalculation)
+            {
+                throw new Exception("Expected to have tried greeks calculation");
+            }
+        }
+
+
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 9456757;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-2.864"},
+            {"Tracking Error", "0.058"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/OptionExpiryDateTodayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExpiryDateTodayRegressionAlgorithm.cs
@@ -40,14 +40,12 @@ namespace QuantConnect.Algorithm.CSharp
             var option = AddOption("AAPL", Resolution.Minute);
             option.SetFilter((universeFilter) =>
             {
-                return universeFilter.IncludeWeeklys().CallsOnly().Strikes(-1, 1).Expiration(0, 10);
+                return universeFilter.IncludeWeeklys().Strikes(-1, 1).Expiration(0, 10);
             });
             option.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
             _optionSymbol = option.Symbol;
 
             SetWarmUp(TimeSpan.FromDays(3));
-
-            _triedGreeksCalculation = false;
         }
 
         public override void OnData(Slice slice)
@@ -109,7 +107,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 5201032;
+        public long DataPoints => 5227479;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionExpiryDateTodayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExpiryDateTodayRegressionAlgorithm.cs
@@ -32,7 +32,8 @@ namespace QuantConnect.Algorithm.CSharp
         private Symbol _optionSymbol;
         private bool _triedGreeksCalculation;
 
-        public override void Initialize() {
+        public override void Initialize()
+        {
             SetStartDate(2014, 06, 9);
             SetEndDate(2014, 06, 15);
 
@@ -44,18 +45,23 @@ namespace QuantConnect.Algorithm.CSharp
             option.PriceModel = OptionPriceModels.BaroneAdesiWhaley();
             _optionSymbol = option.Symbol;
 
-            SetWarmUp(TimeSpan.FromDays(4));
+            SetWarmUp(TimeSpan.FromDays(3));
 
             _triedGreeksCalculation = false;
+            QLNet.Settings.includeReferenceDateEvents = true;
         }
 
-        public override void OnData(Slice slice) {
-            if (IsWarmingUp || Time.Hour > 10) {
+        public override void OnData(Slice slice)
+        {
+            if (IsWarmingUp || Time.Hour > 10)
+            {
                 return;
             }
 
-            foreach (var kvp in slice.OptionChains) {
-                if (kvp.Key != _optionSymbol) {
+            foreach (var kvp in slice.OptionChains)
+            {
+                if (kvp.Key != _optionSymbol)
+                {
                     continue;
                 }
 
@@ -65,7 +71,8 @@ namespace QuantConnect.Algorithm.CSharp
                     .Where(contract => contract.Expiry.Date == Time.Date && contract.Strike < chain.Underlying.Price)
                     .ToList();
 
-                if (contracts.Count == 0) {
+                if (contracts.Count == 0)
+                {
                     return;
                 }
 
@@ -76,13 +83,14 @@ namespace QuantConnect.Algorithm.CSharp
                     var greeks = contract.Greeks;
                     if (greeks.Delta == 0m && greeks.Gamma == 0m && greeks.Theta == 0m && greeks.Vega == 0m && greeks.Rho == 0m)
                     {
-                        throw new Exception($"Expected greeks to not be zero simultaneously for {contract.Symbol} at contract expiration date");
+                        throw new Exception($"Expected greeks to not be zero simultaneously for {contract.Symbol} at contract expiration date {contract.Expiry}");
                     }
                 }
             }
         }
 
-        public override void OnEndOfAlgorithm() {
+        public override void OnEndOfAlgorithm()
+        {
             if (!_triedGreeksCalculation)
             {
                 throw new Exception("Expected to have tried greeks calculation");
@@ -102,7 +110,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 5201819;
+        public long DataPoints => 5201032;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Common/Securities/Option/QLOptionPriceModel.cs
+++ b/Common/Securities/Option/QLOptionPriceModel.cs
@@ -55,8 +55,12 @@ namespace QuantConnect.Securities.Option
         /// </summary>
         public OptionStyle[] AllowedOptionStyles { get; }
 
+        /// <summary>
+        /// Static constructor for the <see cref="QLOptionPriceModel"/> class
+        /// </summary>
         static QLOptionPriceModel()
         {
+            // Required for QL consider the option as not expired on the expiration date
             QLNet.Settings.includeReferenceDateEvents = true;
         }
 

--- a/Common/Securities/Option/QLOptionPriceModel.cs
+++ b/Common/Securities/Option/QLOptionPriceModel.cs
@@ -111,10 +111,8 @@ namespace QuantConnect.Securities.Option
 
             try
             {
-                var securityExchangeHours = security.Exchange.Hours;
-
                 // expired options have no price
-                if (contract.Time > securityExchangeHours.GetNextMarketClose(contract.Expiry, false))
+                if (contract.Time.Date > contract.Expiry.Date)
                 {
                     return OptionPriceModelResult.None;
                 }
@@ -124,6 +122,7 @@ namespace QuantConnect.Securities.Option
                 var dayCounter = new Actual365Fixed();
                 var optionSecurity = (Option)security;
 
+                var securityExchangeHours = security.Exchange.Hours;
                 var settlementDate = AddDays(contract.Time.Date, Option.DefaultSettlementDays, securityExchangeHours);
                 var maturityDate = AddDays(contract.Expiry.Date, Option.DefaultSettlementDays, securityExchangeHours);
                 var underlyingQuoteValue = new SimpleQuote((double)optionSecurity.Underlying.Price);
@@ -292,7 +291,7 @@ namespace QuantConnect.Securities.Option
 
         private static DateTime AddDays(DateTime date, int days, SecurityExchangeHours marketHours)
         {
-            var forwardDate = date.AddDays(Option.DefaultSettlementDays);
+            var forwardDate = date.AddDays(days);
 
             if (!marketHours.IsDateOpen(forwardDate))
             {

--- a/Common/Securities/Option/QLOptionPriceModel.cs
+++ b/Common/Securities/Option/QLOptionPriceModel.cs
@@ -102,8 +102,8 @@ namespace QuantConnect.Securities.Option
 
             try
             {
-                // expired options has no price
-                if (contract.Time > contract.Expiry)
+                // expired options have no price
+                if (contract.Time.Date > contract.Expiry.Date)
                 {
                     return OptionPriceModelResult.None;
                 }

--- a/Common/Securities/Option/QLOptionPriceModel.cs
+++ b/Common/Securities/Option/QLOptionPriceModel.cs
@@ -56,15 +56,6 @@ namespace QuantConnect.Securities.Option
         public OptionStyle[] AllowedOptionStyles { get; }
 
         /// <summary>
-        /// Static constructor for the <see cref="QLOptionPriceModel"/> class
-        /// </summary>
-        static QLOptionPriceModel()
-        {
-            // Required for QL consider the option as not expired on the expiration date
-            QLNet.Settings.includeReferenceDateEvents = true;
-        }
-
-        /// <summary>
         /// Method constructs QuantLib option price model with necessary estimators of underlying volatility, risk free rate, and underlying dividend yield
         /// </summary>
         /// <param name="pricingEngineFunc">Function modeled stochastic process, and returns new pricing engine to run calculations for that option</param>
@@ -91,6 +82,9 @@ namespace QuantConnect.Securities.Option
             _dividendYieldEstimator = dividendYieldEstimator ?? new ConstantQLDividendYieldEstimator();
 
             AllowedOptionStyles = allowedOptionStyles ?? _defaultAllowedOptionStyles;
+
+            // Required for QL to consider the option as not expired on the expiration date
+            QLNet.Settings.includeReferenceDateEvents = true;
         }
 
         /// <summary>

--- a/Common/Securities/Option/QLOptionPriceModel.cs
+++ b/Common/Securities/Option/QLOptionPriceModel.cs
@@ -83,7 +83,10 @@ namespace QuantConnect.Securities.Option
 
             AllowedOptionStyles = allowedOptionStyles ?? _defaultAllowedOptionStyles;
 
-            // Required for QL to consider the option as not expired on the expiration date
+            // Required for QL to consider the option as not expired on the expiration date.
+            // This is done in the constructor instead of a static contructor because QLNet.Settings attributes are ThreadStatic,
+            // so doing it in a static constructor would only set it for the first thread that instantiates QLOptionPriceModel or
+            // accesses any of its static members.
             QLNet.Settings.includeReferenceDateEvents = true;
         }
 


### PR DESCRIPTION
#### Description

Greeks were always zero for contracts expiring "today". This was maily due to QuantLib considering the contracts expired on the expiration date instead on dates past the expiration date. This can and was overriden by setting QL's flag `QL.Settings.includeReferenceDateEvents` to `true`.

Also, on `QLOptionPriceModel.Evaluate()`, settlement date was being calculated by just adding days to the contract date, without considering holidays and weekends. This was also addressed. 

#### Related Issue
Closes #4548 

#### Motivation and Context

For contracts expiring "today", greeks always had 0-value. Greeks should have no-zero values on the expiration date.

#### Requires Documentation Change

These changes do not require documentation change

#### How Has This Been Tested?

A regression algorithm was implemented asserting that not all greeks have 0-value for contracts expiring "today".

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
