### PR TITLE
TensorFlow Placeholder Fix

### DIFF
--- a/Algorithm.Python/TensorFlowNeuralNetworkAlgorithm.py
+++ b/Algorithm.Python/TensorFlowNeuralNetworkAlgorithm.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 from AlgorithmImports import *
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 class TensorFlowNeuralNetworkAlgorithm(QCAlgorithm):
 
@@ -65,6 +65,7 @@ class TensorFlowNeuralNetworkAlgorithm(QCAlgorithm):
                 y_data = np.array(self.prices_y[symbol]).astype(np.float32).reshape((-1,1))
                 
                 # define placeholder for inputs to network
+                tf.disable_v2_behavior()
                 xs = tf.placeholder(tf.float32, [None, 1])
                 ys = tf.placeholder(tf.float32, [None, 1])
                 


### PR DESCRIPTION
Fixed this error from happening when running the TensorFlow example:

tf.placeholder() is not compatible with eager execution.
  at placeholder
    raise RuntimeError("tf.placeholder() is not compatible with "
 in array_ops.py: line 3341
  at NetTrain
    xs = tf.compat.v1.placeholder(tf.float32 in /QuantConnect/backtesting/./cache/algorithm/project/main.py: line 57

