### PR TITLE
Add support for enumerating `FutureHistory` and `OptionHistory`

### DIFF
--- a/Research/FutureHistory.cs
+++ b/Research/FutureHistory.cs
@@ -1,11 +1,11 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 using Python.Runtime;
 using QuantConnect.Data;
 using QuantConnect.Python;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -24,7 +25,7 @@ namespace QuantConnect.Research
     /// <summary>
     /// Class to manage information from History Request of Futures
     /// </summary>
-    public class FutureHistory
+    public class FutureHistory : IEnumerable<Slice>
     {
         private IEnumerable<Slice> _data;
         private PandasConverter _converter;
@@ -71,5 +72,19 @@ namespace QuantConnect.Research
         {
             return _converter.ToString();
         }
+
+        #region IEnumerable implementation
+
+        public IEnumerator<Slice> GetEnumerator()
+        {
+            return _data.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        #endregion
     }
 }

--- a/Research/OptionHistory.cs
+++ b/Research/OptionHistory.cs
@@ -1,11 +1,11 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 using Python.Runtime;
 using QuantConnect.Data;
 using QuantConnect.Python;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -24,7 +25,7 @@ namespace QuantConnect.Research
     /// <summary>
     /// Class to manage information from History Request of Options
     /// </summary>
-    public class OptionHistory 
+    public class OptionHistory : IEnumerable<Slice>
     {
         private IEnumerable<Slice> _data;
         private PandasConverter _converter;
@@ -49,7 +50,7 @@ namespace QuantConnect.Research
         {
             return _dataframe;
         }
-        
+
         /// <summary>
         /// Gets all strikes in the option history
         /// </summary>
@@ -84,5 +85,19 @@ namespace QuantConnect.Research
         {
             return _converter.ToString();
         }
+
+        #region IEnumerable implementation
+
+        public IEnumerator<Slice> GetEnumerator()
+        {
+            return _data.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        #endregion
     }
 }

--- a/Tests/Research/QuantBookHistoryTests.cs
+++ b/Tests/Research/QuantBookHistoryTests.cs
@@ -418,5 +418,83 @@ namespace QuantConnect.Tests.Research
                 Assert.AreEqual(expectedCount, historyCount);
             }
         }
+
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void OptionHistoryObjectIsIterable(Language language)
+        {
+            var qb = new QuantBook();
+            var start = new DateTime(2013, 10, 11);
+            var end = new DateTime(2013, 10, 15);
+
+            var spy = qb.AddEquity("SPY");
+            var history = qb.GetOptionHistory(spy.Symbol, start, end, Resolution.Minute);
+
+            Assert.DoesNotThrow(() =>
+            {
+                if (language == Language.CSharp)
+                {
+                    Assert.AreEqual(780, history.Count());
+                }
+                else
+                {
+                    using (Py.GIL())
+                    {
+                        var testModule = PyModule.FromString("testModule",
+                        @"
+def getOptionHistory(qb, symbol, start, end, resolution):
+    return qb.GetOptionHistory(symbol, start, end, resolution)
+
+def getHistoryCount(history):
+    return len(list(history))
+        ");
+
+                        dynamic getOptionHistory = testModule.GetAttr("getOptionHistory");
+                        dynamic getHistoryCount = testModule.GetAttr("getHistoryCount");
+                        var pyHistory = getOptionHistory(qb, spy.Symbol, start, end, Resolution.Minute);
+                        Assert.AreEqual(780, getHistoryCount(pyHistory).AsManagedObject(typeof(int)));
+                    }
+                }
+            });
+        }
+
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void FutureHistoryObjectIsIterable(Language language)
+        {
+            var qb = new QuantBook();
+            var start = new DateTime(2013, 10, 6);
+            var end = new DateTime(2013, 10, 15);
+
+            var futureSymbol = Symbol.CreateFuture(Futures.Indices.SP500EMini, Market.CME, new DateTime(2013, 12, 20));
+            var history = qb.GetFutureHistory(futureSymbol, start, end, Resolution.Minute);
+
+            Assert.DoesNotThrow(() =>
+            {
+                if (language == Language.CSharp)
+                {
+                    Assert.AreEqual(2700, history.Count());
+                }
+                else
+                {
+                    using (Py.GIL())
+                    {
+                        var testModule = PyModule.FromString("testModule",
+                        @"
+def getFutureHistory(qb, symbol, start, end, resolution):
+    return qb.GetFutureHistory(symbol, start, end, resolution)
+
+def getHistoryCount(history):
+    return len(list(history))
+        ");
+
+                        dynamic getFutureHistory = testModule.GetAttr("getFutureHistory");
+                        dynamic getHistoryCount = testModule.GetAttr("getHistoryCount");
+                        var pyHistory = getFutureHistory(qb, futureSymbol, start, end, Resolution.Minute);
+                        Assert.AreEqual(2700, getHistoryCount(pyHistory).AsManagedObject(typeof(int)));
+                    }
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This adds support for accessing the history slices in research environment. History can either be accessed by enumerating the object or getting a Pandas data frame through the `GetAllData` method.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6489 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
