### PR TITLE
Removes Cash Account Restriction for Framework Algorithms

### DIFF
--- a/Algorithm/QCAlgorithm.Framework.cs
+++ b/Algorithm/QCAlgorithm.Framework.cs
@@ -84,15 +84,6 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(AlgorithmFramework)]
         public void FrameworkPostInitialize()
         {
-            //Prevents execution in the case of cash brokerage with IExecutionModel and IPortfolioConstructionModel
-            if (PortfolioConstruction.GetType() != typeof(NullPortfolioConstructionModel)
-                && Execution.GetType() != typeof(NullExecutionModel)
-                && BrokerageModel.AccountType == AccountType.Cash)
-            {
-                throw new InvalidOperationException($"Non null {nameof(IExecutionModel)} and {nameof(IPortfolioConstructionModel)} are currently unsuitable for Cash Modeled brokerages (e.g. GDAX) and may result in unexpected trades."
-                                                    + " To prevent possible user error we've restricted them to Margin trading. You can select margin account types with"
-                                                    + $" SetBrokerage( ... AccountType.Margin). Or please set them to {nameof(NullExecutionModel)}, {nameof(NullPortfolioConstructionModel)}");
-            }
             foreach (var universe in UniverseSelection.CreateUniverses(this))
             {
                 lock(_pendingUniverseAdditionsLock)


### PR DESCRIPTION
#### Description
The user will be responsible for choosing/using models that fit the brokerage account type.

#### Related Issue
Closes #3165

#### Motivation and Context
Improve Framework model usage.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
The algorithm from GitHub issue #3165.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`