### PR TITLE
Add example algo of call calendar spread with SPXW

### DIFF
--- a/Algorithm.CSharp/IndexOptionCallCalendarSpreadAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallCalendarSpreadAlgorithm.cs
@@ -1,0 +1,87 @@
+/* 
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class IndexOptionCallCalendarSpreadAlgorithm : QCAlgorithm
+    {
+        private Symbol _option;
+        private DateTime _firstExpiry = DateTime.MaxValue;
+
+        public override void Initialize()
+        {
+            SetStartDate(2020, 1, 1);
+            SetEndDate(2023, 1, 1);
+            SetCash(50000);
+
+            AddEquity("VXZ", Resolution.Minute);
+
+            var index = AddIndex("VIX", Resolution.Minute).Symbol;
+            var option = AddIndexOption(index, "VIXW", Resolution.Minute);
+            option.SetFilter((x) => x.Strikes(-2, 2).Expiration(15, 45));
+            _option = option.Symbol;
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (!Portfolio["VXZ"].Invested)
+            {
+                MarketOrder("VXZ", 100);
+            }
+            
+            var indexOptionsInvested = Portfolio.Values.Where(x => x.Type == SecurityType.IndexOption && x.Invested);
+            // Liquidate if the shorter term option is about to expire
+            if (_firstExpiry < Time.AddDays(2))
+            {
+                foreach (var holding in indexOptionsInvested)
+                {
+                    Liquidate(holding.Symbol);
+                }
+            }
+            // Return if there is any opening index option position
+            else if (indexOptionsInvested.Count() > 0)
+            {
+                return;
+            }
+
+            // Get the OptionChain
+            var chain = slice.OptionChains.get(_option);
+            if (chain == null) return;
+
+            // Get ATM strike price
+            var strike = chain.OrderBy(x => Math.Abs(x.Strike - chain.Underlying.Value)).First().Strike;
+            
+            // Select the ATM call Option contracts and sort by expiration date
+            var calls = chain.Where(x => x.Strike == strike && x.Right == OptionRight.Call)
+                            .OrderBy(x => x.Expiry).ToArray();
+            if (calls.Length < 2) return;
+            _firstExpiry = calls[0].Expiry;
+
+            // Create combo order legs
+            var legs = new List<Leg>
+            {
+                Leg.Create(calls[0].Symbol, -1),
+                Leg.Create(calls[^1].Symbol, 1)
+            };
+            ComboMarketOrder(legs, -1, asynchronous: true);
+        }
+    }
+}

--- a/Algorithm.Python/IndexOptionCallCalendarSpreadAlgorithm.py
+++ b/Algorithm.Python/IndexOptionCallCalendarSpreadAlgorithm.py
@@ -1,0 +1,64 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+class IndexOptionCallCalendarSpreadAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetStartDate(2020, 1, 1)
+        self.SetEndDate(2023, 1, 1)
+        self.SetCash(50000)
+
+        self.AddEquity("VXZ", Resolution.Minute)
+
+        index = self.AddIndex("VIX", Resolution.Minute).Symbol
+        option = self.AddIndexOption(index, "VIXW", Resolution.Minute)
+        option.SetFilter(lambda x: x.Strikes(-2, 2).Expiration(15, 45))
+        self.symbol = option.Symbol
+
+        self.expiry = datetime.max
+
+    def OnData(self, slice: Slice) -> None:
+        if not self.Portfolio["VXZ"].Invested:
+            self.MarketOrder("VXZ", 100)
+        
+        index_options_invested = [x for x in self.Portfolio.Values
+                                  if x.Type == SecurityType.IndexOption and x.Invested]
+        # Liquidate if the shorter term option is about to expire
+        if self.expiry < self.Time + timedelta(2):
+            for holding in index_options_invested:
+                self.Liquidate(holding.Symbol)
+        # Return if there is any opening index option position
+        elif index_options_invested:
+            return
+
+        # Get the OptionChain
+        chain = slice.OptionChains.get(self.symbol)
+        if not chain: return
+
+        # Get ATM strike price
+        strike = sorted(chain, key = lambda x: abs(x.Strike - chain.Underlying.Value))[0].Strike
+        
+        # Select the ATM call Option contracts and sort by expiration date
+        calls = sorted([i for i in chain if i.Strike == strike and i.Right == OptionRight.Call], 
+                        key=lambda x: x.Expiry)
+        if len(calls) < 2: return
+        self.expiry = calls[0].Expiry
+
+        # Create combo order legs
+        legs = [
+            Leg.Create(calls[0].Symbol, -1),
+            Leg.Create(calls[-1].Symbol, 1)
+        ]
+        self.ComboMarketOrder(legs, -1, asynchronous=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
To add example algorithm of SPXW weekly index options for Call Calendar Spread option strategy.

#### Related Issue
NA

#### Motivation and Context
Lack of combo order examples with index weeklies.

#### Requires Documentation Change
Add the link of example in the Call Calendar Spread option strategy page.

#### How Has This Been Tested?
NA

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
   non-breaking change, `/Data` does not have data for regression
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
