### PR TITLE
Fix checking market open for post market segments

### DIFF
--- a/Common/Securities/LocalMarketHours.cs
+++ b/Common/Securities/LocalMarketHours.cs
@@ -146,11 +146,18 @@ namespace QuantConnect.Securities
                 var segment = Segments[i];
                 if (segment.State == MarketHoursState.Closed || segment.End <= time)
                 {
-                    previousSegment = segment.End;
-                    prevSegmentIsFromPrevDay = false;
+                    // update prev segment end time only if the current segment could have been taken into account
+                    // (regular hours or, when enabled, extended hours segment)
+                    if (segment.State == MarketHoursState.Market || extendedMarket)
+                    {
+                        previousSegment = segment.End;
+                        prevSegmentIsFromPrevDay = false;
+                    }
+
                     continue;
                 }
 
+                // let's try this segment if it's regular market hours or if it is extended market hours and extended market is allowed
                 if (segment.State == MarketHoursState.Market || extendedMarket)
                 {
                     if (!IsContinuousMarketOpen(previousSegment, segment.Start, prevSegmentIsFromPrevDay))

--- a/Common/Securities/SecurityExchangeHours.cs
+++ b/Common/Securities/SecurityExchangeHours.cs
@@ -496,7 +496,7 @@ namespace QuantConnect.Securities
                 }
                 marketHours = new LocalMarketHours(localDateTime.DayOfWeek, newSegments);
             }
-            
+
             // If the lateOpenTime is between a segment, change the start time with it
             // and add it before the segments previous to the lateOpenTime
             // Otherwise, just take the segments previous to the lateOpenTime

--- a/Tests/Common/Securities/LocalMarketHoursTests.cs
+++ b/Tests/Common/Securities/LocalMarketHoursTests.cs
@@ -88,6 +88,42 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(expected, LocalMarketHours.IsContinuousMarketOpen(previousSegmentEnd, nextSegmentStart));
         }
 
+        [Test]
+        public void GetsMarketOpenForRegularHours()
+        {
+            var marketHours = new LocalMarketHours(DayOfWeek.Monday, new MarketHoursSegment[]
+            {
+                new MarketHoursSegment(MarketHoursState.PreMarket, new TimeSpan(0, 0, 0), new TimeSpan(8, 0, 0)),
+                new MarketHoursSegment(MarketHoursState.Market, new TimeSpan(8, 0, 0), new TimeSpan(16, 0, 0)),
+                new MarketHoursSegment(MarketHoursState.PostMarket, new TimeSpan(17, 0, 0), new TimeSpan(1, 0, 0, 0))
+            });
+            var prevDayLastSegmentEnd = new TimeSpan(1, 0, 0, 0);
+
+            Assert.AreEqual(new TimeSpan(8, 0, 0), marketHours.GetMarketOpen(new TimeSpan(0, 0, 0), false, prevDayLastSegmentEnd));
+            Assert.AreEqual(null, marketHours.GetMarketOpen(new TimeSpan(8, 0, 0), false, prevDayLastSegmentEnd));
+            Assert.AreEqual(null, marketHours.GetMarketOpen(new TimeSpan(16, 0, 0), false, prevDayLastSegmentEnd));
+            Assert.AreEqual(null, marketHours.GetMarketOpen(new TimeSpan(17, 0, 0), false, prevDayLastSegmentEnd));
+            Assert.AreEqual(null, marketHours.GetMarketOpen(new TimeSpan(18, 0, 0), false, prevDayLastSegmentEnd));
+        }
+
+        [Test]
+        public void GetsMarketOpenWithExtendedHours()
+        {
+            var marketHours = new LocalMarketHours(DayOfWeek.Monday, new MarketHoursSegment[]
+            {
+                new MarketHoursSegment(MarketHoursState.PreMarket, new TimeSpan(0, 0, 0), new TimeSpan(8, 0, 0)),
+                new MarketHoursSegment(MarketHoursState.Market, new TimeSpan(8, 0, 0), new TimeSpan(16, 0, 0)),
+                new MarketHoursSegment(MarketHoursState.PostMarket, new TimeSpan(17, 0, 0), new TimeSpan(1, 0, 0, 0))
+            });
+            var prevDayLastSegmentEnd = new TimeSpan(1, 0, 0, 0);
+
+            Assert.AreEqual(new TimeSpan(17, 0, 0), marketHours.GetMarketOpen(new TimeSpan(0, 0, 0), true, prevDayLastSegmentEnd));
+            Assert.AreEqual(new TimeSpan(17, 0, 0), marketHours.GetMarketOpen(new TimeSpan(8, 0, 0), true, prevDayLastSegmentEnd));
+            Assert.AreEqual(new TimeSpan(17, 0, 0), marketHours.GetMarketOpen(new TimeSpan(16, 0, 0), true, prevDayLastSegmentEnd));
+            Assert.AreEqual(new TimeSpan(17, 0, 0), marketHours.GetMarketOpen(new TimeSpan(17, 0, 0), true, prevDayLastSegmentEnd));
+            Assert.AreEqual(new TimeSpan(17, 0, 0), marketHours.GetMarketOpen(new TimeSpan(18, 0, 0), true, prevDayLastSegmentEnd));
+        }
+
         private static LocalMarketHours GetUsEquityWeekDayMarketHours()
         {
             return new LocalMarketHours(DayOfWeek.Friday, USEquityPreOpen, USEquityOpen, USEquityClose, USEquityPostClose);

--- a/Tests/Common/Securities/SecurityExchangeHoursTests.cs
+++ b/Tests/Common/Securities/SecurityExchangeHoursTests.cs
@@ -292,6 +292,66 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
+        public void GetNextMarketOpenForRegularHoursFromCloseDay()
+        {
+            var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
+
+            var startTime = new DateTime(2022, 1, 1); // Saturday
+            var nextMarketOpen = exchangeHours.GetNextMarketOpen(startTime, false);
+            Assert.AreEqual(new DateTime(2022, 1, 3, 9, 30, 0), nextMarketOpen);
+        }
+
+        [Test]
+        public void GetNextMarketOpenForRegularHours()
+        {
+            var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
+
+            var startTime = new DateTime(2022, 1, 3, 8, 0, 0); // Monday
+            var nextMarketOpen = exchangeHours.GetNextMarketOpen(startTime, false);
+            Assert.AreEqual(new DateTime(2022, 1, 3, 9, 30, 0), nextMarketOpen);
+        }
+
+        [Test]
+        public void GetNextMarketOpenWithExtendedHoursFromCloseDay()
+        {
+            var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
+
+            var startTime = new DateTime(2022, 1, 1); // Saturday
+            var nextMarketOpen = exchangeHours.GetNextMarketOpen(startTime, true);
+            Assert.AreEqual(new DateTime(2022, 1, 2, 18, 0, 0), nextMarketOpen);
+        }
+
+        [Test]
+        public void GetNextMarketOpenWithExtendedHours()
+        {
+            var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
+
+            var startTime = new DateTime(2022, 1, 2, 18, 0, 0); // Sunday
+            var nextMarketOpen = exchangeHours.GetNextMarketOpen(startTime, true);
+            Assert.AreEqual(new DateTime(2022, 1, 3, 18, 0, 0), nextMarketOpen);
+        }
+
+        [Test]
+        public void GetNextMarketOpenWithExtendedHours2()
+        {
+            var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
+
+            var startTime = new DateTime(2022, 1, 3, 12, 0, 0); // Monday
+            var nextMarketOpen = exchangeHours.GetNextMarketOpen(startTime, true);
+            Assert.AreEqual(new DateTime(2022, 1, 3, 18, 0, 0), nextMarketOpen);
+        }
+
+        [Test]
+        public void GetNextMarketOpenWithExtendedHours3()
+        {
+            var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
+
+            var startTime = new DateTime(2022, 1, 3, 16, 0, 0); // Monday
+            var nextMarketOpen = exchangeHours.GetNextMarketOpen(startTime, true);
+            Assert.AreEqual(new DateTime(2022, 1, 3, 18, 0, 0), nextMarketOpen);
+        }
+
+        [Test]
         public void GetLastMarketOpenForContinuousSchedules()
         {
             var exchangeHours = CreateUsFutureSecurityExchangeHours();
@@ -407,7 +467,7 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var exchangeHours = CreateForexSecurityExchangeHours();
 
-            var startTime = new DateTime(2019, 1, 1, 16, 59, 59);
+            var startTime = new DateTime(2019, 1, 1, 16, 59, 59); // Friday
             var nextMarketOpen = exchangeHours.GetNextMarketOpen(startTime, false);
             Assert.AreEqual(new DateTime(2019, 1, 1, 17, 0, 0), nextMarketOpen);
         }
@@ -573,6 +633,53 @@ namespace QuantConnect.Tests.Common.Securities
                 DayOfWeek.Friday,
                 new MarketHoursSegment(MarketHoursState.Market, new TimeSpan(0, 0, 0), new TimeSpan(16, 15, 0)),
                 new MarketHoursSegment(MarketHoursState.Market, new TimeSpan(16, 30, 0), new TimeSpan(17, 0, 0))
+            );
+            var saturday = LocalMarketHours.ClosedAllDay(DayOfWeek.Saturday);
+
+            var earlyCloses = new Dictionary<DateTime, TimeSpan> { { new DateTime(2013, 11, 28), new TimeSpan(10, 30, 0) },
+                { new DateTime(2013, 11, 29), new TimeSpan(12, 15, 0)} };
+            var lateOpens = new Dictionary<DateTime, TimeSpan>();
+            var exchangeHours = new SecurityExchangeHours(TimeZones.NewYork, USHoliday.Dates.Select(x => x.Date), new[]
+            {
+                sunday, monday, tuesday, wednesday, thursday, friday, saturday
+            }.ToDictionary(x => x.DayOfWeek), earlyCloses, lateOpens);
+            return exchangeHours;
+        }
+
+        public static SecurityExchangeHours CreateUsFutureSecurityExchangeHoursWithExtendedHours()
+        {
+            var sunday = new LocalMarketHours(
+                DayOfWeek.Sunday,
+                new MarketHoursSegment(MarketHoursState.PreMarket, new TimeSpan(18, 0, 0), new TimeSpan(1, 0 ,0, 0))
+            );
+            var monday = new LocalMarketHours(
+                DayOfWeek.Monday,
+                new MarketHoursSegment(MarketHoursState.PreMarket, new TimeSpan(0, 0, 0), new TimeSpan(9, 30, 0)),
+                new MarketHoursSegment(MarketHoursState.Market, new TimeSpan(9, 30, 0), new TimeSpan(16, 0, 0)),
+                new MarketHoursSegment(MarketHoursState.PostMarket, new TimeSpan(18, 0, 0), new TimeSpan(1, 0, 0, 0))
+            );
+            var tuesday = new LocalMarketHours(
+                DayOfWeek.Tuesday,
+                new MarketHoursSegment(MarketHoursState.PreMarket, new TimeSpan(0, 0, 0), new TimeSpan(9, 30, 0)),
+                new MarketHoursSegment(MarketHoursState.Market, new TimeSpan(9, 30, 0), new TimeSpan(16, 0, 0)),
+                new MarketHoursSegment(MarketHoursState.PostMarket, new TimeSpan(18, 0, 0), new TimeSpan(1, 0, 0, 0))
+            );
+            var wednesday = new LocalMarketHours(
+                DayOfWeek.Wednesday,
+                new MarketHoursSegment(MarketHoursState.PreMarket, new TimeSpan(0, 0, 0), new TimeSpan(9, 30, 0)),
+                new MarketHoursSegment(MarketHoursState.Market, new TimeSpan(9, 30, 0), new TimeSpan(16, 0, 0)),
+                new MarketHoursSegment(MarketHoursState.PostMarket, new TimeSpan(18, 0, 0), new TimeSpan(1, 0, 0, 0))
+            );
+            var thursday = new LocalMarketHours(
+                DayOfWeek.Thursday,
+                new MarketHoursSegment(MarketHoursState.PreMarket, new TimeSpan(0, 0, 0), new TimeSpan(9, 30, 0)),
+                new MarketHoursSegment(MarketHoursState.Market, new TimeSpan(9, 30, 0), new TimeSpan(16, 0, 0)),
+                new MarketHoursSegment(MarketHoursState.PostMarket, new TimeSpan(18, 0, 0), new TimeSpan(1, 0, 0, 0))
+            );
+            var friday = new LocalMarketHours(
+                DayOfWeek.Friday,
+                new MarketHoursSegment(MarketHoursState.PreMarket, new TimeSpan(0, 0, 0), new TimeSpan(9, 30, 0)),
+                new MarketHoursSegment(MarketHoursState.Market, new TimeSpan(9, 30, 0), new TimeSpan(16, 0, 0))
             );
             var saturday = LocalMarketHours.ClosedAllDay(DayOfWeek.Saturday);
 

--- a/Tests/Common/Securities/SecurityExchangeHoursTests.cs
+++ b/Tests/Common/Securities/SecurityExchangeHoursTests.cs
@@ -292,7 +292,7 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
-        public void GetNextMarketOpenForRegularHoursFromCloseDay()
+        public void GetNextMarketOpenForRegularHoursFromClosedDay()
         {
             var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
 
@@ -312,7 +312,7 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
-        public void GetNextMarketOpenWithExtendedHoursFromCloseDay()
+        public void GetNextMarketOpenWithExtendedHoursFromClosedDay()
         {
             var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This fix makes `LocalMarketHours.GetMarketOpen()` take into account post-market segments start time as market open. Also, it considers continous segments to be considered as one long market segment (that is, no market close/open) when a segment's end time and the next segment's start time are the same in the same day.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Part of #2470 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

While trying to add extended market hours support for futures (#2470), market hours for futures were being split into pre-market, market and post-market segments and data points count was being reduced. This was caused by post-market segments, which are generally one hour apart from regular market segment for futures, not being taken into account when checking for market open hours.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

No

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were added for `LocalMarketHours` to check that `GetMarketOpen()` returns what is expected, the market open hour after the given reference time, with and without extended market hours enabled.

Also, unit tests where added for `SecurityExchangeHours` to check that the correct next market open was returned by `GetNextMarketOpen()` when enabling extended market hours.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
