### PR TITLE
Fix optimization json converter

### DIFF
--- a/Common/Api/OptimizationBacktestJsonConverter.cs
+++ b/Common/Api/OptimizationBacktestJsonConverter.cs
@@ -79,14 +79,18 @@ namespace QuantConnect.Api
                 writer.WriteStartArray();
                 foreach (var keyValuePair in optimizationBacktest.Statistics.OrderBy(pair => pair.Key))
                 {
-                    var statistic = keyValuePair.Value.Replace("%", string.Empty).Replace("$", string.Empty);
+                    var statistic = keyValuePair.Value.Replace("%", string.Empty);
+                    foreach (var currencySymbol in Currencies.CurrencySymbols.Values)
+                    {
+                        statistic = statistic.Replace(currencySymbol, string.Empty);
+                    }
+
                     if (string.IsNullOrEmpty(statistic))
                     {
                         continue;
                     }
 
-                    decimal result;
-                    if (decimal.TryParse(statistic, NumberStyles.Any, CultureInfo.InvariantCulture, out result))
+                    if (decimal.TryParse(statistic, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
                     {
                         writer.WriteValue(result);
                     }

--- a/Tests/Api/OptimizationBacktestJsonConverterTests.cs
+++ b/Tests/Api/OptimizationBacktestJsonConverterTests.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -71,7 +70,7 @@ namespace QuantConnect.Tests.API
                 { "Tracking Error", "0.233" },
                 { "Treynor Ratio", "-0.558" },
                 { "Total Fees", "$1390.49" },
-                { "Estimated Strategy Capacity", "$6300000.00" },
+                { "Estimated Strategy Capacity", "₿6300000.00" },
             };
 
             optimizationBacktest.Equity = new Series


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix optimization json converter, not handling correctly different
  account currencies. Updating unit test to reproduce issue

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Optimization backtests results would be missing statistic fields
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and optimization reproducing the issue
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
