### PR TITLE
Fixes Time Zone in Python Version of BaseFrameworkRegressionAlgorithm

### DIFF
--- a/Algorithm.Python/BaseFrameworkRegressionAlgorithm.py
+++ b/Algorithm.Python/BaseFrameworkRegressionAlgorithm.py
@@ -35,7 +35,7 @@ class BaseFrameworkRegressionAlgorithm(QCAlgorithm):
         # With this procedure, the Alpha Model will experience multiple universe changes
         self.AddUniverseSelection(ScheduledUniverseSelectionModel(
             self.DateRules.EveryDay(), self.TimeRules.Midnight,
-            lambda dt: symbols if dt < self.EndDate.astimezone(dt.tzinfo) - timedelta(1) else []))
+            lambda dt: symbols if dt.replace(tzinfo=None) < self.EndDate - timedelta(1) else []))
 
         self.SetAlpha(ConstantAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(31), 0.025, None))
         self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())


### PR DESCRIPTION
#### Description
If we use `.astimezone(dt.tzinfo)`, the new time was converting the timezone from local (e.g. PST) to GMT (dt.tzinfo). In this case, we only want to remove the timezone to enable the operation.

#### Motivation and Context
C# vs Python behavior.

#### How Has This Been Tested?
Regression tests with local Lean in Canada and Portugal.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`