### PR TITLE
`GetParameter` number conversion overloads

### DIFF
--- a/Algorithm.Python/ParameterizedAlgorithm.py
+++ b/Algorithm.Python/ParameterizedAlgorithm.py
@@ -30,8 +30,8 @@ class ParameterizedAlgorithm(QCAlgorithm):
         self.AddEquity("SPY")
 
         # Receive parameters from the Job
-        fast_period = int(self.GetParameter("ema-fast", "100"))
-        slow_period = int(self.GetParameter("ema-slow", "200"))
+        fast_period = self.GetParameter("ema-fast", 100)
+        slow_period = self.GetParameter("ema-slow", 200)
 
         self.fast = self.EMA("SPY", fast_period)
         self.slow = self.EMA("SPY", slow_period)

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -661,6 +661,45 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// </summary>
+        /// <param name="name">The name of the parameter to get</param>
+        /// <param name="defaultValue">The default value to return</param>
+        /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
+        [DocumentationAttribute(ParameterAndOptimization)]
+        public int? GetParameter(string name, int? defaultValue = null)
+        {
+            return _parameters.TryGetValue(name, out var strValue) && int.TryParse(strValue, out var value) ? value : defaultValue;
+        }
+
+        /// <summary>
+        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// </summary>
+        /// <param name="name">The name of the parameter to get</param>
+        /// <param name="defaultValue">The default value to return</param>
+        /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
+        [DocumentationAttribute(ParameterAndOptimization)]
+        public double? GetParameter(string name, double? defaultValue = null)
+        {
+            return _parameters.TryGetValue(name, out var strValue) && double.TryParse(strValue, out var value) ? value : defaultValue;
+        }
+
+        /// <summary>
+        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// </summary>
+        /// <param name="name">The name of the parameter to get</param>
+        /// <param name="defaultValue">The default value to return</param>
+        /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
+        [DocumentationAttribute(ParameterAndOptimization)]
+        public decimal? GetParameter(string name, decimal? defaultValue = null)
+        {
+            return _parameters.TryGetValue(name, out var strValue) && decimal.TryParse(strValue, out var value) ? value : defaultValue;
+        }
+
+        /// <summary>
         /// Gets a read-only dictionary with all current parameters
         /// </summary>
         [DocumentationAttribute(ParameterAndOptimization)]

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -661,7 +661,7 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// Gets the parameter with the specified name parsed as an integer. If a parameter with the specified name does not exist,
         /// or the conversion is not possible, the given default value is returned if any, else null
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>
@@ -674,7 +674,7 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// Gets the parameter with the specified name parsed as a double. If a parameter with the specified name does not exist,
         /// or the conversion is not possible, the given default value is returned if any, else null
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -517,6 +517,33 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         public string GetParameter(string name, string defaultValue = null) => _baseAlgorithm.GetParameter(name, defaultValue);
 
         /// <summary>
+        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// </summary>
+        /// <param name="name">The name of the parameter to get</param>
+        /// <param name="defaultValue">The default value to return</param>
+        /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
+        public int? GetParameter(string name, int? defaultValue = null) => _baseAlgorithm.GetParameter(name, defaultValue);
+
+        /// <summary>
+        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// </summary>
+        /// <param name="name">The name of the parameter to get</param>
+        /// <param name="defaultValue">The default value to return</param>
+        /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
+        public double? GetParameter(string name, double? defaultValue = null) => _baseAlgorithm.GetParameter(name, defaultValue);
+
+        /// <summary>
+        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// </summary>
+        /// <param name="name">The name of the parameter to get</param>
+        /// <param name="defaultValue">The default value to return</param>
+        /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
+        public decimal? GetParameter(string name, decimal? defaultValue = null) => _baseAlgorithm.GetParameter(name, defaultValue);
+
+        /// <summary>
         /// Initialise the Algorithm and Prepare Required Data:
         /// </summary>
         public void Initialize()

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -517,7 +517,7 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         public string GetParameter(string name, string defaultValue = null) => _baseAlgorithm.GetParameter(name, defaultValue);
 
         /// <summary>
-        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// Gets the parameter with the specified name parsed as an integer. If a parameter with the specified name does not exist,
         /// or the conversion is not possible, the given default value is returned if any, else null
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>
@@ -526,7 +526,7 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         public int? GetParameter(string name, int? defaultValue = null) => _baseAlgorithm.GetParameter(name, defaultValue);
 
         /// <summary>
-        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// Gets the parameter with the specified name parsed as a double. If a parameter with the specified name does not exist,
         /// or the conversion is not possible, the given default value is returned if any, else null
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -357,6 +357,33 @@ namespace QuantConnect.Interfaces
         string GetParameter(string name, string defaultValue = null);
 
         /// <summary>
+        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// </summary>
+        /// <param name="name">The name of the parameter to get</param>
+        /// <param name="defaultValue">The default value to return</param>
+        /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
+        int? GetParameter(string name, int? defaultValue = null);
+
+        /// <summary>
+        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// </summary>
+        /// <param name="name">The name of the parameter to get</param>
+        /// <param name="defaultValue">The default value to return</param>
+        /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
+        double? GetParameter(string name, double? defaultValue = null);
+
+        /// <summary>
+        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// </summary>
+        /// <param name="name">The name of the parameter to get</param>
+        /// <param name="defaultValue">The default value to return</param>
+        /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
+        decimal? GetParameter(string name, decimal? defaultValue = null);
+
+        /// <summary>
         /// Sets the parameters from the dictionary
         /// </summary>
         /// <param name="parameters">Dictionary containing the parameter names to values</param>

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -357,7 +357,7 @@ namespace QuantConnect.Interfaces
         string GetParameter(string name, string defaultValue = null);
 
         /// <summary>
-        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// Gets the parameter with the specified name parsed as an integer. If a parameter with the specified name does not exist,
         /// or the conversion is not possible, the given default value is returned if any, else null
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>
@@ -366,7 +366,7 @@ namespace QuantConnect.Interfaces
         int? GetParameter(string name, int? defaultValue = null);
 
         /// <summary>
-        /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
+        /// Gets the parameter with the specified name parsed as a double. If a parameter with the specified name does not exist,
         /// or the conversion is not possible, the given default value is returned if any, else null
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>

--- a/Tests/Algorithm/AlgorithmGetParameterTests.cs
+++ b/Tests/Algorithm/AlgorithmGetParameterTests.cs
@@ -1,0 +1,124 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Algorithm;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    [TestFixture]
+    public class AlgorithmGetParameterTests
+    {
+        [TestCase(Language.CSharp, "numeric_parameter", 2, false)]
+        [TestCase(Language.CSharp, "not_a_parameter", 2, true)]
+        [TestCase(Language.CSharp, "string_parameter", 2, true)]
+        [TestCase(Language.Python, "numeric_parameter", 2, false)]
+        [TestCase(Language.Python, "not_a_parameter", 2, true)]
+        [TestCase(Language.Python, "string_parameter", 2, true)]
+        public void GetParameterConvertsToNumericTypes(Language language, string parameterName, int defaultValue, bool shouldReturnDefaultValue)
+        {
+            var parameters = new Dictionary<string, string>
+            {
+                { "numeric_parameter", "1" },
+                { "string_parameter", "string value" },
+            };
+            var doubleDefaultValue = Convert.ToDouble(defaultValue);
+            var decimalDefaultValue = Convert.ToDecimal(defaultValue);
+
+            if (language == Language.CSharp)
+            {
+                var algorithm = new QCAlgorithm();
+                algorithm.SetParameters(parameters);
+
+                var intValue = algorithm.GetParameter(parameterName, defaultValue);
+                var doubleValue = algorithm.GetParameter(parameterName, doubleDefaultValue);
+                var decimalValue = algorithm.GetParameter(parameterName, decimalDefaultValue);
+
+                Assert.AreEqual(typeof(int), intValue.GetType());
+                Assert.AreEqual(typeof(double), doubleValue.GetType());
+                Assert.AreEqual(typeof(decimal), decimalValue.GetType());
+
+                if (!shouldReturnDefaultValue && parameters.TryGetValue(parameterName, out var parameterValue))
+                {
+                    Assert.AreEqual(int.Parse(parameterValue), intValue);
+                    Assert.AreEqual(double.Parse(parameterValue), doubleValue);
+                    Assert.AreEqual(decimal.Parse(parameterValue), decimalValue);
+                }
+                else
+                {
+                    Assert.AreEqual(defaultValue, intValue);
+                    Assert.AreEqual(doubleDefaultValue, doubleValue);
+                    Assert.AreEqual(decimalDefaultValue, decimalValue);
+                }
+            }
+            else
+            {
+                using (Py.GIL())
+                {
+                    var testModule = PyModule.FromString("testModule",
+                        @"
+from AlgorithmImports import *
+
+def getAlgorithm():
+    algorithm = QCAlgorithm()
+    # algorithm.SetParameters({
+    #     'numeric_parameter': 1,
+    #     'string_parameter': 'string value',
+    # })
+    return algorithm
+
+def isInt(value):
+    return isinstance(value, int)
+
+def isFloat(value):
+    return isinstance(value, float)
+        ");
+
+                    var getAlgorithm = testModule.GetAttr("getAlgorithm");
+                    var algorithm = getAlgorithm.Invoke();
+                    algorithm.GetAttr("SetParameters").Invoke(PyDict.FromManagedObject(parameters));
+
+                    var intValue = algorithm.GetAttr("GetParameter").Invoke(parameterName.ToPython(), defaultValue.ToPython());
+                    var doubleValue = algorithm.GetAttr("GetParameter").Invoke(parameterName.ToPython(), doubleDefaultValue.ToPython());
+                    var decimalValue = algorithm.GetAttr("GetParameter").Invoke(parameterName.ToPython(), decimalDefaultValue.ToPython());
+
+                    Assert.IsTrue(testModule.GetAttr("isInt").Invoke(intValue).As<bool>(),
+                        $"Expected 'intValue' to be of type int but was {intValue.GetPythonType().ToString()} instead");
+                    Assert.IsTrue(testModule.GetAttr("isFloat").Invoke(doubleValue).As<bool>(),
+                        $"Expected 'doubleValue' to be of type float but was {doubleValue.GetPythonType().ToString()} instead");
+                    Assert.IsTrue(testModule.GetAttr("isFloat").Invoke(decimalValue).As<bool>(),
+                        $"Expected 'decimalValue' to be of type float but was {decimalValue.GetPythonType().ToString()} instead");
+
+                    if (!shouldReturnDefaultValue && parameters.TryGetValue(parameterName, out var parameterValue))
+                    {
+                        Assert.AreEqual(int.Parse(parameterValue), intValue.As<int>());
+                        Assert.AreEqual(double.Parse(parameterValue), doubleValue.As<double>());
+                        Assert.AreEqual(decimal.Parse(parameterValue), decimalValue.As<decimal>());
+                    }
+                    else
+                    {
+                        Assert.AreEqual(defaultValue, intValue.As<int>());
+                        Assert.AreEqual(doubleDefaultValue, doubleValue.As<double>());
+                        Assert.AreEqual(decimalDefaultValue, decimalValue.As<decimal>());
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/Tests/Algorithm/AlgorithmGetParameterTests.cs
+++ b/Tests/Algorithm/AlgorithmGetParameterTests.cs
@@ -53,6 +53,7 @@ namespace QuantConnect.Tests.Algorithm
                 Assert.AreEqual(typeof(double), doubleValue.GetType());
                 Assert.AreEqual(typeof(decimal), decimalValue.GetType());
 
+                // If the parameter is not found or is not numeric, the default value should be returned
                 if (!shouldReturnDefaultValue && parameters.TryGetValue(parameterName, out var parameterValue))
                 {
                     Assert.AreEqual(int.Parse(parameterValue), intValue);
@@ -75,12 +76,7 @@ namespace QuantConnect.Tests.Algorithm
 from AlgorithmImports import *
 
 def getAlgorithm():
-    algorithm = QCAlgorithm()
-    # algorithm.SetParameters({
-    #     'numeric_parameter': 1,
-    #     'string_parameter': 'string value',
-    # })
-    return algorithm
+    return QCAlgorithm()
 
 def isInt(value):
     return isinstance(value, int)
@@ -104,6 +100,7 @@ def isFloat(value):
                     Assert.IsTrue(testModule.GetAttr("isFloat").Invoke(decimalValue).As<bool>(),
                         $"Expected 'decimalValue' to be of type float but was {decimalValue.GetPythonType().ToString()} instead");
 
+                    // If the parameter is not found or is not numeric, the default value should be returned
                     if (!shouldReturnDefaultValue && parameters.TryGetValue(parameterName, out var parameterValue))
                     {
                         Assert.AreEqual(int.Parse(parameterValue), intValue.As<int>());

--- a/Tests/Python/AlgorithmPythonWrapperTests.cs
+++ b/Tests/Python/AlgorithmPythonWrapperTests.cs
@@ -65,7 +65,7 @@ namespace QuantConnect.Tests.Python
             using (Py.GIL())
             {
                 var algorithm = GetAlgorithm(code);
-
+                
                 Assert.Null(algorithm.RunTimeError);
                 Assert.DoesNotThrow(() => algorithm.OnEndOfDay());
                 Assert.Null(algorithm.RunTimeError);
@@ -146,46 +146,6 @@ namespace QuantConnect.Tests.Python
                 Assert.Null(algorithm.RunTimeError);
                 Assert.DoesNotThrow(() => algorithm.OnEndOfDay(Symbols.SPY));
                 Assert.NotNull(algorithm.RunTimeError);
-            }
-        }
-
-        [TestCase("numeric_parameter", 2, false)]
-        [TestCase("not_a_parameter", 2, true)]
-        [TestCase("string_parameter", 2, true)]
-        public void GetParameterConvertsToNumericTypes(string parameterName, int defaultValue, bool shouldReturnDefaultValue)
-        {
-            using (Py.GIL())
-            {
-                var algorithm = GetAlgorithm("");
-                var parameters = new Dictionary<string, string>
-                {
-                    { "numeric_parameter", "1" },
-                    { "string_parameter", "string value" },
-                };
-                algorithm.SetParameters(parameters);
-
-                var doubleDefaultValue = Convert.ToDouble(defaultValue);
-                var decimalDefaultValue = Convert.ToDecimal(defaultValue);
-                var intValue = algorithm.GetParameter(parameterName, (int)defaultValue);
-                var doubleValue = algorithm.GetParameter(parameterName, doubleDefaultValue);
-                var decimalValue = algorithm.GetParameter(parameterName, decimalDefaultValue);
-
-                Assert.AreEqual(typeof(int), intValue.GetType());
-                Assert.AreEqual(typeof(double), doubleValue.GetType());
-                Assert.AreEqual(typeof(decimal), decimalValue.GetType());
-
-                if (!shouldReturnDefaultValue && parameters.TryGetValue(parameterName, out var parameterValue))
-                {
-                    Assert.AreEqual(int.Parse(parameterValue), intValue);
-                    Assert.AreEqual(double.Parse(parameterValue), doubleValue);
-                    Assert.AreEqual(decimal.Parse(parameterValue), decimalValue);
-                }
-                else
-                {
-                    Assert.AreEqual(defaultValue, intValue);
-                    Assert.AreEqual(doubleDefaultValue, doubleValue);
-                    Assert.AreEqual(decimalDefaultValue, decimalValue);
-                }
             }
         }
 

--- a/Tests/Python/AlgorithmPythonWrapperTests.cs
+++ b/Tests/Python/AlgorithmPythonWrapperTests.cs
@@ -152,7 +152,7 @@ namespace QuantConnect.Tests.Python
         [TestCase("numeric_parameter", 2, false)]
         [TestCase("not_a_parameter", 2, true)]
         [TestCase("string_parameter", 2, true)]
-        public void GetParameterConvertsToIntType(string parameterName, int defaultValue, bool shouldReturnDefaultValue)
+        public void GetParameterConvertsToNumericTypes(string parameterName, int defaultValue, bool shouldReturnDefaultValue)
         {
             using (Py.GIL())
             {
@@ -176,7 +176,6 @@ namespace QuantConnect.Tests.Python
 
                 if (!shouldReturnDefaultValue && parameters.TryGetValue(parameterName, out var parameterValue))
                 {
-
                     Assert.AreEqual(int.Parse(parameterValue), intValue);
                     Assert.AreEqual(double.Parse(parameterValue), doubleValue);
                     Assert.AreEqual(decimal.Parse(parameterValue), decimalValue);

--- a/Tests/Python/AlgorithmPythonWrapperTests.cs
+++ b/Tests/Python/AlgorithmPythonWrapperTests.cs
@@ -65,7 +65,7 @@ namespace QuantConnect.Tests.Python
             using (Py.GIL())
             {
                 var algorithm = GetAlgorithm(code);
-                
+
                 Assert.Null(algorithm.RunTimeError);
                 Assert.DoesNotThrow(() => algorithm.OnEndOfDay());
                 Assert.Null(algorithm.RunTimeError);
@@ -146,6 +146,47 @@ namespace QuantConnect.Tests.Python
                 Assert.Null(algorithm.RunTimeError);
                 Assert.DoesNotThrow(() => algorithm.OnEndOfDay(Symbols.SPY));
                 Assert.NotNull(algorithm.RunTimeError);
+            }
+        }
+
+        [TestCase("numeric_parameter", 2, false)]
+        [TestCase("not_a_parameter", 2, true)]
+        [TestCase("string_parameter", 2, true)]
+        public void GetParameterConvertsToIntType(string parameterName, int defaultValue, bool shouldReturnDefaultValue)
+        {
+            using (Py.GIL())
+            {
+                var algorithm = GetAlgorithm("");
+                var parameters = new Dictionary<string, string>
+                {
+                    { "numeric_parameter", "1" },
+                    { "string_parameter", "string value" },
+                };
+                algorithm.SetParameters(parameters);
+
+                var doubleDefaultValue = Convert.ToDouble(defaultValue);
+                var decimalDefaultValue = Convert.ToDecimal(defaultValue);
+                var intValue = algorithm.GetParameter(parameterName, (int)defaultValue);
+                var doubleValue = algorithm.GetParameter(parameterName, doubleDefaultValue);
+                var decimalValue = algorithm.GetParameter(parameterName, decimalDefaultValue);
+
+                Assert.AreEqual(typeof(int), intValue.GetType());
+                Assert.AreEqual(typeof(double), doubleValue.GetType());
+                Assert.AreEqual(typeof(decimal), decimalValue.GetType());
+
+                if (!shouldReturnDefaultValue && parameters.TryGetValue(parameterName, out var parameterValue))
+                {
+
+                    Assert.AreEqual(int.Parse(parameterValue), intValue);
+                    Assert.AreEqual(double.Parse(parameterValue), doubleValue);
+                    Assert.AreEqual(decimal.Parse(parameterValue), decimalValue);
+                }
+                else
+                {
+                    Assert.AreEqual(defaultValue, intValue);
+                    Assert.AreEqual(doubleDefaultValue, doubleValue);
+                    Assert.AreEqual(decimalDefaultValue, decimalValue);
+                }
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Add `GetParameter()` overloads to handle automatic parameter value conversion to numeric types when possible,

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6449 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Regression algorithms and unit tests asserting the expected behavior

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
