### PR TITLE
Changes SuperTrend Type from TradeBarIndicator to BarIndicator

### DIFF
--- a/Indicators/SuperTrend.cs
+++ b/Indicators/SuperTrend.cs
@@ -22,7 +22,7 @@ namespace QuantConnect.Indicators
     /// Formula can be found here via the excel file:
     /// https://tradingtuitions.com/supertrend-indicator-excel-sheet-with-realtime-buy-sell-signals/
     /// </summary>
-    public class SuperTrend : TradeBarIndicator, IIndicatorWarmUpPeriodProvider
+    public class SuperTrend : BarIndicator, IIndicatorWarmUpPeriodProvider
     {
         private readonly decimal _multiplier;
         private decimal _superTrend;
@@ -100,7 +100,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="input">The input given to the indicator</param>
         /// <returns>A new value for this indicator</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             if (!_averageTrueRange.Update(input))
             {

--- a/Tests/Indicators/SuperTrendTests.cs
+++ b/Tests/Indicators/SuperTrendTests.cs
@@ -21,9 +21,9 @@ using QuantConnect.Indicators;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class SuperTrendTests : CommonIndicatorTests<TradeBar>
+    public class SuperTrendTests : CommonIndicatorTests<IBaseDataBar>
     {
-        protected override IndicatorBase<TradeBar> CreateIndicator()
+        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
             return new SuperTrend(10,3);
         }
@@ -32,7 +32,7 @@ namespace QuantConnect.Tests.Indicators
 
         protected override string TestColumnName => "Super";
 
-        protected override Action<IndicatorBase<TradeBar>, double> Assertion
+        protected override Action<IndicatorBase<IBaseDataBar>, double> Assertion
         {
             get { return (indicator, expected) => Assert.AreEqual(expected, (double)indicator.Current.Value, 0.05); }
         }


### PR DESCRIPTION
#### Description
Changes the` SuperTrend` type from `TradeBarIndicator` to `BarIndicator` since it doesn't need the `Volume`.

#### Motivation and Context
Bug fix. We cannot use `SuperTrend` with Forex and CFD, since these assets don't support trade bar data.

#### Requires Documentation Change
Yes, but it's code-generated.

#### How Has This Been Tested?
Current Unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`