### PR TITLE
Handle prices getting stuck on data generation

### DIFF
--- a/Tests/ToolBox/RandomDataGenerator/RandomValueGeneratorTests.cs
+++ b/Tests/ToolBox/RandomDataGenerator/RandomValueGeneratorTests.cs
@@ -82,6 +82,51 @@ namespace QuantConnect.Tests.ToolBox.RandomDataGenerator
         }
 
         [Test]
+        public void NextPrice_ReturnsZeroForOptionsZeroReferencePrice()
+        {
+            var price = randomValueGenerator.NextPrice(SecurityType.Option, Market.USA, 0m, 1m);
+            Assert.AreEqual(0m, price);
+        }
+
+        [Test]
+        public void NextPrice_ThrowsIfReferencePriceIsInvalid([Values] SecurityType securityType)
+        {
+            // Negative reference price
+            Assert.Throws<ArgumentException>(() =>
+                randomValueGenerator.NextPrice(securityType, null, -1m, 1m)
+            );
+
+            // Zero reference price
+            if (securityType != SecurityType.Option)
+            {
+                Assert.Throws<ArgumentException>(() =>
+                    randomValueGenerator.NextPrice(securityType, null, 0m, 1m)
+                );
+            }
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void NextPrice_ThrowsIfMaximumPercentDeviationIsInvalid(decimal maximumPercentDeviation)
+        {
+            Assert.Throws<ArgumentException>(() =>
+                randomValueGenerator.NextPrice(SecurityType.Equity, null, 100m, maximumPercentDeviation)
+            );
+        }
+
+        [Test]
+        public void NextPrice_ReturnsSamePriceIfFailsToGetAValidOne()
+        {
+            // Default min price variation for crypto is 0.01
+            var maximumPercentDeviation = 0.45m;
+            var referencePrice = 0.1m; // too close to the minimum price variation
+
+            var price = randomValueGenerator.NextPrice(SecurityType.Crypto, Market.GDAX, referencePrice, maximumPercentDeviation);
+
+            Assert.AreEqual(referencePrice, price);
+        }
+
+        [Test]
         public void NextPrice_PricesIsUpdatedEvenIfMaxPercentageDeviationIsLessThanMinPriceVariation()
         {
             // Default min price variation for crypto is 0.01

--- a/Tests/ToolBox/RandomDataGenerator/RandomValueGeneratorTests.cs
+++ b/Tests/ToolBox/RandomDataGenerator/RandomValueGeneratorTests.cs
@@ -80,5 +80,20 @@ namespace QuantConnect.Tests.ToolBox.RandomDataGenerator
                 randomValueGenerator.NextDate(min, max, DayOfWeek.Monday)
             );
         }
+
+        [Test]
+        public void NextPrice_PricesIsUpdatedEvenIfMaxPercentageDeviationIsLessThanMinPriceVariation()
+        {
+            // Default min price variation for crypto is 0.01
+            var maximumPercentDeviation = 0.45m;
+            var referencePrice = 2m;
+
+            // The maximum price variation is 0.45% of 2, which is 0.009, less than the minimum price variation of 0.01.
+            // The generated price will be rounded back to 2m, but this should be properly handled.
+
+            var price = randomValueGenerator.NextPrice(SecurityType.Crypto, Market.GDAX, referencePrice, maximumPercentDeviation);
+
+            Assert.AreNotEqual(referencePrice, price);
+        }
     }
 }

--- a/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
+++ b/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
@@ -148,7 +148,7 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
 
             if (maximumPercentDeviation <= 0)
             {
-                throw new ArgumentException("The provided maximum percent deviation must be a postive number");
+                throw new ArgumentException("The provided maximum percent deviation must be a positive number");
             }
 
             // convert from percent space to decimal space


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This adds a fix for prices getting stuck at certain point on data generation, specifically when the calculated deviation (with the maximum percent deviation) is less than the minimum price variation, making the price to be rounded to the same reference price.

These plots correspond windows of the same data generated in the issue for 4.5 years of minute data:
`lean data generate --verbose --start 20180101 --end 20220601  --security-type Crypto --resolution Minute --symbol-count 1`

![image](https://user-images.githubusercontent.com/25215064/220385474-7d9749df-fe95-48aa-a2da-3e9ab01bd534.png)
![image](https://user-images.githubusercontent.com/25215064/220385490-ed74519f-3b60-43b6-beb6-62e71e030d57.png)


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #5630 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual data generation and unit test.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
