### PR TITLE
Forbid tick resolution period-based history requests

### DIFF
--- a/Algorithm.CSharp/PeriodBasedHistoryRequestNotAllowedWithTickResolutionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/PeriodBasedHistoryRequestNotAllowedWithTickResolutionRegressionAlgorithm.cs
@@ -1,0 +1,141 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Interfaces;
+using QuantConnect.Data.Market;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm for testing that period-based history requests are not allowed with tick resolution
+    /// </summary>
+    public class PeriodBasedHistoryRequestNotAllowedWithTickResolutionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 08);
+            SetEndDate(2013, 10, 09);
+
+            var spy = AddEquity("SPY", Resolution.Tick).Symbol;
+
+            // Tick resolution is not allowed for period-based history requests
+            AssertThatHistoryThrowsForTickResolution(() => History<Tick>(spy, 1),
+                "Tick history call with implicit tick resolution");
+            AssertThatHistoryThrowsForTickResolution(() => History<Tick>(spy, 1, Resolution.Tick),
+                "Tick history call with explicit tick resolution");
+            AssertThatHistoryThrowsForTickResolution(() => History<Tick>(new [] { spy }, 1),
+                "Tick history call with symbol array with implicit tick resolution");
+            AssertThatHistoryThrowsForTickResolution(() => History<Tick>(new [] { spy }, 1, Resolution.Tick),
+                "Tick history call with symbol array with explicit tick resolution");
+
+            var history = History<Tick>(spy, TimeSpan.FromHours(12));
+            if (history.Count() == 0)
+            {
+                throw new Exception("On history call with implicit tick resolution: history returned no results");
+            }
+
+            history = History<Tick>(spy, TimeSpan.FromHours(12), Resolution.Tick);
+            if (history.Count() == 0)
+            {
+                throw new Exception("On history call with explicit tick resolution: history returned no results");
+            }
+        }
+
+        private void AssertThatHistoryThrowsForTickResolution(Action historyCall, string historyCallDescription)
+        {
+            try
+            {
+                historyCall();
+                throw new Exception($"{historyCallDescription}: expected an exception to be thrown");
+            }
+            catch (ArgumentException)
+            {
+                // expected
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 7682413;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 2489880;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.Python/PeriodBasedHistoryRequestNotAllowedWithTickResolutionRegressionAlgorithm.py
+++ b/Algorithm.Python/PeriodBasedHistoryRequestNotAllowedWithTickResolutionRegressionAlgorithm.py
@@ -1,0 +1,50 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression algorithm for testing that period-based history requests are not allowed with tick resolution
+### </summary>
+class PeriodBasedHistoryRequestNotAllowedWithTickResolutionRegressionAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        self.SetStartDate(2013, 10, 8)
+        self.SetEndDate(2013, 10, 9)
+
+        spy = self.AddEquity("SPY", Resolution.Tick).Symbol
+
+        # Tick resolution is not allowed for period-based history requests
+        self.AssertThatHistoryThrowsForTickResolution(lambda: self.History[Tick](spy, 1),
+            "Tick history call with implicit tick resolution")
+        self.AssertThatHistoryThrowsForTickResolution(lambda: self.History[Tick](spy, 1, Resolution.Tick),
+            "Tick history call with explicit tick resolution")
+        self.AssertThatHistoryThrowsForTickResolution(lambda: self.History[Tick]([spy], 1),
+            "Tick history call with symbol array with implicit tick resolution")
+        self.AssertThatHistoryThrowsForTickResolution(lambda: self.History[Tick]([spy], 1, Resolution.Tick),
+            "Tick history call with symbol array with explicit tick resolution")
+
+        history = self.History[Tick](spy, TimeSpan.FromHours(12))
+        if len(list(history)) == 0:
+            raise Exception("On history call with implicit tick resolution: history returned no results")
+
+        history = self.History[Tick](spy, TimeSpan.FromHours(12), Resolution.Tick)
+        if len(list(history)) == 0:
+            raise Exception("On history call with explicit tick resolution: history returned no results")
+
+    def AssertThatHistoryThrowsForTickResolution(self, historyCall, historyCallDescription):
+        try:
+            historyCall()
+            raise Exception(f"{historyCallDescription}: expected an exception to be thrown")
+        except ArgumentException:
+            # expected
+            pass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Detect and throw on tick resolution period based `History` functions. It was only being handled in some cases, as stated in the original issue (#6508).

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6508 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Both unit tests and regression algorithms where added asserting the expected behavior

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
