### PR TITLE
Fix KeyError in report generator due to missing color mappings

### DIFF
--- a/Report/ReportChartTests.py
+++ b/Report/ReportChartTests.py
@@ -161,16 +161,16 @@ result = charts.GetLeverage(backtest, live)
 
 ## Test GetExposurePlot
 time = [pd.Timestamp(x).to_pydatetime() for x in pd.date_range('2014-10-01', periods=365)]
-long_securities = ['Equity']
-short_securities = ['Forex']
-long = [np.random.uniform(0, 0.5, 365)]
-short = [np.random.uniform(-0.5, 0, 365)]
+long_securities = ['Equity', 'Option', 'Commodity', 'Forex', 'Future', 'Cfd', 'Crypto', 'FutureOption', 'IndexOption']
+short_securities = long_securities
+long = [np.random.uniform(0, 0.5, 365) for x in long_securities]
+short = [np.random.uniform(-0.5, 0, 365) for x in short_securities]
 
 live_time = [pd.Timestamp(x).to_pydatetime() for x in pd.date_range('2015-10-01', periods=100)]
-live_long = [np.random.uniform(0, 0.5, 100)]
-live_short = [np.random.uniform(-0.5, -0, 100)]
-live_long_securities = ['Equity']
-live_short_securities = ['Forex']
+live_long_securities = long_securities
+live_short_securities = long_securities
+live_long = [np.random.uniform(0, 0.5, 100) for x in live_long_securities]
+live_short = [np.random.uniform(-0.5, -0, 100) for x in live_short_securities]
 
 result = charts.GetExposure()
 result = charts.GetExposure(time, long_securities = long_securities, long_data=long, short_securities=[], short_data=[list(np.zeros(len(long[0])))])

--- a/Report/ReportCharts.py
+++ b/Report/ReportCharts.py
@@ -962,9 +962,11 @@ class ReportCharts:
             return base64
 
         color_map = {'Equity': "#71c3fc", 'Option':'#A0522D', 'Commodity':'#4B0082',
-                    'Forex':'#0000FF', 'Future':'#6B8E23', 'Cfd':'#FF8C00', 'Crypto':'#BDB76B'}
+                    'Forex':'#0000FF', 'Future':'#6B8E23', 'Cfd':'#FF8C00', 'Crypto':'#BDB76B',
+                    'FutureOption':'#BDB76C', 'IndexOption':'#BDB76E'}
         live_color_map = {'Equity': "#ff9914" , 'Option': '#DAA520', 'Commodity': '#9400D3',
-                          'Forex':'#6495ED', 'Future':'#808000', 'Cfd':'#FFD700', 'Crypto':'#FFDAB9'}
+                          'Forex':'#6495ED', 'Future':'#808000', 'Cfd':'#FFD700', 'Crypto':'#FFDAB9',
+                          'FutureOption':'#FFDABA', 'IndexOption':'#FFDABC'}
 
         for k, v in list(color_map.items()):
             color_map[k + ' - Short'] = '#' + hex(int(v[1:], 16) ^ 0xffffff)[2:].zfill(6)

--- a/Report/ReportCharts.py
+++ b/Report/ReportCharts.py
@@ -961,18 +961,23 @@ class ReportCharts:
             plt.close('all')
             return base64
 
-        color_map = {'Equity': "#71c3fc", 'Option':'#A0522D', 'Commodity':'#4B0082',
-                    'Forex':'#0000FF', 'Future':'#6B8E23', 'Cfd':'#FF8C00', 'Crypto':'#BDB76B',
-                    'FutureOption':'#BDB76C', 'IndexOption':'#BDB76E'}
-        live_color_map = {'Equity': "#ff9914" , 'Option': '#DAA520', 'Commodity': '#9400D3',
-                          'Forex':'#6495ED', 'Future':'#808000', 'Cfd':'#FFD700', 'Crypto':'#FFDAB9',
-                          'FutureOption':'#FFDABA', 'IndexOption':'#FFDABC'}
+        color_map = {
+            "Equity": "#ff9914",
+            "Option": "#DAA520",
+            "Commodity": "#9400D3",
+            "Forex": "#6495ED",
+            "Future": "#808000",
+            "Cfd": "#FFD700",
+            "Crypto": "#FFDAB9",
+            "FutureOption": "#1ED3A9",
+            "IndexOption": "#A4AACC",
+        }
 
         for k, v in list(color_map.items()):
             color_map[k + ' - Short'] = '#' + hex(int(v[1:], 16) ^ 0xffffff)[2:].zfill(6)
 
-        for k, v in list(live_color_map.items()):
-            live_color_map[k + ' - Short'] = '#' + hex(int(v[1:], 16) ^ 0xffffff)[2:].zfill(6)
+        for k, v in list(color_map.items()):
+            color_map[k + ' - Short'] = '#' + hex(int(v[1:], 16) ^ 0xffffff)[2:].zfill(6)
 
         labels = long_securities + short_securities
         live_labels = live_long_securities + live_short_securities
@@ -1071,14 +1076,14 @@ class ReportCharts:
 
         if max([len(x) for x in live_long_data_copy]) > max([len(x) for x in live_short_data_copy]):
             ax.stackplot(live_time_copy[:max([len(x) for x in live_long_data_copy])], np.vstack(live_long_data_copy),
-                         color=[live_color_map[security] for security in live_long_securities], alpha = 0.75)
+                         color=[color_map[security] for security in live_long_securities], alpha = 0.75)
             ax.stackplot(live_time_copy[:max([len(x) for x in live_short_data_copy])], np.vstack(live_short_data_copy),
-                         color=[live_color_map[security + ' - Short'] for security in live_short_securities], alpha = 0.75)
+                         color=[color_map[security + ' - Short'] for security in live_short_securities], alpha = 0.75)
         else:
             ax.stackplot(live_time_copy[:max([len(x) for x in live_short_data_copy])], np.vstack(live_short_data_copy),
-                         color=[live_color_map[security + ' - Short'] for security in live_short_securities], alpha=0.75)
+                         color=[color_map[security + ' - Short'] for security in live_short_securities], alpha=0.75)
             ax.stackplot(live_time_copy[:max([len(x) for x in live_long_data_copy])], np.vstack(live_long_data_copy),
-                         color=[live_color_map[security] for security in live_long_securities], alpha=0.75)
+                         color=[color_map[security] for security in live_long_securities], alpha=0.75)
 
         for security in short_securities:
             if not all([all([abs(y) == 0.0 for y in x]) for x in short_data]):
@@ -1091,7 +1096,7 @@ class ReportCharts:
         labels = list(set(labels))
         live_labels = list(set(live_labels))
         rectangles = [plt.Rectangle((0, 0), 1, 1, fc=color_map[lab]) for lab in labels]
-        live_rectangles = [plt.Rectangle((0, 0), 1, 1, fc=live_color_map[lab]) for lab in live_labels]
+        live_rectangles = [plt.Rectangle((0, 0), 1, 1, fc=color_map[lab]) for lab in live_labels]
         ax.legend(rectangles + live_rectangles, labels + [f'{lab} - Live' for lab in live_labels], handlelength=0.8,
                   handleheight=0.8, frameon=False, fontsize=8, ncol=len(labels), loc='upper right')
         fig = ax.get_figure()

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -248,6 +248,9 @@
     <Content Include="TestData\00010101_05_example_psychsignal_testdata.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestData\test_report_data.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="TestData\spy_dpo.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Tests/Report/ReportChartsTest.cs
+++ b/Tests/Report/ReportChartsTest.cs
@@ -48,7 +48,8 @@ namespace QuantConnect.Tests.Report
                 Converters = new List<JsonConverter> { new NullResultValueTypeJsonConverter<BacktestResult>() },
                 FloatParseHandling = FloatParseHandling.Decimal
             };
-            var backtest = JsonConvert.DeserializeObject<BacktestResult>(File.ReadAllText(Path.Combine("TestData", "test_report_data.json")), backtestSettings);
+            var backtest = JsonConvert.DeserializeObject<BacktestResult>(
+                File.ReadAllText(Path.Combine("TestData", "test_report_data.json")), backtestSettings);
             LiveResult live = null;
             var report = new QuantConnect.Report.Report("Report", "Report", "v1.0.0", backtest, live);
 

--- a/Tests/Report/ReportChartsTest.cs
+++ b/Tests/Report/ReportChartsTest.cs
@@ -1,0 +1,58 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Python.Runtime;
+using QuantConnect.Packets;
+using QuantConnect.Orders;
+using QuantConnect.Statistics;
+using QuantConnect.Report;
+using Newtonsoft.Json;
+
+namespace QuantConnect.Tests.Report
+{
+    [TestFixture]
+    public class ReportChartTests
+    {
+        [Test]
+        public void RunsAllReportCartTests()
+        {
+            using (Py.GIL())
+            {
+                var code = File.ReadAllText("../../../Report/ReportChartTests.py");
+                using var scope = Py.CreateScope();
+                Assert.DoesNotThrow(() => scope.Exec(code));
+            }
+        }
+
+        [Test]
+        public void ExposureReportWorksForEverySecurityType()
+        {
+            var backtestSettings = new JsonSerializerSettings
+            {
+                Converters = new List<JsonConverter> { new NullResultValueTypeJsonConverter<BacktestResult>() },
+                FloatParseHandling = FloatParseHandling.Decimal
+            };
+            var backtest = JsonConvert.DeserializeObject<BacktestResult>(File.ReadAllText(Path.Combine("TestData", "test_report_data.json")), backtestSettings);
+            LiveResult live = null;
+            var report = new QuantConnect.Report.Report("Report", "Report", "v1.0.0", backtest, live);
+
+            Assert.DoesNotThrow(() => report.Compile(out _, out _));
+        }
+    }
+}

--- a/Tests/Report/ReportChartsTest.cs
+++ b/Tests/Report/ReportChartsTest.cs
@@ -50,10 +50,12 @@ namespace QuantConnect.Tests.Report
             };
             var backtest = JsonConvert.DeserializeObject<BacktestResult>(
                 File.ReadAllText(Path.Combine("TestData", "test_report_data.json")), backtestSettings);
-            LiveResult live = null;
-            var report = new QuantConnect.Report.Report("Report", "Report", "v1.0.0", backtest, live);
+            QuantConnect.Report.Report report = null;
 
-            Assert.DoesNotThrow(() => report.Compile(out _, out _));
+            Assert.DoesNotThrow(() => report = new QuantConnect.Report.Report("Report", "Report", "v1.0.0", backtest, (LiveResult)null));
+            string html = "";
+            Assert.DoesNotThrow(() => report.Compile(out html, out _));
+            Assert.IsNotEmpty(html);
         }
     }
 }

--- a/Tests/TestData/test_report_data.json
+++ b/Tests/TestData/test_report_data.json
@@ -103,113 +103,113 @@
                     "Color": "",
                     "ScatterMarkerSymbol": "none",
                     "Values": [
-                        { "x": 1609822800, "y": 0.0019 },
-                        { "x": 1609909200, "y": 0.0014 },
-                        { "x": 1609995600, "y": 0.0013 }
+                        { "x": 1609822800, "y": 0.019 },
+                        { "x": 1609909200, "y": 0.014 },
+                        { "x": 1609995600, "y": 0.013 }
                     ]
                 },
                 "Option": {
                     "Name": "Option",
                     "Unit": "",
-                    "Index": 0,
+                    "Index": 1,
                     "SeriesType": 0,
                     "Color": "",
                     "ScatterMarkerSymbol": "none",
                     "Values": [
-                        { "x": 1609822800, "y": 0.0020 },
-                        { "x": 1609909200, "y": 0.0004 },
-                        { "x": 1609995600, "y": 0.0011 }
+                        { "x": 1609822800, "y": 0.020 },
+                        { "x": 1609909200, "y": 0.004 },
+                        { "x": 1609995600, "y": 0.011 }
                     ]
                 },
                 "Commodity": {
                     "Name": "Commodity",
                     "Unit": "",
-                    "Index": 0,
+                    "Index": 2,
                     "SeriesType": 0,
                     "Color": "",
                     "ScatterMarkerSymbol": "none",
                     "Values": [
-                        { "x": 1609822800, "y": 0.0016 },
-                        { "x": 1609909200, "y": 0.0012 },
-                        { "x": 1609995600, "y": 0.0010 }
+                        { "x": 1609822800, "y": 0.016 },
+                        { "x": 1609909200, "y": 0.012 },
+                        { "x": 1609995600, "y": 0.010 }
                     ]
                 },
                 "Forex": {
                     "Name": "Forex",
                     "Unit": "",
-                    "Index": 0,
+                    "Index": 3,
                     "SeriesType": 0,
                     "Color": "",
                     "ScatterMarkerSymbol": "none",
                     "Values": [
-                        { "x": 1609822800, "y": 0.0012 },
-                        { "x": 1609909200, "y": 0.0019 },
-                        { "x": 1609995600, "y": 0.0020 }
+                        { "x": 1609822800, "y": 0.012 },
+                        { "x": 1609909200, "y": 0.019 },
+                        { "x": 1609995600, "y": 0.020 }
                     ]
                 },
                 "Future": {
                     "Name": "Future",
                     "Unit": "",
-                    "Index": 0,
+                    "Index": 4,
                     "SeriesType": 0,
                     "Color": "",
                     "ScatterMarkerSymbol": "none",
                     "Values": [
-                        { "x": 1609822800, "y": 0.0013 },
-                        { "x": 1609909200, "y": 0.0015 },
-                        { "x": 1609995600, "y": 0.0017 }
+                        { "x": 1609822800, "y": 0.013 },
+                        { "x": 1609909200, "y": 0.015 },
+                        { "x": 1609995600, "y": 0.017 }
                     ]
                 },
                 "Cfd": {
                     "Name": "Cfd",
                     "Unit": "",
-                    "Index": 0,
+                    "Index": 5,
                     "SeriesType": 0,
                     "Color": "",
                     "ScatterMarkerSymbol": "none",
                     "Values": [
-                        { "x": 1609822800, "y": 0.0014 },
-                        { "x": 1609909200, "y": 0.0015 },
-                        { "x": 1609995600, "y": 0.0014 }
+                        { "x": 1609822800, "y": 0.014 },
+                        { "x": 1609909200, "y": 0.015 },
+                        { "x": 1609995600, "y": 0.014 }
                     ]
                 },
                 "Crypto": {
                     "Name": "Crypto",
                     "Unit": "",
-                    "Index": 0,
+                    "Index": 6,
                     "SeriesType": 0,
                     "Color": "",
                     "ScatterMarkerSymbol": "none",
                     "Values": [
-                        { "x": 1609822800, "y": 0.0013 },
-                        { "x": 1609909200, "y": 0.0015 },
-                        { "x": 1609995600, "y": 0.0017 }
+                        { "x": 1609822800, "y": 0.013 },
+                        { "x": 1609909200, "y": 0.015 },
+                        { "x": 1609995600, "y": 0.017 }
                     ]
                 },
                 "FutureOption": {
                     "Name": "FutureOption",
                     "Unit": "",
-                    "Index": 0,
+                    "Index": 7,
                     "SeriesType": 0,
                     "Color": "",
                     "ScatterMarkerSymbol": "none",
                     "Values": [
-                        { "x": 1609822800, "y": 0.0022 },
-                        { "x": 1609909200, "y": 0.0014 },
-                        { "x": 1609995600, "y": 0.0020 }
+                        { "x": 1609822800, "y": 0.022 },
+                        { "x": 1609909200, "y": 0.014 },
+                        { "x": 1609995600, "y": 0.020 }
                     ]
                 },
                 "IndexOption": {
                     "Name": "IndexOption",
                     "Unit": "",
-                    "Index": 0,
+                    "Index": 8,
                     "SeriesType": 0,
                     "Color": "",
                     "ScatterMarkerSymbol": "none",
                     "Values": [
-                        { "x": 1609822800, "y": 0.0017 },
-                        { "x": 1609909200, "y": 0.0015 },
-                        { "x": 1609995600, "y": 0.0015 }
+                        { "x": 1609822800, "y": 0.017 },
+                        { "x": 1609909200, "y": 0.015 },
+                        { "x": 1609995600, "y": 0.015 }
                     ]
                 }
             }
@@ -252,32 +252,271 @@
             "Type": 0,
             "Id": 1,
             "ContingentId": 0,
-            "BrokerId": [ "1" ],
+            "BrokerId": [
+                "1"
+            ],
             "Symbol": {
-                "Value": "VIX   210120C00010000",
-                "ID": "VIX XLCXXK57591Q|VIX 31",
-                "Permtick": "VIX   210120C00010000",
-                "Underlying": {
-                    "Value": "VIX",
-                    "ID": "VIX 31",
-                    "Permtick": "VIX"
-                }
+                "Value": "BTCUSD",
+                "ID": "BTCUSD XJ",
+                "Permtick": "BTCUSD"
             },
-            "Price": 16.7,
+            "Price": 32843.35,
             "PriceCurrency": "USD",
-            "Time": "2021-01-04T21:00:00Z",
-            "CreatedTime": "2021-01-04T21:00:00Z",
-            "LastFillTime": "2021-01-04T21:00:00Z",
+            "Time": "2021-01-24T05:00:00Z",
+            "CreatedTime": "2021-01-24T05:00:00Z",
+            "LastFillTime": "2021-01-24T05:00:00Z",
+            "Quantity": 0.1,
+            "Status": 3,
+            "Properties": {
+                "TimeInForce": {}
+            },
+            "SecurityType": 7,
+            "Direction": 0,
+            "Value": 3284.335,
+            "OrderSubmissionData": {
+                "BidPrice": 32840.47,
+                "AskPrice": 32843.35,
+                "LastPrice": 32841.91
+            },
+            "IsMarketable": true
+        },
+        "2": {
+            "Type": 0,
+            "Id": 2,
+            "ContingentId": 0,
+            "BrokerId": [
+                "2"
+            ],
+            "Symbol": {
+                "Value": "EURUSD",
+                "ID": "EURUSD 8G",
+                "Permtick": "EURUSD"
+            },
+            "Price": 1.21761,
+            "PriceCurrency": "USD",
+            "Time": "2021-01-24T22:01:00Z",
+            "CreatedTime": "2021-01-24T22:01:00Z",
+            "LastFillTime": "2021-01-24T22:01:00Z",
+            "Quantity": 4097282612.0,
+            "Status": 3,
+            "Properties": {
+                "TimeInForce": {}
+            },
+            "SecurityType": 4,
+            "Direction": 0,
+            "Value": 4988892281.19732,
+            "OrderSubmissionData": {
+                "BidPrice": 1.21696,
+                "AskPrice": 1.21761,
+                "LastPrice": 1.217285
+            },
+            "IsMarketable": true
+        },
+        "3": {
+            "Type": 0,
+            "Id": 3,
+            "ContingentId": 0,
+            "BrokerId": [
+                "3"
+            ],
+            "Symbol": {
+                "Value": "ES19H21",
+                "ID": "ES XMXYBDF3IXHD",
+                "Permtick": "ES19H21"
+            },
+            "Price": 3838.75,
+            "PriceCurrency": "USD",
+            "Time": "2021-01-24T23:01:00Z",
+            "CreatedTime": "2021-01-24T23:01:00Z",
+            "LastFillTime": "2021-01-24T23:01:00Z",
             "Quantity": 1.0,
             "Status": 3,
-            "Properties": { "TimeInForce": {} },
+            "Properties": {
+                "TimeInForce": {}
+            },
+            "SecurityType": 5,
+            "Direction": 0,
+            "Value": 3838.75,
+            "OrderSubmissionData": {
+                "BidPrice": 3838.5,
+                "AskPrice": 3838.75,
+                "LastPrice": 3838.625
+            },
+            "IsMarketable": true
+        },
+        "4": {
+            "Type": 0,
+            "Id": 4,
+            "ContingentId": 0,
+            "BrokerId": [
+                "4"
+            ],
+            "Symbol": {
+                "Value": "DE30EUR",
+                "ID": "DE30EUR 8I",
+                "Permtick": "DE30EUR"
+            },
+            "Price": 13882.3,
+            "PriceCurrency": "EUR",
+            "Time": "2021-01-25T00:16:00Z",
+            "CreatedTime": "2021-01-25T00:16:00Z",
+            "LastFillTime": "2021-01-25T00:16:00Z",
+            "Quantity": 3.0,
+            "Status": 3,
+            "Tag": "Warning: fill at stale price (01/22/2021 22:00:00 Europe/Berlin)",
+            "Properties": {
+                "TimeInForce": {}
+            },
+            "SecurityType": 6,
+            "Direction": 0,
+            "Value": 41646.9,
+            "OrderSubmissionData": {
+                "BidPrice": 13878.8,
+                "AskPrice": 13882.3,
+                "LastPrice": 13880.55
+            },
+            "IsMarketable": true
+        },
+        "5": {
+            "Type": 4,
+            "Id": 5,
+            "ContingentId": 0,
+            "BrokerId": [
+                "5"
+            ],
+            "Symbol": {
+                "Value": "SPX   231215C03825000",
+                "ID": "SPX YEBOD23D7ZOU|SPX 31",
+                "Permtick": "SPX   231215C03825000",
+                "Underlying": {
+                    "Value": "SPX",
+                    "ID": "SPX 31",
+                    "Permtick": "SPX"
+                }
+            },
+            "Price": 515.3,
+            "PriceCurrency": "USD",
+            "Time": "2021-01-25T12:30:00Z",
+            "CreatedTime": "2021-01-25T12:30:00Z",
+            "LastFillTime": "2021-01-25T15:31:00Z",
+            "Quantity": 1.0,
+            "Status": 3,
+            "Properties": {
+                "TimeInForce": {}
+            },
             "SecurityType": 10,
             "Direction": 0,
-            "Value": 16.7,
+            "Value": 515.3,
             "OrderSubmissionData": {
-                "BidPrice": 16.5000,
-                "AskPrice": 16.7000,
-                "LastPrice": 16.6000
+                "BidPrice": 480.5000,
+                "AskPrice": 525.5000,
+                "LastPrice": 503.0000
+            },
+            "IsMarketable": false
+        },
+        "6": {
+            "Type": 0,
+            "Id": 6,
+            "ContingentId": 0,
+            "BrokerId": [
+                "6"
+            ],
+            "Symbol": {
+                "Value": "SPY",
+                "ID": "SPY R735QTJ8XC9X",
+                "Permtick": "SPY"
+            },
+            "Price": 384.02,
+            "PriceCurrency": "USD",
+            "Time": "2021-01-25T14:31:00Z",
+            "CreatedTime": "2021-01-25T14:31:00Z",
+            "LastFillTime": "2021-01-25T14:31:00Z",
+            "Quantity": 1.0,
+            "Status": 3,
+            "Properties": {
+                "TimeInForce": {}
+            },
+            "SecurityType": 1,
+            "Direction": 0,
+            "Value": 384.02,
+            "OrderSubmissionData": {
+                "BidPrice": 384.0000,
+                "AskPrice": 384.0200,
+                "LastPrice": 384.0300
+            },
+            "IsMarketable": true
+        },
+        "7": {
+            "Type": 0,
+            "Id": 7,
+            "ContingentId": 0,
+            "BrokerId": [
+                "7"
+            ],
+            "Symbol": {
+                "Value": "SPY   210716P00385000",
+                "ID": "SPY 31PB4NZP2BWX2|SPY R735QTJ8XC9X",
+                "Permtick": "SPY   210716P00385000",
+                "Underlying": {
+                    "Value": "SPY",
+                    "ID": "SPY R735QTJ8XC9X",
+                    "Permtick": "SPY"
+                }
+            },
+            "Price": 23.42,
+            "PriceCurrency": "USD",
+            "Time": "2021-01-25T14:31:00Z",
+            "CreatedTime": "2021-01-25T14:31:00Z",
+            "LastFillTime": "2021-01-25T14:31:00Z",
+            "Quantity": 2.0,
+            "Status": 3,
+            "Properties": {
+                "TimeInForce": {}
+            },
+            "SecurityType": 2,
+            "Direction": 0,
+            "Value": 46.84,
+            "OrderSubmissionData": {
+                "BidPrice": 23.1300,
+                "AskPrice": 23.4200,
+                "LastPrice": 23.2750
+            },
+            "IsMarketable": true
+        },
+        "8": {
+            "Type": 0,
+            "Id": 8,
+            "ContingentId": 0,
+            "BrokerId": [
+                "8"
+            ],
+            "Symbol": {
+                "Value": "OG    220328C01835000",
+                "ID": "OG XX67IKNPHUOW|GC XXZQX57AFQ8T",
+                "Permtick": "OG    220328C01835000",
+                "Underlying": {
+                    "Value": "GC27J22",
+                    "ID": "GC XXZQX57AFQ8T",
+                    "Permtick": "GC27J22"
+                }
+            },
+            "Price": 49.0,
+            "PriceCurrency": "USD",
+            "Time": "2022-01-02T23:01:00Z",
+            "CreatedTime": "2022-01-02T23:01:00Z",
+            "LastFillTime": "2022-01-02T23:01:00Z",
+            "Quantity": 1.0,
+            "Status": 3,
+            "Properties": {
+                "TimeInForce": {}
+            },
+            "SecurityType": 8,
+            "Direction": 0,
+            "Value": 49.0,
+            "OrderSubmissionData": {
+                "BidPrice": 48.2,
+                "AskPrice": 49.0,
+                "LastPrice": 48.6
             },
             "IsMarketable": true
         }

--- a/Tests/TestData/test_report_data.json
+++ b/Tests/TestData/test_report_data.json
@@ -1,0 +1,184 @@
+{
+    "RollingWindow": {},
+    "AlphaRuntimeStatistics": {},
+    "Charts": {
+        "Benchmark": {
+            "Name": "Benchmark",
+            "ChartType": 0,
+            "Series": {
+                "Benchmark": {
+                    "Name": "Benchmark",
+                    "Unit": "$",
+                    "Index": 0,
+                    "Values": [
+                        { "x": 1609736400, "y": 366.2371 },
+                        { "x": 1609822800, "y": 361.2511 },
+                        { "x": 1609909200, "y": 363.7392 }
+                    ],
+                    "SeriesType": 0,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none"
+                }
+            }
+        },
+        "Drawdown": {
+            "Name": "Drawdown",
+            "ChartType": 0,
+            "Series": {
+                "Equity Drawdown": {
+                    "Name": "Equity Drawdown",
+                    "Unit": "%",
+                    "Index": 0,
+                    "Values": [
+                        { "x": 1609736400, "y": 0.0 },
+                        { "x": 1609822800, "y": 0.0 },
+                        { "x": 1609909200, "y": -0.01 }
+                    ],
+                    "SeriesType": 0,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none"
+                }
+            }
+        },
+        "Capacity": {
+            "Name": "Capacity",
+            "ChartType": 0,
+            "Series": {
+                "Strategy Capacity": {
+                    "Name": "Strategy Capacity",
+                    "Unit": "$",
+                    "Index": 0,
+                    "Values": [
+                        { "x": 1609736400, "y": 0.0 },
+                        { "x": 1609822800, "y": 0.0 },
+                        { "x": 1609909200, "y": 0.0 }
+                    ],
+                    "SeriesType": 0,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none"
+                }
+            }
+        },
+        "Strategy Equity": {
+            "Name": "Strategy Equity",
+            "ChartType": 0,
+            "Series": {
+                "Equity": {
+                    "Name": "Equity",
+                    "Unit": "$",
+                    "Index": 0,
+                    "Values": [
+                        { "x": 1609736400, "y": 1000000.0 },
+                        { "x": 1609748160, "y": 1000000.0 },
+                        { "x": 1609748820, "y": 1000000.0 }
+                    ],
+                    "SeriesType": 2,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none"
+                },
+                "Daily Performance": {
+                    "Name": "Daily Performance",
+                    "Unit": "%",
+                    "Index": 1,
+                    "Values": [
+                        { "x": 1609736400, "y": 0.0 },
+                        { "x": 1609822800, "y": 0.0 },
+                        { "x": 1609909200, "y": -0.013 }
+                    ],
+                    "SeriesType": 3,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none"
+                }
+            }
+        },
+        "Exposure": {
+            "Name": "Exposure",
+            "ChartType": 0,
+            "Series": {
+                "IndexOption - Long Ratio": {
+                    "Name": "IndexOption - Long Ratio",
+                    "Unit": "",
+                    "Index": 0,
+                    "SeriesType": 0,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none",
+                    "Values": [
+                        { "x": 1609822800, "y": 0.0017 },
+                        { "x": 1609909200, "y": 0.0015 },
+                        { "x": 1609995600, "y": 0.0015 }
+                    ]
+                }
+            }
+        },
+        "Assets Sales Volume": {
+            "Name": "Assets Sales Volume",
+            "ChartType": 0,
+            "Series": {
+                "VIX   210120C00010000": {
+                    "Name": "VIX   210120C00010000",
+                    "Unit": "$",
+                    "Index": 0,
+                    "Values": [
+                        { "x": 1609822800, "y": 1670.0 },
+                        { "x": 1609909200, "y": 1670.0 },
+                        { "x": 1609995600, "y": 1670.0 }
+                    ],
+                    "SeriesType": 7,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none"
+                },
+                "VIX   210217C00010000": {
+                    "Name": "VIX   210217C00010000",
+                    "Unit": "$",
+                    "Index": 0,
+                    "Values": [
+                        { "x": 1611291600, "y": 1490.0 },
+                        { "x": 1611378000, "y": 1490.0 },
+                        { "x": 1611464400, "y": 1490.0 }
+                    ],
+                    "SeriesType": 7,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none"
+                }
+            }
+        }
+    },
+    "Orders": {
+        "1": {
+            "Type": 0,
+            "Id": 1,
+            "ContingentId": 0,
+            "BrokerId": [ "1" ],
+            "Symbol": {
+                "Value": "VIX   210120C00010000",
+                "ID": "VIX XLCXXK57591Q|VIX 31",
+                "Permtick": "VIX   210120C00010000",
+                "Underlying": {
+                    "Value": "VIX",
+                    "ID": "VIX 31",
+                    "Permtick": "VIX"
+                }
+            },
+            "Price": 16.7,
+            "PriceCurrency": "USD",
+            "Time": "2021-01-04T21:00:00Z",
+            "CreatedTime": "2021-01-04T21:00:00Z",
+            "LastFillTime": "2021-01-04T21:00:00Z",
+            "Quantity": 1.0,
+            "Status": 3,
+            "Properties": { "TimeInForce": {} },
+            "SecurityType": 10,
+            "Direction": 0,
+            "Value": 16.7,
+            "OrderSubmissionData": {
+                "BidPrice": 16.5000,
+                "AskPrice": 16.7000,
+                "LastPrice": 16.6000
+            },
+            "IsMarketable": true
+        }
+    },
+    "ProfitLoss": {},
+    "Statistics": {},
+    "RuntimeStatistics": {}
+}

--- a/Tests/TestData/test_report_data.json
+++ b/Tests/TestData/test_report_data.json
@@ -95,8 +95,112 @@
             "Name": "Exposure",
             "ChartType": 0,
             "Series": {
-                "IndexOption - Long Ratio": {
-                    "Name": "IndexOption - Long Ratio",
+                "Equity": {
+                    "Name": "Equity",
+                    "Unit": "",
+                    "Index": 0,
+                    "SeriesType": 0,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none",
+                    "Values": [
+                        { "x": 1609822800, "y": 0.0019 },
+                        { "x": 1609909200, "y": 0.0014 },
+                        { "x": 1609995600, "y": 0.0013 }
+                    ]
+                },
+                "Option": {
+                    "Name": "Option",
+                    "Unit": "",
+                    "Index": 0,
+                    "SeriesType": 0,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none",
+                    "Values": [
+                        { "x": 1609822800, "y": 0.0020 },
+                        { "x": 1609909200, "y": 0.0004 },
+                        { "x": 1609995600, "y": 0.0011 }
+                    ]
+                },
+                "Commodity": {
+                    "Name": "Commodity",
+                    "Unit": "",
+                    "Index": 0,
+                    "SeriesType": 0,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none",
+                    "Values": [
+                        { "x": 1609822800, "y": 0.0016 },
+                        { "x": 1609909200, "y": 0.0012 },
+                        { "x": 1609995600, "y": 0.0010 }
+                    ]
+                },
+                "Forex": {
+                    "Name": "Forex",
+                    "Unit": "",
+                    "Index": 0,
+                    "SeriesType": 0,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none",
+                    "Values": [
+                        { "x": 1609822800, "y": 0.0012 },
+                        { "x": 1609909200, "y": 0.0019 },
+                        { "x": 1609995600, "y": 0.0020 }
+                    ]
+                },
+                "Future": {
+                    "Name": "Future",
+                    "Unit": "",
+                    "Index": 0,
+                    "SeriesType": 0,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none",
+                    "Values": [
+                        { "x": 1609822800, "y": 0.0013 },
+                        { "x": 1609909200, "y": 0.0015 },
+                        { "x": 1609995600, "y": 0.0017 }
+                    ]
+                },
+                "Cfd": {
+                    "Name": "Cfd",
+                    "Unit": "",
+                    "Index": 0,
+                    "SeriesType": 0,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none",
+                    "Values": [
+                        { "x": 1609822800, "y": 0.0014 },
+                        { "x": 1609909200, "y": 0.0015 },
+                        { "x": 1609995600, "y": 0.0014 }
+                    ]
+                },
+                "Crypto": {
+                    "Name": "Crypto",
+                    "Unit": "",
+                    "Index": 0,
+                    "SeriesType": 0,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none",
+                    "Values": [
+                        { "x": 1609822800, "y": 0.0013 },
+                        { "x": 1609909200, "y": 0.0015 },
+                        { "x": 1609995600, "y": 0.0017 }
+                    ]
+                },
+                "FutureOption": {
+                    "Name": "FutureOption",
+                    "Unit": "",
+                    "Index": 0,
+                    "SeriesType": 0,
+                    "Color": "",
+                    "ScatterMarkerSymbol": "none",
+                    "Values": [
+                        { "x": 1609822800, "y": 0.0022 },
+                        { "x": 1609909200, "y": 0.0014 },
+                        { "x": 1609995600, "y": 0.0020 }
+                    ]
+                },
+                "IndexOption": {
+                    "Name": "IndexOption",
                     "Unit": "",
                     "Index": 0,
                     "SeriesType": 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Index option and future option colors where missing in report generator's exposure charts generation method, which was causing the KeyError. The colors where added and now a single color maps is used for both backtesting and live.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6532 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
