### PR TITLE
Fixes Liquidate Existing Holdings Behavior for SetHoldings for Multiple Targets

### DIFF
--- a/Algorithm.CSharp/SetHoldingsLiquidateExistingHoldingsMultipleTargetsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SetHoldingsLiquidateExistingHoldingsMultipleTargetsRegressionAlgorithm.cs
@@ -1,0 +1,88 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Data;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm testing GH feature 3790, using SetHoldings with a collection of targets
+    /// which will be ordered by margin impact before being executed, with the objective of avoiding any
+    /// margin errors
+    /// Asserts that liquidateExistingHoldings equal false does not close positions inadvertedly (GH 7008) 
+    /// </summary>
+    public class SetHoldingsLiquidateExistingHoldingsMultipleTargetsRegressionAlgorithm : SetHoldingsMultipleTargetsRegressionAlgorithm
+    {
+        public override void OnData(Slice data)
+        {
+            if (!Portfolio.Invested)
+            {
+                SetHoldings(new List<PortfolioTarget> { new("SPY", 0.8m), new("IBM", 0.2m) },
+                    liquidateExistingHoldings: true);
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new()
+        {
+            {"Total Trades", "2"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "300.863%"},
+            {"Drawdown", "2.100%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "1.791%"},
+            {"Sharpe Ratio", "9.78"},
+            {"Probabilistic Sharpe Ratio", "67.282%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0.21"},
+            {"Beta", "0.995"},
+            {"Annual Standard Deviation", "0.223"},
+            {"Annual Variance", "0.05"},
+            {"Information Ratio", "7.104"},
+            {"Tracking Error", "0.028"},
+            {"Treynor Ratio", "2.194"},
+            {"Total Fees", "$3.76"},
+            {"Estimated Strategy Capacity", "$40000000.00"},
+            {"Lowest Capacity Asset", "IBM R735QTJ8XC9X"},
+            {"Fitness Score", "0.246"},
+            {"Kelly Criterion Estimate", "0"},
+            {"Kelly Criterion Probability Value", "0"},
+            {"Sortino Ratio", "10.452"},
+            {"Return Over Maximum Drawdown", "111.348"},
+            {"Portfolio Turnover", "0.249"},
+            {"Total Insights Generated", "0"},
+            {"Total Insights Closed", "0"},
+            {"Total Insights Analysis Completed", "0"},
+            {"Long Insight Count", "0"},
+            {"Short Insight Count", "0"},
+            {"Long/Short Ratio", "100%"},
+            {"Estimated Monthly Alpha Value", "$0"},
+            {"Total Accumulated Estimated Alpha Value", "$0"},
+            {"Mean Population Estimated Insight Value", "$0"},
+            {"Mean Population Direction", "0%"},
+            {"Mean Population Magnitude", "0%"},
+            {"Rolling Averaged Population Direction", "0%"},
+            {"Rolling Averaged Population Magnitude", "0%"},
+            {"OrderListHash", "4897db8b98ab7b556f1cb2e4b7757238"}
+        };
+    }
+}

--- a/Algorithm.CSharp/SetHoldingsMultipleTargetsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SetHoldingsMultipleTargetsRegressionAlgorithm.cs
@@ -66,27 +66,27 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
         /// </summary>
-        public bool CanRunLocally { get; } = true;
+        public virtual bool CanRunLocally { get; } = true;
 
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+        public virtual Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 7842;
+        public virtual long DataPoints => 7842;
 
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 0;
+        public virtual int AlgorithmHistoryDataPoints => 0;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
-        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        public virtual Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "149"},
             {"Average Win", "0.00%"},

--- a/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.PythonTools.pyproj
@@ -149,6 +149,7 @@
     <Compile Include="ScikitLearnLinearRegressionAlgorithm.py" />
     <Compile Include="SectorExposureRiskFrameworkAlgorithm.py" />
     <Compile Include="SectorWeightingFrameworkAlgorithm.py" />
+    <Compile Include="SetHoldingsLiquidateExistingHoldingsMultipleTargetsRegressionAlgorithm.py" />
     <Compile Include="SetHoldingsMultipleTargetsRegressionAlgorithm.py" />
     <Compile Include="SmaCrossUniverseSelectionAlgorithm.py" />
     <Compile Include="StandardDeviationExecutionModelRegressionAlgorithm.py" />

--- a/Algorithm.Python/SetHoldingsLiquidateExistingHoldingsMultipleTargetsRegressionAlgorithm.py
+++ b/Algorithm.Python/SetHoldingsLiquidateExistingHoldingsMultipleTargetsRegressionAlgorithm.py
@@ -1,0 +1,27 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+from SetHoldingsMultipleTargetsRegressionAlgorithm import SetHoldingsMultipleTargetsRegressionAlgorithm
+
+### <summary>
+### Regression algorithm testing GH feature 3790, using SetHoldings with a collection of targets
+### which will be ordered by margin impact before being executed, with the objective of avoiding any
+### margin errors
+### Asserts that liquidateExistingHoldings equal false does not close positions inadvertedly (GH 7008) 
+### </summary>
+class SetHoldingsLiquidateExistingHoldingsMultipleTargetsRegressionAlgorithm(SetHoldingsMultipleTargetsRegressionAlgorithm):
+    def OnData(self, data):
+        if not self.Portfolio.Invested:
+            self.SetHoldings([PortfolioTarget(self._spy, 0.8), PortfolioTarget(self._ibm, 0.2)],
+                             liquidateExistingHoldings=True)

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -1149,7 +1149,7 @@ namespace QuantConnect.Algorithm
             //If they triggered a liquidate
             if (liquidateExistingHoldings)
             {
-                LiquidateExistingHoldings(null, tag, orderProperties);
+                LiquidateExistingHoldings(targets.Select(x => x.Symbol).ToHashSet(), tag, orderProperties);
             }
 
             foreach (var portfolioTarget in targets 
@@ -1232,7 +1232,7 @@ namespace QuantConnect.Algorithm
             //If they triggered a liquidate
             if (liquidateExistingHoldings)
             {
-                LiquidateExistingHoldings(symbol, tag, orderProperties);
+                LiquidateExistingHoldings(new HashSet<Symbol> { symbol }, tag, orderProperties);
             }
 
             //Calculate total unfilled quantity for open market orders
@@ -1266,18 +1266,18 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Liquidate existing holdings, except for the target Symbol.
+        /// Liquidate existing holdings, except for the target list of Symbol.
         /// </summary>
-        /// <param name="symbol">Symbol indexer</param>
+        /// <param name="symbols">List of Symbol indexer</param>
         /// <param name="tag">Tag the order with a short string.</param>
         /// <param name="orderProperties">The order properties to use. Defaults to <see cref="DefaultOrderProperties"/></param>
-        private void LiquidateExistingHoldings(Symbol symbol, string tag = "", IOrderProperties orderProperties = null)
+        private void LiquidateExistingHoldings(HashSet<Symbol> symbols, string tag = "", IOrderProperties orderProperties = null)
         {
             foreach (var kvp in Portfolio)
             {
                 var holdingSymbol = kvp.Key;
                 var holdings = kvp.Value;
-                if (holdingSymbol != symbol && holdings.AbsoluteQuantity > 0)
+                if (!symbols.Contains(holdingSymbol) && holdings.AbsoluteQuantity > 0)
                 {
                     //Go through all existing holdings [synchronously], market order the inverse quantity:
                     var liquidationQuantity = CalculateOrderQuantity(holdingSymbol, 0m);


### PR DESCRIPTION
#### Description
Liquidate existing holdings before open new positions.

#### Related Issue
Closes #7008

#### Motivation and Context
Bug fix.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New regression test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)