### PR TITLE
Allows Market-On-Close Orders Outside Buffer Period

### DIFF
--- a/Algorithm.CSharp/MarketOnCloseOrderBufferExtendedMarketHoursRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MarketOnCloseOrderBufferExtendedMarketHoursRegressionAlgorithm.cs
@@ -22,10 +22,14 @@ using QuantConnect.Orders;
 
 namespace QuantConnect.Algorithm.CSharp
 {
-    public class MarketOnCloseOrderBufferRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    /// <summary>
+    /// See <see cref="MarketOnCloseOrderBufferExtendedMarketHoursRegressionAlgorithm"/>
+    /// </summary>
+    public class MarketOnCloseOrderBufferExtendedMarketHoursRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private OrderTicket _validOrderTicket;
         private OrderTicket _invalidOrderTicket;
+        private OrderTicket _validOrderTicketAtMidnight;
         private OrderTicket _validOrderTicketExtendedMarketHours;
 
         public override void Initialize()
@@ -34,11 +38,11 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2013, 10, 8); //Set End Date
 
             var ticker = "SPY";
-            AddEquity(ticker, Resolution.Minute);
+            AddEquity(ticker, Resolution.Minute, extendedMarketHours: true);
 
-            Schedule.On(DateRules.Today, TimeRules.At(17,00), () =>
+            Schedule.On(DateRules.Tomorrow, TimeRules.Midnight, () =>
             {
-                _validOrderTicketExtendedMarketHours = MarketOnCloseOrder("SPY", 2);
+                _validOrderTicketAtMidnight = MarketOnCloseOrder("SPY", 2);
             });
 
             // Modify our submission buffer time to 10 minutes
@@ -60,6 +64,12 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 // Will throw an order error and be marked invalid
                 _invalidOrderTicket = MarketOnCloseOrder("SPY", 2);
+            }
+
+            if (Time.Hour == 16 && Time.Minute == 48 && _validOrderTicketExtendedMarketHours == null)
+            {
+                // Will not throw an order error and execute
+                _validOrderTicketExtendedMarketHours = MarketOnCloseOrder("SPY", 2);
             }
         }
 
@@ -85,6 +95,12 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 throw new Exception("Valid order during extended market hours failed to fill");
             }
+
+            // Verify that our third good order filled
+            if (_validOrderTicketAtMidnight.Status != OrderStatus.Filled)
+            {
+                throw new Exception("Valid order at midnight failed to fill");
+            }
         }
 
         /// <summary>
@@ -100,7 +116,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 1582;
+        public long DataPoints => 3862;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -112,7 +128,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new()
         {
-            {"Total Trades", "2"},
+            {"Total Trades", "3"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
             {"Compounding Annual Return", "0%"},
@@ -131,15 +147,15 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$2.00"},
-            {"Estimated Strategy Capacity", "$18000000000.00"},
+            {"Total Fees", "$3.00"},
+            {"Estimated Strategy Capacity", "$910000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
-            {"Fitness Score", "0.001"},
+            {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "79228162514264337593543950335"},
-            {"Return Over Maximum Drawdown", "-261.069"},
-            {"Portfolio Turnover", "0.002"},
+            {"Sortino Ratio", "-46.084"},
+            {"Return Over Maximum Drawdown", "-198.32"},
+            {"Portfolio Turnover", "0.004"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
             {"Total Insights Analysis Completed", "0"},
@@ -153,7 +169,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "1a356e0edb136b31a7f12c661cf5de74"}
+            {"OrderListHash", "21a9fc316b33b82d2d99c508040649cd"}
         };
     }
 }

--- a/Algorithm.CSharp/MarketOnCloseOrderBufferExtendedMarketHoursRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MarketOnCloseOrderBufferExtendedMarketHoursRegressionAlgorithm.cs
@@ -23,7 +23,8 @@ using QuantConnect.Orders;
 namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
-    /// See <see cref="MarketOnCloseOrderBufferExtendedMarketHoursRegressionAlgorithm"/>
+    /// This regression test is a version of <see cref="MarketOnCloseOrderBufferRegressionAlgorithm"/>
+    /// where we test market-on-close modeling with data from the post market.
     /// </summary>
     public class MarketOnCloseOrderBufferExtendedMarketHoursRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {

--- a/Algorithm.CSharp/MarketOnCloseOrderBufferRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MarketOnCloseOrderBufferRegressionAlgorithm.cs
@@ -26,14 +26,20 @@ namespace QuantConnect.Algorithm.CSharp
     {
         private OrderTicket _validOrderTicket;
         private OrderTicket _invalidOrderTicket;
+        private OrderTicket _validOrderTicketAtMidnight;
 
         public override void Initialize()
         {
-            SetStartDate(2013, 10, 4); //Set Start Date
-            SetEndDate(2013, 10, 4); //Set End Date
+            SetStartDate(2013, 10, 7); //Set Start Date
+            SetEndDate(2013, 10, 8); //Set End Date
 
             var ticker = "SPY";
             AddEquity(ticker, Resolution.Minute);
+
+            Schedule.On(DateRules.Tomorrow, TimeRules.Midnight, () =>
+            {
+                _validOrderTicketAtMidnight = MarketOnCloseOrder("SPY", 2);
+            });
 
             // Modify our submission buffer time to 10 minutes
             Orders.MarketOnCloseOrder.SubmissionTimeBuffer = TimeSpan.FromMinutes(10);
@@ -44,14 +50,13 @@ namespace QuantConnect.Algorithm.CSharp
             // Test our ability to submit MarketOnCloseOrders
             // Because we set our buffer to 10 minutes, any order placed
             // before 3:50PM should be accepted, any after marked invalid
-
-            if (Time.Hour == 15 && Time.Minute == 49)
+            if (Time.Hour == 15 && Time.Minute == 49 && _validOrderTicket == null)
             {
                 // Will not throw an order error and execute
                 _validOrderTicket = MarketOnCloseOrder("SPY", 2);
             }
 
-            if (Time.Hour == 15 && Time.Minute == 51)
+            if (Time.Hour == 15 && Time.Minute == 51 && _invalidOrderTicket == null)
             {
                 // Will throw an order error and be marked invalid
                 _invalidOrderTicket = MarketOnCloseOrder("SPY", 2);
@@ -74,6 +79,12 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 throw new Exception("Invalid order was not rejected");
             }
+
+            // Verify that our second good order filled
+            if (_validOrderTicketAtMidnight.Status != OrderStatus.Filled)
+            {
+                throw new Exception("Valid order at midnight failed to fill");
+            }
         }
 
         /// <summary>
@@ -89,7 +100,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 795;
+        public long DataPoints => 1582;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -99,9 +110,9 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
-        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        public Dictionary<string, string> ExpectedStatistics => new()
         {
-            {"Total Trades", "1"},
+            {"Total Trades", "2"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
             {"Compounding Annual Return", "0%"},
@@ -120,15 +131,15 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$1.00"},
-            {"Estimated Strategy Capacity", "$23000000000.00"},
+            {"Total Fees", "$2.00"},
+            {"Estimated Strategy Capacity", "$18000000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
-            {"Fitness Score", "0"},
+            {"Fitness Score", "0.001"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "0"},
-            {"Return Over Maximum Drawdown", "0"},
-            {"Portfolio Turnover", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "-261.069"},
+            {"Portfolio Turnover", "0.002"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
             {"Total Insights Analysis Completed", "0"},
@@ -142,7 +153,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "8c2178d2b47a3773c217e9d0e3eaa179"}
+            {"OrderListHash", "7face6a6dd09558cebc2b3c7d63f0e33"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionChainConsistencyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionChainConsistencyRegressionAlgorithm.cs
@@ -172,7 +172,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "b657be3f1b7f7f59cc7f260c99a89d00"}
+            {"OrderListHash", "9eb3755d30e065aca2cafd3a25498d3e"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionOpenInterestRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionOpenInterestRegressionAlgorithm.cs
@@ -170,7 +170,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "f9eae263aaa6586eabfd09bb2ae96175"}
+            {"OrderListHash", "78074d21830f357128c4309fd6f9793f"}
         };
     }
 }

--- a/Algorithm.Python/MarketOnCloseOrderBufferExtendedMarketHoursRegressionAlgorithm.py
+++ b/Algorithm.Python/MarketOnCloseOrderBufferExtendedMarketHoursRegressionAlgorithm.py
@@ -14,7 +14,8 @@
 from AlgorithmImports import *
 
 class MarketOnCloseOrderBufferExtendedMarketHoursRegressionAlgorithm(QCAlgorithm):
-    '''See MarketOnCloseOrderBufferRegressionAlgorithm'''
+    '''This regression test is a version of "MarketOnCloseOrderBufferRegressionAlgorithm"
+     where we test market-on-close modeling with data from the post market.'''
     validOrderTicket = None
     invalidOrderTicket = None
     validOrderTicketExtendedMarketHours = None

--- a/Algorithm.Python/MarketOnCloseOrderBufferExtendedMarketHoursRegressionAlgorithm.py
+++ b/Algorithm.Python/MarketOnCloseOrderBufferExtendedMarketHoursRegressionAlgorithm.py
@@ -13,21 +13,23 @@
 
 from AlgorithmImports import *
 
-class MarketOnCloseOrderBufferRegressionAlgorithm(QCAlgorithm):
+class MarketOnCloseOrderBufferExtendedMarketHoursRegressionAlgorithm(QCAlgorithm):
+    '''See MarketOnCloseOrderBufferRegressionAlgorithm'''
     validOrderTicket = None
     invalidOrderTicket = None
+    validOrderTicketExtendedMarketHours = None
 
     def Initialize(self):
         self.SetStartDate(2013,10,7)   #Set Start Date
         self.SetEndDate(2013,10,8)    #Set End Date
 
-        self.AddEquity("SPY", Resolution.Minute)
+        self.AddEquity("SPY", Resolution.Minute, extendedMarketHours = True)
 
-        def mocAtPostMarket():
-            self.validOrderTicketExtendedMarketHours = self.MarketOnCloseOrder("SPY", 2)
+        def mocAtMidNight():
+            self.validOrderTicketAtMidnight = self.MarketOnCloseOrder("SPY", 2)
 
-        self.Schedule.On(self.DateRules.Today, self.TimeRules.At(17,0), mocAtPostMarket)
-                
+        self.Schedule.On(self.DateRules.Tomorrow, self.TimeRules.Midnight, mocAtMidNight)
+
         # Modify our submission buffer time to 10 minutes
         MarketOnCloseOrder.SubmissionTimeBuffer = timedelta(minutes=10)
 
@@ -43,6 +45,10 @@ class MarketOnCloseOrderBufferRegressionAlgorithm(QCAlgorithm):
         # Will throw an order error and be marked invalid
         if self.Time.hour == 15 and self.Time.minute == 51 and not self.invalidOrderTicket:
             self.invalidOrderTicket = self.MarketOnCloseOrder("SPY", 2)
+
+        # Will not throw an order error and execute
+        if self.Time.hour == 16 and self.Time.minute == 48 and not self.validOrderTicketExtendedMarketHours:
+            self.validOrderTicketExtendedMarketHours = self.MarketOnCloseOrder("SPY", 2)
 
     def OnEndOfAlgorithm(self):
         # Set it back to default for other regressions

--- a/Algorithm.Python/MarketOnCloseOrderBufferRegressionAlgorithm.py
+++ b/Algorithm.Python/MarketOnCloseOrderBufferRegressionAlgorithm.py
@@ -14,13 +14,20 @@
 from AlgorithmImports import *
 
 class MarketOnCloseOrderBufferRegressionAlgorithm(QCAlgorithm):
+    validOrderTicket = None
+    invalidOrderTicket = None
 
     def Initialize(self):
-        self.SetStartDate(2013,10,4)   #Set Start Date
-        self.SetEndDate(2013,10,4)    #Set End Date
+        self.SetStartDate(2013,10,7)   #Set Start Date
+        self.SetEndDate(2013,10,8)    #Set End Date
 
         self.AddEquity("SPY", Resolution.Minute)
 
+        def mocAtMidnight():
+            self.validOrderTicketAtMidnight = self.MarketOnCloseOrder("SPY", 2)
+
+        self.Schedule.On(self.DateRules.Tomorrow, self.TimeRules.Midnight, mocAtMidnight)
+            
         # Modify our submission buffer time to 10 minutes
         MarketOnCloseOrder.SubmissionTimeBuffer = timedelta(minutes=10)
 
@@ -30,11 +37,11 @@ class MarketOnCloseOrderBufferRegressionAlgorithm(QCAlgorithm):
         # before 3:50PM should be accepted, any after marked invalid
 
         # Will not throw an order error and execute
-        if self.Time.hour == 15 and self.Time.minute == 49:
+        if self.Time.hour == 15 and self.Time.minute == 49 and not self.validOrderTicket:
             self.validOrderTicket = self.MarketOnCloseOrder("SPY", 2)
 
         # Will throw an order error and be marked invalid
-        if self.Time.hour == 15 and self.Time.minute == 51:
+        if self.Time.hour == 15 and self.Time.minute == 51 and not self.invalidOrderTicket:
             self.invalidOrderTicket = self.MarketOnCloseOrder("SPY", 2)
 
     def OnEndOfAlgorithm(self):
@@ -46,3 +53,6 @@ class MarketOnCloseOrderBufferRegressionAlgorithm(QCAlgorithm):
 
         if self.invalidOrderTicket.Status != OrderStatus.Invalid:
             raise Exception("Invalid order was not rejected")
+
+        if self.validOrderTicketAtMidnight.Status != OrderStatus.Filled:
+            raise Exception("Valid order at midnight failed to fill")

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -804,14 +804,6 @@ namespace QuantConnect.Algorithm
 
             var price = security.Price;
 
-            //Check the exchange is open before sending a market on close orders
-            if (request.OrderType == OrderType.MarketOnClose && !security.Exchange.ExchangeOpen)
-            {
-                return OrderResponse.Error(request, OrderResponseErrorCode.ExchangeNotOpen,
-                    $"{request.OrderType} order and exchange not open."
-                );
-            }
-
             //Check the exchange is open before sending a exercise orders
             if (request.OrderType == OrderType.OptionExercise && !security.Exchange.ExchangeOpen)
             {
@@ -840,9 +832,8 @@ namespace QuantConnect.Algorithm
             }
 
             // check quote currency existence/conversion rate on all orders
-            Cash quoteCash;
             var quoteCurrency = security.QuoteCurrency.Symbol;
-            if (!Portfolio.CashBook.TryGetValue(quoteCurrency, out quoteCash))
+            if (!Portfolio.CashBook.TryGetValue(quoteCurrency, out var quoteCash))
             {
                 return OrderResponse.Error(request, OrderResponseErrorCode.QuoteCurrencyRequired,
                     $"{request.Symbol.Value}: requires {quoteCurrency} in the cashbook to trade."
@@ -858,9 +849,8 @@ namespace QuantConnect.Algorithm
             // need to also check base currency existence/conversion rate on forex orders
             if (security.Type == SecurityType.Forex || security.Type == SecurityType.Crypto)
             {
-                Cash baseCash;
                 var baseCurrency = ((IBaseCurrencySymbol)security).BaseCurrencySymbol;
-                if (!Portfolio.CashBook.TryGetValue(baseCurrency, out baseCash))
+                if (!Portfolio.CashBook.TryGetValue(baseCurrency, out var baseCash))
                 {
                     return OrderResponse.Error(request, OrderResponseErrorCode.ForexBaseAndQuoteCurrenciesRequired,
                         $"{request.Symbol.Value}: requires {baseCurrency} and {quoteCurrency} in the cashbook to trade."
@@ -940,7 +930,7 @@ namespace QuantConnect.Algorithm
 
                 // Enforce MarketOnClose submission buffer
                 var latestSubmissionTime = nextMarketClose.Subtract(Orders.MarketOnCloseOrder.SubmissionTimeBuffer);
-                if (!security.Exchange.ExchangeOpen || Time > latestSubmissionTime)
+                if (Time > latestSubmissionTime && nextMarketClose > Time)
                 {
                     // Tell user the required buffer on these orders, also inform them it can be changed for special cases.
                     // Default buffer is 15.5 minutes because with minute data a user will receive the 3:44->3:45 bar at 3:45,

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -930,7 +930,7 @@ namespace QuantConnect.Algorithm
 
                 // Enforce MarketOnClose submission buffer
                 var latestSubmissionTime = nextMarketClose.Subtract(Orders.MarketOnCloseOrder.SubmissionTimeBuffer);
-                if (Time > latestSubmissionTime && nextMarketClose > Time)
+                if (Time > latestSubmissionTime)
                 {
                     // Tell user the required buffer on these orders, also inform them it can be changed for special cases.
                     // Default buffer is 15.5 minutes because with minute data a user will receive the 3:44->3:45 bar at 3:45,

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -1384,7 +1384,7 @@ namespace QuantConnect.Tests.Algorithm
             algo.SetHoldings(Symbols.MSFT, 1.0m);
             algo.SetHoldings(Symbols.MSFT, 1.0f);
 
-            int expected = 35;
+            const int expected = 38;
             Assert.AreEqual(expected, algo.Transactions.LastOrderId);
         }
 


### PR DESCRIPTION
#### Description
Market-On-Close orders can be submitted before and after the buffer period from 15:45 to 16:00 (tested with TWS) meaning that we can submit MOC when the market is closed and, consequently, use daily resolution data.

#### Related Issue
Closes #6313

#### Motivation and Context
Bug fix. The demand for an open market doesn't model reality correctly.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Regression test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`