### PR TITLE
chore(.NET 6): Update references from `dotnet 5` to `dotnet 6` #6560

### DIFF
--- a/.vs/readme.md
+++ b/.vs/readme.md
@@ -18,7 +18,7 @@ To use Lean CLI follow the instructions for installation and tutorial for usage 
 
 <h2>Option 2: Install Locally</h2>
 
-1. Install [.Net 5](https://dotnet.microsoft.com/download) for the project
+1. Install [.Net 6](https://dotnet.microsoft.com/download) for the project
 
 2. (Optional) Get [Python 3.6.8](https://www.python.org/downloads/release/python-368/) for running Python algorithms
     - Follow Python instructions [here](https://github.com/QuantConnect/Lean/tree/master/Algorithm.Python#installing-python-36) for your platform

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,8 +3,8 @@
         VS Code Launch configurations for the LEAN engine
 
         Launch:
-        Builds the project with dotnet 5 and then launches the program using coreclr; supports debugging.
-        In order to use this you need dotnet 5 on your system path, As well as the C# extension from the 
+        Builds the project with dotnet 6 and then launches the program using coreclr; supports debugging.
+        In order to use this you need dotnet 6 on your system path, As well as the C# extension from the 
         marketplace.
 
         Attach to Python:

--- a/.vscode/readme.md
+++ b/.vscode/readme.md
@@ -18,7 +18,7 @@ To use Lean CLI follow the instructions for installation and tutorial for usage 
 
 <h2>Option 2: Install Dependencies Locally</h2>
 
-1. Install [.Net 5](https://dotnet.microsoft.com/download) for the project
+1. Install [.Net 6](https://dotnet.microsoft.com/download) for the project
 
 2. (Optional) Get [Python 3.6.8](https://www.python.org/downloads/release/python-368/) for running Python algorithms
     - Follow Python instructions [here](https://github.com/QuantConnect/Lean/tree/master/Algorithm.Python#installing-python-36) for your platform

--- a/DockerfileLeanFoundationARM
+++ b/DockerfileLeanFoundationARM
@@ -36,7 +36,7 @@ RUN mkdir -p /root/ibgateway && \
     sed -i "s/-lt \"152\"/-lt \"$java_patch_version\"/" /root/ibgateway/ibgateway && \
     sed -i "s/-gt \"152\"/-gt \"$java_patch_version\"/" /root/ibgateway/ibgateway
 
-# Install dotnet 5 sdk & runtime
+# Install dotnet 6 sdk & runtime
 # The .deb packages don't support ARM, the install script does
 ENV PATH="/root/.dotnet:${PATH}"
 RUN wget https://dot.net/v1/dotnet-install.sh && \

--- a/Tests/Python/PandasTests/PandasMapperTests.py
+++ b/Tests/Python/PandasTests/PandasMapperTests.py
@@ -34,7 +34,7 @@ dlldir = os.path.join(fileDirectory, dlldir)
 os.chdir(dlldir)
 sys.path.append(dlldir)
 
-# Tell PythonNet to use .dotnet 5
+# Tell PythonNet to use .dotnet 6
 from pythonnet import set_runtime
 import clr_loader
 set_runtime(clr_loader.get_coreclr(os.path.join(dlldir, "QuantConnect.Lean.Launcher.runtimeconfig.json")))

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ dotnet QuantConnect.Lean.Launcher.dll
 
 ### Linux (Debian, Ubuntu)
 
-- Install [dotnet 5](https://docs.microsoft.com/en-us/dotnet/core/install/linux):
+- Install [dotnet 6](https://docs.microsoft.com/en-us/dotnet/core/install/linux):
 - Compile Lean Solution:
 ```
 dotnet build QuantConnect.Lean.sln


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Update references from `dotnet 5` to `dotnet 6`

#### Related Issue
#6560 6560

#### Motivation and Context
Clarify install dependency requirements and steps for new open source users.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

#### Not Implemented
There are lots of `lib/net5.0` references in various `assets.json` files.

I am requesting help from someone with more experience with the library to update these and ensure they are correct.

Alternatively, we can just merge in the `docs` updates in this PR and deal with the `*.assets.json` updates in a separate Issue.
```bash
Lean$ grep -r 'net5.0' | wc -l
131
```
