### PR TITLE
Add fill forward and extended market parameters to QuantBook's history methods

### DIFF
--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -317,8 +317,11 @@ namespace QuantConnect.Research
         /// <param name="start">The history request start time</param>
         /// <param name="end">The history request end time. Defaults to 1 day if null</param>
         /// <param name="resolution">The resolution to request</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="extendedMarket">True to include extended market hours data, false otherwise</param>
         /// <returns>A <see cref="OptionHistory"/> object that contains historical option data.</returns>
-        public OptionHistory GetOptionHistory(Symbol symbol, DateTime start, DateTime? end = null, Resolution? resolution = null)
+        public OptionHistory GetOptionHistory(Symbol symbol, DateTime start, DateTime? end = null, Resolution? resolution = null,
+            bool fillForward = true, bool extendedMarket = false)
         {
             if (!end.HasValue || end.Value == start)
             {
@@ -328,7 +331,7 @@ namespace QuantConnect.Research
             // Load a canonical option Symbol if the user provides us with an underlying Symbol
             if (!symbol.SecurityType.IsOption())
             {
-                var option = AddOption(symbol, resolution, symbol.ID.Market);
+                var option = AddOption(symbol, resolution, symbol.ID.Market, fillForward);
 
                 // Allow 20 strikes from the money for futures. No expiry filter is applied
                 // so that any future contract provided will have data returned.
@@ -359,15 +362,16 @@ namespace QuantConnect.Research
                     if (symbol.Underlying.SecurityType == SecurityType.Equity)
                     {
                         // only add underlying if not present
-                        AddEquity(symbol.Underlying.Value, resolutionToUseForUnderlying);
+                        AddEquity(symbol.Underlying.Value, resolutionToUseForUnderlying, fillDataForward: fillForward,
+                            extendedMarketHours: extendedMarket);
                     }
                     if (symbol.Underlying.SecurityType == SecurityType.Future && symbol.Underlying.IsCanonical())
                     {
-                        AddFuture(symbol.Underlying.ID.Symbol, resolutionToUseForUnderlying);
+                        AddFuture(symbol.Underlying.ID.Symbol, resolutionToUseForUnderlying, fillDataForward: fillForward);
                     }
                     else if (symbol.Underlying.SecurityType == SecurityType.Future)
                     {
-                        AddFutureContract(symbol.Underlying, resolutionToUseForUnderlying);
+                        AddFutureContract(symbol.Underlying, resolutionToUseForUnderlying, fillDataForward: fillForward);
                     }
                 }
                 var allSymbols = new List<Symbol>();
@@ -396,7 +400,7 @@ namespace QuantConnect.Research
                 symbols = new List<Symbol>{ symbol };
             }
 
-            return new OptionHistory(History(symbols, start, end.Value, resolution));
+            return new OptionHistory(History(symbols, start, end.Value, resolution, fillForward, extendedMarket));
         }
 
         /// <summary>
@@ -406,8 +410,11 @@ namespace QuantConnect.Research
         /// <param name="start">The history request start time</param>
         /// <param name="end">The history request end time. Defaults to 1 day if null</param>
         /// <param name="resolution">The resolution to request</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="extendedMarket">True to include extended market hours data, false otherwise</param>
         /// <returns>A <see cref="FutureHistory"/> object that contains historical future data.</returns>
-        public FutureHistory GetFutureHistory(Symbol symbol, DateTime start, DateTime? end = null, Resolution? resolution = null)
+        public FutureHistory GetFutureHistory(Symbol symbol, DateTime start, DateTime? end = null, Resolution? resolution = null,
+            bool fillForward = true, bool extendedMarket = false)
         {
             if (!end.HasValue || end.Value == start)
             {
@@ -437,7 +444,7 @@ namespace QuantConnect.Research
                 allSymbols.Add(symbol);
             }
 
-            return new FutureHistory(History(allSymbols, start, end.Value, resolution));
+            return new FutureHistory(History(allSymbols, start, end.Value, resolution, fillForward, extendedMarket));
         }
 
         /// <summary>

--- a/Tests/Research/QuantBookHistoryTests.cs
+++ b/Tests/Research/QuantBookHistoryTests.cs
@@ -344,5 +344,43 @@ namespace QuantConnect.Tests.Research
                 qb.GetOptionHistory(future, default(DateTime), DateTime.MaxValue, Resolution.Minute);
             });
         }
+
+        [TestCase(true, true, 1920)]
+        [TestCase(true, false, 780)]
+        [TestCase(false, true, 776)]
+        [TestCase(false, false, 390)]
+        public void OptionHistorySpecifyingFillForward(bool fillForward, bool extendedMarket, int expectedCount)
+        {
+            using (Py.GIL())
+            {
+                var qb = new QuantBook();
+                var start = new DateTime(2013, 10, 11);
+                var end = new DateTime(2013, 10, 15);
+
+                var spy = qb.AddEquity("SPY");
+                dynamic history = qb.GetOptionHistory(spy.Symbol, start, end, Resolution.Minute, fillForward, extendedMarket).GetAllData();
+                var historyCount = (history.shape[0] as PyObject).As<int>();
+
+                Assert.AreEqual(expectedCount, historyCount);
+            }
+        }
+
+        [TestCase(true, 360)]
+        [TestCase(false, 60)]
+        public void FutureHistorySpecifyingFillForward(bool fillForward, int expectedCount)
+        {
+            using (Py.GIL())
+            {
+                var qb = new QuantBook();
+                var start = new DateTime(2020, 1, 5);
+                var end = new DateTime(2020, 1, 6);
+
+                var future = Symbol.CreateFuture(Futures.Indices.SP500EMini, Market.CME, new DateTime(2020, 3, 20));
+                dynamic history = qb.GetFutureHistory(future, start, end, Resolution.Minute, fillForward: fillForward).GetAllData();
+                var historyCount = (history.shape[0] as PyObject).As<int>();
+
+                Assert.AreEqual(expectedCount, historyCount);
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Fill forward and extended market parameters where added to `QuantBook`'s `GetOptionHistory()` and `GetFutureHistory()` methods in order to be able to indicate these flags to these history requests. 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Part of #2470 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This is required as part of #2470 in order to be able to indicate whether to use fill forwarding and extended market hours in these history requests.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

No

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were added to assert that using fill forward or extended market hours returns a history with more slices than doing so without fill forwarding or allowing extended market.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
