### PR TITLE
Polygon Handles Data Subscriptions with One Security Type

### DIFF
--- a/Configuration/ToolboxArgumentParser.cs
+++ b/Configuration/ToolboxArgumentParser.cs
@@ -55,7 +55,7 @@ namespace QuantConnect.Configuration
                 new CommandLineOption("to-date", CommandOptionType.SingleValue, "[OPTIONAL for downloaders] If not provided 'DateTime.UtcNow' will "
                                                                                 + "be used. --to-date=yyyyMMdd-HH:mm:ss"),
                 new CommandLineOption("exchange", CommandOptionType.SingleValue, "[REQUIRED for CryptoiqDownloader] [Optional for KaikoDataConverter] The exchange to process, if not defined, all exchanges will be processed."),
-                new CommandLineOption("api-key", CommandOptionType.SingleValue, "[REQUIRED for QuandlBitfinexDownloader, IEXDownloader]"),
+                new CommandLineOption("api-key", CommandOptionType.SingleValue, "[REQUIRED for QuandlBitfinexDownloader, IEXDownloader, PolygonDownloader]"),
                 new CommandLineOption("date", CommandOptionType.SingleValue, "[REQUIRED for AlgoSeekFuturesConverter, AlgoSeekOptionsConverter, KaikoDataConverter]"
                                                                              + "Date for the option bz files: --date=yyyyMMdd"),
                 new CommandLineOption("source-dir", CommandOptionType.SingleValue, "[REQUIRED for IVolatilityEquityConverter, KaikoDataConverter,"

--- a/Tests/ToolBox/PolygonHistoryTests.cs
+++ b/Tests/ToolBox/PolygonHistoryTests.cs
@@ -50,7 +50,8 @@ namespace QuantConnect.Tests.ToolBox
         [TestCaseSource(nameof(HistoryTestCases))]
         public void GetsHistory(Symbol symbol, Resolution resolution, TickType tickType, TimeSpan period, bool shouldBeEmpty)
         {
-            var now = new DateTime(2020, 5, 20, 15, 0, 0).RoundDown(resolution.ToTimeSpan());
+            // 3 pm of the previous day
+            var now = DateTime.UtcNow.Date.AddHours(-9).RoundDown(resolution.ToTimeSpan());
 
             var dataType = LeanData.GetDataType(resolution, tickType);
 
@@ -141,7 +142,12 @@ namespace QuantConnect.Tests.ToolBox
             new TestCaseData(Symbols.BTCUSD, Resolution.Minute, TickType.Trade, Time.OneHour, false),
             new TestCaseData(Symbols.BTCUSD, Resolution.Hour, TickType.Trade, TimeSpan.FromHours(6), false),
             new TestCaseData(Symbols.BTCUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(5), false),
-
+            new TestCaseData(Symbols.BTCUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(5), false),
+            new TestCaseData(Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Bitfinex), Resolution.Daily, TickType.Trade, TimeSpan.FromDays(5), false),
+            new TestCaseData(Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Kraken), Resolution.Daily, TickType.Trade, TimeSpan.FromDays(5), false),
+            new TestCaseData(Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Bitstamp), Resolution.Daily, TickType.Trade, TimeSpan.FromDays(5), false),
+            new TestCaseData(Symbol.Create("BTCUSD", SecurityType.Crypto, Market.HitBTC), Resolution.Daily, TickType.Trade, TimeSpan.FromDays(5), false),
+    
             // invalid security type/tick type combination, no error, empty result
             new TestCaseData(Symbols.EURUSD, Resolution.Tick, TickType.Trade, TimeSpan.FromSeconds(15), true),
             new TestCaseData(Symbols.BTCUSD, Resolution.Second, TickType.Quote, Time.OneMinute, true),

--- a/ToolBox/Polygon/PolygonDataQueueHandler.cs
+++ b/ToolBox/Polygon/PolygonDataQueueHandler.cs
@@ -65,14 +65,17 @@ namespace QuantConnect.ToolBox.Polygon
         private readonly SymbolPropertiesDatabase _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
 
         // exchange time zones by symbol
-        private readonly Dictionary<Symbol, DateTimeZone> _symbolExchangeTimeZones = new Dictionary<Symbol, DateTimeZone>();
+        private readonly Dictionary<Symbol, DateTimeZone> _symbolExchangeTimeZones = new();
 
         // map Polygon exchange -> Lean market
         // Crypto exchanges from: https://api.polygon.io/v1/meta/crypto-exchanges?apiKey=xxx
-        private readonly Dictionary<int, string> _cryptoExchangeMap = new Dictionary<int, string>
+        private readonly Dictionary<int, string> _cryptoExchangeMap = new()
         {
             { 1, Market.GDAX },
-            { 2, Market.Bitfinex }
+            { 2, Market.Bitfinex },
+            { 6, Market.Bitstamp },
+            { 10, Market.HitBTC },
+            { 23, Market.Kraken }
         };
 
         private int _dataPointCount;
@@ -100,24 +103,44 @@ namespace QuantConnect.ToolBox.Polygon
         {
             if (streamingEnabled)
             {
-                foreach (var securityType in new[] { SecurityType.Equity, SecurityType.Forex, SecurityType.Crypto })
+                var securityTypes = new[] { SecurityType.Equity, SecurityType.Forex, SecurityType.Crypto };
+
+                foreach (var securityType in securityTypes)
                 {
                     _failedAuthentication.Reset();
                     _successfulAuthentication.Reset();
 
-                    _webSocketClientWrappers[securityType] = new PolygonWebSocketClientWrapper(_apiKey, _symbolMapper, securityType, OnMessage);
+                    var websocket = new PolygonWebSocketClientWrapper(_apiKey, _symbolMapper, securityType, OnMessage);
 
                     var timedout = WaitHandle.WaitAny(new WaitHandle[] { _failedAuthentication, _successfulAuthentication }, TimeSpan.FromMinutes(2));
                     if (timedout == WaitHandle.WaitTimeout)
                     {
+                        // Close current websocket connection
+                        websocket.Close();
+                        // Close all connections that have been successful so far
                         ShutdownWebSockets();
                         throw new TimeoutException($"Timeout waiting for websocket to connect for {securityType}");
                     }
-                    else if (_failedAuthentication.WaitOne(0))
+
+                    // If it hasn't timed out, it could still have failed.
+                    // For example, the API keys do not have rights to subscribe to the current security type
+                    // In this case, we close this connect and move on
+                    if (_failedAuthentication.WaitOne(0))
                     {
-                        ShutdownWebSockets();
-                        throw new InvalidOperationException($"Websocket authentication failed for {securityType}");
+                        websocket.Close();
+                        continue;
                     }
+
+                    _webSocketClientWrappers[securityType] = websocket;
+                }
+
+                // If we could not connect to any websocket because of the API rights,
+                // we exit this data queue handler
+                if (_webSocketClientWrappers.Count == 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Websocket authentication failed for all security types: {string.Join(", ", securityTypes)}." +
+                        "Please confirm whether the subscription plan associated with your API keys includes support to websockets.");
                 }
             }
 
@@ -735,8 +758,7 @@ namespace QuantConnect.ToolBox.Polygon
 
             // Perform a check of the number of bars requested, this must not exceed a static limit
             var aggregatesCountPerResolution = GetAggregatesCountPerReselection(request.Resolution);
-            var dataRequestedCount = (end - start).Ticks
-                                     / resolutionTimeSpan.Ticks / aggregatesCountPerResolution;
+            var dataRequestedCount = (end - start).Ticks / resolutionTimeSpan.Ticks / aggregatesCountPerResolution;
 
             if (dataRequestedCount > ResponseSizeLimitAggregateData)
             {
@@ -744,7 +766,7 @@ namespace QuantConnect.ToolBox.Polygon
                 end = end.Date;
             }
 
-            while (start < lastRequestedBarStartTime.Date)
+            while (start < lastRequestedBarStartTime)
             {
                 var url = $"{HistoryBaseUrl}/v2/aggs/ticker/{tickerPrefix}{request.Symbol.Value}/range/1/{historyTimespan}/{start.Date:yyyy-MM-dd}/{end.Date:yyyy-MM-dd}" +
                           $"?apiKey={_apiKey}&limit={ResponseSizeLimitAggregateData}";
@@ -1050,11 +1072,19 @@ namespace QuantConnect.ToolBox.Polygon
 
         private DateTime GetTickTime(Symbol symbol, DateTime utcTime)
         {
-            DateTimeZone exchangeTimeZone;
-            if (!_symbolExchangeTimeZones.TryGetValue(symbol, out exchangeTimeZone))
+            if (!_symbolExchangeTimeZones.TryGetValue(symbol, out var exchangeTimeZone))
             {
                 // read the exchange time zone from market-hours-database
-                exchangeTimeZone = _marketHoursDatabase.GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType).TimeZone;
+                if (_marketHoursDatabase.TryGetEntry(symbol.ID.Market, symbol, symbol.SecurityType, out var entry))
+                {
+                    exchangeTimeZone = entry.ExchangeHours.TimeZone;
+                }
+                // If there is no entry for the given Symbol, default to New York
+                else
+                {
+                    exchangeTimeZone = TimeZones.NewYork;
+                }
+
                 _symbolExchangeTimeZones.Add(symbol, exchangeTimeZone);
             }
 
@@ -1090,9 +1120,23 @@ namespace QuantConnect.ToolBox.Polygon
                 return null;
             }
 
+            // If the data download was not successful, log the reason
+            var parsedResult = JObject.Parse(result);
+            var success = parsedResult["success"]?.Value<bool>() ?? false;
+            if (!success)
+            {
+                success = parsedResult["status"]?.ToString().ToUpperInvariant() == "OK";
+            }
+
+            if (!success)
+            {
+                Log.Debug($"No data for {url}. Reason: {result}");
+                return null;
+            }
+
             if (jsonPropertyName != null)
             {
-                result = JObject.Parse(result)[jsonPropertyName]?.ToString();
+                result = parsedResult[jsonPropertyName]?.ToString();
             }
 
             return result == null ? null : JsonConvert.DeserializeObject(result, type);

--- a/ToolBox/Polygon/PolygonDownloaderProgram.cs
+++ b/ToolBox/Polygon/PolygonDownloaderProgram.cs
@@ -29,20 +29,24 @@ namespace QuantConnect.ToolBox.Polygon
         /// <summary>
         /// Primary entry point to the program. This program only supports SecurityType.Equity
         /// </summary>
-        public static void PolygonDownloader(IList<string> tickers, string securityTypeString, string market, string resolutionString, DateTime fromDate, DateTime toDate)
+        public static void PolygonDownloader(IList<string> tickers, string securityTypeString, string market, string resolutionString, DateTime fromDate, DateTime toDate, string apiKey)
         {
-            if (tickers.IsNullOrEmpty() || securityTypeString.IsNullOrEmpty() || market.IsNullOrEmpty() || resolutionString.IsNullOrEmpty())
+            if (tickers.IsNullOrEmpty() || securityTypeString.IsNullOrEmpty() || market.IsNullOrEmpty() || resolutionString.IsNullOrEmpty() || apiKey.IsNullOrEmpty())
             {
                 Console.WriteLine("PolygonDownloader ERROR: '--tickers=' or '--security-type=' or '--market=' or '--resolution=' parameter is missing");
                 Console.WriteLine("--tickers=eg SPY,AAPL");
                 Console.WriteLine("--security-type=Equity");
                 Console.WriteLine("--market=usa");
                 Console.WriteLine("--resolution=Minute/Hour/Daily");
+                Console.WriteLine("--api-key=<apiKey>");
                 Environment.Exit(1);
             }
 
             try
             {
+                // Set API Key
+                Config.Set("polygon-api-key", apiKey);
+
                 // Load settings from command line
                 var resolution = (Resolution)Enum.Parse(typeof(Resolution), resolutionString);
                 var securityType = (SecurityType)Enum.Parse(typeof(SecurityType), securityTypeString);

--- a/ToolBox/Polygon/PolygonDownloaderProgram.cs
+++ b/ToolBox/Polygon/PolygonDownloaderProgram.cs
@@ -33,7 +33,7 @@ namespace QuantConnect.ToolBox.Polygon
         {
             if (tickers.IsNullOrEmpty() || securityTypeString.IsNullOrEmpty() || market.IsNullOrEmpty() || resolutionString.IsNullOrEmpty() || apiKey.IsNullOrEmpty())
             {
-                Console.WriteLine("PolygonDownloader ERROR: '--tickers=' or '--security-type=' or '--market=' or '--resolution=' parameter is missing");
+                Console.WriteLine("PolygonDownloader ERROR: '--tickers=' or '--security-type=' or '--market=' or '--resolution=' or '--api-key=' parameter is missing");
                 Console.WriteLine("--tickers=eg SPY,AAPL");
                 Console.WriteLine("--security-type=Equity");
                 Console.WriteLine("--market=usa");

--- a/ToolBox/Program.cs
+++ b/ToolBox/Program.cs
@@ -79,6 +79,7 @@ namespace QuantConnect.ToolBox
                 var toDate = optionsObject.ContainsKey("to-date")
                     ? Parse.DateTimeExact(optionsObject["to-date"].ToString(), "yyyyMMdd-HH:mm:ss")
                     : DateTime.UtcNow;
+                var apiKey = optionsObject.ContainsKey("api-key") ? optionsObject["api-key"].ToString() : "";
                 switch (targetApp)
                 {
                     case "cdl":
@@ -114,7 +115,8 @@ namespace QuantConnect.ToolBox
                             GetParameterOrExit(optionsObject, "market"),
                             resolution,
                             fromDate,
-                            toDate);
+                            toDate,
+                            apiKey);
                         break;
 
                     case "avdl":


### PR DESCRIPTION
#### Description
Polygon sells data subscriptions for security types separately, so we should not test whether the users have all three subscriptions, Equity, Forex, and Crypto. Users just need the type they will use.

Adds new crypto markets, and unit tests for them. Adapt unit test.

#### Related Issue
Closes https://github.com/QuantConnect/Lean/issues/6687

#### Motivation and Context
Provide working alternative data feed for local development.

#### How Has This Been Tested?
New unit tests and testing with local live deployment.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`