### PR TITLE
Add delisted futures and FOP regression algorithms with daily resolution

### DIFF
--- a/Algorithm.CSharp/DelistedFutureLiquidateDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DelistedFutureLiquidateDailyRegressionAlgorithm.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
-    /// Regression algorithm which reproduces GH issue 4446
+    /// Regression algorithm which reproduces GH issue 4446, in the case of daily resolution.
     /// </summary>
     public class DelistedFutureLiquidateDailyRegressionAlgorithm : DelistedFutureLiquidateRegressionAlgorithm
     {

--- a/Algorithm.CSharp/DelistedFutureLiquidateDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DelistedFutureLiquidateDailyRegressionAlgorithm.cs
@@ -1,0 +1,82 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm which reproduces GH issue 4446
+    /// </summary>
+    public class DelistedFutureLiquidateDailyRegressionAlgorithm : DelistedFutureLiquidateRegressionAlgorithm
+    {
+        protected override Resolution Resolution => Resolution.Daily;
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public override long DataPoints => 1637;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "2"},
+            {"Average Win", "7.78%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "38.034%"},
+            {"Drawdown", "1.000%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "7.779%"},
+            {"Sharpe Ratio", "2.639"},
+            {"Probabilistic Sharpe Ratio", "93.699%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "100%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0.206"},
+            {"Beta", "0.13"},
+            {"Annual Standard Deviation", "0.098"},
+            {"Annual Variance", "0.01"},
+            {"Information Ratio", "-1.152"},
+            {"Tracking Error", "0.121"},
+            {"Treynor Ratio", "1.981"},
+            {"Total Fees", "$1.85"},
+            {"Estimated Strategy Capacity", "$62000000000.00"},
+            {"Lowest Capacity Asset", "ES VMKLFZIH2MTD"},
+            {"Fitness Score", "0.018"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "4.641"},
+            {"Return Over Maximum Drawdown", "39.421"},
+            {"Portfolio Turnover", "0.019"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "bbd8ee011b21ef33f4b15b0509c96bbb"}
+        };
+    }
+}

--- a/Algorithm.CSharp/DelistedFutureLiquidateRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DelistedFutureLiquidateRegressionAlgorithm.cs
@@ -30,6 +30,7 @@ namespace QuantConnect.Algorithm.CSharp
     public class DelistedFutureLiquidateRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private Symbol _contractSymbol;
+        protected virtual Resolution Resolution => Resolution.Minute;
 
         /// <summary>
         /// Initialize your algorithm and add desired assets.
@@ -39,7 +40,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2013, 10, 08);
             SetEndDate(2013, 12, 30);
 
-            var futureSP500 = AddFuture(Futures.Indices.SP500EMini);
+            var futureSP500 = AddFuture(Futures.Indices.SP500EMini, Resolution);
             futureSP500.SetFilter(0, 182);
         }
 
@@ -91,7 +92,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 1224778;
+        public virtual long DataPoints => 1224778;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -101,7 +102,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
-        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        public virtual Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "2"},
             {"Average Win", "1.64%"},

--- a/Algorithm.CSharp/DelistingFutureOptionDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DelistingFutureOptionDailyRegressionAlgorithm.cs
@@ -18,7 +18,8 @@ using System.Collections.Generic;
 namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
-    /// Regression algorithm reproducing issue #5160 where delisting order would be cancelled because it was placed at the market close on the delisting day
+    /// Regression algorithm reproducing issue #5160 where delisting order would be cancelled because it was placed at the market close on the delisting day,
+    /// in the case of daily resolution.
     /// </summary>
     public class DelistingFutureOptionDailyRegressionAlgorithm : DelistingFutureOptionRegressionAlgorithm
     {

--- a/Algorithm.CSharp/DelistingFutureOptionDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DelistingFutureOptionDailyRegressionAlgorithm.cs
@@ -1,0 +1,81 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm reproducing issue #5160 where delisting order would be cancelled because it was placed at the market close on the delisting day
+    /// </summary>
+    public class DelistingFutureOptionDailyRegressionAlgorithm : DelistingFutureOptionRegressionAlgorithm
+    {
+        protected override Resolution Resolution => Resolution.Daily;
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public override long DataPoints => 15192;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "16"},
+            {"Average Win", "0.01%"},
+            {"Average Loss", "-0.02%"},
+            {"Compounding Annual Return", "-0.111%"},
+            {"Drawdown", "0.100%"},
+            {"Expectancy", "-0.678"},
+            {"Net Profit", "-0.111%"},
+            {"Sharpe Ratio", "-0.965"},
+            {"Probabilistic Sharpe Ratio", "0.000%"},
+            {"Loss Rate", "80%"},
+            {"Win Rate", "20%"},
+            {"Profit-Loss Ratio", "0.61"},
+            {"Alpha", "-0.001"},
+            {"Beta", "-0.001"},
+            {"Annual Standard Deviation", "0.001"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-1.073"},
+            {"Tracking Error", "0.107"},
+            {"Treynor Ratio", "1.349"},
+            {"Total Fees", "$14.80"},
+            {"Estimated Strategy Capacity", "$2400000.00"},
+            {"Lowest Capacity Asset", "DC V5E8PHPRCHJ8|DC V5E8P9SH0U0X"},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "-0.128"},
+            {"Return Over Maximum Drawdown", "-0.992"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "2152bd1d4f1770068595a4c3bc8585ee"}
+        };
+    }
+}

--- a/Algorithm.CSharp/DelistingFutureOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DelistingFutureOptionRegressionAlgorithm.cs
@@ -19,6 +19,7 @@ using QuantConnect.Interfaces;
 using QuantConnect.Securities;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Orders;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -27,6 +28,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// </summary>
     public class DelistingFutureOptionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
+        protected virtual Resolution Resolution => Resolution.Minute;
         private bool _traded;
         private int _lastMonth;
 
@@ -36,11 +38,15 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2013, 1, 1);
             SetCash(10000000);
 
-            var dc = AddFuture(Futures.Dairy.ClassIIIMilk, Resolution.Minute, Market.CME);
+            var dc = AddFuture(Futures.Dairy.ClassIIIMilk, Resolution, Market.CME);
             dc.SetFilter(1, 120);
 
             AddFutureOption(dc.Symbol, universe => universe.Strikes(-2, 2));
             _lastMonth = -1;
+
+            // This is required to prevent the algorithm from automatically delisting the underlying. Without this, future options will be subscribed
+            // with resolution default to Minute insted of this.Resolution. This could be replaced after GH issue #6491 is implemented.
+            UniverseSettings.Resolution = Resolution;
         }
 
         public override void OnData(Slice data)
@@ -100,8 +106,8 @@ namespace QuantConnect.Algorithm.CSharp
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm
-        /// </summary>
-        public long DataPoints => 15228955;
+        /// </summary>0
+        public virtual long DataPoints => 15228955;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -111,7 +117,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
-        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        public virtual Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "16"},
             {"Average Win", "0.01%"},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This changes cover two things:

- Implement regression algorithms for delisted futures and future options with daily resolution.
- For future options with daily resolution, find a way to initially prevent algorithms from automatically delisting the underlying future. This is happening due to universe settings defaulting to minute resolution instead of using the same one (daily) as the underlying. 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Part of #2470 

#### Motivation and Context

Testing that futures and FOPs are properly delisted for daily resolution. Previously, this was being tested only with minute resolution.

#### Requires Documentation Change

No

#### How Has This Been Tested?

`DelistedFutureLiquidateRegressionAlgorithm` and `DelistingFutureOptionRegressionAlgorithm` were adapted for other algorithms to be able to derive from them and makei it use another resolution. Two regression algorithms implementing each of them were added to test that futures and FOPs are properly delisted for daily resolution.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
