### PR TITLE
Get history for a specific bar type in Python

### DIFF
--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -930,7 +930,7 @@ namespace QuantConnect.Algorithm
             var requestedType = type.CreateType();
             var requests = CreateDateRangeHistoryRequests(symbols, requestedType, start, end, resolution, fillForward, extendedMarket,
                 dataMappingMode, dataNormalizationMode, contractDepthOffset);
-            return PandasConverter.GetDataFrame(History(requests.Where(x => x != null)));
+            return PandasConverter.GetDataFrame(History(requests.Where(x => x != null)), requestedType);
         }
 
         /// <summary>
@@ -955,7 +955,7 @@ namespace QuantConnect.Algorithm
             var requestedType = type.CreateType();
             var requests = CreateBarCountHistoryRequests(symbols, requestedType, periods, resolution);
 
-            return PandasConverter.GetDataFrame(History(requests.Where(x => x != null)).Memoize());
+            return PandasConverter.GetDataFrame(History(requests.Where(x => x != null)).Memoize(), requestedType);
         }
 
         /// <summary>
@@ -993,7 +993,7 @@ namespace QuantConnect.Algorithm
                 throw new ArgumentException("The specified security is not of the requested type. Symbol: " + symbol.ToString() + " Requested Type: " + requestedType.Name + " Actual Type: " + actualType);
             }
 
-            return PandasConverter.GetDataFrame(History(request).Memoize());
+            return PandasConverter.GetDataFrame(History(request).Memoize(), requestedType);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -987,7 +987,7 @@ namespace QuantConnect.Algorithm
         {
             var requestedType = type.CreateType();
             var requests = CreateDateRangeHistoryRequests(new [] {  symbol }, requestedType, start, end, resolution);
-            if (requests == null || !requests.Any())
+            if (requests.IsNullOrEmpty())
             {
                 throw new ArgumentException($"No history data could be fetched. " +
                     $"This could be due to the specified security not being of the requested type. Symbol: {symbol} Requested Type: {requestedType.Name}");

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -986,14 +986,14 @@ namespace QuantConnect.Algorithm
         public PyObject History(PyObject type, Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null)
         {
             var requestedType = type.CreateType();
-            var request = CreateDateRangeHistoryRequests(new [] {  symbol }, requestedType, start, end, resolution).FirstOrDefault();
-            if (request == null)
+            var requests = CreateDateRangeHistoryRequests(new [] {  symbol }, requestedType, start, end, resolution);
+            if (requests == null || !requests.Any())
             {
-                var actualType = GetMatchingSubscription(symbol, typeof(BaseData)).Type;
-                throw new ArgumentException("The specified security is not of the requested type. Symbol: " + symbol.ToString() + " Requested Type: " + requestedType.Name + " Actual Type: " + actualType);
+                throw new ArgumentException($"No history data could be fetched. " +
+                    $"This could be due to the specified security not being of the requested type. Symbol: {symbol} Requested Type: {requestedType.Name}");
             }
 
-            return PandasConverter.GetDataFrame(History(request).Memoize(), requestedType);
+            return PandasConverter.GetDataFrame(History(requests).Memoize(), requestedType);
         }
 
         /// <summary>

--- a/Common/Python/PandasConverter.cs
+++ b/Common/Python/PandasConverter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -235,10 +235,11 @@ namespace QuantConnect.Python
         /// </summary>
         private void AddSliceDataToDict(Slice slice, IDictionary<Symbol, PandasData> sliceDataDict, ref int maxLevels)
         {
-            foreach (var key in slice.Keys)
+            foreach (var kvp in slice)
             {
-                var baseData = slice[key];
-                var value = GetPandasDataValue(sliceDataDict, key, baseData, ref maxLevels);
+                var symbol = kvp.Key;
+                var baseData = kvp.Value;
+                var value = GetPandasDataValue(sliceDataDict, symbol, baseData, ref maxLevels);
 
                 if (value.IsCustomData)
                 {
@@ -246,11 +247,10 @@ namespace QuantConnect.Python
                 }
                 else
                 {
-                    var ticks = slice.Ticks.ContainsKey(key) ? slice.Ticks[key] : null;
-                    var tradeBars = slice.Bars.ContainsKey(key) ? slice.Bars[key] : null;
-                    var quoteBars = slice.QuoteBars.ContainsKey(key) ? slice.QuoteBars[key] : null;
+                    var ticks = slice.Ticks.ContainsKey(symbol) ? slice.Ticks[symbol] : null;
+                    var tradeBars = slice.Bars.ContainsKey(symbol) ? slice.Bars[symbol] : null;
+                    var quoteBars = slice.QuoteBars.ContainsKey(symbol) ? slice.QuoteBars[symbol] : null;
                     value.Add(ticks, tradeBars, quoteBars);
-
                 }
             }
         }
@@ -264,10 +264,11 @@ namespace QuantConnect.Python
             // Access ticks directly since slice.Get(typeof(Tick)) and slice.Get(typeof(OpenInterest)) will return only the last tick
             var sliceData = isTick ? slice.Ticks : slice.Get(dataType);
 
-            foreach (var key in sliceData.Keys)
+            foreach (var kvp in sliceData)
             {
-                var baseData = sliceData[key];
-                var value = GetPandasDataValue(sliceDataDict, key, baseData, ref maxLevels);
+                Symbol symbol = kvp.Key;
+                var baseData = kvp.Value;
+                PandasData value = GetPandasDataValue(sliceDataDict, symbol, baseData, ref maxLevels);
 
                 if (value.IsCustomData)
                 {

--- a/Common/Python/PandasConverter.cs
+++ b/Common/Python/PandasConverter.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -235,11 +235,10 @@ namespace QuantConnect.Python
         /// </summary>
         private void AddSliceDataToDict(Slice slice, IDictionary<Symbol, PandasData> sliceDataDict, ref int maxLevels)
         {
-            foreach (var kvp in slice)
+            foreach (var key in slice.Keys)
             {
-                var symbol = kvp.Key;
-                var baseData = kvp.Value;
-                var value = GetPandasDataValue(sliceDataDict, symbol, baseData, ref maxLevels);
+                var baseData = slice[key];
+                var value = GetPandasDataValue(sliceDataDict, key, baseData, ref maxLevels);
 
                 if (value.IsCustomData)
                 {
@@ -247,9 +246,9 @@ namespace QuantConnect.Python
                 }
                 else
                 {
-                    var ticks = slice.Ticks.ContainsKey(symbol) ? slice.Ticks[symbol] : null;
-                    var tradeBars = slice.Bars.ContainsKey(symbol) ? slice.Bars[symbol] : null;
-                    var quoteBars = slice.QuoteBars.ContainsKey(symbol) ? slice.QuoteBars[symbol] : null;
+                    var ticks = slice.Ticks.ContainsKey(key) ? slice.Ticks[key] : null;
+                    var tradeBars = slice.Bars.ContainsKey(key) ? slice.Bars[key] : null;
+                    var quoteBars = slice.QuoteBars.ContainsKey(key) ? slice.QuoteBars[key] : null;
                     value.Add(ticks, tradeBars, quoteBars);
                 }
             }
@@ -264,11 +263,10 @@ namespace QuantConnect.Python
             // Access ticks directly since slice.Get(typeof(Tick)) and slice.Get(typeof(OpenInterest)) will return only the last tick
             var sliceData = isTick ? slice.Ticks : slice.Get(dataType);
 
-            foreach (var kvp in sliceData)
+            foreach (var key in sliceData.Keys)
             {
-                Symbol symbol = kvp.Key;
-                var baseData = kvp.Value;
-                PandasData value = GetPandasDataValue(sliceDataDict, symbol, baseData, ref maxLevels);
+                var baseData = sliceData[key];
+                PandasData value = GetPandasDataValue(sliceDataDict, key, baseData, ref maxLevels);
 
                 if (value.IsCustomData)
                 {

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -1260,16 +1260,16 @@ def getHistoryForContractDepthOffset(algorithm, symbol, start, end, resolution, 
             if (language == Language.CSharp)
             {
                 var tradeHistory = algorithm.History<TradeBar>(ibmSymbol, ibmHistoryStart, ibmHistoryEnd);
-                Assert.IsTrue(tradeHistory.Any());
+                Assert.AreEqual(390, tradeHistory.Count());
 
                 var quoteHistory = algorithm.History<QuoteBar>(ibmSymbol, ibmHistoryStart, ibmHistoryEnd);
-                Assert.IsTrue(quoteHistory.Any());
+                Assert.AreEqual(390, quoteHistory.Count());
 
                 var tickHistory = algorithm.History<Tick>(ibmSymbol, ibmHistoryStart, ibmHistoryEnd, Resolution.Tick);
-                Assert.IsTrue(tickHistory.Any());
+                Assert.AreEqual(57460, tickHistory.Count());
 
                 var openInterestHistory = algorithm.History<OpenInterest>(twxSymbol, twxHistoryStart, twxHistoryEnd);
-                Assert.IsTrue(openInterestHistory.Any());
+                Assert.AreEqual(1050, openInterestHistory.Count());
             }
             else
             {
@@ -1300,16 +1300,16 @@ def getOpenInterestHistory(algorithm, symbol, start, end):
                     algorithm.SetPandasConverter();
 
                     dynamic tradeHistory = getTradeBarHistory(algorithm, ibmSymbol, ibmHistoryStart, ibmHistoryEnd);
-                    Assert.IsFalse(tradeHistory.empty.As<bool>());
+                    Assert.AreEqual(390, tradeHistory.shape[0].As<int>());
 
                     dynamic quoteHistory = getQuoteBarHistory(algorithm, ibmSymbol, ibmHistoryStart, ibmHistoryEnd);
-                    Assert.IsFalse(quoteHistory.empty.As<bool>());
+                    Assert.AreEqual(390, quoteHistory.shape[0].As<int>());
 
                     dynamic tickHistory = getTickHistory(algorithm, ibmSymbol, ibmHistoryStart, ibmHistoryEnd);
-                    Assert.IsFalse(tickHistory.empty.As<bool>());
+                    Assert.AreEqual(24106, tickHistory.shape[0].As<int>());
 
                     dynamic openInterestHistory = getOpenInterestHistory(algorithm, twxSymbol, twxHistoryStart, twxHistoryEnd);
-                    Assert.IsFalse(openInterestHistory.empty.As<bool>());
+                    Assert.AreEqual(1050, openInterestHistory.shape[0].As<int>());
                 }
             }
         }

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -1306,7 +1306,7 @@ def getOpenInterestHistory(algorithm, symbol, start, end):
                     Assert.AreEqual(390, quoteHistory.shape[0].As<int>());
 
                     dynamic tickHistory = getTickHistory(algorithm, ibmSymbol, ibmHistoryStart, ibmHistoryEnd);
-                    Assert.AreEqual(24106, tickHistory.shape[0].As<int>());
+                    Assert.AreEqual(132104, tickHistory.shape[0].As<int>());
 
                     dynamic openInterestHistory = getOpenInterestHistory(algorithm, twxSymbol, twxHistoryStart, twxHistoryEnd);
                     Assert.AreEqual(1050, openInterestHistory.shape[0].As<int>());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Allowing to get history for a specific bar type from Python. The `PandasConverter.GetDataFrame()` method was not taking quote bars into account when the specified type was `QuoteBar` since `Slice.Keys` is empty in this case. `PandasConverter.GetDataFrame()` has now an optional parameter to pass in the requested data type. Omiting this parameter results in the previous behavior of going through the whole slice.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Close #6290 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
