### PR TITLE
Period consolidator adjusments

### DIFF
--- a/Common/Data/Consolidators/DynamicDataConsolidator.cs
+++ b/Common/Data/Consolidators/DynamicDataConsolidator.cs
@@ -85,7 +85,7 @@ namespace QuantConnect.Data.Consolidators
                 workingBar = new TradeBar
                 {
                     Symbol = data.Symbol,
-                    Time = GetRoundedBarTime(data.Time),
+                    Time = GetRoundedBarTime(data),
                     Open = open,
                     High = high,
                     Low = low,

--- a/Common/Data/Consolidators/OpenInterestConsolidator.cs
+++ b/Common/Data/Consolidators/OpenInterestConsolidator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -104,7 +104,7 @@ namespace QuantConnect.Data.Consolidators
                 workingBar = new OpenInterest
                 {
                     Symbol = tick.Symbol,
-                    Time = GetRoundedBarTime(tick.Time),
+                    Time = GetRoundedBarTime(tick),
                     Value = tick.Value
                 };
 

--- a/Common/Data/Consolidators/QuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/QuoteBarConsolidator.cs
@@ -84,7 +84,7 @@ namespace QuantConnect.Data.Consolidators
 
             if (workingBar == null)
             {
-                workingBar = new QuoteBar(GetRoundedBarTime(data.Time), data.Symbol, null, 0, null, 0, IsTimeBased && Period.HasValue ? Period : data.Period);
+                workingBar = new QuoteBar(GetRoundedBarTime(data), data.Symbol, null, 0, null, 0, IsTimeBased && Period.HasValue ? Period : data.Period);
 
                 // open ask and bid should match previous close ask and bid
                 if (Consolidated != null)

--- a/Common/Data/Consolidators/TickConsolidator.cs
+++ b/Common/Data/Consolidators/TickConsolidator.cs
@@ -91,7 +91,7 @@ namespace QuantConnect.Data.Consolidators
         {
             if (workingBar == null)
             {
-                workingBar = new TradeBar(GetRoundedBarTime(data.Time),
+                workingBar = new TradeBar(GetRoundedBarTime(data),
                     data.Symbol,
                     data.Value,
                     data.Value,

--- a/Common/Data/Consolidators/TickQuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/TickQuoteBarConsolidator.cs
@@ -91,7 +91,7 @@ namespace QuantConnect.Data.Consolidators
         {
             if (workingBar == null)
             {
-                workingBar = new QuoteBar(GetRoundedBarTime(data.Time), data.Symbol, null, decimal.Zero, null, decimal.Zero, Period);
+                workingBar = new QuoteBar(GetRoundedBarTime(data), data.Symbol, null, decimal.Zero, null, decimal.Zero, Period);
 
                 // open ask and bid should match previous close ask and bid
                 if (Consolidated != null)

--- a/Common/Data/Consolidators/TradeBarConsolidator.cs
+++ b/Common/Data/Consolidators/TradeBarConsolidator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -97,7 +97,7 @@ namespace QuantConnect.Data.Consolidators
             {
                 workingBar = new TradeBar
                 {
-                    Time = GetRoundedBarTime(data.Time),
+                    Time = GetRoundedBarTime(data),
                     Symbol = data.Symbol,
                     Open = data.Open,
                     High = data.High,

--- a/Tests/Common/Data/TradeBarConsolidatorTests.cs
+++ b/Tests/Common/Data/TradeBarConsolidatorTests.cs
@@ -438,11 +438,16 @@ namespace QuantConnect.Tests.Common.Data
             };
 
             var reference = new DateTime(2015, 04, 13);
+            var bar = new TradeBar { Time = reference, Period = Time.OneDay };
+            consolidator.Update(bar);
 
-            consolidator.Update(new TradeBar { Time = reference, Period = Time.OneDay });
+            Assert.IsNull(consolidated);
+            consolidator.Scan(bar.EndTime);
+            Assert.IsNotNull(consolidated);
 
             Assert.IsNotNull(consolidated);
             Assert.AreEqual(reference, consolidated.Time);
+            Assert.AreEqual(Time.OneDay, consolidated.Period);
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Replace logic to convert `TimeSpan` based `PeriodConsolidator` into count
  based, by an override of the 'potentialStartTime' in the case we could
  be falling into a look ahead consolidated bar end time

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See https://github.com/QuantConnect/Lean/pull/6408
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allow multiple resolutions for consolidation
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests using multiple resolutions. Algorithm using multiple resolutions for consolidation
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
