### PR TITLE
Fixes Buying Power Model Selection for Cash Account

### DIFF
--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -358,15 +358,20 @@ namespace QuantConnect.Brokerages
         /// <returns>The buying power model for this brokerage/security</returns>
         public virtual IBuyingPowerModel GetBuyingPowerModel(Security security)
         {
-            return security.Type switch
+            IBuyingPowerModel getCurrencyBuyingPowerModel() =>
+                AccountType == AccountType.Cash
+                    ? new CashBuyingPowerModel()
+                    : new SecurityMarginModel(GetLeverage(security), RequiredFreeBuyingPowerPercent);
+
+            return security?.Type switch
             {
+                SecurityType.Crypto => getCurrencyBuyingPowerModel(),
+                SecurityType.Forex => getCurrencyBuyingPowerModel(),
                 SecurityType.Future => new FutureMarginModel(RequiredFreeBuyingPowerPercent, security),
                 SecurityType.FutureOption => new FuturesOptionsMarginModel(RequiredFreeBuyingPowerPercent, (Option)security),
                 SecurityType.IndexOption => new OptionMarginModel(RequiredFreeBuyingPowerPercent),
                 SecurityType.Option => new OptionMarginModel(RequiredFreeBuyingPowerPercent),
-                _ => AccountType == AccountType.Cash
-                    ? new CashBuyingPowerModel()
-                    : new SecurityMarginModel(GetLeverage(security), RequiredFreeBuyingPowerPercent)
+                _ => new SecurityMarginModel(GetLeverage(security), RequiredFreeBuyingPowerPercent)
             };
         }
 


### PR DESCRIPTION
#### Description
`DefaultBrokerageModel` was selecting `CashBuyingPowerModel` for securities not supported by this model as it only supports Crypto and Forex.

#### Related Issue
Closes #6466 
Fixes bug introduced by https://github.com/QuantConnect/Lean/pull/6215

#### Motivation and Context
Bug fix.

#### How Has This Been Tested?
New unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`