### PR TITLE
Fix for ApiDataProvider race condition

### DIFF
--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -38,6 +38,7 @@ namespace QuantConnect.Api
     /// </summary>
     public class Api : IApi, IDownloadProvider
     {
+        private readonly HttpClient _client = new HttpClient();
         private string _dataFolder;
 
         /// <summary>
@@ -877,9 +878,7 @@ namespace QuantConnect.Api
             {
                 // Download the file
                 var uri = new Uri(dataLink.Url);
-
-                using var client = new HttpClient();
-                using var dataStream = client.GetStreamAsync(uri);
+                using var dataStream = _client.GetStreamAsync(uri);
 
                 using var fileStream = new FileStream(filePath, FileMode.Create);
                 dataStream.Result.CopyTo(fileStream);
@@ -997,7 +996,7 @@ namespace QuantConnect.Api
         /// <filterpriority>2</filterpriority>
         public virtual void Dispose()
         {
-            // NOP
+            _client.DisposeSafely();
         }
 
         /// <summary>

--- a/Engine/DataFeeds/BaseDownloaderDataProvider.cs
+++ b/Engine/DataFeeds/BaseDownloaderDataProvider.cs
@@ -51,17 +51,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         _currentDownloads.TryRemove(key, out _);
                         return base.Fetch(key);
                     }
-
-                    // this is rare
-                    _currentDownloads.TryGetValue(key, out var existingKey);
-                    lock (existingKey ?? new object())
-                    {
-                        return base.Fetch(key);
-                    }
                 }
             }
 
-            return base.Fetch(key);
+            // even though we should not download in this path, we need to wait for any download in progress to be finished
+            // in this case it would be present in the '_currentDownloads' collection with it's lock taken
+            _currentDownloads.TryGetValue(key, out var existingKey);
+            lock (existingKey ?? new object())
+            {
+                return base.Fetch(key);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Avoid race condition while downloading data, where lean would try to access a file still being downloaded
- Reused http client for downloads

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
```
2022-07-05T18:07:23.2747303Z ERROR:: ZipDataCacheProvider.Fetch(): Inner try/catch System.IO.IOException: The process cannot access the file 'E:\QuantConnect\Data\option\usa\minute\abcl\20220513_openinterest_american.zip' because it is being used by another process.
   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
   at QuantConnect.Lean.Engine.DataFeeds.DefaultDataProvider.Fetch(String key) in D:\QuantConnect\MyLean\Lean\Engine\DataFeeds\DefaultDataProvider.cs:line 36
   at QuantConnect.Lean.Engine.DataFeeds.BaseDownloaderDataProvider.DownloadOnce(String key, Action`1 download) in D:\QuantConnect\MyLean\Lean\Engine\DataFeeds\BaseDownloaderDataProvider.cs:line 64
   at QuantConnect.Lean.Engine.DataFeeds.ApiDataProvider.Fetch(String key) in D:\QuantConnect\MyLean\Lean\Engine\DataFeeds\ApiDataProvider.cs:line 131
   at QuantConnect.Lean.Engine.DataFeeds.ZipDataCacheProvider.CacheAndCreateEntryStream(String filename, String entryName) in D:\QuantConnect\MyLean\Lean\Engine\DataFeeds\ZipDataCacheProvider.cs:line 270
   at QuantConnect.Lean.Engine.DataFeeds.ZipDataCacheProvider.Fetch(String key) in D:\QuantConnect\MyLean\Lean\Engine\DataFeeds\ZipDataCacheProvider.cs:line 75
```
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
N/A
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running ApiDataProvider locally
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
