### PR TITLE
Normalize time in universe behavior

### DIFF
--- a/Algorithm.CSharp/FutureNoTimeInUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureNoTimeInUniverseRegressionAlgorithm.cs
@@ -18,31 +18,44 @@ using System;
 using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
+using QuantConnect.Securities;
 using System.Collections.Generic;
 
 namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
-    /// Regression algorithm asserting the behavior of option warmup
+    /// Regression algorithm asserting the behavior of a zero time in universe setting. Related to GH issue #6653
     /// </summary>
-    public class WarmupOptionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    public class FutureNoTimeInUniverseRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
-        private const string UnderlyingTicker = "GOOG";
-        private Symbol _optionSymbol;
+        private Dictionary<DateTime, Symbol> _seenSymbols = new();
+        private Symbol _sp500;
 
-        protected List<DateTime> OptionWarmupTimes { get; } = new();
-
+        /// <summary>
+        /// Initialize your algorithm and add desired assets.
+        /// </summary>
         public override void Initialize()
         {
-            SetStartDate(2015, 12, 24);
-            SetEndDate(2015, 12, 24);
-            SetCash(100000);
+            SetStartDate(2013, 10, 08);
+            SetEndDate(2013, 10, 10);
 
-            var option = AddOption(UnderlyingTicker);
-            _optionSymbol = option.Symbol;
+            UniverseSettings.MinimumTimeInUniverse = TimeSpan.Zero;
+            var futureSP500 = AddFuture(Futures.Indices.SP500EMini);
 
-            option.SetFilter(u => u.Strikes(-5, +5).Expiration(0, 180).IncludeWeeklys());
-            SetWarmUp(TimeSpan.FromDays(1));
+            _sp500 = futureSP500.Symbol;
+            futureSP500.SetFilter(u =>
+            {
+                return u.Where(s =>
+                {
+                    if (_seenSymbols.ContainsKey(Time) || _seenSymbols.ContainsValue(s))
+                    {
+                        // for each timestamp we select a single symbol which we haven't selected before
+                        return false;
+                    }
+                    _seenSymbols[Time] = s;
+                    return true;
+                });
+            });
         }
 
         /// <summary>
@@ -51,53 +64,17 @@ namespace QuantConnect.Algorithm.CSharp
         /// <param name="slice">The current slice of data keyed by symbol string</param>
         public override void OnData(Slice slice)
         {
-            if (slice.OptionChains.TryGetValue(_optionSymbol, out var chain))
+            var futureContracts = slice.FutureChains.GetValue(_sp500);
+            if(futureContracts == null)
             {
-                // we find at the money (ATM) put contract with farthest expiration
-                var atmContract = chain
-                    .OrderByDescending(x => x.Expiry)
-                    .ThenBy(x => Math.Abs(chain.Underlying.Price - x.Strike))
-                    .ThenByDescending(x => x.Right)
-                    .FirstOrDefault();
-
-                if (atmContract != null)
-                {
-                    // during warmup, using daily resolution (with the same TZ as the algorithm) the last bar.EndTime of warmup
-                    // overlaps with the algorithm start time, considered not to be in warmup anymore.
-                    // This bar would also be emitted by lean if no warmup was set and daily resolution used, see 'BasicTemplateDailyAlgorithm'
-                    if (Time <= StartDate)
-                    {
-                        if(atmContract.LastPrice == 0)
-                        {
-                            throw new Exception("Contract price is not set!");
-                        }
-                        OptionWarmupTimes.Add(Time);
-                    }
-                    else if (!Portfolio.Invested && IsMarketOpen(_optionSymbol))
-                    {
-                        // if found, trade it
-                        MarketOrder(atmContract.Symbol, 1);
-                        MarketOnCloseOrder(atmContract.Symbol, -1);
-                    }
-                }
+                return;
             }
-        }
+            var futureSymbols = futureContracts.Select(future => future.Symbol).ToHashSet();
 
-        public override void OnEndOfAlgorithm()
-        {
-            var start = new DateTime(2015, 12, 23, 9, 31, 0);
-            var end = new DateTime(2015, 12, 23, 16, 0, 0);
-            var count = 0;
-            do
+            if (futureSymbols.Count > 2)
             {
-                if (OptionWarmupTimes[count] != start)
-                {
-                    throw new Exception($"Unexpected time {OptionWarmupTimes[count]} expected {start}");
-                }
-                count++;
-                start = start.AddMinutes(1);
+                throw new Exception($"At {Time} found {futureSymbols.Count}. Future symbols: [{string.Join(",", futureSymbols)}]");
             }
-            while (start < end);
         }
 
         /// <summary>
@@ -113,7 +90,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public virtual long DataPoints => 1111432;
+        public long DataPoints => 14931;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -123,9 +100,9 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
-        public virtual Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "2"},
+            {"Total Trades", "0"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
             {"Compounding Annual Return", "0%"},
@@ -141,12 +118,12 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "0"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "0"},
-            {"Tracking Error", "0"},
+            {"Information Ratio", "-66.775"},
+            {"Tracking Error", "0.243"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$2.00"},
-            {"Estimated Strategy Capacity", "$1300000.00"},
-            {"Lowest Capacity Asset", "GOOCV 30AKMEIPOSS1Y|GOOCV VP83T1ZUHROL"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
@@ -166,7 +143,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "9d9f9248ee8fe30d87ff0a6f6fea5112"}
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureNoTimeInUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureNoTimeInUniverseRegressionAlgorithm.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Algorithm.CSharp
             }
             var futureSymbols = futureContracts.Select(future => future.Symbol).ToHashSet();
 
-            if (futureSymbols.Count > 2)
+            if (futureSymbols.Count > 1)
             {
                 throw new Exception($"At {Time} found {futureSymbols.Count}. Future symbols: [{string.Join(",", futureSymbols)}]");
             }

--- a/Algorithm.CSharp/OptionRenameRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionRenameRegressionAlgorithm.cs
@@ -141,7 +141,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 297191;
+        public long DataPoints => 297190;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -173,7 +173,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0.001"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$4.00"},
-            {"Estimated Strategy Capacity", "$760000.00"},
+            {"Estimated Strategy Capacity", "$620000.00"},
             {"Lowest Capacity Asset", "NWSA VJ5IKAXU7WBQ|NWSA T3MO1488O0H1"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},

--- a/Algorithm.CSharp/WarmupOptionResolutionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WarmupOptionResolutionRegressionAlgorithm.cs
@@ -50,6 +50,6 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 1037073;
+        public override long DataPoints => 1036943;
     }
 }

--- a/Algorithm.Framework/Selection/OptionUniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/OptionUniverseSelectionModel.py
@@ -86,7 +86,7 @@ class OptionUniverseSelectionModel(UniverseSelectionModel):
         # force option chain security to not be directly tradable AFTER it's configured to ensure it's not overwritten
         optionChain.IsTradable = False
 
-        return OptionChainUniverse(optionChain, settings, algorithm.LiveMode)
+        return OptionChainUniverse(optionChain, settings)
 
     def CreateOptionChainSecurity(self, algorithm, symbol, settings):
         '''Creates the canonical option chain security for a given symbol

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1712,7 +1712,7 @@ namespace QuantConnect.Algorithm
                 if (!UniverseManager.TryGetValue(symbol, out universe) && !IsAlreadyPending(symbol))
                 {
                     var canonicalConfig = configs.First();
-                    var settings = new UniverseSettings(canonicalConfig.Resolution, leverage, fillDataForward, extendedMarketHours, TimeSpan.Zero);
+                    var settings = new UniverseSettings(canonicalConfig.Resolution, leverage, fillDataForward, extendedMarketHours, UniverseSettings.MinimumTimeInUniverse);
                     if (symbol.SecurityType.IsOption())
                     {
                         universe = new OptionChainUniverse((Option)security, settings, LiveMode);

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1715,7 +1715,7 @@ namespace QuantConnect.Algorithm
                     var settings = new UniverseSettings(canonicalConfig.Resolution, leverage, fillDataForward, extendedMarketHours, UniverseSettings.MinimumTimeInUniverse);
                     if (symbol.SecurityType.IsOption())
                     {
-                        universe = new OptionChainUniverse((Option)security, settings, LiveMode);
+                        universe = new OptionChainUniverse((Option)security, settings);
                     }
                     else
                     {

--- a/Common/Data/UniverseSelection/FuturesChainUniverse.cs
+++ b/Common/Data/UniverseSelection/FuturesChainUniverse.cs
@@ -87,41 +87,6 @@ namespace QuantConnect.Data.UniverseSelection
         }
 
         /// <summary>
-        /// Determines whether or not the specified security can be removed from
-        /// this universe. This is useful to prevent securities from being taken
-        /// out of a universe before the algorithm has had enough time to make
-        /// decisions on the security
-        /// </summary>
-        /// <param name="utcTime">The current utc time</param>
-        /// <param name="security">The security to check if its ok to remove</param>
-        /// <returns>True if we can remove the security, false otherwise</returns>
-        public override bool CanRemoveMember(DateTime utcTime, Security security)
-        {
-            // can always remove securities after dispose requested
-            if (DisposeRequested)
-            {
-                return true;
-            }
-
-            // if we haven't begun receiving data for this security then it's safe to remove
-            var lastData = security.Cache.GetData();
-            if (lastData == null)
-            {
-                return true;
-            }
-
-            // only remove members on day changes, this prevents us from needing to
-            // fast forward contracts continuously as price moves and out filtered
-            // contracts change thoughout the day
-            var localTime = utcTime.ConvertFromUtc(security.Exchange.TimeZone);
-            if (localTime.Date != lastData.Time.Date)
-            {
-                return true;
-            }
-            return false;
-        }
-
-        /// <summary>
         /// Gets the subscription requests to be added for the specified security
         /// </summary>
         /// <param name="security">The security to get subscriptions for</param>

--- a/Common/Data/UniverseSelection/OptionChainUniverse.cs
+++ b/Common/Data/UniverseSelection/OptionChainUniverse.cs
@@ -30,30 +30,23 @@ namespace QuantConnect.Data.UniverseSelection
     {
         private readonly OptionFilterUniverse _optionFilterUniverse;
         private readonly UniverseSettings _universeSettings;
-        private readonly bool _liveMode;
         // as an array to make it easy to prepend to selected symbols
         private readonly Symbol[] _underlyingSymbol;
         private DateTime _cacheDate;
         private DateTime _lastExchangeDate;
-
-        // used for time-based removals in live mode
-        private readonly Dictionary<Symbol, DateTime> _addTimesBySymbol = new Dictionary<Symbol, DateTime>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OptionChainUniverse"/> class
         /// </summary>
         /// <param name="option">The canonical option chain security</param>
         /// <param name="universeSettings">The universe settings to be used for new subscriptions</param>
-        /// <param name="liveMode">True if we're running in live mode, false for backtest mode</param>
         public OptionChainUniverse(Option option,
-            UniverseSettings universeSettings,
-            bool liveMode)
+            UniverseSettings universeSettings)
             : base(option.SubscriptionDataConfig)
         {
             Option = option;
             _underlyingSymbol = new[] { Option.Symbol.Underlying };
             _universeSettings = new UniverseSettings(universeSettings) { DataNormalizationMode = DataNormalizationMode.Raw };
-            _liveMode = liveMode;
             _optionFilterUniverse = new OptionFilterUniverse();
         }
 
@@ -131,14 +124,7 @@ namespace QuantConnect.Data.UniverseSelection
                 Securities.TryRemove(security.Symbol, out member);
             }
 
-            var added = Securities.TryAdd(security.Symbol, new Member(utcTime, security, isInternal));
-
-            if (added && _liveMode)
-            {
-                _addTimesBySymbol[security.Symbol] = utcTime;
-            }
-
-            return added;
+            return Securities.TryAdd(security.Symbol, new Member(utcTime, security, isInternal));
         }
 
         /// <summary>

--- a/Common/Data/UniverseSelection/Universe.cs
+++ b/Common/Data/UniverseSelection/Universe.cs
@@ -141,6 +141,13 @@ namespace QuantConnect.Data.UniverseSelection
                 return true;
             }
 
+            // if we haven't begun receiving data for this security then it's safe to remove
+            var lastData = security.Cache.GetData();
+            if (lastData == null)
+            {
+                return true;
+            }
+
             Member member;
             if (Securities.TryGetValue(security.Symbol, out member))
             {

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -3518,7 +3518,7 @@ namespace QuantConnect
             // force option chain security to not be directly tradable AFTER it's configured to ensure it's not overwritten
             optionChain.IsTradable = false;
 
-            return new OptionChainUniverse(optionChain, settings, algorithm.LiveMode);
+            return new OptionChainUniverse(optionChain, settings);
         }
 
         /// <summary>

--- a/Tests/Common/Data/UniverseSelection/UniverseTests.cs
+++ b/Tests/Common/Data/UniverseSelection/UniverseTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -52,6 +52,7 @@ namespace QuantConnect.Tests.Common.Data.UniverseSelection
                 ErrorCurrencyConverter.Instance,
                 RegisteredSecurityDataTypesProvider.Null,
                 new SecurityCache());
+            _security.SetMarketPrice(new TradeBar(new DateTime(2022, 10, 10), _security.Symbol, 1, 1, 1, 1, 1));
         }
 
         [Test]

--- a/Tests/Engine/DataFeeds/Enumerators/DataQueueOptionChainUniverseDataCollectionEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/DataQueueOptionChainUniverseDataCollectionEnumeratorTests.cs
@@ -167,7 +167,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             option.Underlying = underlying;
 
             var universeSettings = new UniverseSettings(resolution, 0, true, false, TimeSpan.Zero);
-            var universe = new OptionChainUniverse(option, universeSettings, liveMode: false);
+            var universe = new OptionChainUniverse(option, universeSettings);
             return new SubscriptionRequest(true, universe, option, config, startTime, Time.EndOfTime);
         }
 

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/OptionChainUniverseSubscriptionEnumeratorFactoryTests.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             var factory = new OptionChainUniverseSubscriptionEnumeratorFactory(underlyingEnumeratorFunc, symbolUniverse, timeProvider);
 
             var universeSettings = new UniverseSettings(Resolution.Minute, 0, true, false, TimeSpan.Zero);
-            var universe = new OptionChainUniverse(option, universeSettings, true);
+            var universe = new OptionChainUniverse(option, universeSettings);
             var request = new SubscriptionRequest(true, universe, option, config, startTime, Time.EndOfTime);
             var enumerator = (DataQueueOptionChainUniverseDataCollectionEnumerator) factory.CreateEnumerator(request, TestGlobals.DataProvider);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Normalize Option & Future chain universe behavior regarding their assets time in universe. They will now respect the universe settings time in universe value. Adding new regression algorithms asserting the behavior
- Updating existing option algorithms which were removing option when the last data point of the security was of a different date than the selection time, which might be later than the default minimum time in universe of 1 day
```
            var localTime = utcTime.ConvertFromUtc(security.Exchange.TimeZone);
            if (localTime.Date != lastData.Time.Date)
```

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/6294
Closes https://github.com/QuantConnect/Lean/issues/6653
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
N/A
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added & existing tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
