### PR TITLE
Add data normalization mode parameter to AddEquity method

### DIFF
--- a/Algorithm.CSharp/SetEquityDataNormalizationModeOnAddEquity.cs
+++ b/Algorithm.CSharp/SetEquityDataNormalizationModeOnAddEquity.cs
@@ -1,0 +1,135 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities.Equity;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This regression algorithm has examples of how to add an equity indicating the <see cref="DataNormalizationMode"/>
+    /// directly with the <see cref="QCAlgorithm.AddEquity"/> method instead of using the <see cref="Equity.SetDataNormalizationMode"/> method.
+    /// </summary>
+    public class SetEquityDataNormalizationModeOnAddEquity : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private readonly DataNormalizationMode _spyNormalizationMode = DataNormalizationMode.Raw;
+        private readonly DataNormalizationMode _googNormalizationMode = DataNormalizationMode.Adjusted;
+        private readonly DataNormalizationMode _aaplNormalizationMode = DataNormalizationMode.TotalReturn;
+        private Equity _spyEquity;
+        private Equity _googEquity;
+        private Equity _aaplEquity;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 7);
+            SetEndDate(2013, 10, 7);
+
+            _spyEquity = AddEquity("SPY", Resolution.Minute, dataNormalizationMode: _spyNormalizationMode);
+            CheckEquityDataNormalizationMode(_spyEquity, _spyNormalizationMode);
+
+            _googEquity = AddEquity("GOOG", Resolution.Minute, dataNormalizationMode: _googNormalizationMode);
+            CheckEquityDataNormalizationMode(_googEquity, _googNormalizationMode);
+
+            _aaplEquity = AddEquity("AAPL", Resolution.Minute, dataNormalizationMode: _aaplNormalizationMode);
+            CheckEquityDataNormalizationMode(_aaplEquity, _aaplNormalizationMode);
+        }
+
+        public override void OnData(Slice slice)
+        {
+        }
+
+        private void CheckEquityDataNormalizationMode(Equity equity, DataNormalizationMode expectedNormalizationMode)
+        {
+            var subscriptions = SubscriptionManager.Subscriptions.Where(x => x.Symbol == equity.Symbol);
+            if (subscriptions.Any(x => x.DataNormalizationMode != expectedNormalizationMode))
+            {
+                throw new Exception($"Expected {equity.Symbol} to have data normalization mode {expectedNormalizationMode} but was {subscriptions.First().DataNormalizationMode}");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 5227479;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "5.176"},
+            {"Tracking Error", "0.071"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/SetEquityDataNormalizationModeOnAddEquity.cs
+++ b/Algorithm.CSharp/SetEquityDataNormalizationModeOnAddEquity.cs
@@ -59,12 +59,9 @@ namespace QuantConnect.Algorithm.CSharp
                 var minExpectedPrice = kvp.Value.Item1;
                 var maxExpectedPrice = kvp.Value.Item2;
 
-                if (equity.HasData)
+                if (equity.HasData && (equity.Price < minExpectedPrice || equity.Price > maxExpectedPrice))
                 {
-                    if (equity.Price < minExpectedPrice || equity.Price > maxExpectedPrice)
-                    {
-                        throw new Exception($"{equity.Symbol}: Price {equity.Price} is  out of expected range [{minExpectedPrice}, {maxExpectedPrice}]");
-                    }
+                    throw new Exception($"{equity.Symbol}: Price {equity.Price} is  out of expected range [{minExpectedPrice}, {maxExpectedPrice}]");
                 }
             }
         }

--- a/Algorithm.CSharp/SetEquityDataNormalizationModeOnAddEquity.cs
+++ b/Algorithm.CSharp/SetEquityDataNormalizationModeOnAddEquity.cs
@@ -86,7 +86,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp };
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm

--- a/Algorithm.Python/SetEquityDataNormalizationModeOnAddEquity.py
+++ b/Algorithm.Python/SetEquityDataNormalizationModeOnAddEquity.py
@@ -42,10 +42,8 @@ class SetEquityDataNormalizationModeOnAddEquity(QCAlgorithm):
 
     def OnData(self, slice):
         for equity, (minExpectedPrice, maxExpectedPrice) in self._priceRanges.items():
-
-            if equity.HasData:
-                if equity.Price < minExpectedPrice or equity.Price > maxExpectedPrice:
-                    raise Exception(f"{equity.Symbol}: Price {equity.Price} is out of expected range [{minExpectedPrice}, {maxExpectedPrice}]")
+            if equity.HasData and (equity.Price < minExpectedPrice or equity.Price > maxExpectedPrice):
+                raise Exception(f"{equity.Symbol}: Price {equity.Price} is out of expected range [{minExpectedPrice}, {maxExpectedPrice}]")
 
     def CheckEquityDataNormalizationMode(self, equity, expectedNormalizationMode):
         subscriptions = [x for x in self.SubscriptionManager.Subscriptions if x.Symbol == equity.Symbol]

--- a/Algorithm.Python/SetEquityDataNormalizationModeOnAddEquity.py
+++ b/Algorithm.Python/SetEquityDataNormalizationModeOnAddEquity.py
@@ -1,0 +1,55 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### This regression algorithm has examples of how to add an equity indicating the <see cref="DataNormalizationMode"/>
+### directly with the <see cref="QCAlgorithm.AddEquity"/> method instead of using the <see cref="Equity.SetDataNormalizationMode"/> method.
+### </summary>
+class SetEquityDataNormalizationModeOnAddEquity(QCAlgorithm):
+    def Initialize(self):
+        self.SetStartDate(2013, 10, 7)
+        self.SetEndDate(2013, 10, 7)
+
+        spyNormalizationMode = DataNormalizationMode.Raw
+        ibmNormalizationMode = DataNormalizationMode.Adjusted
+        aigNormalizationMode = DataNormalizationMode.TotalReturn
+
+        self._priceRanges = {}
+
+        spyEquity = self.AddEquity("SPY", Resolution.Minute, dataNormalizationMode=spyNormalizationMode)
+        self.CheckEquityDataNormalizationMode(spyEquity, spyNormalizationMode)
+        self._priceRanges[spyEquity] = (167.28, 168.37)
+
+        ibmEquity = self.AddEquity("IBM", Resolution.Minute, dataNormalizationMode=ibmNormalizationMode)
+        self.CheckEquityDataNormalizationMode(ibmEquity, ibmNormalizationMode)
+        self._priceRanges[ibmEquity] = (135.864131052, 136.819606508)
+
+        aigEquity = self.AddEquity("AIG", Resolution.Minute, dataNormalizationMode=aigNormalizationMode)
+        self.CheckEquityDataNormalizationMode(aigEquity, aigNormalizationMode)
+        self._priceRanges[aigEquity] = (48.73, 49.10)
+
+    def OnData(self, slice):
+        for equity, (minExpectedPrice, maxExpectedPrice) in self._priceRanges.items():
+
+            if equity.HasData:
+                if equity.Price < minExpectedPrice or equity.Price > maxExpectedPrice:
+                    raise Exception(f"{equity.Symbol}: Price {equity.Price} is out of expected range [{minExpectedPrice}, {maxExpectedPrice}]")
+
+    def CheckEquityDataNormalizationMode(self, equity, expectedNormalizationMode):
+        subscriptions = [x for x in self.SubscriptionManager.Subscriptions if x.Symbol == equity.Symbol]
+        if any([x.DataNormalizationMode != expectedNormalizationMode for x in subscriptions]):
+            raise Exception(f"Expected {equity.Symbol} to have data normalization mode {expectedNormalizationMode} but was {subscriptions[0].DataNormalizationMode}")
+
+

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1723,11 +1723,13 @@ namespace QuantConnect.Algorithm
         /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">True to send data during pre and post market sessions. Default is <value>false</value></param>
+        /// <param name="dataNormalizationMode">The price scaling mode to use for the equity</param>
         /// <returns>The new <see cref="Equity"/> security</returns>
         [DocumentationAttribute(AddingData)]
-        public Equity AddEquity(string ticker, Resolution? resolution = null, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage, bool extendedMarketHours = false)
+        public Equity AddEquity(string ticker, Resolution? resolution = null, string market = null, bool fillDataForward = true,
+            decimal leverage = Security.NullLeverage, bool extendedMarketHours = false, DataNormalizationMode? dataNormalizationMode = null)
         {
-            return AddSecurity<Equity>(SecurityType.Equity, ticker, resolution, market, fillDataForward, leverage, extendedMarketHours);
+            return AddSecurity<Equity>(SecurityType.Equity, ticker, resolution, market, fillDataForward, leverage, extendedMarketHours, normalizationMode: dataNormalizationMode);
         }
 
         /// <summary>

--- a/Tests/Algorithm/AlgorithmAddSecurityTests.cs
+++ b/Tests/Algorithm/AlgorithmAddSecurityTests.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Securities;
@@ -104,6 +105,15 @@ namespace QuantConnect.Tests.Algorithm
             }
         }
 
+        [TestCaseSource(nameof(DataNormalizationModes))]
+        public void AddsEquityWithExpectedDataNormalizationMode(DataNormalizationMode dataNormalizationMode)
+        {
+            var algorithm = new QCAlgorithm();
+            var equity = algorithm.AddEquity("AAPL", dataNormalizationMode: dataNormalizationMode);
+            Assert.That(algorithm.SubscriptionManager.Subscriptions.Where(x => x.Symbol == equity.Symbol).Select(x => x.DataNormalizationMode),
+                Has.All.EqualTo(dataNormalizationMode));
+        }
+
         private static TestCaseData[] TestAddSecurityWithSymbol
         {
             get
@@ -140,5 +150,7 @@ namespace QuantConnect.Tests.Algorithm
                 return result.ToArray();
             }
         }
+
+        private static DataNormalizationMode[] DataNormalizationModes => (DataNormalizationMode[])Enum.GetValues(typeof(DataNormalizationMode));
     }
 }

--- a/Tests/Algorithm/AlgorithmAddSecurityTests.cs
+++ b/Tests/Algorithm/AlgorithmAddSecurityTests.cs
@@ -105,10 +105,11 @@ namespace QuantConnect.Tests.Algorithm
             }
         }
 
-        [TestCaseSource(nameof(DataNormalizationModes))]
+        [TestCaseSource(nameof(GetDataNormalizationModes))]
         public void AddsEquityWithExpectedDataNormalizationMode(DataNormalizationMode dataNormalizationMode)
         {
             var algorithm = new QCAlgorithm();
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(_dataFeed, algorithm));
             var equity = algorithm.AddEquity("AAPL", dataNormalizationMode: dataNormalizationMode);
             Assert.That(algorithm.SubscriptionManager.Subscriptions.Where(x => x.Symbol == equity.Symbol).Select(x => x.DataNormalizationMode),
                 Has.All.EqualTo(dataNormalizationMode));
@@ -151,6 +152,9 @@ namespace QuantConnect.Tests.Algorithm
             }
         }
 
-        private static DataNormalizationMode[] DataNormalizationModes => (DataNormalizationMode[])Enum.GetValues(typeof(DataNormalizationMode));
+        private static DataNormalizationMode[] GetDataNormalizationModes()
+        {
+            return (DataNormalizationMode[])Enum.GetValues(typeof(DataNormalizationMode));
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description

The `dataNormalizationMode` parameter was added to `QCAlgorithm.AddEquity()` to allow setting the data normalization mode at equity registration.

#### Related Issue

Closes #6402 

#### Motivation and Context

This feature allows to set the data normalization mode at equity creation (by using `AddEquity()`) instead of setting it afterwards by using `Equity.SetDataNormalizationMode()`.

#### Requires Documentation Change

This change does not required documentation changes

#### How Has This Been Tested?

Both unit tests and a regression algorithm (C# and Python) were implementing ilustrating how to set the data normalization mode at equity creation and asserting that the mode is properly set and equity prices are in the expected range.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
