### PR TITLE
Fixes EquityFillModel.StopMarketFill

### DIFF
--- a/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
+++ b/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
@@ -558,12 +558,12 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "8"},
             {"Average Win", "0%"},
             {"Average Loss", "-0.01%"},
-            {"Compounding Annual Return", "92.027%"},
+            {"Compounding Annual Return", "92.073%"},
             {"Drawdown", "0.100%"},
             {"Expectancy", "-1"},
             {"Net Profit", "0.838%"},
-            {"Sharpe Ratio", "12.96"},
-            {"Probabilistic Sharpe Ratio", "99.089%"},
+            {"Sharpe Ratio", "12.969"},
+            {"Probabilistic Sharpe Ratio", "99.104%"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
@@ -571,13 +571,13 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "0.229"},
             {"Annual Standard Deviation", "0.054"},
             {"Annual Variance", "0.003"},
-            {"Information Ratio", "-7.418"},
+            {"Information Ratio", "-7.415"},
             {"Tracking Error", "0.172"},
-            {"Treynor Ratio", "3.066"},
+            {"Treynor Ratio", "3.069"},
             {"Total Fees", "$8.00"},
             {"Estimated Strategy Capacity", "$48000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
-            {"Return Over Maximum Drawdown", "1183.499"},
+            {"Return Over Maximum Drawdown", "1191.657"},
             {"Portfolio Turnover", "0.093"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
@@ -585,7 +585,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Long Insight Count", "0"},
             {"Short Insight Count", "0"},
             {"Long/Short Ratio", "100%"},
-            {"OrderListHash", "3f7c620ad37d096af1af0ca341fbbe48"}
+            {"OrderListHash", "77f92a9299871d8aba2a232a0537e16c"}
         };
     }
 }

--- a/Algorithm.CSharp/StopLossOnOrderEventRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StopLossOnOrderEventRegressionAlgorithm.cs
@@ -114,7 +114,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Long Insight Count", "0"},
             {"Short Insight Count", "0"},
             {"Long/Short Ratio", "100%"},
-            {"OrderListHash", "91e6afbb270fb141af81c177c7fb8ecb"}
+            {"OrderListHash", "1ec025ef7aa0d11969f2b01304009bd0"}
         };
     }
 }

--- a/Algorithm.CSharp/StopLossOnOrderEventRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StopLossOnOrderEventRegressionAlgorithm.cs
@@ -85,16 +85,16 @@ namespace QuantConnect.Algorithm.CSharp
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "2"},
-            {"Average Win", "0.00%"},
-            {"Average Loss", "0%"},
-            {"Compounding Annual Return", "0.250%"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0.00%"},
+            {"Compounding Annual Return", "-0.359%"},
             {"Drawdown", "0.000%"},
-            {"Expectancy", "0"},
-            {"Net Profit", "0.003%"},
+            {"Expectancy", "-1"},
+            {"Net Profit", "-0.005%"},
             {"Sharpe Ratio", "0"},
             {"Probabilistic Sharpe Ratio", "0%"},
-            {"Loss Rate", "0%"},
-            {"Win Rate", "100%"},
+            {"Loss Rate", "100%"},
+            {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
             {"Alpha", "0"},
             {"Beta", "0"},
@@ -106,7 +106,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Fees", "$2.00"},
             {"Estimated Strategy Capacity", "$18000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
-            {"Return Over Maximum Drawdown", "79228162514264337593543950335"},
+            {"Return Over Maximum Drawdown", "-82.863"},
             {"Portfolio Turnover", "0.072"},
             {"Total Insights Generated", "0"},
             {"Total Insights Closed", "0"},
@@ -114,7 +114,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Long Insight Count", "0"},
             {"Short Insight Count", "0"},
             {"Long/Short Ratio", "100%"},
-            {"OrderListHash", "d78a4f8592bd22fae98d2e718901f5e8"}
+            {"OrderListHash", "91e6afbb270fb141af81c177c7fb8ecb"}
         };
     }
 }

--- a/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
@@ -235,7 +235,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Long Insight Count", "0"},
             {"Short Insight Count", "0"},
             {"Long/Short Ratio", "100%"},
-            {"OrderListHash", "aba923888a5a290754ea58f11f567288"}
+            {"OrderListHash", "7601626d70ec06969356ec2c3b9082ad"}
         };
     }
 }

--- a/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
@@ -208,11 +208,11 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Trades", "21"},
             {"Average Win", "0%"},
             {"Average Loss", "-1.51%"},
-            {"Compounding Annual Return", "-7.319%"},
+            {"Compounding Annual Return", "-7.337%"},
             {"Drawdown", "15.000%"},
             {"Expectancy", "-1"},
-            {"Net Profit", "-14.102%"},
-            {"Sharpe Ratio", "-1.09"},
+            {"Net Profit", "-14.135%"},
+            {"Sharpe Ratio", "-1.092"},
             {"Probabilistic Sharpe Ratio", "0.026%"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
@@ -223,7 +223,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Annual Variance", "0.002"},
             {"Information Ratio", "-1.525"},
             {"Tracking Error", "0.135"},
-            {"Treynor Ratio", "0.12"},
+            {"Treynor Ratio", "0.121"},
             {"Total Fees", "$21.00"},
             {"Estimated Strategy Capacity", "$3000000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
@@ -235,7 +235,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Long Insight Count", "0"},
             {"Short Insight Count", "0"},
             {"Long/Short Ratio", "100%"},
-            {"OrderListHash", "308c3da05b4bd6f294158736c998ef36"}
+            {"OrderListHash", "aba923888a5a290754ea58f11f567288"}
         };
     }
 }

--- a/Common/Messages/Messages.Orders.Fills.cs
+++ b/Common/Messages/Messages.Orders.Fills.cs
@@ -132,6 +132,13 @@ namespace QuantConnect
                 return Invariant($@"Warning: No quote information available at {tradeBar.EndTime.ToStringInvariant()} {
                     security.Exchange.TimeZone}, order filled using TradeBar data");
             }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string FilledWithOpenDueToUnfavorableGap(Securities.Security security, decimal open, DateTime endTimeUtc)
+            {
+                var endTime = endTimeUtc.ConvertFromUtc(security.Exchange.TimeZone).ToStringInvariant();
+                return Invariant($@"Warning: Due to an unfavorable gap at {endTime} {security.Exchange.TimeZone}, order filled using the open price ({open})");
+            }
         }
     }
 }

--- a/Common/Messages/Messages.Orders.Fills.cs
+++ b/Common/Messages/Messages.Orders.Fills.cs
@@ -137,7 +137,7 @@ namespace QuantConnect
             public static string FilledWithOpenDueToUnfavorableGap(Securities.Security security, decimal open, DateTime endTimeUtc)
             {
                 var endTime = endTimeUtc.ConvertFromUtc(security.Exchange.TimeZone).ToStringInvariant();
-                return Invariant($@"Warning: Due to an unfavorable gap at {endTime} {security.Exchange.TimeZone}, order filled using the open price ({open})");
+                return Invariant($@"Due to an unfavorable gap at {endTime} {security.Exchange.TimeZone}, order filled using the open price ({open})");
             }
         }
     }

--- a/Common/Orders/Fills/EquityFillModel.cs
+++ b/Common/Orders/Fills/EquityFillModel.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using QLNet;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Market;
@@ -183,58 +184,113 @@ namespace QuantConnect.Orders.Fills
         }
 
         /// <summary>
-        /// Default stop fill model implementation in base class security. (Stop Market Order Type)
+        /// Stop fill model implementation for Equity.
         /// </summary>
         /// <param name="asset">Security asset we're filling</param>
         /// <param name="order">Order packet to model</param>
         /// <returns>Order fill information detailing the average price and quantity filled.</returns>
+        /// <remarks>
+        /// A Stop order is an instruction to submit a buy or sell market order
+        /// if and when the user-specified stop trigger price is attained or penetrated.
+        ///
+        /// A Sell Stop order is always placed below the current market price.
+        /// We assume a fluid/continuous, high volume market. Therefore, it is filled at the stop trigger price
+        /// if the current low price of trades is less than or equal to this price.
+        ///
+        /// A Buy Stop order is always placed above the current market price.
+        /// We assume a fluid, high volume market. Therefore, it is filled at the stop trigger price
+        /// if the current high price of trades is greater or equal than this price.
+        ///
+        /// The continuous market assumption is not valid if the market opens with an unfavorable gap.
+        /// In this case, a new bar opens below/above the stop trigger price, and the order is filled with the opening price.
         /// <seealso cref="MarketFill(Security, MarketOrder)"/>
         public override OrderEvent StopMarketFill(Security asset, StopMarketOrder order)
         {
-            //Default order event to return.
+            // Default order event to return.
             var utcTime = asset.LocalTime.ConvertToUtc(asset.Exchange.TimeZone);
             var fill = new OrderEvent(order, utcTime, OrderFee.Zero);
 
-            //If its cancelled don't need anymore checks:
+            // If cancelled, don't need anymore checks:
             if (order.Status == OrderStatus.Canceled) return fill;
 
-            // make sure the exchange is open/normal market hours before filling
+            // Make sure the exchange is open/normal market hours before filling
             if (!IsExchangeOpen(asset, false)) return fill;
 
-            //Get the range of prices in the last bar:
-            var prices = GetPricesCheckingPythonWrapper(asset, order.Direction);
-            var pricesEndTime = prices.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
+            // Get the range of prices in the last bar:
+            var tradeOpen = 0m;
+            var tradeHigh = 0m;
+            var tradeLow = 0m;
+            var endTimeUtc = DateTime.MinValue;
 
-            // do not fill on stale data
-            if (pricesEndTime <= order.Time) return fill;
+            var subscribedTypes = GetSubscribedTypes(asset);
 
-            //Calculate the model slippage: e.g. 0.01c
-            var slip = asset.SlippageModel.GetSlippageApproximation(asset, order);
+            if (subscribedTypes.Contains(typeof(Tick)))
+            {
+                var trades = asset.Cache.GetAll<Tick>().Where(x => x.TickType == TickType.Trade && x.Price > 0);
 
-            //Check if the Stop Order was filled: opposite to a limit order
+                foreach (var trade in trades)
+                {
+                    tradeOpen = tradeOpen == 0 ? trade.Price : tradeOpen;
+                    tradeHigh = Math.Max(tradeHigh, trade.Price);
+                    tradeLow = tradeLow == 0 ? trade.Price : Math.Min(tradeLow, trade.Price);
+                    endTimeUtc = trade.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
+                }
+            }
+            else if (subscribedTypes.Contains(typeof(TradeBar)))
+            {
+                var tradeBar = asset.Cache.GetData<TradeBar>();
+
+                if (tradeBar != null)
+                {
+                    tradeOpen = tradeBar.Open;
+                    tradeHigh = tradeBar.High;
+                    tradeLow = tradeBar.Low;
+                    endTimeUtc = tradeBar.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
+                }
+            }
+
+            // Do not fill on stale data
+            if (endTimeUtc <= order.Time) return fill;
+            
             switch (order.Direction)
             {
                 case OrderDirection.Sell:
-                    //-> 1.1 Sell Stop: If Price below setpoint, Sell:
-                    if (prices.Low < order.StopPrice)
+                    if (tradeLow <= order.StopPrice)
                     {
                         fill.Status = OrderStatus.Filled;
-                        // Assuming worse case scenario fill - fill at lowest of the stop & asset price.
-                        fill.FillPrice = Math.Min(order.StopPrice, prices.Current - slip);
-                        // assume the order completely filled
                         fill.FillQuantity = order.Quantity;
+
+                        var slip = asset.SlippageModel.GetSlippageApproximation(asset, order);
+
+                        // Unfavorable gap case: if the bar opens below the stop price, fill at open price
+                        if (tradeOpen <= order.StopPrice)
+                        {
+                            fill.FillPrice = tradeOpen - slip;
+                            fill.Message = Messages.EquityFillModel.FilledWithOpenDueToUnfavorableGap(asset, tradeOpen, endTimeUtc);
+                            return fill;
+                        }
+
+                        fill.FillPrice = order.StopPrice - slip;
                     }
                     break;
 
                 case OrderDirection.Buy:
-                    //-> 1.2 Buy Stop: If Price Above Setpoint, Buy:
-                    if (prices.High > order.StopPrice)
+                    if (tradeHigh >= order.StopPrice)
                     {
                         fill.Status = OrderStatus.Filled;
-                        // Assuming worse case scenario fill - fill at highest of the stop & asset price.
-                        fill.FillPrice = Math.Max(order.StopPrice, prices.Current + slip);
-                        // assume the order completely filled
                         fill.FillQuantity = order.Quantity;
+
+                        var slip = asset.SlippageModel.GetSlippageApproximation(asset, order);
+
+                        // Unfavorable gap case: if the bar opens above the stop price, fill at open price
+                        if (tradeOpen >= order.StopPrice)
+                        {
+                            fill.FillPrice = tradeOpen + slip;
+                            fill.Message = Messages.EquityFillModel.FilledWithOpenDueToUnfavorableGap(asset, tradeOpen, endTimeUtc);
+                            return fill;
+                        }
+
+                        fill.FillPrice = order.StopPrice + slip;
                     }
                     break;
             }

--- a/Common/Orders/Fills/EquityFillModel.cs
+++ b/Common/Orders/Fills/EquityFillModel.cs
@@ -218,21 +218,21 @@ namespace QuantConnect.Orders.Fills
 
             // Get the range of prices in the last bar:
             var tradeOpen = 0m;
-            var tradeHigh = 0m;
-            var tradeLow = 0m;
+            var tradeHigh = decimal.MinValue;
+            var tradeLow = decimal.MaxValue;
             var endTimeUtc = DateTime.MinValue;
 
             var subscribedTypes = GetSubscribedTypes(asset);
 
             if (subscribedTypes.Contains(typeof(Tick)))
             {
-                var trades = asset.Cache.GetAll<Tick>().Where(x => x.TickType == TickType.Trade && x.Price > 0);
+                var trades = asset.Cache.GetAll<Tick>().Where(x => x.TickType == TickType.Trade);
 
                 foreach (var trade in trades)
                 {
                     tradeOpen = tradeOpen == 0 ? trade.Price : tradeOpen;
                     tradeHigh = Math.Max(tradeHigh, trade.Price);
-                    tradeLow = tradeLow == 0 ? trade.Price : Math.Min(tradeLow, trade.Price);
+                    tradeLow = Math.Min(tradeLow, trade.Price);
                     endTimeUtc = trade.EndTime.ConvertToUtc(asset.Exchange.TimeZone);
                 }
             }

--- a/Tests/Common/Orders/Fills/EquityFillModelTests.StopMarketFill.cs
+++ b/Tests/Common/Orders/Fills/EquityFillModelTests.StopMarketFill.cs
@@ -1,0 +1,328 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Optimizer.Parameters;
+using QuantConnect.Orders;
+using QuantConnect.Orders.Fills;
+using QuantConnect.Securities;
+using QuantConnect.Tests.Common.Data;
+using QuantConnect.Tests.Common.Securities;
+
+namespace QuantConnect.Tests.Common.Orders.Fills
+{
+    [TestFixture]
+    public partial class EquityFillModelTests
+    {
+        [Test]
+        public void PerformsStopMarketFillBuy()
+        {
+            var model = new EquityFillModel();
+            var order = new StopMarketOrder(Symbols.SPY, 100, 101.5m, Noon);
+
+            var parameters = GetFillModelParameters(order);
+
+            var security = parameters.Security;
+            security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 101m, 101m, 101m, 101m, 100));
+
+            var fill = model.Fill(parameters).Single();
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 101m, 102.5m, 101m, 102m, 100));
+
+            fill = model.StopMarketFill(security, order);
+
+            Assert.AreEqual(order.Quantity, fill.FillQuantity);
+            Assert.AreEqual(order.StopPrice, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+        }
+
+        [Test]
+        public void PerformsStopMarketFillSell()
+        {
+            var model = new EquityFillModel();
+            var order = new StopMarketOrder(Symbols.SPY, -100, 101.5m, Noon);
+
+            var parameters = GetFillModelParameters(order);
+
+            var security = parameters.Security;
+            security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 102m, 102m, 102m, 102m, 100));
+
+            var fill = model.Fill(parameters).Single();
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            security.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 102m, 102.5m, 101m, 101.5m, 100));
+
+            fill = model.StopMarketFill(security, order);
+
+            Assert.AreEqual(order.Quantity, fill.FillQuantity);
+            Assert.AreEqual(order.StopPrice, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+        }
+
+        [TestCase(100, 290.50)]
+        [TestCase(-100, 291.50)]
+        public void PerformsStopMarketFillWithTickTradeData(decimal orderQuantity, decimal stopPrice)
+        {
+            var time = new DateTime(2018, 9, 24, 9, 30, 0);
+            var timeKeeper = new TimeKeeper(time.ConvertToUtc(TimeZones.NewYork), TimeZones.NewYork);
+
+            var fillModel = new EquityFillModel();
+            var order = new StopMarketOrder(Symbols.SPY, orderQuantity, stopPrice, time.ConvertToUtc(TimeZones.NewYork));
+
+            var configTick = CreateTickConfig(Symbols.SPY);
+            var equity = CreateEquity(configTick);
+
+            equity.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            // The order will not fill with this price
+            var tradeTick = new Tick { TickType = TickType.Trade, Time = time, Value = 291m };
+            equity.SetMarketPrice(tradeTick);
+
+            time += TimeSpan.FromMinutes(1);
+            timeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
+
+            var fill = fillModel.Fill(new FillModelParameters(
+                equity,
+                order,
+                new MockSubscriptionDataConfigProvider(configTick),
+                Time.OneHour,
+                null)).Single();
+
+            // Do not fill on stale data
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            time += TimeSpan.FromMinutes(2);
+            timeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
+
+            // Create a series of price where the last value will not fill
+            // and the fill model need to use the minimum/maximum instead
+            var trades = new[] { 0.1m, -0.1m, 0m, 0.1m, 0m }
+                .Select(delta => new Tick 
+                    { 
+                        TickType = TickType.Trade,
+                        Time = time, 
+                        Value = stopPrice - delta * Math.Sign(orderQuantity)
+                    })
+                .ToList();
+
+            equity.Update(trades, typeof(Tick));
+
+            fill = fillModel.StopMarketFill(equity, order);
+
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+            Assert.AreEqual(order.Quantity, fill.FillQuantity);
+            // Fill at the stop price because the equity price matches it
+            Assert.AreEqual(stopPrice, fill.FillPrice);
+        }
+
+        [TestCase(100, 290.50)]
+        [TestCase(-100, 291.50)]
+        public void StopMarketOrderDoesNotFillUsingQuoteBar(decimal orderQuantity, decimal stopPrice)
+        {
+            var time = new DateTime(2018, 9, 24, 9, 30, 0);
+            var timeKeeper = new TimeKeeper(time.ConvertToUtc(TimeZones.NewYork), TimeZones.NewYork);
+
+            var fillModel = new EquityFillModel();
+            var order = new StopMarketOrder(Symbols.SPY, orderQuantity, stopPrice, time.ConvertToUtc(TimeZones.NewYork));
+
+            var parameters = GetFillModelParameters(order);
+
+            var equity = parameters.Security;
+            equity.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            // The order will not fill with these prices
+            var tradeBar = new TradeBar(time.AddMinutes(-10), Symbols.SPY, 291m, 291m, 291m, 291m, 12345);
+            equity.SetMarketPrice(tradeBar);
+
+            time += TimeSpan.FromMinutes(1);
+            timeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
+
+            var fill = fillModel.Fill(parameters).Single();
+
+            // Do not fill on stale data
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            time += TimeSpan.FromMinutes(2);
+            timeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
+            
+            var quoteBar = new QuoteBar(time, Symbols.SPY, 
+                new Bar(290m, 292m, 289m, 291m), 12345,
+                new Bar(290m, 292m, 289m, 291m), 12345);
+            equity.SetMarketPrice(quoteBar);
+
+            fill = fillModel.StopMarketFill(equity, order);
+
+            // Stop market orders don't fill with QuoteBar:
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+        }
+
+        [TestCase(100, 290.50)]
+        [TestCase(-100, 291.50)]
+        public void StopMarketOrderDoesNotFillUsingTickTypeQuote(decimal orderQuantity, decimal stopPrice)
+        {
+            var time = new DateTime(2018, 9, 24, 9, 30, 0);
+            var timeKeeper = new TimeKeeper(time.ConvertToUtc(TimeZones.NewYork), TimeZones.NewYork);
+
+            var fillModel = new EquityFillModel();
+            var order = new StopMarketOrder(Symbols.SPY, orderQuantity, stopPrice, time.ConvertToUtc(TimeZones.NewYork));
+
+            var configTick = CreateTickConfig(Symbols.SPY);
+            var equity = CreateEquity(configTick);
+
+            equity.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            // The order will not fill with this price
+            var tradeTick = new Tick { TickType = TickType.Trade, Time = time, Value = 291m };
+            equity.SetMarketPrice(tradeTick);
+
+            time += TimeSpan.FromMinutes(1);
+            timeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
+
+            var fill = fillModel.Fill(new FillModelParameters(
+                equity,
+                order,
+                new MockSubscriptionDataConfigProvider(configTick),
+                Time.OneHour,
+                null)).Single();
+
+            // Do not fill on stale data
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            time += TimeSpan.FromMinutes(2);
+            timeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
+
+            var price = stopPrice - 0.1m * Math.Sign(orderQuantity);
+            var quoteTick = new Tick { TickType = TickType.Quote, Time = time, BidPrice = price, AskPrice = price };
+            equity.SetMarketPrice(quoteTick);
+            
+            fill = fillModel.StopMarketFill(equity, order);
+
+            // Stop market orders don't fill with TickType.Quote:
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+        }
+
+        [TestCase(100, 290.50)]
+        [TestCase(-100, 291.50)]
+        public void StopMarketOrderFillsAtOpenWithUnfavourableGap(decimal orderQuantity, decimal stopPrice)
+        {
+            // See https://github.com/QuantConnect/Lean/issues/4545
+            var time = new DateTime(2018, 9, 24, 9, 30, 0);
+            var timeKeeper = new TimeKeeper(time.ConvertToUtc(TimeZones.NewYork), TimeZones.NewYork);
+
+            var fillModel = new EquityFillModel();
+            var order = new StopMarketOrder(Symbols.SPY, orderQuantity, stopPrice, time.ConvertToUtc(TimeZones.NewYork));
+
+            var parameters = GetFillModelParameters(order);
+            
+            var equity = parameters.Security;
+            equity.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            // The order will not fill with these prices
+            equity.SetMarketPrice(new TradeBar(time.AddMinutes(-10), Symbols.SPY, 291m, 291m, 291m, 291m, 12345));
+
+            var fill = fillModel.Fill(parameters).Single();
+
+            // Do not fill on stale data
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            time += TimeSpan.FromMinutes(2);
+            timeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
+
+            // The Gap TradeBar has all prices below/above the stop price 
+            var gapTradeBar = Math.Sign(orderQuantity) switch
+            { 
+                1 => new TradeBar(time, Symbols.SPY, stopPrice + 1, stopPrice + 2, stopPrice + 1, stopPrice + 1, 12345),
+                -1 => new TradeBar(time, Symbols.SPY, stopPrice - 1, stopPrice - 1, stopPrice - 2, stopPrice - 1, 12345),
+            };
+
+            equity.SetMarketPrice(gapTradeBar);
+
+            fill = fillModel.StopMarketFill(equity, order);
+
+            // Fills at the open
+            Assert.AreEqual(gapTradeBar.Open, fill.FillPrice);
+            Assert.AreEqual(order.Quantity, fill.FillQuantity);
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+        }
+        
+        [TestCase(100, 291.50)]
+        [TestCase(-100, 290.50)]
+        public void StopMarketOrderDoesNotFillUsingDataBeforeSubmitTime(decimal orderQuantity, decimal stopPrice)
+        {
+            var time = new DateTime(2018, 9, 24, 9, 30, 0);
+            var timeKeeper = new TimeKeeper(time.ConvertToUtc(TimeZones.NewYork), TimeZones.NewYork);
+
+            var fillModel = new EquityFillModel();
+            var order = new StopMarketOrder(Symbols.SPY, orderQuantity, stopPrice, time.ConvertToUtc(TimeZones.NewYork));
+
+            var parameters = GetFillModelParameters(order);
+
+            var security = parameters.Security;
+            security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            var tradeBar = new TradeBar(time.AddMinutes(-10), Symbols.SPY, 290m, 292m, 289m, 291m, 12345);
+            security.SetMarketPrice(tradeBar);
+
+            time += TimeSpan.FromMinutes(1);
+            timeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
+
+            var fillForwardBar = (TradeBar)tradeBar.Clone(true);
+            security.SetMarketPrice(fillForwardBar);
+
+            var fill = fillModel.Fill(parameters).Single();
+
+            Assert.AreEqual(0, fill.FillQuantity);
+            Assert.AreEqual(0, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+
+            time += TimeSpan.FromMinutes(1);
+            timeKeeper.SetUtcDateTime(time.ConvertToUtc(TimeZones.NewYork));
+
+            tradeBar = new TradeBar(time, Symbols.SPY, stopPrice - 0.01m * Math.Sign(orderQuantity), 292m, 289m, stopPrice, 12345);
+            security.SetMarketPrice(tradeBar);
+
+            fill = fillModel.StopMarketFill(security, order);
+
+            Assert.AreEqual(orderQuantity, fill.FillQuantity);
+            Assert.AreEqual(stopPrice, fill.FillPrice);
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+        }
+    }
+}


### PR DESCRIPTION
#### Description
These unit tests cover new scenarios:
- Cannot trigger on quote data (QuoteBar or TickRype.Quote);
- Adds missing test for tick data (TickType.Trade)
- Unfavorable gap (see #4545)
 
Fixes EquityFillModel StopMarketFill
- Use the entire tick history to find the trigger price
- Fill price is the stop price, unless there is an unfavorable gap.

Update Regression Tests
- All regression tests keep the total trades. The difference are due to the time that the stop market orders are triggered and the prices that are filled. The `StopLossOnOrderEventRegressionAlgorithm` and the `UpdateOrderRegressionAlgorithm` observe the unfavorable gap case.

![Capture](https://user-images.githubusercontent.com/6889033/223286962-d15276e1-de75-4156-b1ee-95ef18e05ed8.png)

#### Related Issue
Closes #6972 and #4545

#### Motivation and Context
Improve modeling.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Old and new unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`