### PR TITLE
Remove annualization in RiskParityPCM & unify C#/Py optimizing algorithm

### DIFF
--- a/Algorithm.CSharp/RiskParityPortfolioAlgorithm.cs
+++ b/Algorithm.CSharp/RiskParityPortfolioAlgorithm.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.DataLibrary.Tests
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp };
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm

--- a/Algorithm.Framework/Portfolio/RiskParityPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/RiskParityPortfolioConstructionModel.py
@@ -145,7 +145,7 @@ class RiskParityPortfolioConstructionModel(PortfolioConstructionModel):
         @property
         def Return(self):
             return pd.Series(
-                data = [(1 + float(x.Value))**252 - 1 for x in self.window],
+                data = [x.Value for x in self.window],
                 index = [x.EndTime for x in self.window])
 
         @property
@@ -153,4 +153,4 @@ class RiskParityPortfolioConstructionModel(PortfolioConstructionModel):
             return self.window.IsReady
 
         def __str__(self, **kwargs):
-            return '{}: {:.2%}'.format(self.roc.Name, (1 + self.window[0])**252 - 1)
+            return '{}: {:.2%}'.format(self.roc.Name, self.window[0])

--- a/Algorithm.Framework/Portfolio/RiskParityPortfolioOptimizer.py
+++ b/Algorithm.Framework/Portfolio/RiskParityPortfolioOptimizer.py
@@ -56,8 +56,8 @@ class RiskParityPortfolioOptimizer:
         objective = lambda weights: 0.5 * weights.T @ covariance @ weights - budget.T @ np.log(weights)
         gradient = lambda weights: covariance @ weights - budget / weights
         hessian = lambda weights: covariance + np.diag((budget / weights**2).flatten())
-        bounds = tuple((self.minimum_weight, self.maximum_weight) for _ in range(size))
-        solver = minimize(objective, jac=gradient, hess=hessian, x0=x0, bounds=bounds, method="trust-constr")
+        solver = minimize(objective, jac=gradient, hess=hessian, x0=x0, method="Newton-CG")
 
+        if not solver["success"]: return x0
         # Normalize weights: w = x / x^T.1
-        return solver["x"]/np.sum(solver["x"]) if solver["success"] else x0
+        return np.clip(solver["x"]/np.sum(solver["x"]), self.minimum_weight, self.maximum_weight)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
- Remove incorrect annualization in RiskParityPortfolioOptimizationAlgorithm
- Unify Python's optimizer to C#'s (NewtonCG)

#### Related Issue
closes #7061

#### Motivation and Context
bug, and inconsistency

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
Added unit test, regression test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
