### PR TITLE
Period timespan consolidation improvements

### DIFF
--- a/Algorithm.CSharp/AutomaticIndicatorWarmupDataTypeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AutomaticIndicatorWarmupDataTypeRegressionAlgorithm.cs
@@ -67,7 +67,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Test case: custom IndicatorBase<QuoteBar> indicator using Future subscribed symbol
             var indicator = new CustomIndicator();
-            var consolidator = CreateConsolidator(TimeSpan.FromMinutes(1), typeof(QuoteBar));
+            var consolidator = CreateConsolidator(TimeSpan.FromMinutes(2), typeof(QuoteBar));
             RegisterIndicator(_symbol, indicator, consolidator);
 
             AssertIndicatorState(indicator, isReady: false);

--- a/Algorithm.CSharp/PeriodConsolidatorRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/PeriodConsolidatorRegressionAlgorithm.cs
@@ -1,0 +1,146 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Data.Market;
+using System.Collections.Generic;
+using QuantConnect.Data.Consolidators;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting the behavior of a period consolidator
+    /// </summary>
+    public class PeriodConsolidatorRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Queue<string> _periodConsolidation = new();
+        private Queue<string> _countConsolidation = new();
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 08);
+            
+            var symbol = AddEquity("SPY").Symbol;
+
+            var periodConsolidator = new TradeBarConsolidator(Resolution.Minute.ToTimeSpan());
+            periodConsolidator.DataConsolidated += PeriodConsolidator_DataConsolidated;
+            var countConsolidator = new TradeBarConsolidator(1);
+            countConsolidator.DataConsolidated += CountConsolidator_DataConsolidated;
+
+            SubscriptionManager.AddConsolidator(symbol, periodConsolidator);
+            SubscriptionManager.AddConsolidator(symbol, countConsolidator);
+        }
+
+        private void PeriodConsolidator_DataConsolidated(object sender, TradeBar e)
+        {
+            _periodConsolidation.Enqueue($"{Time} - {e.EndTime} {e}");
+        }
+        private void CountConsolidator_DataConsolidated(object sender, TradeBar e)
+        {
+            _countConsolidation.Enqueue($"{Time} - {e.EndTime} {e}");
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_countConsolidation.Count == 0 || _countConsolidation.Count != _periodConsolidation.Count)
+            {
+                throw new Exception($"Unexpected consolidated data count. Period: {_periodConsolidation.Count} Count: {_countConsolidation.Count}");
+            }
+
+            while (_countConsolidation.TryDequeue(out var countData))
+            {
+                var periodData = _periodConsolidation.Dequeue();
+                if (periodData != countData)
+                {
+                    throw new Exception($"Unexpected consolidated data. Period: '{periodData}' != Count: '{countData}'");
+                }
+            }
+            _periodConsolidation.Clear();
+            _countConsolidation.Clear();
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 1582;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.Python/FractionalQuantityRegressionAlgorithm.py
+++ b/Algorithm.Python/FractionalQuantityRegressionAlgorithm.py
@@ -41,7 +41,7 @@ class FractionalQuantityRegressionAlgorithm(QCAlgorithm):
         ### Since this test algorithm uses leverage we need to set a buying power model with margin.
         security.SetBuyingPowerModel(SecurityMarginModel(3.3))
 
-        con = TradeBarConsolidator(timedelta(1))
+        con = TradeBarConsolidator(1)
         self.SubscriptionManager.AddConsolidator("BTCUSD", con)
         con.DataConsolidated += self.DataConsolidated
         self.SetBenchmark(security.Symbol)

--- a/Tests/Common/Data/TradeBarConsolidatorTests.cs
+++ b/Tests/Common/Data/TradeBarConsolidatorTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  * 
@@ -30,7 +30,7 @@ namespace QuantConnect.Tests.Common.Data
             // defining a TradeBarConsolidator with a zero max count should cause it to always fire identity
 
             TradeBar consolidated = null;
-            var consolidator = new TradeBarConsolidator(0);
+            using var consolidator = new TradeBarConsolidator(0);
             consolidator.DataConsolidated += (sender, bar) =>
             {
                 consolidated = bar;
@@ -46,7 +46,7 @@ namespace QuantConnect.Tests.Common.Data
             // defining a TradeBarConsolidator with a one max count should cause it to always fire identity
 
             TradeBar consolidated = null;
-            var consolidator = new TradeBarConsolidator(1);
+            using var consolidator = new TradeBarConsolidator(1);
             consolidator.DataConsolidated += (sender, bar) =>
             {
                 consolidated = bar;
@@ -62,7 +62,7 @@ namespace QuantConnect.Tests.Common.Data
             // defining a TradeBarConsolidator with a two max count should cause it to fire every other TradeBar
 
             TradeBar consolidated = null;
-            var consolidator = new TradeBarConsolidator(2);
+            using var consolidator = new TradeBarConsolidator(2);
             consolidator.DataConsolidated += (sender, bar) =>
             {
                 consolidated = bar;
@@ -84,56 +84,19 @@ namespace QuantConnect.Tests.Common.Data
         }
 
         [Test]
-        public void ZeroSpanAlwaysFires()
+        public void ZeroSpanAlwaysThrows()
         {
-            // defining a TradeBarConsolidator with a zero period should cause it to always fire identity
+            // defining a TradeBarConsolidator with a zero period should cause it to always throw an exception
 
             TradeBar consolidated = null;
-            var consolidator = new TradeBarConsolidator(TimeSpan.Zero);
+            using var consolidator = new TradeBarConsolidator(TimeSpan.Zero);
             consolidator.DataConsolidated += (sender, bar) =>
             {
                 consolidated = bar;
             };
 
             var reference = new DateTime(2014, 12, 01, 01, 01, 00);
-            consolidator.Update(new TradeBar {Close = 1m, Time = reference});
-            Assert.IsNotNull(consolidated);
-            Assert.AreEqual(1, consolidated.Close);
-
-            consolidator.Update(new TradeBar {Close = 2m, Time = reference});
-            Assert.IsNotNull(consolidated);
-            Assert.AreEqual(2, consolidated.Close);
-
-            consolidator.Update(new TradeBar {Close = 3m, Time = reference});
-            Assert.IsNotNull(consolidated);
-            Assert.AreEqual(3, consolidated.Close);
-        }
-
-        [Test]
-        public void OneMinuteAlwaysFiresEveryTimeOnMinuteDataExceptFirstPoint()
-        {
-            // defining a TradeBarConsolidator with the same period as the resolution of input data will cause
-            // it to not fire on the first piece of data as it is initializing, but will then fire for each
-            // consecutive data point
-
-            TradeBar consolidated = null;
-            var consolidator = new TradeBarConsolidator(TimeSpan.FromMinutes(1));
-            consolidator.DataConsolidated += (sender, bar) =>
-            {
-                consolidated = bar;
-            };
-
-            var reference = new DateTime(2014, 12, 01, 01, 01, 00);
-            consolidator.Update(new TradeBar {Close = 1m, Time = reference});
-            Assert.IsNull(consolidated);
-
-            consolidator.Update(new TradeBar {Close = 2m, Time = reference.AddMinutes(1)});
-            Assert.IsNotNull(consolidated);
-            Assert.AreEqual(1, consolidated.Close);
-
-            consolidator.Update(new TradeBar {Close = 3m, Time = reference.AddMinutes(2)});
-            Assert.IsNotNull(consolidated);
-            Assert.AreEqual(2, consolidated.Close);
+            Assert.Throws<ArgumentException>(() => consolidator.Update(new TradeBar { Time = reference, Period = Time.OneDay }));
         }
 
         [Test]
@@ -142,7 +105,7 @@ namespace QuantConnect.Tests.Common.Data
             // verifies that the TradeBarConsolidator correctly consolidates OHLCV data into a new TradeBar instance
 
             TradeBar consolidated = null;
-            var consolidator = new TradeBarConsolidator(3);
+            using var consolidator = new TradeBarConsolidator(3);
             consolidator.DataConsolidated += (sender, bar) =>
             {
                 consolidated = bar;
@@ -199,7 +162,7 @@ namespace QuantConnect.Tests.Common.Data
         {
             // verifies that the TradeBarConsolidator does not consolidate data with different symbols
 
-            var consolidator = new TradeBarConsolidator(2);
+            using var consolidator = new TradeBarConsolidator(2);
 
             var tb1 = new TradeBar
             {
@@ -226,7 +189,7 @@ namespace QuantConnect.Tests.Common.Data
             consolidator.Update(tb1);
 
             Exception ex = Assert.Throws<InvalidOperationException>(() => consolidator.Update(tb2));
-            Assert.IsTrue(ex.Message.Contains("is not the same"));
+            Assert.IsTrue(ex.Message.Contains("is not the same", StringComparison.InvariantCultureIgnoreCase));
         }
 
         [Test]
@@ -235,7 +198,7 @@ namespace QuantConnect.Tests.Common.Data
             // verifies that the consolidated bar uses the time from the beginning of the first bar
             // in the period that covers the current bar
 
-            var consolidator = new TradeBarConsolidator(TimeSpan.FromMinutes(1));
+            using var consolidator = new TradeBarConsolidator(TimeSpan.FromMinutes(2));
 
             TradeBar consolidated = null;
             consolidator.DataConsolidated += (sender, bar) =>
@@ -245,46 +208,50 @@ namespace QuantConnect.Tests.Common.Data
 
             var reference = new DateTime(2014, 12, 1, 10, 00, 0);
 
-            //10:00 - new
+            //10:00 - start new
             consolidator.Update(new TradeBar {Time = reference});
             Assert.IsNull(consolidated);
 
-            //10:01 - aggregate/fire
+            //10:01 - aggregate
             consolidator.Update(new TradeBar {Time = reference.AddMinutes(1)});
+            Assert.IsNull(consolidated);
+
+            //10:02 - fire & start new
+            consolidator.Update(new TradeBar {Time = reference.AddMinutes(2)});
             Assert.IsNotNull(consolidated);
             Assert.AreEqual(reference, consolidated.Time);
+            consolidated = null;
 
-            //10:02 - new/fire
-            consolidator.Update(new TradeBar {Time = reference.AddMinutes(2)});
-            Assert.AreEqual(reference.AddMinutes(1), consolidated.Time);
-
-            //10:03 - new/fire
+            //10:03 - aggregate
             consolidator.Update(new TradeBar {Time = reference.AddMinutes(3)});
-            Assert.AreEqual(reference.AddMinutes(2), consolidated.Time);
+            Assert.IsNull(consolidated);
 
-            //10:05 - new/fire
+            //10:05 - fire & start new
             consolidator.Update(new TradeBar {Time = reference.AddMinutes(5)});
-            Assert.AreEqual(reference.AddMinutes(3), consolidated.Time);
+            Assert.IsNotNull(consolidated);
+            Assert.AreEqual(reference.AddMinutes(2), consolidated.Time);
+            consolidated = null;
 
-            //10:08 - new/fire
+            //10:08 - fire & start new
             consolidator.Update(new TradeBar {Time = reference.AddMinutes(8)});
-            Assert.AreEqual(reference.AddMinutes(5), consolidated.Time);
+            Assert.IsNotNull(consolidated);
+            Assert.AreEqual(reference.AddMinutes(4), consolidated.Time);
+            consolidated = null;
 
-            //10:08:01 - new
+            //10:08:01 - aggregate
             consolidator.Update(new TradeBar {Time = reference.AddMinutes(8).AddSeconds(1)});
-            Assert.AreEqual(reference.AddMinutes(5), consolidated.Time);
+            Assert.IsNull(consolidated);
 
-            //10:09 - new/fire
+            //10:09 - aggregate
             consolidator.Update(new TradeBar {Time = reference.AddMinutes(9)});
-            Assert.AreEqual(reference.AddMinutes(8), consolidated.Time);
-
+            Assert.IsNull(consolidated);
         }
 
         [Test]
         public void HandlesDataGapsInMixedMode()
         {
             // define a three minute consolidator on a one minute stream of data
-            var consolidator = new TradeBarConsolidator(3, TimeSpan.FromMinutes(3));
+            using var consolidator = new TradeBarConsolidator(3, TimeSpan.FromMinutes(3));
 
             TradeBar consolidated = null;
             consolidator.DataConsolidated += (sender, bar) =>
@@ -325,7 +292,7 @@ namespace QuantConnect.Tests.Common.Data
         {
             // this test requires inspection to verify we're getting clean bars on the correct times
 
-            var consolidator = new TradeBarConsolidator(TimeSpan.FromHours(1));
+            using var consolidator = new TradeBarConsolidator(TimeSpan.FromHours(1));
 
             TradeBar consolidated = null;
             consolidator.DataConsolidated += (sender, bar) =>
@@ -353,7 +320,7 @@ namespace QuantConnect.Tests.Common.Data
         {
             // define a three minute consolidator 
             int timeSpanUnits = 3;
-            var consolidator = new TradeBarConsolidator(TimeSpan.FromMinutes(timeSpanUnits));
+            using var consolidator = new TradeBarConsolidator(TimeSpan.FromMinutes(timeSpanUnits));
 
             TradeBar consolidated = null;
             consolidator.DataConsolidated += (sender, bar) =>
@@ -390,7 +357,7 @@ namespace QuantConnect.Tests.Common.Data
         {
             TradeBar consolidated = null;
             var period = TimeSpan.FromDays(1);
-            var consolidator = new TradeBarConsolidator(2);
+            using var consolidator = new TradeBarConsolidator(2);
             consolidator.DataConsolidated += (sender, bar) =>
             {
                 consolidated = bar;
@@ -419,78 +386,78 @@ namespace QuantConnect.Tests.Common.Data
         public void AggregatesPeriodInPeriodModeWithDailyData()
         {
             TradeBar consolidated = null;
-            var period = TimeSpan.FromDays(1);
-            var consolidator = new TradeBarConsolidator(period);
+            var period = TimeSpan.FromDays(2);
+            using var consolidator = new TradeBarConsolidator(period);
             consolidator.DataConsolidated += (sender, bar) =>
             {
                 consolidated = bar;
             };
 
             var reference = new DateTime(2015, 04, 13);
-            consolidator.Update(new TradeBar { Time = reference, Period = period});
+            consolidator.Update(new TradeBar { Time = reference, Period = Time.OneDay});
             Assert.IsNull(consolidated);
 
-            consolidator.Update(new TradeBar { Time = reference.AddDays(1), Period = period });
+            consolidator.Update(new TradeBar { Time = reference.AddDays(1), Period = Time.OneDay });
+            Assert.IsNull(consolidated);
+
+            consolidator.Update(new TradeBar { Time = reference.AddDays(2), Period = Time.OneDay });
             Assert.IsNotNull(consolidated);
             Assert.AreEqual(period, consolidated.Period);
             consolidated = null;
 
-            consolidator.Update(new TradeBar { Time = reference.AddDays(2), Period = period });
-            Assert.IsNotNull(consolidated);
-            Assert.AreEqual(period, consolidated.Period);
-            consolidated = null;
+            consolidator.Update(new TradeBar { Time = reference.AddDays(3), Period = Time.OneDay });
+            Assert.IsNull(consolidated);
 
-            consolidator.Update(new TradeBar { Time = reference.AddDays(3), Period = period });
+            consolidator.Update(new TradeBar { Time = reference.AddDays(4), Period = Time.OneDay });
             Assert.IsNotNull(consolidated);
             Assert.AreEqual(period, consolidated.Period);
         }
 
         [Test]
-        public void AggregatesPeriodInPeriodModeWithDailyDataAndRoundedTime()
+        public void ThrowsWhenPeriodIsSmallerThanDataPeriod()
         {
             TradeBar consolidated = null;
-            var period = TimeSpan.FromDays(1);
-            var consolidator = new TradeBarConsolidator(period);
+            using var consolidator = new TradeBarConsolidator(Time.OneHour);
             consolidator.DataConsolidated += (sender, bar) =>
             {
                 consolidated = bar;
             };
 
             var reference = new DateTime(2015, 04, 13);
-            consolidator.Update(new TradeBar { Time = reference.AddSeconds(45), Period = period });
-            Assert.IsNull(consolidated);
+            Assert.Throws<ArgumentException>(() => consolidator.Update(new TradeBar { Time = reference, Period = Time.OneDay }));
+        }
 
-            consolidator.Update(new TradeBar { Time = reference.AddDays(1).AddMinutes(1), Period = period });
+        [Test]
+        public void GentlyHandlesPeriodAndDataAreSameResolution()
+        {
+            TradeBar consolidated = null;
+            using var consolidator = new TradeBarConsolidator(Time.OneDay);
+            consolidator.DataConsolidated += (sender, bar) =>
+            {
+                consolidated = bar;
+            };
+
+            var reference = new DateTime(2015, 04, 13);
+
+            consolidator.Update(new TradeBar { Time = reference, Period = Time.OneDay });
+
             Assert.IsNotNull(consolidated);
-            Assert.AreEqual(period, consolidated.Period);
             Assert.AreEqual(reference, consolidated.Time);
-            consolidated = null;
-
-            consolidator.Update(new TradeBar { Time = reference.AddDays(2).AddHours(1), Period = period });
-            Assert.IsNotNull(consolidated);
-            Assert.AreEqual(period, consolidated.Period);
-            Assert.AreEqual(reference.AddDays(1), consolidated.Time);
-            consolidated = null;
-
-            consolidator.Update(new TradeBar { Time = reference.AddDays(3).AddMinutes(1).AddSeconds(1), Period = period });
-            Assert.IsNotNull(consolidated);
-            Assert.AreEqual(period, consolidated.Period);
-            Assert.AreEqual(reference.AddDays(2), consolidated.Time);
         }
 
         [Test]
         public void FiresEventAfterTimePassesViaScan()
         {
             TradeBar consolidated = null;
-            var period = TimeSpan.FromDays(1);
-            var consolidator = new TradeBarConsolidator(period);
+            var period = TimeSpan.FromDays(2);
+            using var consolidator = new TradeBarConsolidator(period);
             consolidator.DataConsolidated += (sender, bar) =>
             {
                 consolidated = bar;
             };
 
             var reference = new DateTime(2015, 04, 13);
-            consolidator.Update(new TradeBar { Time = reference.AddSeconds(45), Period = period });
+            consolidator.Update(new TradeBar { Time = reference, Period = Time.OneDay });
             Assert.IsNull(consolidated);
 
             consolidator.Scan(reference + period);
@@ -503,7 +470,7 @@ namespace QuantConnect.Tests.Common.Data
         {
             TradeBar consolidated = null;
             var period = TimeSpan.FromMinutes(2);
-            var consolidator = new TradeBarConsolidator(period);
+            using var consolidator = new TradeBarConsolidator(period);
             consolidator.DataConsolidated += (sender, bar) =>
             {
                 consolidated = bar;
@@ -525,7 +492,7 @@ namespace QuantConnect.Tests.Common.Data
         {
             TradeBar consolidated = null;
             var period = TimeSpan.FromMinutes(2);
-            var consolidator = new TradeBarConsolidator(period);
+            using var consolidator = new TradeBarConsolidator(period);
             consolidator.DataConsolidated += (sender, bar) =>
             {
                 consolidated = bar;

--- a/Tests/Indicators/IndicatorTests.cs
+++ b/Tests/Indicators/IndicatorTests.cs
@@ -220,8 +220,11 @@ namespace QuantConnect.Tests.Indicators
                 }
             }
 
-            // All indicators should have the same EndTime
-            Assert.AreEqual(1, indicatorTimeList.Distinct().Count());
+            // All indicators should have the same EndTime, with xx:31:00 & xx:32:00
+            Assert.AreEqual(6, indicatorTimeList.Count);
+            Assert.AreEqual(2, indicatorTimeList.Distinct().Count());
+            Assert.AreEqual(3, indicatorTimeList.Count(x => x.Minute == 31));
+            Assert.AreEqual(3, indicatorTimeList.Count(x => x.Minute == 32));
         }
 
         private static void TestComparisonOperators<TValue>()

--- a/Tests/Python/DataConsolidatorPythonWrapperTests.cs
+++ b/Tests/Python/DataConsolidatorPythonWrapperTests.cs
@@ -194,7 +194,7 @@ namespace QuantConnect.Tests.Python
                     "class ImplementingClass():\n" +
                     "   def __init__(self):\n" +
                     "       self.EventCalled = False\n" +
-                    "       self.Consolidator = CustomConsolidator(timedelta(minutes=1))\n" +
+                    "       self.Consolidator = CustomConsolidator(timedelta(minutes=2))\n" +
                     "       self.Consolidator.DataConsolidated += self.ConsolidatorEvent\n" +
                     "   def ConsolidatorEvent(self, sender, bar):\n" +
                     "       self.EventCalled = True\n" +
@@ -226,7 +226,7 @@ namespace QuantConnect.Tests.Python
                 };
 
                 wrapper.Update(bar1);
-                wrapper.Scan(time.AddMinutes(1));
+                wrapper.Scan(time.AddMinutes(2));
                 implementingClass.GetAttr("EventCalled").TryConvert(out called);
                 Assert.True(called);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- If user is trying to consolidate a period providing data of a bigger
  period we will now throw an exception. Adding tests
- If both consolidated and given data share the same period, gently
  adjust the consolidator into a data count of 1. Adding tests
- Fixing bug in QuoteBarConsolidator period double accounting. Adding unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/3062
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Accurate data consolidation
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests and existing unit and regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
