### PR TITLE
Fixes Consolidator Removal from Subscription Manager in Python Algorithms

### DIFF
--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -180,7 +180,11 @@ namespace QuantConnect.Data
         /// <param name="pyConsolidator">The custom python consolidator</param>
         public void AddConsolidator(Symbol symbol, PyObject pyConsolidator)
         {
-            IDataConsolidator consolidator = new DataConsolidatorPythonWrapper(pyConsolidator);
+            if (!pyConsolidator.TryConvert(out IDataConsolidator consolidator))
+            {
+                consolidator = new DataConsolidatorPythonWrapper(pyConsolidator);
+            }
+
             AddConsolidator(symbol, consolidator);
         }
 


### PR DESCRIPTION
#### Description
- Adds unit test: Asserts that we can remove a previously added consolidator.
- AddConsolidator Method Only Wraps Non-C# Consolidators: 
  - This behavior was implemented in `QCAlgorithm.RegisterIndicator` ([QCAlgorithm.Python.cs#L577](https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.Python.cs#L577)) to avoid wrapping an object unnecessarily.

#### Related Issue
Closes #7099

#### Motivation and Context
Bug fix. Allow Python algorithms to remove indicators that were previously added.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`