### PR TITLE
Add data normalization mode parameter to `QCAlgorithm.History()`

### DIFF
--- a/Algorithm.CSharp/HistoryWithDifferentDataNormalizationModeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HistoryWithDifferentDataNormalizationModeRegressionAlgorithm.cs
@@ -64,7 +64,7 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(x => History(new [] { symbol }, start, end, resolution, dataNormalizationMode: x).ToList())
                 .ToList();
 
-            if (historyResults.Count == 0 || historyResults.Any(x => x.Count != historyResults.First().Count))
+            if (historyResults.Any(x => x.Count == 0 || x.Count != historyResults.First().Count))
             {
                 throw new Exception($"History results for {symbol} have different number of bars");
             }
@@ -75,7 +75,7 @@ namespace QuantConnect.Algorithm.CSharp
                 var closePrices = historyResults.Select(hr => hr[j].Bars.First().Value.Close).ToHashSet();
                 if (closePrices.Count != dataNormalizationModes.Length)
                 {
-                    throw new Exception("History results for " + symbol + " have different close prices at the same time");
+                    throw new Exception($"History results for {symbol} have different close prices at the same time");
                 }
             }
         }
@@ -88,7 +88,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp };
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm

--- a/Algorithm.CSharp/HistoryWithDifferentDataNormalizationModeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HistoryWithDifferentDataNormalizationModeRegressionAlgorithm.cs
@@ -1,0 +1,152 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm illustrating how to request history data for different data normalization modes.
+    /// </summary>
+    public class HistoryWithDifferentDataNormalizationModeRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _aaplEquitySymbol;
+        private Symbol _esFutureSymbol;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 7);
+            SetEndDate(2014, 1, 1);
+
+            _aaplEquitySymbol = AddEquity("AAPL", Resolution.Daily).Symbol;
+            _esFutureSymbol = AddFuture(Futures.Indices.SP500EMini, Resolution.Daily).Symbol;
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            var equityDataNormalizationModes = new DataNormalizationMode[]{
+                DataNormalizationMode.Raw,
+                DataNormalizationMode.Adjusted,
+                DataNormalizationMode.SplitAdjusted
+            };
+            CheckHistoryResultsForDataNormalizationModes(_aaplEquitySymbol, StartDate, EndDate, Resolution.Daily, equityDataNormalizationModes);
+
+            var futureDataNormalizationModes = new DataNormalizationMode[]{
+                DataNormalizationMode.Raw,
+                DataNormalizationMode.BackwardsRatio,
+                DataNormalizationMode.BackwardsPanamaCanal,
+                DataNormalizationMode.ForwardPanamaCanal
+            };
+            CheckHistoryResultsForDataNormalizationModes(_esFutureSymbol, StartDate, EndDate, Resolution.Daily, futureDataNormalizationModes);
+        }
+
+        private void CheckHistoryResultsForDataNormalizationModes(Symbol symbol, DateTime start, DateTime end, Resolution resolution,
+            DataNormalizationMode[] dataNormalizationModes)
+        {
+            var historyResults = dataNormalizationModes
+                .Select(x => History(new [] { symbol }, start, end, resolution, dataNormalizationMode: x).ToList())
+                .ToList();
+
+            if (historyResults.Count == 0 || historyResults.Any(x => x.Count != historyResults.First().Count))
+            {
+                throw new Exception($"History results for {symbol} have different number of bars");
+            }
+
+            // Check that, for each history result, close prices at each time are different for these securities (AAPL and ES)
+            for (int j = 0; j < historyResults[0].Count; j++)
+            {
+                var closePrices = historyResults.Select(hr => hr[j].Bars.First().Value.Close).ToHashSet();
+                if (closePrices.Count != dataNormalizationModes.Length)
+                {
+                    throw new Exception("History results for " + symbol + " have different close prices at the same time");
+                }
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 1387;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 772;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-4.178"},
+            {"Tracking Error", "0.085"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.Python/HistoryWithDifferentDataNormalizationModeRegressionAlgorithm.py
+++ b/Algorithm.Python/HistoryWithDifferentDataNormalizationModeRegressionAlgorithm.py
@@ -1,0 +1,56 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression algorithm illustrating how to request history data for different data normalization modes.
+### </summary>
+class HistoryWithDifferentDataMappingModeRegressionAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        self.SetStartDate(2013, 10, 7)
+        self.SetEndDate(2014, 1, 1)
+        self.aaplEquitySymbol = self.AddEquity("AAPL", Resolution.Daily).Symbol
+        self.esFutureSymbol = self.AddFuture(Futures.Indices.SP500EMini, Resolution.Daily).Symbol
+
+    def OnEndOfAlgorithm(self):
+        equityDataNormalizationModes = [
+            DataNormalizationMode.Raw,
+            DataNormalizationMode.Adjusted,
+            DataNormalizationMode.SplitAdjusted
+        ]
+        self.CheckHistoryResultsForDataNormalizationModes(self.aaplEquitySymbol, self.StartDate, self.EndDate, Resolution.Daily,
+            equityDataNormalizationModes)
+
+        futureDataNormalizationModes = [
+            DataNormalizationMode.Raw,
+            DataNormalizationMode.BackwardsRatio,
+            DataNormalizationMode.BackwardsPanamaCanal,
+            DataNormalizationMode.ForwardPanamaCanal
+        ]
+        self.CheckHistoryResultsForDataNormalizationModes(self.esFutureSymbol, self.StartDate, self.EndDate, Resolution.Daily,
+            futureDataNormalizationModes)
+
+    def CheckHistoryResultsForDataNormalizationModes(self, symbol, start, end, resolution, dataNormalizationModes):
+        historyResults = [self.History([symbol], start, end, resolution, dataNormalizationMode=x) for x in dataNormalizationModes]
+        historyResults = [x.droplevel(0, axis=0) for x in historyResults] if len(historyResults[0].index.levels) == 3 else historyResults
+        historyResults = [x.loc[symbol].close for x in historyResults]
+
+        if any(x.size == 0 or x.size != historyResults[0].size for x in historyResults):
+            raise Exception(f"History results for {symbol} have different number of bars")
+
+        # Check that, for each history result, close prices at each time are different for these securities (AAPL and ES)
+        for j in range(historyResults[0].size):
+            closePrices = set(historyResults[i][j] for i in range(len(historyResults)))
+            if len(closePrices) != len(dataNormalizationModes):
+                raise Exception(f"History results for {symbol} have different close prices at the same time")

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -877,13 +877,15 @@ namespace QuantConnect.Algorithm
         /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <param name="extendedMarket">True to include extended market hours data, false otherwise</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security history request</param>
+        /// <param name="dataNormalizationMode">The price scaling mode to use for the securities history</param>
         /// <returns>A python dictionary with a pandas DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
         public PyObject History(PyObject tickers, DateTime start, DateTime end, Resolution? resolution = null, bool? fillForward = null,
-            bool? extendedMarket = null, DataMappingMode? dataMappingMode = null)
+            bool? extendedMarket = null, DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
-            return PandasConverter.GetDataFrame(History(symbols, start, end, resolution, fillForward, extendedMarket, dataMappingMode));
+            return PandasConverter.GetDataFrame(
+                History(symbols, start, end, resolution, fillForward, extendedMarket, dataMappingMode, dataNormalizationMode));
         }
 
         /// <summary>

--- a/Common/Data/HistoryRequestFactory.cs
+++ b/Common/Data/HistoryRequestFactory.cs
@@ -46,13 +46,15 @@ namespace QuantConnect.Data
         /// <param name="exchangeHours">Security exchange hours</param>
         /// <param name="resolution">The resolution to use. If null will use <see cref="SubscriptionDataConfig.Resolution"/></param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security history request</param>
+        /// <param name="dataNormalizationMode">The price scaling mode to use for the securities history</param>
         /// <returns>The new <see cref="HistoryRequest"/></returns>
         public HistoryRequest CreateHistoryRequest(SubscriptionDataConfig subscription,
             DateTime startAlgoTz,
             DateTime endAlgoTz,
             SecurityExchangeHours exchangeHours,
             Resolution? resolution,
-            DataMappingMode? dataMappingMode = null)
+            DataMappingMode? dataMappingMode = null,
+            DataNormalizationMode? dataNormalizationMode = null)
         {
             resolution ??= subscription.Resolution;
 
@@ -79,6 +81,11 @@ namespace QuantConnect.Data
             if (dataMappingMode != null)
             {
                 request.DataMappingMode = dataMappingMode.Value;
+            }
+
+            if (dataNormalizationMode != null)
+            {
+                request.DataNormalizationMode = dataNormalizationMode.Value;
             }
 
             return request;

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -693,15 +693,12 @@ class Test(PythonData):
             for (int j = 0; j < historyResults[0].Count; j++)
             {
                 var closePrices = historyResults.Select(hr => hr[j].Bars.First().Value.Close).ToHashSet();
-                if (closePrices.Count != expectedPricesCount)
-                {
-                    throw new Exception(message);
-                }
+                Assert.AreEqual(expectedPricesCount, closePrices.Count, message);
             }
         }
 
         /// <summary>
-        /// Helper method to check that, for each history result, close prices at each time are different
+        /// Helper method to perform history checks on different data normalization modes
         /// </summary>
         private static void CheckHistoryResultsForDataNormalizationModes(QCAlgorithm algorithm, Symbol symbol, DateTime start,
             DateTime end, Resolution resolution, DataNormalizationMode[] dataNormalizationModes)

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -454,8 +454,7 @@ class Test(PythonData):
                 .Select(x => _algorithm.History(new [] { symbol }, historyStart, historyEnd, resolution, dataMappingMode: x).ToList())
                 .ToList();
 
-            var expectedBarsCount = historyResults.First().Count;
-            Assert.That(historyResults, Has.All.Not.Empty.And.All.Count.EqualTo(expectedBarsCount));
+            CheckThatHistoryResultsHaveEqualBarCount(historyResults);
 
             // Check that all history results have a mapping date at some point in the history
             HashSet<DateTime> mappingDates = new HashSet<DateTime>();
@@ -486,15 +485,109 @@ class Test(PythonData):
                 throw new Exception($"History results should have had different mapping dates for each data mapping mode");
             }
 
-            // Check that close prices at each time are different for different data mapping modes
-            for (int j = 0; j < historyResults[0].Count; j++)
+            CheckThatHistoryResultsHaveDifferentClosePrices(historyResults, dataMappingModes.Length,
+                $"History results close prices should have been different for each data mapping mode at each time");
+        }
+
+        [TestCase(DataNormalizationMode.BackwardsRatio)]
+        [TestCase(DataNormalizationMode.BackwardsPanamaCanal)]
+        [TestCase(DataNormalizationMode.ForwardPanamaCanal)]
+        public void HistoryThrowsForUnsupportedDataNormalizationMode_Equity(DataNormalizationMode dataNormalizationMode)
+        {
+            _algorithm = GetAlgorithmWithEquity(new DateTime(2014, 6, 6));
+            Assert.AreEqual(2, _algorithm.SubscriptionManager.Subscriptions.ToList().Count);
+            var equity = _algorithm.SubscriptionManager.Subscriptions.First();
+            Assert.AreEqual(SecurityType.Equity, equity.SecurityType);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
-                var closePrices = historyResults.Select(hr => hr[j].Bars.First().Value.Close).ToHashSet();
-                if (closePrices.Count != dataMappingModes.Length)
-                {
-                    throw new Exception($"History results close prices should have been different for each data mapping mode at each time");
-                }
-            }
+                _algorithm.History(new [] { equity.Symbol }, _algorithm.Time.AddDays(-1), _algorithm.Time, equity.Resolution,
+                    dataNormalizationMode: dataNormalizationMode).ToList();
+            });
+        }
+
+        [TestCase(DataNormalizationMode.Adjusted)]
+        [TestCase(DataNormalizationMode.SplitAdjusted)]
+        [TestCase(DataNormalizationMode.TotalReturn)]
+        public void HistoryThrowsForUnsupportedDataNormalizationMode_Future(DataNormalizationMode dataNormalizationMode)
+        {
+            _algorithm = GetAlgorithmWithFuture(new DateTime(2014, 1, 1));
+            Assert.IsNotEmpty(_algorithm.SubscriptionManager.Subscriptions);
+            var future = _algorithm.SubscriptionManager.Subscriptions.First();
+            Assert.AreEqual(SecurityType.Future, future.SecurityType);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                _algorithm.History(new [] { future.Symbol }, _algorithm.StartDate, _algorithm.Time, future.Resolution,
+                    dataNormalizationMode: dataNormalizationMode).ToList();
+            });
+        }
+
+        [TestCase(DataNormalizationMode.Raw)]
+        [TestCase(DataNormalizationMode.Adjusted)]
+        [TestCase(DataNormalizationMode.SplitAdjusted)]
+        [TestCase(DataNormalizationMode.TotalReturn)]
+        public void HistoryDoesNotThrowForSupportedDataNormalizationMode_Equity(DataNormalizationMode dataNormalizationMode)
+        {
+            _algorithm = GetAlgorithmWithEquity(new DateTime(2014, 6, 6));
+            Assert.AreEqual(2, _algorithm.SubscriptionManager.Subscriptions.ToList().Count);
+            var equity = _algorithm.SubscriptionManager.Subscriptions.First();
+            Assert.AreEqual(SecurityType.Equity, equity.SecurityType);
+
+            Assert.DoesNotThrow(() =>
+            {
+                _algorithm.History(new [] { equity.Symbol }, _algorithm.Time.AddDays(-1), _algorithm.Time, equity.Resolution,
+                    dataNormalizationMode: dataNormalizationMode).ToList();
+            });
+        }
+
+        [TestCase(DataNormalizationMode.Raw)]
+        [TestCase(DataNormalizationMode.BackwardsRatio)]
+        [TestCase(DataNormalizationMode.BackwardsPanamaCanal)]
+        [TestCase(DataNormalizationMode.ForwardPanamaCanal)]
+        public void HistoryDoesNotThrowForSupportedDataNormalizationMode_Future(DataNormalizationMode dataNormalizationMode)
+        {
+            _algorithm = GetAlgorithmWithFuture(new DateTime(2014, 1, 1));
+            Assert.IsNotEmpty(_algorithm.SubscriptionManager.Subscriptions);
+            var future = _algorithm.SubscriptionManager.Subscriptions.First();
+            Assert.AreEqual(SecurityType.Future, future.SecurityType);
+
+            Assert.DoesNotThrow(() =>
+            {
+                _algorithm.History(new [] { future.Symbol }, _algorithm.StartDate, _algorithm.Time, future.Resolution,
+                    dataNormalizationMode: dataNormalizationMode).ToList();
+            });
+        }
+
+        [Test]
+        public void SubscriptionHistoryRequestWithDifferentDataNormalizationModes_Equity()
+        {
+            var dataNormalizationModes = new DataNormalizationMode[]{
+                DataNormalizationMode.Raw,
+                DataNormalizationMode.Adjusted,
+                DataNormalizationMode.SplitAdjusted
+            };
+            _algorithm = GetAlgorithmWithEquity(new DateTime(2014, 6, 6));
+            var equity = _algorithm.SubscriptionManager.Subscriptions.First();
+
+            CheckHistoryResultsForDataNormalizationModes(_algorithm, equity.Symbol, _algorithm.Time.AddDays(-1), _algorithm.Time, equity.Resolution,
+                dataNormalizationModes);
+        }
+
+        [Test]
+        public void SubscriptionHistoryRequestWithDifferentDataNormalizationModes_Future()
+        {
+            var dataNormalizationModes = new DataNormalizationMode[]{
+                DataNormalizationMode.Raw,
+                DataNormalizationMode.BackwardsRatio,
+                DataNormalizationMode.BackwardsPanamaCanal,
+                DataNormalizationMode.ForwardPanamaCanal
+            };
+            _algorithm = GetAlgorithmWithFuture(new DateTime(2014, 1, 1));
+            var future = _algorithm.SubscriptionManager.Subscriptions.First();
+
+            CheckHistoryResultsForDataNormalizationModes(_algorithm, future.Symbol, new DateTime(2013, 10, 6), _algorithm.Time, future.Resolution,
+                dataNormalizationModes);
         }
 
         private QCAlgorithm GetAlgorithm(DateTime dateTime)
@@ -565,9 +658,71 @@ class Test(PythonData):
             }
         }
 
+        private QCAlgorithm GetAlgorithmWithEquity(DateTime dateTime)
+        {
+            var resolution = Resolution.Minute;
+            var algorithm = GetAlgorithm(dateTime);
+            algorithm.AddEquity("AAPL", resolution);
+
+            return algorithm;
+        }
+
+        private QCAlgorithm GetAlgorithmWithFuture(DateTime dateTime)
+        {
+            var resolution = Resolution.Daily;
+            var algorithm = GetAlgorithm(dateTime);
+            algorithm.AddFuture(Futures.Indices.SP500EMini, resolution);
+
+            return algorithm;
+        }
+
+        /// <summary>
+        /// Helper method to check that all history results have the same bar count
+        /// </summary>
+        private static void CheckThatHistoryResultsHaveEqualBarCount(List<List<Slice>> historyResults)
+        {
+            var expectedBarsCount = historyResults.First().Count;
+            Assert.That(historyResults, Has.All.Not.Empty.And.All.Count.EqualTo(expectedBarsCount));
+        }
+
+        /// <summary>
+        /// Helper method to check that, for each history result, close prices at each time are different
+        /// </summary>
+        private static void CheckThatHistoryResultsHaveDifferentClosePrices(List<List<Slice>> historyResults, int expectedPricesCount, string message)
+        {
+            for (int j = 0; j < historyResults[0].Count; j++)
+            {
+                var closePrices = historyResults.Select(hr => hr[j].Bars.First().Value.Close).ToHashSet();
+                if (closePrices.Count != expectedPricesCount)
+                {
+                    throw new Exception(message);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Helper method to check that, for each history result, close prices at each time are different
+        /// </summary>
+        private static void CheckHistoryResultsForDataNormalizationModes(QCAlgorithm algorithm, Symbol symbol, DateTime start,
+            DateTime end, Resolution resolution, DataNormalizationMode[] dataNormalizationModes)
+        {
+            var historyResults = dataNormalizationModes
+                .Select(x => algorithm.History(new [] { symbol }, start, end, resolution, dataNormalizationMode: x).ToList())
+                .ToList();
+
+            CheckThatHistoryResultsHaveEqualBarCount(historyResults);
+            CheckThatHistoryResultsHaveDifferentClosePrices(historyResults, dataNormalizationModes.Length,
+                $"History results close prices should have been different for each data normalization mode at each time");
+        }
+
         private static DataMappingMode[] GetAllDataMappingModes()
         {
             return (DataMappingMode[])Enum.GetValues(typeof(DataMappingMode));
+        }
+
+        private static DataNormalizationMode[] GetAllDataNormalizationModes()
+        {
+            return (DataNormalizationMode[])Enum.GetValues(typeof(DataNormalizationMode));
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description

The `dataNormalizationMode` parameter was added to the `QCAlgorithm.History()` family of methods to allow getting historical data using a different data normalization mode that the one used for the security subscription.

#### Related Issue

Part of #4882 

#### Motivation and Context

This will allow to get historical data using a different data normalization mode that the one used for the security subscription.

#### Requires Documentation Change

Yes

#### How Has This Been Tested?

Unit and regressions tests were implemented asserting that when getting historical data with different data normalization modes, the prices are not the same at a given timestamp when the security has different scaling factors for each data normalization mode.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
