### PR TITLE
docs: `portfolio` readability fixes

### DIFF
--- a/Algorithm.CSharp/CryptoBaseCurrencyFeeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CryptoBaseCurrencyFeeRegressionAlgorithm.cs
@@ -73,12 +73,12 @@ namespace QuantConnect.Algorithm.CSharp
                     || filledEvent.FillQuantity != ticket.QuantityFilled
                     || (0.1m - filledEvent.OrderFee.Value.Amount) != ticket.QuantityFilled)
                 {
-                    throw new Exception($"Unexpected BaseCurrency porfoltio status. Event {filledEvent}. CashBook: {Portfolio.CashBook}. ");
+                    throw new Exception($"Unexpected BaseCurrency portfolio status. Event {filledEvent}. CashBook: {Portfolio.CashBook}. ");
                 }
 
                 if (Portfolio.CashBook[quoteCurrency].Amount != (initialQuoteCurrency - 0.1m * filledEvent.FillPrice))
                 {
-                    throw new Exception($"Unexpected QuoteCurrency porfoltio status. Event {filledEvent}. CashBook: {Portfolio.CashBook}. ");
+                    throw new Exception($"Unexpected QuoteCurrency portfolio status. Event {filledEvent}. CashBook: {Portfolio.CashBook}. ");
                 }
 
                 if (Securities[_symbol].Holdings.Quantity != (0.1m - filledEvent.OrderFee.Value.Amount))

--- a/Algorithm.Framework/Execution/SpreadExecutionModel.cs
+++ b/Algorithm.Framework/Execution/SpreadExecutionModel.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Algorithm.Framework.Execution
         }
 
         /// <summary>
-        /// Submit orders for the specified portolio targets if the spread is tighter/equal to preset level
+        /// Submit orders for the specified portfolio targets if the spread is tighter/equal to preset level
         /// </summary>
         /// <param name="algorithm">The algorithm instance</param>
         /// <param name="targets">The portfolio targets to be ordered</param>

--- a/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.cs
+++ b/Algorithm.Framework/Execution/VolumeWeightedAveragePriceExecutionModel.cs
@@ -42,7 +42,7 @@ namespace QuantConnect.Algorithm.Framework.Execution
         public decimal MaximumOrderQuantityPercentVolume { get; set; } = 0.01m;
 
         /// <summary>
-        /// Submit orders for the specified portolio targets.
+        /// Submit orders for the specified portfolio targets.
         /// This model is free to delay or spread out these orders as it sees fit
         /// </summary>
         /// <param name="algorithm">The algorithm instance</param>

--- a/Algorithm/Execution/ExecutionModel.cs
+++ b/Algorithm/Execution/ExecutionModel.cs
@@ -24,7 +24,7 @@ namespace QuantConnect.Algorithm.Framework.Execution
     public class ExecutionModel : IExecutionModel
     {
         /// <summary>
-        /// Submit orders for the specified portolio targets.
+        /// Submit orders for the specified portfolio targets.
         /// This model is free to delay or spread out these orders as it sees fit
         /// </summary>
         /// <param name="algorithm">The algorithm instance</param>

--- a/Algorithm/Execution/ExecutionModelPythonWrapper.cs
+++ b/Algorithm/Execution/ExecutionModelPythonWrapper.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.Algorithm.Framework.Execution
         }
 
         /// <summary>
-        /// Submit orders for the specified portolio targets.
+        /// Submit orders for the specified portfolio targets.
         /// This model is free to delay or spread out these orders as it sees fit
         /// </summary>
         /// <param name="algorithm">The algorithm instance</param>

--- a/Common/Algorithm/Framework/Portfolio/PortfolioTargetCollection.cs
+++ b/Common/Algorithm/Framework/Portfolio/PortfolioTargetCollection.cs
@@ -260,7 +260,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// Gets or sets the portfolio target for the specified symbol
         /// </summary>
         /// <param name="symbol">The symbol</param>
-        /// <returns>The symbol's portolio target if it exists in this collection, if not a <see cref="KeyNotFoundException"/> will be thrown.</returns>
+        /// <returns>The symbol's portfolio target if it exists in this collection, if not a <see cref="KeyNotFoundException"/> will be thrown.</returns>
         public IPortfolioTarget this[Symbol symbol]
         {
             get { return _targets[symbol]; }


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>


Global replace `portolio` -> `portfolio`

#### Description
`portolio` -> `portfolio`

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

