### PR TITLE
Adds NullBuyingPowerModel

### DIFF
--- a/Algorithm.CSharp/NullBuyingPowerOptionBullCallSpreadAlgorithm.cs
+++ b/Algorithm.CSharp/NullBuyingPowerOptionBullCallSpreadAlgorithm.cs
@@ -84,6 +84,14 @@ namespace QuantConnect.Algorithm.CSharp
             }
         }
 
+        public override void OnEndOfAlgorithm()
+        {
+            if (Portfolio.TotalMarginUsed != 0)
+            {
+                throw new Exception("The TotalMarginUsed should be zero to avoid margin calls.");
+            }
+        }
+
         /// <summary>
         /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
         /// </summary>
@@ -129,7 +137,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$500.00"},
-            {"Estimated Strategy Capacity", "$1000.00"},
+            {"Estimated Strategy Capacity", "$36000.00"},
             {"Lowest Capacity Asset", "GOOCV W78ZERHAOVVQ|GOOCV VP83T1ZUHROL"},
             {"Fitness Score", "0"},
             {"Kelly Criterion Estimate", "0"},

--- a/Algorithm.CSharp/NullBuyingPowerOptionBullCallSpreadAlgorithm.cs
+++ b/Algorithm.CSharp/NullBuyingPowerOptionBullCallSpreadAlgorithm.cs
@@ -1,0 +1,156 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Shows how setting to use the SecurityMarginModel.Null (or BuyingPowerModel.Null)
+    /// to disable the sufficient margin call verification.
+    /// See also: <see cref="OptionEquityBullCallSpreadRegressionAlgorithm"/>
+    /// </summary>
+    /// <meta name="tag" content="reality model" />
+    public class NullBuyingPowerOptionBullCallSpreadAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _optionSymbol;
+
+        public override void Initialize()
+        {
+            SetStartDate(2015, 12, 24);
+            SetEndDate(2015, 12, 24);
+            SetCash(200000);
+
+            SetSecurityInitializer(security => security.MarginModel = SecurityMarginModel.Null);
+
+            var equity = AddEquity("GOOG");
+            var option = AddOption(equity.Symbol);
+            _optionSymbol = option.Symbol;
+
+            option.SetFilter(-2, +2, 0, 180);
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (!Portfolio.Invested && IsMarketOpen(_optionSymbol) &&
+                slice.OptionChains.TryGetValue(_optionSymbol, out var chain))
+            {
+                var callContracts = chain
+                    .Where(contract => contract.Right == OptionRight.Call).ToList();
+
+                var expiry = callContracts.Min(x => x.Expiry);
+
+                callContracts = callContracts
+                    .Where(x => x.Expiry == expiry)
+                    .OrderBy(x => x.Strike)
+                    .ToList();
+
+                var longCall = callContracts.First();
+                var shortCall = callContracts.First(contract => contract.Strike > longCall.Strike);
+
+                const int quantity = 1000;
+
+                var tickets = new[]
+                {
+                    MarketOrder(shortCall.Symbol, -quantity),
+                    MarketOrder(longCall.Symbol, quantity)
+                };
+
+                foreach (var ticket in tickets)
+                {
+                    if (ticket.Status != OrderStatus.Filled)
+                    {
+                        throw new Exception($"There should be no restriction on buying {ticket.Quantity} of {ticket.Symbol} with BuyingPowerModel.Null");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 884208;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new()
+        {
+            {"Total Trades", "2"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$500.00"},
+            {"Estimated Strategy Capacity", "$1000.00"},
+            {"Lowest Capacity Asset", "GOOCV W78ZERHAOVVQ|GOOCV VP83T1ZUHROL"},
+            {"Fitness Score", "0"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "0"},
+            {"Return Over Maximum Drawdown", "0"},
+            {"Portfolio Turnover", "0"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "5c32a1e90845e321ae1cc8b893353acd"}
+        };
+    }
+}

--- a/Algorithm.Python/NullBuyingPowerOptionBullCallSpreadAlgorithm.py
+++ b/Algorithm.Python/NullBuyingPowerOptionBullCallSpreadAlgorithm.py
@@ -1,0 +1,62 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Shows how setting to use the SecurityMarginModel.Null (or BuyingPowerModel.Null)
+### to disable the sufficient margin call verification.
+### See also: <see cref="OptionEquityBullCallSpreadRegressionAlgorithm"/>
+### </summary>
+### <meta name="tag" content="reality model" />
+class NullBuyingPowerOptionBullCallSpreadAlgorithm(QCAlgorithm):
+    def Initialize(self):
+
+        self.SetStartDate(2015, 12, 24)
+        self.SetEndDate(2015, 12, 24)
+        self.SetCash(200000)
+
+        self.SetSecurityInitializer(lambda security: security.SetMarginModel(SecurityMarginModel.Null))
+
+        equity = self.AddEquity("GOOG")
+        option = self.AddOption(equity.Symbol)
+        self.optionSymbol = option.Symbol
+
+        option.SetFilter(-2, 2, 0, 180)
+        
+    def OnData(self, slice):
+        if self.Portfolio.Invested or not self.IsMarketOpen(self.optionSymbol):
+            return
+       
+        chain = slice.OptionChains.get(self.optionSymbol)
+        if chain:
+            call_contracts = [x for x in chain if x.Right == OptionRight.Call]
+
+            expiry = min(x.Expiry for x in call_contracts)
+
+            call_contracts = sorted([x for x in call_contracts if x.Expiry == expiry],
+                key = lambda x: x.Strike)
+
+            long_call = call_contracts[0]
+            short_call = [x for x in call_contracts if x.Strike > long_call.Strike][0]
+
+            quantity = 1000
+
+            tickets = [
+                self.MarketOrder(short_call.Symbol, -quantity),
+                self.MarketOrder(long_call.Symbol, quantity)
+            ]
+                
+            for ticket in tickets:
+                if ticket.Status != OrderStatus.Filled:
+                    raise Exception(f"There should be no restriction on buying {ticket.Quantity} of {ticket.Symbol} with BuyingPowerModel.Null")

--- a/Algorithm.Python/NullBuyingPowerOptionBullCallSpreadAlgorithm.py
+++ b/Algorithm.Python/NullBuyingPowerOptionBullCallSpreadAlgorithm.py
@@ -60,3 +60,8 @@ class NullBuyingPowerOptionBullCallSpreadAlgorithm(QCAlgorithm):
             for ticket in tickets:
                 if ticket.Status != OrderStatus.Filled:
                     raise Exception(f"There should be no restriction on buying {ticket.Quantity} of {ticket.Symbol} with BuyingPowerModel.Null")
+
+
+    def OnEndOfAlgorithm(self) -> None:
+        if self.Portfolio.TotalMarginUsed != 0:
+            raise Exception("The TotalMarginUsed should be zero to avoid margin calls.")

--- a/Common/Securities/BuyingPowerModel.cs
+++ b/Common/Securities/BuyingPowerModel.cs
@@ -25,6 +25,12 @@ namespace QuantConnect.Securities
     /// </summary>
     public class BuyingPowerModel : IBuyingPowerModel
     {
+        /// <summary>
+        /// Gets an implementation of <see cref="IBuyingPowerModel"/> that
+        /// does not check for sufficient buying power
+        /// </summary>
+        public static readonly IBuyingPowerModel Null = new NullBuyingPowerModel();
+
         private decimal _initialMarginRequirement;
         private decimal _maintenanceMarginRequirement;
 

--- a/Common/Securities/NullBuyingPowerModel.cs
+++ b/Common/Securities/NullBuyingPowerModel.cs
@@ -21,6 +21,16 @@ namespace QuantConnect.Securities
     public class NullBuyingPowerModel : BuyingPowerModel
     {
         /// <summary>
+        /// Gets the margin currently allocated to the specified holding
+        /// </summary>
+        /// <param name="parameters">An object containing the security</param>
+        /// <returns>The maintenance margin required for the provided holdings quantity/cost/value</returns>
+        public override MaintenanceMargin GetMaintenanceMargin(MaintenanceMarginParameters parameters)
+        {
+            return new MaintenanceMargin(decimal.Zero);
+        }
+
+        /// <summary>
         /// Check if there is sufficient buying power to execute this order.
         /// </summary>
         /// <param name="parameters">An object containing the portfolio, the security and the order</param>

--- a/Common/Securities/NullBuyingPowerModel.cs
+++ b/Common/Securities/NullBuyingPowerModel.cs
@@ -1,0 +1,33 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Provides a buying power model considers that there is sufficient buying power for all orders
+    /// </summary>
+    public class NullBuyingPowerModel : BuyingPowerModel
+    {
+        /// <summary>
+        /// Check if there is sufficient buying power to execute this order.
+        /// </summary>
+        /// <param name="parameters">An object containing the portfolio, the security and the order</param>
+        /// <returns>Returns buying power information for an order</returns>
+        public override HasSufficientBuyingPowerForOrderResult HasSufficientBuyingPowerForOrder(HasSufficientBuyingPowerForOrderParameters parameters)
+        {
+            return parameters.Sufficient();
+        }
+    }
+}


### PR DESCRIPTION
#### Description
The `NullBuyingPowerModel` considers that we have sufficient buying power for all orders.

Adds an example using a bull call spread since an equity buy and hold would not show the impact of this model in the position group buying power model.

#### Related Issue
Closes #3157

#### Motivation and Context
The buying power model prevents orders in live trading if it considers there is not sufficient buying power. If users want to submit the orders, they can use this model to bypass the validation. 

#### Requires Documentation Change
Yes. List this model on
https://www.quantconnect.com/docs/v2/writing-algorithms/reality-modeling/buying-power

#### How Has This Been Tested?
Regression tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`