### PR TITLE
Make `PlotIndicator` able to receive IndicatorBase

### DIFF
--- a/Algorithm/QCAlgorithm.Plotting.cs
+++ b/Algorithm/QCAlgorithm.Plotting.cs
@@ -264,8 +264,7 @@ namespace QuantConnect.Algorithm
         /// </summary>
         [DocumentationAttribute(Charting)]
         [DocumentationAttribute(Indicators)]
-        public void PlotIndicator<T>(string chart, params IndicatorBase<T>[] indicators)
-            where T : IBaseData
+        public void PlotIndicator(string chart, params IndicatorBase[] indicators)
         {
             foreach (var i in indicators)
             {
@@ -285,8 +284,7 @@ namespace QuantConnect.Algorithm
         /// </summary>
         [DocumentationAttribute(Charting)]
         [DocumentationAttribute(Indicators)]
-        public void PlotIndicator<T>(string chart, bool waitForReady, params IndicatorBase<T>[] indicators)
-            where T : IBaseData
+        public void PlotIndicator(string chart, bool waitForReady, params IndicatorBase[] indicators)
         {
             foreach (var i in indicators)
             {

--- a/Algorithm/QCAlgorithm.Plotting.cs
+++ b/Algorithm/QCAlgorithm.Plotting.cs
@@ -266,17 +266,7 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(Indicators)]
         public void PlotIndicator(string chart, params IndicatorBase[] indicators)
         {
-            foreach (var i in indicators)
-            {
-                if (i == null) continue;
-
-                // copy loop variable for usage in closure
-                var ilocal = i;
-                i.Updated += (sender, args) =>
-                {
-                    Plot(chart, ilocal);
-                };
-            }
+            PlotIndicator(chart, false, indicators);
         }
 
         /// <summary>

--- a/Tests/Algorithm/AlgorithmPlottingTests.cs
+++ b/Tests/Algorithm/AlgorithmPlottingTests.cs
@@ -200,5 +200,25 @@ class CustomIndicator:
                 Assert.AreEqual(10, charts.First().Series["PlotTest"].Values.First().y);
             }
         }
+
+        [Test]
+        public void PlotIndicatorPlotsBaseIndicator()
+        {
+            var sma1 = new SimpleMovingAverage(1);
+            var sma2 = new SimpleMovingAverage(1);
+            var ratio = sma1.Over(sma2);
+
+            Assert.DoesNotThrow(() => _algorithm.PlotIndicator("PlotTest", ratio));
+
+            sma1.Update(new DateTime(2022, 11, 15), 1);
+            sma2.Update(new DateTime(2022, 11, 15), 2);
+
+            var charts = _algorithm.GetChartUpdates();
+            Assert.IsTrue(charts.Where(x => x.Name == "PlotTest").Any());
+
+            var chart = charts.First();
+            Assert.AreEqual("PlotTest", chart.Name);
+            Assert.AreEqual(sma1.Current.Value / sma2.Current.Value, chart.Series[ratio.Name].Values.First().y);
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

`PlotIndicator` was receiving `IndicatorBase<T>` instead of `IndicatorBase` so plotting indicators from extensions like `Over()` was not possible.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6730 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests
Manual tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
