### PR TITLE
Add example of bull/bear call spread using index option

### DIFF
--- a/Algorithm.CSharp/IndexOptionBearCallSpreadAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionBearCallSpreadAlgorithm.cs
@@ -1,0 +1,71 @@
+/* 
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Linq;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class IndexOptionBearCallSpreadAlgorithm : QCAlgorithm
+    {
+        private Symbol _symbol;
+
+        public override void Initialize()
+        {
+            SetStartDate(2020, 1, 1);
+            SetEndDate(2021, 1, 1);
+            SetCash(100000);
+
+            AddEquity("SPY", Resolution.Minute);
+
+            var index = AddIndex("SPX", Resolution.Minute).Symbol;
+            var option = AddIndexOption(index, "SPXW", Resolution.Minute);
+            option.SetFilter((x) => x.WeeklysOnly().Strikes(-5, 5).Expiration(40, 60));
+            _symbol = option.Symbol;
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (!Portfolio["SPY"].Invested)
+            {
+                MarketOrder("SPY", 100);
+            }
+        
+            // Return if hedge position presents
+            if (Portfolio.Values.Any(x => x.Type == SecurityType.IndexOption && x.Invested)) return;
+
+            // Get the OptionChain
+            var chain = slice.OptionChains.get(_symbol);
+            if (chain == null) return;
+
+            // Get the nearest expiry date of the contracts
+            var expiry = chain.Select(x => x.Expiry).OrderBy(x => x).First();
+            
+            // Select the call Option contracts with the nearest expiry and sort by strike price
+            var calls = chain.Where(x => x.Expiry == expiry && x.Right == OptionRight.Call).OrderBy(x => x.Strike);
+            if (calls.Count() == 0) return;
+
+            // Create combo order legs
+            var legs = new List<Leg>
+            {
+                Leg.Create(calls.First().Symbol, 1),
+                Leg.Create(calls.Last().Symbol, -1)
+            };
+            ComboMarketOrder(legs, 1);
+        }
+    }
+}

--- a/Algorithm.CSharp/IndexOptionBearCallSpreadAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionBearCallSpreadAlgorithm.cs
@@ -22,7 +22,7 @@ namespace QuantConnect.Algorithm.CSharp
 {
     public class IndexOptionBearCallSpreadAlgorithm : QCAlgorithm
     {
-        private Symbol _symbol;
+        private Symbol _option, _spy;
 
         public override void Initialize()
         {
@@ -30,40 +30,40 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2021, 1, 1);
             SetCash(100000);
 
-            AddEquity("SPY", Resolution.Minute);
+            _spy = AddEquity("SPY", Resolution.Minute).Symbol;
 
             var index = AddIndex("VIX", Resolution.Minute).Symbol;
             var option = AddIndexOption(index, "VIXW", Resolution.Minute);
             option.SetFilter((x) => x.Strikes(-5, 5).Expiration(90, 120));
-            _symbol = option.Symbol;
+            _option = option.Symbol;
         }
 
         public override void OnData(Slice slice)
         {
-            if (!Portfolio["SPY"].Invested)
+            if (!Portfolio[_spy].Invested)
             {
-                MarketOrder("SPY", 100);
+                MarketOrder(_spy, 100);
             }
         
             // Return if hedge position presents
-            if (Portfolio.Values.Any(x => x.Type == SecurityType.IndexOption && x.Invested)) return;
+            if (Portfolio.Any(x => x.Value.Type == SecurityType.IndexOption && x.Value.Invested)) return;
 
             // Get the OptionChain
-            var chain = slice.OptionChains.get(_symbol);
-            if (chain == null) return;
+            if (!slice.OptionChains.TryGetValue(_option, out var chain)) return;
 
             // Get the nearest expiry date of the contracts
             var expiry = chain.Min(x => x.Expiry);
             
             // Select the call Option contracts with the nearest expiry and sort by strike price
-            var calls = chain.Where(x => x.Expiry == expiry && x.Right == OptionRight.Call).OrderBy(x => x.Strike);
-            if (calls.Count() == 0) return;
+            var calls = chain.Where(x => x.Expiry == expiry && x.Right == OptionRight.Call)
+                            .OrderBy(x => x.Strike).ToArray();
+            if (calls.Length < 2) return;
 
             // Create combo order legs
             var legs = new List<Leg>
             {
-                Leg.Create(calls.First().Symbol, -1),
-                Leg.Create(calls.Last().Symbol, 1)
+                Leg.Create(calls[0].Symbol, -1),
+                Leg.Create(calls[^1].Symbol, 1)
             };
             ComboMarketOrder(legs, 1);
         }

--- a/Algorithm.CSharp/IndexOptionBearCallSpreadAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionBearCallSpreadAlgorithm.cs
@@ -22,7 +22,8 @@ namespace QuantConnect.Algorithm.CSharp
 {
     public class IndexOptionBearCallSpreadAlgorithm : QCAlgorithm
     {
-        private Symbol _option, _spy;
+        private Symbol _vixw, _spy;
+        private List<Leg> _legs = new();
 
         public override void Initialize()
         {
@@ -35,7 +36,7 @@ namespace QuantConnect.Algorithm.CSharp
             var index = AddIndex("VIX", Resolution.Minute).Symbol;
             var option = AddIndexOption(index, "VIXW", Resolution.Minute);
             option.SetFilter((x) => x.Strikes(-5, 5).Expiration(15, 45));
-            _option = option.Symbol;
+            _vixw = option.Symbol;
         }
 
         public override void OnData(Slice slice)
@@ -46,10 +47,10 @@ namespace QuantConnect.Algorithm.CSharp
             }
         
             // Return if hedge position presents
-            if (Portfolio.Values.Any(x => x.Type == SecurityType.IndexOption && x.Invested)) return;
+            if (_legs.Any(x => Portfolio[x.Symbol].Invested)) return;
 
             // Get the OptionChain
-            if (!slice.OptionChains.TryGetValue(_option, out var chain)) return;
+            if (!slice.OptionChains.TryGetValue(_vixw, out var chain)) return;
 
             // Get the nearest expiry date of the contracts
             var expiry = chain.Min(x => x.Expiry);
@@ -60,12 +61,12 @@ namespace QuantConnect.Algorithm.CSharp
             if (calls.Length < 2) return;
 
             // Create combo order legs
-            var legs = new List<Leg>
+            _legs = new List<Leg>
             {
                 Leg.Create(calls[0].Symbol, -1),
                 Leg.Create(calls[^1].Symbol, 1)
             };
-            ComboMarketOrder(legs, 1);
+            ComboMarketOrder(_legs, 1);
         }
     }
 }

--- a/Algorithm.CSharp/IndexOptionBearCallSpreadAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionBearCallSpreadAlgorithm.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             var index = AddIndex("VIX", Resolution.Minute).Symbol;
             var option = AddIndexOption(index, "VIXW", Resolution.Minute);
-            option.SetFilter((x) => x.Strikes(-5, 5).Expiration(90, 120));
+            option.SetFilter((x) => x.Strikes(-5, 5).Expiration(15, 45));
             _option = option.Symbol;
         }
 

--- a/Algorithm.CSharp/IndexOptionBearCallSpreadAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionBearCallSpreadAlgorithm.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Algorithm.CSharp
             }
         
             // Return if hedge position presents
-            if (Portfolio.Any(x => x.Value.Type == SecurityType.IndexOption && x.Value.Invested)) return;
+            if (Portfolio.Values.Any(x => x.Type == SecurityType.IndexOption && x.Invested)) return;
 
             // Get the OptionChain
             if (!slice.OptionChains.TryGetValue(_option, out var chain)) return;

--- a/Algorithm.CSharp/IndexOptionBearCallSpreadAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionBearCallSpreadAlgorithm.cs
@@ -30,10 +30,10 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2021, 1, 1);
             SetCash(100000);
 
-            AddEquity("SPY", Resolution.Hour);
+            AddEquity("SPY", Resolution.Minute);
 
-            var index = AddIndex("VIX", Resolution.Hour).Symbol;
-            var option = AddIndexOption(index, "VIXW", Resolution.Hour);
+            var index = AddIndex("VIX", Resolution.Minute).Symbol;
+            var option = AddIndexOption(index, "VIXW", Resolution.Minute);
             option.SetFilter((x) => x.Strikes(-5, 5).Expiration(90, 120));
             _symbol = option.Symbol;
         }
@@ -53,7 +53,7 @@ namespace QuantConnect.Algorithm.CSharp
             if (chain == null) return;
 
             // Get the nearest expiry date of the contracts
-            var expiry = chain.Select(x => x.Expiry).OrderBy(x => x).First();
+            var expiry = chain.Min(x => x.Expiry);
             
             // Select the call Option contracts with the nearest expiry and sort by strike price
             var calls = chain.Where(x => x.Expiry == expiry && x.Right == OptionRight.Call).OrderBy(x => x.Strike);

--- a/Algorithm.CSharp/IndexOptionBullCallSpreadAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionBullCallSpreadAlgorithm.cs
@@ -53,7 +53,7 @@ namespace QuantConnect.Algorithm.CSharp
             if (chain == null) return;
 
             // Get the nearest expiry date of the contracts
-            var expiry = chain.Select(x => x.Expiry).OrderBy(x => x).First();
+            var expiry = chain.Min(x => x.Expiry);
             
             // Select the call Option contracts with the nearest expiry and sort by strike price
             var calls = chain.Where(x => x.Expiry == expiry && x.Right == OptionRight.Call).OrderBy(x => x.Strike);

--- a/Algorithm.CSharp/IndexOptionBullCallSpreadAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionBullCallSpreadAlgorithm.cs
@@ -20,7 +20,7 @@ using QuantConnect.Orders;
 
 namespace QuantConnect.Algorithm.CSharp
 {
-    public class IndexOptionBearCallSpreadAlgorithm : QCAlgorithm
+    public class IndexOptionBullCallSpreadAlgorithm : QCAlgorithm
     {
         private Symbol _symbol;
 
@@ -30,11 +30,11 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2021, 1, 1);
             SetCash(100000);
 
-            AddEquity("SPY", Resolution.Hour);
+            AddEquity("SPY", Resolution.Minute);
 
-            var index = AddIndex("VIX", Resolution.Hour).Symbol;
-            var option = AddIndexOption(index, "VIXW", Resolution.Hour);
-            option.SetFilter((x) => x.Strikes(-5, 5).Expiration(90, 120));
+            var index = AddIndex("SPX", Resolution.Minute).Symbol;
+            var option = AddIndexOption(index, "SPXW", Resolution.Minute);
+            option.SetFilter((x) => x.WeeklysOnly().Strikes(-5, 5).Expiration(40, 60));
             _symbol = option.Symbol;
         }
 
@@ -62,8 +62,8 @@ namespace QuantConnect.Algorithm.CSharp
             // Create combo order legs
             var legs = new List<Leg>
             {
-                Leg.Create(calls.First().Symbol, -1),
-                Leg.Create(calls.Last().Symbol, 1)
+                Leg.Create(calls.First().Symbol, 1),
+                Leg.Create(calls.Last().Symbol, -1)
             };
             ComboMarketOrder(legs, 1);
         }

--- a/Algorithm.CSharp/IndexOptionBullCallSpreadAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionBullCallSpreadAlgorithm.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Algorithm.CSharp
             }
         
             // Return if hedge position presents
-            if (Portfolio.Any(x => x.Value.Type == SecurityType.IndexOption && x.Value.Invested)) return;
+            if (Portfolio.Values.Any(x => x.Type == SecurityType.IndexOption && x.Invested)) return;
 
             // Get the OptionChain
             if (!slice.OptionChains.TryGetValue(_option, out var chain)) return;

--- a/Algorithm.Python/IndexOptionBearCallSpreadAlgorithm.py
+++ b/Algorithm.Python/IndexOptionBearCallSpreadAlgorithm.py
@@ -26,7 +26,7 @@ class IndexOptionBearCallSpreadAlgorithm(QCAlgorithm):
 
         index = self.AddIndex("SPX", Resolution.Minute).Symbol
         option = self.AddIndexOption(index, "SPXW", Resolution.Minute)
-        option.SetFilter(lambda x: x.Strikes(-5, 5).Expiration(40, 60))
+        option.SetFilter(lambda x: x.WeeklysOnly().Strikes(-5, 5).Expiration(40, 60))
         self.symbol = option.Symbol
 
     def OnData(self, slice: Slice) -> None:
@@ -34,7 +34,7 @@ class IndexOptionBearCallSpreadAlgorithm(QCAlgorithm):
             self.MarketOrder("SPY", 100)
         
         # Return if hedge position presents
-        if any([x.Type == SecurityType.IndexOption for x in self.Portfolio.Values if x.Invested]):
+        if any([x.Type == SecurityType.IndexOption and x.Invested for x in self.Portfolio.Values]):
             return
 
         # Return if hedge position presents

--- a/Algorithm.Python/IndexOptionBearCallSpreadAlgorithm.py
+++ b/Algorithm.Python/IndexOptionBearCallSpreadAlgorithm.py
@@ -34,7 +34,7 @@ class IndexOptionBearCallSpreadAlgorithm(QCAlgorithm):
             self.MarketOrder(self.spy, 100)
         
         # Return if hedge position presents
-        if any([x.Values.Type == SecurityType.IndexOption and x.Values.Invested for x in self.Portfolio]):
+        if any([x.Type == SecurityType.IndexOption and x.Invested for x in self.Portfolio.Values]):
             return
 
         # Return if hedge position presents

--- a/Algorithm.Python/IndexOptionBearCallSpreadAlgorithm.py
+++ b/Algorithm.Python/IndexOptionBearCallSpreadAlgorithm.py
@@ -1,0 +1,57 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#region imports
+from AlgorithmImports import *
+#endregion
+
+class IndexOptionBearCallSpreadAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetStartDate(2020, 1, 1)
+        self.SetEndDate(2021, 1, 1)
+        self.SetCash(100000)
+
+        self.AddEquity("SPY", Resolution.Minute)
+
+        index = self.AddIndex("SPX", Resolution.Minute).Symbol
+        option = self.AddIndexOption(index, "SPXW", Resolution.Minute)
+        option.SetFilter(lambda x: x.Strikes(-5, 5).Expiration(40, 60))
+        self.symbol = option.Symbol
+
+    def OnData(self, slice: Slice) -> None:
+        if not self.Portfolio["SPY"].Invested:
+            self.MarketOrder("SPY", 100)
+        
+        # Return if hedge position presents
+        if any([x.Type == SecurityType.IndexOption for x in self.Portfolio.Values if x.Invested]):
+            return
+
+        # Return if hedge position presents
+        chain = slice.OptionChains.get(self.symbol)
+        if not chain: return
+
+        # Get the nearest expiry date of the contracts
+        expiry = sorted(chain, key = lambda x: x.Expiry)[0].Expiry
+        
+        # Select the call Option contracts with the nearest expiry and sort by strike price
+        calls = sorted([i for i in chain if i.Expiry == expiry and i.Right == OptionRight.Call], 
+                        key=lambda x: x.Strike)
+        if len(calls) == 0: return
+
+        # Create combo order legs by selecting the ITM and OTM contract
+        legs = [
+            Leg.Create(calls[0].Symbol, 1),
+            Leg.Create(calls[-1].Symbol, -1)
+        ]
+        self.ComboMarketOrder(legs, 1)

--- a/Algorithm.Python/IndexOptionBearCallSpreadAlgorithm.py
+++ b/Algorithm.Python/IndexOptionBearCallSpreadAlgorithm.py
@@ -26,7 +26,7 @@ class IndexOptionBearCallSpreadAlgorithm(QCAlgorithm):
 
         index = self.AddIndex("VIX", Resolution.Minute).Symbol
         option = self.AddIndexOption(index, "VIXW", Resolution.Minute)
-        option.SetFilter(lambda x: x.Strikes(-5, 5).Expiration(90, 120))
+        option.SetFilter(lambda x: x.Strikes(-5, 5).Expiration(15, 45))
         self.option = option.Symbol
 
     def OnData(self, slice: Slice) -> None:

--- a/Algorithm.Python/IndexOptionBearCallSpreadAlgorithm.py
+++ b/Algorithm.Python/IndexOptionBearCallSpreadAlgorithm.py
@@ -22,10 +22,10 @@ class IndexOptionBearCallSpreadAlgorithm(QCAlgorithm):
         self.SetEndDate(2021, 1, 1)
         self.SetCash(100000)
 
-        self.AddEquity("SPY", Resolution.Hour)
+        self.AddEquity("SPY", Resolution.Minute)
 
-        index = self.AddIndex("VIX", Resolution.Hour).Symbol
-        option = self.AddIndexOption(index, "VIXW", Resolution.Hour)
+        index = self.AddIndex("VIX", Resolution.Minute).Symbol
+        option = self.AddIndexOption(index, "VIXW", Resolution.Minute)
         option.SetFilter(lambda x: x.Strikes(-5, 5).Expiration(90, 120))
         self.symbol = option.Symbol
 
@@ -41,12 +41,12 @@ class IndexOptionBearCallSpreadAlgorithm(QCAlgorithm):
         if not chain: return
 
         # Get the nearest expiry date of the contracts
-        expiry = sorted(chain, key = lambda x: x.Expiry)[0].Expiry
+        expiry = min([x.Expiry for x in chain])
         
         # Select the call Option contracts with the nearest expiry and sort by strike price
         calls = sorted([i for i in chain if i.Expiry == expiry and i.Right == OptionRight.Call], 
                         key=lambda x: x.Strike)
-        if len(calls) == 0: return
+        if not calls: return
 
         # Create combo order legs by selecting the ITM and OTM contract
         legs = [

--- a/Algorithm.Python/IndexOptionBullCallSpreadAlgorithm.py
+++ b/Algorithm.Python/IndexOptionBullCallSpreadAlgorithm.py
@@ -22,23 +22,23 @@ class IndexOptionBullCallSpreadAlgorithm(QCAlgorithm):
         self.SetEndDate(2021, 1, 1)
         self.SetCash(100000)
 
-        self.AddEquity("SPY", Resolution.Minute)
+        self.spy = self.AddEquity("SPY", Resolution.Minute).Symbol
 
         index = self.AddIndex("SPX", Resolution.Minute).Symbol
         option = self.AddIndexOption(index, "SPXW", Resolution.Minute)
         option.SetFilter(lambda x: x.WeeklysOnly().Strikes(-5, 5).Expiration(40, 60))
-        self.symbol = option.Symbol
+        self.option = option.Symbol
 
     def OnData(self, slice: Slice) -> None:
-        if not self.Portfolio["SPY"].Invested:
-            self.MarketOrder("SPY", 100)
+        if not self.Portfolio[self.spy].Invested:
+            self.MarketOrder(self.spy, 100)
         
         # Return if hedge position presents
-        if any([x.Type == SecurityType.IndexOption and x.Invested for x in self.Portfolio.Values]):
+        if any([x.Values.Type == SecurityType.IndexOption and x.Values.Invested for x in self.Portfolio]):
             return
 
         # Return if hedge position presents
-        chain = slice.OptionChains.get(self.symbol)
+        chain = slice.OptionChains.get(self.option)
         if not chain: return
 
         # Get the nearest expiry date of the contracts
@@ -47,7 +47,7 @@ class IndexOptionBullCallSpreadAlgorithm(QCAlgorithm):
         # Select the call Option contracts with the nearest expiry and sort by strike price
         calls = sorted([i for i in chain if i.Expiry == expiry and i.Right == OptionRight.Call], 
                         key=lambda x: x.Strike)
-        if not calls: return
+        if len(calls) < 2: return
 
         # Create combo order legs by selecting the ITM and OTM contract
         legs = [

--- a/Algorithm.Python/IndexOptionBullCallSpreadAlgorithm.py
+++ b/Algorithm.Python/IndexOptionBullCallSpreadAlgorithm.py
@@ -27,18 +27,20 @@ class IndexOptionBullCallSpreadAlgorithm(QCAlgorithm):
         index = self.AddIndex("SPX", Resolution.Minute).Symbol
         option = self.AddIndexOption(index, "SPXW", Resolution.Minute)
         option.SetFilter(lambda x: x.WeeklysOnly().Strikes(-5, 5).Expiration(40, 60))
-        self.option = option.Symbol
+        
+        self.spxw = option.Symbol
+        self.legs = []
 
     def OnData(self, slice: Slice) -> None:
         if not self.Portfolio[self.spy].Invested:
             self.MarketOrder(self.spy, 100)
         
         # Return if hedge position presents
-        if any([x.Type == SecurityType.IndexOption and x.Invested for x in self.Portfolio.Values]):
+        if any([self.Portfolio[x.Symbol].Invested for x in self.legs]):
             return
 
         # Return if hedge position presents
-        chain = slice.OptionChains.get(self.option)
+        chain = slice.OptionChains.get(self.spxw)
         if not chain: return
 
         # Get the nearest expiry date of the contracts
@@ -50,8 +52,8 @@ class IndexOptionBullCallSpreadAlgorithm(QCAlgorithm):
         if len(calls) < 2: return
 
         # Create combo order legs by selecting the ITM and OTM contract
-        legs = [
+        self.legs = [
             Leg.Create(calls[0].Symbol, 1),
             Leg.Create(calls[-1].Symbol, -1)
         ]
-        self.ComboMarketOrder(legs, 1)
+        self.ComboMarketOrder(self.legs, 1)

--- a/Algorithm.Python/IndexOptionBullCallSpreadAlgorithm.py
+++ b/Algorithm.Python/IndexOptionBullCallSpreadAlgorithm.py
@@ -34,7 +34,7 @@ class IndexOptionBullCallSpreadAlgorithm(QCAlgorithm):
             self.MarketOrder(self.spy, 100)
         
         # Return if hedge position presents
-        if any([x.Values.Type == SecurityType.IndexOption and x.Values.Invested for x in self.Portfolio]):
+        if any([x.Type == SecurityType.IndexOption and x.Invested for x in self.Portfolio.Values]):
             return
 
         # Return if hedge position presents

--- a/Algorithm.Python/IndexOptionBullCallSpreadAlgorithm.py
+++ b/Algorithm.Python/IndexOptionBullCallSpreadAlgorithm.py
@@ -15,24 +15,25 @@
 from AlgorithmImports import *
 #endregion
 
-class IndexOptionBearCallSpreadAlgorithm(QCAlgorithm):
+class IndexOptionBullCallSpreadAlgorithm(QCAlgorithm):
 
     def Initialize(self):
         self.SetStartDate(2020, 1, 1)
         self.SetEndDate(2021, 1, 1)
         self.SetCash(100000)
 
-        self.AddEquity("SPY", Resolution.Hour)
+        self.AddEquity("SPY", Resolution.Minute)
 
-        index = self.AddIndex("VIX", Resolution.Hour).Symbol
-        option = self.AddIndexOption(index, "VIXW", Resolution.Hour)
-        option.SetFilter(lambda x: x.Strikes(-5, 5).Expiration(90, 120))
+        index = self.AddIndex("SPX", Resolution.Minute).Symbol
+        option = self.AddIndexOption(index, "SPXW", Resolution.Minute)
+        option.SetFilter(lambda x: x.WeeklysOnly().Strikes(-5, 5).Expiration(40, 60))
         self.symbol = option.Symbol
 
     def OnData(self, slice: Slice) -> None:
         if not self.Portfolio["SPY"].Invested:
             self.MarketOrder("SPY", 100)
         
+        # Return if hedge position presents
         if any([x.Type == SecurityType.IndexOption and x.Invested for x in self.Portfolio.Values]):
             return
 
@@ -50,7 +51,7 @@ class IndexOptionBearCallSpreadAlgorithm(QCAlgorithm):
 
         # Create combo order legs by selecting the ITM and OTM contract
         legs = [
-            Leg.Create(calls[0].Symbol, -1),
-            Leg.Create(calls[-1].Symbol, 1)
+            Leg.Create(calls[0].Symbol, 1),
+            Leg.Create(calls[-1].Symbol, -1)
         ]
         self.ComboMarketOrder(legs, 1)

--- a/Algorithm.Python/IndexOptionBullCallSpreadAlgorithm.py
+++ b/Algorithm.Python/IndexOptionBullCallSpreadAlgorithm.py
@@ -42,12 +42,12 @@ class IndexOptionBullCallSpreadAlgorithm(QCAlgorithm):
         if not chain: return
 
         # Get the nearest expiry date of the contracts
-        expiry = sorted(chain, key = lambda x: x.Expiry)[0].Expiry
+        expiry = min([x.Expiry for x in chain])
         
         # Select the call Option contracts with the nearest expiry and sort by strike price
         calls = sorted([i for i in chain if i.Expiry == expiry and i.Right == OptionRight.Call], 
                         key=lambda x: x.Strike)
-        if len(calls) == 0: return
+        if not calls: return
 
         # Create combo order legs by selecting the ITM and OTM contract
         legs = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
To add example algorithm of SPXW weekly index options for Bull/Bear Call Spread option strategy.

#### Related Issue
NA

#### Motivation and Context
Lack of combo order examples with index weeklies.

#### Requires Documentation Change
Add the link of example in the Bull/Bear Call Spread option strategy page.

#### How Has This Been Tested?
Bull call spread
- C#: https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_97b791e4fe7212aa248fced841c8ab24.html
- Py: https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_43f213fef12f1c3f6df2428b98cccde4.html

Bear call spread:
- C#: https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_e4069731a06c426802de85d1ec1dae62.html
- Py: https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_8885bb7daa3dd06e9ee4ca58093fc689.html

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
   non-breaking change, `/Data` does not have data for regression
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
