### PR TITLE
Make UserDefinedUniverse thread safe

### DIFF
--- a/Algorithm/QCAlgorithm.Framework.cs
+++ b/Algorithm/QCAlgorithm.Framework.cs
@@ -89,9 +89,12 @@ namespace QuantConnect.Algorithm
             }
             foreach (var universe in UniverseSelection.CreateUniverses(this))
             {
-                // on purpose we don't call 'AddUniverse' here so that these universes don't get registered as user added
-                // this is so that later during 'UniverseSelection.CreateUniverses' we wont remove them from UniverseManager
-                _pendingUniverseAdditions.Add(universe);
+                lock(_pendingUniverseAdditionsLock)
+                {
+                    // on purpose we don't call 'AddUniverse' here so that these universes don't get registered as user added
+                    // this is so that later during 'UniverseSelection.CreateUniverses' we wont remove them from UniverseManager
+                    _pendingUniverseAdditions.Add(universe);
+                }
             }
 
             if (DebugMode)

--- a/Common/Data/UniverseSelection/UserDefinedUniverse.cs
+++ b/Common/Data/UniverseSelection/UserDefinedUniverse.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -14,12 +14,12 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
+using QuantConnect.Util;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
-using QuantConnect.Util;
+using System.Collections.Generic;
+using System.Collections.Specialized;
 
 namespace QuantConnect.Data.UniverseSelection
 {
@@ -40,6 +40,7 @@ namespace QuantConnect.Data.UniverseSelection
         private readonly HashSet<SubscriptionDataConfig> _pendingRemovedConfigs = new HashSet<SubscriptionDataConfig>();
         private readonly UniverseSettings _universeSettings;
         private readonly Func<DateTime, IEnumerable<Symbol>> _selector;
+        private readonly object _lock = new ();
 
         /// <summary>
         /// Event fired when a symbol is added or removed from this universe
@@ -76,7 +77,12 @@ namespace QuantConnect.Data.UniverseSelection
             _symbols = symbols.ToHashSet();
             _universeSettings = universeSettings;
             // the selector Func will be the union of the provided symbols and the added symbols or subscriptions data configurations
-            _selector = time => _subscriptionDataConfigs.Select(x => x.Symbol).Union(_symbols);
+            _selector = time => {
+                lock(_lock)
+                {
+                    return _subscriptionDataConfigs.Select(x => x.Symbol).Union(_symbols).ToHashSet();
+                }
+            };
         }
 
         /// <summary>
@@ -120,7 +126,14 @@ namespace QuantConnect.Data.UniverseSelection
         /// <returns>True if the symbol was added, false if it was already present</returns>
         public bool Add(Symbol symbol)
         {
-            if (_symbols.Add(symbol))
+            var added = false;
+            lock (_lock)
+            {
+                // let's not call the event having the lock if we don't need too
+                added = _symbols.Add(symbol);
+            }
+
+            if (added)
             {
                 OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, symbol));
                 return true;
@@ -135,7 +148,14 @@ namespace QuantConnect.Data.UniverseSelection
         /// <returns>True if the subscriptionDataConfig was added, false if it was already present</returns>
         public bool Add(SubscriptionDataConfig subscriptionDataConfig)
         {
-            if (_subscriptionDataConfigs.Add(subscriptionDataConfig))
+            var added = false;
+            lock (_lock)
+            {
+                // let's not call the event having the lock if we don't need too
+                added = _subscriptionDataConfigs.Add(subscriptionDataConfig);
+            }
+
+            if (added)
             {
                 OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, subscriptionDataConfig.Symbol));
                 return true;
@@ -216,19 +236,23 @@ namespace QuantConnect.Data.UniverseSelection
             DateTime maximumEndTimeUtc,
             ISubscriptionDataConfigService subscriptionService)
         {
-            var result = _subscriptionDataConfigs.Where(x => x.Symbol == security.Symbol).ToList();
-            if (!result.Any())
+            List<SubscriptionDataConfig> result;
+            lock (_lock)
             {
-                result = _pendingRemovedConfigs.Where(x => x.Symbol == security.Symbol).ToList();
-                if (result.Any())
+                result = _subscriptionDataConfigs.Where(x => x.Symbol == security.Symbol).ToList();
+                if (!result.Any())
                 {
-                    _pendingRemovedConfigs.RemoveWhere(x => x.Symbol == security.Symbol);
-                }
-                else
-                {
-                    result = base.GetSubscriptionRequests(security, currentTimeUtc, maximumEndTimeUtc, subscriptionService).Select(x => x.Configuration).ToList();
-                    // we create subscription data configs ourselves, add the configs
-                    _subscriptionDataConfigs.UnionWith(result);
+                    result = _pendingRemovedConfigs.Where(x => x.Symbol == security.Symbol).ToList();
+                    if (result.Any())
+                    {
+                        _pendingRemovedConfigs.RemoveWhere(x => x.Symbol == security.Symbol);
+                    }
+                    else
+                    {
+                        result = base.GetSubscriptionRequests(security, currentTimeUtc, maximumEndTimeUtc, subscriptionService).Select(x => x.Configuration).ToList();
+                        // we create subscription data configs ourselves, add the configs
+                        _subscriptionDataConfigs.UnionWith(result);
+                    }
                 }
             }
             return result.Select(config => new SubscriptionRequest(isUniverseSubscription: false,
@@ -258,17 +282,20 @@ namespace QuantConnect.Data.UniverseSelection
 
         private bool RemoveAndKeepTrack(Symbol symbol)
         {
-            var toBeRemoved = _subscriptionDataConfigs.Where(x => x.Symbol == symbol).ToList();
-            var removedSymbol = _symbols.Remove(symbol);
-
-            if (removedSymbol || toBeRemoved.Any())
+            lock (_lock)
             {
-                _subscriptionDataConfigs.RemoveWhere(x => x.Symbol == symbol);
-                _pendingRemovedConfigs.UnionWith(toBeRemoved);
-                return true;
-            }
+                var toBeRemoved = _subscriptionDataConfigs.Where(x => x.Symbol == symbol).ToList();
+                var removedSymbol = _symbols.Remove(symbol);
 
-            return false;
+                if (removedSymbol || toBeRemoved.Any())
+                {
+                    _subscriptionDataConfigs.RemoveWhere(x => x.Symbol == symbol);
+                    _pendingRemovedConfigs.UnionWith(toBeRemoved);
+                    return true;
+                }
+
+                return false;
+            }
         }
     }
 }

--- a/Engine/Results/RegressionResultHandler.cs
+++ b/Engine/Results/RegressionResultHandler.cs
@@ -64,6 +64,11 @@ namespace QuantConnect.Lean.Engine.Results
             : $"./{AlgorithmId}/{DateTime.Now:yyyy-MM-dd-hh-mm-ss}.{Language.ToLower()}.details.log";
 
         /// <summary>
+        /// True if there was a runtime error running the algorithm
+        /// </summary>
+        public bool HasRuntimeError { get; private set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RegressionResultHandler"/> class
         /// </summary>
         public RegressionResultHandler()
@@ -254,6 +259,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="stacktrace">Stacktrace information string</param>
         public override void RuntimeError(string message, string stacktrace = "")
         {
+            HasRuntimeError = true;
             base.RuntimeError(message, stacktrace);
 
             stacktrace = string.IsNullOrEmpty(stacktrace) ? null : Environment.NewLine + stacktrace;

--- a/Tests/AlgorithmRunner.cs
+++ b/Tests/AlgorithmRunner.cs
@@ -166,9 +166,14 @@ namespace QuantConnect.Tests
                         }
                     }).Wait();
 
-                    var backtestingResultHandler = (BacktestingResultHandler)algorithmHandlers.Results;
-                    results = backtestingResultHandler;
-                    statistics = backtestingResultHandler.FinalStatistics;
+                    var regressionResultHandler = (RegressionResultHandler)algorithmHandlers.Results;
+                    results = regressionResultHandler;
+                    statistics = regressionResultHandler.FinalStatistics;
+
+                    if (expectedFinalStatus == AlgorithmStatus.Completed && regressionResultHandler.HasRuntimeError)
+                    {
+                        Assert.Fail($"There was a runtime error running the algorithm");
+                    }
 
                     var defaultAlphaHandler = (DefaultAlphaHandler) algorithmHandlers.Alphas;
                     alphaStatistics = defaultAlphaHandler.RuntimeStatistics;

--- a/Tests/Common/Data/UniverseSelection/UserDefinedUniverseTests.cs
+++ b/Tests/Common/Data/UniverseSelection/UserDefinedUniverseTests.cs
@@ -1,0 +1,107 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using System.Threading;
+using QuantConnect.Data;
+using System.Collections.Generic;
+using QuantConnect.Algorithm.CSharp;
+
+namespace QuantConnect.Tests.Common.Data.UniverseSelection
+{
+    [TestFixture]
+    public class UserDefinedUniverseTests
+    {
+        [Test]
+        public void ThreadSafety()
+        {
+            // allow the system to stabilize
+            Thread.Sleep(1000);
+            var results = AlgorithmRunner.RunLocalBacktest(nameof(TestUserDefinedUniverseAlgorithm),
+                new Dictionary<string, string> { { "Total Trades", "1" } },
+                null,
+                Language.CSharp,
+                AlgorithmStatus.Completed,
+                algorithmLocation: "QuantConnect.Tests.dll");
+
+            Assert.GreaterOrEqual(TestUserDefinedUniverseAlgorithm.AdditionCount, 50, $"We added {TestUserDefinedUniverseAlgorithm.AdditionCount} times");
+        }
+    }
+
+    public class TestUserDefinedUniverseAlgorithm : BasicTemplateAlgorithm
+    {
+        public static long AdditionCount;
+
+        private Thread _thread;
+        private CancellationTokenSource _cancellationTokenSource = new();
+        private ManualResetEvent _threadStarted = new (false);
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 11);
+
+            var spy = AddEquity("SPY", Resolution.Minute, dataNormalizationMode: DataNormalizationMode.Raw).Symbol;
+
+            _thread = new Thread(() =>
+            {
+                _threadStarted.Set();
+                try
+                {
+                    while (!_cancellationTokenSource.IsCancellationRequested && AdditionCount < 250)
+                    {
+                        var currentCount = Interlocked.Increment(ref AdditionCount);
+                        var contract = QuantConnect.Symbol.CreateOption(spy, QuantConnect.Market.USA, OptionStyle.American, OptionRight.Call, currentCount, new DateTime(2022, 10, 10));
+                        AddOptionContract(contract);
+
+
+                        if (currentCount % 2 == 0)
+                        {
+                            RemoveSecurity("AAPL");
+                        }
+                        else
+                        {
+                            AddEquity("AAPL");
+                        }
+                        if (currentCount % 25 == 0)
+                        {
+                            Thread.Sleep(10);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Error(ex);
+                    SetStatus(AlgorithmStatus.RuntimeError);
+                }
+            }) { IsBackground = true };
+        }
+
+        public override void OnData(Slice data)
+        {
+            if (!_threadStarted.WaitOne(0))
+            {
+                _thread.Start();
+                _threadStarted.WaitOne();
+            }
+            base.OnData(data);
+        }
+        public override void OnEndOfAlgorithm()
+        {
+            _thread.StopSafely(TimeSpan.FromSeconds(2), _cancellationTokenSource);
+            base.OnEndOfAlgorithm();
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Make UserDefinedUniverse thread safe. Adding regression test
- Adjust algorithm to use the pending additions lock everywhere it's required

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/6678
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- This can rarely happen in live trading if adding and removing assets async
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added regression tests reproducing issue
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
