### PR TITLE
Fix `BlackLittermanPortfolioConstructionModel`

### DIFF
--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
@@ -378,7 +378,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// <param name="insights">Array of insight that represent the investors' views</param>
         /// <param name="P">A matrix that identifies the assets involved in the views (size: K x N)</param>
         /// <param name="Q">A view vector (size: K x 1)</param>
-        private bool TryGetViews(ICollection<Insight> insights, out double[,] P, out double[] Q)
+        protected bool TryGetViews(ICollection<Insight> insights, out double[,] P, out double[] Q)
         {
             try
             {

--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
@@ -382,6 +382,8 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         {
             try
             {
+                var symbols = insights.Select(insight => insight.Symbol).ToList();
+
                 var tmpQ = insights.GroupBy(insight => insight.SourceModel)
                     .Select(values =>
                     {
@@ -402,7 +404,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                             return value / q;
                         });
                         // Add zero for other symbols that are listed but active insight
-                        foreach (var symbol in insights.Select(insight => insight.Symbol).ToList())
+                        foreach (var symbol in symbols)
                         {
                             if (!results.ContainsKey(symbol))
                             {

--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
@@ -382,6 +382,8 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         {
             try
             {
+                var symbols = insights.Select(insight => insight.Symbol);
+
                 var tmpQ = insights.GroupBy(insight => insight.SourceModel)
                     .Select(values =>
                     {
@@ -402,7 +404,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                             return value / q;
                         });
                         // Add zero for other symbols that are listed but active insight
-                        foreach (var symbol in _symbolDataDict.Keys)
+                        foreach (var symbol in symbols)
                         {
                             if (!results.ContainsKey(symbol))
                             {
@@ -451,9 +453,6 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                 // Compute posterior estimate of the uncertainty in the mean
                 var M = Στ.Subtract(A.Dot(P).Dot(Στ));
                 Σ = Σ.Add(M).Multiply(_delta);
-
-                // Compute posterior weights based on uncertainty in mean
-                var W = Π.Dot(Σ.Inverse());
             }
         }
     }

--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
@@ -382,8 +382,6 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         {
             try
             {
-                var symbols = insights.Select(insight => insight.Symbol);
-
                 var tmpQ = insights.GroupBy(insight => insight.SourceModel)
                     .Select(values =>
                     {
@@ -404,7 +402,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                             return value / q;
                         });
                         // Add zero for other symbols that are listed but active insight
-                        foreach (var symbol in symbols)
+                        foreach (var symbol in insights.Select(insight => insight.Symbol).ToList())
                         {
                             if (!results.ContainsKey(symbol))
                             {

--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
@@ -382,7 +382,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         {
             try
             {
-                var symbols = insights.Select(insight => insight.Symbol).ToList();
+                var symbols = insights.Select(insight => insight.Symbol).ToHashSet();
 
                 var tmpQ = insights.GroupBy(insight => insight.SourceModel)
                     .Select(values =>

--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
@@ -248,12 +248,12 @@ class BlackLittermanOptimizationPortfolioConstructionModel(PortfolioConstruction
 
                 # generate the link matrix of views: P
                 P[model] = dict()
-                for insight in group:
-                    value = insight.Direction * np.abs(insight.Magnitude)
-                    P[model][insight.Symbol] = value / q
-                # Add zero for other symbols that are listed but active insight
-                for symbol in self.symbolDataBySymbol.keys():
-                    if symbol not in P[model]:
+                for insight in insights:
+                    if insight in group:
+                        value = insight.Direction * np.abs(insight.Magnitude)
+                        P[model][insight.Symbol] = value / q
+                    # Add zero for other symbols that are listed but active insight
+                    else:
                         P[model][symbol] = 0
 
             Q = np.array([[x] for x in Q.values()])

--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
@@ -254,7 +254,7 @@ class BlackLittermanOptimizationPortfolioConstructionModel(PortfolioConstruction
                         P[model][insight.Symbol] = value / q
                     # Add zero for other symbols that are listed but active insight
                     else:
-                        P[model][symbol] = 0
+                        P[model][insight.Symbol] = 0
 
             Q = np.array([[x] for x in Q.values()])
             if len(Q) > 0:

--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
@@ -229,6 +229,8 @@ class BlackLittermanOptimizationPortfolioConstructionModel(PortfolioConstruction
         try:
             P = {}
             Q = {}
+            symbols = set(insight.Symbol for insight in insights)
+            
             for model, group in groupby(insights, lambda x: x.SourceModel):
                 group = list(group)
 
@@ -251,12 +253,14 @@ class BlackLittermanOptimizationPortfolioConstructionModel(PortfolioConstruction
                 for insight in group:
                     value = insight.Direction * np.abs(insight.Magnitude)
                     P[model][insight.Symbol] = value / q
+                # Add zero for other symbols that are listed but active insight
+                for symbol in symbols:
+                    if symbol not in P[model]:
+                        P[model][symbol] = 0
 
             Q = np.array([[x] for x in Q.values()])
             if len(Q) > 0:
                 P = np.array([list(x.values()) for x in P.values()])
-                # Fill nan with 0 (symbols with no view in a source model)
-                P = np.nan_to_num(P)
                 return P, Q
         except:
             pass

--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
@@ -248,14 +248,15 @@ class BlackLittermanOptimizationPortfolioConstructionModel(PortfolioConstruction
 
                 # generate the link matrix of views: P
                 P[model] = dict()
-                for insight in insights:
-                    if insight in group:
-                        value = insight.Direction * np.abs(insight.Magnitude)
-                        P[model][insight.Symbol] = value / q
+                for insight in group:
+                    value = insight.Direction * np.abs(insight.Magnitude)
+                    P[model][insight.Symbol] = value / q
 
             Q = np.array([[x] for x in Q.values()])
             if len(Q) > 0:
                 P = np.array([list(x.values()) for x in P.values()])
+                # Fill nan with 0 (symbols with no view in a source model)
+                P = np.nan_to_num(P)
                 return P, Q
         except:
             pass

--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
@@ -252,9 +252,6 @@ class BlackLittermanOptimizationPortfolioConstructionModel(PortfolioConstruction
                     if insight in group:
                         value = insight.Direction * np.abs(insight.Magnitude)
                         P[model][insight.Symbol] = value / q
-                    # Add zero for other symbols that are listed but active insight
-                    else:
-                        P[model][insight.Symbol] = 0
 
             Q = np.array([[x] for x in Q.values()])
             if len(Q) > 0:

--- a/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
@@ -155,6 +155,64 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         }
 
         [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void OneViewDimensionTest(Language language)
+        {
+            SetPortfolioConstruction(language);
+
+            // Results from http://www.blacklitterman.org/code/hl_py.html (View 1+2)
+            var expectedTargets = new[]
+            {
+                PortfolioTarget.Percent(_algorithm, GetSymbol("AUS"), 0.0152381),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("CAN"), 0.41863571),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("FRA"), -0.03409321),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("GER"), 0.33582847),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("JAP"), 0.11047619),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("UK"), -0.08173526),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("USA"), 0.18803095)
+            };
+
+            double[,] P;
+            double[] Q;
+            ((BLOPCM)_algorithm.PortfolioConstruction).TestTryGetViews(_view1Insights, out P, out Q);
+            
+            Assert.AreEqual(P.GetLength(0), 1);
+            Assert.AreEqual(P.GetLength(1), 7);
+            Assert.AreEqual(Q.GetLength(0), 7);
+        }
+
+        [Test]
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void TwoViewsDimensionTest(Language language)
+        {
+            SetPortfolioConstruction(language);
+
+            // Results from http://www.blacklitterman.org/code/hl_py.html (View 1+2)
+            var expectedTargets = new[]
+            {
+                PortfolioTarget.Percent(_algorithm, GetSymbol("AUS"), 0.0152381),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("CAN"), 0.41863571),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("FRA"), -0.03409321),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("GER"), 0.33582847),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("JAP"), 0.11047619),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("UK"), -0.08173526),
+                PortfolioTarget.Percent(_algorithm, GetSymbol("USA"), 0.18803095)
+            };
+
+            var insights = _view1Insights.Concat(_view2Insights).ToList();
+
+            double[,] P;
+            double[] Q;
+            ((BLOPCM)_algorithm.PortfolioConstruction).TestTryGetViews(insights, out P, out Q);
+
+            Assert.AreEqual(P.GetLength(0), 2);
+            Assert.AreEqual(P.GetLength(1), 7);
+            Assert.AreEqual(Q.GetLength(0), 7);
+        }
+
+        [Test]
         [TestCase(Language.CSharp, 11, true)]
         [TestCase(Language.CSharp, -11, true)]
         [TestCase(Language.CSharp, 0.001d, true)]
@@ -358,6 +416,11 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 // Equilibrium covariance matrix
                 Σ = Elementwise.Multiply(C, σ.Outer(σ));
                 return w.Dot(Σ.Multiply(delta));
+            }
+
+            public bool TestTryGetViews(ICollection<Insight> insights, out double[,] P, out double[] Q)
+            {
+                return base.TryGetViews(insights, out P, out Q);
             }
 
             public override void OnSecuritiesChanged(QCAlgorithm algorithm, SecurityChanges changes)

--- a/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
@@ -171,18 +171,6 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         {
             SetPortfolioConstruction(language);
 
-            // Results from http://www.blacklitterman.org/code/hl_py.html (View 1+2)
-            var expectedTargets = new[]
-            {
-                PortfolioTarget.Percent(_algorithm, GetSymbol("AUS"), 0.0152381),
-                PortfolioTarget.Percent(_algorithm, GetSymbol("CAN"), 0.41863571),
-                PortfolioTarget.Percent(_algorithm, GetSymbol("FRA"), -0.03409321),
-                PortfolioTarget.Percent(_algorithm, GetSymbol("GER"), 0.33582847),
-                PortfolioTarget.Percent(_algorithm, GetSymbol("JAP"), 0.11047619),
-                PortfolioTarget.Percent(_algorithm, GetSymbol("UK"), -0.08173526),
-                PortfolioTarget.Percent(_algorithm, GetSymbol("USA"), 0.18803095)
-            };
-
             if (language == Language.CSharp)
             {
                 double[,] P;
@@ -214,19 +202,8 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         {
             SetPortfolioConstruction(language);
 
-            // Results from http://www.blacklitterman.org/code/hl_py.html (View 1+2)
-            var expectedTargets = new[]
-            {
-                PortfolioTarget.Percent(_algorithm, GetSymbol("AUS"), 0.0152381),
-                PortfolioTarget.Percent(_algorithm, GetSymbol("CAN"), 0.41863571),
-                PortfolioTarget.Percent(_algorithm, GetSymbol("FRA"), -0.03409321),
-                PortfolioTarget.Percent(_algorithm, GetSymbol("GER"), 0.33582847),
-                PortfolioTarget.Percent(_algorithm, GetSymbol("JAP"), 0.11047619),
-                PortfolioTarget.Percent(_algorithm, GetSymbol("UK"), -0.08173526),
-                PortfolioTarget.Percent(_algorithm, GetSymbol("USA"), 0.18803095)
-            };
-
-            var insights = _view1Insights.Concat(_view2Insights).ToList();
+            // Test if a symbol has no view in one of the source models
+            var insights = _view1Insights.Concat(_view2Insights.Skip(1)).ToList();
 
             if (language == Language.CSharp)
             {

--- a/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
@@ -98,6 +98,11 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         {
             SetPortfolioConstruction(language);
 
+            // Add outdated insight to check if only the latest one was considered
+            var outdatedInsight = GetInsight("View 1", "CAN", 0.05);
+            outdatedInsight.GeneratedTimeUtc -= TimeSpan.FromHours(1);
+            outdatedInsight.CloseTimeUtc -= TimeSpan.FromHours(1);
+
             // Results from http://www.blacklitterman.org/code/hl_py.html (View 1)
             var expectedTargets = new[]
             {
@@ -110,7 +115,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 PortfolioTarget.Percent(_algorithm, GetSymbol("USA"), 0.58571429)
             };
 
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, _view1Insights);
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, _view1Insights.Concat(new[] {outdatedInsight}).ToArray());
 
             Assert.AreEqual(expectedTargets.Count(), actualTargets.Count());
 
@@ -141,7 +146,12 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 PortfolioTarget.Percent(_algorithm, GetSymbol("USA"), 0.18803095)
             };
 
-            var insights = _view1Insights.Concat(_view2Insights);
+            // Add outdated insight to check if only the latest one was considered
+            var outdatedInsight = GetInsight("View 2", "USA", 0.05);
+            outdatedInsight.GeneratedTimeUtc -= TimeSpan.FromHours(1);
+            outdatedInsight.CloseTimeUtc -= TimeSpan.FromHours(1);
+
+            var insights = _view1Insights.Concat(_view2Insights).Concat(new[] {outdatedInsight});
             var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights.ToArray());
 
             Assert.AreEqual(expectedTargets.Count(), actualTargets.Count());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Remove redundant dimensions that throw errors when applying the BL master equation.

#### Related Issue
closes #5627

#### Motivation and Context
The current model would throw error since assets with no active insight would be considered in the linking matrix P, causing problem in matrix operation. Refer to issue #5627 for example.

#### Requires Documentation Change
NA

#### How Has This Been Tested?
By the same problematic backtest in the issue:
C#: https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_6fedebe722a65a68cd3aa26f2e216b6f.html
Py: https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_cbb94b8900253495802a7637ee74f5f2.html

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
