### PR TITLE
`Portfolio.UnsettledCashBook` update when quote currency is not the account currency

### DIFF
--- a/Algorithm.CSharp/UnsettledCashWhenQuoteCurrencyIsNotAccountCurrencyAlgorithm.cs
+++ b/Algorithm.CSharp/UnsettledCashWhenQuoteCurrencyIsNotAccountCurrencyAlgorithm.cs
@@ -23,10 +23,10 @@ using QuantConnect.Orders;
 namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
-    /// Algorithm asserting that the unsettled cash book is updated correctly when the account currency is not USD.
-    /// It reproduces GH issue #6859.
+    /// Algorithm asserting that the unsettled cash book is updated correctly when the quote currency is not the account currency.
+    /// Reproduces GH issue #6859.
     /// </summary>
-    public class UnsettledCashWithNonUSDAccountCurrencyAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    public class UnsettledCashWhenQuoteCurrencyIsNotAccountCurrencyAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private Symbol _spy;
 

--- a/Algorithm.CSharp/UnsettledCashWhenQuoteCurrencyIsNotAccountCurrencyAlgorithm.cs
+++ b/Algorithm.CSharp/UnsettledCashWhenQuoteCurrencyIsNotAccountCurrencyAlgorithm.cs
@@ -136,12 +136,12 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Fees", "€10.32"},
             {"Estimated Strategy Capacity", "€7700000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
-            {"Fitness Score", "0.796"},
+            {"Fitness Score", "0.58"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
             {"Sortino Ratio", "79228162514264337593543950335"},
-            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
-            {"Portfolio Turnover", "0.796"},
+            {"Return Over Maximum Drawdown", "-2.929"},
+            {"Portfolio Turnover", "1.036"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
             {"Total Insights Analysis Completed", "0"},
@@ -155,7 +155,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "1cd26ea7fbdc73902f4d63d92929aa0e"}
+            {"OrderListHash", "a08299c3ae9e54b878847fbf6f56e596"}
         };
     }
 }

--- a/Algorithm.CSharp/UnsettledCashWithNonUSDAccountCurrencyAlgorithm.cs
+++ b/Algorithm.CSharp/UnsettledCashWithNonUSDAccountCurrencyAlgorithm.cs
@@ -1,0 +1,161 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Brokerages;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Algorithm asserting that the unsettled cash book is updated correctly when the account currency is not USD.
+    /// It reproduces GH issue #6859.
+    /// </summary>
+    public class UnsettledCashWithNonUSDAccountCurrencyAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _spy;
+
+        private decimal _lastUnsettledCash;
+
+        private DateTime _lastTradeDate;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 08);
+
+            SetAccountCurrency("EUR");
+            SetCash(100000);
+
+            SetBrokerageModel(BrokerageName.InteractiveBrokersBrokerage, AccountType.Cash);
+
+            _spy = AddEquity("SPY", Resolution.Minute).Symbol;
+        }
+
+        public override void OnData(Slice data)
+        {
+            if (Time - _lastTradeDate < TimeSpan.FromHours(1))
+            {
+                return;
+            }
+
+            _lastTradeDate = Time;
+
+            if (!Portfolio.Invested)
+            {
+                SetHoldings(_spy, 0.1);
+            }
+            else
+            {
+                Liquidate();
+            }
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            if (orderEvent.Status == OrderStatus.Filled && orderEvent.Direction == OrderDirection.Sell)
+            {
+                Debug($"OrderEvent: {orderEvent}");
+                Debug($"UnsettledCashBook:\n{Portfolio.UnsettledCashBook}\n");
+
+                if (!Portfolio.UnsettledCashBook.TryGetValue(orderEvent.FillPriceCurrency, out var unsettledCash))
+                {
+                    throw new Exception($"Unsettled cash entry for {orderEvent.FillPriceCurrency} not found");
+                }
+
+                var expectedUnsettledCash = Math.Abs(orderEvent.FillPrice * orderEvent.FillQuantity);
+                var actualUnsettledCash = unsettledCash.Amount - _lastUnsettledCash;
+                if (actualUnsettledCash != expectedUnsettledCash)
+                {
+                    throw new Exception($"Expected unsettled cash to be {expectedUnsettledCash} but was {actualUnsettledCash}");
+                }
+
+                _lastUnsettledCash = unsettledCash.Amount;
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 1561;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 7622;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "14"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "€10.32"},
+            {"Estimated Strategy Capacity", "€7700000.00"},
+            {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
+            {"Fitness Score", "0.796"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Portfolio Turnover", "0.796"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "€0"},
+            {"Total Accumulated Estimated Alpha Value", "€0"},
+            {"Mean Population Estimated Insight Value", "€0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "1cd26ea7fbdc73902f4d63d92929aa0e"}
+        };
+    }
+}

--- a/Common/Global.cs
+++ b/Common/Global.cs
@@ -730,6 +730,25 @@ namespace QuantConnect
     }
 
     /// <summary>
+    /// The different types of <see cref="CashBook.Updated"/> events
+    /// </summary>
+    public enum CashBookUpdateType
+    {
+        /// <summary>
+        /// A new <see cref="Cash.Symbol"/> was added (0)
+        /// </summary>
+        Added,
+        /// <summary>
+        /// One or more <see cref="Cash"/> instances were removed (1)
+        /// </summary>
+        Removed,
+        /// <summary>
+        /// An existing <see cref="Cash.Symbol"/> was updated (2)
+        /// </summary>
+        Updated
+    }
+
+    /// <summary>
     /// Defines Lean exchanges codes and names
     /// </summary>
     public static class Exchanges

--- a/Common/Securities/CashBook.cs
+++ b/Common/Securities/CashBook.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Securities
         /// Event fired when a <see cref="Cash"/> instance is added or removed, and when
         /// the <see cref="Cash.Updated"/> is triggered for the currently hold instances
         /// </summary>
-        public event EventHandler<UpdateType> Updated;
+        public event EventHandler<CashBookUpdatedEventArgs> Updated;
 
         /// <summary>
         /// Gets the base currency used
@@ -253,7 +253,7 @@ namespace QuantConnect.Securities
         public void Clear()
         {
             _currencies.Clear();
-            OnUpdate(UpdateType.Removed);
+            OnUpdate(UpdateType.Removed, null);
         }
 
         /// <summary>
@@ -403,7 +403,7 @@ namespace QuantConnect.Securities
                 value.Updated += OnCashUpdate;
                 _currencies.AddOrUpdate(symbol, value);
 
-                OnUpdate(UpdateType.Added);
+                OnUpdate(UpdateType.Added, value);
 
                 return value;
             }
@@ -434,7 +434,7 @@ namespace QuantConnect.Securities
                 cash.Updated -= OnCashUpdate;
                 if (!calledInternally)
                 {
-                    OnUpdate(UpdateType.Removed);
+                    OnUpdate(UpdateType.Removed, cash);
                 }
             }
             return removed;
@@ -442,12 +442,12 @@ namespace QuantConnect.Securities
 
         private void OnCashUpdate(object sender, EventArgs eventArgs)
         {
-            OnUpdate(UpdateType.Updated);
+            OnUpdate(UpdateType.Updated, sender as Cash);
         }
 
-        private void OnUpdate(UpdateType updateType)
+        private void OnUpdate(UpdateType updateType, Cash cash)
         {
-            Updated?.Invoke(this, updateType);
+            Updated?.Invoke(this, new CashBookUpdatedEventArgs(updateType, cash));
         }
 
         /// <summary>

--- a/Common/Securities/CashBook.cs
+++ b/Common/Securities/CashBook.cs
@@ -253,7 +253,7 @@ namespace QuantConnect.Securities
         public void Clear()
         {
             _currencies.Clear();
-            OnUpdate(UpdateType.Removed, null);
+            OnUpdate(CashBookUpdateType.Removed, null);
         }
 
         /// <summary>
@@ -403,7 +403,7 @@ namespace QuantConnect.Securities
                 value.Updated += OnCashUpdate;
                 _currencies.AddOrUpdate(symbol, value);
 
-                OnUpdate(UpdateType.Added, value);
+                OnUpdate(CashBookUpdateType.Added, value);
 
                 return value;
             }
@@ -434,7 +434,7 @@ namespace QuantConnect.Securities
                 cash.Updated -= OnCashUpdate;
                 if (!calledInternally)
                 {
-                    OnUpdate(UpdateType.Removed, cash);
+                    OnUpdate(CashBookUpdateType.Removed, cash);
                 }
             }
             return removed;
@@ -442,31 +442,12 @@ namespace QuantConnect.Securities
 
         private void OnCashUpdate(object sender, EventArgs eventArgs)
         {
-            OnUpdate(UpdateType.Updated, sender as Cash);
+            OnUpdate(CashBookUpdateType.Updated, sender as Cash);
         }
 
-        private void OnUpdate(UpdateType updateType, Cash cash)
+        private void OnUpdate(CashBookUpdateType updateType, Cash cash)
         {
             Updated?.Invoke(this, new CashBookUpdatedEventArgs(updateType, cash));
-        }
-
-        /// <summary>
-        /// The different types of <see cref="Updated"/> events
-        /// </summary>
-        public enum UpdateType
-        {
-            /// <summary>
-            /// A new <see cref="Cash.Symbol"/> was added (0)
-            /// </summary>
-            Added,
-            /// <summary>
-            /// One or more <see cref="Cash"/> instances were removed (1)
-            /// </summary>
-            Removed,
-            /// <summary>
-            /// An existing <see cref="Cash.Symbol"/> was updated (2)
-            /// </summary>
-            Updated
         }
     }
 }

--- a/Common/Securities/CashBookUpdatedEventArgs.cs
+++ b/Common/Securities/CashBookUpdatedEventArgs.cs
@@ -1,0 +1,48 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+
+using static QuantConnect.Securities.CashBook;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Event fired when the cash book is updated
+    /// </summary>
+    public class CashBookUpdatedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The update type
+        /// </summary>
+        public UpdateType UpdateType { get; }
+
+        /// <summary>
+        /// The added cash instance.
+        /// </summary>
+        /// <remarks>This will be null for <see cref="UpdateType.Removed"/> events that clear the whole cash book</remarks>
+        public Cash Cash { get; }
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        public CashBookUpdatedEventArgs(UpdateType type, Cash cash)
+        {
+            UpdateType = type;
+            Cash = cash;
+        }
+    }
+}

--- a/Common/Securities/CashBookUpdatedEventArgs.cs
+++ b/Common/Securities/CashBookUpdatedEventArgs.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Securities
         public UpdateType UpdateType { get; }
 
         /// <summary>
-        /// The added cash instance.
+        /// The updated cash instance.
         /// </summary>
         /// <remarks>This will be null for <see cref="UpdateType.Removed"/> events that clear the whole cash book</remarks>
         public Cash Cash { get; }

--- a/Common/Securities/CashBookUpdatedEventArgs.cs
+++ b/Common/Securities/CashBookUpdatedEventArgs.cs
@@ -16,8 +16,6 @@
 
 using System;
 
-using static QuantConnect.Securities.CashBook;
-
 namespace QuantConnect.Securities
 {
     /// <summary>
@@ -28,18 +26,18 @@ namespace QuantConnect.Securities
         /// <summary>
         /// The update type
         /// </summary>
-        public UpdateType UpdateType { get; }
+        public CashBookUpdateType UpdateType { get; }
 
         /// <summary>
         /// The updated cash instance.
         /// </summary>
-        /// <remarks>This will be null for <see cref="UpdateType.Removed"/> events that clear the whole cash book</remarks>
+        /// <remarks>This will be null for <see cref="CashBookUpdateType.Removed"/> events that clear the whole cash book</remarks>
         public Cash Cash { get; }
 
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        public CashBookUpdatedEventArgs(UpdateType type, Cash cash)
+        public CashBookUpdatedEventArgs(CashBookUpdateType type, Cash cash)
         {
             UpdateType = type;
             Cash = cash;

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -98,7 +98,7 @@ namespace QuantConnect.Securities
 
             CashBook.Updated += (sender, args) =>
             {
-                if (args.UpdateType == CashBook.UpdateType.Added)
+                if (args.UpdateType == CashBookUpdateType.Added)
                 {
                     // add the same currency entry to the unsettled cashbook as well
                     UnsettledCashBook.Add(args.Cash.Symbol, new Cash(args.Cash.Symbol, 0, args.Cash.ConversionRate));

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -103,13 +103,6 @@ namespace QuantConnect.Securities
                     // add the same currency entry to the unsettled cashbook as well
                     UnsettledCashBook.Add(args.Cash.Symbol, new Cash(args.Cash.Symbol, 0, args.Cash.ConversionRate));
                 }
-                // if updated, let's keep track of conversion rate changes
-                else if (args.UpdateType == CashBook.UpdateType.Updated &&
-                         UnsettledCashBook.TryGetValue(args.Cash.Symbol, out var cash) &&
-                         args.Cash.ConversionRate != cash.ConversionRate)
-                {
-                    cash.ConversionRate = args.Cash.ConversionRate;
-                }
 
                 InvalidateTotalPortfolioValue();
             };

--- a/Engine/DataFeeds/CurrencySubscriptionDataConfigManager.cs
+++ b/Engine/DataFeeds/CurrencySubscriptionDataConfigManager.cs
@@ -55,7 +55,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         {
             cashBook.Updated += (sender, args) =>
             {
-                if (args.UpdateType == CashBook.UpdateType.Added)
+                if (args.UpdateType == CashBookUpdateType.Added)
                 {
                     _ensureCurrencyDataFeeds = true;
                 }

--- a/Engine/DataFeeds/CurrencySubscriptionDataConfigManager.cs
+++ b/Engine/DataFeeds/CurrencySubscriptionDataConfigManager.cs
@@ -53,9 +53,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             ISecurityService securityService,
             Resolution defaultResolution)
         {
-            cashBook.Updated += (sender, updateType) =>
+            cashBook.Updated += (sender, args) =>
             {
-                if (updateType == CashBook.UpdateType.Added)
+                if (args.UpdateType == CashBook.UpdateType.Added)
                 {
                     _ensureCurrencyDataFeeds = true;
                 }

--- a/Tests/Common/Securities/CashBookTests.cs
+++ b/Tests/Common/Securities/CashBookTests.cs
@@ -158,7 +158,7 @@ namespace QuantConnect.Tests.Common.Securities
             cashBook.Add(cash.Symbol, cash);
             cashBook.Updated += (sender, args) =>
             {
-                if (args.UpdateType == CashBook.UpdateType.Added)
+                if (args.UpdateType == CashBookUpdateType.Added)
                 {
                     called = true;
                 }
@@ -177,7 +177,7 @@ namespace QuantConnect.Tests.Common.Securities
             cashBook.Add(cash.Symbol, cash);
             cashBook.Updated += (sender, args) =>
             {
-                if (args.UpdateType == CashBook.UpdateType.Updated)
+                if (args.UpdateType == CashBookUpdateType.Updated)
                 {
                     called = true;
                 }
@@ -199,7 +199,7 @@ namespace QuantConnect.Tests.Common.Securities
             var cash = new Cash(Currencies.USD, 1, 1);
             cashBook.Updated += (sender, args) =>
             {
-                if (args.UpdateType == CashBook.UpdateType.Added)
+                if (args.UpdateType == CashBookUpdateType.Added)
                 {
                     called = true;
                 }
@@ -219,7 +219,7 @@ namespace QuantConnect.Tests.Common.Securities
             var cash = new Cash(Currencies.USD, 1, 1);
             cashBook.Updated += (sender, args) =>
             {
-                if (args.UpdateType == CashBook.UpdateType.Added)
+                if (args.UpdateType == CashBookUpdateType.Added)
                 {
                     called = true;
                 }
@@ -239,7 +239,7 @@ namespace QuantConnect.Tests.Common.Securities
             cashBook.Add(cash.Symbol, cash);
             cashBook.Updated += (sender, args) =>
             {
-                if (args.UpdateType == CashBook.UpdateType.Removed)
+                if (args.UpdateType == CashBookUpdateType.Removed)
                 {
                     called = true;
                 }
@@ -281,7 +281,7 @@ namespace QuantConnect.Tests.Common.Securities
             cashBook.Updated += (sender, args) =>
             {
                 called = true;
-                updatedCalled = args.UpdateType == CashBook.UpdateType.Updated;
+                updatedCalled = args.UpdateType == CashBookUpdateType.Updated;
             };
             cash.Update();
             var conversionRate = cash.ConversionRate;
@@ -304,7 +304,7 @@ namespace QuantConnect.Tests.Common.Securities
             cashBook.Updated += (sender, args) =>
             {
                 called++;
-                calledUpdated = args.UpdateType == CashBook.UpdateType.Updated;
+                calledUpdated = args.UpdateType == CashBookUpdateType.Updated;
             };
 
             cashBook.Add(cash.Symbol, new Cash(Currencies.USD, 1, 2));
@@ -322,7 +322,7 @@ namespace QuantConnect.Tests.Common.Securities
             cashBook.Add(cash.Symbol, cash);
             cashBook.Updated += (sender, args) =>
             {
-                called = args.UpdateType == CashBook.UpdateType.Removed;
+                called = args.UpdateType == CashBookUpdateType.Removed;
             };
 
             cashBook.Clear();

--- a/Tests/Common/Securities/CashBookTests.cs
+++ b/Tests/Common/Securities/CashBookTests.cs
@@ -157,9 +157,9 @@ namespace QuantConnect.Tests.Common.Securities
             var called = false;
             var cash = new Cash(Currencies.USD, 1, 1);
             cashBook.Add(cash.Symbol, cash);
-            cashBook.Updated += (sender, updateType) =>
+            cashBook.Updated += (sender, args) =>
             {
-                if (updateType == CashBook.UpdateType.Added)
+                if (args.UpdateType == CashBook.UpdateType.Added)
                 {
                     called = true;
                 }
@@ -176,9 +176,9 @@ namespace QuantConnect.Tests.Common.Securities
             var called = false;
             var cash = new Cash(Currencies.USD, 1, 1);
             cashBook.Add(cash.Symbol, cash);
-            cashBook.Updated += (sender, updateType) =>
+            cashBook.Updated += (sender, args) =>
             {
-                if (updateType == CashBook.UpdateType.Updated)
+                if (args.UpdateType == CashBook.UpdateType.Updated)
                 {
                     called = true;
                 }
@@ -198,9 +198,9 @@ namespace QuantConnect.Tests.Common.Securities
             cashBook.Clear();
             var called = false;
             var cash = new Cash(Currencies.USD, 1, 1);
-            cashBook.Updated += (sender, updateType) =>
+            cashBook.Updated += (sender, args) =>
             {
-                if (updateType == CashBook.UpdateType.Added)
+                if (args.UpdateType == CashBook.UpdateType.Added)
                 {
                     called = true;
                 }
@@ -218,9 +218,9 @@ namespace QuantConnect.Tests.Common.Securities
             cashBook.Clear();
             var called = false;
             var cash = new Cash(Currencies.USD, 1, 1);
-            cashBook.Updated += (sender, updateType) =>
+            cashBook.Updated += (sender, args) =>
             {
-                if (updateType == CashBook.UpdateType.Added)
+                if (args.UpdateType == CashBook.UpdateType.Added)
                 {
                     called = true;
                 }
@@ -238,9 +238,9 @@ namespace QuantConnect.Tests.Common.Securities
             var called = false;
             var cash = new Cash(Currencies.USD, 1, 1);
             cashBook.Add(cash.Symbol, cash);
-            cashBook.Updated += (sender, updateType) =>
+            cashBook.Updated += (sender, args) =>
             {
-                if (updateType == CashBook.UpdateType.Removed)
+                if (args.UpdateType == CashBook.UpdateType.Removed)
                 {
                     called = true;
                 }
@@ -279,10 +279,10 @@ namespace QuantConnect.Tests.Common.Securities
             cashBook.Add(cash.Symbol, cash);
             cashBook.Add(cash.Symbol, cash2);
 
-            cashBook.Updated += (sender, updateType) =>
+            cashBook.Updated += (sender, args) =>
             {
                 called = true;
-                updatedCalled = updateType == CashBook.UpdateType.Updated;
+                updatedCalled = args.UpdateType == CashBook.UpdateType.Updated;
             };
             cash.Update();
             var conversionRate = cash.ConversionRate;
@@ -302,10 +302,10 @@ namespace QuantConnect.Tests.Common.Securities
             var calledUpdated = false;
             var cash = new Cash(Currencies.USD, 1, 1);
             cashBook.Add(cash.Symbol, cash);
-            cashBook.Updated += (sender, updateType) =>
+            cashBook.Updated += (sender, args) =>
             {
                 called++;
-                calledUpdated = updateType == CashBook.UpdateType.Updated;
+                calledUpdated = args.UpdateType == CashBook.UpdateType.Updated;
             };
 
             cashBook.Add(cash.Symbol, new Cash(Currencies.USD, 1, 2));
@@ -321,9 +321,9 @@ namespace QuantConnect.Tests.Common.Securities
             var called = false;
             var cash = new Cash(Currencies.USD, 1, 1);
             cashBook.Add(cash.Symbol, cash);
-            cashBook.Updated += (sender, updateType) =>
+            cashBook.Updated += (sender, args) =>
             {
-                called = updateType == CashBook.UpdateType.Removed;
+                called = args.UpdateType == CashBook.UpdateType.Removed;
             };
 
             cashBook.Clear();

--- a/Tests/Common/Securities/CashBookTests.cs
+++ b/Tests/Common/Securities/CashBookTests.cs
@@ -17,7 +17,6 @@ using System;
 using System.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using QuantConnect.Data.Market;
 using QuantConnect.Packets;
 using QuantConnect.Securities;
 

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -35,7 +35,6 @@ using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Lean.Engine.Results;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Tests.Engine.DataFeeds;
-using static QuantConnect.Securities.CashBook;
 
 namespace QuantConnect.Tests.Common.Securities
 {
@@ -2688,7 +2687,7 @@ namespace QuantConnect.Tests.Common.Securities
             var additions = 0;
             portfolio.UnsettledCashBook.Updated += (sender, args) =>
             {
-                if (args.UpdateType == UpdateType.Added)
+                if (args.UpdateType == CashBookUpdateType.Added)
                 {
                     additions++;
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Hold securities quote currency cash instances in `Portfolio.UnsettledCashBook` to track unsettled cash amounts with currencies different thant the account currency.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6859 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

When selling assets with currencies different than the account one, the unsettled cash amount was not being added to the unsettled cash book because there was no entry for currencies other than the account one.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit tests
- Regression algorithm

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
