### PR TITLE
Fixes PythonData.EndTime

### DIFF
--- a/Algorithm.CSharp/ConsolidateRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ConsolidateRegressionAlgorithm.cs
@@ -142,7 +142,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 5449;
+        public long DataPoints => 5450;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -157,7 +157,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "1"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "256943094.482%"},
+            {"Compounding Annual Return", "87589624.963%"},
             {"Drawdown", "15.900%"},
             {"Expectancy", "0"},
             {"Net Profit", "16.178%"},
@@ -180,8 +180,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
             {"Sortino Ratio", "79228162514264337593543950335"},
-            {"Return Over Maximum Drawdown", "23807.525"},
-            {"Portfolio Turnover", "3.518"},
+            {"Return Over Maximum Drawdown", "6752050.52"},
+            {"Portfolio Turnover", "2.638"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
             {"Total Insights Analysis Completed", "0"},

--- a/Algorithm.CSharp/CustomDataBitcoinAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataBitcoinAlgorithm.cs
@@ -93,6 +93,16 @@ namespace QuantConnect.Algorithm.CSharp
             public decimal VolumeUSD = 0;
 
             /// <summary>
+            /// The end time of this data. Some data covers spans (trade bars)
+            /// and as such we want to know the entire time span covered
+            /// </summary>
+            /// <remarks>
+            /// This property is overriden to allow different values for Time and EndTime
+            /// if they are set in the Reader. In the base implementation EndTime equals Time
+            /// </remarks>
+            public override DateTime EndTime { get; set; }
+
+            /// <summary>
             /// 1. DEFAULT CONSTRUCTOR: Custom data types need a default constructor.
             /// We search for a default constructor so please provide one here. It won't be used for data, just to generate the "Factory".
             /// </summary>

--- a/Algorithm.CSharp/CustomDataPropertiesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataPropertiesRegressionAlgorithm.cs
@@ -109,7 +109,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 10489;
+        public long DataPoints => 10491;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -124,30 +124,30 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "1"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "157.498%"},
+            {"Compounding Annual Return", "155.211%"},
             {"Drawdown", "84.800%"},
             {"Expectancy", "0"},
-            {"Net Profit", "5319.081%"},
-            {"Sharpe Ratio", "2.086"},
-            {"Probabilistic Sharpe Ratio", "69.456%"},
+            {"Net Profit", "5123.242%"},
+            {"Sharpe Ratio", "2.067"},
+            {"Probabilistic Sharpe Ratio", "68.833%"},
             {"Loss Rate", "0%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "1.747"},
-            {"Beta", "0.047"},
-            {"Annual Standard Deviation", "0.84"},
-            {"Annual Variance", "0.706"},
-            {"Information Ratio", "1.922"},
+            {"Alpha", "1.732"},
+            {"Beta", "0.043"},
+            {"Annual Standard Deviation", "0.841"},
+            {"Annual Variance", "0.707"},
+            {"Information Ratio", "1.902"},
             {"Tracking Error", "0.848"},
-            {"Treynor Ratio", "37.47"},
+            {"Treynor Ratio", "40.467"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "BTC.Bitcoin 2S"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "2.269"},
-            {"Return Over Maximum Drawdown", "1.858"},
+            {"Sortino Ratio", "2.236"},
+            {"Return Over Maximum Drawdown", "1.83"},
             {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
@@ -189,6 +189,16 @@ namespace QuantConnect.Algorithm.CSharp
             [JsonProperty("volume")]
             public decimal VolumeBTC = 0;
             public decimal VolumeUSD = 0;
+
+            /// <summary>
+            /// The end time of this data. Some data covers spans (trade bars)
+            /// and as such we want to know the entire time span covered
+            /// </summary>
+            /// <remarks>
+            /// This property is overriden to allow different values for Time and EndTime
+            /// if they are set in the Reader. In the base implementation EndTime equals Time
+            /// </remarks>
+            public override DateTime EndTime { get; set; }
 
             /// <summary>
             /// 1. DEFAULT CONSTRUCTOR: Custom data types need a default constructor.

--- a/Algorithm.CSharp/CustomDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataRegressionAlgorithm.cs
@@ -110,7 +110,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 8942;
+        public long DataPoints => 8943;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -125,30 +125,30 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "1"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "157.655%"},
+            {"Compounding Annual Return", "155.365%"},
             {"Drawdown", "84.800%"},
             {"Expectancy", "0"},
-            {"Net Profit", "5319.007%"},
-            {"Sharpe Ratio", "2.123"},
-            {"Probabilistic Sharpe Ratio", "70.581%"},
+            {"Net Profit", "5123.170%"},
+            {"Sharpe Ratio", "2.103"},
+            {"Probabilistic Sharpe Ratio", "69.967%"},
             {"Loss Rate", "0%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "1.776"},
-            {"Beta", "0.059"},
+            {"Alpha", "1.76"},
+            {"Beta", "0.055"},
             {"Annual Standard Deviation", "0.84"},
             {"Annual Variance", "0.706"},
-            {"Information Ratio", "1.962"},
-            {"Tracking Error", "0.847"},
-            {"Treynor Ratio", "30.455"},
+            {"Information Ratio", "1.942"},
+            {"Tracking Error", "0.848"},
+            {"Treynor Ratio", "32.317"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "BTC.Bitcoin 2S"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "2.271"},
-            {"Return Over Maximum Drawdown", "1.86"},
+            {"Sortino Ratio", "2.238"},
+            {"Return Over Maximum Drawdown", "1.832"},
             {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
@@ -190,6 +190,16 @@ namespace QuantConnect.Algorithm.CSharp
             [JsonProperty("volume")]
             public decimal VolumeBTC = 0;
             public decimal VolumeUSD = 0;
+
+            /// <summary>
+            /// The end time of this data. Some data covers spans (trade bars)
+            /// and as such we want to know the entire time span covered
+            /// </summary>
+            /// <remarks>
+            /// This property is overriden to allow different values for Time and EndTime
+            /// if they are set in the Reader. In the base implementation EndTime equals Time
+            /// </remarks>
+            public override DateTime EndTime { get; set; }
 
             /// <summary>
             /// 1. DEFAULT CONSTRUCTOR: Custom data types need a default constructor.

--- a/Algorithm.CSharp/LiveFeaturesAlgorithm.cs
+++ b/Algorithm.CSharp/LiveFeaturesAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -113,6 +113,16 @@ namespace QuantConnect.Algorithm.CSharp
             [JsonProperty("volume")]
             public decimal VolumeBTC = 0;
             public decimal VolumeUSD = 0;
+
+            /// <summary>
+            /// The end time of this data. Some data covers spans (trade bars)
+            /// and as such we want to know the entire time span covered
+            /// </summary>
+            /// <remarks>
+            /// This property is overriden to allow different values for Time and EndTime
+            /// if they are set in the Reader. In the base implementation EndTime equals Time
+            /// </remarks>
+            public override DateTime EndTime { get; set; }
 
             /// <summary>
             /// 1. DEFAULT CONSTRUCTOR: Custom data types need a default constructor.

--- a/Algorithm.CSharp/RegisterIndicatorRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegisterIndicatorRegressionAlgorithm.cs
@@ -160,7 +160,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 4089;
+        public long DataPoints => 4090;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -199,7 +199,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Kelly Criterion Probability Value", "0"},
             {"Sortino Ratio", "-0.825"},
             {"Return Over Maximum Drawdown", "-7.875"},
-            {"Portfolio Turnover", "4.637"},
+            {"Portfolio Turnover", "3.091"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
             {"Total Insights Analysis Completed", "0"},

--- a/Common/Data/DynamicData.cs
+++ b/Common/Data/DynamicData.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -55,6 +55,10 @@ namespace QuantConnect.Data
             {
                 Time = (DateTime)value;
             }
+            if (name == "endtime")
+            {
+                EndTime = (DateTime)value;
+            }
             if (name == "value")
             {
                 Value = (decimal)value;
@@ -92,6 +96,10 @@ namespace QuantConnect.Data
             if (name == "time")
             {
                 return Time;
+            }
+            if (name == "endtime")
+            {
+                return EndTime;
             }
             if (name == "value")
             {

--- a/Common/Python/PythonData.cs
+++ b/Common/Python/PythonData.cs
@@ -32,6 +32,21 @@ namespace QuantConnect.Python
         private readonly dynamic _supportedResolutions;
         private readonly dynamic _isSparseData;
         private readonly dynamic _requiresMapping;
+        private DateTime _endTime;
+
+        /// <summary>
+        /// The end time of this data. Some data covers spans (trade bars)
+        /// and as such we want to know the entire time span covered
+        /// </summary>
+        /// <remarks>
+        /// This property is overriden to allow different values for Time and EndTime
+        /// if they are set in the Reader. In the base implementation EndTime equals Time
+        /// </remarks>
+        public override DateTime EndTime
+        {
+            get => _endTime == default ? Time : _endTime;
+            set => _endTime = value;
+        }
 
         /// <summary>
         /// Constructor for initializing the PythonData class

--- a/Common/Python/PythonData.cs
+++ b/Common/Python/PythonData.cs
@@ -44,8 +44,19 @@ namespace QuantConnect.Python
         /// </remarks>
         public override DateTime EndTime
         {
-            get => _endTime == default ? Time : _endTime;
-            set => _endTime = value;
+            get
+            {
+                return _endTime == default ? Time : _endTime;
+            }
+            set
+            {
+                _endTime = value;
+                if(Time == default)
+                {
+                    // if Time hasn't been set let's set it, like BaseData does. If the user overrides it that's okay
+                    Time = value;
+                }
+            }
         }
 
         /// <summary>

--- a/Tests/Common/Data/DynamicDataTests.cs
+++ b/Tests/Common/Data/DynamicDataTests.cs
@@ -46,9 +46,17 @@ namespace QuantConnect.Tests.Common.Data
 
             BaseData baseData = data;
             Assert.AreEqual(time, baseData.Time);
+            Assert.AreEqual(time, baseData.EndTime);
             Assert.AreEqual(value, baseData.Value);
             Assert.AreEqual(value, baseData.Price);
             Assert.AreEqual(symbol, baseData.Symbol);
+
+            // let's access the properties through the dynamic handling
+            Assert.AreEqual(time, data.Time);
+            Assert.AreEqual(time, data.EndTime);
+            Assert.AreEqual(value, data.Value);
+            Assert.AreEqual(value, data.Price);
+            Assert.AreEqual(symbol, data.Symbol);
         }
 
         [Test]

--- a/Tests/Python/PythonDataTests.cs
+++ b/Tests/Python/PythonDataTests.cs
@@ -1,0 +1,110 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NodaTime;
+using Python.Runtime;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Python;
+
+namespace QuantConnect.Tests.Python
+{
+    [TestFixture]
+    public class PythonDataTests
+    {
+        [Test]
+        public void TimeAndEndTimeCanBeSet()
+        {
+            using (Py.GIL())
+            {
+                dynamic testModule = PyModule.FromString("testModule",
+                    @"
+from AlgorithmImports import *
+
+class CustomDataTest(PythonData):
+    def Reader(self, config, line, date, isLiveMode):
+        result = CustomDataTest()
+        result.Symbol = config.Symbol
+        result.Value = 10
+        result.Time = datetime.strptime(""2022-05-05"", ""%Y-%m-%d"")
+        result.EndTime = datetime.strptime(""2022-05-15"", ""%Y-%m-%d"")
+        return result");
+
+                var data = GetDataFromModule(testModule);
+
+                Assert.AreEqual(new DateTime(2022, 5, 5), data.Time);
+                Assert.AreEqual(new DateTime(2022, 5, 15), data.EndTime);
+            }
+        }
+
+        [Test]
+        public void OnlyEndTimeCanBeSet()
+        {
+            using (Py.GIL())
+            {
+                dynamic testModule = PyModule.FromString("testModule",
+                    @"
+from AlgorithmImports import *
+
+class CustomDataTest(PythonData):
+    def Reader(self, config, line, date, isLiveMode):
+        result = CustomDataTest()
+        result.Symbol = config.Symbol
+        result.Value = 10
+        result.EndTime = datetime.strptime(""2022-05-05"", ""%Y-%m-%d"")
+        return result");
+
+                var data = GetDataFromModule(testModule);
+
+                Assert.AreEqual(new DateTime(2022, 5, 5), data.Time);
+                Assert.AreEqual(new DateTime(2022, 5, 5), data.EndTime);
+            }
+        }
+
+        [Test]
+        public void OnlyTimeCanBeSet()
+        {
+            using (Py.GIL())
+            {
+                dynamic testModule = PyModule.FromString("testModule",
+                    @"
+from AlgorithmImports import *
+
+class CustomDataTest(PythonData):
+    def Reader(self, config, line, date, isLiveMode):
+        result = CustomDataTest()
+        result.Symbol = config.Symbol
+        result.Value = 10
+        result.Time = datetime.strptime(""2022-05-05"", ""%Y-%m-%d"")
+        return result");
+
+                var data = GetDataFromModule(testModule);
+
+                Assert.AreEqual(new DateTime(2022, 5, 5), data.Time);
+                Assert.AreEqual(new DateTime(2022, 5, 5), data.EndTime);
+            }
+        }
+
+        private static BaseData GetDataFromModule(dynamic testModule)
+        {
+            var type = Extensions.CreateType(testModule.GetAttr("CustomDataTest"));
+            var customDataTest = new PythonData(testModule.GetAttr("CustomDataTest")());
+            var config = new SubscriptionDataConfig(type, Symbols.SPY, Resolution.Daily, DateTimeZone.Utc,
+                DateTimeZone.Utc, false, false, false, isCustom: true);
+            return customDataTest.Reader(config, "something", DateTime.UtcNow, false);
+        }
+    }
+}


### PR DESCRIPTION
#### Description
The `EndTime` property of `PythonData` didn't override the base implementation in `BaseData`. Therefore `EndTime` was always set as `Time`.

Fixes Regression Tests
- The C# version of `Bitcoin` class needs to implement `EndTime`-
- Fixes regression tests

#### Related Issue
Closes #6601 

#### Motivation and Context
Bug fix.

#### Requires Documentation Change
Yes. The Importing data should show `EndTime` override in C# examples. 

#### How Has This Been Tested?
Regression tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`