### PR TITLE
Fix report's exposure plot colors and other bugs

### DIFF
--- a/Report/ReportChartTests.py
+++ b/Report/ReportChartTests.py
@@ -128,18 +128,20 @@ live = [time, six, time, twelve]
 result = charts.GetRollingBeta(live)
 
 ## Test GetRollingSharpeRatioPlot
-data = list(np.random.uniform(1, 3, 365 * 2))
+six = list(np.random.uniform(1, 3, 365 * 2))
+twelve = [np.nan for x in range(365)] + list(np.random.uniform(1, 3, 365))
 time = [pd.Timestamp(x).to_pydatetime() for x in pd.date_range('2012-10-01 00:00:00', periods=365 * 2)]
-backtest = [time, data]
+six_live = list(np.random.uniform(1, 3, 365 + 180))
+twelve_live = [np.nan for x in range(180)] + list(np.random.uniform(1, 3, 365))
+time_live = [pd.Timestamp(x).to_pydatetime() for x in pd.date_range('2014-10-01 00:00:00', periods=365 + 180)]
 
-data = list(np.random.uniform(1, 3, 365))
-time = [pd.Timestamp(x).to_pydatetime() for x in pd.date_range('2014-10-01 00:00:00', periods=365)]
-live = [time, data]
-
-empty = [[], []]
-result = charts.GetRollingSharpeRatio(empty, empty)
-result = charts.GetRollingSharpeRatio(backtest, empty)
-result = charts.GetRollingSharpeRatio(backtest, live)
+empty = [[], [], [], []]
+result = charts.GetRollingSharpeRatio([time, six, time, twelve], empty)
+result = charts.GetRollingSharpeRatio([time, six, [], []], empty)
+result = charts.GetRollingSharpeRatio([time, six, time, twelve], [time_live, six_live, time_live, twelve_live])
+result = charts.GetRollingSharpeRatio([time, six, [], []], [time_live, six_live, time_live, twelve_live])
+result = charts.GetRollingSharpeRatio([time, six, time, twelve], [time_live, six_live, [], []])
+result = charts.GetRollingSharpeRatio([time, six, [], []], [time_live, six_live, [], []])
 
 ## Test GetAssetAllocationPlot
 backtest = [['SPY', 'IBM', 'NFLX', 'AAPL'], [0.50, 0.25, 0.125, 0.125]]

--- a/Report/ReportCharts.py
+++ b/Report/ReportCharts.py
@@ -642,7 +642,8 @@ class ReportCharts:
         return base64
 
     def GetRollingBeta(self, data = [[],[],[],[]], live_data = [[],[],[],[]], name = "rolling-portfolio-beta-to-equity.png",
-                           width = 11.5, height = 2.5):
+                        width = 11.5, height = 2.5, live_six_months_color = "#ff9914", live_twelve_months_color = "#ffd700",
+                        backtest_six_months_color = "#71c3fc", backtest_twelve_months_color = "#1d7dc1"):
 
         if len(data[0]) == 0 and len(live_data[0]) == 0:
             fig = plt.figure()
@@ -683,26 +684,34 @@ class ReportCharts:
         rectangles = []
 
         if len(backtest_six_month_beta) > 0:
-            labels += ['6 mo.', '12 mo.']
-            rectangles += [plt.Rectangle((0, 0), 1, 1, fc="#71c3fc"), plt.Rectangle((0, 0), 1, 1, fc="#1d7dc1")]
+            labels += ['6 mo.']
+            rectangles += [plt.Rectangle((0, 0), 1, 1, fc=backtest_six_months_color)]
+        if len(backtest_twelve_month_beta) > 0:
+            labels += ['12 mo.']
+            rectangles += [plt.Rectangle((0, 0), 1, 1, fc=backtest_twelve_months_color)]
         if len(live_six_month_beta) > 0:
-            labels += ['Live 6 mo.', 'Live 12 mo.']
-            rectangles += [plt.Rectangle((0, 0), 1, 1, fc="#ff9914"), plt.Rectangle((0, 0), 1, 1, fc="#ffd700")]
+            labels += ['Live 6 mo.']
+            rectangles += [plt.Rectangle((0, 0), 1, 1, fc=live_six_months_color)]
+        if len(live_twelve_month_beta) > 0:
+            labels += ['Live 12 mo.']
+            rectangles += [plt.Rectangle((0, 0), 1, 1, fc=live_twelve_months_color)]
 
         plt.figure()
         ax = plt.gca()
         fig = ax.get_figure()
         ax.xaxis.set_major_formatter(DateFormatter("%b %Y"))
 
-        if len(backtest_six_month_beta_dates) > 0:
-            # Backtest
-            ax.plot(backtest_six_month_beta_dates, backtest_six_month_beta, linewidth = 0.5, color = "#71c3fc")
-            ax.plot(backtest_twelve_month_beta_dates, backtest_twelve_month_beta, linewidth=0.5, color="#1d7dc1")
+        # Backtest
+        if len(backtest_six_month_beta) > 0:
+            ax.plot(backtest_six_month_beta_dates, backtest_six_month_beta, linewidth=0.5, color=backtest_six_months_color)
+        if len(backtest_twelve_month_beta) > 0:
+            ax.plot(backtest_twelve_month_beta_dates, backtest_twelve_month_beta, linewidth=0.5, color=backtest_twelve_months_color)
 
         # Live
         if len(live_six_month_beta) > 0:
-            ax.plot(live_six_month_beta_dates, live_six_month_beta, linewidth=0.5, color="#ff9914")
-            ax.plot(live_twelve_month_beta_dates, live_twelve_month_beta, linewidth=0.5, color="#ffd700")
+            ax.plot(live_six_month_beta_dates, live_six_month_beta, linewidth=0.5, color=live_six_months_color)
+        if len(live_twelve_month_beta) > 0:
+            ax.plot(live_twelve_month_beta_dates, live_twelve_month_beta, linewidth=0.5, color=live_twelve_months_color)
 
         leg = ax.legend(rectangles, labels, handlelength=0.8, handleheight=0.8,
                         frameon=False, fontsize=8, ncol=2)
@@ -754,9 +763,6 @@ class ReportCharts:
             plt.close('all')
             return base64
 
-        labels = []
-        rectangles = []
-
         plt.figure()
         ax = plt.gca()
         ax.xaxis.set_major_formatter(DateFormatter("%b %Y"))
@@ -768,21 +774,32 @@ class ReportCharts:
         live_six_month_rolling_sharpe_dates, live_six_month_rolling_sharpe = (live_data[0], live_data[1])
         live_twelve_month_rolling_sharpe_dates, live_twelve_month_rolling_sharpe = (live_data[2], live_data[3])
 
+        labels = []
+        rectangles = []
+
         if len(backtest_six_month_rolling_sharpe) > 0:
-            labels += ['6 mo.', '12 mo.']
-            rectangles += [plt.Rectangle((0, 0), 1, 1, fc=backtest_six_months_color), plt.Rectangle((0, 0), 1, 1, fc=backtest_twelve_months_color)]
+            labels += ['6 mo.']
+            rectangles += [plt.Rectangle((0, 0), 1, 1, fc=backtest_six_months_color)]
+        if len(backtest_twelve_month_rolling_sharpe) > 0:
+            labels += ['12 mo.']
+            rectangles += [plt.Rectangle((0, 0), 1, 1, fc=backtest_twelve_months_color)]
         if len(live_six_month_rolling_sharpe) > 0:
-            labels += ['Live 6 mo.', 'Live 12 mo.']
-            rectangles += [plt.Rectangle((0, 0), 1, 1, fc=live_six_months_color), plt.Rectangle((0, 0), 1, 1, fc=live_twelve_months_color)]
+            labels += ['Live 6 mo.']
+            rectangles += [plt.Rectangle((0, 0), 1, 1, fc=live_six_months_color)]
+        if len(live_twelve_month_rolling_sharpe) > 0:
+            labels += ['Live 12 mo.']
+            rectangles += [plt.Rectangle((0, 0), 1, 1, fc=live_twelve_months_color)]
 
         # Backtest
-        if len(backtest_six_month_rolling_sharpe_dates) > 0:
+        if len(backtest_six_month_rolling_sharpe) > 0:
             ax.plot(backtest_six_month_rolling_sharpe_dates, backtest_six_month_rolling_sharpe, linewidth=0.5, color=backtest_six_months_color)
+        if len(backtest_twelve_month_rolling_sharpe) > 0:
             ax.plot(backtest_twelve_month_rolling_sharpe_dates, backtest_twelve_month_rolling_sharpe, linewidth=0.5, color=backtest_twelve_months_color)
 
         # Live
         if len(live_six_month_rolling_sharpe) > 0:
             ax.plot(live_six_month_rolling_sharpe_dates, live_six_month_rolling_sharpe, linewidth=0.5, color=live_six_months_color)
+        if len(live_twelve_month_rolling_sharpe) > 0:
             ax.plot(live_twelve_month_rolling_sharpe_dates, live_twelve_month_rolling_sharpe, linewidth=0.5, color=live_twelve_months_color)
 
         leg = ax.legend(rectangles, labels, handlelength=0.8, handleheight=0.8,
@@ -1104,6 +1121,7 @@ class ReportCharts:
             if not all([all([abs(y) == 0.0 for y in x]) for x in live_short_data]):
                 live_labels.append(security + ' - Short')
 
+        # use dict.fromkeys() instead of set() to remove duplicates and preserve order
         labels = list(dict.fromkeys(labels))
         live_labels = list(dict.fromkeys(live_labels))
         rectangles = [plt.Rectangle((0, 0), 1, 1, fc=color_map[lab]) for lab in labels]

--- a/Report/ReportCharts.py
+++ b/Report/ReportCharts.py
@@ -979,8 +979,10 @@ class ReportCharts:
         for k, v in list(color_map.items()):
             color_map[k + ' - Short'] = '#' + hex(int(v[1:], 16) ^ 0xffffff)[2:].zfill(6)
 
-        labels = long_securities + short_securities
-        live_labels = live_long_securities + live_short_securities
+        long_colors = [color_map[security] for security in long_securities]
+        long_live_colors = [color_map[security] for security in live_long_securities]
+        short_colors = [color_map[security + ' - Short'] for security in short_securities]
+        short_live_colors = [color_map[security + ' - Short'] for security in live_short_securities]
 
         ax = plt.gca()
 
@@ -1064,26 +1066,25 @@ class ReportCharts:
 
         # No need to check if live is empty or not, this will handle it, just needs to plot whichever has the longer time index first
         if max([len(x) for x in long_data_copy]) > max([len(x) for x in short_data_copy]):
-            ax.stackplot(time_copy[:max([len(x) for x in long_data_copy])], np.vstack(long_data_copy),
-                         color=[color_map[security] for security in long_securities], alpha = 0.75)
-            ax.stackplot(time_copy[:max([len(x) for x in short_data_copy])], np.vstack(short_data_copy),
-                         color=[color_map[security + ' - Short'] for security in short_securities], alpha=0.75)
+            ax.stackplot(time_copy[:max([len(x) for x in long_data_copy])], np.vstack(long_data_copy), colors=long_colors, alpha = 0.75)
+            ax.stackplot(time_copy[:max([len(x) for x in short_data_copy])], np.vstack(short_data_copy),color=short_colors, alpha=0.75)
         else:
-            ax.stackplot(time_copy[:max([len(x) for x in short_data_copy])], np.vstack(short_data_copy),
-                         color=[color_map[security + ' - Short'] for security in short_securities], alpha=0.75)
-            ax.stackplot(time_copy[:max([len(x) for x in long_data_copy])], np.vstack(long_data_copy),
-                         color=[color_map[security] for security in long_securities], alpha=0.75)
+            ax.stackplot(time_copy[:max([len(x) for x in short_data_copy])], np.vstack(short_data_copy), color=short_colors, alpha=0.75)
+            ax.stackplot(time_copy[:max([len(x) for x in long_data_copy])], np.vstack(long_data_copy), colors=long_colors, alpha=0.75)
 
         if max([len(x) for x in live_long_data_copy]) > max([len(x) for x in live_short_data_copy]):
             ax.stackplot(live_time_copy[:max([len(x) for x in live_long_data_copy])], np.vstack(live_long_data_copy),
-                         color=[color_map[security] for security in live_long_securities], alpha = 0.75)
+                         color=long_live_colors, alpha = 0.75)
             ax.stackplot(live_time_copy[:max([len(x) for x in live_short_data_copy])], np.vstack(live_short_data_copy),
-                         color=[color_map[security + ' - Short'] for security in live_short_securities], alpha = 0.75)
+                         color=short_live_colors, alpha = 0.75)
         else:
             ax.stackplot(live_time_copy[:max([len(x) for x in live_short_data_copy])], np.vstack(live_short_data_copy),
-                         color=[color_map[security + ' - Short'] for security in live_short_securities], alpha=0.75)
+                         color=short_live_colors, alpha=0.75)
             ax.stackplot(live_time_copy[:max([len(x) for x in live_long_data_copy])], np.vstack(live_long_data_copy),
-                         color=[color_map[security] for security in live_long_securities], alpha=0.75)
+                         color=long_live_colors, alpha=0.75)
+
+        labels = long_securities
+        live_labels = live_long_securities
 
         for security in short_securities:
             if not all([all([abs(y) == 0.0 for y in x]) for x in short_data]):
@@ -1093,8 +1094,8 @@ class ReportCharts:
             if not all([all([abs(y) == 0.0 for y in x]) for x in live_short_data]):
                 live_labels.append(security + ' - Short')
 
-        labels = list(set(labels))
-        live_labels = list(set(live_labels))
+        labels = list(dict.fromkeys(labels))
+        live_labels = list(dict.fromkeys(live_labels))
         rectangles = [plt.Rectangle((0, 0), 1, 1, fc=color_map[lab]) for lab in labels]
         live_rectangles = [plt.Rectangle((0, 0), 1, 1, fc=color_map[lab]) for lab in live_labels]
         ax.legend(rectangles + live_rectangles, labels + [f'{lab} - Live' for lab in live_labels], handlelength=0.8,

--- a/Report/ReportCharts.py
+++ b/Report/ReportCharts.py
@@ -1003,13 +1003,11 @@ class ReportCharts:
         for k, v in list(color_map.items()):
             color_map[k + ' - Short'] = '#' + hex(int(v[1:], 16) ^ 0xffffff)[2:].zfill(6)
 
-        for k, v in list(color_map.items()):
-            color_map[k + ' - Short'] = '#' + hex(int(v[1:], 16) ^ 0xffffff)[2:].zfill(6)
-
-        long_colors = [color_map[security] for security in long_securities]
-        long_live_colors = [color_map[security] for security in live_long_securities]
-        short_colors = [color_map[security + ' - Short'] for security in short_securities]
-        short_live_colors = [color_map[security + ' - Short'] for security in live_short_securities]
+        # None if no colors can be mapped, so stackplot gets None and doesn't try to access this color list
+        long_colors = [color_map[security] for security in long_securities] if len(long_securities) > 0 else None
+        long_live_colors = [color_map[security] for security in live_long_securities] if len(live_long_securities) > 0 else None
+        short_colors = [color_map[security + ' - Short'] for security in short_securities] if len(short_securities) > 0 else None
+        short_live_colors = [color_map[security + ' - Short'] for security in live_short_securities] if len(live_short_securities) > 0 else None
 
         ax = plt.gca()
 
@@ -1094,24 +1092,24 @@ class ReportCharts:
         # No need to check if live is empty or not, this will handle it, just needs to plot whichever has the longer time index first
         if max([len(x) for x in long_data_copy]) > max([len(x) for x in short_data_copy]):
             ax.stackplot(time_copy[:max([len(x) for x in long_data_copy])], np.vstack(long_data_copy), colors=long_colors, alpha = 0.75)
-            ax.stackplot(time_copy[:max([len(x) for x in short_data_copy])], np.vstack(short_data_copy),color=short_colors, alpha=0.75)
+            ax.stackplot(time_copy[:max([len(x) for x in short_data_copy])], np.vstack(short_data_copy), colors=short_colors, alpha=0.75)
         else:
-            ax.stackplot(time_copy[:max([len(x) for x in short_data_copy])], np.vstack(short_data_copy), color=short_colors, alpha=0.75)
+            ax.stackplot(time_copy[:max([len(x) for x in short_data_copy])], np.vstack(short_data_copy), colors=short_colors, alpha=0.75)
             ax.stackplot(time_copy[:max([len(x) for x in long_data_copy])], np.vstack(long_data_copy), colors=long_colors, alpha=0.75)
 
         if max([len(x) for x in live_long_data_copy]) > max([len(x) for x in live_short_data_copy]):
             ax.stackplot(live_time_copy[:max([len(x) for x in live_long_data_copy])], np.vstack(live_long_data_copy),
-                         color=long_live_colors, alpha = 0.75)
+                         colors=long_live_colors, alpha = 0.75)
             ax.stackplot(live_time_copy[:max([len(x) for x in live_short_data_copy])], np.vstack(live_short_data_copy),
-                         color=short_live_colors, alpha = 0.75)
+                         colors=short_live_colors, alpha = 0.75)
         else:
             ax.stackplot(live_time_copy[:max([len(x) for x in live_short_data_copy])], np.vstack(live_short_data_copy),
-                         color=short_live_colors, alpha=0.75)
+                         colors=short_live_colors, alpha=0.75)
             ax.stackplot(live_time_copy[:max([len(x) for x in live_long_data_copy])], np.vstack(live_long_data_copy),
-                         color=long_live_colors, alpha=0.75)
+                         colors=long_live_colors, alpha=0.75)
 
-        labels = long_securities
-        live_labels = live_long_securities
+        labels = long_securities + short_securities
+        live_labels = live_long_securities + live_short_securities
 
         for security in short_securities:
             if not all([all([abs(y) == 0.0 for y in x]) for x in short_data]):

--- a/Report/ReportCharts.py
+++ b/Report/ReportCharts.py
@@ -725,7 +725,8 @@ class ReportCharts:
         return base64
 
     def GetRollingSharpeRatio(self, data = [[],[]], live_data = [[],[]], name = "rolling-sharpe-ratio.png",
-                                  width = 11.5, height = 2.5, live_color = "#ff9914", backtest_color = "#71c3fc"):
+                                width = 11.5, height = 2.5, live_six_months_color = "#ff9914", live_twelve_months_color = "#ffd700",
+                                backtest_six_months_color = "#71c3fc", backtest_twelve_months_color = "#1d7dc1"):
         if len(data[0]) == 0:
             fig = plt.figure()
             fig.set_size_inches(width, height)
@@ -753,27 +754,36 @@ class ReportCharts:
             plt.close('all')
             return base64
 
-        labels = ['6 mo.']
-        rectangles = [plt.Rectangle((0, 0), 1, 1, fc=backtest_color)]
+        labels = []
+        rectangles = []
 
         plt.figure()
         ax = plt.gca()
         ax.xaxis.set_major_formatter(DateFormatter("%b %Y"))
 
-        backtest_rolling_sharpe_dates, backtest_rolling_sharpe = (data[0], data[1])
-        live_rolling_sharpe_dates, live_rolling_sharpe = (live_data[0], live_data[1])
+        # Data will come in the following format:
+        # [six month rolling sharpe time, six month rolling sharpe, twelve month rolling sharpe time, twelve month rolling sharpe]
+        backtest_six_month_rolling_sharpe_dates, backtest_six_month_rolling_sharpe = (data[0], data[1])
+        backtest_twelve_month_rolling_sharpe_dates, backtest_twelve_month_rolling_sharpe = (data[2], data[3])
+        live_six_month_rolling_sharpe_dates, live_six_month_rolling_sharpe = (live_data[0], live_data[1])
+        live_twelve_month_rolling_sharpe_dates, live_twelve_month_rolling_sharpe = (live_data[2], live_data[3])
 
-        # Check after the fact if we have any live values since we might not be far
-        # enough into live trading to generate the live rolling sharpe graph
-        if len(live_rolling_sharpe) > 0:
-            rectangles += [plt.Rectangle((0, 0,), 1, 1, fc=live_color)]
-            labels += ["Live 6 mo."]
+        if len(backtest_six_month_rolling_sharpe) > 0:
+            labels += ['6 mo.', '12 mo.']
+            rectangles += [plt.Rectangle((0, 0), 1, 1, fc=backtest_six_months_color), plt.Rectangle((0, 0), 1, 1, fc=backtest_twelve_months_color)]
+        if len(live_six_month_rolling_sharpe) > 0:
+            labels += ['Live 6 mo.', 'Live 12 mo.']
+            rectangles += [plt.Rectangle((0, 0), 1, 1, fc=live_six_months_color), plt.Rectangle((0, 0), 1, 1, fc=live_twelve_months_color)]
 
         # Backtest
-        ax.plot(backtest_rolling_sharpe_dates, backtest_rolling_sharpe, color=backtest_color, linewidth=0.5, zorder=2)
+        if len(backtest_six_month_rolling_sharpe_dates) > 0:
+            ax.plot(backtest_six_month_rolling_sharpe_dates, backtest_six_month_rolling_sharpe, linewidth=0.5, color=backtest_six_months_color)
+            ax.plot(backtest_twelve_month_rolling_sharpe_dates, backtest_twelve_month_rolling_sharpe, linewidth=0.5, color=backtest_twelve_months_color)
 
         # Live
-        ax.plot(live_rolling_sharpe_dates, live_rolling_sharpe, color=live_color, linewidth=0.5, zorder=2)
+        if len(live_six_month_rolling_sharpe) > 0:
+            ax.plot(live_six_month_rolling_sharpe_dates, live_six_month_rolling_sharpe, linewidth=0.5, color=live_six_months_color)
+            ax.plot(live_twelve_month_rolling_sharpe_dates, live_twelve_month_rolling_sharpe, linewidth=0.5, color=live_twelve_months_color)
 
         leg = ax.legend(rectangles, labels, handlelength=0.8, handleheight=0.8,
                         frameon=False, fontsize=8)

--- a/Report/ReportElements/RollingSharpeReportElement.cs
+++ b/Report/ReportElements/RollingSharpeReportElement.cs
@@ -49,8 +49,13 @@ namespace QuantConnect.Report.ReportElements
             var backtestPoints = ResultsUtil.EquityPoints(_backtest);
             var livePoints = ResultsUtil.EquityPoints(_live);
 
-            var backtestRollingSharpe = Rolling.Sharpe(new Series<DateTime, double>(backtestPoints), 6).DropMissing();
-            var liveRollingSharpe = Rolling.Sharpe(new Series<DateTime, double>(livePoints), 6).DropMissing();
+            var backtestSeries = new Series<DateTime, double>(backtestPoints);
+            var liveSeries = new Series<DateTime, double>(livePoints);
+
+            var backtestRollingSharpeSixMonths = Rolling.Sharpe(backtestSeries, 6).DropMissing();
+            var backtestRollingSharpeTwelveMonths = Rolling.Sharpe(backtestSeries, 12).DropMissing();
+            var liveRollingSharpeSixMonths = Rolling.Sharpe(liveSeries, 6).DropMissing();
+            var liveRollingSharpeTwelveMonths = Rolling.Sharpe(liveSeries, 12).DropMissing();
 
             var base64 = "";
             using (Py.GIL())
@@ -58,11 +63,15 @@ namespace QuantConnect.Report.ReportElements
                 var backtestList = new PyList();
                 var liveList = new PyList();
 
-                backtestList.Append(backtestRollingSharpe.Keys.ToList().ToPython());
-                backtestList.Append(backtestRollingSharpe.Values.ToList().ToPython());
+                backtestList.Append(backtestRollingSharpeSixMonths.Keys.ToList().ToPython());
+                backtestList.Append(backtestRollingSharpeSixMonths.Values.ToList().ToPython());
+                backtestList.Append(backtestRollingSharpeTwelveMonths.Keys.ToList().ToPython());
+                backtestList.Append(backtestRollingSharpeTwelveMonths.Values.ToList().ToPython());
 
-                liveList.Append(liveRollingSharpe.Keys.ToList().ToPython());
-                liveList.Append(liveRollingSharpe.Values.ToList().ToPython());
+                liveList.Append(liveRollingSharpeSixMonths.Keys.ToList().ToPython());
+                liveList.Append(liveRollingSharpeSixMonths.Values.ToList().ToPython());
+                liveList.Append(liveRollingSharpeTwelveMonths.Keys.ToList().ToPython());
+                liveList.Append(liveRollingSharpeTwelveMonths.Values.ToList().ToPython());
 
                 base64 = Charting.GetRollingSharpeRatio(backtestList, liveList);
             }

--- a/Report/template.html
+++ b/Report/template.html
@@ -219,7 +219,7 @@
                             <table class="table compact">
                                 <thead>
                                 <tr>
-                                    <th>Rolling Portfolio Beta (6 Months)</th>
+                                    <th>Rolling Portfolio Beta</th>
                                 </tr>
                                 </thead>
                                 <tbody>
@@ -237,7 +237,7 @@
                             <table class="table compact">
                                 <thead>
                                 <tr>
-                                    <th>Rolling Sharpe Ratio (6 Months)</th>
+                                    <th>Rolling Sharpe Ratio</th>
                                 </tr>
                                 </thead>
                                 <tbody>

--- a/Tests/Report/ReportChartsTest.cs
+++ b/Tests/Report/ReportChartsTest.cs
@@ -29,7 +29,7 @@ namespace QuantConnect.Tests.Report
     public class ReportChartTests
     {
         [Test]
-        public void RunsAllReportCartTests()
+        public void RunsAllReportChartTests()
         {
             using (Py.GIL())
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

- Use the right colors for each exposure stackplot series and make them match the legend.
- Removed "6 month" label from rolling beta and sharpe plot titles.
- Added a 12-month rolling sharpe series to the plot just like in the rolling beta one. 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6112 

**Note**: regarding the daily returns plot, the gray bars are the negative values for daily returns, both for backtest and live. Keeping it like that for now.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Generated reports and made sure the plots are correct.

- Run the backtest in the linked issue.
- Generate a report resulting in the following:
  - [Json file used to generate the report](https://github.com/QuantConnect/Lean/files/9419596/23db5416adcd1d05eab4c07be6a081c7.zip)
  - [HTML report](https://github.com/QuantConnect/Lean/files/9419602/Report.zip)

![image](https://user-images.githubusercontent.com/25215064/186529232-3d73b9f3-2dc3-4373-8ad8-463b3828119d.png)
![image](https://user-images.githubusercontent.com/25215064/186529277-788df31b-baaf-472b-8b21-3668f7ab6a5f.png)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
