### PR TITLE
Improves MinimumVariancePortfolioOptimizer Values Handling

### DIFF
--- a/Tests/Algorithm/Framework/Portfolio/RiskParityPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/RiskParityPortfolioConstructionModelTests.cs
@@ -146,6 +146,8 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 new Insight(_nowUtc.AddDays(2), spy.Symbol, TimeSpan.FromDays(1), InsightType.Price, InsightDirection.Up, null, null)
             };
             
+            _algorithm.Insights.AddRange(insights);
+
             var targets = _algorithm.PortfolioConstruction.CreateTargets(_algorithm, insights).ToArray();
             Assert.AreEqual(targets[0].Quantity, 30m);      // AAPL
             Assert.AreEqual(targets[1].Quantity, 18m);      // SPY


### PR DESCRIPTION
#### Description
The C# version of the `MinimumVariancePortfolioOptimizer` generated NaN resulting in unit tests failing.
If the solver returns NaN for an item, we set it to zero. if all items are NaN or Zero, we return the initial guess, since the sum cannot be zero.

#### Related Issue
Ref.: #4120

#### Motivation and Context
Bug fix.

#### How Has This Been Tested?
Existing unit tests that were failing.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`