### PR TITLE
Fill forward runtime adjustment

### DIFF
--- a/Algorithm.CSharp/CustomUniverseWithBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomUniverseWithBenchmarkRegressionAlgorithm.cs
@@ -172,8 +172,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        /// <remarks>Using -1 to skip regression test until the gh issue #6253 isn't resolved</remarks>
-        public long DataPoints => -1;
+        public long DataPoints => 3500;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/ForexInternalFeedOnDataHigherResolutionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ForexInternalFeedOnDataHigherResolutionRegressionAlgorithm.cs
@@ -101,7 +101,12 @@ namespace QuantConnect.Algorithm.CSharp
             // EURUSD has only one day of hourly data, because it was added on the first time step instead of during Initialize
             var expectedDataPointsPerSymbol = new Dictionary<string, int>
             {
-                { "EURGBP", 3 },
+                // 1 daily bar 10/7/2013 8:00:00 PM
+                // Hour resolution 'EURUSD added
+                // 1 daily bar '10/8/2013 8:00:00 PM'
+                // we start to FF
+                // +4 fill forwarded bars till '10/9/2013 12:00:00 AM'
+                { "EURGBP", 6},
                 { "EURUSD", 28 }
             };
 
@@ -131,7 +136,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 57;
+        public long DataPoints => 63;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -159,8 +164,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "0"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "5.91"},
-            {"Tracking Error", "0.13"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},

--- a/Algorithm.CSharp/OptionChainSubscriptionRemovalRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionChainSubscriptionRemovalRegressionAlgorithm.cs
@@ -113,8 +113,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        /// <remarks>Using -1 to skip regression test, issue to be determined</remarks>
-        public long DataPoints => -1;
+        public long DataPoints => 111963764;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/RegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionAlgorithm.cs
@@ -83,7 +83,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 16896627;
+        public long DataPoints => 16896626;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -95,14 +95,14 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Trades", "1589"},
+            {"Total Trades", "1587"},
             {"Average Win", "0.00%"},
             {"Average Loss", "0.00%"},
-            {"Compounding Annual Return", "-1.158%"},
+            {"Compounding Annual Return", "-1.257%"},
             {"Drawdown", "0.000%"},
             {"Expectancy", "-0.989"},
             {"Net Profit", "-0.016%"},
-            {"Sharpe Ratio", "-9.754"},
+            {"Sharpe Ratio", "-9.719"},
             {"Probabilistic Sharpe Ratio", "0.000%"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
@@ -111,14 +111,14 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "-0.001"},
             {"Annual Standard Deviation", "0.001"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-8.943"},
+            {"Information Ratio", "-8.944"},
             {"Tracking Error", "0.223"},
-            {"Treynor Ratio", "14.427"},
-            {"Total Fees", "$1589.00"},
-            {"Estimated Strategy Capacity", "$67000000.00"},
-            {"Lowest Capacity Asset", "AIG R735QTJ8XC9X"},
-            {"Portfolio Turnover", "1.87%"},
-            {"OrderListHash", "b500cbcfb4acc2e3b07a6ee1b7f41d1a"}
+            {"Treynor Ratio", "14.483"},
+            {"Total Fees", "$1587.00"},
+            {"Estimated Strategy Capacity", "$64000.00"},
+            {"Lowest Capacity Asset", "IBM R735QTJ8XC9X"},
+            {"Portfolio Turnover", "1.86%"},
+            {"OrderListHash", "6d4e987268f968b8d9c2878739b2971c"}
         };
     }
 }

--- a/Algorithm.CSharp/RegressionTests/Universes/ETFConstituentUniverseMappedCompositeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionTests/Universes/ETFConstituentUniverseMappedCompositeRegressionAlgorithm.cs
@@ -157,7 +157,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 703;
+        public long DataPoints => 759;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -976,8 +976,7 @@ namespace QuantConnect
             List<Tick> list;
             if (!dictionary.TryGetValue(key, out list))
             {
-                list = new List<Tick>(1);
-                dictionary.Add(key, list);
+                dictionary[key] = list = new List<Tick>(1);
             }
             list.Add(tick);
         }

--- a/Engine/DataFeeds/FillForwardResolutionChangedEvent.cs
+++ b/Engine/DataFeeds/FillForwardResolutionChangedEvent.cs
@@ -1,0 +1,36 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+
+namespace QuantConnect.Lean.Engine.DataFeeds
+{
+    /// <summary>
+    /// Helper class for fill forward resolution change events
+    /// </summary>
+    public class FillForwardResolutionChangedEvent
+    {
+        /// <summary>
+        /// The old fill forward time span
+        /// </summary>
+        public TimeSpan Old { get; set; }
+
+        /// <summary>
+        /// The new fill forward time span
+        /// </summary>
+        public TimeSpan New { get; set; }
+    }
+}

--- a/Engine/DataFeeds/SubscriptionCollection.cs
+++ b/Engine/DataFeeds/SubscriptionCollection.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -31,11 +31,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     {
         private readonly ConcurrentDictionary<SubscriptionDataConfig, Subscription> _subscriptions;
         private bool _sortingSubscriptionRequired;
+        private bool _frozen;
         private readonly Ref<TimeSpan> _fillForwardResolution;
 
         // some asset types (options, futures, crypto) have multiple subscriptions for different tick types,
         // we keep a sorted list of subscriptions so we can return them in a deterministic order
         private List<Subscription> _subscriptionsByTickType;
+
+        /// <summary>
+        /// Event fired when the fill forward resolution changes
+        /// </summary>
+        public event EventHandler<FillForwardResolutionChangedEvent> FillForwardResolutionChanged;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SubscriptionCollection"/> class
@@ -140,6 +146,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         }
 
         /// <summary>
+        /// Will disable or enable fill forward resolution updates
+        /// </summary>
+        public void FreezeFillForwardResolution(bool freeze)
+        {
+            _frozen = freeze;
+        }
+
+        /// <summary>
         /// Helper method to validate a configuration to be included in the fill forward calculation
         /// </summary>
         private static bool ValidateFillForwardResolution(SubscriptionDataConfig configuration)
@@ -152,6 +166,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         private void UpdateFillForwardResolution(FillForwardResolutionOperation operation, SubscriptionDataConfig configuration)
         {
+            if(_frozen)
+            {
+                return;
+            }
+
             // Due to performance implications let's be jealous in updating the _fillForwardResolution
             if (ValidateFillForwardResolution(configuration) &&
                 (
@@ -166,11 +185,18 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 var configurations = (operation == FillForwardResolutionOperation.BeforeAdd)
                     ? _subscriptions.Keys.Concat(new[] { configuration }) : _subscriptions.Keys;
 
+                var eventArgs = new FillForwardResolutionChangedEvent { Old = _fillForwardResolution.Value };
                 _fillForwardResolution.Value = configurations.Where(ValidateFillForwardResolution)
                                                              .Select(x => x.Resolution)
                                                              .Distinct()
                                                              .DefaultIfEmpty(Resolution.Minute)
                                                              .Min().ToTimeSpan();
+                if (_fillForwardResolution.Value != eventArgs.Old)
+                {
+                    eventArgs.New = _fillForwardResolution.Value;
+                    // notify consumers if any
+                    FillForwardResolutionChanged?.Invoke(this, eventArgs);
+                }
             }
         }
 

--- a/Engine/DataFeeds/SubscriptionUtils.cs
+++ b/Engine/DataFeeds/SubscriptionUtils.cs
@@ -42,6 +42,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             SubscriptionRequest request,
             IEnumerator<BaseData> enumerator)
         {
+            if (enumerator == null)
+            {
+                return GetEndedSubscription(request);
+            }
             var exchangeHours = request.Security.Exchange.Hours;
             var timeZoneOffsetProvider = new TimeZoneOffsetProvider(request.Configuration.ExchangeTimeZone, request.StartTimeUtc, request.EndTimeUtc);
             var dataEnumerator = new SubscriptionDataEnumerator(
@@ -69,6 +73,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             IFactorFileProvider factorFileProvider,
             bool enablePriceScale)
         {
+            if(enumerator == null)
+            {
+                return GetEndedSubscription(request);
+            }
             var exchangeHours = request.Security.Exchange.Hours;
             var enqueueable = new EnqueueableEnumerator<SubscriptionData>(true);
             var timeZoneOffsetProvider = new TimeZoneOffsetProvider(request.Configuration.ExchangeTimeZone, request.StartTimeUtc, request.EndTimeUtc);
@@ -165,6 +173,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             );
 
             return subscription;
+        }
+
+        /// <summary>
+        /// Return an ended subscription so it doesn't blow up at runtime on the data worker, this can happen if there's no tradable date
+        /// </summary>
+        private static Subscription GetEndedSubscription(SubscriptionRequest request)
+        {
+            var result = new Subscription(request, null, null);
+            // set subscription as ended
+            result.Dispose();
+            return result;
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix for fill forward adjustment at runtime since the data stack runs async, we will remove and readd afected subscriptions.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/6253
Closes https://github.com/QuantConnect/Lean/issues/6255
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
N/A
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
