### PR TITLE
Add basic template algorithm for Cfd and FutureOption

### DIFF
--- a/Algorithm.CSharp/BasicTemplateCfdAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateCfdAlgorithm.cs
@@ -1,0 +1,72 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Algorithm demonstrating CFD asset types and requesting history.
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="history" />
+    /// <meta name="tag" content="cfd" />
+    public class BasicTemplateCfdAlgorithm : QCAlgorithm
+    {
+        private Symbol _symbol;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetAccountCurrency("EUR");
+
+            SetStartDate(2019, 2, 20);
+            SetEndDate(2019, 2, 21);
+            SetCash("EUR", 100000);
+
+            _symbol = AddCfd("DE30EUR").Symbol;
+
+            // Historical Data
+            var history = History(_symbol, 60, Resolution.Daily);
+            Log($"Received {history.Count()} bars from CFD historical data call.");
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
+        {
+            // Access Data
+            if (slice.QuoteBars.ContainsKey(_symbol))
+            {
+                var quoteBar = slice.QuoteBars[_symbol];
+                Log($"{quoteBar.EndTime} :: {quoteBar.Close}");
+            }
+
+            if (!Portfolio.Invested)
+                SetHoldings(_symbol, 1);
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            Debug($"{Time} {orderEvent.ToString()}");
+        }
+    }
+}

--- a/Algorithm.CSharp/BasicTemplateFutureOptionAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFutureOptionAlgorithm.cs
@@ -1,0 +1,95 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Algorithm demonstrating FutureOption asset types and requesting history.
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="history" />
+    /// <meta name="tag" content="future option" />
+    public class BasicTemplateFutureOptionAlgorithm : QCAlgorithm
+    {
+        private Symbol _symbol;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2022, 1, 1);
+            SetEndDate(2022, 2, 1);
+            SetCash(100000);
+
+            var gold_futures = AddFuture(Futures.Metals.Gold, Resolution.Minute);
+            gold_futures.SetFilter(0, 180);
+            _symbol = gold_futures.Symbol;
+            AddFutureOption(_symbol, universe => universe.Strikes(-5, +5)
+                                                        .CallsOnly()
+                                                        .BackMonth()
+                                                        .OnlyApplyFilterAtMarketOpen());
+
+            // Historical Data
+            var history = History(_symbol, 60, Resolution.Daily);
+            Log($"Received {history.Count()} bars from {_symbol} FutureOption historical data call.");
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
+        {
+            // Access Data
+            foreach(var kvp in slice.OptionChains)
+            {
+                var underlyingFutureContract = kvp.Key.Underlying;
+                var chain = kvp.Value;
+
+                if (chain.Count() == 0) continue;
+
+                foreach(var contract in chain)
+                {
+                    Log($@"Canonical Symbol: {kvp.Key}; 
+                        Contract: {contract}; 
+                        Right: {contract.Right}; 
+                        Expiry: {contract.Expiry}; 
+                        Bid price: {contract.BidPrice}; 
+                        Ask price: {contract.AskPrice}; 
+                        Implied Volatility: {contract.ImpliedVolatility}");
+                }
+
+                if (!Portfolio.Invested)
+                {
+                    var atmStrike = chain.OrderBy(x => Math.Abs(chain.Underlying.Price - x.Strike)).First().Strike;
+                    var selectedContract = chain.Where(x => x.Strike == atmStrike).OrderByDescending(x => x.Expiry).First();
+                    MarketOrder(selectedContract.Symbol, 1);
+                }
+            }
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            Debug($"{Time} {orderEvent.ToString()}");
+        }
+    }
+}

--- a/Algorithm.Python/BasicTemplateCfdAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateCfdAlgorithm.py
@@ -1,0 +1,53 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### The demonstration algorithm shows some of the most common order methods when working with CFD assets.
+### </summary>
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="using quantconnect" />
+### <meta name="tag" content="trading and orders" />
+
+class BasicTemplateCfdAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+        self.SetAccountCurrency('EUR')
+
+        self.SetStartDate(2019, 2, 20)
+        self.SetEndDate(2019, 2, 21)
+        self.SetCash('EUR', 100000)
+
+        self.symbol = self.AddCfd('DE30EUR').Symbol
+
+        # Historical Data
+        history = self.History(self.symbol, 60, Resolution.Daily)
+        self.Log(f"Received {len(history)} bars from CFD historical data call.")
+
+    def OnData(self, data):
+        '''OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        Arguments:
+            slice: Slice object keyed by symbol containing the stock data
+        '''
+        # Access Data
+        if data.QuoteBars.ContainsKey(self.symbol):
+            quoteBar = data.QuoteBars[self.symbol]
+            self.Log(f"{quoteBar.EndTime} :: {quoteBar.Close}")
+
+        if not self.Portfolio.Invested:
+            self.SetHoldings(self.symbol, 1)
+
+    def OnOrderEvent(self, orderEvent):
+        self.Debug("{} {}".format(self.Time, orderEvent.ToString()))

--- a/Algorithm.Python/BasicTemplateFutureOptionAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFutureOptionAlgorithm.py
@@ -1,0 +1,71 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### The demonstration algorithm shows some of the most common order methods when working with FutureOption assets.
+### </summary>
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="using quantconnect" />
+### <meta name="tag" content="trading and orders" />
+
+class BasicTemplateFutureOptionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+        self.SetStartDate(2022, 1, 1)
+        self.SetEndDate(2022, 2, 1)
+        self.SetCash(100000)
+
+        gold_futures = self.AddFuture(Futures.Metals.Gold, Resolution.Minute)
+        gold_futures.SetFilter(0, 180)
+        self.symbol = gold_futures.Symbol
+        self.AddFutureOption(self.symbol, lambda universe: universe.Strikes(-5, +5)
+                                                                    .CallsOnly()
+                                                                    .BackMonth()
+                                                                    .OnlyApplyFilterAtMarketOpen())
+
+        # Historical Data
+        history = self.History(self.symbol, 60, Resolution.Daily)
+        self.Log(f"Received {len(history)} bars from {self.symbol} FutureOption historical data call.")
+
+    def OnData(self, data):
+        '''OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        Arguments:
+            slice: Slice object keyed by symbol containing the stock data
+        '''
+        # Access Data
+        for kvp in data.OptionChains:
+            underlying_future_contract = kvp.Key.Underlying
+            chain = kvp.Value
+
+            if not chain: continue
+
+            for contract in chain:
+                self.Log(f"""Canonical Symbol: {kvp.Key}; 
+                    Contract: {contract}; 
+                    Right: {contract.Right}; 
+                    Expiry: {contract.Expiry}; 
+                    Bid price: {contract.BidPrice}; 
+                    Ask price: {contract.AskPrice}; 
+                    Implied Volatility: {contract.ImpliedVolatility}""")
+
+            if not self.Portfolio.Invested:
+                atm_strike = sorted(chain, key = lambda x: abs(chain.Underlying.Price - x.Strike))[0].Strike
+                selected_contract = sorted([contract for contract in chain if contract.Strike == atm_strike], \
+                           key = lambda x: x.Expiry, reverse=True)[0]
+                self.MarketOrder(selected_contract.Symbol, 1)
+
+    def OnOrderEvent(self, orderEvent):
+        self.Debug("{} {}".format(self.Time, orderEvent.ToString()))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Adding basic template C# & Py algorithms of CFD and FutureOption asset types.

#### Related Issue
closes #6453 

#### Motivation and Context
As example references in docs v2

#### Requires Documentation Change
Inclusion in Example sections of the asset classes' pages

#### How Has This Been Tested?
Tested working in cloud IDE

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
      Not needed
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
