### PR TITLE
Refactor Portfolio Construction Models to Use Insight Manager

### DIFF
--- a/Algorithm.CSharp/PortfolioRebalanceOnSecurityChangesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/PortfolioRebalanceOnSecurityChangesRegressionAlgorithm.cs
@@ -31,6 +31,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// </summary>
     public class PortfolioRebalanceOnSecurityChangesRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
+        private int _generatedInsightsCount;
         private Dictionary<Symbol, DateTime> _lastOrderFilled;
 
         /// <summary>
@@ -62,6 +63,8 @@ namespace QuantConnect.Algorithm.CSharp
             SetExecution(new ImmediateExecutionModel());
 
             _lastOrderFilled = new Dictionary<Symbol, DateTime>();
+
+            InsightsGenerated += (_, e) => _generatedInsightsCount += e.Insights.Length;
         }
 
         public override void OnOrderEvent(OrderEvent orderEvent)
@@ -79,6 +82,16 @@ namespace QuantConnect.Algorithm.CSharp
                 _lastOrderFilled[orderEvent.Symbol] = UtcTime;
 
                 Debug($"{orderEvent}");
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (Insights.Count == _generatedInsightsCount)
+            {
+                // The number of insights is modified by the Portfolio Construction Model,
+                // since it removes expired insights and insights from removed securities 
+                throw new Exception($"The number of insights in the insight manager should be different of the number of all insights generated ({_generatedInsightsCount})");
             }
         }
 

--- a/Algorithm.Framework/Portfolio/AccumulativeInsightPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/AccumulativeInsightPortfolioConstructionModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -19,7 +19,6 @@ using System.Linq;
 using Python.Runtime;
 using QuantConnect.Algorithm.Framework.Alphas;
 using QuantConnect.Scheduling;
-using QuantConnect.Util;
 
 namespace QuantConnect.Algorithm.Framework.Portfolio
 {
@@ -116,7 +115,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         {
             SetRebalancingFunc(rebalance);
         }
-
+        
         /// <summary>
         /// Initialize a new instance of <see cref="AccumulativeInsightPortfolioConstructionModel"/>
         /// </summary>
@@ -153,7 +152,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// <returns>An enumerable of the target insights</returns>
         protected override List<Insight> GetTargetInsights()
         {
-            return InsightCollection.GetActiveInsights(Algorithm.UtcTime)
+            return Algorithm.Insights.GetActiveInsights(Algorithm.UtcTime).Where(ShouldCreateTargetForInsight)
                 .OrderBy(insight => insight.GeneratedTimeUtc)
                 .ToList();
         }

--- a/Algorithm.Framework/Portfolio/AccumulativeInsightPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/AccumulativeInsightPortfolioConstructionModel.py
@@ -47,7 +47,7 @@ class AccumulativeInsightPortfolioConstructionModel(EqualWeightingPortfolioConst
             activeInsights: The active insights to generate a target for'''
         percentPerSymbol = {}
 
-        insights = sorted(self.InsightCollection.GetActiveInsights(self.currentUtcTime), key=lambda insight: insight.GeneratedTimeUtc)
+        insights = sorted(self.Algorithm.Insights.GetActiveInsights(self.currentUtcTime), key=lambda insight: insight.GeneratedTimeUtc)
 
         for insight in insights:
             targetPercent = 0

--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -249,15 +249,12 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         {
             var targets = new Dictionary<Insight, double>();
 
-            double[,] P;
-            double[] Q;
-            if (TryGetViews(lastActiveInsights, out P, out Q))
+            if (TryGetViews(lastActiveInsights, out var P, out var Q))
             {
                 // Updates the ReturnsSymbolData with insights
                 foreach (var insight in lastActiveInsights)
                 {
-                    ReturnsSymbolData symbolData;
-                    if (_symbolDataDict.TryGetValue(insight.Symbol, out symbolData))
+                    if (_symbolDataDict.TryGetValue(insight.Symbol, out var symbolData))
                     {
                         if (insight.Magnitude == null)
                         {
@@ -272,8 +269,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                 var returns = _symbolDataDict.FormReturnsMatrix(symbols);
 
                 // Calculate posterior estimate of the mean and uncertainty in the mean
-                double[,] Σ;
-                var Π = GetEquilibriumReturns(returns, out Σ);
+                var Π = GetEquilibriumReturns(returns, out var Σ);
 
                 ApplyBlackLittermanMasterFormula(ref Π, ref Σ, P, Q);
 
@@ -306,7 +302,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         protected override List<Insight> GetTargetInsights()
         {
             // Get insight that haven't expired of each symbol that is still in the universe
-            var activeInsights = InsightCollection.GetActiveInsights(Algorithm.UtcTime);
+            var activeInsights = Algorithm.Insights.GetActiveInsights(Algorithm.UtcTime).Where(ShouldCreateTargetForInsight);
 
             // Get the last generated active insight for each symbol
             return (from insight in activeInsights

--- a/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModel.py
@@ -78,7 +78,7 @@ class BlackLittermanOptimizationPortfolioConstructionModel(PortfolioConstruction
             self.SetRebalancingFunc(rebalancingFunc)
 
     def ShouldCreateTargetForInsight(self, insight):
-        return len(PortfolioConstructionModel.FilterInvalidInsightMagnitude(self.Algorithm, [ insight ])) != 0
+        return PortfolioConstructionModel.FilterInvalidInsightMagnitude(self.Algorithm, [ insight ])
 
     def DetermineTargetPercent(self, lastActiveInsights):
         targets = {}
@@ -123,7 +123,8 @@ class BlackLittermanOptimizationPortfolioConstructionModel(PortfolioConstruction
 
     def GetTargetInsights(self):
         # Get insight that haven't expired of each symbol that is still in the universe
-        activeInsights = self.InsightCollection.GetActiveInsights(self.Algorithm.UtcTime)
+        activeInsights = filter(self.ShouldCreateTargetForInsight,
+            self.Algorithm.Insights.GetActiveInsights(self.Algorithm.UtcTime))
 
         # Get the last generated active insight for each symbol
         lastActiveInsights = []

--- a/Tests/Algorithm/Framework/Portfolio/AccumulativeInsightPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/AccumulativeInsightPortfolioConstructionModelTests.cs
@@ -430,6 +430,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             _algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, SecurityChangesTests.AddedNonInternal(appl, spy, ibm, aig, qqq));
 
             var createdValidTarget = false;
+            _algorithm.Insights.AddRange(insights);
             foreach (var target in _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights))
             {
                 QuantConnect.Logging.Log.Trace($"{target.Symbol}: {target.Quantity}");
@@ -461,10 +462,11 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 
         private Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null, double? confidence = DefaultPercent)
         {
-            period = period ?? TimeSpan.FromDays(1);
+            period ??= TimeSpan.FromDays(1);
             var insight = Insight.Price(symbol, period.Value, direction, confidence: confidence);
             insight.GeneratedTimeUtc = generatedTimeUtc;
             insight.CloseTimeUtc = generatedTimeUtc.Add(period.Value);
+            _algorithm.Insights.Add(insight);
             return insight;
         }
 

--- a/Tests/Algorithm/Framework/Portfolio/BaseWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/BaseWeightingPortfolioConstructionModelTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -18,7 +18,6 @@ using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Algorithm.Framework.Alphas;
 using QuantConnect.Algorithm.Framework.Portfolio;
-using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Equity;
 using QuantConnect.Tests.Engine.DataFeeds;
@@ -44,6 +43,9 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             Algorithm = new QCAlgorithm();
             Algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(Algorithm));
         }
+        [TearDown]
+        public void TearDown() => Algorithm.Insights.Clear(Algorithm.Securities.Keys.ToArray());
+
 
         [Test]
         [TestCase(Language.CSharp)]

--- a/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/BlackLittermanOptimizationPortfolioConstructionModelTests.cs
@@ -28,6 +28,7 @@ using QuantConnect.Algorithm;
 using QuantConnect.Tests.Engine.DataFeeds;
 using System.Collections.Generic;
 using QuantConnect.Tests.Common.Data.UniverseSelection;
+using QuantConnect.Interfaces;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 {
@@ -115,7 +116,10 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 PortfolioTarget.Percent(_algorithm, GetSymbol("USA"), 0.58571429)
             };
 
-            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, _view1Insights.Concat(new[] {outdatedInsight}).ToArray());
+            var insights = _view1Insights.Concat(new[] { outdatedInsight }).ToArray();
+            Clear();
+            _algorithm.Insights.AddRange(insights);
+            var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights);
 
             Assert.AreEqual(expectedTargets.Count(), actualTargets.Count());
 
@@ -253,6 +257,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             SetPortfolioConstruction(language);
             _algorithm.Settings.MaxAbsolutePortfolioTargetPercentage = 10;
             _algorithm.Settings.MinAbsolutePortfolioTargetPercentage = 0.01m;
+            Clear();
 
             var insights = new[]
             {
@@ -264,7 +269,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 GetInsight("View 1", "UK" , magnitude),
                 GetInsight("View 1", "USA", magnitude)
             };
-
+            
             var actualTargets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights);
 
             if (expectZero)
@@ -373,6 +378,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             var insight = Insight.Price(GetSymbol(ticker), period, direction, magnitude, sourceModel: SourceModel);
             insight.GeneratedTimeUtc = _algorithm.UtcTime;
             insight.CloseTimeUtc = _algorithm.UtcTime.Add(insight.Period);
+            _algorithm.Insights.Add(insight);
             return insight;
         }
 
@@ -486,6 +492,8 @@ class BLOPCM(BlackLittermanOptimizationPortfolioConstructionModel):
     def OnSecuritiesChanged(self, algorithm, changes):
         pass";
         }
+
+        private void Clear() => _algorithm.Insights.Clear(_algorithm.Securities.Keys.ToArray());
 
         private class NewSymbolPortfolioConstructionModel : BlackLittermanOptimizationPortfolioConstructionModel
         {

--- a/Tests/Algorithm/Framework/Portfolio/ConfidenceWeightedPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/ConfidenceWeightedPortfolioConstructionModelTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -61,6 +61,8 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             }
         }
 
+        [TearDown]
+        public void TearDown() => _algorithm.Insights.Clear(_algorithm.Securities.Keys.ToArray());
 
         [Test]
         [TestCase(Language.CSharp)]
@@ -381,10 +383,11 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 
         private Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null, double? confidence = Confidence)
         {
-            period = period ?? TimeSpan.FromDays(1);
+            period ??= TimeSpan.FromDays(1);
             var insight = Insight.Price(symbol, period.Value, direction, confidence: confidence);
             insight.GeneratedTimeUtc = generatedTimeUtc;
             insight.CloseTimeUtc = generatedTimeUtc.Add(period.Value);
+            _algorithm.Insights.Add(insight);
             return insight;
         }
 

--- a/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
@@ -211,10 +211,11 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 
         public override Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null, double? weight = 0.01)
         {
-            period = period ?? TimeSpan.FromDays(1);
+            period ??= TimeSpan.FromDays(1);
             var insight = Insight.Price(symbol, period.Value, direction, weight: Math.Max(0.01, Algorithm.Securities.Count));
             insight.GeneratedTimeUtc = generatedTimeUtc;
             insight.CloseTimeUtc = generatedTimeUtc.Add(period.Value);
+            Algorithm.Insights.Add(insight);
             return insight;
         }
 

--- a/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/InsightWeightingPortfolioConstructionModelTests.cs
@@ -107,10 +107,11 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 
         public override Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null, double? weight = _weight)
         {
-            period = period ?? TimeSpan.FromDays(1);
+            period ??= TimeSpan.FromDays(1);
             var insight = Insight.Price(symbol, period.Value, direction, weight: weight);
             insight.GeneratedTimeUtc = generatedTimeUtc;
             insight.CloseTimeUtc = generatedTimeUtc.Add(period.Value);
+            Algorithm.Insights.Add(insight);
             return insight;
         }
 

--- a/Tests/Algorithm/Framework/Portfolio/MeanReversionPortfolioConstructionModelTest.cs
+++ b/Tests/Algorithm/Framework/Portfolio/MeanReversionPortfolioConstructionModelTest.cs
@@ -344,6 +344,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 new Insight(_nowUtc, aapl.Symbol, TimeSpan.FromDays(1), InsightType.Price, direction1, magnitude1, null),
                 new Insight(_nowUtc, spy.Symbol, TimeSpan.FromDays(1), InsightType.Price, direction2, magnitude2, null),
             };
+            _algorithm.Insights.AddRange(insights);
             _algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, SecurityChangesTests.AddedNonInternal(aapl, spy));
 
             return _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights);

--- a/Tests/Algorithm/Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/MeanVarianceOptimizationPortfolioConstructionModelTests.cs
@@ -61,6 +61,8 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 new DataPermissionManager()));
         }
 
+        private void Clear() => _algorithm.Insights.Clear(_algorithm.Securities.Keys.ToArray());
+
         [TestCase(Language.CSharp, PortfolioBias.Long, 0.1, -0.1)]
         [TestCase(Language.Python, PortfolioBias.Long, 0.1, -0.1)]
         [TestCase(Language.CSharp, PortfolioBias.Short, -0.1, 0.1)]
@@ -100,7 +102,8 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                                       decimal expectedQty1,
                                       decimal expectedQty2)
         {
-            var targets = GeneratePortfolioTargets(language, direction1, direction2, magnitude1, magnitude2);
+            var targets = GeneratePortfolioTargets(language, direction1, direction2, magnitude1, magnitude2).ToList();
+            Clear();
             var quantities = targets.ToDictionary(target => {
                 QuantConnect.Logging.Log.Trace($"{target.Symbol}: {target.Quantity}");
                 return target.Symbol.Value;
@@ -198,6 +201,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 new Insight(_nowUtc, aapl.Symbol, TimeSpan.FromDays(1), InsightType.Price, direction1, magnitude1, null),
                 new Insight(_nowUtc, spy.Symbol, TimeSpan.FromDays(1), InsightType.Price, direction2, magnitude2, null),
             };
+            _algorithm.Insights.AddRange(insights);
             _algorithm.PortfolioConstruction.OnSecuritiesChanged(_algorithm, SecurityChangesTests.AddedNonInternal(aapl, spy));
 
             return _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights);

--- a/Tests/Algorithm/Framework/Portfolio/PortfolioConstructionModelPythonWrapperTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/PortfolioConstructionModelPythonWrapperTests.cs
@@ -86,6 +86,7 @@ class PyPCM(EqualWeightingPortfolioConstructionModel):
                 Assert.IsTrue((bool)model.OnSecuritiesChanged_WasCalled);
 
                 var insight = new Insight(now, aapl.Symbol, TimeSpan.FromDays(1), InsightType.Price, InsightDirection.Down, null, null);
+                algorithm.Insights.Add(insight);
                 var result = wrappedModel.CreateTargets(algorithm, new[] { insight }).ToList();
                 Assert.AreEqual(1, result.Count);
                 Assert.IsTrue((bool)model.CreateTargets_WasCalled);
@@ -153,6 +154,7 @@ class PyPCM(EqualWeightingPortfolioConstructionModel):
                 Assert.IsTrue((bool)model.OnSecuritiesChanged_WasCalled);
 
                 var insight = new Insight(now, aapl.Symbol, TimeSpan.FromDays(1), InsightType.Price, InsightDirection.Down, null, null);
+                algorithm.Insights.Add(insight);
                 var result = wrappedModel.CreateTargets(algorithm, new[] { insight }).ToList();
                 Assert.AreEqual(1, result.Count);
                 Assert.IsTrue((bool)model.CreateTargets_WasCalled);

--- a/Tests/Algorithm/Framework/Portfolio/PortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/PortfolioConstructionModelTests.cs
@@ -17,6 +17,7 @@ using System;
 using NodaTime;
 using NUnit.Framework;
 using Python.Runtime;
+using QuantConnect.Algorithm;
 using QuantConnect.Algorithm.Framework.Alphas;
 using QuantConnect.Algorithm.Framework.Portfolio;
 using QuantConnect.Data.UniverseSelection;
@@ -30,6 +31,14 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
     [TestFixture]
     public class PortfolioConstructionModelTests
     {
+        private QCAlgorithm _algorithm;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _algorithm = new QCAlgorithm();
+        }
+
         [TestCase(Language.Python)]
         [TestCase(Language.CSharp)]
         public void RebalanceFunctionPeriodDue(Language language)
@@ -53,6 +62,8 @@ def RebalanceFunc(time):
             {
                 constructionModel = new TestPortfolioConstructionModel(time => time.AddDays(1));
             }
+
+            constructionModel.OnSecuritiesChanged(_algorithm, SecurityChanges.None);
 
             Assert.IsFalse(constructionModel.IsRebalanceDueWrapper(new DateTime(2020, 1, 1), new Insight[0]));
             Assert.IsFalse(constructionModel.IsRebalanceDueWrapper(
@@ -88,6 +99,8 @@ def RebalanceFunc(time):
                 constructionModel = new TestPortfolioConstructionModel(time => time.AddDays(1));
             }
 
+            constructionModel.OnSecuritiesChanged(_algorithm, SecurityChanges.None);
+
             Assert.IsFalse(constructionModel.IsRebalanceDueWrapper(
                 new DateTime(2020, 1, 2, 1, 0, 0), new Insight[0]));
 
@@ -99,7 +112,7 @@ def RebalanceFunc(time):
                 new RegisteredSecurityDataTypesProvider(),
                 new SecurityCache());
 
-            constructionModel.OnSecuritiesChanged(null, SecurityChangesTests.AddedNonInternal(security));
+            constructionModel.OnSecuritiesChanged(_algorithm, SecurityChangesTests.AddedNonInternal(security));
             Assert.IsTrue(constructionModel.IsRebalanceDueWrapper(new DateTime(2020, 1, 2), new Insight[0]));
             Assert.IsFalse(constructionModel.IsRebalanceDueWrapper(new DateTime(2020, 1, 2), new Insight[0]));
         }
@@ -127,6 +140,8 @@ def RebalanceFunc(time):
             {
                 constructionModel = new TestPortfolioConstructionModel(time => time.AddDays(1));
             }
+            
+            constructionModel.OnSecuritiesChanged(_algorithm, SecurityChanges.None);
 
             Assert.IsFalse(constructionModel.IsRebalanceDueWrapper(new DateTime(2020, 1, 1), new Insight[0]));
 
@@ -162,6 +177,8 @@ def RebalanceFunc(time):
                 constructionModel = new TestPortfolioConstructionModel(time => time.AddDays(10));
             }
 
+            constructionModel.OnSecuritiesChanged(_algorithm, SecurityChanges.None);
+
             constructionModel.SetNextExpiration(new DateTime(2020, 1, 2));
             constructionModel.RebalanceOnInsightChanges = false;
             Assert.IsFalse(constructionModel.IsRebalanceDueWrapper(new DateTime(2020, 1, 3), new Insight[0]));
@@ -195,6 +212,8 @@ def RebalanceFunc():
                 constructionModel = new TestPortfolioConstructionModel();
             }
 
+            constructionModel.OnSecuritiesChanged(_algorithm, SecurityChanges.None);
+
             Assert.IsTrue(constructionModel.IsRebalanceDueWrapper(new DateTime(2020, 1, 1), new Insight[0]));
             Assert.IsTrue(constructionModel.IsRebalanceDueWrapper(new DateTime(2020, 1, 2), new Insight[0]));
             Assert.IsTrue(constructionModel.IsRebalanceDueWrapper(new DateTime(2020, 1, 3), new Insight[0]));
@@ -207,9 +226,9 @@ def RebalanceFunc():
                 new RegisteredSecurityDataTypesProvider(),
                 new SecurityCache());
 
-            constructionModel.OnSecuritiesChanged(null, SecurityChangesTests.AddedNonInternal(security));
+            constructionModel.OnSecuritiesChanged(_algorithm, SecurityChangesTests.AddedNonInternal(security));
             Assert.IsTrue(constructionModel.IsRebalanceDueWrapper(new DateTime(2020, 1, 1), new Insight[0]));
-            constructionModel.OnSecuritiesChanged(null, SecurityChanges.None);
+            constructionModel.OnSecuritiesChanged(_algorithm, SecurityChanges.None);
             Assert.IsTrue(constructionModel.IsRebalanceDueWrapper(new DateTime(2020, 1, 1), new Insight[0]));
         }
 
@@ -254,6 +273,8 @@ def RebalanceFunc(time):
                         return null;
                     });
             }
+
+            constructionModel.OnSecuritiesChanged(_algorithm, SecurityChanges.None);
 
             Assert.IsFalse(constructionModel.IsRebalanceDueWrapper(new DateTime(2020, 1, 1), new Insight[0]));
             Assert.IsFalse(constructionModel.IsRebalanceDueWrapper(
@@ -304,6 +325,8 @@ def RebalanceFunc(dateRules):
                 var dateRule = dateRules.On(new DateTime(2015, 1, 10), new DateTime(2015, 1, 30));
                 constructionModel = new TestPortfolioConstructionModel(dateRule);
             }
+
+            constructionModel.OnSecuritiesChanged(_algorithm, SecurityChanges.None);
 
             Assert.IsFalse(constructionModel.IsRebalanceDueWrapper(new DateTime(2015, 1, 1), new Insight[0]));
             Assert.IsTrue(constructionModel.IsRebalanceDueWrapper(new DateTime(2015, 1, 10), new Insight[0]));
@@ -363,6 +386,8 @@ def RebalanceFunc():
                 constructionModel = new TestPortfolioConstructionModel(time => time.AddMinutes(20));
             }
 
+            constructionModel.OnSecuritiesChanged(_algorithm, SecurityChanges.None);
+
             Assert.IsFalse(constructionModel.IsRebalanceDueWrapper(new DateTime(2015, 1, 1), new Insight[0]));
             Assert.IsTrue(constructionModel.IsRebalanceDueWrapper(new DateTime(2015, 1, 1, 0, 20, 0), new Insight[0]));
             Assert.IsFalse(constructionModel.IsRebalanceDueWrapper(new DateTime(2015, 1, 1, 0, 22, 0), new Insight[0]));
@@ -399,7 +424,7 @@ def RebalanceFunc():
 
             public void SetNextExpiration(DateTime nextExpiration)
             {
-                InsightCollection.Add(
+                Algorithm.Insights.Add(
                     new Insight(Symbols.SPY, time => nextExpiration, InsightType.Price, InsightDirection.Down));
             }
         }

--- a/Tests/Algorithm/Framework/Portfolio/SectorWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/SectorWeightingPortfolioConstructionModelTests.cs
@@ -271,10 +271,11 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 
         public override Insight GetInsight(Symbol symbol, InsightDirection direction, DateTime generatedTimeUtc, TimeSpan? period = null, double? weight = _weight)
         {
-            period = period ?? TimeSpan.FromDays(1);
+            period ??= TimeSpan.FromDays(1);
             var insight = Insight.Price(symbol, period.Value, direction, weight: weight);
             insight.GeneratedTimeUtc = generatedTimeUtc;
             insight.CloseTimeUtc = generatedTimeUtc.Add(period.Value);
+            Algorithm.Insights.Add(insight);
             return insight;
         }
 


### PR DESCRIPTION
#### Description
Asserts Number of Insights In One PCM Regression Test
If the `EqualWeightingPortfolioConstructionModel` interacts with the `QCAlgorithm.Insights`, the number of elements in the collection should not be the sum of emitted insights.

#### Related Issue
Closes #7074

#### Motivation and Context
Implement a new feature, `QCAlgorithm.Insights`, to existing Portfolio Construction Models to enable insight management across framework models.

#### Requires Documentation Change
Yes. We should document that these PCMs will remove insights from the manager, so other framework models should be aware of this behavior.

#### How Has This Been Tested?
Existing unit and regression tests. Improve a regression test to assert that the collection was modified by the PCM.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`