### PR TITLE
Adds BaseAlphaModelFrameworkRegressionAlgorithm

### DIFF
--- a/Algorithm.CSharp/BaseAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/BaseAlphaModelFrameworkRegressionAlgorithm.cs
@@ -72,17 +72,17 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public abstract Language[] Languages { get; }
+        public virtual Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public abstract long DataPoints { get; }
+        public virtual long DataPoints => 14869;
 
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public abstract int AlgorithmHistoryDataPoints { get; }
+        public virtual int AlgorithmHistoryDataPoints => 152;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/BaseAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/BaseAlphaModelFrameworkRegressionAlgorithm.cs
@@ -1,0 +1,92 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Risk;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Abstract regression Framework algorithm used by <see cref="EmaCrossAlphaModelFrameworkAlgorithm"/>.
+    /// </summary>
+    public abstract class BaseAlphaModelFrameworkRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 11);
+
+            var symbols = new[] { "SPY", "AIG", "BAC", "IBM" }
+                .Select(ticker => QuantConnect.Symbol.Create(ticker, SecurityType.Equity, Market.USA))
+                .ToList();
+
+            // Manually add SPY and AIG when the algorithm starts
+            SetUniverseSelection(new ManualUniverseSelectionModel(symbols.Take(2)));
+
+            // At midnight, add all securities every day except on the last data
+            // With this procedure, the Alpha Model will experience multiple universe changes
+            AddUniverseSelection(new ScheduledUniverseSelectionModel(
+                DateRules.EveryDay(), TimeRules.Midnight,
+                dt => dt < EndDate.AddDays(-1) ? symbols : Enumerable.Empty<Symbol>()));
+
+            SetAlpha(new NullAlphaModel());
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            SetExecution(new ImmediateExecutionModel());
+            SetRiskManagement(new NullRiskManagementModel());
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            // We have removed all securities from the universe. The Alpha Model should remove the consolidator
+            var consolidatorCount = SubscriptionManager.Subscriptions.Sum(s => s.Consolidators.Count);
+            if (consolidatorCount > 0)
+            {
+                throw new Exception($"The number of consolidator is should be zero. Actual: {consolidatorCount}");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public abstract Language[] Languages { get; }
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public abstract long DataPoints { get; }
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public abstract int AlgorithmHistoryDataPoints { get; }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public abstract Dictionary<string, string> ExpectedStatistics { get; }
+    }
+}

--- a/Algorithm.CSharp/EmaCrossAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/EmaCrossAlphaModelFrameworkAlgorithm.cs
@@ -28,19 +28,7 @@ namespace QuantConnect.Algorithm.CSharp
             base.Initialize();
             SetAlpha(new EmaCrossAlphaModel());
         }
-
-        public override Language[] Languages { get; } = { Language.CSharp };
-
-        /// <summary>
-        /// Data Points count of all timeslices of algorithm
-        /// </summary>
-        public override long DataPoints => 14869;
-
-        /// <summary>
-        /// Data Points count of the algorithm history
-        /// </summary>
-        public override int AlgorithmHistoryDataPoints => 152;
-
+        
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>

--- a/Algorithm.CSharp/EmaCrossAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/EmaCrossAlphaModelFrameworkAlgorithm.cs
@@ -13,106 +13,63 @@
  * limitations under the License.
 */
 
-using System;
-using QuantConnect.Algorithm.Framework.Alphas;
-using QuantConnect.Algorithm.Framework.Execution;
-using QuantConnect.Algorithm.Framework.Portfolio;
-using QuantConnect.Algorithm.Framework.Risk;
-using QuantConnect.Algorithm.Framework.Selection;
-using QuantConnect.Interfaces;
 using System.Collections.Generic;
-using System.Linq;
+using QuantConnect.Algorithm.Framework.Alphas;
 
 namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
     /// Framework algorithm that uses the <see cref="EmaCrossAlphaModel"/>.
     /// </summary>
-    public class EmaCrossAlphaModelFrameworkAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    public class EmaCrossAlphaModelFrameworkAlgorithm : BaseAlphaModelFrameworkRegressionAlgorithm
     {
         public override void Initialize()
         {
-            SetStartDate(2013, 10, 07);
-            SetEndDate(2013, 10, 11);
-
-            var symbols = new[] { "SPY", "AIG", "BAC", "IBM" }
-                .Select(ticker => QuantConnect.Symbol.Create(ticker, SecurityType.Equity, Market.USA))
-                .ToList();
-
-            // Manually add SPY and AIG when the algorithm starts
-            SetUniverseSelection(new ManualUniverseSelectionModel(symbols.Take(2)));
-
-            // At midnight, add all securities every day except on the last data
-            // With this procedure, the Alpha Model will experience multiple universe changes
-            AddUniverseSelection(new ScheduledUniverseSelectionModel(
-                DateRules.EveryDay(), TimeRules.Midnight,
-                dt => dt < EndDate.AddDays(-1) ? symbols : Enumerable.Empty<Symbol>()));
-
+            base.Initialize();
             SetAlpha(new EmaCrossAlphaModel());
-            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
-            SetExecution(new ImmediateExecutionModel());
-            SetRiskManagement(new NullRiskManagementModel());
         }
 
-        public override void OnEndOfAlgorithm()
-        {
-            // We have removed all securities from the universe. The Alpha Model should remove the consolidator
-            var consolidatorCount = SubscriptionManager.Subscriptions.Sum(s => s.Consolidators.Count);
-            if (consolidatorCount > 0)
-            {
-                throw new Exception($"The number of consolidator is should be zero. Actual: {consolidatorCount}");
-            }
-        }
-
-        /// <summary>
-        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
-        /// </summary>
-        public bool CanRunLocally { get; } = true;
-
-        /// <summary>
-        /// This is used by the regression test system to indicate which languages this algorithm is written in.
-        /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp };
+        public override Language[] Languages { get; } = { Language.CSharp };
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 14869;
+        public override long DataPoints => 14869;
 
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 152;
+        public override int AlgorithmHistoryDataPoints => 152;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
-        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        public override Dictionary<string, string> ExpectedStatistics => new()
         {
-            {"Total Trades", "12"},
-            {"Average Win", "0.37%"},
-            {"Average Loss", "-0.15%"},
-            {"Compounding Annual Return", "0.081%"},
-            {"Drawdown", "1.900%"},
-            {"Expectancy", "0.001"},
-            {"Net Profit", "0.001%"},
-            {"Sharpe Ratio", "1.25"},
-            {"Probabilistic Sharpe Ratio", "50.694%"},
-            {"Loss Rate", "71%"},
-            {"Win Rate", "29%"},
-            {"Profit-Loss Ratio", "2.50"},
-            {"Alpha", "-1.023"},
-            {"Beta", "0.607"},
-            {"Annual Standard Deviation", "0.144"},
-            {"Annual Variance", "0.021"},
-            {"Information Ratio", "-18.002"},
-            {"Tracking Error", "0.1"},
-            {"Treynor Ratio", "0.296"},
-            {"Total Fees", "$20.20"},
-            {"Estimated Strategy Capacity", "$4800000.00"},
-            {"Lowest Capacity Asset", "AIG R735QTJ8XC9X"},
-            {"Portfolio Turnover", "53.84%"},
-            {"OrderListHash", "98ea2f4cdd1627b817fdba3f2087284b"}
+            { "Total Trades", "12" },
+            { "Average Win", "0.37%" },
+            { "Average Loss", "-0.15%" },
+            { "Compounding Annual Return", "0.081%" },
+            { "Drawdown", "1.900%" },
+            { "Expectancy", "0.001" },
+            { "Net Profit", "0.001%" },
+            { "Sharpe Ratio", "1.25" },
+            { "Probabilistic Sharpe Ratio", "50.694%" },
+            { "Loss Rate", "71%" },
+            { "Win Rate", "29%" },
+            { "Profit-Loss Ratio", "2.50" },
+            { "Alpha", "-1.023" },
+            { "Beta", "0.607" },
+            { "Annual Standard Deviation", "0.144" },
+            { "Annual Variance", "0.021" },
+            { "Information Ratio", "-18.002" },
+            { "Tracking Error", "0.1" },
+            { "Treynor Ratio", "0.296" },
+            { "Total Fees", "$20.20" },
+            { "Estimated Strategy Capacity", "$4800000.00" },
+            { "Lowest Capacity Asset", "AIG R735QTJ8XC9X" },
+            { "Portfolio Turnover", "53.84%" },
+            { "OrderListHash", "98ea2f4cdd1627b817fdba3f2087284b" }
         };
     }
 }

--- a/Algorithm.Python/BaseAlphaModelFrameworkRegressionAlgorithm.py
+++ b/Algorithm.Python/BaseAlphaModelFrameworkRegressionAlgorithm.py
@@ -1,0 +1,46 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Abstract regression Framework algorithm used by <see cref="EmaCrossAlphaModelFrameworkAlgorithm"/>.
+### </summary>
+class BaseAlphaModelFrameworkRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetStartDate(2013, 10, 7)    #Set Start Date
+        self.SetEndDate(2013, 10, 11)      #Set End Date
+        
+        symbols = [Symbol.Create(ticker, SecurityType.Equity, Market.USA)
+            for ticker in ["SPY", "AIG", "BAC", "IBM"]]
+
+        # Manually add SPY and AIG when the algorithm starts
+        self.SetUniverseSelection(ManualUniverseSelectionModel(symbols[:2]))
+
+        # At midnight, add all securities every day except on the last data
+        # With this procedure, the Alpha Model will experience multiple universe changes
+        self.AddUniverseSelection(ScheduledUniverseSelectionModel(
+            self.DateRules.EveryDay(), self.TimeRules.Midnight,
+            lambda dt: symbols if dt < self.EndDate.astimezone(dt.tzinfo) - timedelta(1) else []))
+
+        self.SetAlpha(NullAlphaModel())
+        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())
+        self.SetExecution(ImmediateExecutionModel())
+        self.SetRiskManagement(NullRiskManagementModel())
+
+    def OnEndOfAlgorithm(self):
+        # We have removed all securities from the universe. The Alpha Model should remove the consolidator
+        consolidatorCount = sum(s.Consolidators.Count for s in self.SubscriptionManager.Subscriptions)
+        if consolidatorCount > 0:
+            raise Exception(f"The number of consolidator is should be zero. Actual: {consolidatorCount}")

--- a/Algorithm.Python/EmaCrossAlphaModelFrameworkAlgorithm.py
+++ b/Algorithm.Python/EmaCrossAlphaModelFrameworkAlgorithm.py
@@ -1,0 +1,25 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+from BaseAlphaModelFrameworkRegressionAlgorithm import BaseAlphaModelFrameworkRegressionAlgorithm
+from Alphas.EmaCrossAlphaModel import EmaCrossAlphaModel
+
+### <summary>
+### Framework algorithm that uses the <see cref="EmaCrossAlphaModel"/>.
+### </summary>
+class EmaCrossAlphaModelFrameworkAlgorithm(BaseAlphaModelFrameworkRegressionAlgorithm):
+
+    def Initialize(self):
+        super().Initialize()
+        self.SetAlpha(EmaCrossAlphaModel())


### PR DESCRIPTION
#### Description
`BaseAlphaModelFrameworkRegressionAlgorithm` will be used to validate Alpha Model regression algorithm with the same universe.
- HistoricalReturnsAlphaModelFrameworkAlgorithm
- EmaCrossAlphaModelFrameworkAlgorithm
- MacdAlphaModelFrameworkAlgorithm
- RsiAlphaModelFrameworkAlgorithm
- BasePairsTradingAlphaModelFrameworkAlgorithm

#### Related Issue
N/A

#### Motivation and Context
Alpha Model testing.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`