### PR TITLE
Fix QuoteBar Non Time Based Consolidator Period

### DIFF
--- a/Common/Data/Consolidators/QuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/QuoteBarConsolidator.cs
@@ -94,6 +94,12 @@ namespace QuantConnect.Data.Consolidators
                     workingBar.Update(0, previous.Bid?.Close ?? 0, previous.Ask?.Close ?? 0, 0, previous.LastBidSize, previous.LastAskSize);
                 }
             }
+            else if (!IsTimeBased)
+            {
+                // we should only increment the period after the first data we get, else we would be accouting twice for the inital bars period
+                // because in the `if` above we are already providing the `data.Period` as argument. See test 'AggregatesNewCountQuoteBarProperly' which assert period
+                workingBar.Period += data.Period;
+            }
 
             // update the bid and ask
             if (bid != null)
@@ -126,7 +132,6 @@ namespace QuantConnect.Data.Consolidators
             }
 
             workingBar.Value = data.Value;
-            if (!IsTimeBased) workingBar.Period += data.Period;
         }
     }
 }

--- a/Tests/Common/Data/QuoteBarConsolidatorTests.cs
+++ b/Tests/Common/Data/QuoteBarConsolidatorTests.cs
@@ -102,6 +102,8 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(bar4.LastAskSize, quoteBar.LastAskSize);
             Assert.AreEqual(bar1.Value, quoteBar.Value);
 
+            Assert.AreEqual(bar1.Time, quoteBar.Time);
+            Assert.AreEqual(bar4.EndTime, quoteBar.EndTime);
             Assert.AreEqual(TimeSpan.FromMinutes(4), quoteBar.Period);
         }
 
@@ -164,7 +166,7 @@ namespace QuantConnect.Tests.Common.Data
             
             Assert.AreEqual(bar1.Symbol, quoteBar.Symbol);
             Assert.AreEqual(bar1.Time, quoteBar.Time);
-            Assert.AreEqual(time + TimeSpan.FromMinutes(2), quoteBar.EndTime);
+            Assert.AreEqual(bar2.EndTime, quoteBar.EndTime);
             Assert.AreEqual(TimeSpan.FromMinutes(2), quoteBar.Period);
 
             // Bid

--- a/Tests/Common/Data/QuoteBarConsolidatorTests.cs
+++ b/Tests/Common/Data/QuoteBarConsolidatorTests.cs
@@ -27,14 +27,13 @@ namespace QuantConnect.Tests.Common.Data
         public void AggregatesNewCountQuoteBarProperly()
         {
             QuoteBar quoteBar = null;
-            var creator = new QuoteBarConsolidator(4);
+            using var creator = new QuoteBarConsolidator(4);
             creator.DataConsolidated += (sender, args) =>
             {
                 quoteBar = args;
             };
 
             var time = DateTime.Today;
-            var period = TimeSpan.FromMinutes(1);
             var bar1 = new QuoteBar
             {
                 Time = time,
@@ -44,49 +43,49 @@ namespace QuantConnect.Tests.Common.Data
                 Ask = null,
                 LastAskSize = 0,
                 Value = 1,
-                Period = period
+                Period = Time.OneMinute
             };
             creator.Update(bar1);
             Assert.IsNull(quoteBar);
 
             var bar2 = new QuoteBar
             {
-                Time = time + TimeSpan.FromMinutes(1),
+                Time = bar1.EndTime,
                 Symbol = Symbols.SPY,
                 Bid = new Bar(1.1m, 2.2m, 0.9m, 2.1m),
                 LastBidSize = 3,
                 Ask = new Bar(2.2m, 4.4m, 3.3m, 3.3m),
                 LastAskSize = 0,
                 Value = 1,
-                Period = period
+                Period = Time.OneMinute
             };
             creator.Update(bar2);
             Assert.IsNull(quoteBar);
 
             var bar3 = new QuoteBar
             {
-                Time = time + TimeSpan.FromMinutes(2),
+                Time = bar2.EndTime,
                 Symbol = Symbols.SPY,
                 Bid = new Bar(1, 2, 0.5m, 1.75m),
                 LastBidSize = 3,
                 Ask = null,
                 LastAskSize = 0,
                 Value = 1,
-                Period = period
+                Period = Time.OneMinute
             };
             creator.Update(bar3);
             Assert.IsNull(quoteBar);
 
             var bar4 = new QuoteBar
             {
-                Time = time + TimeSpan.FromMinutes(3),
+                Time = bar3.EndTime,
                 Symbol = Symbols.SPY,
                 Bid = null,
                 LastBidSize = 0,
                 Ask = new Bar(1, 7, 0.5m, 4.4m),
                 LastAskSize = 4,
                 Value = 1,
-                Period = period
+                Period = Time.OneMinute
             };
             creator.Update(bar4);
             Assert.IsNotNull(quoteBar);
@@ -102,20 +101,21 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(bar3.LastBidSize, quoteBar.LastBidSize);
             Assert.AreEqual(bar4.LastAskSize, quoteBar.LastAskSize);
             Assert.AreEqual(bar1.Value, quoteBar.Value);
+
+            Assert.AreEqual(TimeSpan.FromMinutes(4), quoteBar.Period);
         }
 
         [Test]
         public void AggregatesNewTimeSpanQuoteBarProperly()
         {
             QuoteBar quoteBar = null;
-            var creator = new QuoteBarConsolidator(TimeSpan.FromMinutes(2));
+            using var creator = new QuoteBarConsolidator(TimeSpan.FromMinutes(2));
             creator.DataConsolidated += (sender, args) =>
             {
                 quoteBar = args;
             };
 
             var time = DateTime.Today;
-            var period = TimeSpan.FromMinutes(1);
             var bar1 = new QuoteBar
             {
                 Time = time,
@@ -125,21 +125,21 @@ namespace QuantConnect.Tests.Common.Data
                 Ask = null,
                 LastAskSize = 0,
                 Value = 1,
-                Period = period
+                Period = Time.OneMinute
             };
             creator.Update(bar1);
             Assert.IsNull(quoteBar);
 
             var bar2 = new QuoteBar
             {
-                Time = time + TimeSpan.FromMinutes(1),
+                Time = bar1.EndTime,
                 Symbol = Symbols.SPY,
                 Bid = new Bar(1.1m, 2.2m, 0.9m, 2.1m),
                 LastBidSize = 3,
                 Ask = new Bar(2.2m, 4.4m, 3.3m, 3.3m),
                 LastAskSize = 0,
                 Value = 1,
-                Period = period
+                Period = Time.OneMinute
             };
             creator.Update(bar2);
             Assert.IsNull(quoteBar);
@@ -147,14 +147,14 @@ namespace QuantConnect.Tests.Common.Data
             // pushing another bar to force the fire
             var bar3 = new QuoteBar
             {
-                Time = time + TimeSpan.FromMinutes(2),
+                Time = bar2.EndTime,
                 Symbol = Symbols.SPY,
                 Bid = new Bar(1, 2, 0.5m, 1.75m),
                 LastBidSize = 3,
                 Ask = null,
                 LastAskSize = 0,
                 Value = 1,
-                Period = period
+                Period = Time.OneMinute
             };
             creator.Update(bar3);
 
@@ -187,7 +187,7 @@ namespace QuantConnect.Tests.Common.Data
         [Test]
         public void DoesNotConsolidateDifferentSymbols()
         {
-            var consolidator = new QuoteBarConsolidator(2);
+            using var consolidator = new QuoteBarConsolidator(2);
 
             var time = DateTime.Today;
             var period = TimeSpan.FromMinutes(1);
@@ -219,14 +219,14 @@ namespace QuantConnect.Tests.Common.Data
             consolidator.Update(bar1);
 
             Exception ex = Assert.Throws<InvalidOperationException>(() => consolidator.Update(bar2));
-            Assert.IsTrue(ex.Message.Contains("is not the same"));
+            Assert.IsTrue(ex.Message.Contains("is not the same", StringComparison.InvariantCultureIgnoreCase));
         }
 
         [Test]
         public void LastCloseAndCurrentOpenPriceShouldBeSameConsolidatedOnTimeSpan()
         {
             QuoteBar quoteBar = null;
-            var creator = new QuoteBarConsolidator(TimeSpan.FromMinutes(2));
+            using var creator = new QuoteBarConsolidator(TimeSpan.FromMinutes(2));
             creator.DataConsolidated += (sender, args) =>
             {
                 quoteBar = args;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix QuoteBar non timebased consolidator period, that was accounting
  twice for the initial bar period. Updating unit tests

See `TradeBarConsolidator` following a similar pattern
![image](https://user-images.githubusercontent.com/18473240/174404640-48e6fdce-5204-417e-8491-25339acf97ce.png)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Accurate consolidating
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updating unit tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
