### PR TITLE
Adds `typing` Import to AlgorithmImports

### DIFF
--- a/Common/AlgorithmImports.py
+++ b/Common/AlgorithmImports.py
@@ -87,6 +87,7 @@ except:
     pass
 
 from datetime import date, time, datetime, timedelta
+from typing import *
 import math
 import json
 


### PR DESCRIPTION
#### Description
Adds `typing` Import to AlgorithmImports script.

#### Motivation and Context
In order to use [typing](https://docs.python.org/3/library/typing.html) in an algorithm that includes `List` arguments and/or return types.

#### How Has This Been Tested?
```python
from Selection.OptionUniverseSelectionModel import OptionUniverseSelectionModel 

def Initialize(self) -> None:
    universe = OptionUniverseSelectionModel(timedelta(days=1), self.option_chain_symbol_selector)
    self.SetUniverseSelection(universe)

def option_chain_symbol_selector(self, utc_time: datetime) -> List[Symbol]:
    tickers = ["SPY", "QQQ", "TLT"]
    return [Symbol.Create(ticker, SecurityType.Option, Market.USA) for ticker in tickers]
```
#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`