### PR TITLE
Allows Algorithms to Define Whether Market Orders Fill On Stale Prices

### DIFF
--- a/Algorithm.CSharp/MarketFillOnNextBarRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MarketFillOnNextBarRegressionAlgorithm.cs
@@ -1,0 +1,132 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Demonstration algorithm showing how to disable fill on stale prices for market orders
+    /// <meta name="tag" content="trading and orders" />
+    /// </summary>
+    public class MarketFillOnNextBarRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _symbol;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 7);
+            SetEndDate(2013, 10, 11);
+            SetCash(10000);
+
+            // Do not allow fill on stale prices
+            Settings.FillOnStalePrices = false;
+
+            _symbol = AddEquity("AAPL", Resolution.Hour, Market.USA, true, 1).Symbol;
+            AddEquity("SPY", Resolution.Minute, Market.USA, true, 1);
+        }
+
+        public override void OnData(Slice data)
+        {
+            if (Time.Day != 8) return;
+
+            if (Time.Hour == 9 && Time.Minute == 45)
+            {
+                var lastData = Securities[_symbol].GetLastData();
+
+                // log price from market close of 10/7/2013 at 4 PM
+                Log($"{Time} - latest price: {lastData.EndTime} - {lastData.Price}");
+
+                // this market order will be filled at the open of the next hourly bar (10:00 AM)
+                SetHoldings(_symbol, 0.85);
+
+                if (Portfolio.Invested)
+                {
+                    // order filled at price of last market close
+                    throw new Exception("Unexpected fill on fill-forward bar with stale price.");
+                }
+            }
+            if (Time.Hour == 9 && Time.Minute == 50)
+            {
+                var openOrders = Transactions.GetOpenOrders(_symbol);
+                if (openOrders.Count == 0)
+                {
+                    throw new Exception("Pending market order was expected on current bar.");
+                }
+            }
+            else if (Time.Hour == 10 && Time.Minute == 0)
+            {
+                if (!Portfolio.Invested)
+                {
+                    throw new Exception("Order fill was expected on current bar.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 5864;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new ()
+        {
+            {"Total Trades", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "59.593%"},
+            {"Drawdown", "1.600%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0.599%"},
+            {"Sharpe Ratio", "2.685"},
+            {"Probabilistic Sharpe Ratio", "54.624%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "-0.617"},
+            {"Beta", "0.551"},
+            {"Annual Standard Deviation", "0.177"},
+            {"Annual Variance", "0.031"},
+            {"Information Ratio", "-9.317"},
+            {"Tracking Error", "0.162"},
+            {"Treynor Ratio", "0.862"},
+            {"Total Fees", "$2.75"},
+            {"Estimated Strategy Capacity", "$44000000.00"},
+            {"Lowest Capacity Asset", "AAPL R735QTJ8XC9X"},
+            {"Portfolio Turnover", "17.25%"},
+            {"OrderListHash", "fc4ade727a8bcd957cea4f8f129376f7"}
+        };
+    }
+}

--- a/Algorithm.Python/MarketFillOnNextBarRegressionAlgorithm.py
+++ b/Algorithm.Python/MarketFillOnNextBarRegressionAlgorithm.py
@@ -1,0 +1,56 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Demonstration algorithm showing how to disable fill on stale prices for market orders
+### <meta name="tag" content="trading and orders" />
+### </summary>
+class MarketFillOnNextBarRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetStartDate(2013,10,7)
+        self.SetEndDate(2013,10,11)
+        self.SetCash(10000)
+
+        # Do not allow fill on stale prices
+        self.Settings.FillOnStalePrices = False
+
+        self.symbol = self.AddEquity("AAPL", Resolution.Hour, Market.USA, True, 1).Symbol
+        self.AddEquity("SPY", Resolution.Minute, Market.USA, True, 1)
+
+    def OnData(self, data):
+        if self.Time.day != 8: return
+
+        if self.Time.hour == 9 and self.Time.minute == 45:
+            lastData = self.Securities[self.symbol].GetLastData()
+
+            # log price from market close of 10/7/2013 at 4 PM
+            self.Log(f"{self.Time} - latest price: {lastData.EndTime} - {lastData.Price}")
+
+            # this market order will be filled at the open of the next hourly bar (10:00 AM)
+            self.SetHoldings(self.symbol, 0.85)
+
+            if self.Portfolio.Invested:
+                # order filled at price of last market close
+                raise Exception("Unexpected fill on fill-forward bar with stale price.")
+
+        if self.Time.hour == 9 and self.Time.minute == 50:
+            openOrders = self.Transactions.GetOpenOrders(self.symbol)
+            if not openOrders:
+                raise Exception("Pending market order was expected on current bar.")
+
+        elif self.Time.hour == 10 and self.Time.minute == 0:
+             if not self.Portfolio.Invested:
+                raise Exception("Order fill was expected on current bar.")

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -348,7 +348,8 @@ namespace QuantConnect.Brokerages.Backtesting
                                     order,
                                     Algorithm.SubscriptionManager.SubscriptionDataConfigService,
                                     Algorithm.Settings.StalePriceTimeSpan,
-                                    securities);
+                                    securities,
+                                    Algorithm.Settings.FillOnStalePrices);
 
                                 // check if the fill should be emitted
                                 var fill = model.Fill(context);

--- a/Common/AlgorithmSettings.cs
+++ b/Common/AlgorithmSettings.cs
@@ -96,6 +96,17 @@ namespace QuantConnect
         public TimeSpan StalePriceTimeSpan { get; set; }
 
         /// <summary>
+        /// Gets/sets if orders can fill on stale prices
+        /// </summary>
+        /// <remarks>
+        /// By default, the fill models handle stale prices for all order types, except the market fill,
+        /// since market orders don't depend on the price. Therefore this property defaults to true.
+        /// This property allows users to modify this assumption and force the algorithm to wait for the
+        /// first market data after the market order is placed.
+        /// </remarks>
+        public bool FillOnStalePrices { get; set; }
+
+        /// <summary>
         /// The warmup resolution to use if any
         /// </summary>
         /// <remarks>This allows improving the warmup speed by setting it to a lower resolution than the one added in the algorithm</remarks>
@@ -131,6 +142,7 @@ namespace QuantConnect
             StalePriceTimeSpan = Time.OneHour;
             MaxAbsolutePortfolioTargetPercentage = 1000000000;
             MinAbsolutePortfolioTargetPercentage = 0.0000000001m;
+            FillOnStalePrices = true;
         }
     }
 }

--- a/Common/Interfaces/IAlgorithmSettings.cs
+++ b/Common/Interfaces/IAlgorithmSettings.cs
@@ -88,6 +88,11 @@ namespace QuantConnect.Interfaces
         TimeSpan StalePriceTimeSpan { get; set; }
 
         /// <summary>
+        /// Gets/sets if orders can fill on stale prices
+        /// </summary>
+        bool FillOnStalePrices { get; set; }
+
+        /// <summary>
         /// The warmup resolution to use if any
         /// </summary>
         /// <remarks>This allows improving the warmup speed by setting it to a lower resolution than the one added in the algorithm</remarks>

--- a/Common/Orders/Fills/FillModelParameters.cs
+++ b/Common/Orders/Fills/FillModelParameters.cs
@@ -53,6 +53,11 @@ namespace QuantConnect.Orders.Fills
         public Dictionary<Order, Security> SecuritiesForOrders { get; }
 
         /// <summary>
+        /// Allow orders to fill on stale prices
+        /// </summary>
+        public bool FillOnStalePrices { get; }
+
+        /// <summary>
         /// Creates a new instance
         /// </summary>
         /// <param name="security">Security asset we're filling</param>
@@ -60,18 +65,21 @@ namespace QuantConnect.Orders.Fills
         /// <param name="configProvider">The <see cref="ISubscriptionDataConfigProvider"/> to use</param>
         /// <param name="stalePriceTimeSpan">The minimum time span elapsed to consider a fill price as stale</param>
         /// <param name="securitiesForOrders">Collection of securities for each order</param>
+        /// <param name="fillOnStalePrices">Allow order to fill on stale prices</param>
         public FillModelParameters(
             Security security,
             Order order,
             ISubscriptionDataConfigProvider configProvider,
             TimeSpan stalePriceTimeSpan,
-            Dictionary<Order, Security> securitiesForOrders)
+            Dictionary<Order, Security> securitiesForOrders,
+            bool fillOnStalePrices = true)
         {
             Security = security;
             Order = order;
             ConfigProvider = configProvider;
             StalePriceTimeSpan = stalePriceTimeSpan;
             SecuritiesForOrders = securitiesForOrders;
+            FillOnStalePrices = fillOnStalePrices;
         }
     }
 }


### PR DESCRIPTION
#### Description
Adds `FillOnStalePrices` parameter to `FillModelParameters` and `AlgorithmSettings`
This new property will control whether market orders can fill on stale prices.

Refactors `EquityFillModel`:
The market fill method tries to get the best effort bid/ask price. Failure means that the price is stale/invalid.
The `GetBestEffortBidPrice` and `GetBestEffortAskPrice` were refactored into `TryGetBestEffortBidPrice` and `TryGetBestEffortAskPrice` for the market fill model. The other fill models don't allow fill on stale prices.

#### Related Issue
Closes #2762

#### Motivation and Context
The fill models assume that market orders do not depend on the current market price to fill, so we allow fill on stale prices. A new algorithm setting will allow us to wait for new data.

#### Requires Documentation Change
Yes. We should document this option.

#### How Has This Been Tested?
New unit and regression tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`