### PR TITLE
Normalize Algorithm EndDate Initilization

### DIFF
--- a/Tests/Algorithm/AlgorithmInitializeTests.cs
+++ b/Tests/Algorithm/AlgorithmInitializeTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -35,6 +35,19 @@ namespace QuantConnect.Tests.Algorithm
         private const BrokerageName BrokerageName = QuantConnect.Brokerages.BrokerageName.FxcmBrokerage;
         private const int RoundingPrecision = 20;
         private readonly MarketOrder _order = new MarketOrder { Quantity = 1000 };
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void Validates_SetEndTime(bool explicitSet)
+        {
+            var algorithm = GetAlgorithm();
+            if (explicitSet)
+            {
+                algorithm.SetEndDate(DateTime.Now);
+            }
+            var excepted = DateTime.Now.RoundDown(TimeSpan.FromDays(1)).AddTicks(-1);
+            Assert.AreEqual(algorithm.EndDate, excepted);
+        }
 
         [Test]
         public void Validates_SetBrokerageModel_AddForex()


### PR DESCRIPTION
#### Description
Use `SetEndDate` to set `EndDate` in `QCAlgorithm` constructor. It will ensure that the `EndDate` is independent of the time the algorithm is executed if `SetEndDate` is not called in `Initilaize`.

Some users don't implement `SetEndDate` to run the algorithm to the latest datapoint, but this is not true if we run the algorithm during the day as the latest datapoint will be 24 hours before the execution time while there is data until the current day midnight.

#### Related Issue
Close #6670 

#### Motivation and Context
Bug fix.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Unit test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`