### PR TITLE
Allow optional selector in classic renko consolidator in Python and C#

### DIFF
--- a/Common/Data/Consolidators/ClassicRenkoConsolidator.cs
+++ b/Common/Data/Consolidators/ClassicRenkoConsolidator.cs
@@ -140,30 +140,33 @@ namespace QuantConnect.Data.Consolidators
             bool evenBars = true)
             : this(barSize, evenBars)
         {
-            if (selector != null)
+            using (Py.GIL())
             {
-                if (!selector.TryConvertToDelegate(out _selector))
+                if (selector != null && !selector.IsNone())
                 {
-                    throw new ArgumentException(
-                        "Unable to convert parameter 'selector' to delegate type Func<IBaseData, decimal>");
+                    if (!selector.TryConvertToDelegate(out _selector))
+                    {
+                        throw new ArgumentException(
+                            "Unable to convert parameter 'selector' to delegate type Func<IBaseData, decimal>");
+                    }
                 }
-            }
-            else
-            {
-                _selector = x => x.Value;
-            }
+                else
+                {
+                    _selector = x => x.Value;
+                }
 
-            if (volumeSelector != null)
-            {
-                if (!volumeSelector.TryConvertToDelegate(out _volumeSelector))
+                if (volumeSelector != null && !volumeSelector.IsNone())
                 {
-                    throw new ArgumentException(
-                        "Unable to convert parameter 'volumeSelector' to delegate type Func<IBaseData, decimal>");
+                    if (!volumeSelector.TryConvertToDelegate(out _volumeSelector))
+                    {
+                        throw new ArgumentException(
+                            "Unable to convert parameter 'volumeSelector' to delegate type Func<IBaseData, decimal>");
+                    }
                 }
-            }
-            else
-            {
-                _volumeSelector = x => 0;
+                else
+                {
+                    _volumeSelector = x => 0;
+                }
             }
         }
 
@@ -282,7 +285,7 @@ namespace QuantConnect.Data.Consolidators
             : this(barSize, x => x.Value, x => 0, evenBars)
         {
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassicRenkoConsolidator"/> class using the specified <paramref name="barSize"/>.
         /// The value selector will by default select <see cref="IBaseData.Value"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Allowing optional selector in `ClassicRenkoConsolidator` in Python and C# (with `None` and `null`).

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6751 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
