### PR TITLE
Handle non-unique multi-index error in history dataframe creation

### DIFF
--- a/Algorithm.Python/PandasDataFrameFromMultipleTickTypeTickHistoryRegressionAlgorithm.py
+++ b/Algorithm.Python/PandasDataFrameFromMultipleTickTypeTickHistoryRegressionAlgorithm.py
@@ -1,0 +1,44 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression algorithm for asserting that tick history that includes multiple tick types (trade, quote) is correctly converted to a pandas
+### dataframe without raising exceptions. The main exception in this case was a "non-unique multi-index" error due to trades adn quote ticks with
+### duplicated timestamps.
+### </summary>
+class PandasDataFrameFromMultipleTickTypeTickHistoryRegressionAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        self.SetStartDate(2013, 10, 8)
+        self.SetEndDate(2013, 10, 8)
+
+        spy = self.AddEquity("SPY", Resolution.Minute).Symbol
+
+        subscriptions = [x for x in self.SubscriptionManager.Subscriptions if x.Symbol == spy]
+        if len(subscriptions) != 2:
+            raise Exception(f"Expected 2 subscriptions, but found {len(subscriptions)}")
+
+        history = pd.DataFrame()
+        try:
+            history = self.History(Tick, spy, timedelta(days=1), Resolution.Tick)
+        except Exception as e:
+            raise Exception(f"History call failed: {e}")
+
+        if history.shape[0] == 0:
+            raise Exception("SPY tick history is empty")
+
+        if not np.array_equal(history.columns.to_numpy(), ['askprice', 'asksize', 'bidprice', 'bidsize', 'exchange', 'lastprice', 'quantity']):
+            raise Exception("Unexpected columns in SPY tick history")
+
+        self.Quit()

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -227,6 +227,9 @@ namespace QuantConnect.Python
 
                     var time = tick.EndTime;
 
+                    // We will fill some series with null for tick types that don't have a value for that series, so that we make sure
+                    // the indices are the same for every tick series.
+
                     if (tick.TickType == TickType.Quote)
                     {
                         AddToSeries("askprice", time, tick.AskPrice);
@@ -236,6 +239,7 @@ namespace QuantConnect.Python
                     }
                     else
                     {
+                        // Trade and open interest ticks don't have these values, so we'll fill them with null.
                         AddToSeries("askprice", time, null);
                         AddToSeries("asksize", time, null);
                         AddToSeries("bidprice", time, null);

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -226,9 +226,6 @@ namespace QuantConnect.Python
                     if (tick == null) continue;
 
                     var time = tick.EndTime;
-                    var column = tick.TickType == TickType.OpenInterest
-                        ? "openinterest"
-                        : "lastprice";
 
                     if (tick.TickType == TickType.Quote)
                     {
@@ -237,10 +234,28 @@ namespace QuantConnect.Python
                         AddToSeries("bidprice", time, tick.BidPrice);
                         AddToSeries("bidsize", time, tick.BidSize);
                     }
+                    else
+                    {
+                        AddToSeries("askprice", time, null);
+                        AddToSeries("asksize", time, null);
+                        AddToSeries("bidprice", time, null);
+                        AddToSeries("bidsize", time, null);
+                    }
+
                     AddToSeries("exchange", time, tick.Exchange);
                     AddToSeries("suspicious", time, tick.Suspicious);
                     AddToSeries("quantity", time, tick.Quantity);
-                    AddToSeries(column, time, tick.LastPrice);
+
+                    if (tick.TickType == TickType.OpenInterest)
+                    {
+                        AddToSeries("openinterest", time, tick.Value);
+                        AddToSeries("lastprice", time, null);
+                    }
+                    else
+                    {
+                        AddToSeries("lastprice", time, tick.Value);
+                        AddToSeries("openinterest", time, null);
+                    }
                 }
             }
         }

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -3743,11 +3743,11 @@ def DataFrameIsEmpty():
                             time
                         )
                     },
-"                             askprice  asksize  bidprice  bidsize exchange  lastprice  openinterest  quantity\n" +
-"symbol           time                                                                                        \n" +
-"SPY R735QTJ8XC9X 2013-10-08       NaN      NaN       NaN      NaN   NASDAQ        1.0           NaN     100.0\n" +
-"                 2013-10-08     120.0    150.0     110.0    100.0     ARCA        0.0           NaN       0.0\n" +
-"                 2013-10-08       NaN      NaN       NaN      NaN                 NaN         150.0       0.0"
+$"                             askprice  asksize  bidprice  bidsize exchange  lastprice  openinterest  quantity{Environment.NewLine}" +
+$"symbol           time                                                                                        {Environment.NewLine}" +
+$"SPY R735QTJ8XC9X 2013-10-08       NaN      NaN       NaN      NaN   NASDAQ        1.0           NaN     100.0{Environment.NewLine}" +
+$"                 2013-10-08     120.0    150.0     110.0    100.0     ARCA        0.0           NaN       0.0{Environment.NewLine}" +
+$"                 2013-10-08       NaN      NaN       NaN      NaN                 NaN         150.0       0.0"
                 ),
                 // Trade tick
                 new TestCaseData(
@@ -3763,9 +3763,9 @@ def DataFrameIsEmpty():
                             time
                         )
                     },
-"                            exchange  lastprice  quantity\n" +
-"symbol           time                                    \n" +
-"SPY R735QTJ8XC9X 2013-10-08   NASDAQ        1.0     100.0"
+$"                            exchange  lastprice  quantity{Environment.NewLine}" +
+$"symbol           time                                    {Environment.NewLine}" +
+$"SPY R735QTJ8XC9X 2013-10-08   NASDAQ        1.0     100.0"
                 ),
                 // Trade ticks with same timestamp
                 new TestCaseData(
@@ -3782,10 +3782,10 @@ def DataFrameIsEmpty():
                             time
                         )
                     },
-"                            exchange  lastprice  quantity\n" +
-"symbol           time                                    \n" +
-"SPY R735QTJ8XC9X 2013-10-08   NASDAQ        1.0     100.0\n" +
-"                 2013-10-08   NASDAQ        2.0     200.0"
+$"                            exchange  lastprice  quantity{Environment.NewLine}" +
+$"symbol           time                                    {Environment.NewLine}" +
+$"SPY R735QTJ8XC9X 2013-10-08   NASDAQ        1.0     100.0{Environment.NewLine}" +
+$"                 2013-10-08   NASDAQ        2.0     200.0"
                 ),
                 // Quote tick
                 new TestCaseData(
@@ -3801,9 +3801,9 @@ def DataFrameIsEmpty():
                             time
                         )
                     },
-"                      askprice  asksize  bidprice  bidsize\n" +
-"symbol    time                                            \n" +
-"BTCUSD XJ 2013-10-08     120.0    150.0     110.0    100.0"
+$"                      askprice  asksize  bidprice  bidsize{Environment.NewLine}" +
+$"symbol    time                                            {Environment.NewLine}" +
+$"BTCUSD XJ 2013-10-08     120.0    150.0     110.0    100.0"
                 ),
                 // Quote ticks with same timestamp
                 new TestCaseData(
@@ -3820,10 +3820,10 @@ def DataFrameIsEmpty():
                             time
                         )
                     },
-"                      askprice  asksize  bidprice  bidsize\n" +
-"symbol    time                                            \n" +
-"BTCUSD XJ 2013-10-08     120.0    150.0     110.0    100.0\n" +
-"          2013-10-08     220.0    250.0     210.0    200.0"
+$"                      askprice  asksize  bidprice  bidsize{Environment.NewLine}" +
+$"symbol    time                                            {Environment.NewLine}" +
+$"BTCUSD XJ 2013-10-08     120.0    150.0     110.0    100.0{Environment.NewLine}" +
+$"          2013-10-08     220.0    250.0     210.0    200.0"
                 ),
                 // Open interest tick
                 new TestCaseData(
@@ -3839,9 +3839,9 @@ def DataFrameIsEmpty():
                             time
                         )
                     },
-"                             openinterest\n" +
-"symbol           time                    \n" +
-"SPY R735QTJ8XC9X 2013-10-08         150.0"
+$"                             openinterest{Environment.NewLine}" +
+$"symbol           time                    {Environment.NewLine}" +
+$"SPY R735QTJ8XC9X 2013-10-08         150.0"
                 ),
                 // Open interest ticks with same timestamp
                 new TestCaseData(
@@ -3858,10 +3858,10 @@ def DataFrameIsEmpty():
                             time
                         )
                     },
-"                             openinterest\n" +
-"symbol           time                    \n" +
-"SPY R735QTJ8XC9X 2013-10-08         150.0\n" +
-"                 2013-10-08         250.0"
+$"                             openinterest{Environment.NewLine}" +
+$"symbol           time                    {Environment.NewLine}" +
+$"SPY R735QTJ8XC9X 2013-10-08         150.0{Environment.NewLine}" +
+$"                 2013-10-08         250.0"
                 ),
                 // Trade, quote and open interest ticks with different times
                 new TestCaseData(
@@ -3879,11 +3879,11 @@ def DataFrameIsEmpty():
                             time
                         )
                     },
-"                                          askprice  asksize  bidprice  bidsize exchange  lastprice  openinterest  quantity\n" +
-"symbol           time                                                                                                     \n" +
-"SPY R735QTJ8XC9X 2013-10-08 00:00:00.000       NaN      NaN       NaN      NaN   NASDAQ        1.0           NaN     100.0\n" +
-"                 2013-10-08 00:00:00.100     120.0    150.0     110.0    100.0     ARCA        0.0           NaN       0.0\n" +
-"                 2013-10-31 03:33:20.000       NaN      NaN       NaN      NaN                 NaN         150.0       0.0"
+$"                                          askprice  asksize  bidprice  bidsize exchange  lastprice  openinterest  quantity{Environment.NewLine}" +
+$"symbol           time                                                                                                     {Environment.NewLine}" +
+$"SPY R735QTJ8XC9X 2013-10-08 00:00:00.000       NaN      NaN       NaN      NaN   NASDAQ        1.0           NaN     100.0{Environment.NewLine}" +
+$"                 2013-10-08 00:00:00.100     120.0    150.0     110.0    100.0     ARCA        0.0           NaN       0.0{Environment.NewLine}" +
+$"                 2013-10-31 03:33:20.000       NaN      NaN       NaN      NaN                 NaN         150.0       0.0"
                 ),
                 // Trade and quote bars
                 new TestCaseData(
@@ -3900,9 +3900,9 @@ def DataFrameIsEmpty():
                             time
                         )
                     },
-"                                      askclose  askhigh  asklow  askopen  asksize  bidclose  bidhigh  bidlow  bidopen  bidsize  close   high    low   open  volume\n" +
-"symbol           time                                                                                                                                             \n" +
-"SPY R735QTJ8XC9X 2013-10-08 00:01:00     110.0    112.0   105.0    110.0     98.0     101.0    102.0   100.0    101.0     99.0  101.0  102.0  100.0  101.0    10.0"
+$"                                      askclose  askhigh  asklow  askopen  asksize  bidclose  bidhigh  bidlow  bidopen  bidsize  close   high    low   open  volume{Environment.NewLine}" +
+$"symbol           time                                                                                                                                             {Environment.NewLine}" +
+$"SPY R735QTJ8XC9X 2013-10-08 00:01:00     110.0    112.0   105.0    110.0     98.0     101.0    102.0   100.0    101.0     99.0  101.0  102.0  100.0  101.0    10.0"
                 ),
                 // Trade bar
                 new TestCaseData(
@@ -3918,9 +3918,9 @@ def DataFrameIsEmpty():
                             time
                         )
                     },
-"                                      close   high    low   open  volume\n" +
-"symbol           time                                                   \n" +
-"SPY R735QTJ8XC9X 2013-10-08 00:01:00  101.0  102.0  100.0  101.0    10.0"
+$"                                      close   high    low   open  volume{Environment.NewLine}" +
+$"symbol           time                                                   {Environment.NewLine}" +
+$"SPY R735QTJ8XC9X 2013-10-08 00:01:00  101.0  102.0  100.0  101.0    10.0"
                 ),
                 // Quote bar
                 new TestCaseData(
@@ -3936,9 +3936,9 @@ def DataFrameIsEmpty():
                             time
                         )
                     },
-"                               askclose  askhigh  asklow  askopen  asksize  bidclose  bidhigh  bidlow  bidopen  bidsize  close   high    low   open\n" +
-"symbol    time                                                                                                                                     \n" +
-"BTCUSD XJ 2013-10-08 00:01:00     110.0    112.0   105.0    110.0     98.0     101.0    102.0   100.0    101.0     99.0  105.5  107.0  102.5  105.5"
+$"                               askclose  askhigh  asklow  askopen  asksize  bidclose  bidhigh  bidlow  bidopen  bidsize  close   high    low   open{Environment.NewLine}" +
+$"symbol    time                                                                                                                                     {Environment.NewLine}" +
+$"BTCUSD XJ 2013-10-08 00:01:00     110.0    112.0   105.0    110.0     98.0     101.0    102.0   100.0    101.0     99.0  105.5  107.0  102.5  105.5"
                 ),
                 // Trade and quote bars with different times
                 new TestCaseData(
@@ -3961,10 +3961,10 @@ def DataFrameIsEmpty():
                             },
                             time.AddMinutes(1))
                     },
-"                               askclose  askhigh  asklow  askopen  asksize  bidclose  bidhigh  bidlow  bidopen  bidsize  close   high    low   open  volume\n" +
-"symbol    time                                                                                                                                             \n" +
-"BTCUSD XJ 2013-10-08 00:01:00       NaN      NaN     NaN      NaN      NaN       NaN      NaN     NaN      NaN      NaN  101.0  102.0  100.0  101.0    10.0\n" +
-"          2013-10-08 00:02:01     110.0    112.0   105.0    110.0     98.0     101.0    102.0   100.0    101.0     99.0  105.5  107.0  102.5  105.5     NaN"
+$"                               askclose  askhigh  asklow  askopen  asksize  bidclose  bidhigh  bidlow  bidopen  bidsize  close   high    low   open  volume{Environment.NewLine}" +
+$"symbol    time                                                                                                                                             {Environment.NewLine}" +
+$"BTCUSD XJ 2013-10-08 00:01:00       NaN      NaN     NaN      NaN      NaN       NaN      NaN     NaN      NaN      NaN  101.0  102.0  100.0  101.0    10.0{Environment.NewLine}" +
+$"          2013-10-08 00:02:01     110.0    112.0   105.0    110.0     98.0     101.0    102.0   100.0    101.0     99.0  105.5  107.0  102.5  105.5     NaN"
                 ),
             };
         }

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -3646,6 +3646,43 @@ def DataFrameIsEmpty():
             }
         }
 
+        [Test]
+        public void RunDataFrameFromTickHistoryRegressionAlgorithm()
+        {
+            var parameter = new RegressionTests.AlgorithmStatisticsTestParameters(
+                "PandasDataFrameFromMultipleTickTypeTickHistoryRegressionAlgorithm",
+                new Dictionary<string, string> {
+                    {"Total Trades", "0"},
+                    {"Average Win", "0%"},
+                    {"Average Loss", "0%"},
+                    {"Compounding Annual Return", "0%"},
+                    {"Drawdown", "0%"},
+                    {"Expectancy", "0"},
+                    {"Net Profit", "0%"},
+                    {"Sharpe Ratio", "0"},
+                    {"Probabilistic Sharpe Ratio", "0%"},
+                    {"Loss Rate", "0%"},
+                    {"Win Rate", "0%"},
+                    {"Profit-Loss Ratio", "0"},
+                    {"Alpha", "0"},
+                    {"Beta", "0"},
+                    {"Annual Standard Deviation", "0"},
+                    {"Annual Variance", "0"},
+                    {"Information Ratio", "0"},
+                    {"Tracking Error", "0"},
+                    {"Treynor Ratio", "0"},
+                    {"Total Fees", "$0.00"}
+                },
+                Language.Python,
+                AlgorithmStatus.Completed);
+
+            AlgorithmRunner.RunLocalBacktest(parameter.Algorithm,
+                parameter.Statistics,
+                parameter.AlphaStatistics,
+                parameter.Language,
+                parameter.ExpectedFinalStatus);
+        }
+
         public IEnumerable<Slice> GetHistory<T>(Symbol symbol, Resolution resolution, IEnumerable<T> data)
             where T : IBaseData
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Requesting tick history for securities with both trade and quote subscriptions, the result contains both trade and quote ticks. Converting this slices into a dataframe was resulting in a non-unique multi-index error. This was caused when there were quote and trade ticks with same timestamps, the series would have diferent indexes depending on the tick type (tick quotes have ask/bid size/price series, while trade ticks don't) which resulted in Pandas trying to reindex when creating the dataframe from the series.

Now we treat all ticks as if they had all the columns, regardless of the tick type, adding null (NaN) to the columns that don't apply (ask/bid size/price for trade ticks, for instance). If only trades are passed, some columns like ask/bid size/price will end up having only NaN values, making that columns to be ignored when creating the dataframe, as expected.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #4297 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests and regression algorithm

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
