### PR TITLE
docs(VixDualThrustAlpha): readability improvements

### DIFF
--- a/Algorithm.CSharp/Alphas/VixDualThrustAlpha.cs
+++ b/Algorithm.CSharp/Alphas/VixDualThrustAlpha.cs
@@ -202,7 +202,7 @@ namespace QuantConnect.Algorithm.CSharp.Alphas
                 SymbolData symbolData;
                 if (_symbolDataBySymbol.TryGetValue(removed.Symbol, out symbolData))
                 {
-                    // unsibscribe consolidator from data updates
+                    // unsubscribe consolidator from data updates
                     algorithm.SubscriptionManager.RemoveConsolidator(removed.Symbol, symbolData.GetConsolidator());
 
                     // remove item from dictionary collection

--- a/Algorithm.CSharp/Alphas/VixDualThrustAlpha.cs
+++ b/Algorithm.CSharp/Alphas/VixDualThrustAlpha.cs
@@ -109,7 +109,7 @@ namespace QuantConnect.Algorithm.CSharp.Alphas
             int barsToConsolidate = 1
             )
         {
-            // coefficient that used to determinte upper and lower borders of a breakout channel
+            // coefficient that used to determine upper and lower borders of a breakout channel
             _k1 = k1;
             _k2 = k2;
 

--- a/Algorithm.Python/Alphas/VIXDualThrustAlpha.py
+++ b/Algorithm.Python/Alphas/VIXDualThrustAlpha.py
@@ -80,7 +80,7 @@ class DualThrustAlphaModel(AlphaModel):
                 from the standard resolution - 1m 1h etc. - we need to pass this parameters along
                 with proper data resolution'''
 
-        # coefficient that used to determinte upper and lower borders of a breakout channel
+        # coefficient that used to determine upper and lower borders of a breakout channel
         self.k1 = k1
         self.k2 = k2
 


### PR DESCRIPTION

#### Description
small readability fixups in `VixDualThrustAlpha`

#### Types of changes
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
