### PR TITLE
Avoid Invalid historical data piping in StandardDeviationExecutionModel

### DIFF
--- a/Algorithm.CSharp/StandardDeviationExecutionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StandardDeviationExecutionModelRegressionAlgorithm.cs
@@ -75,7 +75,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 536;
+        public int AlgorithmHistoryDataPoints => -1;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
+++ b/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
@@ -120,9 +120,9 @@ class SymbolData:
         # warmup our indicators by pushing history through the indicators
         history = algorithm.History(symbol, period, resolution)
         if 'close' in history:
-            history = history.close.unstack(0).squeeze()
+            history = history.close.unstack(0).squeeze().replace([np.inf, -np.inf], np.nan)
             # remove non-numeric rows from the close price series
-            history = history[pd.to_numeric(history, errors='coerce').notnull()]
+            #history = history[pd.to_numeric(history, errors='coerce').notnull()]
             for time, value in history.iteritems():
                 self.SMA.Update(time, value)
                 self.STD.Update(time, value)

--- a/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
+++ b/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
@@ -118,11 +118,8 @@ class SymbolData:
         algorithm.RegisterIndicator(symbol, self.STD, self.Consolidator)
 
         # warmup our indicators by pushing history through the indicators
-        history = algorithm.History(symbol, period, resolution)
-        if 'close' in history:
-            history = history.close.unstack(0).squeeze().replace([np.inf, -np.inf], np.nan)
-            # remove non-numeric rows from the close price series
-            #history = history[pd.to_numeric(history, errors='coerce').notnull()]
-            for time, value in history.iteritems():
-                self.SMA.Update(time, value)
-                self.STD.Update(time, value)
+        data_type = QuoteBar if security.Type == SecurityType.Forex or security.Type == SecurityType.Cfd else TradeBar
+        bars = algorithm.History[data_type](symbol, period, resolution)
+        for bar in bars:
+            self.SMA.Update(bar.EndTime, bar.Close)
+            self.STD.Update(bar.EndTime, bar.Close)

--- a/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
+++ b/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
@@ -118,8 +118,7 @@ class SymbolData:
         algorithm.RegisterIndicator(symbol, self.STD, self.Consolidator)
 
         # warmup our indicators by pushing history through the indicators
-        data_type = QuoteBar if security.Type == SecurityType.Forex or security.Type == SecurityType.Cfd else TradeBar
-        bars = algorithm.History[data_type](symbol, period, resolution)
+        bars = algorithm.History[self.Consolidator.InputType](symbol, period, resolution)
         for bar in bars:
             self.SMA.Update(bar.EndTime, bar.Close)
             self.STD.Update(bar.EndTime, bar.Close)

--- a/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
+++ b/Algorithm.Framework/Execution/StandardDeviationExecutionModel.py
@@ -121,6 +121,8 @@ class SymbolData:
         history = algorithm.History(symbol, period, resolution)
         if 'close' in history:
             history = history.close.unstack(0).squeeze()
+            # remove non-numeric rows from the close price series
+            history = history[pd.to_numeric(history, errors='coerce').notnull()]
             for time, value in history.iteritems():
                 self.SMA.Update(time, value)
                 self.STD.Update(time, value)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Added logic to skip invalid type and NaNs/non-finite number in historical warm up in StandardDeviationExecutionModel

#### Related Issue
closes #6151

#### Motivation and Context
Reported runtime error

#### Requires Documentation Change
NA

#### How Has This Been Tested?
NA, unable to reproduce issue

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- Unable to reproduce issue, only add logic to avoid the reported error
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
