### PR TITLE
Fix `UniverseDefinitions.ETF|Index` overloads

### DIFF
--- a/Algorithm/UniverseDefinitions.cs
+++ b/Algorithm/UniverseDefinitions.cs
@@ -1,11 +1,11 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,12 +29,12 @@ namespace QuantConnect.Algorithm
     public class UniverseDefinitions
     {
         private readonly QCAlgorithm _algorithm;
-        
+
         /// <summary>
         /// Gets a helper that provides methods for creating universes based on daily dollar volumes
         /// </summary>
         public DollarVolumeUniverseDefinitions DollarVolume { get; set; }
-        
+
         /// <summary>
         /// Specifies that universe selection should not make changes on this iteration
         /// </summary>
@@ -49,7 +49,7 @@ namespace QuantConnect.Algorithm
             _algorithm = algorithm;
             DollarVolume = new DollarVolumeUniverseDefinitions(algorithm);
         }
-        
+
         /// <summary>
         /// Creates a universe for the constituents of the provided <paramref name="etfTicker"/>
         /// </summary>
@@ -59,9 +59,9 @@ namespace QuantConnect.Algorithm
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         /// <returns>New ETF constituents Universe</returns>
         public Universe ETF(
-            string etfTicker, 
-            string market = null, 
-            UniverseSettings universeSettings = null, 
+            string etfTicker,
+            string market = null,
+            UniverseSettings universeSettings = null,
             Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc = null)
         {
             market ??= _algorithm.BrokerageModel.DefaultMarkets.TryGetValue(SecurityType.Equity, out var defaultMarket)
@@ -79,7 +79,6 @@ namespace QuantConnect.Algorithm
             return ETF(etfSymbol, universeSettings, universeFilterFunc);
         }
 
-
         /// <summary>
         /// Creates a universe for the constituents of the provided <paramref name="etfTicker"/>
         /// </summary>
@@ -88,13 +87,32 @@ namespace QuantConnect.Algorithm
         /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         /// <returns>New ETF constituents Universe</returns>
-        public Universe ETF(
-            string etfTicker,
-            string market = null,
-            UniverseSettings universeSettings = null,
-            PyObject universeFilterFunc = null)
+        public Universe ETF(string etfTicker, string market, UniverseSettings universeSettings, PyObject universeFilterFunc)
         {
             return ETF(etfTicker, market, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+        }
+
+        /// <summary>
+        /// Creates a universe for the constituents of the provided <paramref name="etfTicker"/>
+        /// </summary>
+        /// <param name="etfTicker">Ticker of the ETF to get constituents for</param>
+        /// <param name="market">Market of the ETF</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        /// <returns>New ETF constituents Universe</returns>
+        public Universe ETF(string etfTicker, string market, PyObject universeFilterFunc)
+        {
+            return ETF(etfTicker, market, null, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+        }
+
+        /// <summary>
+        /// Creates a universe for the constituents of the provided <paramref name="etfTicker"/>
+        /// </summary>
+        /// <param name="etfTicker">Ticker of the ETF to get constituents for</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        /// <returns>New ETF constituents Universe</returns>
+        public Universe ETF(string etfTicker, PyObject universeFilterFunc)
+        {
+            return ETF(etfTicker, null, null, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
         }
 
         /// <summary>
@@ -106,12 +124,12 @@ namespace QuantConnect.Algorithm
         /// <returns>New ETF constituents Universe</returns>
         public Universe ETF(
             Symbol symbol,
-            UniverseSettings universeSettings = null, 
+            UniverseSettings universeSettings = null,
             Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc = null)
         {
             return new ETFConstituentsUniverse(symbol, universeSettings ?? _algorithm.UniverseSettings, universeFilterFunc);
         }
-        
+
         /// <summary>
         /// Creates a universe for the constituents of the provided ETF <paramref name="symbol"/>
         /// </summary>
@@ -119,12 +137,20 @@ namespace QuantConnect.Algorithm
         /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         /// <returns>New ETF constituents Universe</returns>
-        public Universe ETF(
-            Symbol symbol,
-            UniverseSettings universeSettings = null, 
-            PyObject universeFilterFunc = null)
+        public Universe ETF(Symbol symbol, UniverseSettings universeSettings, PyObject universeFilterFunc)
         {
             return ETF(symbol, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+        }
+
+        /// <summary>
+        /// Creates a universe for the constituents of the provided ETF <paramref name="symbol"/>
+        /// </summary>
+        /// <param name="symbol">ETF Symbol to get constituents for</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        /// <returns>New ETF constituents Universe</returns>
+        public Universe ETF(Symbol symbol, PyObject universeFilterFunc)
+        {
+            return ETF(symbol, null, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
         }
 
         /// <summary>
@@ -147,10 +173,10 @@ namespace QuantConnect.Algorithm
 
             return Index(
                 Symbol.Create(indexTicker, SecurityType.Index, market),
-                universeSettings, 
+                universeSettings,
                 universeFilterFunc);
         }
-                
+
         /// <summary>
         /// Creates a universe for the constituents of the provided <paramref name="indexTicker"/>
         /// </summary>
@@ -159,13 +185,33 @@ namespace QuantConnect.Algorithm
         /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         /// <returns>New index constituents Universe</returns>
-        public Universe Index(
-            string indexTicker,
-            string market = null,
-            UniverseSettings universeSettings = null,
-            PyObject universeFilterFunc = null)
+        public Universe Index(string indexTicker, string market, UniverseSettings universeSettings, PyObject universeFilterFunc)
         {
             return Index(indexTicker, market, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+        }
+
+        /// <summary>
+        /// Creates a universe for the constituents of the provided <paramref name="indexTicker"/>
+        /// </summary>
+        /// <param name="indexTicker">Ticker of the index to get constituents for</param>
+        /// <param name="market">Market of the index</param>
+        /// <param name="universeSettings">Universe settings</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        /// <returns>New index constituents Universe</returns>
+        public Universe Index(string indexTicker, string market, PyObject universeFilterFunc)
+        {
+            return Index(indexTicker, market, null, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+        }
+
+        /// <summary>
+        /// Creates a universe for the constituents of the provided <paramref name="indexTicker"/>
+        /// </summary>
+        /// <param name="indexTicker">Ticker of the index to get constituents for</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        /// <returns>New index constituents Universe</returns>
+        public Universe Index(string indexTicker, PyObject universeFilterFunc)
+        {
+            return Index(indexTicker, null, null, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
         }
 
         /// <summary>
@@ -182,7 +228,7 @@ namespace QuantConnect.Algorithm
         {
             return new ETFConstituentsUniverse(indexSymbol, universeSettings ?? _algorithm.UniverseSettings, universeFilterFunc);
         }
-        
+
         /// <summary>
         /// Creates a universe for the constituents of the provided <paramref name="indexSymbol"/>
         /// </summary>
@@ -190,14 +236,22 @@ namespace QuantConnect.Algorithm
         /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         /// <returns>New index constituents Universe</returns>
-        public Universe Index(
-            Symbol indexSymbol,
-            UniverseSettings universeSettings = null,
-            PyObject universeFilterFunc = null)
+        public Universe Index(Symbol indexSymbol, UniverseSettings universeSettings, PyObject universeFilterFunc)
         {
             return Index(indexSymbol, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
         }
-        
+
+        /// <summary>
+        /// Creates a universe for the constituents of the provided <paramref name="indexSymbol"/>
+        /// </summary>
+        /// <param name="indexSymbol">Index Symbol to get constituents for</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        /// <returns>New index constituents Universe</returns>
+        public Universe Index(Symbol indexSymbol, PyObject universeFilterFunc)
+        {
+            return Index(indexSymbol, null, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+        }
+
         /// <summary>
         /// Creates a new fine universe that contains the constituents of QC500 index based onthe company fundamentals
         /// The algorithm creates a default tradable and liquid universe containing 500 US equities
@@ -254,7 +308,7 @@ namespace QuantConnect.Algorithm
                     fine =>
                     {
                         // The company's headquarter must in the U.S.
-                        // The stock must be traded on either the NYSE or NASDAQ 
+                        // The stock must be traded on either the NYSE or NASDAQ
                         // At least half a year since its initial public offering
                         // The stock's market cap must be greater than 500 million
                         var filteredFine =
@@ -280,7 +334,7 @@ namespace QuantConnect.Algorithm
 
                         var percent = numberOfSymbolsFine / (double) count;
 
-                        // select stocks with top dollar volume in every single sector 
+                        // select stocks with top dollar volume in every single sector
                         var topFineBySector =
                             (from x in filteredFine
                                 // Group by sector
@@ -312,7 +366,7 @@ namespace QuantConnect.Algorithm
         public Universe Top(int count, UniverseSettings universeSettings = null)
         {
             universeSettings ??= _algorithm.UniverseSettings;
-            
+
             var symbol = Symbol.Create("us-equity-dollar-volume-top-" + count, SecurityType.Equity, Market.USA);
             var config = new SubscriptionDataConfig(typeof(CoarseFundamental), symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, true);
             return new FuncUniverse(config, universeSettings, selectionData => (

--- a/Algorithm/UniverseDefinitions.cs
+++ b/Algorithm/UniverseDefinitions.cs
@@ -60,9 +60,9 @@ namespace QuantConnect.Algorithm
         /// <returns>New ETF constituents Universe</returns>
         public Universe ETF(
             string etfTicker,
-            string market = null,
-            UniverseSettings universeSettings = null,
-            Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc = null)
+            string market,
+            UniverseSettings universeSettings,
+            Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
         {
             market ??= _algorithm.BrokerageModel.DefaultMarkets.TryGetValue(SecurityType.Equity, out var defaultMarket)
                 ? defaultMarket
@@ -84,12 +84,37 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="etfTicker">Ticker of the ETF to get constituents for</param>
         /// <param name="market">Market of the ETF</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        /// <returns>New ETF constituents Universe</returns>
+        public Universe ETF(string etfTicker, string market, Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
+        {
+            return ETF(etfTicker, market, null, universeFilterFunc);
+        }
+
+        /// <summary>
+        /// Creates a universe for the constituents of the provided <paramref name="etfTicker"/>
+        /// </summary>
+        /// <param name="etfTicker">Ticker of the ETF to get constituents for</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        /// <returns>New ETF constituents Universe</returns>
+        public Universe ETF(string etfTicker, Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
+        {
+            return ETF(etfTicker, null, null, universeFilterFunc);
+        }
+
+        /// <summary>
+        /// Creates a universe for the constituents of the provided <paramref name="etfTicker"/>
+        /// </summary>
+        /// <param name="etfTicker">Ticker of the ETF to get constituents for</param>
         /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         /// <returns>New ETF constituents Universe</returns>
-        public Universe ETF(string etfTicker, string market, UniverseSettings universeSettings, PyObject universeFilterFunc)
+        public Universe ETF(
+            string etfTicker,
+            UniverseSettings universeSettings,
+            Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
         {
-            return ETF(etfTicker, market, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+            return ETF(etfTicker, null, universeSettings, universeFilterFunc);
         }
 
         /// <summary>
@@ -97,22 +122,16 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="etfTicker">Ticker of the ETF to get constituents for</param>
         /// <param name="market">Market of the ETF</param>
+        /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         /// <returns>New ETF constituents Universe</returns>
-        public Universe ETF(string etfTicker, string market, PyObject universeFilterFunc)
+        public Universe ETF(
+            string etfTicker,
+            string market = null,
+            UniverseSettings universeSettings = null,
+            PyObject universeFilterFunc = null)
         {
-            return ETF(etfTicker, market, null, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
-        }
-
-        /// <summary>
-        /// Creates a universe for the constituents of the provided <paramref name="etfTicker"/>
-        /// </summary>
-        /// <param name="etfTicker">Ticker of the ETF to get constituents for</param>
-        /// <param name="universeFilterFunc">Function to filter universe results</param>
-        /// <returns>New ETF constituents Universe</returns>
-        public Universe ETF(string etfTicker, PyObject universeFilterFunc)
-        {
-            return ETF(etfTicker, null, null, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+            return ETF(etfTicker, market, universeSettings, universeFilterFunc?.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
         }
 
         /// <summary>
@@ -122,10 +141,8 @@ namespace QuantConnect.Algorithm
         /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         /// <returns>New ETF constituents Universe</returns>
-        public Universe ETF(
-            Symbol symbol,
-            UniverseSettings universeSettings = null,
-            Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc = null)
+        public Universe ETF(Symbol symbol, UniverseSettings universeSettings,
+            Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
         {
             return new ETFConstituentsUniverse(symbol, universeSettings ?? _algorithm.UniverseSettings, universeFilterFunc);
         }
@@ -134,23 +151,24 @@ namespace QuantConnect.Algorithm
         /// Creates a universe for the constituents of the provided ETF <paramref name="symbol"/>
         /// </summary>
         /// <param name="symbol">ETF Symbol to get constituents for</param>
-        /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         /// <returns>New ETF constituents Universe</returns>
-        public Universe ETF(Symbol symbol, UniverseSettings universeSettings, PyObject universeFilterFunc)
+        public Universe ETF(Symbol symbol, Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
         {
-            return ETF(symbol, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+            return ETF(symbol, null, universeFilterFunc);
         }
 
         /// <summary>
         /// Creates a universe for the constituents of the provided ETF <paramref name="symbol"/>
         /// </summary>
         /// <param name="symbol">ETF Symbol to get constituents for</param>
+        /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         /// <returns>New ETF constituents Universe</returns>
-        public Universe ETF(Symbol symbol, PyObject universeFilterFunc)
+        public Universe ETF(Symbol symbol, UniverseSettings universeSettings = null, PyObject universeFilterFunc = null)
         {
-            return ETF(symbol, null, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+            return ETF(symbol, universeSettings ?? _algorithm.UniverseSettings,
+                universeFilterFunc?.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
         }
 
         /// <summary>
@@ -161,11 +179,8 @@ namespace QuantConnect.Algorithm
         /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         /// <returns>New index constituents Universe</returns>
-        public Universe Index(
-            string indexTicker,
-            string market = null,
-            UniverseSettings universeSettings = null,
-            Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc = null)
+        public Universe Index(string indexTicker, string market, UniverseSettings universeSettings,
+            Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
         {
             market ??= _algorithm.BrokerageModel.DefaultMarkets.TryGetValue(SecurityType.Index, out var defaultMarket)
                 ? defaultMarket
@@ -185,9 +200,20 @@ namespace QuantConnect.Algorithm
         /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         /// <returns>New index constituents Universe</returns>
-        public Universe Index(string indexTicker, string market, UniverseSettings universeSettings, PyObject universeFilterFunc)
+        public Universe Index(string indexTicker, string market, Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
         {
-            return Index(indexTicker, market, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+            return Index(indexTicker, market, null, universeFilterFunc);
+        }
+
+        /// <summary>
+        /// Creates a universe for the constituents of the provided <paramref name="indexTicker"/>
+        /// </summary>
+        /// <param name="indexTicker">Ticker of the index to get constituents for</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        /// <returns>New index constituents Universe</returns>
+        public Universe Index(string indexTicker, Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
+        {
+            return Index(indexTicker, null, null, universeFilterFunc);
         }
 
         /// <summary>
@@ -198,20 +224,51 @@ namespace QuantConnect.Algorithm
         /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         /// <returns>New index constituents Universe</returns>
-        public Universe Index(string indexTicker, string market, PyObject universeFilterFunc)
+        public Universe Index(string indexTicker, UniverseSettings universeSettings,
+            Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
         {
-            return Index(indexTicker, market, null, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+            return Index(indexTicker, null, universeSettings, universeFilterFunc);
         }
 
         /// <summary>
         /// Creates a universe for the constituents of the provided <paramref name="indexTicker"/>
         /// </summary>
         /// <param name="indexTicker">Ticker of the index to get constituents for</param>
+        /// <param name="market">Market of the index</param>
+        /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         /// <returns>New index constituents Universe</returns>
-        public Universe Index(string indexTicker, PyObject universeFilterFunc)
+        public Universe Index(
+            string indexTicker,
+            string market = null,
+            UniverseSettings universeSettings = null,
+            PyObject universeFilterFunc = null)
         {
-            return Index(indexTicker, null, null, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+            return Index(indexTicker, market, universeSettings, universeFilterFunc?.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+        }
+
+        /// <summary>
+        /// Creates a universe for the constituents of the provided <paramref name="indexSymbol"/>
+        /// </summary>
+        /// <param name="indexSymbol">Index Symbol to get constituents for</param>
+        /// <param name="universeSettings">Universe settings</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        /// <returns>New index constituents Universe</returns>
+        public Universe Index(Symbol indexSymbol, UniverseSettings universeSettings,
+            Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
+        {
+            return new ETFConstituentsUniverse(indexSymbol, universeSettings, universeFilterFunc);
+        }
+
+        /// <summary>
+        /// Creates a universe for the constituents of the provided <paramref name="indexSymbol"/>
+        /// </summary>
+        /// <param name="indexSymbol">Index Symbol to get constituents for</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        /// <returns>New index constituents Universe</returns>
+        public Universe Index(Symbol indexSymbol, Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
+        {
+            return Index(indexSymbol, null, universeFilterFunc);
         }
 
         /// <summary>
@@ -224,32 +281,10 @@ namespace QuantConnect.Algorithm
         public Universe Index(
             Symbol indexSymbol,
             UniverseSettings universeSettings = null,
-            Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc = null)
+            PyObject universeFilterFunc = null)
         {
-            return new ETFConstituentsUniverse(indexSymbol, universeSettings ?? _algorithm.UniverseSettings, universeFilterFunc);
-        }
-
-        /// <summary>
-        /// Creates a universe for the constituents of the provided <paramref name="indexSymbol"/>
-        /// </summary>
-        /// <param name="indexSymbol">Index Symbol to get constituents for</param>
-        /// <param name="universeSettings">Universe settings</param>
-        /// <param name="universeFilterFunc">Function to filter universe results</param>
-        /// <returns>New index constituents Universe</returns>
-        public Universe Index(Symbol indexSymbol, UniverseSettings universeSettings, PyObject universeFilterFunc)
-        {
-            return Index(indexSymbol, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
-        }
-
-        /// <summary>
-        /// Creates a universe for the constituents of the provided <paramref name="indexSymbol"/>
-        /// </summary>
-        /// <param name="indexSymbol">Index Symbol to get constituents for</param>
-        /// <param name="universeFilterFunc">Function to filter universe results</param>
-        /// <returns>New index constituents Universe</returns>
-        public Universe Index(Symbol indexSymbol, PyObject universeFilterFunc)
-        {
-            return Index(indexSymbol, null, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+            return Index(indexSymbol, universeSettings ?? _algorithm.UniverseSettings,
+                universeFilterFunc?.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
         }
 
         /// <summary>

--- a/Common/Data/UniverseSelection/ETFConstituentsUniverse.cs
+++ b/Common/Data/UniverseSelection/ETFConstituentsUniverse.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Data.UniverseSelection
     public class ETFConstituentsUniverse : ConstituentsUniverse<ETFConstituentData>
     {
         private const string _etfConstituentsUniverseIdentifier = "qc-universe-etf-constituents";
-        
+
         /// <summary>
         /// Creates a new universe for the constituents of the ETF provided as <paramref name="symbol"/>
         /// </summary>
@@ -44,7 +44,7 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="symbol">The ETF to load constituents for</param>
         /// <param name="universeSettings">Universe settings</param>
         /// <param name="constituentsFilter">The filter function used to filter out ETF constituents from the universe</param>
-        public ETFConstituentsUniverse(Symbol symbol, UniverseSettings universeSettings, PyObject constituentsFilter = null)
+        public ETFConstituentsUniverse(Symbol symbol, UniverseSettings universeSettings, PyObject constituentsFilter)
             : this(symbol, universeSettings, constituentsFilter.ConvertPythonUniverseFilterFunction<ETFConstituentData>())
         {
         }
@@ -58,7 +58,7 @@ namespace QuantConnect.Data.UniverseSelection
         {
             var guid = Guid.NewGuid().ToString();
             var universeTicker = _etfConstituentsUniverseIdentifier + '-' + guid;
-            
+
             return new Symbol(
                 SecurityIdentifier.GenerateConstituentIdentifier(
                     universeTicker,

--- a/Tests/Algorithm/UniverseDefinitionsTests.cs
+++ b/Tests/Algorithm/UniverseDefinitionsTests.cs
@@ -1,0 +1,177 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Algorithm;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    [TestFixture, Parallelizable(ParallelScope.All)]
+    public class UniverseDefinitionsTests
+    {
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void ETFOverloadsAreAllUsable(Language language)
+        {
+            var algorithm = new QCAlgorithm();
+            var universeDefinitions = algorithm.Universe;
+            var universeSettings = new UniverseSettings(Resolution.Minute, Security.NullLeverage, true, false, TimeSpan.FromDays(1));
+
+            List<Universe> etfs = null;
+
+            if (language == Language.CSharp)
+            {
+                etfs = new()
+                {
+                    universeDefinitions.ETF("SPY"),
+                    universeDefinitions.ETF("SPY", Market.USA),
+                    universeDefinitions.ETF("SPY", Market.USA, universeSettings),
+                    universeDefinitions.ETF("SPY", Market.USA, universeSettings, Filter),
+                    universeDefinitions.ETF("SPY", Market.USA, universeFilterFunc: Filter),
+                    universeDefinitions.ETF("SPY", universeSettings: universeSettings),
+                    universeDefinitions.ETF("SPY", universeFilterFunc: Filter),
+                    universeDefinitions.ETF("SPY", universeSettings: universeSettings, universeFilterFunc: Filter),
+                    universeDefinitions.ETF(Symbols.SPY),
+                    universeDefinitions.ETF(Symbols.SPY, universeSettings),
+                    universeDefinitions.ETF(Symbols.SPY, universeFilterFunc: Filter),
+                    universeDefinitions.ETF(Symbols.SPY, universeSettings, Filter),
+                };
+            }
+            else
+            {
+                using (Py.GIL())
+                {
+                    var testModule = PyModule.FromString("testModule",
+                        @"
+from typing import List
+from AlgorithmImports import *
+
+def getETFs(algorithm: QCAlgorithm, symbol: Symbol, universeSettings: UniverseSettings) -> List[Universe]:
+    universeDefinitions = algorithm.Universe;
+    return [
+        universeDefinitions.ETF('SPY'),
+        universeDefinitions.ETF('SPY', Market.USA),
+        universeDefinitions.ETF('SPY', Market.USA, universeSettings),
+        universeDefinitions.ETF('SPY', Market.USA, universeSettings, filterETFs),
+        universeDefinitions.ETF('SPY', Market.USA, universeFilterFunc=filterETFs),
+        universeDefinitions.ETF('SPY', universeSettings=universeSettings),
+        universeDefinitions.ETF('SPY', universeFilterFunc=filterETFs),
+        universeDefinitions.ETF('SPY', universeSettings=universeSettings, universeFilterFunc=filterETFs),
+        universeDefinitions.ETF(symbol),
+        universeDefinitions.ETF(symbol, universeSettings),
+        universeDefinitions.ETF(symbol, universeFilterFunc=filterETFs),
+        universeDefinitions.ETF(symbol, universeSettings, filterETFs),
+    ]
+
+def filterETFs(constituents: List[ETFConstituentData]) -> List[Symbol]:
+    return [x.Symbol for x in constituents]
+        ");
+
+                    var getETFs = testModule.GetAttr("getETFs");
+
+                    etfs = getETFs.Invoke(algorithm.ToPython(), Symbols.SPY.ToPython(), universeSettings.ToPython()).As<List<Universe>>();
+                }
+            }
+
+            AssertETFConstituentsUniverses(etfs);
+        }
+
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void IndexOverloadsAreAllUsable(Language language)
+        {
+            var algorithm = new QCAlgorithm();
+            var universeDefinitions = algorithm.Universe;
+            var universeSettings = new UniverseSettings(Resolution.Minute, Security.NullLeverage, true, false, TimeSpan.FromDays(1));
+
+            List<Universe> indexes = null;
+
+            if (language == Language.CSharp)
+            {
+                indexes = new()
+                {
+                    universeDefinitions.Index("SPY"),
+                    universeDefinitions.Index("SPY", Market.USA),
+                    universeDefinitions.Index("SPY", Market.USA, universeSettings),
+                    universeDefinitions.Index("SPY", Market.USA, universeSettings, Filter),
+                    universeDefinitions.Index("SPY", Market.USA, universeFilterFunc: Filter),
+                    universeDefinitions.Index("SPY", universeSettings: universeSettings),
+                    universeDefinitions.Index("SPY", universeFilterFunc: Filter),
+                    universeDefinitions.Index("SPY", universeSettings: universeSettings, universeFilterFunc: Filter),
+                    universeDefinitions.Index(Symbols.SPY),
+                    universeDefinitions.Index(Symbols.SPY, universeSettings),
+                    universeDefinitions.Index(Symbols.SPY, universeFilterFunc: Filter),
+                    universeDefinitions.Index(Symbols.SPY, universeSettings, Filter),
+                };
+            }
+            else
+            {
+                using (Py.GIL())
+                {
+                    var testModule = PyModule.FromString("testModule",
+                        @"
+from typing import List
+from AlgorithmImports import *
+
+def getIndexes(algorithm: QCAlgorithm, symbol: Symbol, universeSettings: UniverseSettings) -> List[Universe]:
+    universeDefinitions = algorithm.Universe;
+    return [
+        universeDefinitions.Index('SPY'),
+        universeDefinitions.Index('SPY', Market.USA),
+        universeDefinitions.Index('SPY', Market.USA, universeSettings),
+        universeDefinitions.Index('SPY', Market.USA, universeSettings, filterIndexes),
+        universeDefinitions.Index('SPY', Market.USA, universeFilterFunc=filterIndexes),
+        universeDefinitions.Index('SPY', universeSettings=universeSettings),
+        universeDefinitions.Index('SPY', universeFilterFunc=filterIndexes),
+        universeDefinitions.Index('SPY', universeSettings=universeSettings, universeFilterFunc=filterIndexes),
+        universeDefinitions.Index(symbol),
+        universeDefinitions.Index(symbol, universeSettings),
+        universeDefinitions.Index(symbol, universeFilterFunc=filterIndexes),
+        universeDefinitions.Index(symbol, universeSettings, filterIndexes),
+    ]
+
+def filterIndexes(constituents: List[ETFConstituentData]) -> List[Symbol]:
+    return [x.Symbol for x in constituents]
+        ");
+
+                    var getIndexes = testModule.GetAttr("getIndexes");
+
+                    indexes = getIndexes.Invoke(algorithm.ToPython(), Symbols.SPY.ToPython(), universeSettings.ToPython()).As<List<Universe>>();
+                }
+            }
+
+            AssertETFConstituentsUniverses(indexes);
+        }
+
+        private static void AssertETFConstituentsUniverses(List<Universe> universes)
+        {
+            CollectionAssert.AllItemsAreNotNull(universes, "Universes should not be null");
+            CollectionAssert.AllItemsAreInstancesOfType(universes, typeof(ETFConstituentsUniverse),
+                "Universes should be of type ETFConstituentsUniverse");
+        }
+
+        private static IEnumerable<Symbol> Filter(IEnumerable<ETFConstituentData> constituents)
+        {
+            return constituents.Select(x => x.Symbol);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

 `UniverseDefinitions.ETF|Index` methods overloads were ambiguous: calling them without the last argument (the universe filter function) caused a compile time error in C# (not able to resolve to a single overload) and a runtime error in Python (same reason).

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6389 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
