### PR TITLE
Fix FormatException on estimated capacity rendering during report generation

### DIFF
--- a/Common/Api/OptimizationBacktestJsonConverter.cs
+++ b/Common/Api/OptimizationBacktestJsonConverter.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -80,17 +80,7 @@ namespace QuantConnect.Api
                 foreach (var keyValuePair in optimizationBacktest.Statistics.OrderBy(pair => pair.Key))
                 {
                     var statistic = keyValuePair.Value.Replace("%", string.Empty);
-                    foreach (var currencySymbol in Currencies.CurrencySymbols.Values)
-                    {
-                        statistic = statistic.Replace(currencySymbol, string.Empty);
-                    }
-
-                    if (string.IsNullOrEmpty(statistic))
-                    {
-                        continue;
-                    }
-
-                    if (decimal.TryParse(statistic, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
+                    if (Currencies.TryParse(statistic, out var result))
                     {
                         writer.WriteValue(result);
                     }

--- a/Common/Currencies.cs
+++ b/Common/Currencies.cs
@@ -14,6 +14,8 @@
 */
 
 using System.Collections.Generic;
+using System.Linq;
+using System.Globalization;
 
 namespace QuantConnect
 {
@@ -243,6 +245,38 @@ namespace QuantConnect
         {
             string currencySymbol;
             return CurrencySymbols.TryGetValue(currency, out currencySymbol) ? currencySymbol : currency;
+        }
+
+        /// <summary>
+        /// Converts the string representation of number with currency in the format {currency}{value} to its decimal equivalent.
+        /// It throws if the value cannot be converted to a decimal number.
+        /// </summary>
+        /// <param name="value">The value with currency</param>
+        /// <returns>The decimal equivalent to the value</returns>
+        public static decimal Parse(string value)
+        {
+            foreach (var currencySymbol in Currencies.CurrencySymbols.Values.OrderByDescending(x => x.Length))
+            {
+                value = value.Replace(currencySymbol, string.Empty);
+            }
+
+            return decimal.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Converts the string representation of number with currency in the format {currency}{value} to its decimal equivalent.
+        /// </summary>
+        /// <param name="value">The value with currency</param>
+        /// <param name="parsedValue">The decimal equivalent to the string value after conversion</param>
+        /// <returns>True if the value was succesfuly converted</returns>
+        public static bool TryParse(string value, out decimal parsedValue)
+        {
+            foreach (var currencySymbol in Currencies.CurrencySymbols.Values.OrderByDescending(x => x.Length))
+            {
+                value = value.Replace(currencySymbol, string.Empty);
+            }
+
+            return decimal.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out parsedValue);
         }
     }
 }

--- a/Report/ReportElements/EstimatedCapacityReportElement.cs
+++ b/Report/ReportElements/EstimatedCapacityReportElement.cs
@@ -54,9 +54,7 @@ namespace QuantConnect.Report.ReportElements
                 return "-";
             }
 
-            var currency = Currencies.CurrencySymbols.Aggregate("", (longest, current) =>
-                capacityWithCurrency.StartsWith(current.Value) && current.Value.Length > longest.Length ? current.Value : longest);
-            var capacity = decimal.Parse(capacityWithCurrency.Replace(currency, ""), NumberStyles.Any, CultureInfo.InvariantCulture).RoundToSignificantDigits(2);
+            var capacity = Currencies.Parse(capacityWithCurrency).RoundToSignificantDigits(2);
 
             Result = capacity;
 

--- a/Report/ReportElements/EstimatedCapacityReportElement.cs
+++ b/Report/ReportElements/EstimatedCapacityReportElement.cs
@@ -14,6 +14,7 @@
 */
 
 using System.Globalization;
+using System.Linq;
 using QuantConnect.Packets;
 
 namespace QuantConnect.Report.ReportElements
@@ -47,14 +48,15 @@ namespace QuantConnect.Report.ReportElements
         public override string Render()
         {
             var statistics = _backtest?.Statistics;
-            string capacityUsd;
-            if (statistics == null || !statistics.TryGetValue("Estimated Strategy Capacity", out capacityUsd))
+            string capacityWithCurrency;
+            if (statistics == null || !statistics.TryGetValue("Estimated Strategy Capacity", out capacityWithCurrency))
             {
                 return "-";
             }
 
-            var capacity = decimal.Parse(capacityUsd.Replace("$", ""), NumberStyles.Any, CultureInfo.InvariantCulture)
-                .RoundToSignificantDigits(2);
+            var currency = Currencies.CurrencySymbols.Aggregate("", (longest, current) =>
+                capacityWithCurrency.StartsWith(current.Value) && current.Value.Length > longest.Length ? current.Value : longest);
+            var capacity = decimal.Parse(capacityWithCurrency.Replace(currency, ""), NumberStyles.Any, CultureInfo.InvariantCulture).RoundToSignificantDigits(2);
 
             Result = capacity;
 

--- a/Tests/Api/OptimizationBacktestJsonConverterTests.cs
+++ b/Tests/Api/OptimizationBacktestJsonConverterTests.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Tests.API
                 { "Tracking Error", "0.233" },
                 { "Treynor Ratio", "-0.558" },
                 { "Total Fees", "$1390.49" },
-                { "Estimated Strategy Capacity", "₿6300000.00" },
+                { "Estimated Strategy Capacity", "ZRX6300000.00" },
             };
 
             optimizationBacktest.Equity = new Series

--- a/Tests/Common/CurrenciesTests.cs
+++ b/Tests/Common/CurrenciesTests.cs
@@ -103,7 +103,7 @@ namespace QuantConnect.Tests.Common
             [Values("10.000.1", "10.000,1", "1.00001A4", "")] string value)
         {
             string valueWithCurrency = currencySymbol + value;
-            Assert.Throws<FormatException>(() => Currencies.Parse(valueWithCurrency));
+            Assert.Throws<ArgumentException>(() => Currencies.Parse(valueWithCurrency));
             Assert.IsFalse(Currencies.TryParse(valueWithCurrency, out _));
         }
 

--- a/Tests/Common/CurrenciesTests.cs
+++ b/Tests/Common/CurrenciesTests.cs
@@ -13,7 +13,9 @@
  * limitations under the License.
 */
 
+using System;
 using System.Linq;
+using System.Collections.Generic;
 using NUnit.Framework;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Crypto;
@@ -80,5 +82,31 @@ namespace QuantConnect.Tests.Common
         {
             Assert.AreEqual(currency, Currencies.GetCurrencySymbol(currency));
         }
+
+        [Test]
+        public void ParsesValuesWithCurrency(
+            [ValueSource(nameof(CurrencySymbols))] string currencySymbol,
+            [Values("10,000.1", "10000.1", "1.00001e4")] string value)
+        {
+            decimal result = 0;
+            decimal result2;
+            string valueWithCurrency = currencySymbol + value;
+            Assert.DoesNotThrow(() => result = Currencies.Parse(valueWithCurrency));
+            Assert.IsTrue(Currencies.TryParse(valueWithCurrency, out result2));
+            Assert.AreEqual(10000.1m, result);
+            Assert.AreEqual(result, result2);
+        }
+
+        [Test]
+        public void CannotParseInvalidValuesWithCurrency(
+            [ValueSource(nameof(CurrencySymbols))] string currencySymbol,
+            [Values("10.000.1", "10.000,1", "1.00001A4", "")] string value)
+        {
+            string valueWithCurrency = currencySymbol + value;
+            Assert.Throws<FormatException>(() => Currencies.Parse(valueWithCurrency));
+            Assert.IsFalse(Currencies.TryParse(valueWithCurrency, out _));
+        }
+
+        static IEnumerable<string> CurrencySymbols => Currencies.CurrencySymbols.Values.Distinct();
     }
 }

--- a/Tests/TestData/test_report_data.json
+++ b/Tests/TestData/test_report_data.json
@@ -522,6 +522,29 @@
         }
     },
     "ProfitLoss": {},
-    "Statistics": {},
+    "Statistics": {
+        "Total Trades": "7",
+        "Average Win": "11.29%",
+        "Average Loss": "-1.24%",
+        "Compounding Annual Return": "114.572%",
+        "Drawdown": "31.300%",
+        "Expectancy": "1.491",
+        "Net Profit": "361.374%",
+        "Sharpe Ratio": "2.034",
+        "Probabilistic Sharpe Ratio": "80.811%",
+        "Loss Rate": "75%",
+        "Win Rate": "25%",
+        "Profit-Loss Ratio": "9.12",
+        "Alpha": "0",
+        "Beta": "0",
+        "Annual Standard Deviation": "0.396",
+        "Annual Variance": "0.157",
+        "Information Ratio": "2.034",
+        "Tracking Error": "0.396",
+        "Treynor Ratio": "0",
+        "Total Fees": "$0.65",
+        "Estimated Strategy Capacity": "$0",
+        "Lowest Capacity Asset": "ETHBTC 2MN"
+    },
     "RuntimeStatistics": {}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Fix `FormatException` when rendering estimated capacity in report generation when the currency is different than USD ($). Now the `EstimatedCapacityElement` can handle eny currency that Lean can handle.

Additionally, applied the same mechanism to remove the currency from the number to `OptimizationBacktestJsonConverter.WriteJson()`. Without sorting currencies by length, currencies with less characters included in the actual currency characters might remove those characters and leave remaining characters that could not be replaced afterwards (ZRX and R currencies, for example, would leave ZX after replacing R with an empty string).

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6531

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
