### PR TITLE
Changes Crumb Location from Yahoo Downloader

### DIFF
--- a/ToolBox/YahooDownloader/Token.cs
+++ b/ToolBox/YahooDownloader/Token.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -116,7 +116,7 @@ namespace QuantConnect.ToolBox.YahooDownloader
                 //initialize on first time use
                 if (_regexCrumb == null)
                 {
-                    _regexCrumb = new Regex("CrumbStore\":{\"crumb\":\"(?<crumb>.+?)\"}",
+                    _regexCrumb = new Regex("\"crumb\":\"(?<crumb>.+?)\"",
                         RegexOptions.CultureInvariant | RegexOptions.Compiled);
                 }
 


### PR DESCRIPTION
#### Description
Yahoo has changed the location from the crumb which is no longer located in "CrumbStore",

#### Motivation and Context
Quick fix.

#### How Has This Been Tested?
The following command would hang and throw an exception. Now we can download the data.
```
.\QuantConnect.Toolbox --app=YahooDownloader --resolution=Daily --from-date=20200930-00:00:00 --tickers=AAPL
```

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`