### PR TITLE
Symbol to industry-standard security identifier conversion

### DIFF
--- a/Algorithm.CSharp/IndustryStandardSecurityIdentifiersRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndustryStandardSecurityIdentifiersRegressionAlgorithm.cs
@@ -75,7 +75,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
         /// </summary>
-        public bool CanRunLocally { get; } = false;
+        public bool CanRunLocally { get; } = true;
 
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.

--- a/Algorithm.CSharp/IndustryStandardSecurityIdentifiersRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndustryStandardSecurityIdentifiersRegressionAlgorithm.cs
@@ -13,9 +13,11 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 
 using QuantConnect.Interfaces;
+using QuantConnect.Util;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -30,10 +32,44 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2013, 10, 07);
 
             var spy = AddEquity("SPY").Symbol;
-            Log($"\nSPY CUSIP: {spy.CUSIP}" +
-                $"\nSPY Composite FIGI: {spy.CompositeFIGI}" +
-                $"\nSPY SEDOL: {spy.SEDOL}" +
-                $"\nSPY ISIN: {spy.ISIN}");
+
+            var spyCusip = spy.CUSIP;
+            var spyCompositeFigi = spy.CompositeFIGI;
+            var spySedol = spy.SEDOL;
+            var spyIsin = spy.ISIN;
+
+            CheckSymbolRepresentation(spyCusip, "CUSIP");
+            CheckSymbolRepresentation(spyCompositeFigi, "Composite FIGI");
+            CheckSymbolRepresentation(spySedol, "SEDOL");
+            CheckSymbolRepresentation(spyIsin, "ISIN");
+
+            // Check Symbol API vs QCAlgorithm API
+            CheckAPIsSymbolRepresentations(spyCusip, CUSIP(spy), "CUSIP");
+            CheckAPIsSymbolRepresentations(spyCompositeFigi, CompositeFIGI(spy), "Composite FIGI");
+            CheckAPIsSymbolRepresentations(spySedol, SEDOL(spy), "SEDOL");
+            CheckAPIsSymbolRepresentations(spyIsin, ISIN(spy), "ISIN");
+
+            Log($"\nSPY CUSIP: {spyCusip}" +
+                $"\nSPY Composite FIGI: {spyCompositeFigi}" +
+                $"\nSPY SEDOL: {spySedol}" +
+                $"\nSPY ISIN: {spyIsin}");
+        }
+
+        private static void CheckSymbolRepresentation(string symbol, string standard)
+        {
+            if (symbol.IsNullOrEmpty())
+            {
+                throw new Exception($"{standard} symbol representation is null or empty");
+            }
+        }
+
+        private static void CheckAPIsSymbolRepresentations(string symbolApiSymbol, string algorithmApiSymbol, string standard)
+        {
+            if (symbolApiSymbol != algorithmApiSymbol)
+            {
+                throw new Exception($@"Symbol API {standard} symbol representation ({symbolApiSymbol}) does not match QCAlgorithm API {
+                    standard} symbol representation ({algorithmApiSymbol})");
+            }
         }
 
         /// <summary>

--- a/Algorithm.CSharp/IndustryStandardSecurityIdentifiersRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndustryStandardSecurityIdentifiersRegressionAlgorithm.cs
@@ -1,0 +1,108 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Algorithm illustrating how to get a security's industry-standard identifier from its <see cref="Symbol"/>
+    /// </summary>
+    public class IndustryStandardSecurityIdentifiersRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 07);
+
+            var spy = AddEquity("SPY").Symbol;
+            Log($"\nSPY CUSIP: {spy.CUSIP}" +
+                $"\nSPY Composite FIGI: {spy.CompositeFIGI}" +
+                $"\nSPY SEDOL: {spy.SEDOL}" +
+                $"\nSPY ISIN: {spy.ISIN}");
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = false;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 795;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "0"},
+            {"Return Over Maximum Drawdown", "0"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.Python/IndustryStandardSecurityIdentifiersRegressionAlgorithm.py
+++ b/Algorithm.Python/IndustryStandardSecurityIdentifiersRegressionAlgorithm.py
@@ -44,11 +44,11 @@ class IndustryStandardSecurityIdentifiersRegressionAlgorithm(QCAlgorithm):
                  f"\nSPY SEDOL: {spySedol}"
                  f"\nSPY ISIN: {spyIsin}")
 
-    def CheckSymbolRepresentation(symbol: str, standard: str) -> None:
+    def CheckSymbolRepresentation(self, symbol: str, standard: str) -> None:
         if not symbol:
             raise Exception(f"{standard} symbol representation is null or empty")
 
-    def CheckAPIsSymbolRepresentations(symbolApiSymbol: str, algorithmApiSymbol: str, standard: str) -> None:
+    def CheckAPIsSymbolRepresentations(self, symbolApiSymbol: str, algorithmApiSymbol: str, standard: str) -> None:
         if symbolApiSymbol != algorithmApiSymbol:
             raise Exception(f"Symbol API {standard} symbol representation ({symbolApiSymbol}) does not match "
                             f"QCAlgorithm API {standard} symbol representation ({algorithmApiSymbol})")

--- a/Algorithm.Python/IndustryStandardSecurityIdentifiersRegressionAlgorithm.py
+++ b/Algorithm.Python/IndustryStandardSecurityIdentifiersRegressionAlgorithm.py
@@ -23,8 +23,32 @@ class IndustryStandardSecurityIdentifiersRegressionAlgorithm(QCAlgorithm):
 
         spy = self.AddEquity("SPY").Symbol
 
-        self.Log(f"\nSPY CUSIP: {spy.CUSIP}"
-                 f"\nSPY Composite FIGI: {spy.CompositeFIGI}"
-                 f"\nSPY SEDOL: {spy.SEDOL}"
-                 f"\nSPY ISIN: {spy.ISIN}")
+        spyCusip = spy.CUSIP
+        spyCompositeFigi = spy.CompositeFIGI
+        spySedol = spy.SEDOL
+        spyIsin = spy.ISIN
 
+        self.CheckSymbolRepresentation(spyCusip, "CUSIP")
+        self.CheckSymbolRepresentation(spyCompositeFigi, "Composite FIGI")
+        self.CheckSymbolRepresentation(spySedol, "SEDOL")
+        self.CheckSymbolRepresentation(spyIsin, "ISIN")
+
+        # Check Symbol API vs QCAlgorithm API
+        self.CheckAPIsSymbolRepresentations(spyCusip, self.CUSIP(spy), "CUSIP");
+        self.CheckAPIsSymbolRepresentations(spyCompositeFigi, self.CompositeFIGI(spy), "Composite FIGI");
+        self.CheckAPIsSymbolRepresentations(spySedol, self.SEDOL(spy), "SEDOL");
+        self.CheckAPIsSymbolRepresentations(spyIsin, self.ISIN(spy), "ISIN");
+
+        self.Log(f"\nSPY CUSIP: {spyCusip}"
+                 f"\nSPY Composite FIGI: {spyCompositeFigi}"
+                 f"\nSPY SEDOL: {spySedol}"
+                 f"\nSPY ISIN: {spyIsin}")
+
+    def CheckSymbolRepresentation(symbol: str, standard: str) -> None:
+        if not symbol:
+            raise Exception(f"{standard} symbol representation is null or empty")
+
+    def CheckAPIsSymbolRepresentations(symbolApiSymbol: str, algorithmApiSymbol: str, standard: str) -> None:
+        if symbolApiSymbol != algorithmApiSymbol:
+            raise Exception(f"Symbol API {standard} symbol representation ({symbolApiSymbol}) does not match "
+                            f"QCAlgorithm API {standard} symbol representation ({algorithmApiSymbol})")

--- a/Algorithm.Python/IndustryStandardSecurityIdentifiersRegressionAlgorithm.py
+++ b/Algorithm.Python/IndustryStandardSecurityIdentifiersRegressionAlgorithm.py
@@ -1,0 +1,30 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Algorithm illustrating how to get a security's industry-standard identifier from its `Symbol`
+### </summary>
+class IndustryStandardSecurityIdentifiersRegressionAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        self.SetStartDate(2013, 10, 7)
+        self.SetEndDate(2013, 10, 7)
+
+        spy = self.AddEquity("SPY").Symbol
+
+        self.Log(f"\nSPY CUSIP: {spy.CUSIP}"
+                 f"\nSPY Composite FIGI: {spy.CompositeFIGI}"
+                 f"\nSPY SEDOL: {spy.SEDOL}"
+                 f"\nSPY ISIN: {spy.ISIN}")
+

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <Content Include="AccumulativeInsightPortfolioRegressionAlgorithm.py" />
     <Content Include="CorrectConsolidatedBarTypeForTickTypesAlgorithm.py" />
+    <Content Include="IndustryStandardSecurityIdentifiersRegressionAlgorithm.py" />
     <Content Include="AddAlphaModelAlgorithm.py" />
     <Content Include="AddFutureOptionContractDataStreamingRegressionAlgorithm.py" />
     <Content Include="AddFutureOptionSingleOptionChainSelectedInUniverseFilterRegressionAlgorithm.py" />

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2888,11 +2888,23 @@ namespace QuantConnect.Algorithm
         /// The date is used to create a Symbol with the ticker set to the ticker the asset traded under on the trading date.
         /// </param>
         /// <returns>Symbol corresponding to the ISIN. If no Symbol with a matching ISIN was found, returns null.</returns>
-        [DocumentationAttribute(HandlingData)]
-        [DocumentationAttribute(SecuritiesAndPortfolio)]
+        [Documentation(HandlingData)]
+        [Documentation(SecuritiesAndPortfolio)]
         public Symbol ISIN(string isin, DateTime? tradingDate = null)
         {
             return _securityDefinitionSymbolResolver.ISIN(isin, GetVerifiedTradingDate(tradingDate));
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Symbol"/> into an ISIN identifier
+        /// </summary>
+        /// <param name="symbol">The <see cref="Symbol"/></param>
+        /// <returns>ISIN corresponding to the Symbol. If no matching ISIN is found, returns null.</returns>
+        [Documentation(HandlingData)]
+        [Documentation(SecuritiesAndPortfolio)]
+        public string ISIN(Symbol symbol)
+        {
+            return _securityDefinitionSymbolResolver.ISIN(symbol);
         }
 
         /// <summary>
@@ -2908,11 +2920,23 @@ namespace QuantConnect.Algorithm
         /// The composite FIGI differs from an exchange-level FIGI, in that it identifies
         /// an asset across all exchanges in a single country that the asset trades in.
         /// </remarks>
-        [DocumentationAttribute(HandlingData)]
-        [DocumentationAttribute(SecuritiesAndPortfolio)]
+        [Documentation(HandlingData)]
+        [Documentation(SecuritiesAndPortfolio)]
         public Symbol CompositeFIGI(string compositeFigi, DateTime? tradingDate = null)
         {
             return _securityDefinitionSymbolResolver.CompositeFIGI(compositeFigi, GetVerifiedTradingDate(tradingDate));
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Symbol"/> into a composite FIGI identifier
+        /// </summary>
+        /// <param name="symbol">The <see cref="Symbol"/></param>
+        /// <returns>Composite FIGI corresponding to the Symbol. If no matching composite FIGI is found, returns null.</returns>
+        [Documentation(HandlingData)]
+        [Documentation(SecuritiesAndPortfolio)]
+        public string CompositeFIGI(Symbol symbol)
+        {
+            return _securityDefinitionSymbolResolver.CompositeFIGI(symbol);
         }
 
         /// <summary>
@@ -2924,11 +2948,23 @@ namespace QuantConnect.Algorithm
         /// The date is used to create a Symbol with the ticker set to the ticker the asset traded under on the trading date.
         /// </param>
         /// <returns>Symbol corresponding to the CUSIP. If no Symbol with a matching CUSIP was found, returns null.</returns>
-        [DocumentationAttribute(HandlingData)]
-        [DocumentationAttribute(SecuritiesAndPortfolio)]
+        [Documentation(HandlingData)]
+        [Documentation(SecuritiesAndPortfolio)]
         public Symbol CUSIP(string cusip, DateTime? tradingDate = null)
         {
             return _securityDefinitionSymbolResolver.CUSIP(cusip, GetVerifiedTradingDate(tradingDate));
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Symbol"/> into a CUSIP identifier
+        /// </summary>
+        /// <param name="symbol">The <see cref="Symbol"/></param>
+        /// <returns>CUSIP corresponding to the Symbol. If no matching CUSIP is found, returns null.</returns>
+        [Documentation(HandlingData)]
+        [Documentation(SecuritiesAndPortfolio)]
+        public string CUSIP(Symbol symbol)
+        {
+            return _securityDefinitionSymbolResolver.CUSIP(symbol);
         }
 
         /// <summary>
@@ -2940,11 +2976,23 @@ namespace QuantConnect.Algorithm
         /// The date is used to create a Symbol with the ticker set to the ticker the asset traded under on the trading date.
         /// </param>
         /// <returns>Symbol corresponding to the SEDOL. If no Symbol with a matching SEDOL was found, returns null.</returns>
-        [DocumentationAttribute(HandlingData)]
-        [DocumentationAttribute(SecuritiesAndPortfolio)]
+        [Documentation(HandlingData)]
+        [Documentation(SecuritiesAndPortfolio)]
         public Symbol SEDOL(string sedol, DateTime? tradingDate = null)
         {
             return _securityDefinitionSymbolResolver.SEDOL(sedol, GetVerifiedTradingDate(tradingDate));
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Symbol"/> into a SEDOL identifier
+        /// </summary>
+        /// <param name="symbol">The <see cref="Symbol"/></param>
+        /// <returns>SEDOL corresponding to the Symbol. If no matching SEDOL is found, returns null.</returns>
+        [Documentation(HandlingData)]
+        [Documentation(SecuritiesAndPortfolio)]
+        public string SEDOL(Symbol symbol)
+        {
+            return _securityDefinitionSymbolResolver.SEDOL(symbol);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -147,7 +147,7 @@ namespace QuantConnect.Algorithm
             //Initialise End Date:
             SetEndDate(DateTime.UtcNow.ConvertFromUtc(TimeZone));
 
-            _securityDefinitionSymbolResolver = new SecurityDefinitionSymbolResolver();
+            _securityDefinitionSymbolResolver = SecurityDefinitionSymbolResolver.GetInstance();
 
             Settings = new AlgorithmSettings();
             DefaultOrderProperties = new OrderProperties();
@@ -2888,8 +2888,8 @@ namespace QuantConnect.Algorithm
         /// The date is used to create a Symbol with the ticker set to the ticker the asset traded under on the trading date.
         /// </param>
         /// <returns>Symbol corresponding to the ISIN. If no Symbol with a matching ISIN was found, returns null.</returns>
-        [Documentation(HandlingData)]
-        [Documentation(SecuritiesAndPortfolio)]
+        [DocumentationAttribute(HandlingData)]
+        [DocumentationAttribute(SecuritiesAndPortfolio)]
         public Symbol ISIN(string isin, DateTime? tradingDate = null)
         {
             return _securityDefinitionSymbolResolver.ISIN(isin, GetVerifiedTradingDate(tradingDate));
@@ -2900,8 +2900,8 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">The <see cref="Symbol"/></param>
         /// <returns>ISIN corresponding to the Symbol. If no matching ISIN is found, returns null.</returns>
-        [Documentation(HandlingData)]
-        [Documentation(SecuritiesAndPortfolio)]
+        [DocumentationAttribute(HandlingData)]
+        [DocumentationAttribute(SecuritiesAndPortfolio)]
         public string ISIN(Symbol symbol)
         {
             return _securityDefinitionSymbolResolver.ISIN(symbol);
@@ -2920,8 +2920,8 @@ namespace QuantConnect.Algorithm
         /// The composite FIGI differs from an exchange-level FIGI, in that it identifies
         /// an asset across all exchanges in a single country that the asset trades in.
         /// </remarks>
-        [Documentation(HandlingData)]
-        [Documentation(SecuritiesAndPortfolio)]
+        [DocumentationAttribute(HandlingData)]
+        [DocumentationAttribute(SecuritiesAndPortfolio)]
         public Symbol CompositeFIGI(string compositeFigi, DateTime? tradingDate = null)
         {
             return _securityDefinitionSymbolResolver.CompositeFIGI(compositeFigi, GetVerifiedTradingDate(tradingDate));
@@ -2932,8 +2932,8 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">The <see cref="Symbol"/></param>
         /// <returns>Composite FIGI corresponding to the Symbol. If no matching composite FIGI is found, returns null.</returns>
-        [Documentation(HandlingData)]
-        [Documentation(SecuritiesAndPortfolio)]
+        [DocumentationAttribute(HandlingData)]
+        [DocumentationAttribute(SecuritiesAndPortfolio)]
         public string CompositeFIGI(Symbol symbol)
         {
             return _securityDefinitionSymbolResolver.CompositeFIGI(symbol);
@@ -2948,8 +2948,8 @@ namespace QuantConnect.Algorithm
         /// The date is used to create a Symbol with the ticker set to the ticker the asset traded under on the trading date.
         /// </param>
         /// <returns>Symbol corresponding to the CUSIP. If no Symbol with a matching CUSIP was found, returns null.</returns>
-        [Documentation(HandlingData)]
-        [Documentation(SecuritiesAndPortfolio)]
+        [DocumentationAttribute(HandlingData)]
+        [DocumentationAttribute(SecuritiesAndPortfolio)]
         public Symbol CUSIP(string cusip, DateTime? tradingDate = null)
         {
             return _securityDefinitionSymbolResolver.CUSIP(cusip, GetVerifiedTradingDate(tradingDate));
@@ -2960,8 +2960,8 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">The <see cref="Symbol"/></param>
         /// <returns>CUSIP corresponding to the Symbol. If no matching CUSIP is found, returns null.</returns>
-        [Documentation(HandlingData)]
-        [Documentation(SecuritiesAndPortfolio)]
+        [DocumentationAttribute(HandlingData)]
+        [DocumentationAttribute(SecuritiesAndPortfolio)]
         public string CUSIP(Symbol symbol)
         {
             return _securityDefinitionSymbolResolver.CUSIP(symbol);
@@ -2976,8 +2976,8 @@ namespace QuantConnect.Algorithm
         /// The date is used to create a Symbol with the ticker set to the ticker the asset traded under on the trading date.
         /// </param>
         /// <returns>Symbol corresponding to the SEDOL. If no Symbol with a matching SEDOL was found, returns null.</returns>
-        [Documentation(HandlingData)]
-        [Documentation(SecuritiesAndPortfolio)]
+        [DocumentationAttribute(HandlingData)]
+        [DocumentationAttribute(SecuritiesAndPortfolio)]
         public Symbol SEDOL(string sedol, DateTime? tradingDate = null)
         {
             return _securityDefinitionSymbolResolver.SEDOL(sedol, GetVerifiedTradingDate(tradingDate));
@@ -2988,8 +2988,8 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">The <see cref="Symbol"/></param>
         /// <returns>SEDOL corresponding to the Symbol. If no matching SEDOL is found, returns null.</returns>
-        [Documentation(HandlingData)]
-        [Documentation(SecuritiesAndPortfolio)]
+        [DocumentationAttribute(HandlingData)]
+        [DocumentationAttribute(SecuritiesAndPortfolio)]
         public string SEDOL(Symbol symbol)
         {
             return _securityDefinitionSymbolResolver.SEDOL(symbol);

--- a/Common/Securities/SecurityDefinition.cs
+++ b/Common/Securities/SecurityDefinition.cs
@@ -14,10 +14,10 @@
  *
 */
 
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using QLNet;
+
 using QuantConnect.Interfaces;
 
 namespace QuantConnect.Securities
@@ -33,13 +33,13 @@ namespace QuantConnect.Securities
         /// the industry-standard security identifiers contained within this class.
         /// </summary>
         public SecurityIdentifier SecurityIdentifier { get; set; }
-        
+
         /// <summary>
         /// The Committee on Uniform Securities Identification Procedures (CUSIP) number of a security
         /// </summary>
         /// <remarks>For more information on CUSIP numbers: https://en.wikipedia.org/wiki/CUSIP</remarks>
         public string CUSIP { get; set; }
-       
+
         /// <summary>
         /// The composite Financial Instrument Global Identifier (FIGI) of a security
         /// </summary>
@@ -49,19 +49,19 @@ namespace QuantConnect.Securities
         /// For more information about the FIGI standard: https://en.wikipedia.org/wiki/Financial_Instrument_Global_Identifier
         /// </remarks>
         public string CompositeFIGI { get; set; }
-        
+
         /// <summary>
         /// The Stock Exchange Daily Official List (SEDOL) security identifier of a security
         /// </summary>
         /// <remarks>For more information about SEDOL security identifiers: https://en.wikipedia.org/wiki/SEDOL</remarks>
         public string SEDOL { get; set; }
-       
+
         /// <summary>
         /// The International Securities Identification Number (ISIN) of a security
         /// </summary>
         /// <remarks>For more information about the ISIN standard: https://en.wikipedia.org/wiki/International_Securities_Identification_Number</remarks>
         public string ISIN { get; set; }
-        
+
         /// <summary>
         /// Reads data from the specified file and converts it to a list of SecurityDefinition
         /// </summary>
@@ -72,13 +72,13 @@ namespace QuantConnect.Securities
         {
             using var stream = dataProvider.Fetch(securitiesDefinitionKey);
             using var reader = new StreamReader(stream);
-            
+
             var securityDefinitions = new List<SecurityDefinition>();
-            
+
             string line;
             while ((line = reader.ReadLine()) != null)
             {
-                if (string.IsNullOrWhiteSpace(line))
+                if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#", StringComparison.InvariantCulture))
                 {
                     continue;
                 }

--- a/Common/Securities/SecurityDefinitionSymbolResolver.cs
+++ b/Common/Securities/SecurityDefinitionSymbolResolver.cs
@@ -78,6 +78,16 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Converts a Lean <see cref="Symbol"/> to its CUSIP number
+        /// </summary>
+        /// <param name="symbol">The Lean <see cref="Symbol"/></param>
+        /// <returns>The Committee on Uniform Securities Identification Procedures (CUSIP) number corresponding to the given Lean <see cref="Symbol"/></returns>
+        public string CUSIP(Symbol symbol)
+        {
+            return SymbolToSecurityDefinition(symbol)?.CUSIP;
+        }
+
+        /// <summary>
         /// Converts an asset's composite FIGI into a Lean <see cref="Symbol"/>
         /// </summary>
         /// <param name="compositeFigi">
@@ -98,6 +108,16 @@ namespace QuantConnect.Securities
             return SecurityDefinitionToSymbol(
                 GetSecurityDefinitions().FirstOrDefault(x => x.CompositeFIGI != null && x.CompositeFIGI.Equals(compositeFigi, StringComparison.InvariantCultureIgnoreCase)),
                 tradingDate);
+        }
+
+        /// <summary>
+        /// Converts a Lean <see cref="Symbol"/> to its composite FIGI representation
+        /// </summary>
+        /// <param name="symbol">The Lean <see cref="Symbol"/></param>
+        /// <returns>The composite Financial Instrument Global Identifier (FIGI) corresponding to the given Lean <see cref="Symbol"/></returns>
+        public string CompositeFIGI(Symbol symbol)
+        {
+            return SymbolToSecurityDefinition(symbol)?.CompositeFIGI;
         }
 
         /// <summary>
@@ -124,6 +144,16 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Converts a Lean <see cref="Symbol"/> to its SEDOL representation
+        /// </summary>
+        /// <param name="symbol">The Lean <see cref="Symbol"/></param>
+        /// <returns>The Stock Exchange Daily Official List (SEDOL) security identifier corresponding to the given Lean <see cref="Symbol"/></returns>
+        public string SEDOL(Symbol symbol)
+        {
+            return SymbolToSecurityDefinition(symbol)?.SEDOL;
+        }
+
+        /// <summary>
         /// Converts ISIN into a Lean <see cref="Symbol"/>
         /// </summary>
         /// <param name="isin">
@@ -144,6 +174,16 @@ namespace QuantConnect.Securities
             return SecurityDefinitionToSymbol(
                 GetSecurityDefinitions().FirstOrDefault(x => x.ISIN != null && x.ISIN.Equals(isin, StringComparison.InvariantCultureIgnoreCase)),
                 tradingDate);
+        }
+
+        /// <summary>
+        /// Converts a Lean <see cref="Symbol"/> to its ISIN representation
+        /// </summary>
+        /// <param name="symbol">The Lean <see cref="Symbol"/></param>
+        /// <returns>The International Securities Identification Number (ISIN) corresponding to the given Lean <see cref="Symbol"/></returns>
+        public string ISIN(Symbol symbol)
+        {
+            return SymbolToSecurityDefinition(symbol)?.ISIN;
         }
 
         /// <summary>
@@ -182,6 +222,20 @@ namespace QuantConnect.Securities
             return string.IsNullOrWhiteSpace(mappedTicker)
                 ? null
                 : new Symbol(securityDefinition.SecurityIdentifier, mappedTicker);
+        }
+
+        /// <summary>
+        /// Gets the SecurityDefinition corresponding to the given Lean <see cref="Symbol"/>
+        /// </summary>
+        private SecurityDefinition SymbolToSecurityDefinition(Symbol symbol)
+        {
+            if (symbol == null)
+            {
+                return null;
+            }
+
+            return GetSecurityDefinitions()
+                .FirstOrDefault(x => x.SecurityIdentifier.ToString().Equals(symbol.ID.ToString(), StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>

--- a/Common/Securities/SecurityDefinitionSymbolResolver.cs
+++ b/Common/Securities/SecurityDefinitionSymbolResolver.cs
@@ -249,8 +249,8 @@ namespace QuantConnect.Securities
             {
                 if (_securityDefinitions == null && !SecurityDefinition.TryRead(_dataProvider, _securitiesDefinitionKey, out _securityDefinitions))
                 {
-                        _securityDefinitions = new List<SecurityDefinition>();
-                        Log.Error($"SecurityDefinitionSymbolResolver(): No security definitions data loaded from file: {_securitiesDefinitionKey}");
+                    _securityDefinitions = new List<SecurityDefinition>();
+                    Log.Error($"SecurityDefinitionSymbolResolver(): No security definitions data loaded from file: {_securitiesDefinitionKey}");
                 }
             }
 

--- a/Common/Symbol.cs
+++ b/Common/Symbol.cs
@@ -18,6 +18,8 @@ using System;
 using ProtoBuf;
 using Newtonsoft.Json;
 
+using QuantConnect.Securities;
+
 namespace QuantConnect
 {
     /// <summary>
@@ -29,6 +31,8 @@ namespace QuantConnect
     [ProtoContract(SkipConstructor = true)]
     public sealed class Symbol : IEquatable<Symbol>, IComparable
     {
+        private static readonly SecurityDefinitionSymbolResolver _securityDefinitionSymbolResolver = new();
+
         private Symbol _canonical;
         // for performance we register how we compare with empty
         private bool? _isEmpty;
@@ -359,6 +363,26 @@ namespace QuantConnect
         {
             get { return ID.SecurityType; }
         }
+
+        /// <summary>
+        /// The Committee on Uniform Securities Identification Procedures (CUSIP) number corresponding to this <see cref="Symbol"/>
+        /// </summary>
+        public string CUSIP { get { return _securityDefinitionSymbolResolver.CUSIP(this); } }
+
+        /// <summary>
+        /// The composite Financial Instrument Global Identifier (FIGI) corresponding to this <see cref="Symbol"/>
+        /// </summary>
+        public string CompositeFIGI { get { return _securityDefinitionSymbolResolver.CompositeFIGI(this); } }
+
+        /// <summary>
+        /// The Stock Exchange Daily Official List (SEDOL) security identifier corresponding to this <see cref="Symbol"/>
+        /// </summary>
+        public string SEDOL { get { return _securityDefinitionSymbolResolver.SEDOL(this); } }
+
+        /// <summary>
+        /// The International Securities Identification Number (ISIN) corresponding to this <see cref="Symbol"/>
+        /// </summary>
+        public string ISIN { get { return _securityDefinitionSymbolResolver.ISIN(this); } }
 
 
         #endregion

--- a/Common/Symbol.cs
+++ b/Common/Symbol.cs
@@ -31,7 +31,7 @@ namespace QuantConnect
     [ProtoContract(SkipConstructor = true)]
     public sealed class Symbol : IEquatable<Symbol>, IComparable
     {
-        private static readonly SecurityDefinitionSymbolResolver _securityDefinitionSymbolResolver = new();
+        private static readonly SecurityDefinitionSymbolResolver _securityDefinitionSymbolResolver = SecurityDefinitionSymbolResolver.GetInstance();
 
         private Symbol _canonical;
         // for performance we register how we compare with empty

--- a/Data/symbol-properties/security-database.csv
+++ b/Data/symbol-properties/security-database.csv
@@ -1,0 +1,2 @@
+# These are just some fake values we can use for testing and running regression algorithms
+SPY R735QTJ8XC9X,03783310,BBG000B9XRY4,2046251,US0378331005

--- a/Tests/Common/Securities/SecurityDefinitionSymbolResolverTests.cs
+++ b/Tests/Common/Securities/SecurityDefinitionSymbolResolverTests.cs
@@ -42,7 +42,9 @@ namespace QuantConnect.Tests.Common.Securities
             _testingDataDirectory = Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(), "testing_data"));
             var symbolPropertiesDirectory = Directory.CreateDirectory(Path.Combine(_testingDataDirectory.FullName, "symbol-properties"));
             var securityDatabaseFilePath = Path.Combine(symbolPropertiesDirectory.FullName, "security-database.csv");
-            _instance = new SecurityDefinitionSymbolResolver(TestGlobals.DataProvider, securityDatabaseFilePath);
+
+            SecurityDefinitionSymbolResolver.Reset();
+            _instance = SecurityDefinitionSymbolResolver.GetInstance(TestGlobals.DataProvider, securityDatabaseFilePath);
 
             var securityDatabaseLines = string.Join("\n",
                 "AAPL R735QTJ8XC9X,03783310,BBG000B9XRY4,2046251,US0378331005",
@@ -55,6 +57,7 @@ namespace QuantConnect.Tests.Common.Securities
         [OneTimeTearDown]
         public void TearDown()
         {
+            SecurityDefinitionSymbolResolver.Reset();
             _testingDataDirectory.Delete(true);
         }
 
@@ -62,11 +65,11 @@ namespace QuantConnect.Tests.Common.Securities
         public void NoExistingSecurityDefinitions()
         {
             var date = DateTime.UtcNow;
-            var definitionSymbolResolver = new SecurityDefinitionSymbolResolver(TestGlobals.DataProvider);
-            Assert.IsNull(definitionSymbolResolver.ISIN("US46090E1038", date));
-            Assert.IsNull(definitionSymbolResolver.CUSIP("03783310", date));
-            Assert.IsNull(definitionSymbolResolver.CompositeFIGI("BBG000BSWKH7", date));
-            Assert.IsNull(definitionSymbolResolver.SEDOL("bdqyp67", date));
+            // SPY
+            Assert.IsNull(_instance.ISIN("US78462F1030", date));
+            Assert.IsNull(_instance.CUSIP("78462F103", date));
+            Assert.IsNull(_instance.CompositeFIGI("BBG001S72SM3", date));
+            Assert.IsNull(_instance.SEDOL("BDDXTY3", date));
         }
 
         [TestCase("03783310", 2021, 9, 9, "AAPL", Market.USA)]

--- a/Tests/Common/Securities/SecurityDefinitionSymbolResolverTests.cs
+++ b/Tests/Common/Securities/SecurityDefinitionSymbolResolverTests.cs
@@ -18,8 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
-using QuantConnect.Configuration;
-using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Common.Securities
@@ -27,7 +25,6 @@ namespace QuantConnect.Tests.Common.Securities
     [TestFixture]
     public class SecurityDefinitionSymbolResolverTests
     {
-        private string _dataFolderConfig;
         private DirectoryInfo _testingDataDirectory;
         private SecurityDefinitionSymbolResolver _instance;
         private static readonly Dictionary<string, string> _tickerToSecurityIdentifier = new Dictionary<string, string>
@@ -71,7 +68,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.IsNull(definitionSymbolResolver.CompositeFIGI("BBG000BSWKH7", date));
             Assert.IsNull(definitionSymbolResolver.SEDOL("bdqyp67", date));
         }
-        
+
         [TestCase("03783310", 2021, 9, 9, "AAPL", Market.USA)]
         [TestCase("03783310", 2002, 9, 9, "AAPL", Market.USA)]
         [TestCase("03783310", 1995, 1, 1, "AAPL", Market.USA)]
@@ -104,10 +101,21 @@ namespace QuantConnect.Tests.Common.Securities
             var expectedSid = expectedTicker == null
                 ? null
                 : _tickerToSecurityIdentifier[expectedTicker];
-            
-            AssertSymbol(_instance.CUSIP(cusip, tradingDate), expectedTicker, expectedSid, expectedMarket);
+
+            var symbol = _instance.CUSIP(cusip, tradingDate);
+
+            AssertSymbol(symbol, expectedTicker, expectedSid, expectedMarket);
+
+            AssertSymbolIdentifier(symbol, _instance.CUSIP(symbol), cusip);
         }
-        
+
+        [TestCaseSource(nameof(SymbolToCUSIPTestCases))]
+        public void ResolvesSymbolToCUSIP(Symbol symbol, string expectedCusip)
+        {
+            var cusip = _instance.CUSIP(symbol);
+            Assert.AreEqual(expectedCusip, cusip);
+        }
+
         [TestCase("BBG000B9XRY4", 2021, 9, 9, "AAPL", Market.USA)]
         [TestCase("BBG000B9XRY4", 2002, 9, 9, "AAPL", Market.USA)]
         [TestCase("BBG000B9XRY4", 1995, 1, 1, "AAPL", Market.USA)]
@@ -142,10 +150,21 @@ namespace QuantConnect.Tests.Common.Securities
             var expectedSid = expectedTicker == null
                 ? null
                 : _tickerToSecurityIdentifier[expectedTicker];
-            
-            AssertSymbol(_instance.CompositeFIGI(compositeFigi, tradingDate), expectedTicker, expectedSid, expectedMarket);
+
+            var symbol = _instance.CompositeFIGI(compositeFigi, tradingDate);
+
+            AssertSymbol(symbol, expectedTicker, expectedSid, expectedMarket);
+
+            AssertSymbolIdentifier(symbol, _instance.CompositeFIGI(symbol), compositeFigi);
         }
-        
+
+        [TestCaseSource(nameof(SymbolToCompositeFIGITestCases))]
+        public void ResolvesSymbolToCompositeFIGI(Symbol symbol, string expectedCompositeFigi)
+        {
+            var compositeFigi = _instance.CompositeFIGI(symbol);
+            Assert.AreEqual(expectedCompositeFigi, compositeFigi);
+        }
+
         [TestCase("2046251", 2021, 9, 9, "AAPL", Market.USA)]
         [TestCase("2046251", 2002, 9, 9, "AAPL", Market.USA)]
         [TestCase("2046251", 1995, 1, 1, "AAPL", Market.USA)]
@@ -178,10 +197,21 @@ namespace QuantConnect.Tests.Common.Securities
             var expectedSid = expectedTicker == null
                 ? null
                 : _tickerToSecurityIdentifier[expectedTicker];
-            
-            AssertSymbol(_instance.SEDOL(sedol, tradingDate), expectedTicker, expectedSid, expectedMarket);
+
+            var symbol = _instance.SEDOL(sedol, tradingDate);
+
+            AssertSymbol(symbol, expectedTicker, expectedSid, expectedMarket);
+
+            AssertSymbolIdentifier(symbol, _instance.SEDOL(symbol), sedol);
         }
-        
+
+        [TestCaseSource(nameof(SymbolToSEDOLTestCases))]
+        public void ResolvesSymbolToSEDOL(Symbol symbol, string expectedSedol)
+        {
+            var sedol = _instance.SEDOL(symbol);
+            Assert.AreEqual(expectedSedol, sedol);
+        }
+
         [TestCase("US0378331005", 2021, 9, 9, "AAPL", Market.USA)]
         [TestCase("US0378331005", 2002, 9, 9, "AAPL", Market.USA)]
         [TestCase("US0378331005", 1995, 1, 1, "AAPL", Market.USA)]
@@ -214,15 +244,76 @@ namespace QuantConnect.Tests.Common.Securities
             var expectedSid = expectedTicker == null
                 ? null
                 : _tickerToSecurityIdentifier[expectedTicker];
-            
-            AssertSymbol(_instance.ISIN(isin, tradingDate), expectedTicker, expectedSid, expectedMarket);
+
+            var symbol = _instance.ISIN(isin, tradingDate);
+
+            AssertSymbol(symbol, expectedTicker, expectedSid, expectedMarket);
+
+            AssertSymbolIdentifier(symbol, _instance.ISIN(symbol), isin);
         }
 
-        private void AssertSymbol(Symbol actual, string expectedTicker, string expectedSid, string expectedMarket)
+        [TestCaseSource(nameof(SymbolToISINTestCases))]
+        public void ResolvesSymbolToISIN(Symbol symbol, string expectedIsin)
+        {
+            var isin = _instance.ISIN(symbol);
+            Assert.AreEqual(expectedIsin, isin);
+        }
+
+        private static void AssertSymbol(Symbol actual, string expectedTicker, string expectedSid, string expectedMarket)
         {
             Assert.AreEqual(expectedTicker, actual?.Value);
             Assert.AreEqual(expectedSid, actual?.ID.ToString());
             Assert.AreEqual(expectedMarket, actual?.ID.Market ?? expectedMarket);
         }
+
+        private static void AssertSymbolIdentifier(Symbol symbol, string reconvertedIdentifier, string expectedIdentifier)
+        {
+            var expected = symbol != null ? expectedIdentifier.ToUpperInvariant() : null;
+            Assert.AreEqual(expected, reconvertedIdentifier);
+        }
+
+        private static TestCaseData[] SymbolToCUSIPTestCases => new[]
+        {
+            new TestCaseData(Symbol.Create("AAPL", SecurityType.Equity, Market.USA), "03783310"),
+            new TestCaseData(Symbol.Create("GOOG", SecurityType.Equity, Market.USA), "38259P70"),
+            new TestCaseData(Symbol.Create("GOOCV", SecurityType.Equity, Market.USA), "38259P70"),
+            new TestCaseData(Symbol.Create("QQQ", SecurityType.Equity, Market.USA), "73935A10"),
+            new TestCaseData(Symbol.Create("QQQQ", SecurityType.Equity, Market.USA), "73935A10"),
+            new TestCaseData(Symbol.Create("ABCD", SecurityType.Equity, Market.USA), null),
+            new TestCaseData(null, null)
+        };
+
+        private static TestCaseData[] SymbolToCompositeFIGITestCases => new[]
+        {
+            new TestCaseData(Symbol.Create("AAPL", SecurityType.Equity, Market.USA), "BBG000B9XRY4"),
+            new TestCaseData(Symbol.Create("GOOG", SecurityType.Equity, Market.USA), "BBG002W96FT9"),
+            new TestCaseData(Symbol.Create("GOOCV", SecurityType.Equity, Market.USA), "BBG002W96FT9"),
+            new TestCaseData(Symbol.Create("QQQ", SecurityType.Equity, Market.USA), "BBG000BSWKH7"),
+            new TestCaseData(Symbol.Create("QQQQ", SecurityType.Equity, Market.USA), "BBG000BSWKH7"),
+            new TestCaseData(Symbol.Create("ABCD", SecurityType.Equity, Market.USA), null),
+            new TestCaseData(null, null)
+        };
+
+        private static TestCaseData[] SymbolToSEDOLTestCases => new[]
+        {
+            new TestCaseData(Symbol.Create("AAPL", SecurityType.Equity, Market.USA), "2046251"),
+            new TestCaseData(Symbol.Create("GOOG", SecurityType.Equity, Market.USA), "BKM4JZ7"),
+            new TestCaseData(Symbol.Create("GOOCV", SecurityType.Equity, Market.USA), "BKM4JZ7"),
+            new TestCaseData(Symbol.Create("QQQ", SecurityType.Equity, Market.USA), "BDQYP67"),
+            new TestCaseData(Symbol.Create("QQQQ", SecurityType.Equity, Market.USA), "BDQYP67"),
+            new TestCaseData(Symbol.Create("ABCD", SecurityType.Equity, Market.USA), null),
+            new TestCaseData(null, null)
+        };
+
+        private static TestCaseData[] SymbolToISINTestCases => new[]
+        {
+            new TestCaseData(Symbol.Create("AAPL", SecurityType.Equity, Market.USA), "US0378331005"),
+            new TestCaseData(Symbol.Create("GOOG", SecurityType.Equity, Market.USA), "US38259P7069"),
+            new TestCaseData(Symbol.Create("GOOCV", SecurityType.Equity, Market.USA), "US38259P7069"),
+            new TestCaseData(Symbol.Create("QQQ", SecurityType.Equity, Market.USA), "US46090E1038"),
+            new TestCaseData(Symbol.Create("QQQQ", SecurityType.Equity, Market.USA), "US46090E1038"),
+            new TestCaseData(Symbol.Create("ABCD", SecurityType.Equity, Market.USA), null),
+            new TestCaseData(null, null)
+        };
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

We can now get the industry-standard security identifier (CUSIP, Composite FIGI, SEDOL, ISIN) from the `Symbol` as we previoulsy could do it the other way around.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6569 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

Yes

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests and sample algorithms

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
