### PR TITLE
Updates HistoricalReturnsAlphaModel to Cancel Insights Not Emit Flat

### DIFF
--- a/Algorithm.CSharp/HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using QuantConnect.Algorithm.Framework.Alphas;
 
@@ -31,6 +32,11 @@ namespace QuantConnect.Algorithm.CSharp
 
         public override void OnEndOfAlgorithm()
         {
+            const int expected = 76;
+            if (Insights.TotalCount != expected)
+            {
+                throw new Exception($"The total number of insights should be {expected}. Actual: {Insights.TotalCount}");
+            }
         }
 
         public override long DataPoints => 779;

--- a/Algorithm.CSharp/HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm.cs
@@ -32,7 +32,7 @@ namespace QuantConnect.Algorithm.CSharp
 
         public override void OnEndOfAlgorithm()
         {
-            const int expected = 76;
+            const int expected = 74;
             if (Insights.TotalCount != expected)
             {
                 throw new Exception($"The total number of insights should be {expected}. Actual: {Insights.TotalCount}");

--- a/Algorithm.Framework/Alphas/HistoricalReturnsAlphaModel.cs
+++ b/Algorithm.Framework/Alphas/HistoricalReturnsAlphaModel.cs
@@ -136,7 +136,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
             if (_insightCollection.TryGetValue(symbol, out var insights))
             {
                 algorithm.Insights.Cancel(insights);
-                insights.ForEach(i => _insightCollection.Remove(i));
+                _insightCollection.Clear(new[] { symbol });
             }
         }
 

--- a/Algorithm.Framework/Alphas/HistoricalReturnsAlphaModel.py
+++ b/Algorithm.Framework/Alphas/HistoricalReturnsAlphaModel.py
@@ -87,7 +87,7 @@ class HistoricalReturnsAlphaModel(AlphaModel):
             return
         insights = self.insightCollection[symbol]
         algorithm.Insights.Cancel(insights)
-        [self.insightCollection.Remove(i) for i in insights]
+        self.insightCollection.Clear([ symbol ]);
 
 
 class SymbolData:

--- a/Algorithm.Framework/Alphas/HistoricalReturnsAlphaModel.py
+++ b/Algorithm.Framework/Alphas/HistoricalReturnsAlphaModel.py
@@ -1,4 +1,4 @@
-﻿# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
 # Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@ class HistoricalReturnsAlphaModel(AlphaModel):
         self.resolution = kwargs['resolution'] if 'resolution' in kwargs else Resolution.Daily
         self.predictionInterval = Time.Multiply(Extensions.ToTimeSpan(self.resolution), self.lookback)
         self.symbolDataBySymbol = {}
+        self.insightCollection = InsightCollection()
 
     def Update(self, algorithm, data):
         '''Updates this alpha model with the latest data from the algorithm.
@@ -43,9 +44,14 @@ class HistoricalReturnsAlphaModel(AlphaModel):
                 magnitude = symbolData.Return
                 if magnitude > 0: direction = InsightDirection.Up
                 if magnitude < 0: direction = InsightDirection.Down
+                
+                if direction == InsightDirection.Flat:
+                    self.CancelInsights(algorithm, symbol)
+                    continue
 
                 insights.append(Insight.Price(symbol, self.predictionInterval, direction, magnitude, None))
 
+        self.insightCollection.AddRange(insights)
         return insights
 
     def OnSecuritiesChanged(self, algorithm, changes):
@@ -59,6 +65,7 @@ class HistoricalReturnsAlphaModel(AlphaModel):
             symbolData = self.symbolDataBySymbol.pop(removed.Symbol, None)
             if symbolData is not None:
                 symbolData.RemoveConsolidators(algorithm)
+            self.CancelInsights(algorithm, removed.Symbol)
 
         # initialize data for added securities
         symbols = [ x.Symbol for x in changes.AddedSecurities ]
@@ -74,6 +81,13 @@ class HistoricalReturnsAlphaModel(AlphaModel):
                 self.symbolDataBySymbol[symbol] = symbolData
                 symbolData.RegisterIndicators(algorithm, self.resolution)
                 symbolData.WarmUpIndicators(history.loc[ticker])
+
+    def CancelInsights(self, algorithm, symbol):
+        if not self.insightCollection.ContainsKey(symbol):
+            return
+        insights = self.insightCollection[symbol]
+        algorithm.Insights.Cancel(insights)
+        [self.insightCollection.Remove(i) for i in insights]
 
 
 class SymbolData:

--- a/Algorithm.Python/HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm.py
+++ b/Algorithm.Python/HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm.py
@@ -25,6 +25,6 @@ class HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm(BaseFrameworkRegre
         self.SetAlpha(HistoricalReturnsAlphaModel())
 
     def OnEndOfAlgorithm(self):
-        expected = 76
+        expected = 74
         if self.Insights.TotalCount != expected:
             raise Exception(f"The total number of insights should be {expected}. Actual: {self.Insights.TotalCount}")

--- a/Algorithm.Python/HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm.py
+++ b/Algorithm.Python/HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm.py
@@ -25,4 +25,6 @@ class HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm(BaseFrameworkRegre
         self.SetAlpha(HistoricalReturnsAlphaModel())
 
     def OnEndOfAlgorithm(self):
-        pass
+        expected = 76
+        if self.Insights.TotalCount != expected:
+            raise Exception(f"The total number of insights should be {expected}. Actual: {self.Insights.TotalCount}")


### PR DESCRIPTION
#### Description
Updates `HistoricalReturnsAlphaModel` to cancel insights not emit flat

#### Related Issue
Ref. #7088

#### Motivation and Context
Alpha Model should cancel insights instead of emitting flat insights.

#### Requires Documentation Change
Yes. Inform that his Alpha Model cancels active insights if the rate of change is zero.

#### How Has This Been Tested?
Regression tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`