### PR TITLE
Fix `LocalMarketHours.GetMarketClose` for extended market hours

### DIFF
--- a/Common/Securities/LocalMarketHours.cs
+++ b/Common/Securities/LocalMarketHours.cs
@@ -184,7 +184,17 @@ namespace QuantConnect.Securities
 
                 if (i != Segments.Count - 1)
                 {
-                    nextSegment = Segments[i + 1].Start;
+                    var potentialNextSegment = Segments[i+1];
+
+                    // Check whether we can consider PostMarket or not
+                    if (potentialNextSegment.State != MarketHoursState.Market && !extendedMarket)
+                    {
+                        nextSegment = null;
+                    }
+                    else
+                    {
+                        nextSegment = Segments[i+1].Start;
+                    }
                 }
                 else
                 {

--- a/Common/Securities/LocalMarketHours.cs
+++ b/Common/Securities/LocalMarketHours.cs
@@ -26,9 +26,6 @@ namespace QuantConnect.Securities
     /// </summary>
     public class LocalMarketHours
     {
-        private readonly bool _hasPreMarket;
-        private readonly bool _hasPostMarket;
-
         /// <summary>
         /// Gets whether or not this exchange is closed all day
         /// </summary>
@@ -86,16 +83,6 @@ namespace QuantConnect.Securities
             for (var i = 0; i < Segments.Count; i++)
             {
                 var segment = Segments[i];
-                if (segment.State == MarketHoursState.PreMarket)
-                {
-                    _hasPreMarket = true;
-                }
-
-                if (segment.State == MarketHoursState.PostMarket)
-                {
-                    _hasPostMarket = true;
-                }
-
                 if (segment.State == MarketHoursState.Market)
                 {
                     MarketDuration += segment.End - segment.Start;
@@ -179,13 +166,14 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <param name="time">The reference time, the close returned will be the first close after the specified time if there are multiple market open segments</param>
         /// <param name="extendedMarket">True to include extended market hours, false for regular market hours</param>
-        /// <param name="nextDaySegment">Next day first segment. This is used when the potential next market close is
+        /// <param name="nextDaySegmentStart">Next day first segment start. This is used when the potential next market close is
         /// the last segment of the day so we need to check that segment is not continued on next day first segment.
         /// If null, it means there are no segments on the next day</param>
         /// <returns>The market's closing time of day</returns>
-        public TimeSpan? GetMarketClose(TimeSpan time, bool extendedMarket, TimeSpan? nextDaySegment = null)
+        public TimeSpan? GetMarketClose(TimeSpan time, bool extendedMarket, TimeSpan? nextDaySegmentStart = null)
         {
             TimeSpan? nextSegment;
+            bool nextSegmentIsFromNextDay = false;
             for (var i = 0; i < Segments.Count; i++)
             {
                 var segment = Segments[i];
@@ -196,31 +184,16 @@ namespace QuantConnect.Securities
 
                 if (i != Segments.Count - 1)
                 {
-                    var potentialNextSegment = Segments[i+1];
-
-                    // Check whether we can consider PostMarket or not
-                    if (potentialNextSegment.State == MarketHoursState.PostMarket && !extendedMarket)
-                    {
-                        nextSegment = null;
-                    }
-                    else
-                    {
-                        nextSegment = Segments[i+1].Start;
-                    }
+                    nextSegment = Segments[i + 1].Start;
                 }
                 else
                 {
-                    nextSegment = nextDaySegment;
+                    nextSegment = nextDaySegmentStart;
+                    nextSegmentIsFromNextDay = true;
                 }
 
-                if (extendedMarket && _hasPostMarket)
-                {
-                    if (segment.State == MarketHoursState.PostMarket && !IsContinuousMarketOpen(segment.End, nextSegment))
-                    {
-                        return segment.End;
-                    }
-                }
-                else if (segment.State == MarketHoursState.Market && !IsContinuousMarketOpen(segment.End, nextSegment))
+                if ((segment.State == MarketHoursState.Market || extendedMarket) &&
+                    !IsContinuousMarketOpen(segment.End, nextSegment, nextSegmentIsFromNextDay))
                 {
                     return segment.End;
                 }

--- a/Tests/Common/Securities/LocalMarketHoursTests.cs
+++ b/Tests/Common/Securities/LocalMarketHoursTests.cs
@@ -96,6 +96,14 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(expectedMarketOpen, marketHours.GetMarketOpen(referenceTime, extendedMarket, prevDayLastSegmentEnd));
         }
 
+        [TestCaseSource(nameof(GetMarketCloseTestCases))]
+        public void GetsCorrectMarketClose(TimeSpan referenceTime, bool extendedMarket, TimeSpan nextDayFirstSegmentStart, TimeSpan? expectedMarketClose)
+        {
+            var marketHours = GetFutureWeekDayMarketHours();
+
+            Assert.AreEqual(expectedMarketClose, marketHours.GetMarketClose(referenceTime, extendedMarket, nextDayFirstSegmentStart));
+        }
+
         private static LocalMarketHours GetUsEquityWeekDayMarketHours()
         {
             return new LocalMarketHours(DayOfWeek.Friday, USEquityPreOpen, USEquityOpen, USEquityClose, USEquityPostClose);
@@ -148,6 +156,53 @@ namespace QuantConnect.Tests.Common.Securities
                 new TestCaseData(new TimeSpan(16, 0, 0), true, null, new TimeSpan(17, 0, 0)),
                 new TestCaseData(new TimeSpan(17, 0, 0), true, null, new TimeSpan(17, 0, 0)),
                 new TestCaseData(new TimeSpan(18, 0, 0), true, null, new TimeSpan(17, 0, 0)),
+            };
+        }
+
+        private static TestCaseData[] GetMarketCloseTestCases()
+        {
+            return new[]
+            {
+                // Next day's first segment continues from current day's last segment (see GetFutureWeekDayMarketHours, the last segment ends
+                // with 1.00:00:00, so starting next day at 00:00:00, it means the segments are continouous)
+                new TestCaseData(new TimeSpan(0, 0, 0), false, new TimeSpan(0, 0, 0), new TimeSpan(16, 0, 0)),
+                new TestCaseData(new TimeSpan(12, 0, 0), false, new TimeSpan(0, 0, 0), new TimeSpan(16, 0, 0)),
+                new TestCaseData(new TimeSpan(16, 0, 0), false, new TimeSpan(0, 0, 0), null),
+                new TestCaseData(new TimeSpan(17, 0, 0), false, new TimeSpan(0, 0, 0), null),
+                new TestCaseData(new TimeSpan(18, 0, 0), false, new TimeSpan(0, 0, 0), null),
+                new TestCaseData(new TimeSpan(20, 0, 0), false, new TimeSpan(0, 0, 0), null),
+                new TestCaseData(new TimeSpan(0, 0, 0), true, new TimeSpan(0, 0, 0), new TimeSpan(16, 0, 0)),
+                new TestCaseData(new TimeSpan(12, 0, 0), true, new TimeSpan(0, 0, 0), new TimeSpan(16, 0, 0)),
+                new TestCaseData(new TimeSpan(16, 0, 0), true, new TimeSpan(0, 0, 0), null),
+                new TestCaseData(new TimeSpan(17, 0, 0), true, new TimeSpan(0, 0, 0), null),
+                new TestCaseData(new TimeSpan(18, 0, 0), true, new TimeSpan(0, 0, 0), null),
+                new TestCaseData(new TimeSpan(20, 0, 0), true, new TimeSpan(0, 0, 0), null),
+                // Next day's first segment starts after midnight
+                new TestCaseData(new TimeSpan(0, 0, 0), false, new TimeSpan(18, 0, 0), new TimeSpan(16, 0, 0)),
+                new TestCaseData(new TimeSpan(12, 0, 0), false, new TimeSpan(18, 0, 0), new TimeSpan(16, 0, 0)),
+                new TestCaseData(new TimeSpan(16, 0, 0), false, new TimeSpan(18, 0, 0), null),
+                new TestCaseData(new TimeSpan(17, 0, 0), false, new TimeSpan(18, 0, 0), null),
+                new TestCaseData(new TimeSpan(18, 0, 0), false, new TimeSpan(18, 0, 0), null),
+                new TestCaseData(new TimeSpan(20, 0, 0), false, new TimeSpan(18, 0, 0), null),
+                new TestCaseData(new TimeSpan(0, 0, 0), true, new TimeSpan(18, 0, 0), new TimeSpan(16, 0, 0)),
+                new TestCaseData(new TimeSpan(12, 0, 0), true, new TimeSpan(18, 0, 0), new TimeSpan(16, 0, 0)),
+                new TestCaseData(new TimeSpan(16, 0, 0), true, new TimeSpan(18, 0, 0), new TimeSpan(1, 0, 0, 0)),
+                new TestCaseData(new TimeSpan(17, 0, 0), true, new TimeSpan(18, 0, 0), new TimeSpan(1, 0, 0, 0)),
+                new TestCaseData(new TimeSpan(18, 0, 0), true, new TimeSpan(18, 0, 0), new TimeSpan(1, 0, 0, 0)),
+                new TestCaseData(new TimeSpan(20, 0, 0), true, new TimeSpan(18, 0, 0), new TimeSpan(1, 0, 0, 0)),
+                // No next day's first segment
+                new TestCaseData(new TimeSpan(0, 0, 0), false, null, new TimeSpan(16, 0, 0)),
+                new TestCaseData(new TimeSpan(12, 0, 0), false, null, new TimeSpan(16, 0, 0)),
+                new TestCaseData(new TimeSpan(16, 0, 0), false, null, null),
+                new TestCaseData(new TimeSpan(17, 0, 0), false, null, null),
+                new TestCaseData(new TimeSpan(18, 0, 0), false, null, null),
+                new TestCaseData(new TimeSpan(20, 0, 0), false, null, null),
+                new TestCaseData(new TimeSpan(0, 0, 0), true, null, new TimeSpan(16, 0, 0)),
+                new TestCaseData(new TimeSpan(12, 0, 0), true, null, new TimeSpan(16, 0, 0)),
+                new TestCaseData(new TimeSpan(16, 0, 0), true, null, null),
+                new TestCaseData(new TimeSpan(17, 0, 0), true, null, null),
+                new TestCaseData(new TimeSpan(18, 0, 0), true, null, null),
+                new TestCaseData(new TimeSpan(20, 0, 0), true, null, null),
             };
         }
     }

--- a/Tests/Common/Securities/SecurityExchangeHoursTests.cs
+++ b/Tests/Common/Securities/SecurityExchangeHoursTests.cs
@@ -291,64 +291,13 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(new DateTime(2013, 11, 29), nextMarketOpen);
         }
 
-        [Test]
-        public void GetNextMarketOpenForRegularHoursFromClosedDay()
+        [TestCaseSource(nameof(GetNextMarketOpenTestCases))]
+        public void GetNextMarketOpen(DateTime startTime, DateTime expectedNextMarketOpen, bool extendedMarket)
         {
             var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
 
-            var startTime = new DateTime(2022, 1, 1); // Saturday
-            var nextMarketOpen = exchangeHours.GetNextMarketOpen(startTime, false);
-            Assert.AreEqual(new DateTime(2022, 1, 3, 9, 30, 0), nextMarketOpen);
-        }
-
-        [Test]
-        public void GetNextMarketOpenForRegularHours()
-        {
-            var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
-
-            var startTime = new DateTime(2022, 1, 3, 8, 0, 0); // Monday
-            var nextMarketOpen = exchangeHours.GetNextMarketOpen(startTime, false);
-            Assert.AreEqual(new DateTime(2022, 1, 3, 9, 30, 0), nextMarketOpen);
-        }
-
-        [Test]
-        public void GetNextMarketOpenWithExtendedHoursFromClosedDay()
-        {
-            var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
-
-            var startTime = new DateTime(2022, 1, 1); // Saturday
-            var nextMarketOpen = exchangeHours.GetNextMarketOpen(startTime, true);
-            Assert.AreEqual(new DateTime(2022, 1, 2, 18, 0, 0), nextMarketOpen);
-        }
-
-        [Test]
-        public void GetNextMarketOpenWithExtendedHours()
-        {
-            var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
-
-            var startTime = new DateTime(2022, 1, 2, 18, 0, 0); // Sunday
-            var nextMarketOpen = exchangeHours.GetNextMarketOpen(startTime, true);
-            Assert.AreEqual(new DateTime(2022, 1, 3, 18, 0, 0), nextMarketOpen);
-        }
-
-        [Test]
-        public void GetNextMarketOpenWithExtendedHours2()
-        {
-            var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
-
-            var startTime = new DateTime(2022, 1, 3, 12, 0, 0); // Monday
-            var nextMarketOpen = exchangeHours.GetNextMarketOpen(startTime, true);
-            Assert.AreEqual(new DateTime(2022, 1, 3, 18, 0, 0), nextMarketOpen);
-        }
-
-        [Test]
-        public void GetNextMarketOpenWithExtendedHours3()
-        {
-            var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
-
-            var startTime = new DateTime(2022, 1, 3, 16, 0, 0); // Monday
-            var nextMarketOpen = exchangeHours.GetNextMarketOpen(startTime, true);
-            Assert.AreEqual(new DateTime(2022, 1, 3, 18, 0, 0), nextMarketOpen);
+            var nextMarketOpen = exchangeHours.GetNextMarketOpen(startTime, extendedMarket);
+            Assert.AreEqual(expectedNextMarketOpen, nextMarketOpen);
         }
 
         [Test]
@@ -432,6 +381,15 @@ namespace QuantConnect.Tests.Common.Securities
             // Because there is a late open at 4am, the next close is the close of the session after that open.
             var nextMarketOpen = exchangeHours.GetNextMarketClose(startTime, false);
             Assert.AreEqual(new DateTime(2018, 12, 10, 17, 30, 0), nextMarketOpen);
+        }
+
+        [TestCaseSource(nameof(GetNextMarketCloseTestCases))]
+        public void GetNextMarketClose(DateTime startTime, DateTime expectedNextMarketClose, bool extendedMarket)
+        {
+            var exchangeHours = CreateUsFutureSecurityExchangeHoursWithExtendedHours();
+
+            var nextMarketClose = exchangeHours.GetNextMarketClose(startTime, extendedMarket);
+            Assert.AreEqual(expectedNextMarketClose, nextMarketClose);
         }
 
         [Test]
@@ -691,6 +649,37 @@ namespace QuantConnect.Tests.Common.Securities
                 sunday, monday, tuesday, wednesday, thursday, friday, saturday
             }.ToDictionary(x => x.DayOfWeek), earlyCloses, lateOpens);
             return exchangeHours;
+        }
+
+        private static TestCaseData[] GetNextMarketOpenTestCases()
+        {
+            return new[]
+            {
+                new TestCaseData(new DateTime(2022, 1, 1), new DateTime(2022, 1, 3, 9, 30, 0), false),
+                new TestCaseData(new DateTime(2022, 1, 3, 8, 0, 0), new DateTime(2022, 1, 3, 9, 30, 0), false),
+                new TestCaseData(new DateTime(2022, 1, 2, 18, 0, 0), new DateTime(2022, 1, 3, 18, 0, 0), true),
+                new TestCaseData(new DateTime(2022, 1, 3, 12, 0, 0), new DateTime(2022, 1, 3, 18, 0, 0), true),
+                new TestCaseData(new DateTime(2022, 1, 3, 16, 0, 0), new DateTime(2022, 1, 3, 18, 0, 0), true),
+                new TestCaseData(new DateTime(2022, 1, 1), new DateTime(2022, 1, 2, 18, 0, 0), true)
+            };
+        }
+
+        private static TestCaseData[] GetNextMarketCloseTestCases()
+        {
+            return new[]
+            {
+                new TestCaseData(new DateTime(2022, 1, 1), new DateTime(2022, 1, 3, 16, 0, 0), false),
+                new TestCaseData(new DateTime(2022, 1, 2), new DateTime(2022, 1, 3, 16, 0, 0), false),
+                new TestCaseData(new DateTime(2022, 1, 3), new DateTime(2022, 1, 3, 16, 0, 0), false),
+                new TestCaseData(new DateTime(2022, 1, 3, 10, 0, 0), new DateTime(2022, 1, 3, 16, 0, 0), false),
+                new TestCaseData(new DateTime(2022, 1, 3, 18, 0, 0), new DateTime(2022, 1, 4, 16, 0, 0), false),
+                new TestCaseData(new DateTime(2022, 1, 1), new DateTime(2022, 1, 3, 16, 0, 0), true),
+                new TestCaseData(new DateTime(2022, 1, 2), new DateTime(2022, 1, 3, 16, 0, 0), true),
+                new TestCaseData(new DateTime(2022, 1, 2, 18, 0, 0), new DateTime(2022, 1, 3, 16, 0, 0), true),
+                new TestCaseData(new DateTime(2022, 1, 3), new DateTime(2022, 1, 3, 16, 0, 0), true),
+                new TestCaseData(new DateTime(2022, 1, 3, 10, 0, 0), new DateTime(2022, 1, 3, 16, 0, 0), true),
+                new TestCaseData(new DateTime(2022, 1, 3, 18, 0, 0), new DateTime(2022, 1, 4, 16, 0, 0), true),
+            };
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This method was not considering a gap like the one from 16:15 to 16:30 or 17:00 to 18:00 in the following segments when extended market hours is enabled.

```json
[
        {
           "start": "00:00:00",
           "end": "9:30:00",
           "state": "premarket"
        },
        {
           "start": "9:30:00",
           "end": "16:15:00",
           "state": "market"
        },
        {
           "start": "16:30:00",
           "end": "17:00:00",
           "state": "market"
        },
        {
           "start": "18:00:00",
           "end": "1.00:00:00",
           "state": "postmarket"
        }
]
```

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Part of #2470 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

When asking for the next market close (`SecurityExchangeHours.GetNextMarketClose()`) on a monday before 16:15 (given that all the segments above are for every week day), it should return that market close that same monday at 16:15, but it was returnining next friday at 16:15.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were added both for `SecurityExchangeHours` and `LocalMarketHours` asserting that the methods return the correct next market closed in different cases.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
