### PR TITLE
Basic template algorithm for continuous futures rollover

### DIFF
--- a/Algorithm.CSharp/BasicTemplateFutureRolloverAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFutureRolloverAlgorithm.cs
@@ -28,20 +28,19 @@ namespace QuantConnect.Algorithm.CSharp
     /// </summary>
     public class BasicTemplateFutureRolloverAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
-        private Dictionary<Future, ExponentialMovingAverage> _ema = new();
+        private Dictionary<Future, SymbolData> _symbolData = new();
 
         /// <summary>
         /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
         /// </summary>
         public override void Initialize()
         {
+            SetStartDate(2013, 10, 8);
+            SetEndDate(2014, 10, 10);
             SetCash(1000000);
-            SetStartDate(2020, 2, 1);
-            SetEndDate(2020, 4, 1);
 
             var futures = new List<string> {
-                Futures.Indices.SP500EMini,
-                Futures.Metals.Gold
+                Futures.Indices.SP500EMini
             };
 
             foreach (var future in futures)
@@ -55,9 +54,8 @@ namespace QuantConnect.Algorithm.CSharp
                     contractDepthOffset: 0
                 );
 
-                var ema = EMA(continuousContract.Symbol, 20, Resolution.Daily);
-                _ema.Add(continuousContract, ema);
-                Reset(continuousContract);
+                var symbolData = new SymbolData(this, continuousContract);
+                _symbolData.Add(continuousContract, symbolData);
             }
         }
 
@@ -67,7 +65,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
         public override void OnData(Slice slice)
         {
-            foreach (var kvp in _ema)
+            foreach (var kvp in _symbolData)
             {
                 var symbol = kvp.Key.Symbol;
                 
@@ -82,11 +80,11 @@ namespace QuantConnect.Algorithm.CSharp
                     Liquidate(oldSymbol, tag: tag);
                     MarketOrder(newSymbol, quantity, tag: tag);
 
-                    Reset(kvp.Key);
+                    kvp.Value.Reset();
                 }
 
                 var mappedSymbol = kvp.Key.Mapped;
-                var ema = kvp.Value;
+                var ema = kvp.Value.EMA;
 
                 if (mappedSymbol != null && slice.Bars.ContainsKey(symbol) && ema.IsReady)
                 {
@@ -102,12 +100,6 @@ namespace QuantConnect.Algorithm.CSharp
             }
         }
 
-        public void Reset(Future future)
-        {
-            _ema[future].Reset();
-            WarmUpIndicator(future.Symbol, _ema[future], Resolution.Daily);
-        }
-
         /// <summary>
         /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
         /// </summary>
@@ -121,46 +113,46 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 2857;
+        public long DataPoints => 5044;
 
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 0;
+        public int AlgorithmHistoryDataPoints => 35;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "33"},
-            {"Average Win", "2.33%"},
-            {"Average Loss", "-0.35%"},
-            {"Compounding Annual Return", "-0.644%"},
-            {"Drawdown", "4.400%"},
-            {"Expectancy", "-0.039"},
-            {"Net Profit", "-0.109%"},
-            {"Sharpe Ratio", "-0.011"},
-            {"Probabilistic Sharpe Ratio", "31.092%"},
-            {"Loss Rate", "88%"},
-            {"Win Rate", "12%"},
-            {"Profit-Loss Ratio", "6.69"},
-            {"Alpha", "-0.081"},
-            {"Beta", "-0.133"},
-            {"Annual Standard Deviation", "0.086"},
-            {"Annual Variance", "0.007"},
-            {"Information Ratio", "0.958"},
-            {"Tracking Error", "0.63"},
-            {"Treynor Ratio", "0.007"},
-            {"Total Fees", "$77.99"},
-            {"Estimated Strategy Capacity", "$190000000.00"},
-            {"Lowest Capacity Asset", "GC XE1Y0ZJ8NQ8T"},
-            {"Fitness Score", "0.039"},
+            {"Total Trades", "6"},
+            {"Average Win", "0.23%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0.682%"},
+            {"Drawdown", "0.000%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0.687%"},
+            {"Sharpe Ratio", "1.048"},
+            {"Probabilistic Sharpe Ratio", "55.116%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "100%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0.005"},
+            {"Beta", "0.001"},
+            {"Annual Standard Deviation", "0.005"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-1.307"},
+            {"Tracking Error", "0.089"},
+            {"Treynor Ratio", "7.068"},
+            {"Total Fees", "$12.90"},
+            {"Estimated Strategy Capacity", "$580000000000.00"},
+            {"Lowest Capacity Asset", "ES VP274HSU1AF5"},
+            {"Fitness Score", "0.001"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "-0.087"},
-            {"Return Over Maximum Drawdown", "-0.144"},
-            {"Portfolio Turnover", "0.081"},
+            {"Sortino Ratio", "7.656"},
+            {"Return Over Maximum Drawdown", "53.089"},
+            {"Portfolio Turnover", "0.001"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
             {"Total Insights Analysis Completed", "0"},
@@ -174,7 +166,27 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "960f2a002af87a34d20257aeb36ffbb5"}
+            {"OrderListHash", "c77e88c0f30ae1b07fd635292b4de1c9"}
         };
-    }
+
+        public class SymbolData
+        {
+            private QCAlgorithm _algorithm;
+            private Symbol _symbol;
+            public ExponentialMovingAverage EMA;
+
+            public SymbolData(QCAlgorithm algorithm, Future future)
+            {
+                _algorithm = algorithm;
+                _symbol = future.Symbol;
+                EMA = algorithm.EMA(future.Symbol, 20, Resolution.Daily);
+            }
+
+            public void Reset()
+            {
+                EMA.Reset();
+                _algorithm.WarmUpIndicator(_symbol, EMA, Resolution.Daily);
+            }
+        }
+    }  
 }

--- a/Algorithm.CSharp/BasicTemplateFutureRolloverAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFutureRolloverAlgorithm.cs
@@ -1,0 +1,152 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Future;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Example algorithm for trading continuous future
+    /// </summary>
+    public class BasicTemplateFutureRolloverAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Future _continuousContract;
+        private Symbol _symbol, _oldSymbol;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetCash(1000000);
+            SetStartDate(2019, 2, 1);
+            SetEndDate(2021, 6, 1);
+
+            // Requesting data
+            _continuousContract = AddFuture(Futures.Indices.SP500EMini,
+                dataNormalizationMode: DataNormalizationMode.BackwardsRatio,
+                dataMappingMode: DataMappingMode.OpenInterest,
+                contractDepthOffset: 0
+            );
+            _symbol = _continuousContract.Symbol;
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
+        {
+            // Accessing data
+            foreach (var changedEvent in slice.SymbolChangedEvents.Values)
+            {
+                if (changedEvent.Symbol == _symbol)
+                {
+                    _oldSymbol = changedEvent.OldSymbol;
+                    Log($"Symbol changed at {Time}: {_oldSymbol} -> {changedEvent.NewSymbol}");
+                }
+            }
+
+            var mappedSymbol = _continuousContract.Mapped;
+
+            if (!(slice.Bars.ContainsKey(_symbol) && mappedSymbol != null))
+            {
+                return;
+            }
+
+            // Rolling over: to liquidate any position of the old mapped contract and switch to the newly mapped contract
+            if (_oldSymbol != null)
+            {
+                Liquidate(_oldSymbol);
+                MarketOrder(mappedSymbol, 1);
+                _oldSymbol = null;
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 68645;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 340;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "17"},
+            {"Average Win", "1.41%"},
+            {"Average Loss", "-4.03%"},
+            {"Compounding Annual Return", "3.001%"},
+            {"Drawdown", "5.600%"},
+            {"Expectancy", "0.182"},
+            {"Net Profit", "7.144%"},
+            {"Sharpe Ratio", "0.737"},
+            {"Probabilistic Sharpe Ratio", "31.420%"},
+            {"Loss Rate", "12%"},
+            {"Win Rate", "88%"},
+            {"Profit-Loss Ratio", "0.35"},
+            {"Alpha", "-0.003"},
+            {"Beta", "0.138"},
+            {"Annual Standard Deviation", "0.029"},
+            {"Annual Variance", "0.001"},
+            {"Information Ratio", "-0.907"},
+            {"Tracking Error", "0.171"},
+            {"Treynor Ratio", "0.152"},
+            {"Total Fees", "$36.55"},
+            {"Estimated Strategy Capacity", "$58000000000.00"},
+            {"Lowest Capacity Asset", "ES XPFJZVPGHL35"},
+            {"Fitness Score", "0.002"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "0.962"},
+            {"Return Over Maximum Drawdown", "0.53"},
+            {"Portfolio Turnover", "0.003"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "8f92e1528c6477a156449fd1e86527e7"}
+        };
+    }
+}

--- a/Algorithm.CSharp/BasicTemplateFutureRolloverAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFutureRolloverAlgorithm.cs
@@ -108,7 +108,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+        public Language[] Languages { get; } = { Language.CSharp };
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm
@@ -118,7 +118,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 35;
+        public int AlgorithmHistoryDataPoints => 39;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
@@ -143,9 +143,9 @@ namespace QuantConnect.Algorithm.CSharp
             {"Annual Variance", "0"},
             {"Information Ratio", "-1.307"},
             {"Tracking Error", "0.089"},
-            {"Treynor Ratio", "7.068"},
+            {"Treynor Ratio", "7.175"},
             {"Total Fees", "$12.90"},
-            {"Estimated Strategy Capacity", "$580000000000.00"},
+            {"Estimated Strategy Capacity", "$590000000000.00"},
             {"Lowest Capacity Asset", "ES VP274HSU1AF5"},
             {"Fitness Score", "0.001"},
             {"Kelly Criterion Estimate", "0"},
@@ -166,7 +166,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "c77e88c0f30ae1b07fd635292b4de1c9"}
+            {"OrderListHash", "e7d37c37a83b8a40a325d9f0f6c5b81d"}
         };
 
         public class SymbolData
@@ -180,6 +180,8 @@ namespace QuantConnect.Algorithm.CSharp
                 _algorithm = algorithm;
                 _symbol = future.Symbol;
                 EMA = algorithm.EMA(future.Symbol, 20, Resolution.Daily);
+
+                Reset();
             }
 
             public void Reset()

--- a/Algorithm.CSharp/BasicTemplateFutureRolloverAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFutureRolloverAlgorithm.cs
@@ -36,11 +36,12 @@ namespace QuantConnect.Algorithm.CSharp
         public override void Initialize()
         {
             SetCash(1000000);
-            SetStartDate(2019, 2, 1);
-            SetEndDate(2021, 6, 1);
+            SetStartDate(2013, 10, 8);
+            SetEndDate(2014, 10, 10);
 
             // Requesting data
             _continuousContract = AddFuture(Futures.Indices.SP500EMini,
+                resolution: Resolution.Daily,
                 dataNormalizationMode: DataNormalizationMode.BackwardsRatio,
                 dataMappingMode: DataMappingMode.OpenInterest,
                 contractDepthOffset: 0
@@ -93,46 +94,46 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 68645;
+        public long DataPoints => 4542;
 
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 340;
+        public int AlgorithmHistoryDataPoints => 0;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "17"},
-            {"Average Win", "1.41%"},
-            {"Average Loss", "-4.03%"},
-            {"Compounding Annual Return", "3.001%"},
-            {"Drawdown", "5.600%"},
-            {"Expectancy", "0.182"},
-            {"Net Profit", "7.144%"},
-            {"Sharpe Ratio", "0.737"},
-            {"Probabilistic Sharpe Ratio", "31.420%"},
-            {"Loss Rate", "12%"},
-            {"Win Rate", "88%"},
-            {"Profit-Loss Ratio", "0.35"},
-            {"Alpha", "-0.003"},
-            {"Beta", "0.138"},
-            {"Annual Standard Deviation", "0.029"},
-            {"Annual Variance", "0.001"},
-            {"Information Ratio", "-0.907"},
-            {"Tracking Error", "0.171"},
-            {"Treynor Ratio", "0.152"},
-            {"Total Fees", "$36.55"},
-            {"Estimated Strategy Capacity", "$58000000000.00"},
-            {"Lowest Capacity Asset", "ES XPFJZVPGHL35"},
-            {"Fitness Score", "0.002"},
+            {"Total Trades", "2"},
+            {"Average Win", "0.06%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0.057%"},
+            {"Drawdown", "0.000%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0.057%"},
+            {"Sharpe Ratio", "0.665"},
+            {"Probabilistic Sharpe Ratio", "25.882%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "100%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0.001"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-1.357"},
+            {"Tracking Error", "0.089"},
+            {"Treynor Ratio", "1.135"},
+            {"Total Fees", "$4.30"},
+            {"Estimated Strategy Capacity", "$600000000000.00"},
+            {"Lowest Capacity Asset", "ES VP274HSU1AF5"},
+            {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
-            {"Sortino Ratio", "0.962"},
-            {"Return Over Maximum Drawdown", "0.53"},
-            {"Portfolio Turnover", "0.003"},
+            {"Sortino Ratio", "0.417"},
+            {"Return Over Maximum Drawdown", "4.379"},
+            {"Portfolio Turnover", "0"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
             {"Total Insights Analysis Completed", "0"},
@@ -146,7 +147,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "8f92e1528c6477a156449fd1e86527e7"}
+            {"OrderListHash", "960f2a002af87a34d20257aeb36ffbb5"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateFutureRolloverAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFutureRolloverAlgorithm.cs
@@ -169,7 +169,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "e7d37c37a83b8a40a325d9f0f6c5b81d"}
+            {"OrderListHash", "cbcf6f62060fa17482bd7073801d1384"}
         };
 
         public class SymbolData

--- a/Algorithm.Python/BasicTemplateFutureRolloverAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFutureRolloverAlgorithm.py
@@ -1,0 +1,51 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Example algorithm for trading continuous future
+### </summary>
+class BasicTemplateFutureRolloverAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetCash(1000000)
+        self.SetStartDate(2019, 2, 1)
+        self.SetEndDate(2021, 6, 1)
+
+        # Requesting data
+        self.continuous_contract = self.AddFuture(Futures.Indices.SP500EMini,
+            dataNormalizationMode = DataNormalizationMode.BackwardsRatio,
+            dataMappingMode = DataMappingMode.OpenInterest,
+            contractDepthOffset = 0
+        )
+        self.symbol = self.continuous_contract.Symbol
+        self.old_symbol = None
+
+    def OnData(self, slice):
+        # Accessing data
+        for changedEvent in slice.SymbolChangedEvents.Values:
+            if changedEvent.Symbol == self.symbol:
+                self.old_symbol = changedEvent.OldSymbol
+                self.Log(f"Symbol changed at {self.Time}: {self.old_symbol} -> {changedEvent.NewSymbol}")
+
+        mapped_symbol = self.continuous_contract.Mapped
+
+        if not slice.Bars.ContainsKey(self.symbol) or not mapped_symbol:
+            return
+
+        # Rolling over: to liquidate any position of the old mapped contract and switch to the newly mapped contract
+        if self.old_symbol:
+            self.Liquidate(self.old_symbol)
+            self.MarketOrder(mapped_symbol, 1)
+            self.old_symbol = None

--- a/Algorithm.Python/BasicTemplateFutureRolloverAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFutureRolloverAlgorithm.py
@@ -23,7 +23,7 @@ class BasicTemplateFutureRolloverAlgorithm(QCAlgorithm):
         self.SetEndDate(2014, 10, 10)
         self.SetCash(1000000)
         
-        self.symbolData = {}
+        self.symbol_data_by_future = {}
         
         futures = [
             Futures.Indices.SP500EMini
@@ -39,11 +39,11 @@ class BasicTemplateFutureRolloverAlgorithm(QCAlgorithm):
                 contractDepthOffset = 0
             )
             
-            symbolData = SymbolData(self, continuous_contract)
-            self.symbolData[continuous_contract] = symbolData
+            symbol_data = SymbolData(self, continuous_contract)
+            self.symbol_data_by_future[continuous_contract] = symbol_data
 
     def OnData(self, slice):
-        for future, symbolData in self.symbolData.items():
+        for future, symbol_data in self.symbol_data_by_future.items():
             symbol = future.Symbol
             
             # Accessing data
@@ -58,10 +58,10 @@ class BasicTemplateFutureRolloverAlgorithm(QCAlgorithm):
                 self.Liquidate(old_symbol, tag=tag)
                 self.MarketOrder(new_symbol, quantity, tag=tag)
 
-                symbolData.Reset()
+                symbol_data.Reset()
                 
             mapped_symbol = future.Mapped
-            ema = symbolData.EMA
+            ema = symbol_data.EMA
 
             if mapped_symbol is not None and slice.Bars.ContainsKey(symbol) and ema.IsReady:
                 if ema.Current.Value < slice.Bars[symbol].Price and not self.Portfolio[mapped_symbol].IsLong:

--- a/Algorithm.Python/BasicTemplateFutureRolloverAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFutureRolloverAlgorithm.py
@@ -20,11 +20,12 @@ class BasicTemplateFutureRolloverAlgorithm(QCAlgorithm):
 
     def Initialize(self):
         self.SetCash(1000000)
-        self.SetStartDate(2019, 2, 1)
-        self.SetEndDate(2021, 6, 1)
+        self.SetStartDate(2013, 10, 8)
+        self.SetEndDate(2014, 10, 10)
 
         # Requesting data
         self.continuous_contract = self.AddFuture(Futures.Indices.SP500EMini,
+            resolution = Resolution.Daily,
             dataNormalizationMode = DataNormalizationMode.BackwardsRatio,
             dataMappingMode = DataMappingMode.OpenInterest,
             contractDepthOffset = 0

--- a/Algorithm.Python/BasicTemplateFutureRolloverAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFutureRolloverAlgorithm.py
@@ -75,6 +75,8 @@ class SymbolData:
         self._algorithm = algorithm
         self._symbol = future.Symbol
         self.EMA = algorithm.EMA(future.Symbol, 20, Resolution.Daily)
+
+        self.Reset()
         
     def Reset(self):
         self.EMA.Reset()

--- a/Algorithm.Python/BasicTemplateFutureRolloverAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFutureRolloverAlgorithm.py
@@ -18,12 +18,15 @@ from AlgorithmImports import *
 ### </summary>
 class BasicTemplateFutureRolloverAlgorithm(QCAlgorithm):
 
+    ### <summary>
+    ### Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+    ### </summary>
     def Initialize(self):
         self.SetStartDate(2013, 10, 8)
-        self.SetEndDate(2014, 10, 10)
+        self.SetEndDate(2013, 12, 10)
         self.SetCash(1000000)
-        
-        self.symbol_data_by_future = {}
+
+        self.symbol_data_by_symbol = {}
         
         futures = [
             Futures.Indices.SP500EMini
@@ -40,44 +43,87 @@ class BasicTemplateFutureRolloverAlgorithm(QCAlgorithm):
             )
             
             symbol_data = SymbolData(self, continuous_contract)
-            self.symbol_data_by_future[continuous_contract] = symbol_data
+            self.symbol_data_by_symbol[continuous_contract.Symbol] = symbol_data
 
+    ### <summary>
+    ### OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+    ### </summary>
+    ### <param name="slice">Slice object keyed by symbol containing the stock data</param>
     def OnData(self, slice):
-        for future, symbol_data in self.symbol_data_by_future.items():
-            symbol = future.Symbol
+        for symbol, symbol_data in self.symbol_data_by_symbol.items():
+            # Call SymbolData.Update() method to handle new data slice received
+            symbol_data.Update(slice)
             
-            # Accessing data
-            if slice.SymbolChangedEvents.ContainsKey(symbol):
-                changedEvent = slice.SymbolChangedEvents[symbol]
-                old_symbol = changedEvent.OldSymbol
-                new_symbol = changedEvent.NewSymbol
-                tag = f"Rollover - Symbol changed at {self.Time}: {old_symbol} -> {new_symbol}"
-                quantity = self.Portfolio[old_symbol].Quantity
-                
-                # Rolling over: to liquidate any position of the old mapped contract and switch to the newly mapped contract
-                self.Liquidate(old_symbol, tag=tag)
-                self.MarketOrder(new_symbol, quantity, tag=tag)
-
-                symbol_data.Reset()
-                
-            mapped_symbol = future.Mapped
-            ema = symbol_data.EMA
-
-            if mapped_symbol is not None and slice.Bars.ContainsKey(symbol) and ema.IsReady:
-                if ema.Current.Value < slice.Bars[symbol].Price and not self.Portfolio[mapped_symbol].IsLong:
-                    self.MarketOrder(mapped_symbol, 1)
-                elif ema.Current.Value > slice.Bars[symbol].Price and not self.Portfolio[mapped_symbol].IsShort:
-                    self.MarketOrder(mapped_symbol, -1)
+            # Check if information in SymbolData class and new slice data are ready for trading
+            if not symbol_data.IsReady or not slice.Bars.ContainsKey(symbol):
+                return
+            
+            ema_current_value = symbol_data.EMA.Current.Value
+            if ema_current_value < symbol_data.Price and not symbol_data.IsLong:
+                self.MarketOrder(symbol_data.Mapped, 1)
+            elif ema_current_value > symbol_data.Price and not symbol_data.IsShort:
+                self.MarketOrder(symbol_data.Mapped, -1)
     
+### <summary>
+### Abstracted class object to hold information (state, indicators, methods, etc.) from a Symbol/Security in a multi-security algorithm
+### </summary>
 class SymbolData:
     
+    ### <summary>
+    ### Constructor to instantiate the information needed to be hold
+    ### </summary>
     def __init__(self, algorithm, future):
         self._algorithm = algorithm
-        self._symbol = future.Symbol
+        self._future = future
         self.EMA = algorithm.EMA(future.Symbol, 20, Resolution.Daily)
+        self.Price = 0
+        self.IsLong = False
+        self.IsShort = False
 
         self.Reset()
+    
+    @property
+    def Symbol(self):
+        return self._future.Symbol
+    
+    @property
+    def Mapped(self):
+        return self._future.Mapped
+    
+    @property
+    def IsReady(self):
+        return self.Mapped is not None and self.EMA.IsReady
+    
+    ### <summary>
+    ### Handler of new slice of data received
+    ### </summary>
+    def Update(self, slice):
+        if slice.SymbolChangedEvents.ContainsKey(self.Symbol):
+            changed_event = slice.SymbolChangedEvents[self.Symbol]
+            old_symbol = changed_event.OldSymbol
+            new_symbol = changed_event.NewSymbol
+            tag = f"Rollover - Symbol changed at {self._algorithm.Time}: {old_symbol} -> {new_symbol}"
+            quantity = self._algorithm.Portfolio[old_symbol].Quantity
+
+            # Rolling over: to liquidate any position of the old mapped contract and switch to the newly mapped contract
+            self._algorithm.Liquidate(old_symbol, tag = tag)
+            self._algorithm.MarketOrder(new_symbol, quantity, tag = tag)
+
+            self.Reset()
         
+        self.Price = slice.Bars[self.Symbol].Price if slice.Bars.ContainsKey(self.Symbol) else self.Price
+        self.IsLong = self._algorithm.Portfolio[self.Mapped].IsLong
+        self.IsShort = self._algorithm.Portfolio[self.Mapped].IsShort
+        
+    ### <summary>
+    ### Reset RollingWindow/indicator to adapt to newly mapped contract, then warm up the RollingWindow/indicator
+    ### </summary>
     def Reset(self):
         self.EMA.Reset()
-        self._algorithm.WarmUpIndicator(self._symbol, self.EMA, Resolution.Daily)
+        self._algorithm.WarmUpIndicator(self.Symbol, self.EMA, Resolution.Daily)
+            
+    ### <summary>
+    ### Disposal method to remove consolidator/update method handler, and reset RollingWindow/indicator to free up memory and speed
+    ### </summary>
+    def Dispose(self):
+        self.EMA.Reset()

--- a/Algorithm.Python/BasicTemplateFutureRolloverAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFutureRolloverAlgorithm.py
@@ -19,15 +19,14 @@ from AlgorithmImports import *
 class BasicTemplateFutureRolloverAlgorithm(QCAlgorithm):
 
     def Initialize(self):
+        self.SetStartDate(2013, 10, 8)
+        self.SetEndDate(2014, 10, 10)
         self.SetCash(1000000)
-        self.SetStartDate(2020, 2, 1)
-        self.SetEndDate(2020, 4, 1)
         
-        self.ema = {}
+        self.symbolData = {}
         
         futures = [
-            Futures.Indices.SP500EMini,
-            Futures.Metals.Gold
+            Futures.Indices.SP500EMini
         ]
 
         for future in futures:
@@ -40,12 +39,11 @@ class BasicTemplateFutureRolloverAlgorithm(QCAlgorithm):
                 contractDepthOffset = 0
             )
             
-            ema = self.EMA(continuous_contract.Symbol, 20, Resolution.Daily)
-            self.ema[continuous_contract] = ema
-            self.Reset(continuous_contract)
+            symbolData = SymbolData(self, continuous_contract)
+            self.symbolData[continuous_contract] = symbolData
 
     def OnData(self, slice):
-        for future, ema in self.ema.items():
+        for future, symbolData in self.symbolData.items():
             symbol = future.Symbol
             
             # Accessing data
@@ -60,9 +58,10 @@ class BasicTemplateFutureRolloverAlgorithm(QCAlgorithm):
                 self.Liquidate(old_symbol, tag=tag)
                 self.MarketOrder(new_symbol, quantity, tag=tag)
 
-                self.Reset(future)
+                symbolData.Reset()
                 
             mapped_symbol = future.Mapped
+            ema = symbolData.EMA
 
             if mapped_symbol is not None and slice.Bars.ContainsKey(symbol) and ema.IsReady:
                 if ema.Current.Value < slice.Bars[symbol].Price and not self.Portfolio[mapped_symbol].IsLong:
@@ -70,6 +69,13 @@ class BasicTemplateFutureRolloverAlgorithm(QCAlgorithm):
                 elif ema.Current.Value > slice.Bars[symbol].Price and not self.Portfolio[mapped_symbol].IsShort:
                     self.MarketOrder(mapped_symbol, -1)
     
-    def Reset(self, future):
-        self.ema[future].Reset()
-        self.WarmUpIndicator(future.Symbol, self.ema[future], Resolution.Daily)
+class SymbolData:
+    
+    def __init__(self, algorithm, future):
+        self._algorithm = algorithm
+        self._symbol = future.Symbol
+        self.EMA = algorithm.EMA(future.Symbol, 20, Resolution.Daily)
+        
+    def Reset(self):
+        self.EMA.Reset()
+        self._algorithm.WarmUpIndicator(self._symbol, self.EMA, Resolution.Daily)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
To include a basic template algorithm for switching mapped contracts as continuous futures rollover, for both C# and Python.

#### Related Issue
closes #6802 

#### Motivation and Context
Provide example on usage

#### Requires Documentation Change
Nil

#### How Has This Been Tested?
Regression test inclusive

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
