### PR TITLE
Added configuration parameters to Python `QCAlgorithm.History()` method that takes custom data source type

### DIFF
--- a/Algorithm.CSharp/HistoryWithCustomDataSourceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HistoryWithCustomDataSourceRegressionAlgorithm.cs
@@ -1,0 +1,184 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities.Equity;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression test illustrating how history from custom data sources can be requested.
+    /// </summary>
+    public class HistoryWithCustomDataSourceRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _aapl;
+        private Symbol _spy;
+
+        public override void Initialize()
+        {
+            SetStartDate(2014, 6, 5);
+            SetEndDate(2014, 6, 6);
+
+            _aapl = AddData<CustomData>("AAPL", Resolution.Minute).Symbol;
+            _spy = AddData<CustomData>("SPY", Resolution.Minute).Symbol;
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            // We remove the symbol from history data in order to compare values only
+            Func<CustomData, Object> getRawCustomData = data => new {
+                Time = data.Time,
+                Value = data.Value,
+                Close = data.Close,
+                Open = data.Open,
+                High = data.High,
+                Low = data.Low,
+                Volume = data.Volume,
+            };
+
+            var aaplHistory = History<CustomData>("AAPL", StartDate, EndDate, Resolution.Minute).Select(getRawCustomData);
+            var spyHistory = History<CustomData>("SPY", StartDate, EndDate, Resolution.Minute).Select(getRawCustomData);
+
+            var a = aaplHistory.ToList();
+            var b = spyHistory.ToList();
+
+            if (a.Count == 0 || b.Count == 0)
+            {
+                throw new Exception("At least one of the history results is empty");
+            }
+
+            // Check that both b contain the same data, since CustomData fetches APPL data regardless of the symbol
+            if (!a.SequenceEqual(spyHistory))
+            {
+                throw new Exception("Histories are not equal");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 2960;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 2938;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+
+        /// <summary>
+        /// Custom data source for the regression test algorithm, which returns AAPL equity data regardless of the symbol requested.
+        /// </summary>
+        public class CustomData : BaseData
+        {
+            public decimal Open;
+            public decimal High;
+            public decimal Low;
+            public decimal Close;
+            public decimal Volume;
+
+            public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
+            {
+                return new TradeBar().GetSource(
+                    new SubscriptionDataConfig(
+                        config,
+                        typeof(CustomData),
+                        // Create a new symbol as equity so we find the existing data files
+                        // Symbol.Create(config.MappedSymbol, SecurityType.Equity, config.Market)),
+                        Symbol.Create("AAPL", SecurityType.Equity, config.Market)),
+                    date,
+                    isLiveMode);
+            }
+
+            public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
+            {
+                var tradeBar = TradeBar.ParseEquity(config, line, date);
+
+                return new CustomData {
+                    Symbol = config.Symbol,
+                    Time = tradeBar.Time,
+                    Value = tradeBar.Value,
+                    Close = tradeBar.Close,
+                    Open = tradeBar.Open,
+                    High = tradeBar.High,
+                    Low = tradeBar.Low,
+                    Volume = tradeBar.Volume,
+                };
+            }
+        }
+    }
+}

--- a/Algorithm.CSharp/HistoryWithCustomDataSourceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HistoryWithCustomDataSourceRegressionAlgorithm.cs
@@ -53,19 +53,16 @@ namespace QuantConnect.Algorithm.CSharp
                 Volume = data.Volume,
             };
 
-            var aaplHistory = History<CustomData>("AAPL", StartDate, EndDate, Resolution.Minute).Select(getRawCustomData);
-            var spyHistory = History<CustomData>("SPY", StartDate, EndDate, Resolution.Minute).Select(getRawCustomData);
+            var aaplHistory = History<CustomData>("AAPL", StartDate, EndDate, Resolution.Minute).Select(getRawCustomData).ToList();
+            var spyHistory = History<CustomData>("SPY", StartDate, EndDate, Resolution.Minute).Select(getRawCustomData).ToList();
 
-            var a = aaplHistory.ToList();
-            var b = spyHistory.ToList();
-
-            if (a.Count == 0 || b.Count == 0)
+            if (aaplHistory.Count == 0 || spyHistory.Count == 0)
             {
                 throw new Exception("At least one of the history results is empty");
             }
 
-            // Check that both b contain the same data, since CustomData fetches APPL data regardless of the symbol
-            if (!a.SequenceEqual(spyHistory))
+            // Check that both results contain the same data, since CustomData fetches APPL data regardless of the symbol
+            if (!aaplHistory.SequenceEqual(spyHistory))
             {
                 throw new Exception("Histories are not equal");
             }

--- a/Algorithm.CSharp/HistoryWithCustomDataSourceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HistoryWithCustomDataSourceRegressionAlgorithm.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp };
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm

--- a/Algorithm.Python/HistoryWithCustomDataSourceRegressionAlgorithm.py
+++ b/Algorithm.Python/HistoryWithCustomDataSourceRegressionAlgorithm.py
@@ -14,7 +14,8 @@
 from AlgorithmImports import *
 
 ### <summary>
-### Regression test illustrating how history from custom data sources can be requested.
+### Regression test illustrating how history from custom data sources can be requested. The <see cref="QCAlgorithm.History"/> method used in this
+### example also allows to specify other parameters than just the resolution, such as the data normalization mode, the data mapping mode, etc.
 ### </summary>
 class HistoryWithCustomDataSourceRegressionAlgorithm(QCAlgorithm):
     def Initialize(self):
@@ -26,9 +27,9 @@ class HistoryWithCustomDataSourceRegressionAlgorithm(QCAlgorithm):
 
     def OnEndOfAlgorithm(self):
         aaplHistory = self.History(CustomData, self.aapl, self.StartDate, self.EndDate, Resolution.Minute,
-            dataNormalizationMode=DataNormalizationMode.Raw).droplevel(0, axis=0)
+            fillForward=False, extendedMarket=False, dataNormalizationMode=DataNormalizationMode.Raw).droplevel(0, axis=0)
         spyHistory = self.History(CustomData, self.spy, self.StartDate, self.EndDate, Resolution.Minute,
-            dataNormalizationMode=DataNormalizationMode.Raw).droplevel(0, axis=0)
+            fillForward=False, extendedMarket=False, dataNormalizationMode=DataNormalizationMode.Raw).droplevel(0, axis=0)
 
         if aaplHistory.size == 0 or spyHistory.size == 0:
             raise Exception("At least one of the history results is empty")

--- a/Algorithm.Python/HistoryWithCustomDataSourceRegressionAlgorithm.py
+++ b/Algorithm.Python/HistoryWithCustomDataSourceRegressionAlgorithm.py
@@ -1,0 +1,65 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression test illustrating how history from custom data sources can be requested.
+### </summary>
+class HistoryWithCustomDataSourceRegressionAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        self.SetStartDate(2014, 6, 5)
+        self.SetEndDate(2014, 6, 6)
+
+        self.aapl = self.AddData(CustomData, "AAPL", Resolution.Minute).Symbol
+        self.spy = self.AddData(CustomData, "SPY", Resolution.Minute).Symbol
+
+    def OnEndOfAlgorithm(self):
+        aaplHistory = self.History(CustomData, self.aapl, self.StartDate, self.EndDate, Resolution.Minute,
+            dataNormalizationMode=DataNormalizationMode.Raw).droplevel(0, axis=0)
+        spyHistory = self.History(CustomData, self.spy, self.StartDate, self.EndDate, Resolution.Minute,
+            dataNormalizationMode=DataNormalizationMode.Raw).droplevel(0, axis=0)
+
+        if aaplHistory.size == 0 or spyHistory.size == 0:
+            raise Exception("At least one of the history results is empty")
+
+        # Check that both resutls contain the same data, since CustomData fetches APPL data regardless of the symbol
+        if not aaplHistory.equals(spyHistory):
+            raise Exception("Histories are not equal")
+
+class CustomData(PythonData):
+    '''Custom data source for the regression test algorithm, which returns AAPL equity data regardless of the symbol requested.'''
+
+    def GetSource(self, config, date, isLiveMode):
+        return TradeBar().GetSource(
+            SubscriptionDataConfig(
+                config,
+                CustomData,
+                # Create a new symbol as equity so we find the existing data files
+                # Symbol.Create(config.MappedSymbol, SecurityType.Equity, config.Market)),
+                Symbol.Create("AAPL", SecurityType.Equity, config.Market)),
+            date,
+            isLiveMode)
+
+    def Reader(self, config, line, date, isLiveMode):
+        tradeBar = TradeBar.ParseEquity(config, line, date)
+        data = CustomData()
+        data.Time = tradeBar.Time
+        data.Value = tradeBar.Value
+        data.Close = tradeBar.Close
+        data.Open = tradeBar.Open
+        data.High = tradeBar.High
+        data.Low = tradeBar.Low
+        data.Volume = tradeBar.Volume
+
+        return data

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -711,12 +711,11 @@ namespace QuantConnect.Algorithm
 
                 foreach (var config in GetMatchingSubscriptions(x, requestedType, resolution))
                 {
-                    var res = GetResolution(x, resolution);
-                    var request = _historyRequestFactory.CreateHistoryRequest(config, startAlgoTz, endAlgoTz, GetExchangeHours(x), res,
+                    var request = _historyRequestFactory.CreateHistoryRequest(config, startAlgoTz, endAlgoTz, GetExchangeHours(x), resolution,
                         dataMappingMode, dataNormalizationMode, contractDepthOffset);
 
                     // apply overrides
-                    if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? res : (Resolution?)null;
+                    if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? GetResolution(x, resolution) : (Resolution?)null;
                     if (extendedMarket.HasValue) request.IncludeExtendedMarketHours = extendedMarket.Value;
 
                     requests.Add(request);

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -694,17 +694,28 @@ namespace QuantConnect.Algorithm
             Resolution? resolution = null, bool? fillForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
+            return CreateDateRangeHistoryRequests(symbols, typeof(BaseData), startAlgoTz, endAlgoTz, resolution, fillForward, extendedMarket,
+                dataMappingMode, dataNormalizationMode, contractDepthOffset);
+        }
+
+        /// <summary>
+        /// Helper method to create history requests from a date range with custom data type
+        /// </summary>
+        private IEnumerable<HistoryRequest> CreateDateRangeHistoryRequests(IEnumerable<Symbol> symbols, Type requestedType, DateTime startAlgoTz, DateTime endAlgoTz,
+            Resolution? resolution = null, bool? fillForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
+            DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
+        {
             return symbols.Where(HistoryRequestValid).SelectMany(x =>
             {
                 var requests = new List<HistoryRequest>();
 
-                foreach (var config in GetMatchingSubscriptions(x, typeof(BaseData), resolution))
+                foreach (var config in GetMatchingSubscriptions(x, requestedType, resolution))
                 {
-                    var request = _historyRequestFactory.CreateHistoryRequest(config, startAlgoTz, endAlgoTz, GetExchangeHours(x), resolution,
+                    var res = GetResolution(x, resolution);
+                    var request = _historyRequestFactory.CreateHistoryRequest(config, startAlgoTz, endAlgoTz, GetExchangeHours(x), res,
                         dataMappingMode, dataNormalizationMode, contractDepthOffset);
 
                     // apply overrides
-                    var res = GetResolution(x, resolution);
                     if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? res : (Resolution?)null;
                     if (extendedMarket.HasValue) request.IncludeExtendedMarketHours = extendedMarket.Value;
 
@@ -721,11 +732,22 @@ namespace QuantConnect.Algorithm
         private IEnumerable<HistoryRequest> CreateBarCountHistoryRequests(IEnumerable<Symbol> symbols, int periods, Resolution? resolution = null,
             DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
+            return CreateBarCountHistoryRequests(symbols, typeof(BaseData), periods, resolution, dataMappingMode, dataNormalizationMode,
+                contractDepthOffset);
+        }
+
+        /// <summary>
+        /// Helper methods to create a history request for the specified symbols and bar count with custom data type
+        /// </summary>
+        private IEnumerable<HistoryRequest> CreateBarCountHistoryRequests(IEnumerable<Symbol> symbols, Type requestedType, int periods,
+            Resolution? resolution = null, DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null,
+            int? contractDepthOffset = null)
+        {
             return symbols.Where(HistoryRequestValid).SelectMany(x =>
             {
                 var res = GetResolution(x, resolution);
                 var exchange = GetExchangeHours(x);
-                var configs = GetMatchingSubscriptions(x, typeof(BaseData), resolution).ToList();
+                var configs = GetMatchingSubscriptions(x, requestedType, resolution).ToList();
                 if (!configs.Any())
                 {
                     return Enumerable.Empty<HistoryRequest>();

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -930,8 +930,7 @@ namespace QuantConnect.Algorithm
             var requestedType = type.CreateType();
             var requests = CreateDateRangeHistoryRequests(symbols, requestedType, start, end, resolution, fillForward, extendedMarket,
                 dataMappingMode, dataNormalizationMode, contractDepthOffset);
-
-            return PandasConverter.GetDataFrame(History(requests.Where(x => x != null)).Memoize());
+            return PandasConverter.GetDataFrame(History(requests.Where(x => x != null)));
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -985,7 +985,7 @@ namespace QuantConnect.Algorithm
             var request = CreateDateRangeHistoryRequests(new [] {  symbol }, requestedType, start, end, resolution).FirstOrDefault();
             if (request == null)
             {
-                var actualType = Securities[symbol].Subscriptions.Select(x => x.Type.Name).DefaultIfEmpty("[None]").FirstOrDefault();
+                var actualType = GetMatchingSubscription(symbol, typeof(BaseData)).Type;
                 throw new ArgumentException("The specified security is not of the requested type. Symbol: " + symbol.ToString() + " Requested Type: " + requestedType.Name + " Actual Type: " + actualType);
             }
 

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -892,43 +892,6 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Gets the historical data for the specified symbols between the specified dates. The symbols must exist in the Securities collection.
-        /// </summary>
-        /// <param name="type">The data type of the symbols</param>
-        /// <param name="tickers">The symbols to retrieve historical data for</param>
-        /// <param name="start">The start time in the algorithm's time zone</param>
-        /// <param name="end">The end time in the algorithm's time zone</param>
-        /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
-        /// <param name="extendedMarket">True to include extended market hours data, false otherwise</param>
-        /// <param name="dataMappingMode">The contract mapping mode to use for the security history request</param>
-        /// <param name="dataNormalizationMode">The price scaling mode to use for the securities history</param>
-        /// <param name="contractDepthOffset">The continuous contract desired offset from the current front month.
-        /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
-        /// <returns>A python dictionary with a pandas DataFrame containing the requested historical data</returns>
-        [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, PyObject tickers, DateTime start, DateTime end, Resolution? resolution = null,
-            bool? fillForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
-            DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
-        {
-            var symbols = tickers.ConvertToSymbolEnumerable();
-            var requestedType = type.CreateType();
-
-            var requests = symbols.Select(x =>
-            {
-                var security = Securities[x];
-                var config = security.Subscriptions.OrderByDescending(s => s.Resolution)
-                        .FirstOrDefault(s => s.Type.BaseType == requestedType.BaseType);
-                if (config == null) return null;
-
-                return _historyRequestFactory.CreateHistoryRequest(config, start, end, GetExchangeHours(x), resolution, dataMappingMode,
-                    dataNormalizationMode, contractDepthOffset);
-            });
-
-            return PandasConverter.GetDataFrame(History(requests.Where(x => x != null)).Memoize());
-        }
-
-        /// <summary>
         /// Gets the historical data for the specified symbol between the specified dates. The symbol must exist in the Securities collection.
         /// </summary>
         /// <param name="tickers">The symbols to retrieve historical data for</param>
@@ -951,9 +914,17 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="extendedMarket">True to include extended market hours data, false otherwise</param>
+        /// <param name="dataMappingMode">The contract mapping mode to use for the security history request</param>
+        /// <param name="dataNormalizationMode">The price scaling mode to use for the securities history</param>
+        /// <param name="contractDepthOffset">The continuous contract desired offset from the current front month.
+        /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, PyObject tickers, DateTime start, DateTime end, Resolution? resolution = null)
+        public PyObject History(PyObject type, PyObject tickers, DateTime start, DateTime end, Resolution? resolution = null,
+            bool? fillForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
+            DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
             var requestedType = type.CreateType();
@@ -965,7 +936,16 @@ namespace QuantConnect.Algorithm
                         .FirstOrDefault(s => s.Type.BaseType == requestedType.BaseType);
                 if (config == null) return null;
 
-                return _historyRequestFactory.CreateHistoryRequest(config, start, end, GetExchangeHours(x), resolution);
+                var request =  _historyRequestFactory.CreateHistoryRequest(config, start, end, GetExchangeHours(x), resolution, dataMappingMode,
+                    dataNormalizationMode, contractDepthOffset);
+
+                // apply overrides
+                var res = GetResolution(x, resolution);
+                if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? res : (Resolution?)null;
+                if (extendedMarket.HasValue) request.IncludeExtendedMarketHours = extendedMarket.Value;
+
+                return request;
+
             });
 
             return PandasConverter.GetDataFrame(History(requests.Where(x => x != null)).Memoize());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

The `fillForward`, `extendedMarket`, `dataMappingMode`, `dataNormalizationMode` and `contractDepthOffset` parameters were added to Python `QCAlgorithm.History()` method that takes custom data source type to allow full configuration of the history request.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4882 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This changes will allow full configuration of history requests with custom data source from Python.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

Yes

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Regression tests were added illustrating how to fetch historical data with custom data sources using parameters that allow full configuration for the request.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
