### PR TITLE
Add Log.Error at OptionSymbol.IsOptionContractExpired

### DIFF
--- a/Common/Securities/Option/OptionSymbol.cs
+++ b/Common/Securities/Option/OptionSymbol.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 
 namespace QuantConnect.Securities.Option
 {
@@ -22,6 +23,8 @@ namespace QuantConnect.Securities.Option
     /// </summary>
     public static class OptionSymbol
     {
+        private static readonly Dictionary<string, byte> _optionExpirationErrorLog = new();
+
         /// <summary>
         /// Returns true if the option is a standard contract that expires 3rd Friday of the month
         /// </summary>
@@ -122,10 +125,19 @@ namespace QuantConnect.Securities.Option
             var expiryTime = exchangeHours.GetNextMarketClose(expiryDay, false);
 
             // Once bug 6189 was solved in ´GetNextMarketClose()´ there was found possible bugs on some futures symbol.ID.Date or delisting/liquidation handle event.
-            // Specifically see 'DelistingFutureOptionRegressionAlgorithm' where Symbol.ID.Date: 4/1/2012 00:00 ExpiryTime: 4/2/2012 16:00. Related to #6062 and #5487
-            // So let's limit the expiry time to up to end of day of expiration
+            // Specifically see 'DelistingFutureOptionRegressionAlgorithm' where Symbol.ID.Date: 4/1/2012 00:00 ExpiryTime: 4/2/2012 16:00 for Milk 3 futures options.
+            // See 'bug-milk-class-3-future-options-expiration' branch. So let's limit the expiry time to up to end of day of expiration
             if (expiryTime >= symbol.ID.Date.AddDays(1).Date)
             {
+                lock (_optionExpirationErrorLog)
+                {
+                    if (symbol.ID.Underlying != null
+                        // let's log this once per underlying and expiration date: avoiding the same log for multiple option contracts with different strikes/rights
+                        && _optionExpirationErrorLog.TryAdd($"{symbol.ID.Underlying}-{symbol.ID.Date}", 1))
+                    {
+                        Logging.Log.Error($"OptionSymbol.IsOptionContractExpired(): limiting unexpected option expiration time for symbol {symbol.ID}. Symbol.ID.Date {symbol.ID.Date}. ExpiryTime: {expiryTime}");
+                    }
+                }
                 expiryTime = symbol.ID.Date.AddDays(1).Date;
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Add error log at `OptionSymbol.IsOptionContractExpired` in the case we
  detect an unexpected expiration time. That could be related to
  Symbol.ID.Date being incorrect

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See https://github.com/QuantConnect/Lean/pull/6397
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Register unexpected symbol.ID.Date expirations
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running `DelistingFutureOptionRegressionAlgorithm`
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
