### PR TITLE
Use data end time to timestamp fundalmental data dictionaries

### DIFF
--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -860,11 +860,11 @@ namespace QuantConnect.Research
 
                         lock (data)
                         {
-                            if (!data.ContainsKey(time))
+                            if (!data.TryGetValue(time, out var dataAtTime))
                             {
-                                data[time] = new DataDictionary<dynamic>(time);
+                                dataAtTime = data[time] = new DataDictionary<dynamic>(time);
                             }
-                            data[time].Add(currentData.Symbol, dataPoint);
+                            dataAtTime.Add(currentData.Symbol, dataPoint);
                         }
                     }
                 }

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -852,17 +852,19 @@ namespace QuantConnect.Research
                 {
                     while (enumerator.MoveNext())
                     {
+                        var currentData = enumerator.Current;
+                        var time = currentData.EndTime;
                         var dataPoint = string.IsNullOrWhiteSpace(selector)
-                            ? enumerator.Current
-                            : GetPropertyValue(enumerator.Current, selector);
+                            ? currentData
+                            : GetPropertyValue(currentData, selector);
 
                         lock (data)
                         {
-                            if (!data.ContainsKey(enumerator.Current.Time))
+                            if (!data.ContainsKey(time))
                             {
-                                data[enumerator.Current.Time] = new DataDictionary<dynamic>(enumerator.Current.Time);
+                                data[time] = new DataDictionary<dynamic>(time);
                             }
-                            data[enumerator.Current.Time].Add(enumerator.Current.Symbol, dataPoint);
+                            data[time].Add(currentData.Symbol, dataPoint);
                         }
                     }
                 }

--- a/Tests/Research/QuantBookFundamentalTests.cs
+++ b/Tests/Research/QuantBookFundamentalTests.cs
@@ -72,13 +72,15 @@ namespace QuantConnect.Tests.Research
             // Expected end date should be either today if tradable, or last tradable day
             var aapl = _qb.AddEquity("AAPL");
             var now = DateTime.UtcNow.Date;
-            var expectedDate = aapl.Exchange.Hours.IsDateOpen(now) ? now : aapl.Exchange.Hours.GetPreviousTradingDay(now);
+            var expectedEndDate = aapl.Exchange.Hours.IsDateOpen(now) ? now : aapl.Exchange.Hours.GetPreviousTradingDay(now);
+            expectedEndDate = expectedEndDate.AddDays(1);
 
-            IEnumerable<DataDictionary<dynamic>> data = _qb.GetFundamental("AAPL", "ValuationRatios.PERatio", startDate);
+            IEnumerable<DataDictionary<dynamic>> data = _qb.GetFundamental("AAPL", "", startDate);
 
             // Check that the last day in the collection is as expected
             var lastDay = data.Last();
-            Assert.AreEqual(expectedDate, lastDay.Time);
+            Assert.AreEqual(expectedEndDate, lastDay.Time);
+            Assert.AreEqual(expectedEndDate, lastDay[aapl.Symbol].EndTime);
         }
 
         [TestCaseSource(nameof(DataTestCases))]
@@ -92,8 +94,8 @@ namespace QuantConnect.Tests.Research
                 // Should not be empty
                 Assert.IsFalse(dataFrame.empty.AsManagedObject(typeof(bool)));
 
-                // Get the test row
-                var testRow = dataFrame.loc[_startDate.ToPython()];
+                // Get the test row (plus 1 day since data is time-stamped with the base data's end time)
+                var testRow = dataFrame.loc[_startDate.AddDays(1).ToPython()];
                 Assert.IsFalse(testRow.empty.AsManagedObject(typeof(bool)));
 
                 // Check the length
@@ -119,9 +121,13 @@ namespace QuantConnect.Tests.Research
         public void CSharpFundamentalData(dynamic input)
         {
             var data = _qb.GetFundamental(input[0], input[1], _startDate, _endDate);
+            var currentDate = _startDate;
 
             foreach (var day in data)
             {
+                // plus 1 day since data is time-stamped with the base data's end time
+                currentDate = currentDate.AddDays(1);
+
                 foreach (var value in day.Values)
                 {
                     if (input.Length == 4)
@@ -132,7 +138,7 @@ namespace QuantConnect.Tests.Research
                     {
                         Assert.AreEqual(input[2], value);
                     }
-                    Assert.AreEqual(_startDate, day.Time);
+                    Assert.AreEqual(currentDate, day.Time);
                 }
             }
         }
@@ -155,6 +161,32 @@ namespace QuantConnect.Tests.Research
             Assert.IsEmpty(data);
         }
 
+        [TestCaseSource(nameof(FundamentalEndTimeTestCases))]
+        public void FundamentalDataEndTime(DateTime startDate, DateTime endDate)
+        {
+            var originalQBEndDate = _qb.EndDate;
+            _qb.SetEndDate(endDate);
+
+            var security = _qb.AddEquity("AAPL");
+
+            var history = _qb.History(Symbols.AAPL, startDate, endDate, Resolution.Daily).ToList();
+            var fundamental = (_qb.GetFundamental("AAPL", "", startDate, endDate) as IEnumerable<DataDictionary<dynamic>>).ToList();
+
+            var isEndDateOpen = security.Exchange.Hours.IsDateOpen(endDate);
+            var expectedFundamentalCount = isEndDateOpen ? history.Count + 1 : history.Count;
+            Assert.AreEqual(expectedFundamentalCount, fundamental.Count);
+
+            var historyTimes = history.Select(x => x.EndTime);
+            var fundamentalTimes = fundamental.Select(x => x.Time).SkipLast(isEndDateOpen ? 1 : 0);
+
+            CollectionAssert.AreEqual(historyTimes, fundamentalTimes);
+
+            Assert.IsTrue(fundamental.All(x => x.Time == x.Values.Cast<FineFundamental>().Single().EndTime));
+
+            _qb.RemoveSecurity(security.Symbol);
+            _qb.SetEndDate(originalQBEndDate);
+        }
+
         // Different requests and their expected values
         private static readonly object[] DataTestCases =
         {
@@ -170,6 +202,14 @@ namespace QuantConnect.Tests.Research
         {
             new object[] {Symbol.Create("AIG", SecurityType.Equity, Market.USA), "ValuationRatios.PERatio", new DateTime(1972, 4, 1),  new DateTime(1972, 4, 1)},
             new object[] {Symbol.Create("IBM", SecurityType.Equity, Market.USA), "ValuationRatios.BookValuePerShare", new DateTime(2014, 4, 1), new DateTime(2014, 3, 31)},
+        };
+
+        private static readonly TestCaseData[] FundamentalEndTimeTestCases =
+        {
+            // monday,friday
+            new TestCaseData(new DateTime(2014, 3, 31), new DateTime(2014, 4, 11)),
+            // monday,saturday
+            new TestCaseData(new DateTime(2014, 3, 31), new DateTime(2014, 4, 12))
         };
     }
 }

--- a/Tests/Research/QuantBookFundamentalTests.cs
+++ b/Tests/Research/QuantBookFundamentalTests.cs
@@ -170,11 +170,16 @@ namespace QuantConnect.Tests.Research
             var security = _qb.AddEquity("AAPL");
 
             var history = _qb.History(Symbols.AAPL, startDate, endDate, Resolution.Daily).ToList();
+            Assert.IsNotEmpty(history);
+
             var fundamental = (_qb.GetFundamental("AAPL", "", startDate, endDate) as IEnumerable<DataDictionary<dynamic>>).ToList();
 
             var isEndDateOpen = security.Exchange.Hours.IsDateOpen(endDate);
-            var expectedFundamentalCount = isEndDateOpen ? history.Count + 1 : history.Count;
+            var expectedFundamentalCount = 10;
+            var expectedHistoryCount = isEndDateOpen ? expectedFundamentalCount - 1 : expectedFundamentalCount;
+
             Assert.AreEqual(expectedFundamentalCount, fundamental.Count);
+            Assert.AreEqual(expectedHistoryCount, history.Count);
 
             var historyTimes = history.Select(x => x.EndTime);
             var fundamentalTimes = fundamental.Select(x => x.Time).SkipLast(isEndDateOpen ? 1 : 0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Using end-of-period time to timestamp fundamental data dictionaries.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6325 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Match fundamentals timestamps with daily history requests timestamps.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
