### PR TITLE
Reuse Code To Find Best Effort TradeBar

### DIFF
--- a/Common/Messages/Messages.Orders.Fills.cs
+++ b/Common/Messages/Messages.Orders.Fills.cs
@@ -134,10 +134,9 @@ namespace QuantConnect
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static string FilledWithOpenDueToUnfavorableGap(Securities.Security security, decimal open, DateTime endTimeUtc)
+            public static string FilledWithOpenDueToUnfavorableGap(Securities.Security security, TradeBar tradeBar)
             {
-                var endTime = endTimeUtc.ConvertFromUtc(security.Exchange.TimeZone).ToStringInvariant();
-                return Invariant($@"Due to an unfavorable gap at {endTime} {security.Exchange.TimeZone}, order filled using the open price ({open})");
+                return Invariant($@"Due to an unfavorable gap at {tradeBar.EndTime.ToStringInvariant()} {security.Exchange.TimeZone}, order filled using the open price ({tradeBar.Open})");
             }
         }
     }

--- a/Tests/Common/Orders/Fills/EquityFillModelTests.LimitFill.cs
+++ b/Tests/Common/Orders/Fills/EquityFillModelTests.LimitFill.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var equity = CreateEquity(configTradeBar);
 
             equity.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
-            equity.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 102m));
+            equity.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 102m, 102m, 102m, 102m, 100));
 
             var fill = model.Fill(new FillModelParameters(
                 equity,
@@ -69,7 +69,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             var configTradeBar = CreateTradeBarConfig(Symbols.SPY);
             var equity = CreateEquity(configTradeBar);
             equity.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
-            equity.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101m));
+            equity.SetMarketPrice(new TradeBar(Noon, Symbols.SPY, 101m, 101m, 101m, 101m, 100));
 
             var fill = model.Fill(new FillModelParameters(
                 equity,


### PR DESCRIPTION
#### Description
The `LimitFill`, `LimitIfTouchedFill`, and `StopMaketFill` methods require `TradeBar` data to test price levels. We create a method to serve these methods as well as other methods that will require this information.

Removes `Price > 0` check for `TradeType.Trade` data. Unnecessary check, since a tick price cannot be less or equal to zero.

#### Related Issue
See #7042

#### Motivation and Context
Code reuse avoids bugs.

#### How Has This Been Tested?
N/A refactor. All unit tests have passed. We need to fix Limit fill tests that were not using market data types (not valid subscriptions) to set the price.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`