### PR TITLE
Fixes BasePairsTradingAlphaModel

### DIFF
--- a/Algorithm.CSharp/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.cs
@@ -41,8 +41,11 @@ namespace QuantConnect.Algorithm.CSharp
                 .Select(ticker => QuantConnect.Symbol.Create(ticker, SecurityType.Equity, Market.USA))
                 .ToList();
 
+            // Manually add SPY and AIG when the algorithm starts
             SetUniverseSelection(new ManualUniverseSelectionModel(symbols.Take(2)));
 
+            // At midnight, add all securities every day except on the last data
+            // With this procedure, the Alpha Model will experience multiple universe changes
             AddUniverseSelection(new ScheduledUniverseSelectionModel(
                 DateRules.EveryDay(), TimeRules.Midnight,
                 dt => dt < EndDate.AddDays(-1) ? symbols : Enumerable.Empty<Symbol>()));

--- a/Algorithm.CSharp/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using QuantConnect.Algorithm.Framework.Alphas;
 using QuantConnect.Algorithm.Framework.Execution;
 using QuantConnect.Algorithm.Framework.Portfolio;
@@ -20,6 +21,7 @@ using QuantConnect.Algorithm.Framework.Risk;
 using QuantConnect.Algorithm.Framework.Selection;
 using QuantConnect.Interfaces;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -35,16 +37,30 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2013, 10, 07);
             SetEndDate(2013, 10, 11);
 
-            SetUniverseSelection(new ManualUniverseSelectionModel(
-                QuantConnect.Symbol.Create("AIG", SecurityType.Equity, Market.USA),
-                QuantConnect.Symbol.Create("BAC", SecurityType.Equity, Market.USA),
-                QuantConnect.Symbol.Create("IBM", SecurityType.Equity, Market.USA),
-                QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA)));
+            var symbols = new[] { "SPY", "AIG", "BAC", "IBM" }
+                .Select(ticker => QuantConnect.Symbol.Create(ticker, SecurityType.Equity, Market.USA))
+                .ToList();
+
+            SetUniverseSelection(new ManualUniverseSelectionModel(symbols.Take(2)));
+
+            AddUniverseSelection(new ScheduledUniverseSelectionModel(
+                DateRules.EveryDay(), TimeRules.Midnight,
+                dt => dt < EndDate.AddDays(-1) ? symbols : Enumerable.Empty<Symbol>()));
 
             SetAlpha(new PearsonCorrelationPairsTradingAlphaModel(252, Resolution.Daily));
             SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
             SetExecution(new ImmediateExecutionModel());
             SetRiskManagement(new NullRiskManagementModel());
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            // We have removed all securities from the universe. The Alpha Model should remove the consolidator
+            var consolidatorCount = SubscriptionManager.Subscriptions.Sum(s => s.Consolidators.Count);
+            if (consolidatorCount > 0)
+            {
+                throw new Exception($"The number of consolidator is should be zero. Actual: {consolidatorCount}");
+            }
         }
 
         /// <summary>
@@ -60,7 +76,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 15643;
+        public long DataPoints => 14089;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -73,33 +89,33 @@ namespace QuantConnect.Algorithm.CSharp
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "6"},
-            {"Average Win", "0.82%"},
-            {"Average Loss", "-0.39%"},
-            {"Compounding Annual Return", "47.234%"},
-            {"Drawdown", "0.700%"},
-            {"Expectancy", "0.548"},
-            {"Net Profit", "0.496%"},
-            {"Sharpe Ratio", "10.749"},
-            {"Probabilistic Sharpe Ratio", "86.164%"},
+            {"Average Win", "0.99%"},
+            {"Average Loss", "-0.84%"},
+            {"Compounding Annual Return", "24.021%"},
+            {"Drawdown", "0.800%"},
+            {"Expectancy", "0.089"},
+            {"Net Profit", "0.295%"},
+            {"Sharpe Ratio", "4.364"},
+            {"Probabilistic Sharpe Ratio", "61.706%"},
             {"Loss Rate", "50%"},
             {"Win Rate", "50%"},
-            {"Profit-Loss Ratio", "2.10"},
-            {"Alpha", "0.235"},
-            {"Beta", "0.066"},
-            {"Annual Standard Deviation", "0.034"},
-            {"Annual Variance", "0.001"},
-            {"Information Ratio", "-7.696"},
-            {"Tracking Error", "0.21"},
-            {"Treynor Ratio", "5.536"},
-            {"Total Fees", "$25.78"},
-            {"Estimated Strategy Capacity", "$1900000.00"},
+            {"Profit-Loss Ratio", "1.18"},
+            {"Alpha", "0.087"},
+            {"Beta", "0.06"},
+            {"Annual Standard Deviation", "0.047"},
+            {"Annual Variance", "0.002"},
+            {"Information Ratio", "-8.305"},
+            {"Tracking Error", "0.214"},
+            {"Treynor Ratio", "3.438"},
+            {"Total Fees", "$31.60"},
+            {"Estimated Strategy Capacity", "$3200000.00"},
             {"Lowest Capacity Asset", "AIG R735QTJ8XC9X"},
-            {"Fitness Score", "0.752"},
+            {"Fitness Score", "0.804"},
             {"Kelly Criterion Estimate", "0"},
             {"Kelly Criterion Probability Value", "0"},
             {"Sortino Ratio", "79228162514264337593543950335"},
-            {"Return Over Maximum Drawdown", "147.522"},
-            {"Portfolio Turnover", "0.753"},
+            {"Return Over Maximum Drawdown", "76.481"},
+            {"Portfolio Turnover", "0.804"},
             {"Total Insights Generated", "4"},
             {"Total Insights Closed", "0"},
             {"Total Insights Analysis Completed", "0"},
@@ -113,7 +129,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Mean Population Magnitude", "0%"},
             {"Rolling Averaged Population Direction", "0%"},
             {"Rolling Averaged Population Magnitude", "0%"},
-            {"OrderListHash", "b68340c2b8ff6803f585623f720de18a"}
+            {"OrderListHash", "52fd3420623ae793b7c9f7e4846e8874"}
         };
     }
 }

--- a/Algorithm.Framework/Alphas/BasePairsTradingAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/BasePairsTradingAlphaModel.cs
@@ -150,7 +150,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             }
         }
 
-        private class PairData
+        private class PairData : IDisposable
         {
             private enum State
             {
@@ -224,6 +224,9 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 _predictionInterval = period;
             }
 
+            /// <summary>
+            /// On disposal, remove the consolidators from the subscription manager
+            /// </summary>
             public void Dispose()
             {
                 _algorithm.SubscriptionManager.RemoveConsolidator(_asset1, _identityConsolidator1);

--- a/Algorithm.Framework/Alphas/BasePairsTradingAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/BasePairsTradingAlphaModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Data;
+using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Indicators;
 using QuantConnect.Securities;
@@ -102,6 +103,8 @@ namespace QuantConnect.Algorithm.Framework.Alphas
 
                 foreach (var key in keys)
                 {
+                    var pair = _pairs[key];
+                    pair.Dispose();
                     _pairs.Remove(key);
                 }
             }
@@ -158,8 +161,12 @@ namespace QuantConnect.Algorithm.Framework.Alphas
 
             private State _state = State.FlatRatio;
 
+            private readonly QCAlgorithm _algorithm;
             private readonly Symbol _asset1;
             private readonly Symbol _asset2;
+
+            private readonly IDataConsolidator _identityConsolidator1;
+            private readonly IDataConsolidator _identityConsolidator2;
 
             private readonly IndicatorBase<IndicatorDataPoint> _asset1Price;
             private readonly IndicatorBase<IndicatorDataPoint> _asset2Price;
@@ -179,11 +186,31 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             /// <param name="threshold">The percent [0, 100] deviation of the ratio from the mean before emitting an insight</param>
             public PairData(QCAlgorithm algorithm, Symbol asset1, Symbol asset2, TimeSpan period, decimal threshold)
             {
+                _algorithm = algorithm;
                 _asset1 = asset1;
                 _asset2 = asset2;
 
-                _asset1Price = algorithm.Identity(asset1);
-                _asset2Price = algorithm.Identity(asset2);
+                // Created the Identity indicator for a given Symbol and
+                // the consolidator it is registered to. The consolidator reference 
+                // will be used to remove it from SubscriptionManager
+                (Identity, IDataConsolidator) CreateIdentityIndicator(Symbol symbol)
+                {
+                    var resolution = algorithm.SubscriptionManager
+                        .SubscriptionDataConfigService
+                        .GetSubscriptionDataConfigs(symbol)
+                        .Min(x => x.Resolution);
+
+                    var name = algorithm.CreateIndicatorName(symbol, "close", resolution);
+                    var identity = new Identity(name);
+
+                    var consolidator = algorithm.ResolveConsolidator(symbol, resolution);
+                    algorithm.RegisterIndicator(symbol, identity, consolidator);
+
+                    return (identity, consolidator);
+                }
+
+                (_asset1Price, _identityConsolidator1) = CreateIdentityIndicator(asset1);
+                (_asset2Price, _identityConsolidator2) = CreateIdentityIndicator(asset2);
 
                 _ratio = _asset1Price.Over(_asset2Price);
                 _mean = new ExponentialMovingAverage(500).Of(_ratio);
@@ -195,6 +222,12 @@ namespace QuantConnect.Algorithm.Framework.Alphas
                 _lowerThreshold = _mean.Times(lower, "LowerThreshold");
 
                 _predictionInterval = period;
+            }
+
+            public void Dispose()
+            {
+                _algorithm.SubscriptionManager.RemoveConsolidator(_asset1, _identityConsolidator1);
+                _algorithm.SubscriptionManager.RemoveConsolidator(_asset2, _identityConsolidator2);
             }
 
             /// <summary>

--- a/Algorithm.Framework/Alphas/BasePairsTradingAlphaModel.py
+++ b/Algorithm.Framework/Alphas/BasePairsTradingAlphaModel.py
@@ -1,4 +1,4 @@
-﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
 # Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,9 +71,8 @@ class BasePairsTradingAlphaModel(AlphaModel):
 
         for security in changes.RemovedSecurities:
             keys = [k for k in self.pairs.keys() if security.Symbol in k]
-
             for key in keys:
-                self.pairs.pop(key)
+                self.pairs.pop(key).dispose()
 
     def UpdatePairs(self, algorithm):
 
@@ -124,11 +123,26 @@ class BasePairsTradingAlphaModel(AlphaModel):
                 threshold: The percent [0, 100] deviation of the ratio from the mean before emitting an insight'''
             self.state = self.State.FlatRatio
 
+            self.algorithm = algorithm
             self.asset1 = asset1
             self.asset2 = asset2
 
-            self.asset1Price = algorithm.Identity(asset1)
-            self.asset2Price = algorithm.Identity(asset2)
+            # Created the Identity indicator for a given Symbol and
+            # the consolidator it is registered to. The consolidator reference 
+            # will be used to remove it from SubscriptionManager
+            def CreateIdentityIndicator(symbol: Symbol):
+                resolution = min([x.Resolution for x in algorithm.SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(symbol)])
+
+                name = algorithm.CreateIndicatorName(symbol, "close", resolution)
+                identity = Identity(name)
+
+                consolidator = algorithm.ResolveConsolidator(symbol, resolution)
+                algorithm.RegisterIndicator(symbol, identity, consolidator)
+
+                return identity, consolidator
+
+            self.asset1Price, self.identityConsolidator1 = CreateIdentityIndicator(asset1);
+            self.asset2Price, self.identityConsolidator2 = CreateIdentityIndicator(asset2);
 
             self.ratio = IndicatorExtensions.Over(self.asset1Price, self.asset2Price)
             self.mean = IndicatorExtensions.Of(ExponentialMovingAverage(500), self.ratio)
@@ -140,6 +154,10 @@ class BasePairsTradingAlphaModel(AlphaModel):
             self.lowerThreshold = IndicatorExtensions.Times(self.mean, lower)
 
             self.predictionInterval = predictionInterval
+
+        def dispose(self):
+           self.algorithm.SubscriptionManager.RemoveConsolidator(self.asset1, self.identityConsolidator1)
+           self.algorithm.SubscriptionManager.RemoveConsolidator(self.asset2, self.identityConsolidator2)
 
         def GetInsightGroup(self):
             '''Gets the insights group for the pair

--- a/Algorithm.Framework/Alphas/BasePairsTradingAlphaModel.py
+++ b/Algorithm.Framework/Alphas/BasePairsTradingAlphaModel.py
@@ -156,8 +156,11 @@ class BasePairsTradingAlphaModel(AlphaModel):
             self.predictionInterval = predictionInterval
 
         def dispose(self):
-           self.algorithm.SubscriptionManager.RemoveConsolidator(self.asset1, self.identityConsolidator1)
-           self.algorithm.SubscriptionManager.RemoveConsolidator(self.asset2, self.identityConsolidator2)
+            '''
+            On disposal, remove the consolidators from the subscription manager
+            '''
+            self.algorithm.SubscriptionManager.RemoveConsolidator(self.asset1, self.identityConsolidator1)
+            self.algorithm.SubscriptionManager.RemoveConsolidator(self.asset2, self.identityConsolidator2)
 
         def GetInsightGroup(self):
             '''Gets the insights group for the pair

--- a/Algorithm.Python/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.py
+++ b/Algorithm.Python/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.py
@@ -31,8 +31,11 @@ class PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm(QCAlgorithm):
         symbols = [Symbol.Create(ticker, SecurityType.Equity, Market.USA)
             for ticker in ["SPY", "AIG", "BAC", "IBM"]]
 
+        # Manually add SPY and AIG when the algorithm starts
         self.SetUniverseSelection(ManualUniverseSelectionModel(symbols[:2]))
 
+        # At midnight, add all securities every day except on the last data
+        # With this procedure, the Alpha Model will experience multiple universe changes
         self.AddUniverseSelection(ScheduledUniverseSelectionModel(
             self.DateRules.EveryDay(), self.TimeRules.Midnight,
             lambda dt: symbols if dt.day <= (self.EndDate - timedelta(1)).day else []))

--- a/Algorithm.Python/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.py
+++ b/Algorithm.Python/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.py
@@ -28,13 +28,22 @@ class PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm(QCAlgorithm):
         self.SetStartDate(2013,10,7)
         self.SetEndDate(2013,10,11)
 
-        self.SetUniverseSelection(ManualUniverseSelectionModel(
-            Symbol.Create('AIG', SecurityType.Equity, Market.USA),
-            Symbol.Create('BAC', SecurityType.Equity, Market.USA),
-            Symbol.Create('IBM', SecurityType.Equity, Market.USA),
-            Symbol.Create('SPY', SecurityType.Equity, Market.USA)))
+        symbols = [Symbol.Create(ticker, SecurityType.Equity, Market.USA)
+            for ticker in ["SPY", "AIG", "BAC", "IBM"]]
+
+        self.SetUniverseSelection(ManualUniverseSelectionModel(symbols[:2]))
+
+        self.AddUniverseSelection(ScheduledUniverseSelectionModel(
+            self.DateRules.EveryDay(), self.TimeRules.Midnight,
+            lambda dt: symbols if dt.day <= (self.EndDate - timedelta(1)).day else []))
 
         self.SetAlpha(PearsonCorrelationPairsTradingAlphaModel(252, Resolution.Daily))
         self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
         self.SetExecution(ImmediateExecutionModel())
         self.SetRiskManagement(NullRiskManagementModel())
+
+    def OnEndOfAlgorithm(self) -> None:
+        # We have removed all securities from the universe. The Alpha Model should remove the consolidator
+        consolidatorCount = sum(s.Consolidators.Count for s in self.SubscriptionManager.Subscriptions)
+        if consolidatorCount > 0:
+            raise Exception(f"The number of consolidator should be zero. Actual: {consolidatorCount}")


### PR DESCRIPTION
#### Description
The `BasePairsTradingAlphaModel` will create indicators with class constructors and register them to consolidators that will be removed when the security is removed from the universe.

#### Related Issue
Closes #4078

#### Motivation and Context
Improve Lean Base Alpha Model.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Red -> Green Regression Test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`