### PR TITLE
Fix appply options filter on market open when using OnlyApplyFilterAtMarketOpen

### DIFF
--- a/Algorithm.CSharp/AddOptionWithOnMarketOpenOnlyFilterRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddOptionWithOnMarketOpenOnlyFilterRegressionAlgorithm.cs
@@ -1,0 +1,147 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Algorithm asserting that using OnlyApplyFilterAtMarketOpen along with other dynamic filters will make the filters be applied only on market
+    /// open, regardless of the order of configuration of the filters
+    /// </summary>
+    public class AddOptionWithOnMarketOpenOnlyFilterRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2014, 6, 5);
+            SetEndDate(2014, 6, 10);
+
+            // OnlyApplyFilterAtMarketOpen as first filter
+            AddOption("AAPL", Resolution.Minute).SetFilter(u =>
+                u.OnlyApplyFilterAtMarketOpen()
+                 .Strikes(-5, 5)
+                 .Expiration(0, 100)
+                 .IncludeWeeklys());
+
+            // OnlyApplyFilterAtMarketOpen as last filter
+            AddOption("TWX", Resolution.Minute).SetFilter(u =>
+                u.Strikes(-5, 5)
+                 .Expiration(0, 100)
+                 .IncludeWeeklys()
+                 .OnlyApplyFilterAtMarketOpen());
+        }
+
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            // This will be the first call, the underlying securities are added.
+            if (changes.AddedSecurities.All(s => s.Type != SecurityType.Option))
+            {
+                return;
+            }
+
+            var changeOptions = changes.AddedSecurities.Concat(changes.RemovedSecurities)
+                                                                        .Where(s => s.Type == SecurityType.Option);
+
+            // Susbtract one minute to get the actual market open. If market open is at 9:30am, this will be invoked at 9:31am
+            var expectedTime = Time.TimeOfDay - TimeSpan.FromMinutes(1);
+            var allOptionsWereChangedOnMarketOpen = changeOptions.All(s =>
+            {
+                var firstMarketSegment = s.Exchange.Hours.MarketHours[Time.DayOfWeek].Segments
+                                                         .First(segment => segment.State == MarketHoursState.Market);
+
+                return firstMarketSegment.Start == expectedTime;
+            });
+
+            if (!allOptionsWereChangedOnMarketOpen)
+            {
+                throw new Exception("Expected options filter to be run only on market open");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all time slices of algorithm
+        /// </summary>
+        public long DataPoints => 3338420;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-10.144"},
+            {"Tracking Error", "0.033"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Common/Securities/ContractSecurityFilterUniverse.cs
+++ b/Common/Securities/ContractSecurityFilterUniverse.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -30,6 +30,11 @@ namespace QuantConnect.Securities
     public abstract class ContractSecurityFilterUniverse<T> : IDerivativeSecurityFilterUniverse
     where T: ContractSecurityFilterUniverse<T>
     {
+        /// <summary>
+        /// Mark this filter to be applied only on market open, even if it's dynamic
+        /// </summary>
+        private bool _onlyApplyOnMarketOpen;
+
         /// <summary>
         /// Defines listed contract types with Flags attribute
         /// </summary>
@@ -73,7 +78,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// True if the universe is dynamic and filter needs to be reapplied
         /// </summary>
-        public bool IsDynamic => IsDynamicInternal;
+        public bool IsDynamic => IsDynamicInternal && !_onlyApplyOnMarketOpen;
 
         /// <summary>
         /// The underlying price data
@@ -163,6 +168,7 @@ namespace QuantConnect.Securities
             UnderlyingInternal = underlying;
             Type = ContractExpirationType.Standard;
             IsDynamicInternal = false;
+            _onlyApplyOnMarketOpen = false;
         }
 
         /// <summary>
@@ -316,7 +322,7 @@ namespace QuantConnect.Securities
         /// <returns>Universe with filter applied</returns>
         public T OnlyApplyFilterAtMarketOpen()
         {
-            IsDynamicInternal = false;
+            _onlyApplyOnMarketOpen = true;
             return (T) this;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Option filter OnlyApplyFilterAtMarketOpen makes it apply filters on market open only, regardless of the order of configuration of the filters.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6729 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Regression algorithm

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
