### PR TITLE
Fix 'GetParameter()' ambiguous call error when no default parameter is provided

### DIFF
--- a/Algorithm.CSharp/GetParameterRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/GetParameterRegressionAlgorithm.cs
@@ -1,0 +1,132 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm for testing parameterized regression algorithms get valid parameters.
+    /// </summary>
+    public class GetParameterRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+
+            CheckParameter((string)null, GetParameter("non-existing"), "GetParameter(\"non-existing\")");
+            CheckParameter("100", GetParameter("non-existing", "100"), "GetParameter(\"non-existing\", \"100\")");
+            CheckParameter(100, GetParameter("non-existing", 100), "GetParameter(\"non-existing\", 100)");
+            CheckParameter(100d, GetParameter("non-existing", 100d), "GetParameter(\"non-existing\", 100d)");
+            CheckParameter(100m, GetParameter("non-existing", 100m), "GetParameter(\"non-existing\", 100m)");
+
+            CheckParameter("10", GetParameter("ema-fast"), "GetParameter(\"ema-fast\")");
+            CheckParameter(10, GetParameter("ema-fast", 100), "GetParameter(\"ema-fast\", 100)");
+            CheckParameter(10d, GetParameter("ema-fast", 100d), "GetParameter(\"ema-fast\", 100d)");
+            CheckParameter(10m, GetParameter("ema-fast", 100m), "GetParameter(\"ema-fast\", 100m)");
+
+            Quit();
+        }
+
+        private void CheckParameter<T, P>(T expected, P actual, string call)
+        {
+            if (expected == null && actual != null)
+            {
+                throw new Exception($"{call} should have returned null but returned {actual} ({actual.GetType()})");
+            }
+
+            if (expected != null && actual == null)
+            {
+                throw new Exception($"{call} should have returned {expected} ({expected.GetType()}) but returned null");
+            }
+
+            if (expected != null && actual != null && (expected.GetType() != actual.GetType() || !expected.Equals(actual)))
+            {
+                throw new Exception($"{call} should have returned {expected} ({expected.GetType()}) but returned {actual} ({actual.GetType()})");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 0;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "0"},
+            {"Return Over Maximum Drawdown", "0"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.Python/GetParameterRegressionAlgorithm.py
+++ b/Algorithm.Python/GetParameterRegressionAlgorithm.py
@@ -1,0 +1,42 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression algorithm for testing parameterized regression algorithms get valid parameters.
+### </summary>
+class GetParameterRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetStartDate(2013, 10, 7)
+        self.CheckParameter(None, self.GetParameter("non-existing"), "GetParameter(\"non-existing\")")
+        self.CheckParameter("100", self.GetParameter("non-existing", "100"), "GetParameter(\"non-existing\", \"100\")")
+        self.CheckParameter(100, self.GetParameter("non-existing", 100), "GetParameter(\"non-existing\", 100)")
+        self.CheckParameter(100.0, self.GetParameter("non-existing", 100.0), "GetParameter(\"non-existing\", 100.0)")
+
+        self.CheckParameter("10", self.GetParameter("ema-fast"), "GetParameter(\"ema-fast\")")
+        self.CheckParameter(10, self.GetParameter("ema-fast", 100), "GetParameter(\"ema-fast\", 100)")
+        self.CheckParameter(10.0, self.GetParameter("ema-fast", 100.0), "GetParameter(\"ema-fast\", 100.0)")
+
+        self.Quit()
+
+    def CheckParameter(self, expected, actual, call):
+        if expected == None and actual != None:
+            raise Exception(f"{call} should have returned null but returned {actual} ({type(actual)})")
+
+        if expected != None and actual == None:
+            raise Exception(f"{call} should have returned {expected} ({type(expected)}) but returned null")
+
+        if expected != None and actual != None and type(expected) != type(actual) or expected != actual:
+            raise Exception(f"{call} should have returned {expected} ({type(expected)}) but returned {actual} ({type(actual)})")

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -662,39 +662,39 @@ namespace QuantConnect.Algorithm
 
         /// <summary>
         /// Gets the parameter with the specified name parsed as an integer. If a parameter with the specified name does not exist,
-        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// or the conversion is not possible, the given default value is returned
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>
         /// <param name="defaultValue">The default value to return</param>
         /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
         [DocumentationAttribute(ParameterAndOptimization)]
-        public int? GetParameter(string name, int? defaultValue = null)
+        public int GetParameter(string name, int defaultValue)
         {
             return _parameters.TryGetValue(name, out var strValue) && int.TryParse(strValue, out var value) ? value : defaultValue;
         }
 
         /// <summary>
         /// Gets the parameter with the specified name parsed as a double. If a parameter with the specified name does not exist,
-        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// or the conversion is not possible, the given default value is returned
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>
         /// <param name="defaultValue">The default value to return</param>
         /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
         [DocumentationAttribute(ParameterAndOptimization)]
-        public double? GetParameter(string name, double? defaultValue = null)
+        public double GetParameter(string name, double defaultValue)
         {
             return _parameters.TryGetValue(name, out var strValue) && double.TryParse(strValue, out var value) ? value : defaultValue;
         }
 
         /// <summary>
         /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
-        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// or the conversion is not possible, the given default value is returned
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>
         /// <param name="defaultValue">The default value to return</param>
         /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
         [DocumentationAttribute(ParameterAndOptimization)]
-        public decimal? GetParameter(string name, decimal? defaultValue = null)
+        public decimal GetParameter(string name, decimal defaultValue)
         {
             return _parameters.TryGetValue(name, out var strValue) && decimal.TryParse(strValue, out var value) ? value : defaultValue;
         }

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Globalization;
 using NodaTime;
 using NodaTime.TimeZones;
 using QuantConnect.Benchmarks;
@@ -684,7 +685,7 @@ namespace QuantConnect.Algorithm
         public double GetParameter(string name, double defaultValue)
         {
             return _parameters.TryGetValue(name, out var strValue) &&
-                double.TryParse(strValue, System.Globalization.NumberStyles.Any, null, out var value) ? value : defaultValue;
+                double.TryParse(strValue, NumberStyles.Any, CultureInfo.InvariantCulture, out var value) ? value : defaultValue;
         }
 
         /// <summary>
@@ -698,7 +699,7 @@ namespace QuantConnect.Algorithm
         public decimal GetParameter(string name, decimal defaultValue)
         {
             return _parameters.TryGetValue(name, out var strValue) &&
-                decimal.TryParse(strValue, System.Globalization.NumberStyles.Any, null, out var value) ? value : defaultValue;
+                decimal.TryParse(strValue, NumberStyles.Any, CultureInfo.InvariantCulture, out var value) ? value : defaultValue;
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -683,7 +683,8 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(ParameterAndOptimization)]
         public double GetParameter(string name, double defaultValue)
         {
-            return _parameters.TryGetValue(name, out var strValue) && double.TryParse(strValue, out var value) ? value : defaultValue;
+            return _parameters.TryGetValue(name, out var strValue) &&
+                double.TryParse(strValue, System.Globalization.NumberStyles.Any, null, out var value) ? value : defaultValue;
         }
 
         /// <summary>
@@ -696,7 +697,8 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(ParameterAndOptimization)]
         public decimal GetParameter(string name, decimal defaultValue)
         {
-            return _parameters.TryGetValue(name, out var strValue) && decimal.TryParse(strValue, out var value) ? value : defaultValue;
+            return _parameters.TryGetValue(name, out var strValue) &&
+                decimal.TryParse(strValue, System.Globalization.NumberStyles.Any, null, out var value) ? value : defaultValue;
         }
 
         /// <summary>

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -518,30 +518,30 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
 
         /// <summary>
         /// Gets the parameter with the specified name parsed as an integer. If a parameter with the specified name does not exist,
-        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// or the conversion is not possible, the given default value is returned
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>
         /// <param name="defaultValue">The default value to return</param>
         /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
-        public int? GetParameter(string name, int? defaultValue = null) => _baseAlgorithm.GetParameter(name, defaultValue);
+        public int GetParameter(string name, int defaultValue) => _baseAlgorithm.GetParameter(name, defaultValue);
 
         /// <summary>
         /// Gets the parameter with the specified name parsed as a double. If a parameter with the specified name does not exist,
-        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// or the conversion is not possible, the given default value is returned
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>
         /// <param name="defaultValue">The default value to return</param>
         /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
-        public double? GetParameter(string name, double? defaultValue = null) => _baseAlgorithm.GetParameter(name, defaultValue);
+        public double GetParameter(string name, double defaultValue) => _baseAlgorithm.GetParameter(name, defaultValue);
 
         /// <summary>
         /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
-        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// or the conversion is not possible, the given default value is returned
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>
         /// <param name="defaultValue">The default value to return</param>
         /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
-        public decimal? GetParameter(string name, decimal? defaultValue = null) => _baseAlgorithm.GetParameter(name, defaultValue);
+        public decimal GetParameter(string name, decimal defaultValue) => _baseAlgorithm.GetParameter(name, defaultValue);
 
         /// <summary>
         /// Initialise the Algorithm and Prepare Required Data:

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -358,30 +358,30 @@ namespace QuantConnect.Interfaces
 
         /// <summary>
         /// Gets the parameter with the specified name parsed as an integer. If a parameter with the specified name does not exist,
-        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// or the conversion is not possible, the given default value is returned
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>
         /// <param name="defaultValue">The default value to return</param>
         /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
-        int? GetParameter(string name, int? defaultValue = null);
+        int GetParameter(string name, int defaultValue);
 
         /// <summary>
         /// Gets the parameter with the specified name parsed as a double. If a parameter with the specified name does not exist,
-        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// or the conversion is not possible, the given default value is returned
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>
         /// <param name="defaultValue">The default value to return</param>
         /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
-        double? GetParameter(string name, double? defaultValue = null);
+        double GetParameter(string name, double defaultValue);
 
         /// <summary>
         /// Gets the parameter with the specified name parsed as a decimal. If a parameter with the specified name does not exist,
-        /// or the conversion is not possible, the given default value is returned if any, else null
+        /// or the conversion is not possible, the given default value is returned
         /// </summary>
         /// <param name="name">The name of the parameter to get</param>
         /// <param name="defaultValue">The default value to return</param>
         /// <returns>The value of the specified parameter, or defaultValue if not found or null if there's no default value</returns>
-        decimal? GetParameter(string name, decimal? defaultValue = null);
+        decimal GetParameter(string name, decimal defaultValue);
 
         /// <summary>
         /// Sets the parameters from the dictionary


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Calling `algorithm.GetParameter("ema-slow")` (no default parameter) or passing null as defualt value, was causing an ambiguous call among its overloads.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests asserting the behavior

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
