### PR TITLE
Removes Volatility Model Warm Up Requirement

### DIFF
--- a/Algorithm.CSharp/DefaultOptionPriceModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DefaultOptionPriceModelRegressionAlgorithm.cs
@@ -30,12 +30,9 @@ namespace QuantConnect.Algorithm.CSharp
     {
         public override void Initialize()
         {
-            SetStartDate(2015, 12, 24);
-            SetEndDate(2015, 12, 24);
+            SetStartDate(2021, 1, 4);
+            SetEndDate(2021, 1, 4);
             SetCash(100000);
-
-            AddEquity("SPY");
-            AddOption("SPY");
 
             AddIndex("SPX");
             AddIndexOption("SPX");
@@ -67,7 +64,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 13;
+        public long DataPoints => 7118;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -656,19 +656,6 @@ namespace QuantConnect.Algorithm
                 // For backward compatibility we need to refresh the security DataNormalizationMode Property
                 security.RefreshDataNormalizationModeProperty();
             }
-
-            // ensure a volatility model has been set on the underlying
-            if (security.VolatilityModel == VolatilityModel.Null)
-            {
-                var config = configs.FirstOrDefault();
-                var bar = config?.Type.GetBaseDataInstance() ?? typeof(TradeBar).GetBaseDataInstance();
-                bar.Symbol = security.Symbol;
-                
-                var maxSupportedResolution = bar.SupportedResolutions().Max();
-                var updateFrequency = maxSupportedResolution.ToTimeSpan();
-                
-                security.VolatilityModel = new StandardDeviationOfReturnsVolatilityModel(maxSupportedResolution, updateFrequency);
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
#### Description
If the volatility model is not ready, we will use the Brenner and Subrahmanyam (1988) approximation (BS88).
Lean will not set the volatility model if the user doesn't, since the BS88 can handle the null model case

#### Related Issue
Ref.: #5838 #6720

#### Motivation and Context
See #6720

#### Requires Documentation Change
See #6720

#### How Has This Been Tested?
Regression test

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`