### PR TITLE
Adds Pre-Market for LBS

### DIFF
--- a/Data/market-hours/market-hours-database.json
+++ b/Data/market-hours/market-hours-database.json
@@ -1125,12 +1125,22 @@
       "exchangeTimeZone": "America/Chicago",
       "monday": [
         {
+          "start": "06:00:00",
+          "end": "09:00:00",
+          "state": "premarket"
+        },
+        {
           "start": "09:00:00",
           "end": "15:05:00",
           "state": "market"
         }
       ],
       "tuesday": [
+        {
+          "start": "06:00:00",
+          "end": "09:00:00",
+          "state": "premarket"
+        },
         {
           "start": "09:00:00",
           "end": "15:05:00",
@@ -1139,6 +1149,11 @@
       ],
       "wednesday": [
         {
+          "start": "06:00:00",
+          "end": "09:00:00",
+          "state": "premarket"
+        },
+        {
           "start": "09:00:00",
           "end": "15:05:00",
           "state": "market"
@@ -1146,12 +1161,22 @@
       ],
       "thursday": [
         {
+          "start": "06:00:00",
+          "end": "09:00:00",
+          "state": "premarket"
+        },
+        {
           "start": "09:00:00",
           "end": "15:05:00",
           "state": "market"
         }
       ],
       "friday": [
+        {
+          "start": "06:00:00",
+          "end": "09:00:00",
+          "state": "premarket"
+        },
         {
           "start": "09:00:00",
           "end": "15:05:00",


### PR DESCRIPTION
#### Description
The lumber pre-opening window is from 6am to 9am Chicago. 
https://www.cmegroup.com/trading-hours.html#foi=F&search=Lumber

#### Motivation and Context
Fix market hours

#### Requires Documentation Change
No. The market hours will be updates by Docs' scripts.

#### How Has This Been Tested?
An algorithm on QuantConnect Cloud.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`