### PR TITLE
Add `fillForward` parameter to `History` methods

### DIFF
--- a/Algorithm.CSharp/ComboOrderAlgorithm.cs
+++ b/Algorithm.CSharp/ComboOrderAlgorithm.cs
@@ -51,8 +51,8 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2015, 12, 24);
             SetCash(10000);
 
-            var equity = AddEquity("GOOG", leverage: 4, fillDataForward: true);
-            var option = AddOption(equity.Symbol, fillDataForward: true);
+            var equity = AddEquity("GOOG", leverage: 4, fillForward: true);
+            var option = AddOption(equity.Symbol, fillForward: true);
             _optionSymbol = option.Symbol;
 
             option.SetFilter(u => u.Strikes(-2, +2)

--- a/Algorithm.CSharp/ComboOrderTicketDemoAlgorithm.cs
+++ b/Algorithm.CSharp/ComboOrderTicketDemoAlgorithm.cs
@@ -43,8 +43,8 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2015, 12, 24);
             SetCash(100000);
 
-            var equity = AddEquity("GOOG", leverage: 4, fillDataForward: true);
-            var option = AddOption(equity.Symbol, fillDataForward: true);
+            var equity = AddEquity("GOOG", leverage: 4, fillForward: true);
+            var option = AddOption(equity.Symbol, fillForward: true);
             _optionSymbol = option.Symbol;
 
             option.SetFilter(u => u.Strikes(-2, +2)

--- a/Algorithm.CSharp/EuropeanOptionsCannotBeExercisedBeforeExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/EuropeanOptionsCannotBeExercisedBeforeExpiryRegressionAlgorithm.cs
@@ -46,8 +46,8 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2021, 2, 1);
             SetCash(200000);
 
-            var index = AddIndex("SPX", Resolution.Hour, fillDataForward: true);
-            var indexOption = AddIndexOption(index.Symbol, Resolution.Hour, fillDataForward: true);
+            var index = AddIndex("SPX", Resolution.Hour, fillForward: true);
+            var indexOption = AddIndexOption(index.Symbol, Resolution.Hour, fillForward: true);
             indexOption.SetFilter(filterFunc => filterFunc);
 
             _option = indexOption;

--- a/Algorithm.CSharp/ExtendedMarketHoursHistoryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ExtendedMarketHoursHistoryRegressionAlgorithm.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2013, 10, 09);
             SetCash(100000);
 
-            AddEquity("SPY", Resolution.Minute, extendedMarketHours:true, fillDataForward:false);
+            AddEquity("SPY", Resolution.Minute, extendedMarketHours:true, fillForward:false);
 
             Schedule.On("RunHistoryCall", DateRules.EveryDay(), TimeRules.Every(TimeSpan.FromHours(1)), RunHistoryCall);
         }

--- a/Algorithm.CSharp/FutureContractsExtendedMarketHoursRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureContractsExtendedMarketHoursRegressionAlgorithm.cs
@@ -41,10 +41,10 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2013, 10, 11);
 
             var esFutureSymbol = QuantConnect.Symbol.CreateFuture(Futures.Indices.SP500EMini, Market.CME, new DateTime(2013, 12, 20));
-            _es = AddFutureContract(esFutureSymbol, Resolution.Hour, fillDataForward: true, extendedMarketHours: true);
+            _es = AddFutureContract(esFutureSymbol, Resolution.Hour, fillForward: true, extendedMarketHours: true);
 
             var gcFutureSymbol = QuantConnect.Symbol.CreateFuture(Futures.Metals.Gold, Market.COMEX, new DateTime(2013, 10, 29));
-            _gc = AddFutureContract(gcFutureSymbol, Resolution.Hour, fillDataForward: true, extendedMarketHours: false);
+            _gc = AddFutureContract(gcFutureSymbol, Resolution.Hour, fillForward: true, extendedMarketHours: false);
         }
 
         public override void OnData(Slice slice)

--- a/Algorithm.CSharp/FuturesExtendedMarketHoursRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FuturesExtendedMarketHoursRegressionAlgorithm.cs
@@ -40,10 +40,10 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2013, 10, 6);
             SetEndDate(2013, 10, 11);
 
-            _es = AddFuture(Futures.Indices.SP500EMini, Resolution.Hour, fillDataForward: true, extendedMarketHours: true);
+            _es = AddFuture(Futures.Indices.SP500EMini, Resolution.Hour, fillForward: true, extendedMarketHours: true);
             _es.SetFilter(0, 180);
 
-            _gc = AddFuture(Futures.Metals.Gold, Resolution.Hour, fillDataForward: true, extendedMarketHours: false);
+            _gc = AddFuture(Futures.Metals.Gold, Resolution.Hour, fillForward: true, extendedMarketHours: false);
             _gc.SetFilter(0, 180);
         }
 

--- a/Algorithm.CSharp/HourResolutionMappingEventRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HourResolutionMappingEventRegressionAlgorithm.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2008, 08, 20);
             SetEndDate(2008, 10, 1);
 
-            AddEquity("SPWR", Resolution.Hour, fillDataForward:false);
+            AddEquity("SPWR", Resolution.Hour, fillForward:false);
         }
 
         /// <summary>

--- a/Algorithm.CSharp/InteractiveBrokersBrokerageDisablesIndexOptionsExerciseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/InteractiveBrokersBrokerageDisablesIndexOptionsExerciseRegressionAlgorithm.cs
@@ -50,8 +50,8 @@ namespace QuantConnect.Algorithm.CSharp
 
             SetBrokerageModel(new InteractiveBrokersBrokerageModel());
 
-            var index = AddIndex("SPX", Resolution.Hour, fillDataForward: true);
-            var indexOption = AddIndexOption(index.Symbol, Resolution.Hour, fillDataForward: true);
+            var index = AddIndex("SPX", Resolution.Hour, fillForward: true);
+            var indexOption = AddIndexOption(index.Symbol, Resolution.Hour, fillForward: true);
             indexOption.SetFilter(filterFunc => filterFunc.CallsOnly());
 
             _option = indexOption;

--- a/Algorithm.CSharp/MarketOnOpenOnCloseAlgorithm.cs
+++ b/Algorithm.CSharp/MarketOnOpenOnCloseAlgorithm.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2013, 10, 11);    //Set End Date
             SetCash(100000);             //Set Strategy Cash
             // Find more symbols here: http://quantconnect.com/data
-            AddSecurity(SecurityType.Equity, "SPY", Resolution.Second, fillDataForward: true, extendedMarketHours: true);
+            AddSecurity(SecurityType.Equity, "SPY", Resolution.Second, fillForward: true, extendedMarketHours: true);
 
             _security = Securities["SPY"];
         }

--- a/Algorithm.CSharp/RevertComboOrderPositionsAlgorithm.cs
+++ b/Algorithm.CSharp/RevertComboOrderPositionsAlgorithm.cs
@@ -46,8 +46,8 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2015, 12, 24);
             SetCash(10000);
 
-            var equitySymbol = AddEquity("GOOG", leverage: 4, fillDataForward: true).Symbol;
-            _option = AddOption(equitySymbol, fillDataForward: true);
+            var equitySymbol = AddEquity("GOOG", leverage: 4, fillForward: true).Symbol;
+            _option = AddOption(equitySymbol, fillForward: true);
             _option.SetFilter(optionFilterUniverse => optionFilterUniverse
                 .Strikes(-2, 2)
                 .Expiration(0, 180));

--- a/Algorithm.CSharp/WarmupDataTypesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WarmupDataTypesRegressionAlgorithm.cs
@@ -39,8 +39,8 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2013, 10, 08);
             SetEndDate(2013, 10, 10);
 
-            AddEquity("SPY", Resolution.Minute, fillDataForward: false);
-            AddCrypto("BTCUSD", Resolution.Hour, market: Market.Bitfinex, fillDataForward: false);
+            AddEquity("SPY", Resolution.Minute, fillForward: false);
+            AddCrypto("BTCUSD", Resolution.Hour, market: Market.Bitfinex, fillForward: false);
 
             SetWarmUp(24, Resolution.Hour);
         }

--- a/Algorithm.CSharp/WarmupScheduledEventsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WarmupScheduledEventsRegressionAlgorithm.cs
@@ -61,7 +61,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2013, 10, 08);
             SetEndDate(2013, 10, 08);
 
-            AddEquity("SPY", Resolution.Minute, fillDataForward: false);
+            AddEquity("SPY", Resolution.Minute, fillForward: false);
 
             Schedule.On(DateRules.EveryDay(), TimeRules.Every(TimeSpan.FromHours(6)), () =>
             {

--- a/Algorithm.Python/ComboOrderTicketDemoAlgorithm.py
+++ b/Algorithm.Python/ComboOrderTicketDemoAlgorithm.py
@@ -24,8 +24,8 @@ class ComboOrderTicketDemoAlgorithm(QCAlgorithm):
         self.SetEndDate(2015, 12, 24)
         self.SetCash(100000)
 
-        equity = self.AddEquity("GOOG", leverage=4, fillDataForward=True)
-        option = self.AddOption(equity.Symbol, fillDataForward=True)
+        equity = self.AddEquity("GOOG", leverage=4, fillForward=True)
+        option = self.AddOption(equity.Symbol, fillForward=True)
         self._optionSymbol = option.Symbol
 
         option.SetFilter(lambda u: u.Strikes(-2, +2).Expiration(0, 180))

--- a/Algorithm.Python/FutureContractsExtendedMarketHoursRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureContractsExtendedMarketHoursRegressionAlgorithm.py
@@ -22,10 +22,10 @@ class FutureContractsExtendedMarketHoursRegressionAlgorithm(QCAlgorithm):
         self.SetEndDate(2013, 10, 11)
 
         esFutureSymbol = Symbol.CreateFuture(Futures.Indices.SP500EMini, Market.CME, DateTime(2013, 12, 20))
-        self._es = self.AddFutureContract(esFutureSymbol, Resolution.Hour, fillDataForward=True, extendedMarketHours=True)
+        self._es = self.AddFutureContract(esFutureSymbol, Resolution.Hour, fillForward=True, extendedMarketHours=True)
 
         gcFutureSymbol = Symbol.CreateFuture(Futures.Metals.Gold, Market.COMEX, DateTime(2013, 10, 29))
-        self._gc = self.AddFutureContract(gcFutureSymbol, Resolution.Hour, fillDataForward=True, extendedMarketHours=False)
+        self._gc = self.AddFutureContract(gcFutureSymbol, Resolution.Hour, fillForward=True, extendedMarketHours=False)
 
         self._esRanOnRegularHours = False
         self._esRanOnExtendedHours = False

--- a/Algorithm.Python/FuturesExtendedMarketHoursRegressionAlgorithm.py
+++ b/Algorithm.Python/FuturesExtendedMarketHoursRegressionAlgorithm.py
@@ -21,10 +21,10 @@ class FuturesExtendedMarketHoursRegressionAlgorithm(QCAlgorithm):
         self.SetStartDate(2013, 10, 6)
         self.SetEndDate(2013, 10, 11)
 
-        self._es = self.AddFuture(Futures.Indices.SP500EMini, Resolution.Hour, fillDataForward=True, extendedMarketHours=True)
+        self._es = self.AddFuture(Futures.Indices.SP500EMini, Resolution.Hour, fillForward=True, extendedMarketHours=True)
         self._es.SetFilter(0, 180)
 
-        self._gc = self.AddFuture(Futures.Metals.Gold, Resolution.Hour, fillDataForward=True, extendedMarketHours=False)
+        self._gc = self.AddFuture(Futures.Metals.Gold, Resolution.Hour, fillForward=True, extendedMarketHours=False)
         self._gc.SetFilter(0, 180)
 
         self._esRanOnRegularHours = False

--- a/Algorithm.Python/HistoryWithCustomDataSourceRegressionAlgorithm.py
+++ b/Algorithm.Python/HistoryWithCustomDataSourceRegressionAlgorithm.py
@@ -27,9 +27,9 @@ class HistoryWithCustomDataSourceRegressionAlgorithm(QCAlgorithm):
 
     def OnEndOfAlgorithm(self):
         aaplHistory = self.History(CustomData, self.aapl, self.StartDate, self.EndDate, Resolution.Minute,
-            fillDataForward=False, extendedMarket=False, dataNormalizationMode=DataNormalizationMode.Raw).droplevel(0, axis=0)
+            fillForward=False, extendedMarket=False, dataNormalizationMode=DataNormalizationMode.Raw).droplevel(0, axis=0)
         spyHistory = self.History(CustomData, self.spy, self.StartDate, self.EndDate, Resolution.Minute,
-            fillDataForward=False, extendedMarket=False, dataNormalizationMode=DataNormalizationMode.Raw).droplevel(0, axis=0)
+            fillForward=False, extendedMarket=False, dataNormalizationMode=DataNormalizationMode.Raw).droplevel(0, axis=0)
 
         if aaplHistory.size == 0 or spyHistory.size == 0:
             raise Exception("At least one of the history results is empty")

--- a/Algorithm.Python/HistoryWithCustomDataSourceRegressionAlgorithm.py
+++ b/Algorithm.Python/HistoryWithCustomDataSourceRegressionAlgorithm.py
@@ -27,9 +27,9 @@ class HistoryWithCustomDataSourceRegressionAlgorithm(QCAlgorithm):
 
     def OnEndOfAlgorithm(self):
         aaplHistory = self.History(CustomData, self.aapl, self.StartDate, self.EndDate, Resolution.Minute,
-            fillForward=False, extendedMarket=False, dataNormalizationMode=DataNormalizationMode.Raw).droplevel(0, axis=0)
+            fillDataForward=False, extendedMarket=False, dataNormalizationMode=DataNormalizationMode.Raw).droplevel(0, axis=0)
         spyHistory = self.History(CustomData, self.spy, self.StartDate, self.EndDate, Resolution.Minute,
-            fillForward=False, extendedMarket=False, dataNormalizationMode=DataNormalizationMode.Raw).droplevel(0, axis=0)
+            fillDataForward=False, extendedMarket=False, dataNormalizationMode=DataNormalizationMode.Raw).droplevel(0, axis=0)
 
         if aaplHistory.size == 0 or spyHistory.size == 0:
             raise Exception("At least one of the history results is empty")

--- a/Algorithm.Python/MarketOnOpenOnCloseAlgorithm.py
+++ b/Algorithm.Python/MarketOnOpenOnCloseAlgorithm.py
@@ -27,7 +27,7 @@ class MarketOnOpenOnCloseAlgorithm(QCAlgorithm):
         self.SetEndDate(2013,10,11)    #Set End Date
         self.SetCash(100000)           #Set Strategy Cash
         # Find more symbols here: http://quantconnect.com/data
-        self.equity = self.AddEquity("SPY", Resolution.Second, fillDataForward = True, extendedMarketHours = True)
+        self.equity = self.AddEquity("SPY", Resolution.Second, fillForward = True, extendedMarketHours = True)
         self.__submittedMarketOnCloseToday = False
         self.__last = datetime.min
 

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -338,7 +338,7 @@ namespace QuantConnect.Algorithm
                 var config = GetMatchingSubscription(x, typeof(T), res);
                 if (config == null) return null;
 
-                var request = _historyRequestFactory.CreateHistoryRequest(config, start, Time, GetExchangeHours(x), res);
+                var request = _historyRequestFactory.CreateHistoryRequest(config, start, end, GetExchangeHours(x), res);
 
                 // apply overrides
                 if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? GetResolution(x, resolution) : (Resolution?)null;

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -221,12 +221,12 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="span">The span over which to request data. This is a calendar span, so take into consideration weekends and such</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing data over the most recent span for all configured securities</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<Slice> History(TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
+        public IEnumerable<Slice> History(TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
         {
-            return History(Securities.Keys, Time - span, Time, resolution, fillForward).Memoize();
+            return History(Securities.Keys, Time - span, Time, resolution, fillDataForward).Memoize();
         }
 
         /// <summary>
@@ -236,12 +236,12 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing data over the most recent span for all configured securities</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<Slice> History(int periods, Resolution? resolution = null, bool? fillForward = null)
+        public IEnumerable<Slice> History(int periods, Resolution? resolution = null, bool? fillDataForward = null)
         {
-            return History(Securities.Keys, periods, resolution, fillForward).Memoize();
+            return History(Securities.Keys, periods, resolution, fillDataForward).Memoize();
         }
 
         /// <summary>
@@ -251,13 +251,13 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<DataDictionary<T>> History<T>(TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
+        public IEnumerable<DataDictionary<T>> History<T>(TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
             where T : IBaseData
         {
-            return History<T>(Securities.Keys, span, resolution, fillForward).Memoize();
+            return History<T>(Securities.Keys, span, resolution, fillDataForward).Memoize();
         }
 
         /// <summary>
@@ -268,13 +268,13 @@ namespace QuantConnect.Algorithm
         /// <param name="symbols">The symbols to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<DataDictionary<T>> History<T>(IEnumerable<Symbol> symbols, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
+        public IEnumerable<DataDictionary<T>> History<T>(IEnumerable<Symbol> symbols, TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
             where T : IBaseData
         {
-            return History<T>(symbols, Time - span, Time, resolution, fillForward).Memoize();
+            return History<T>(symbols, Time - span, Time, resolution, fillDataForward).Memoize();
         }
 
         /// <summary>
@@ -286,11 +286,11 @@ namespace QuantConnect.Algorithm
         /// <param name="symbols">The symbols to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
         public IEnumerable<DataDictionary<T>> History<T>(IEnumerable<Symbol> symbols, int periods, Resolution? resolution = null,
-            bool? fillForward = null)
+            bool? fillDataForward = null)
             where T : IBaseData
         {
             var requests = symbols.Select(x =>
@@ -307,7 +307,7 @@ namespace QuantConnect.Algorithm
                 var exchange = GetExchangeHours(x);
                 var start = _historyRequestFactory.GetStartTimeAlgoTz(x, periods, res, exchange, config.DataTimeZone);
 
-                return _historyRequestFactory.CreateHistoryRequest(config, start, Time, exchange, res, fillForward);
+                return _historyRequestFactory.CreateHistoryRequest(config, start, Time, exchange, res, fillDataForward);
             });
 
             return GetDataTypedHistory<T>(requests);
@@ -321,11 +321,11 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
         public IEnumerable<DataDictionary<T>> History<T>(IEnumerable<Symbol> symbols, DateTime start, DateTime end, Resolution? resolution = null,
-            bool? fillForward = null)
+            bool? fillDataForward = null)
             where T : IBaseData
         {
             var requests = symbols.Select(x =>
@@ -333,7 +333,7 @@ namespace QuantConnect.Algorithm
                 var config = GetMatchingSubscription(x, typeof(T), resolution);
                 if (config == null) return null;
 
-                return _historyRequestFactory.CreateHistoryRequest(config, start, end, GetExchangeHours(x), resolution, fillForward);
+                return _historyRequestFactory.CreateHistoryRequest(config, start, end, GetExchangeHours(x), resolution, fillDataForward);
             });
 
             return GetDataTypedHistory<T>(requests);
@@ -346,13 +346,13 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<T> History<T>(Symbol symbol, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
+        public IEnumerable<T> History<T>(Symbol symbol, TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
             where T : IBaseData
         {
-            return History<T>(symbol, Time - span, Time, resolution, fillForward).Memoize();
+            return History<T>(symbol, Time - span, Time, resolution, fillDataForward).Memoize();
         }
 
         /// <summary>
@@ -362,10 +362,10 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<TradeBar> History(Symbol symbol, int periods, Resolution? resolution = null, bool? fillForward = null)
+        public IEnumerable<TradeBar> History(Symbol symbol, int periods, Resolution? resolution = null, bool? fillDataForward = null)
         {
             if (symbol == null) throw new ArgumentException(_symbolEmptyErrorMessage);
 
@@ -373,7 +373,7 @@ namespace QuantConnect.Algorithm
             var marketHours = GetMarketHours(symbol);
             var start = _historyRequestFactory.GetStartTimeAlgoTz(symbol, periods, resolution.Value, marketHours.ExchangeHours, marketHours.DataTimeZone);
 
-            return History(symbol, start, Time, resolution, fillForward);
+            return History(symbol, start, Time, resolution, fillDataForward);
         }
 
         /// <summary>
@@ -384,10 +384,10 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<T> History<T>(Symbol symbol, int periods, Resolution? resolution = null, bool? fillForward = null)
+        public IEnumerable<T> History<T>(Symbol symbol, int periods, Resolution? resolution = null, bool? fillDataForward = null)
             where T : IBaseData
         {
             resolution = GetResolution(symbol, resolution);
@@ -396,7 +396,7 @@ namespace QuantConnect.Algorithm
                 throw new ArgumentException("History functions that accept a 'periods' parameter can not be used with Resolution.Tick");
             }
 
-            var requests = CreateBarCountHistoryRequests(new [] { symbol }, typeof(T), periods, resolution, fillForward);
+            var requests = CreateBarCountHistoryRequests(new [] { symbol }, typeof(T), periods, resolution, fillDataForward);
             return GetDataTypedHistory<T>(requests, symbol);
         }
 
@@ -407,13 +407,13 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<T> History<T>(Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null, bool? fillForward = null)
+        public IEnumerable<T> History<T>(Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null, bool? fillDataForward = null)
             where T : IBaseData
         {
-            var requests = CreateDateRangeHistoryRequests(new[] { symbol }, typeof(T), start, end, resolution, fillForward);
+            var requests = CreateDateRangeHistoryRequests(new[] { symbol }, typeof(T), start, end, resolution, fillDataForward);
             return GetDataTypedHistory<T>(requests, symbol);
         }
 
@@ -423,12 +423,12 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<TradeBar> History(Symbol symbol, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
+        public IEnumerable<TradeBar> History(Symbol symbol, TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
         {
-            return History(symbol, Time - span, Time, resolution, fillForward);
+            return History(symbol, Time - span, Time, resolution, fillDataForward);
         }
 
         /// <summary>
@@ -438,10 +438,10 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<TradeBar> History(Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null, bool? fillForward = null)
+        public IEnumerable<TradeBar> History(Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null, bool? fillDataForward = null)
         {
             var securityType = symbol.ID.SecurityType;
             if (securityType == SecurityType.Forex || securityType == SecurityType.Cfd)
@@ -456,7 +456,7 @@ namespace QuantConnect.Algorithm
                                                     " Please use the generic version with Tick type parameter or provide a list of Symbols to use the Slice history request API.");
             }
 
-            return History(new[] { symbol }, start, end, resolutionToUse, fillForward).Get(symbol).Memoize();
+            return History(new[] { symbol }, start, end, resolutionToUse, fillDataForward).Get(symbol).Memoize();
         }
 
         /// <summary>
@@ -467,12 +467,12 @@ namespace QuantConnect.Algorithm
         /// <param name="symbols">The symbols to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<Slice> History(IEnumerable<Symbol> symbols, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
+        public IEnumerable<Slice> History(IEnumerable<Symbol> symbols, TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
         {
-            return History(symbols, Time - span, Time, resolution, fillForward).Memoize();
+            return History(symbols, Time - span, Time, resolution, fillDataForward).Memoize();
         }
 
         /// <summary>
@@ -483,13 +483,13 @@ namespace QuantConnect.Algorithm
         /// <param name="symbols">The symbols to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<Slice> History(IEnumerable<Symbol> symbols, int periods, Resolution? resolution = null, bool? fillForward = null)
+        public IEnumerable<Slice> History(IEnumerable<Symbol> symbols, int periods, Resolution? resolution = null, bool? fillDataForward = null)
         {
             if (resolution == Resolution.Tick) throw new ArgumentException("History functions that accept a 'periods' parameter can not be used with Resolution.Tick");
-            return History(CreateBarCountHistoryRequests(symbols, periods, resolution, fillForward)).Memoize();
+            return History(CreateBarCountHistoryRequests(symbols, periods, resolution, fillDataForward)).Memoize();
         }
 
         /// <summary>
@@ -499,7 +499,7 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <param name="extendedMarket">True to include extended market hours data, false otherwise</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security history request</param>
         /// <param name="dataNormalizationMode">The price scaling mode to use for the securities history</param>
@@ -508,10 +508,10 @@ namespace QuantConnect.Algorithm
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
         public IEnumerable<Slice> History(IEnumerable<Symbol> symbols, DateTime start, DateTime end, Resolution? resolution = null,
-            bool? fillForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
+            bool? fillDataForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
-            return History(CreateDateRangeHistoryRequests(symbols, start, end, resolution, fillForward, extendedMarket, dataMappingMode,
+            return History(CreateDateRangeHistoryRequests(symbols, start, end, resolution, fillDataForward, extendedMarket, dataMappingMode,
                 dataNormalizationMode, contractDepthOffset)).Memoize();
         }
 
@@ -767,10 +767,10 @@ namespace QuantConnect.Algorithm
         /// Helper method to create history requests from a date range
         /// </summary>
         private IEnumerable<HistoryRequest> CreateDateRangeHistoryRequests(IEnumerable<Symbol> symbols, DateTime startAlgoTz, DateTime endAlgoTz,
-            Resolution? resolution = null, bool? fillForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
+            Resolution? resolution = null, bool? fillDataForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
-            return CreateDateRangeHistoryRequests(symbols, typeof(BaseData), startAlgoTz, endAlgoTz, resolution, fillForward, extendedMarket,
+            return CreateDateRangeHistoryRequests(symbols, typeof(BaseData), startAlgoTz, endAlgoTz, resolution, fillDataForward, extendedMarket,
                 dataMappingMode, dataNormalizationMode, contractDepthOffset);
         }
 
@@ -778,7 +778,7 @@ namespace QuantConnect.Algorithm
         /// Helper method to create history requests from a date range with custom data type
         /// </summary>
         private IEnumerable<HistoryRequest> CreateDateRangeHistoryRequests(IEnumerable<Symbol> symbols, Type requestedType, DateTime startAlgoTz, DateTime endAlgoTz,
-            Resolution? resolution = null, bool? fillForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
+            Resolution? resolution = null, bool? fillDataForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
             return symbols.Where(HistoryRequestValid).SelectMany(x =>
@@ -788,7 +788,7 @@ namespace QuantConnect.Algorithm
                 foreach (var config in GetMatchingSubscriptions(x, requestedType, resolution))
                 {
                     var request = _historyRequestFactory.CreateHistoryRequest(config, startAlgoTz, endAlgoTz, GetExchangeHours(x), resolution,
-                        fillForward, extendedMarket, dataMappingMode, dataNormalizationMode, contractDepthOffset);
+                        fillDataForward, extendedMarket, dataMappingMode, dataNormalizationMode, contractDepthOffset);
                     requests.Add(request);
                 }
 
@@ -800,10 +800,10 @@ namespace QuantConnect.Algorithm
         /// Helper methods to create a history request for the specified symbols and bar count
         /// </summary>
         private IEnumerable<HistoryRequest> CreateBarCountHistoryRequests(IEnumerable<Symbol> symbols, int periods, Resolution? resolution = null,
-            bool? fillForward = null, DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null,
+            bool? fillDataForward = null, DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null,
             int? contractDepthOffset = null)
         {
-            return CreateBarCountHistoryRequests(symbols, typeof(BaseData), periods, resolution, fillForward, dataMappingMode,
+            return CreateBarCountHistoryRequests(symbols, typeof(BaseData), periods, resolution, fillDataForward, dataMappingMode,
                 dataNormalizationMode, contractDepthOffset);
         }
 
@@ -811,7 +811,7 @@ namespace QuantConnect.Algorithm
         /// Helper methods to create a history request for the specified symbols and bar count with custom data type
         /// </summary>
         private IEnumerable<HistoryRequest> CreateBarCountHistoryRequests(IEnumerable<Symbol> symbols, Type requestedType, int periods,
-            Resolution? resolution = null, bool? fillForward = null, DataMappingMode? dataMappingMode = null,
+            Resolution? resolution = null, bool? fillDataForward = null, DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
             return symbols.Where(HistoryRequestValid).SelectMany(x =>
@@ -827,7 +827,7 @@ namespace QuantConnect.Algorithm
                 var start = _historyRequestFactory.GetStartTimeAlgoTz(x, periods, res, exchange, configs.First().DataTimeZone);
                 var end = Time;
 
-                return configs.Select(config => _historyRequestFactory.CreateHistoryRequest(config, start, end, exchange, res, fillForward,
+                return configs.Select(config => _historyRequestFactory.CreateHistoryRequest(config, start, end, exchange, res, fillDataForward,
                     null, dataMappingMode, dataNormalizationMode, contractDepthOffset));
             });
         }

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -330,11 +330,10 @@ namespace QuantConnect.Algorithm
         {
             var requests = symbols.Select(x =>
             {
-                var res = GetResolution(x, resolution);
-                var config = GetMatchingSubscription(x, typeof(T), res);
+                var config = GetMatchingSubscription(x, typeof(T), resolution);
                 if (config == null) return null;
 
-                return _historyRequestFactory.CreateHistoryRequest(config, start, end, GetExchangeHours(x), res, fillForward);
+                return _historyRequestFactory.CreateHistoryRequest(config, start, end, GetExchangeHours(x), resolution, fillForward);
             });
 
             return GetDataTypedHistory<T>(requests);
@@ -819,7 +818,7 @@ namespace QuantConnect.Algorithm
             {
                 var res = GetResolution(x, resolution);
                 var exchange = GetExchangeHours(x);
-                var configs = GetMatchingSubscriptions(x, requestedType, res).ToList();
+                var configs = GetMatchingSubscriptions(x, requestedType, resolution).ToList();
                 if (configs.Count == 0)
                 {
                     return Enumerable.Empty<HistoryRequest>();

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -221,12 +221,12 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="span">The span over which to request data. This is a calendar span, so take into consideration weekends and such</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing data over the most recent span for all configured securities</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<Slice> History(TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
+        public IEnumerable<Slice> History(TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
         {
-            return History(Securities.Keys, Time - span, Time, resolution, fillDataForward).Memoize();
+            return History(Securities.Keys, Time - span, Time, resolution, fillForward).Memoize();
         }
 
         /// <summary>
@@ -236,12 +236,12 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing data over the most recent span for all configured securities</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<Slice> History(int periods, Resolution? resolution = null, bool? fillDataForward = null)
+        public IEnumerable<Slice> History(int periods, Resolution? resolution = null, bool? fillForward = null)
         {
-            return History(Securities.Keys, periods, resolution, fillDataForward).Memoize();
+            return History(Securities.Keys, periods, resolution, fillForward).Memoize();
         }
 
         /// <summary>
@@ -251,13 +251,13 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<DataDictionary<T>> History<T>(TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
+        public IEnumerable<DataDictionary<T>> History<T>(TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
             where T : IBaseData
         {
-            return History<T>(Securities.Keys, span, resolution, fillDataForward).Memoize();
+            return History<T>(Securities.Keys, span, resolution, fillForward).Memoize();
         }
 
         /// <summary>
@@ -268,13 +268,13 @@ namespace QuantConnect.Algorithm
         /// <param name="symbols">The symbols to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<DataDictionary<T>> History<T>(IEnumerable<Symbol> symbols, TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
+        public IEnumerable<DataDictionary<T>> History<T>(IEnumerable<Symbol> symbols, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
             where T : IBaseData
         {
-            return History<T>(symbols, Time - span, Time, resolution, fillDataForward).Memoize();
+            return History<T>(symbols, Time - span, Time, resolution, fillForward).Memoize();
         }
 
         /// <summary>
@@ -286,11 +286,11 @@ namespace QuantConnect.Algorithm
         /// <param name="symbols">The symbols to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
         public IEnumerable<DataDictionary<T>> History<T>(IEnumerable<Symbol> symbols, int periods, Resolution? resolution = null,
-            bool? fillDataForward = null)
+            bool? fillForward = null)
             where T : IBaseData
         {
             var requests = symbols.Select(x =>
@@ -307,7 +307,7 @@ namespace QuantConnect.Algorithm
                 var exchange = GetExchangeHours(x);
                 var start = _historyRequestFactory.GetStartTimeAlgoTz(x, periods, res, exchange, config.DataTimeZone);
 
-                return _historyRequestFactory.CreateHistoryRequest(config, start, Time, exchange, res, fillDataForward);
+                return _historyRequestFactory.CreateHistoryRequest(config, start, Time, exchange, res, fillForward);
             });
 
             return GetDataTypedHistory<T>(requests);
@@ -321,11 +321,11 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
         public IEnumerable<DataDictionary<T>> History<T>(IEnumerable<Symbol> symbols, DateTime start, DateTime end, Resolution? resolution = null,
-            bool? fillDataForward = null)
+            bool? fillForward = null)
             where T : IBaseData
         {
             var requests = symbols.Select(x =>
@@ -333,7 +333,7 @@ namespace QuantConnect.Algorithm
                 var config = GetMatchingSubscription(x, typeof(T), resolution);
                 if (config == null) return null;
 
-                return _historyRequestFactory.CreateHistoryRequest(config, start, end, GetExchangeHours(x), resolution, fillDataForward);
+                return _historyRequestFactory.CreateHistoryRequest(config, start, end, GetExchangeHours(x), resolution, fillForward);
             });
 
             return GetDataTypedHistory<T>(requests);
@@ -346,13 +346,13 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<T> History<T>(Symbol symbol, TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
+        public IEnumerable<T> History<T>(Symbol symbol, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
             where T : IBaseData
         {
-            return History<T>(symbol, Time - span, Time, resolution, fillDataForward).Memoize();
+            return History<T>(symbol, Time - span, Time, resolution, fillForward).Memoize();
         }
 
         /// <summary>
@@ -362,10 +362,10 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<TradeBar> History(Symbol symbol, int periods, Resolution? resolution = null, bool? fillDataForward = null)
+        public IEnumerable<TradeBar> History(Symbol symbol, int periods, Resolution? resolution = null, bool? fillForward = null)
         {
             if (symbol == null) throw new ArgumentException(_symbolEmptyErrorMessage);
 
@@ -373,7 +373,7 @@ namespace QuantConnect.Algorithm
             var marketHours = GetMarketHours(symbol);
             var start = _historyRequestFactory.GetStartTimeAlgoTz(symbol, periods, resolution.Value, marketHours.ExchangeHours, marketHours.DataTimeZone);
 
-            return History(symbol, start, Time, resolution, fillDataForward);
+            return History(symbol, start, Time, resolution, fillForward);
         }
 
         /// <summary>
@@ -384,10 +384,10 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<T> History<T>(Symbol symbol, int periods, Resolution? resolution = null, bool? fillDataForward = null)
+        public IEnumerable<T> History<T>(Symbol symbol, int periods, Resolution? resolution = null, bool? fillForward = null)
             where T : IBaseData
         {
             resolution = GetResolution(symbol, resolution);
@@ -396,7 +396,7 @@ namespace QuantConnect.Algorithm
                 throw new ArgumentException("History functions that accept a 'periods' parameter can not be used with Resolution.Tick");
             }
 
-            var requests = CreateBarCountHistoryRequests(new [] { symbol }, typeof(T), periods, resolution, fillDataForward);
+            var requests = CreateBarCountHistoryRequests(new [] { symbol }, typeof(T), periods, resolution, fillForward);
             return GetDataTypedHistory<T>(requests, symbol);
         }
 
@@ -407,13 +407,13 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<T> History<T>(Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null, bool? fillDataForward = null)
+        public IEnumerable<T> History<T>(Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null, bool? fillForward = null)
             where T : IBaseData
         {
-            var requests = CreateDateRangeHistoryRequests(new[] { symbol }, typeof(T), start, end, resolution, fillDataForward);
+            var requests = CreateDateRangeHistoryRequests(new[] { symbol }, typeof(T), start, end, resolution, fillForward);
             return GetDataTypedHistory<T>(requests, symbol);
         }
 
@@ -423,12 +423,12 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<TradeBar> History(Symbol symbol, TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
+        public IEnumerable<TradeBar> History(Symbol symbol, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
         {
-            return History(symbol, Time - span, Time, resolution, fillDataForward);
+            return History(symbol, Time - span, Time, resolution, fillForward);
         }
 
         /// <summary>
@@ -438,10 +438,10 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<TradeBar> History(Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null, bool? fillDataForward = null)
+        public IEnumerable<TradeBar> History(Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null, bool? fillForward = null)
         {
             var securityType = symbol.ID.SecurityType;
             if (securityType == SecurityType.Forex || securityType == SecurityType.Cfd)
@@ -456,7 +456,7 @@ namespace QuantConnect.Algorithm
                                                     " Please use the generic version with Tick type parameter or provide a list of Symbols to use the Slice history request API.");
             }
 
-            return History(new[] { symbol }, start, end, resolutionToUse, fillDataForward).Get(symbol).Memoize();
+            return History(new[] { symbol }, start, end, resolutionToUse, fillForward).Get(symbol).Memoize();
         }
 
         /// <summary>
@@ -467,12 +467,12 @@ namespace QuantConnect.Algorithm
         /// <param name="symbols">The symbols to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<Slice> History(IEnumerable<Symbol> symbols, TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
+        public IEnumerable<Slice> History(IEnumerable<Symbol> symbols, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
         {
-            return History(symbols, Time - span, Time, resolution, fillDataForward).Memoize();
+            return History(symbols, Time - span, Time, resolution, fillForward).Memoize();
         }
 
         /// <summary>
@@ -483,13 +483,13 @@ namespace QuantConnect.Algorithm
         /// <param name="symbols">The symbols to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public IEnumerable<Slice> History(IEnumerable<Symbol> symbols, int periods, Resolution? resolution = null, bool? fillDataForward = null)
+        public IEnumerable<Slice> History(IEnumerable<Symbol> symbols, int periods, Resolution? resolution = null, bool? fillForward = null)
         {
             if (resolution == Resolution.Tick) throw new ArgumentException("History functions that accept a 'periods' parameter can not be used with Resolution.Tick");
-            return History(CreateBarCountHistoryRequests(symbols, periods, resolution, fillDataForward)).Memoize();
+            return History(CreateBarCountHistoryRequests(symbols, periods, resolution, fillForward)).Memoize();
         }
 
         /// <summary>
@@ -499,7 +499,7 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <param name="extendedMarket">True to include extended market hours data, false otherwise</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security history request</param>
         /// <param name="dataNormalizationMode">The price scaling mode to use for the securities history</param>
@@ -508,10 +508,10 @@ namespace QuantConnect.Algorithm
         /// <returns>An enumerable of slice containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
         public IEnumerable<Slice> History(IEnumerable<Symbol> symbols, DateTime start, DateTime end, Resolution? resolution = null,
-            bool? fillDataForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
+            bool? fillForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
-            return History(CreateDateRangeHistoryRequests(symbols, start, end, resolution, fillDataForward, extendedMarket, dataMappingMode,
+            return History(CreateDateRangeHistoryRequests(symbols, start, end, resolution, fillForward, extendedMarket, dataMappingMode,
                 dataNormalizationMode, contractDepthOffset)).Memoize();
         }
 
@@ -767,10 +767,10 @@ namespace QuantConnect.Algorithm
         /// Helper method to create history requests from a date range
         /// </summary>
         private IEnumerable<HistoryRequest> CreateDateRangeHistoryRequests(IEnumerable<Symbol> symbols, DateTime startAlgoTz, DateTime endAlgoTz,
-            Resolution? resolution = null, bool? fillDataForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
+            Resolution? resolution = null, bool? fillForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
-            return CreateDateRangeHistoryRequests(symbols, typeof(BaseData), startAlgoTz, endAlgoTz, resolution, fillDataForward, extendedMarket,
+            return CreateDateRangeHistoryRequests(symbols, typeof(BaseData), startAlgoTz, endAlgoTz, resolution, fillForward, extendedMarket,
                 dataMappingMode, dataNormalizationMode, contractDepthOffset);
         }
 
@@ -778,7 +778,7 @@ namespace QuantConnect.Algorithm
         /// Helper method to create history requests from a date range with custom data type
         /// </summary>
         private IEnumerable<HistoryRequest> CreateDateRangeHistoryRequests(IEnumerable<Symbol> symbols, Type requestedType, DateTime startAlgoTz, DateTime endAlgoTz,
-            Resolution? resolution = null, bool? fillDataForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
+            Resolution? resolution = null, bool? fillForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
             return symbols.Where(HistoryRequestValid).SelectMany(x =>
@@ -788,7 +788,7 @@ namespace QuantConnect.Algorithm
                 foreach (var config in GetMatchingSubscriptions(x, requestedType, resolution))
                 {
                     var request = _historyRequestFactory.CreateHistoryRequest(config, startAlgoTz, endAlgoTz, GetExchangeHours(x), resolution,
-                        fillDataForward, extendedMarket, dataMappingMode, dataNormalizationMode, contractDepthOffset);
+                        fillForward, extendedMarket, dataMappingMode, dataNormalizationMode, contractDepthOffset);
                     requests.Add(request);
                 }
 
@@ -800,10 +800,10 @@ namespace QuantConnect.Algorithm
         /// Helper methods to create a history request for the specified symbols and bar count
         /// </summary>
         private IEnumerable<HistoryRequest> CreateBarCountHistoryRequests(IEnumerable<Symbol> symbols, int periods, Resolution? resolution = null,
-            bool? fillDataForward = null, DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null,
+            bool? fillForward = null, DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null,
             int? contractDepthOffset = null)
         {
-            return CreateBarCountHistoryRequests(symbols, typeof(BaseData), periods, resolution, fillDataForward, dataMappingMode,
+            return CreateBarCountHistoryRequests(symbols, typeof(BaseData), periods, resolution, fillForward, dataMappingMode,
                 dataNormalizationMode, contractDepthOffset);
         }
 
@@ -811,7 +811,7 @@ namespace QuantConnect.Algorithm
         /// Helper methods to create a history request for the specified symbols and bar count with custom data type
         /// </summary>
         private IEnumerable<HistoryRequest> CreateBarCountHistoryRequests(IEnumerable<Symbol> symbols, Type requestedType, int periods,
-            Resolution? resolution = null, bool? fillDataForward = null, DataMappingMode? dataMappingMode = null,
+            Resolution? resolution = null, bool? fillForward = null, DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
             return symbols.Where(HistoryRequestValid).SelectMany(x =>
@@ -827,7 +827,7 @@ namespace QuantConnect.Algorithm
                 var start = _historyRequestFactory.GetStartTimeAlgoTz(x, periods, res, exchange, configs.First().DataTimeZone);
                 var end = Time;
 
-                return configs.Select(config => _historyRequestFactory.CreateHistoryRequest(config, start, end, exchange, res, fillDataForward,
+                return configs.Select(config => _historyRequestFactory.CreateHistoryRequest(config, start, end, exchange, res, fillForward,
                     null, dataMappingMode, dataNormalizationMode, contractDepthOffset));
             });
         }

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -301,7 +301,7 @@ namespace QuantConnect.Algorithm
                     throw new ArgumentException("History functions that accept a 'periods' parameter can not be used with Resolution.Tick");
                 }
 
-                var config = GetMatchingSubscription(x, typeof(T), res);
+                var config = GetMatchingSubscription(x, typeof(T));
                 if (config == null) return null;
 
                 var exchange = GetExchangeHours(x);
@@ -309,7 +309,7 @@ namespace QuantConnect.Algorithm
                 var request = _historyRequestFactory.CreateHistoryRequest(config, start, Time, exchange, res);
 
                 // apply overrides
-                if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? GetResolution(x, resolution) : (Resolution?)null;
+                if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? res : (Resolution?)null;
 
                 return request;
             });
@@ -341,7 +341,7 @@ namespace QuantConnect.Algorithm
                 var request = _historyRequestFactory.CreateHistoryRequest(config, start, end, GetExchangeHours(x), res);
 
                 // apply overrides
-                if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? GetResolution(x, resolution) : (Resolution?)null;
+                if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? res : (Resolution?)null;
 
                 return request;
             });
@@ -793,15 +793,16 @@ namespace QuantConnect.Algorithm
         {
             return symbols.Where(HistoryRequestValid).SelectMany(x =>
             {
+                var res = GetResolution(x, resolution);
                 var requests = new List<HistoryRequest>();
 
                 foreach (var config in GetMatchingSubscriptions(x, requestedType, resolution))
                 {
-                    var request = _historyRequestFactory.CreateHistoryRequest(config, startAlgoTz, endAlgoTz, GetExchangeHours(x), resolution,
+                    var request = _historyRequestFactory.CreateHistoryRequest(config, startAlgoTz, endAlgoTz, GetExchangeHours(x), res,
                         dataMappingMode, dataNormalizationMode, contractDepthOffset);
 
                     // apply overrides
-                    if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? GetResolution(x, resolution) : (Resolution?)null;
+                    if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? res : (Resolution?)null;
                     if (extendedMarket.HasValue) request.IncludeExtendedMarketHours = extendedMarket.Value;
 
                     requests.Add(request);
@@ -833,7 +834,7 @@ namespace QuantConnect.Algorithm
             {
                 var res = GetResolution(x, resolution);
                 var exchange = GetExchangeHours(x);
-                var configs = GetMatchingSubscriptions(x, requestedType, resolution).ToList();
+                var configs = GetMatchingSubscriptions(x, requestedType, res).ToList();
                 if (configs.Count == 0)
                 {
                     return Enumerable.Empty<HistoryRequest>();
@@ -848,7 +849,7 @@ namespace QuantConnect.Algorithm
                         dataNormalizationMode, contractDepthOffset);
 
                     // apply overrides
-                    if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? GetResolution(x, resolution) : (Resolution?)null;
+                    if (fillForward.HasValue) request.FillForwardResolution = fillForward.Value ? res : (Resolution?)null;
 
                     return request;
                 });

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -844,12 +844,13 @@ namespace QuantConnect.Algorithm
         /// <param name="tickers">The symbols to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>A python dictionary with pandas DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject tickers, int periods, Resolution? resolution = null)
+        public PyObject History(PyObject tickers, int periods, Resolution? resolution = null, bool? fillForward = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
-            return GetDataFrame(History(symbols, periods, resolution));
+            return GetDataFrame(History(symbols, periods, resolution, fillForward));
         }
 
         /// <summary>
@@ -859,12 +860,13 @@ namespace QuantConnect.Algorithm
         /// <param name="tickers">The symbols to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>A python dictionary with pandas DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject tickers, TimeSpan span, Resolution? resolution = null)
+        public PyObject History(PyObject tickers, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
-            return GetDataFrame(History(symbols, span, resolution));
+            return GetDataFrame(History(symbols, span, resolution, fillForward));
         }
 
         /// <summary>
@@ -942,9 +944,10 @@ namespace QuantConnect.Algorithm
         /// <param name="tickers">The symbols to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, PyObject tickers, int periods, Resolution? resolution = null)
+        public PyObject History(PyObject type, PyObject tickers, int periods, Resolution? resolution = null, bool? fillForward = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
             if (symbols.Any(symbol => GetResolution(symbol, resolution) == Resolution.Tick))
@@ -953,7 +956,7 @@ namespace QuantConnect.Algorithm
             }
 
             var requestedType = type.CreateType();
-            var requests = CreateBarCountHistoryRequests(symbols, requestedType, periods, resolution);
+            var requests = CreateBarCountHistoryRequests(symbols, requestedType, periods, resolution, fillForward);
 
             return GetDataFrame(History(requests.Where(x => x != null)), requestedType);
         }
@@ -966,11 +969,12 @@ namespace QuantConnect.Algorithm
         /// <param name="tickers">The symbols to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, PyObject tickers, TimeSpan span, Resolution? resolution = null)
+        public PyObject History(PyObject type, PyObject tickers, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
         {
-            return History(type, tickers, Time - span, Time, resolution);
+            return History(type, tickers, Time - span, Time, resolution, fillForward);
         }
 
         /// <summary>
@@ -981,12 +985,13 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null)
+        public PyObject History(PyObject type, Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null, bool? fillForward = null)
         {
             var requestedType = type.CreateType();
-            var requests = CreateDateRangeHistoryRequests(new [] {  symbol }, requestedType, start, end, resolution);
+            var requests = CreateDateRangeHistoryRequests(new [] {  symbol }, requestedType, start, end, resolution, fillForward);
             if (requests.IsNullOrEmpty())
             {
                 throw new ArgumentException($"No history data could be fetched. " +
@@ -1005,9 +1010,10 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, Symbol symbol, int periods, Resolution? resolution = null)
+        public PyObject History(PyObject type, Symbol symbol, int periods, Resolution? resolution = null, bool? fillForward = null)
         {
             resolution = GetResolution(symbol, resolution);
             if (resolution == Resolution.Tick)
@@ -1017,7 +1023,7 @@ namespace QuantConnect.Algorithm
 
             var marketHours = GetMarketHours(symbol);
             var start = _historyRequestFactory.GetStartTimeAlgoTz(symbol, periods, resolution.Value, marketHours.ExchangeHours, marketHours.DataTimeZone);
-            return History(type, symbol, start, Time, resolution);
+            return History(type, symbol, start, Time, resolution, fillForward);
         }
 
         /// <summary>
@@ -1028,11 +1034,12 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, Symbol symbol, TimeSpan span, Resolution? resolution = null)
+        public PyObject History(PyObject type, Symbol symbol, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
         {
-            return History(type, symbol, Time - span, Time, resolution);
+            return History(type, symbol, Time - span, Time, resolution, fillForward);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -98,13 +98,13 @@ namespace QuantConnect.Algorithm
         /// <param name="ticker">Key/Ticker for data</param>
         /// <param name="resolution">Resolution of the Data Required</param>
         /// <param name="timeZone">Specifies the time zone of the raw data</param>
-        /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
+        /// <param name="fillForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
         [DocumentationAttribute(AddingData)]
-        public Security AddData(PyObject type, string ticker, Resolution? resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
+        public Security AddData(PyObject type, string ticker, Resolution? resolution, DateTimeZone timeZone, bool fillForward = false, decimal leverage = 1.0m)
         {
-            return AddData(type.CreateType(), ticker, resolution, timeZone, fillDataForward, leverage);
+            return AddData(type.CreateType(), ticker, resolution, timeZone, fillForward, leverage);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace QuantConnect.Algorithm
         /// <param name="underlying">The underlying symbol for the custom data</param>
         /// <param name="resolution">Resolution of the Data Required</param>
         /// <param name="timeZone">Specifies the time zone of the raw data</param>
-        /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
+        /// <param name="fillForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
         /// <remarks>
@@ -128,9 +128,9 @@ namespace QuantConnect.Algorithm
         /// due to pythonnet's method precedence, as viewable here: https://github.com/QuantConnect/pythonnet/blob/9e29755c54e6008cb016e3dd9d75fbd8cd19fcf7/src/runtime/methodbinder.cs#L215
         /// </remarks>
         [DocumentationAttribute(AddingData)]
-        public Security AddData(PyObject type, Symbol underlying, Resolution? resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
+        public Security AddData(PyObject type, Symbol underlying, Resolution? resolution, DateTimeZone timeZone, bool fillForward = false, decimal leverage = 1.0m)
         {
-            return AddData(type.CreateType(), underlying, resolution, timeZone, fillDataForward, leverage);
+            return AddData(type.CreateType(), underlying, resolution, timeZone, fillForward, leverage);
         }
 
         /// <summary>
@@ -142,11 +142,11 @@ namespace QuantConnect.Algorithm
         /// <param name="ticker">Key/Ticker for data</param>
         /// <param name="resolution">Resolution of the Data Required</param>
         /// <param name="timeZone">Specifies the time zone of the raw data</param>
-        /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
+        /// <param name="fillForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
         [DocumentationAttribute(AddingData)]
-        public Security AddData(Type dataType, string ticker, Resolution? resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
+        public Security AddData(Type dataType, string ticker, Resolution? resolution, DateTimeZone timeZone, bool fillForward = false, decimal leverage = 1.0m)
         {
             // NOTE: Invoking methods on BaseData w/out setting the symbol may provide unexpected behavior
             var baseInstance = dataType.GetBaseDataInstance();
@@ -155,7 +155,7 @@ namespace QuantConnect.Algorithm
                 var symbol = new Symbol(
                     SecurityIdentifier.GenerateBase(dataType, ticker, Market.USA, baseInstance.RequiresMapping()),
                     ticker);
-                return AddDataImpl(dataType, symbol, resolution, timeZone, fillDataForward, leverage);
+                return AddDataImpl(dataType, symbol, resolution, timeZone, fillForward, leverage);
             }
             // If we need a mappable ticker and we can't find one in the SymbolCache, throw
             Symbol underlying;
@@ -167,7 +167,7 @@ namespace QuantConnect.Algorithm
                                                     $"An example use case can be found in CustomDataAddDataRegressionAlgorithm");
             }
 
-            return AddData(dataType, underlying, resolution, timeZone, fillDataForward, leverage);
+            return AddData(dataType, underlying, resolution, timeZone, fillForward, leverage);
         }
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace QuantConnect.Algorithm
         /// <param name="underlying"></param>
         /// <param name="resolution">Resolution of the Data Required</param>
         /// <param name="timeZone">Specifies the time zone of the raw data</param>
-        /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
+        /// <param name="fillForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
         /// <remarks>
@@ -191,10 +191,10 @@ namespace QuantConnect.Algorithm
         /// due to pythonnet's method precedence, as viewable here: https://github.com/QuantConnect/pythonnet/blob/9e29755c54e6008cb016e3dd9d75fbd8cd19fcf7/src/runtime/methodbinder.cs#L215
         /// </remarks>
         [DocumentationAttribute(AddingData)]
-        public Security AddData(Type dataType, Symbol underlying, Resolution? resolution = null, DateTimeZone timeZone = null, bool fillDataForward = false, decimal leverage = 1.0m)
+        public Security AddData(Type dataType, Symbol underlying, Resolution? resolution = null, DateTimeZone timeZone = null, bool fillForward = false, decimal leverage = 1.0m)
         {
             var symbol = QuantConnect.Symbol.CreateBase(dataType, underlying, Market.USA);
-            return AddDataImpl(dataType, symbol, resolution, timeZone, fillDataForward, leverage);
+            return AddDataImpl(dataType, symbol, resolution, timeZone, fillForward, leverage);
         }
 
         /// <summary>
@@ -207,11 +207,11 @@ namespace QuantConnect.Algorithm
         /// <param name="properties">The properties of this new custom data</param>
         /// <param name="exchangeHours">The Exchange hours of this symbol</param>
         /// <param name="resolution">Resolution of the Data Required</param>
-        /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
+        /// <param name="fillForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
         [DocumentationAttribute(AddingData)]
-        public Security AddData(PyObject type, string ticker, SymbolProperties properties, SecurityExchangeHours exchangeHours, Resolution? resolution = null, bool fillDataForward = false, decimal leverage = 1.0m)
+        public Security AddData(PyObject type, string ticker, SymbolProperties properties, SecurityExchangeHours exchangeHours, Resolution? resolution = null, bool fillForward = false, decimal leverage = 1.0m)
         {
             // Get the right key for storage of base type symbols
             var dataType = type.CreateType();
@@ -221,7 +221,7 @@ namespace QuantConnect.Algorithm
             SetDatabaseEntries(key, properties, exchangeHours);
 
             // Then add the data
-            return AddData(dataType, ticker, resolution, null, fillDataForward, leverage);
+            return AddData(dataType, ticker, resolution, null, fillForward, leverage);
         }
 
         /// <summary>
@@ -252,10 +252,10 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">Final symbol that includes underlying (if any)</param>
         /// <param name="resolution">Resolution of the Data required</param>
         /// <param name="timeZone">Specifies the time zone of the raw data</param>
-        /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
+        /// <param name="fillForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
-        private Security AddDataImpl(Type dataType, Symbol symbol, Resolution? resolution, DateTimeZone timeZone, bool fillDataForward, decimal leverage)
+        private Security AddDataImpl(Type dataType, Symbol symbol, Resolution? resolution, DateTimeZone timeZone, bool fillForward, decimal leverage)
         {
             var alias = symbol.ID.Symbol;
             SymbolCache.Set(alias, symbol);
@@ -271,7 +271,7 @@ namespace QuantConnect.Algorithm
                 dataType,
                 symbol,
                 resolution,
-                fillDataForward,
+                fillForward,
                 isCustomData: true,
                 extendedMarketHours: true);
             var security = Securities.CreateSecurity(symbol, config, leverage, addToSymbolCache: false);
@@ -844,13 +844,13 @@ namespace QuantConnect.Algorithm
         /// <param name="tickers">The symbols to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>A python dictionary with pandas DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject tickers, int periods, Resolution? resolution = null, bool? fillDataForward = null)
+        public PyObject History(PyObject tickers, int periods, Resolution? resolution = null, bool? fillForward = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
-            return GetDataFrame(History(symbols, periods, resolution, fillDataForward));
+            return GetDataFrame(History(symbols, periods, resolution, fillForward));
         }
 
         /// <summary>
@@ -860,13 +860,13 @@ namespace QuantConnect.Algorithm
         /// <param name="tickers">The symbols to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>A python dictionary with pandas DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject tickers, TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
+        public PyObject History(PyObject tickers, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
-            return GetDataFrame(History(symbols, span, resolution, fillDataForward));
+            return GetDataFrame(History(symbols, span, resolution, fillForward));
         }
 
         /// <summary>
@@ -876,7 +876,7 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <param name="extendedMarket">True to include extended market hours data, false otherwise</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security history request</param>
         /// <param name="dataNormalizationMode">The price scaling mode to use for the securities history</param>
@@ -884,12 +884,12 @@ namespace QuantConnect.Algorithm
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
         /// <returns>A python dictionary with a pandas DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject tickers, DateTime start, DateTime end, Resolution? resolution = null, bool? fillDataForward = null,
+        public PyObject History(PyObject tickers, DateTime start, DateTime end, Resolution? resolution = null, bool? fillForward = null,
             bool? extendedMarket = null, DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null,
             int? contractDepthOffset = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
-            return GetDataFrame(History(symbols, start, end, resolution, fillDataForward, extendedMarket, dataMappingMode,
+            return GetDataFrame(History(symbols, start, end, resolution, fillForward, extendedMarket, dataMappingMode,
                 dataNormalizationMode, contractDepthOffset));
         }
 
@@ -916,7 +916,7 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <param name="extendedMarket">True to include extended market hours data, false otherwise</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security history request</param>
         /// <param name="dataNormalizationMode">The price scaling mode to use for the securities history</param>
@@ -925,12 +925,12 @@ namespace QuantConnect.Algorithm
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
         public PyObject History(PyObject type, PyObject tickers, DateTime start, DateTime end, Resolution? resolution = null,
-            bool? fillDataForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
+            bool? fillForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
             var requestedType = type.CreateType();
-            var requests = CreateDateRangeHistoryRequests(symbols, requestedType, start, end, resolution, fillDataForward, extendedMarket,
+            var requests = CreateDateRangeHistoryRequests(symbols, requestedType, start, end, resolution, fillForward, extendedMarket,
                 dataMappingMode, dataNormalizationMode, contractDepthOffset);
             return GetDataFrame(History(requests.Where(x => x != null)), requestedType);
         }
@@ -944,10 +944,10 @@ namespace QuantConnect.Algorithm
         /// <param name="tickers">The symbols to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, PyObject tickers, int periods, Resolution? resolution = null, bool? fillDataForward = null)
+        public PyObject History(PyObject type, PyObject tickers, int periods, Resolution? resolution = null, bool? fillForward = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
             if (symbols.Any(symbol => GetResolution(symbol, resolution) == Resolution.Tick))
@@ -956,7 +956,7 @@ namespace QuantConnect.Algorithm
             }
 
             var requestedType = type.CreateType();
-            var requests = CreateBarCountHistoryRequests(symbols, requestedType, periods, resolution, fillDataForward);
+            var requests = CreateBarCountHistoryRequests(symbols, requestedType, periods, resolution, fillForward);
 
             return GetDataFrame(History(requests.Where(x => x != null)), requestedType);
         }
@@ -969,12 +969,12 @@ namespace QuantConnect.Algorithm
         /// <param name="tickers">The symbols to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, PyObject tickers, TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
+        public PyObject History(PyObject type, PyObject tickers, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
         {
-            return History(type, tickers, Time - span, Time, resolution, fillDataForward);
+            return History(type, tickers, Time - span, Time, resolution, fillForward);
         }
 
         /// <summary>
@@ -985,13 +985,13 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null, bool? fillDataForward = null)
+        public PyObject History(PyObject type, Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null, bool? fillForward = null)
         {
             var requestedType = type.CreateType();
-            var requests = CreateDateRangeHistoryRequests(new [] {  symbol }, requestedType, start, end, resolution, fillDataForward);
+            var requests = CreateDateRangeHistoryRequests(new [] {  symbol }, requestedType, start, end, resolution, fillForward);
             if (requests.IsNullOrEmpty())
             {
                 throw new ArgumentException($"No history data could be fetched. " +
@@ -1010,10 +1010,10 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, Symbol symbol, int periods, Resolution? resolution = null, bool? fillDataForward = null)
+        public PyObject History(PyObject type, Symbol symbol, int periods, Resolution? resolution = null, bool? fillForward = null)
         {
             resolution = GetResolution(symbol, resolution);
             if (resolution == Resolution.Tick)
@@ -1023,7 +1023,7 @@ namespace QuantConnect.Algorithm
 
             var marketHours = GetMarketHours(symbol);
             var start = _historyRequestFactory.GetStartTimeAlgoTz(symbol, periods, resolution.Value, marketHours.ExchangeHours, marketHours.DataTimeZone);
-            return History(type, symbol, start, Time, resolution, fillDataForward);
+            return History(type, symbol, start, Time, resolution, fillForward);
         }
 
         /// <summary>
@@ -1034,12 +1034,12 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, Symbol symbol, TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
+        public PyObject History(PyObject type, Symbol symbol, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
         {
-            return History(type, symbol, Time - span, Time, resolution, fillDataForward);
+            return History(type, symbol, Time - span, Time, resolution, fillForward);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -894,21 +894,6 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Gets the historical data for the specified symbol between the specified dates. The symbol must exist in the Securities collection.
-        /// </summary>
-        /// <param name="tickers">The symbols to retrieve historical data for</param>
-        /// <param name="start">The start time in the algorithm's time zone</param>
-        /// <param name="end">The end time in the algorithm's time zone</param>
-        /// <param name="resolution">The resolution to request</param>
-        /// <returns>A python dictionary with pandas DataFrame containing the requested historical data</returns>
-        [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject tickers, DateTime start, DateTime end, Resolution? resolution = null)
-        {
-            var symbols = tickers.ConvertToSymbolEnumerable();
-            return GetDataFrame(History(symbols, start, end, resolution));
-        }
-
-        /// <summary>
         /// Gets the historical data for the specified symbols between the specified dates. The symbols must exist in the Securities collection.
         /// </summary>
         /// <param name="type">The data type of the symbols</param>

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -894,6 +894,21 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Gets the historical data for the specified symbol between the specified dates. The symbol must exist in the Securities collection.
+        /// </summary>
+        /// <param name="tickers">The symbols to retrieve historical data for</param>
+        /// <param name="start">The start time in the algorithm's time zone</param>
+        /// <param name="end">The end time in the algorithm's time zone</param>
+        /// <param name="resolution">The resolution to request</param>
+        /// <returns>A python dictionary with pandas DataFrame containing the requested historical data</returns>
+        [DocumentationAttribute(HistoricalData)]
+        public PyObject History(PyObject tickers, DateTime start, DateTime end, Resolution? resolution = null)
+        {
+            var symbols = tickers.ConvertToSymbolEnumerable();
+            return GetDataFrame(History(symbols, start, end, resolution));
+        }
+
+        /// <summary>
         /// Gets the historical data for the specified symbols between the specified dates. The symbols must exist in the Securities collection.
         /// </summary>
         /// <param name="type">The data type of the symbols</param>

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -844,13 +844,13 @@ namespace QuantConnect.Algorithm
         /// <param name="tickers">The symbols to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>A python dictionary with pandas DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject tickers, int periods, Resolution? resolution = null, bool? fillForward = null)
+        public PyObject History(PyObject tickers, int periods, Resolution? resolution = null, bool? fillDataForward = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
-            return GetDataFrame(History(symbols, periods, resolution, fillForward));
+            return GetDataFrame(History(symbols, periods, resolution, fillDataForward));
         }
 
         /// <summary>
@@ -860,13 +860,13 @@ namespace QuantConnect.Algorithm
         /// <param name="tickers">The symbols to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>A python dictionary with pandas DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject tickers, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
+        public PyObject History(PyObject tickers, TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
-            return GetDataFrame(History(symbols, span, resolution, fillForward));
+            return GetDataFrame(History(symbols, span, resolution, fillDataForward));
         }
 
         /// <summary>
@@ -876,7 +876,7 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <param name="extendedMarket">True to include extended market hours data, false otherwise</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security history request</param>
         /// <param name="dataNormalizationMode">The price scaling mode to use for the securities history</param>
@@ -884,12 +884,12 @@ namespace QuantConnect.Algorithm
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
         /// <returns>A python dictionary with a pandas DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject tickers, DateTime start, DateTime end, Resolution? resolution = null, bool? fillForward = null,
+        public PyObject History(PyObject tickers, DateTime start, DateTime end, Resolution? resolution = null, bool? fillDataForward = null,
             bool? extendedMarket = null, DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null,
             int? contractDepthOffset = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
-            return GetDataFrame(History(symbols, start, end, resolution, fillForward, extendedMarket, dataMappingMode,
+            return GetDataFrame(History(symbols, start, end, resolution, fillDataForward, extendedMarket, dataMappingMode,
                 dataNormalizationMode, contractDepthOffset));
         }
 
@@ -916,7 +916,7 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <param name="extendedMarket">True to include extended market hours data, false otherwise</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security history request</param>
         /// <param name="dataNormalizationMode">The price scaling mode to use for the securities history</param>
@@ -925,12 +925,12 @@ namespace QuantConnect.Algorithm
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
         public PyObject History(PyObject type, PyObject tickers, DateTime start, DateTime end, Resolution? resolution = null,
-            bool? fillForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
+            bool? fillDataForward = null, bool? extendedMarket = null, DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
             var requestedType = type.CreateType();
-            var requests = CreateDateRangeHistoryRequests(symbols, requestedType, start, end, resolution, fillForward, extendedMarket,
+            var requests = CreateDateRangeHistoryRequests(symbols, requestedType, start, end, resolution, fillDataForward, extendedMarket,
                 dataMappingMode, dataNormalizationMode, contractDepthOffset);
             return GetDataFrame(History(requests.Where(x => x != null)), requestedType);
         }
@@ -944,10 +944,10 @@ namespace QuantConnect.Algorithm
         /// <param name="tickers">The symbols to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, PyObject tickers, int periods, Resolution? resolution = null, bool? fillForward = null)
+        public PyObject History(PyObject type, PyObject tickers, int periods, Resolution? resolution = null, bool? fillDataForward = null)
         {
             var symbols = tickers.ConvertToSymbolEnumerable();
             if (symbols.Any(symbol => GetResolution(symbol, resolution) == Resolution.Tick))
@@ -956,7 +956,7 @@ namespace QuantConnect.Algorithm
             }
 
             var requestedType = type.CreateType();
-            var requests = CreateBarCountHistoryRequests(symbols, requestedType, periods, resolution, fillForward);
+            var requests = CreateBarCountHistoryRequests(symbols, requestedType, periods, resolution, fillDataForward);
 
             return GetDataFrame(History(requests.Where(x => x != null)), requestedType);
         }
@@ -969,12 +969,12 @@ namespace QuantConnect.Algorithm
         /// <param name="tickers">The symbols to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, PyObject tickers, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
+        public PyObject History(PyObject type, PyObject tickers, TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
         {
-            return History(type, tickers, Time - span, Time, resolution, fillForward);
+            return History(type, tickers, Time - span, Time, resolution, fillDataForward);
         }
 
         /// <summary>
@@ -985,13 +985,13 @@ namespace QuantConnect.Algorithm
         /// <param name="start">The start time in the algorithm's time zone</param>
         /// <param name="end">The end time in the algorithm's time zone</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null, bool? fillForward = null)
+        public PyObject History(PyObject type, Symbol symbol, DateTime start, DateTime end, Resolution? resolution = null, bool? fillDataForward = null)
         {
             var requestedType = type.CreateType();
-            var requests = CreateDateRangeHistoryRequests(new [] {  symbol }, requestedType, start, end, resolution, fillForward);
+            var requests = CreateDateRangeHistoryRequests(new [] {  symbol }, requestedType, start, end, resolution, fillDataForward);
             if (requests.IsNullOrEmpty())
             {
                 throw new ArgumentException($"No history data could be fetched. " +
@@ -1010,10 +1010,10 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to retrieve historical data for</param>
         /// <param name="periods">The number of bars to request</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, Symbol symbol, int periods, Resolution? resolution = null, bool? fillForward = null)
+        public PyObject History(PyObject type, Symbol symbol, int periods, Resolution? resolution = null, bool? fillDataForward = null)
         {
             resolution = GetResolution(symbol, resolution);
             if (resolution == Resolution.Tick)
@@ -1023,7 +1023,7 @@ namespace QuantConnect.Algorithm
 
             var marketHours = GetMarketHours(symbol);
             var start = _historyRequestFactory.GetStartTimeAlgoTz(symbol, periods, resolution.Value, marketHours.ExchangeHours, marketHours.DataTimeZone);
-            return History(type, symbol, start, Time, resolution, fillForward);
+            return History(type, symbol, start, Time, resolution, fillDataForward);
         }
 
         /// <summary>
@@ -1034,12 +1034,12 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The symbol to retrieve historical data for</param>
         /// <param name="span">The span over which to retrieve recent historical data</param>
         /// <param name="resolution">The resolution to request</param>
-        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="fillDataForward">True to fill forward missing data, false otherwise</param>
         /// <returns>pandas.DataFrame containing the requested historical data</returns>
         [DocumentationAttribute(HistoricalData)]
-        public PyObject History(PyObject type, Symbol symbol, TimeSpan span, Resolution? resolution = null, bool? fillForward = null)
+        public PyObject History(PyObject type, Symbol symbol, TimeSpan span, Resolution? resolution = null, bool? fillDataForward = null)
         {
-            return History(type, symbol, Time - span, Time, resolution, fillForward);
+            return History(type, symbol, Time - span, Time, resolution, fillDataForward);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1589,15 +1589,15 @@ namespace QuantConnect.Algorithm
         /// <param name="securityType">MarketType Type: Equity, Commodity, Future, FOREX or Crypto</param>
         /// <param name="ticker">The security ticker</param>
         /// <param name="resolution">Resolution of the Data Required</param>
-        /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
+        /// <param name="fillForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security</param>
         /// <param name="dataNormalizationMode">The price scaling mode to use for the security</param>
         [DocumentationAttribute(AddingData)]
-        public Security AddSecurity(SecurityType securityType, string ticker, Resolution? resolution = null, bool fillDataForward = true, bool extendedMarketHours = false,
+        public Security AddSecurity(SecurityType securityType, string ticker, Resolution? resolution = null, bool fillForward = true, bool extendedMarketHours = false,
             DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null)
         {
-            return AddSecurity(securityType, ticker, resolution, fillDataForward, Security.NullLeverage, extendedMarketHours, dataMappingMode, dataNormalizationMode);
+            return AddSecurity(securityType, ticker, resolution, fillForward, Security.NullLeverage, extendedMarketHours, dataMappingMode, dataNormalizationMode);
         }
 
         /// <summary>
@@ -1606,17 +1606,17 @@ namespace QuantConnect.Algorithm
         /// <param name="securityType">MarketType Type: Equity, Commodity, Future, FOREX or Crypto</param>
         /// <param name="ticker">The security ticker</param>
         /// <param name="resolution">Resolution of the Data Required</param>
-        /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
+        /// <param name="fillForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security</param>
         /// <param name="dataNormalizationMode">The price scaling mode to use for the security</param>
-        /// <remarks> AddSecurity(SecurityType securityType, Symbol symbol, Resolution resolution, bool fillDataForward, decimal leverage, bool extendedMarketHours)</remarks>
+        /// <remarks> AddSecurity(SecurityType securityType, Symbol symbol, Resolution resolution, bool fillForward, decimal leverage, bool extendedMarketHours)</remarks>
         [DocumentationAttribute(AddingData)]
-        public Security AddSecurity(SecurityType securityType, string ticker, Resolution? resolution, bool fillDataForward, decimal leverage, bool extendedMarketHours,
+        public Security AddSecurity(SecurityType securityType, string ticker, Resolution? resolution, bool fillForward, decimal leverage, bool extendedMarketHours,
             DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null)
         {
-            return AddSecurity(securityType, ticker, resolution, null, fillDataForward, leverage, extendedMarketHours, dataMappingMode, dataNormalizationMode);
+            return AddSecurity(securityType, ticker, resolution, null, fillForward, leverage, extendedMarketHours, dataMappingMode, dataNormalizationMode);
         }
 
         /// <summary>
@@ -1626,24 +1626,24 @@ namespace QuantConnect.Algorithm
         /// <param name="ticker">The security ticker, e.g. AAPL</param>
         /// <param name="resolution">Resolution of the MarketType required: MarketData, Second or Minute</param>
         /// <param name="market">The market the requested security belongs to, such as 'usa' or 'fxcm'</param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice.</param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice.</param>
         /// <param name="leverage">leverage for this security</param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security</param>
         /// <param name="dataNormalizationMode">The price scaling mode to use for the security</param>
         [DocumentationAttribute(AddingData)]
-        public Security AddSecurity(SecurityType securityType, string ticker, Resolution? resolution, string market, bool fillDataForward, decimal leverage, bool extendedMarketHours,
+        public Security AddSecurity(SecurityType securityType, string ticker, Resolution? resolution, string market, bool fillForward, decimal leverage, bool extendedMarketHours,
             DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null)
         {
             // if AddSecurity method is called to add an option or a future, we delegate a call to respective methods
             if (securityType == SecurityType.Option)
             {
-                return AddOption(ticker, resolution, market, fillDataForward, leverage);
+                return AddOption(ticker, resolution, market, fillForward, leverage);
             }
 
             if (securityType == SecurityType.Future)
             {
-                return AddFuture(ticker, resolution, market, fillDataForward, leverage, extendedMarketHours, dataMappingMode, dataNormalizationMode);
+                return AddFuture(ticker, resolution, market, fillForward, leverage, extendedMarketHours, dataMappingMode, dataNormalizationMode);
             }
 
             try
@@ -1664,7 +1664,7 @@ namespace QuantConnect.Algorithm
                     symbol = QuantConnect.Symbol.Create(ticker, securityType, market);
                 }
 
-                return AddSecurity(symbol, resolution, fillDataForward, leverage, extendedMarketHours, dataMappingMode, dataNormalizationMode);
+                return AddSecurity(symbol, resolution, fillForward, leverage, extendedMarketHours, dataMappingMode, dataNormalizationMode);
             }
             catch (Exception err)
             {
@@ -1678,7 +1678,7 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">The security Symbol</param>
         /// <param name="resolution">Resolution of the MarketType required: MarketData, Second or Minute</param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice.</param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice.</param>
         /// <param name="leverage">leverage for this security</param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security</param>
@@ -1687,7 +1687,7 @@ namespace QuantConnect.Algorithm
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
         /// <returns>The new Security that was added to the algorithm</returns>
         [DocumentationAttribute(AddingData)]
-        public Security AddSecurity(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage, bool extendedMarketHours = false,
+        public Security AddSecurity(Symbol symbol, Resolution? resolution = null, bool fillForward = true, decimal leverage = Security.NullLeverage, bool extendedMarketHours = false,
             DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0)
         {
             // allow users to specify negative numbers, we get the abs of it
@@ -1703,7 +1703,7 @@ namespace QuantConnect.Algorithm
             // Short-circuit to AddOptionContract because it will add the underlying if required
             if (!isCanonical && symbol.SecurityType.IsOption())
             {
-                return AddOptionContract(symbol, resolution, fillDataForward, leverage, extendedMarketHours);
+                return AddOptionContract(symbol, resolution, fillForward, leverage, extendedMarketHours);
             }
 
             var isFilteredSubscription = !isCanonical;
@@ -1714,7 +1714,7 @@ namespace QuantConnect.Algorithm
             {
                 configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol,
                     resolution,
-                    fillDataForward,
+                    fillForward,
                     extendedMarketHours,
                     isFilteredSubscription,
                     dataNormalizationMode: dataNormalizationMode.Value,
@@ -1724,7 +1724,7 @@ namespace QuantConnect.Algorithm
             {
                 configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol,
                    resolution,
-                   fillDataForward,
+                   fillForward,
                    extendedMarketHours,
                    isFilteredSubscription,
                    contractDepthOffset: (uint)contractDepthOffset);
@@ -1742,7 +1742,7 @@ namespace QuantConnect.Algorithm
                 if (!UniverseManager.TryGetValue(symbol, out universe) && !IsAlreadyPending(symbol))
                 {
                     var canonicalConfig = configs.First();
-                    var settings = new UniverseSettings(canonicalConfig.Resolution, leverage, fillDataForward, extendedMarketHours, UniverseSettings.MinimumTimeInUniverse);
+                    var settings = new UniverseSettings(canonicalConfig.Resolution, leverage, fillForward, extendedMarketHours, UniverseSettings.MinimumTimeInUniverse);
                     if (symbol.SecurityType.IsOption())
                     {
                         universe = new OptionChainUniverse((Option)security, settings);
@@ -1787,16 +1787,16 @@ namespace QuantConnect.Algorithm
         /// <param name="ticker">The equity ticker symbol</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
         /// <param name="market">The equity's market, <seealso cref="Market"/>. Default value is null and looked up using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">True to send data during pre and post market sessions. Default is <value>false</value></param>
         /// <param name="dataNormalizationMode">The price scaling mode to use for the equity</param>
         /// <returns>The new <see cref="Equity"/> security</returns>
         [DocumentationAttribute(AddingData)]
-        public Equity AddEquity(string ticker, Resolution? resolution = null, string market = null, bool fillDataForward = true,
+        public Equity AddEquity(string ticker, Resolution? resolution = null, string market = null, bool fillForward = true,
             decimal leverage = Security.NullLeverage, bool extendedMarketHours = false, DataNormalizationMode? dataNormalizationMode = null)
         {
-            return AddSecurity<Equity>(SecurityType.Equity, ticker, resolution, market, fillDataForward, leverage, extendedMarketHours, normalizationMode: dataNormalizationMode);
+            return AddSecurity<Equity>(SecurityType.Equity, ticker, resolution, market, fillForward, leverage, extendedMarketHours, normalizationMode: dataNormalizationMode);
         }
 
         /// <summary>
@@ -1805,11 +1805,11 @@ namespace QuantConnect.Algorithm
         /// <param name="underlying">The underlying equity ticker</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
         /// <param name="market">The equity's market, <seealso cref="Market"/>. Default is value null and looked up using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Option"/> security</returns>
         [DocumentationAttribute(AddingData)]
-        public Option AddOption(string underlying, Resolution? resolution = null, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
+        public Option AddOption(string underlying, Resolution? resolution = null, string market = null, bool fillForward = true, decimal leverage = Security.NullLeverage)
         {
             if (market == null)
             {
@@ -1820,7 +1820,7 @@ namespace QuantConnect.Algorithm
             }
 
             var underlyingSymbol = QuantConnect.Symbol.Create(underlying, SecurityType.Equity, market);
-            return AddOption(underlyingSymbol, resolution, market, fillDataForward, leverage);
+            return AddOption(underlyingSymbol, resolution, market, fillForward, leverage);
         }
 
         /// <summary>
@@ -1831,14 +1831,14 @@ namespace QuantConnect.Algorithm
         /// <param name="underlying">Underlying asset Symbol to use as the option's underlying</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
         /// <param name="market">The option's market, <seealso cref="Market"/>. Default value is null, but will be resolved using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
-        /// <param name="fillDataForward">If true, data will be provided to the algorithm every Second, Minute, Hour, or Day, while the asset is open and depending on the Resolution this option was configured to use.</param>
+        /// <param name="fillForward">If true, data will be provided to the algorithm every Second, Minute, Hour, or Day, while the asset is open and depending on the Resolution this option was configured to use.</param>
         /// <param name="leverage">The requested leverage for the </param>
         /// <returns>The new option security instance</returns>
         /// <exception cref="KeyNotFoundException"></exception>
         [DocumentationAttribute(AddingData)]
-        public Option AddOption(Symbol underlying, Resolution? resolution = null, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
+        public Option AddOption(Symbol underlying, Resolution? resolution = null, string market = null, bool fillForward = true, decimal leverage = Security.NullLeverage)
         {
-            return AddOption(underlying, null, resolution, market, fillDataForward, leverage);
+            return AddOption(underlying, null, resolution, market, fillForward, leverage);
         }
 
         /// <summary>
@@ -1850,12 +1850,12 @@ namespace QuantConnect.Algorithm
         /// <param name="targetOption">The target option ticker. This is useful when the option ticker does not match the underlying, e.g. SPX index and the SPXW weekly option. If null is provided will use underlying</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
         /// <param name="market">The option's market, <seealso cref="Market"/>. Default value is null, but will be resolved using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
-        /// <param name="fillDataForward">If true, data will be provided to the algorithm every Second, Minute, Hour, or Day, while the asset is open and depending on the Resolution this option was configured to use.</param>
+        /// <param name="fillForward">If true, data will be provided to the algorithm every Second, Minute, Hour, or Day, while the asset is open and depending on the Resolution this option was configured to use.</param>
         /// <param name="leverage">The requested leverage for the </param>
         /// <returns>The new option security instance</returns>
         /// <exception cref="KeyNotFoundException"></exception>
         public Option AddOption(Symbol underlying, string targetOption, Resolution? resolution = null,
-            string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
+            string market = null, bool fillForward = true, decimal leverage = Security.NullLeverage)
         {
             var optionType = QuantConnect.Symbol.GetOptionTypeFromUnderlying(underlying);
 
@@ -1885,7 +1885,7 @@ namespace QuantConnect.Algorithm
                 canonicalSymbol = QuantConnect.Symbol.CreateCanonicalOption(underlying, targetOption, market, alias);
             }
 
-            return (Option)AddSecurity(canonicalSymbol, resolution, fillDataForward, leverage);
+            return (Option)AddSecurity(canonicalSymbol, resolution, fillForward, leverage);
         }
 
         /// <summary>
@@ -1894,7 +1894,7 @@ namespace QuantConnect.Algorithm
         /// <param name="ticker">The future ticker</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
         /// <param name="market">The futures market, <seealso cref="Market"/>. Default is value null and looked up using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the continuous future contract</param>
@@ -1904,7 +1904,7 @@ namespace QuantConnect.Algorithm
         /// <returns>The new <see cref="Future"/> security</returns>
         [DocumentationAttribute(AddingData)]
         public Future AddFuture(string ticker, Resolution? resolution = null, string market = null,
-            bool fillDataForward = true, decimal leverage = Security.NullLeverage, bool extendedMarketHours = false,
+            bool fillForward = true, decimal leverage = Security.NullLeverage, bool extendedMarketHours = false,
             DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0)
         {
             if (market == null)
@@ -1925,7 +1925,7 @@ namespace QuantConnect.Algorithm
                 canonicalSymbol = QuantConnect.Symbol.Create(ticker, SecurityType.Future, market, alias);
             }
 
-            return (Future)AddSecurity(canonicalSymbol, resolution, fillDataForward, leverage, extendedMarketHours, dataMappingMode: dataMappingMode,
+            return (Future)AddSecurity(canonicalSymbol, resolution, fillForward, leverage, extendedMarketHours, dataMappingMode: dataMappingMode,
                 dataNormalizationMode: dataNormalizationMode, contractDepthOffset: contractDepthOffset);
         }
 
@@ -1934,15 +1934,15 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">The futures contract symbol</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
         /// <returns>The new <see cref="Future"/> security</returns>
         [DocumentationAttribute(AddingData)]
-        public Future AddFutureContract(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true,
+        public Future AddFutureContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true,
             decimal leverage = Security.NullLeverage, bool extendedMarketHours = false)
         {
-            return (Future)AddSecurity(symbol, resolution, fillDataForward, leverage, extendedMarketHours);
+            return (Future)AddSecurity(symbol, resolution, fillForward, leverage, extendedMarketHours);
         }
 
         /// <summary>
@@ -1968,13 +1968,13 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">Option contract Symbol</param>
         /// <param name="resolution">Resolution of the option contract, i.e. the granularity of the data</param>
-        /// <param name="fillDataForward">If true, this will fill in missing data points with the previous data point</param>
+        /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
         /// <param name="leverage">The leverage to apply to the option contract</param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
         /// <returns>Option security</returns>
         /// <exception cref="ArgumentException">Symbol is canonical (i.e. a generic Symbol returned from <see cref="AddFuture"/> or <see cref="AddOption(string, Resolution?, string, bool, decimal)"/>)</exception>
         [DocumentationAttribute(AddingData)]
-        public Option AddFutureOptionContract(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true,
+        public Option AddFutureOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true,
             decimal leverage = Security.NullLeverage, bool extendedMarketHours = false)
         {
             if (symbol.IsCanonical())
@@ -1982,7 +1982,7 @@ namespace QuantConnect.Algorithm
                 throw new ArgumentException("Expected non-canonical Symbol (i.e. a Symbol representing a specific Future contract");
             }
 
-            return AddOptionContract(symbol, resolution, fillDataForward, leverage, extendedMarketHours);
+            return AddOptionContract(symbol, resolution, fillForward, leverage, extendedMarketHours);
         }
 
         /// <summary>
@@ -1991,15 +1991,15 @@ namespace QuantConnect.Algorithm
         /// <param name="ticker">The ticker of the Index Option</param>
         /// <param name="resolution">Resolution of the index option contracts, i.e. the granularity of the data</param>
         /// <param name="market">Market of the index option. If no market is provided, we default to <see cref="Market.USA"/> </param>
-        /// <param name="fillDataForward">If true, this will fill in missing data points with the previous data point</param>
+        /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
         /// <returns>Canonical Option security</returns>
         [DocumentationAttribute(AddingData)]
-        public Option AddIndexOption(string ticker, Resolution? resolution = null, string market = Market.USA, bool fillDataForward = true)
+        public Option AddIndexOption(string ticker, Resolution? resolution = null, string market = Market.USA, bool fillForward = true)
         {
             return AddIndexOption(
                 QuantConnect.Symbol.Create(ticker, SecurityType.Index, market),
                 resolution,
-                fillDataForward);
+                fillForward);
         }
 
         /// <summary>
@@ -2007,12 +2007,12 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">The Symbol of the <see cref="Security"/> returned from <see cref="AddIndex"/></param>
         /// <param name="resolution">Resolution of the index option contracts, i.e. the granularity of the data</param>
-        /// <param name="fillDataForward">If true, this will fill in missing data points with the previous data point</param>
+        /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
         /// <returns>Canonical Option security</returns>
         [DocumentationAttribute(AddingData)]
-        public Option AddIndexOption(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true)
+        public Option AddIndexOption(Symbol symbol, Resolution? resolution = null, bool fillForward = true)
         {
-            return AddIndexOption(symbol, null, resolution, fillDataForward);
+            return AddIndexOption(symbol, null, resolution, fillForward);
         }
 
         /// <summary>
@@ -2021,17 +2021,17 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">The Symbol of the <see cref="Security"/> returned from <see cref="AddIndex"/></param>
         /// <param name="targetOption">The target option ticker. This is useful when the option ticker does not match the underlying, e.g. SPX index and the SPXW weekly option. If null is provided will use underlying</param>
         /// <param name="resolution">Resolution of the index option contracts, i.e. the granularity of the data</param>
-        /// <param name="fillDataForward">If true, this will fill in missing data points with the previous data point</param>
+        /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
         /// <returns>Canonical Option security</returns>
         [DocumentationAttribute(AddingData)]
-        public Option AddIndexOption(Symbol symbol, string targetOption, Resolution? resolution = null, bool fillDataForward = true)
+        public Option AddIndexOption(Symbol symbol, string targetOption, Resolution? resolution = null, bool fillForward = true)
         {
             if (symbol.SecurityType != SecurityType.Index)
             {
                 throw new ArgumentException("Symbol provided must be of type SecurityType.Index");
             }
 
-            return AddOption(symbol, targetOption, resolution, symbol.ID.Market, fillDataForward);
+            return AddOption(symbol, targetOption, resolution, symbol.ID.Market, fillForward);
         }
 
         /// <summary>
@@ -2039,18 +2039,18 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">Symbol of the index option contract</param>
         /// <param name="resolution">Resolution of the index option contract, i.e. the granularity of the data</param>
-        /// <param name="fillDataForward">If true, this will fill in missing data points with the previous data point</param>
+        /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
         /// <returns>Index Option Contract</returns>
         /// <exception cref="ArgumentException">The provided Symbol is not an Index Option</exception>
         [DocumentationAttribute(AddingData)]
-        public Option AddIndexOptionContract(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true)
+        public Option AddIndexOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true)
         {
             if (symbol.SecurityType != SecurityType.IndexOption)
             {
                 throw new ArgumentException("Symbol provided must be of type SecurityType.IndexOption");
             }
 
-            return AddOptionContract(symbol, resolution, fillDataForward);
+            return AddOptionContract(symbol, resolution, fillForward);
         }
 
         /// <summary>
@@ -2058,12 +2058,12 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="symbol">The option contract symbol</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
         /// <returns>The new <see cref="Option"/> security</returns>
         [DocumentationAttribute(AddingData)]
-        public Option AddOptionContract(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true,
+        public Option AddOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true,
             decimal leverage = Security.NullLeverage, bool extendedMarketHours = false)
         {
             if(symbol == null || !symbol.SecurityType.IsOption() || symbol.Underlying == null)
@@ -2078,7 +2078,7 @@ namespace QuantConnect.Algorithm
             List<SubscriptionDataConfig> underlyingConfigs;
             if (!Securities.TryGetValue(underlying, out underlyingSecurity) || !underlyingSecurity.IsTradable)
             {
-                underlyingSecurity = AddSecurity(underlying, resolution, fillDataForward, leverage, extendedMarketHours);
+                underlyingSecurity = AddSecurity(underlying, resolution, fillForward, leverage, extendedMarketHours);
                 underlyingConfigs = SubscriptionManager.SubscriptionDataConfigService
                     .GetSubscriptionDataConfigs(underlying);
             }
@@ -2099,7 +2099,7 @@ namespace QuantConnect.Algorithm
                 }
             }
 
-            var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillDataForward, extendedMarketHours,
+            var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillForward, extendedMarketHours,
                 dataNormalizationMode: DataNormalizationMode.Raw);
             var option = (Option)Securities.CreateSecurity(symbol, configs, leverage, underlying: underlyingSecurity);
 
@@ -2145,13 +2145,13 @@ namespace QuantConnect.Algorithm
         /// <param name="ticker">The currency pair</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
         /// <param name="market">The foreign exchange trading market, <seealso cref="Market"/>. Default value is null and looked up using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Forex"/> security</returns>
         [DocumentationAttribute(AddingData)]
-        public Forex AddForex(string ticker, Resolution? resolution = null, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
+        public Forex AddForex(string ticker, Resolution? resolution = null, string market = null, bool fillForward = true, decimal leverage = Security.NullLeverage)
         {
-            return AddSecurity<Forex>(SecurityType.Forex, ticker, resolution, market, fillDataForward, leverage, false);
+            return AddSecurity<Forex>(SecurityType.Forex, ticker, resolution, market, fillForward, leverage, false);
         }
 
         /// <summary>
@@ -2160,13 +2160,13 @@ namespace QuantConnect.Algorithm
         /// <param name="ticker">The currency pair</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
         /// <param name="market">The cfd trading market, <seealso cref="Market"/>. Default value is null and looked up using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Cfd"/> security</returns>
         [DocumentationAttribute(AddingData)]
-        public Cfd AddCfd(string ticker, Resolution? resolution = null, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
+        public Cfd AddCfd(string ticker, Resolution? resolution = null, string market = null, bool fillForward = true, decimal leverage = Security.NullLeverage)
         {
-            return AddSecurity<Cfd>(SecurityType.Cfd, ticker, resolution, market, fillDataForward, leverage, false);
+            return AddSecurity<Cfd>(SecurityType.Cfd, ticker, resolution, market, fillForward, leverage, false);
         }
 
 
@@ -2176,12 +2176,12 @@ namespace QuantConnect.Algorithm
         /// <param name="ticker">The currency pair</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
         /// <param name="market">The index trading market, <seealso cref="Market"/>. Default value is null and looked up using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <returns>The new <see cref="Index"/> security</returns>
         [DocumentationAttribute(AddingData)]
-        public Index AddIndex(string ticker, Resolution? resolution = null, string market = null, bool fillDataForward = true)
+        public Index AddIndex(string ticker, Resolution? resolution = null, string market = null, bool fillForward = true)
         {
-            var index = AddSecurity<Index>(SecurityType.Index, ticker, resolution, market, fillDataForward, 1, false);
+            var index = AddSecurity<Index>(SecurityType.Index, ticker, resolution, market, fillForward, 1, false);
             return index;
         }
 
@@ -2191,13 +2191,13 @@ namespace QuantConnect.Algorithm
         /// <param name="ticker">The currency pair</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
         /// <param name="market">The cfd trading market, <seealso cref="Market"/>. Default value is null and looked up using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Crypto"/> security</returns>
         [DocumentationAttribute(AddingData)]
-        public Crypto AddCrypto(string ticker, Resolution? resolution = null, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
+        public Crypto AddCrypto(string ticker, Resolution? resolution = null, string market = null, bool fillForward = true, decimal leverage = Security.NullLeverage)
         {
-            return AddSecurity<Crypto>(SecurityType.Crypto, ticker, resolution, market, fillDataForward, leverage, false);
+            return AddSecurity<Crypto>(SecurityType.Crypto, ticker, resolution, market, fillForward, leverage, false);
         }
 
         /// <summary>
@@ -2206,13 +2206,13 @@ namespace QuantConnect.Algorithm
         /// <param name="ticker">The currency pair</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
         /// <param name="market">The cfd trading market, <seealso cref="Market"/>. Default value is null and looked up using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="CryptoFuture"/> security</returns>
         [DocumentationAttribute(AddingData)]
-        public CryptoFuture AddCryptoFuture(string ticker, Resolution? resolution = null, string market = null, bool fillDataForward = true, decimal leverage = Security.NullLeverage)
+        public CryptoFuture AddCryptoFuture(string ticker, Resolution? resolution = null, string market = null, bool fillForward = true, decimal leverage = Security.NullLeverage)
         {
-            return AddSecurity<CryptoFuture>(SecurityType.CryptoFuture, ticker, resolution, market, fillDataForward, leverage, false);
+            return AddSecurity<CryptoFuture>(SecurityType.CryptoFuture, ticker, resolution, market, fillForward, leverage, false);
         }
 
         /// <summary>
@@ -2327,7 +2327,7 @@ namespace QuantConnect.Algorithm
             // Defaults:extended market hours"      = true because we want events 24 hours,
             //          fillforward                 = false because only want to trigger when there's new custom data.
             //          leverage                    = 1 because no leverage on nonmarket data?
-            return AddData<T>(ticker, resolution, fillDataForward: false, leverage: 1m);
+            return AddData<T>(ticker, resolution, fillForward: false, leverage: 1m);
         }
 
         /// <summary>
@@ -2346,7 +2346,7 @@ namespace QuantConnect.Algorithm
             // Defaults:extended market hours"      = true because we want events 24 hours,
             //          fillforward                 = false because only want to trigger when there's new custom data.
             //          leverage                    = 1 because no leverage on nonmarket data?
-            return AddData<T>(underlying, resolution, fillDataForward: false, leverage: 1m);
+            return AddData<T>(underlying, resolution, fillForward: false, leverage: 1m);
         }
 
 
@@ -2356,15 +2356,15 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="ticker">Key/Ticker for data</param>
         /// <param name="resolution">Resolution of the Data Required</param>
-        /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
+        /// <param name="fillForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
         /// <remarks>Generic type T must implement base data</remarks>
         [DocumentationAttribute(AddingData)]
-        public Security AddData<T>(string ticker, Resolution? resolution, bool fillDataForward, decimal leverage = 1.0m)
+        public Security AddData<T>(string ticker, Resolution? resolution, bool fillForward, decimal leverage = 1.0m)
             where T : IBaseData, new()
         {
-            return AddData<T>(ticker, resolution, null, fillDataForward, leverage);
+            return AddData<T>(ticker, resolution, null, fillForward, leverage);
         }
 
         /// <summary>
@@ -2373,15 +2373,15 @@ namespace QuantConnect.Algorithm
         /// </summary>
         /// <param name="underlying">The underlying symbol for the custom data</param>
         /// <param name="resolution">Resolution of the Data Required</param>
-        /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
+        /// <param name="fillForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
         /// <remarks>Generic type T must implement base data</remarks>
         [DocumentationAttribute(AddingData)]
-        public Security AddData<T>(Symbol underlying, Resolution? resolution, bool fillDataForward, decimal leverage = 1.0m)
+        public Security AddData<T>(Symbol underlying, Resolution? resolution, bool fillForward, decimal leverage = 1.0m)
             where T : IBaseData, new()
         {
-            return AddData<T>(underlying, resolution, null, fillDataForward, leverage);
+            return AddData<T>(underlying, resolution, null, fillForward, leverage);
         }
 
         /// <summary>
@@ -2390,15 +2390,15 @@ namespace QuantConnect.Algorithm
         /// <param name="ticker">Key/Ticker for data</param>
         /// <param name="resolution">Resolution of the Data Required</param>
         /// <param name="timeZone">Specifies the time zone of the raw data</param>
-        /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
+        /// <param name="fillForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
         /// <remarks>Generic type T must implement base data</remarks>
         [DocumentationAttribute(AddingData)]
-        public Security AddData<T>(string ticker, Resolution? resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
+        public Security AddData<T>(string ticker, Resolution? resolution, DateTimeZone timeZone, bool fillForward = false, decimal leverage = 1.0m)
             where T : IBaseData, new()
         {
-            return AddData(typeof(T), ticker, resolution, timeZone, fillDataForward, leverage);
+            return AddData(typeof(T), ticker, resolution, timeZone, fillForward, leverage);
         }
 
         /// <summary>
@@ -2407,15 +2407,15 @@ namespace QuantConnect.Algorithm
         /// <param name="underlying">The underlying symbol for the custom data</param>
         /// <param name="resolution">Resolution of the Data Required</param>
         /// <param name="timeZone">Specifies the time zone of the raw data</param>
-        /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
+        /// <param name="fillForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
         /// <remarks>Generic type T must implement base data</remarks>
         [DocumentationAttribute(AddingData)]
-        public Security AddData<T>(Symbol underlying, Resolution? resolution, DateTimeZone timeZone, bool fillDataForward = false, decimal leverage = 1.0m)
+        public Security AddData<T>(Symbol underlying, Resolution? resolution, DateTimeZone timeZone, bool fillForward = false, decimal leverage = 1.0m)
             where T : IBaseData, new()
         {
-            return AddData(typeof(T), underlying, resolution, timeZone, fillDataForward, leverage);
+            return AddData(typeof(T), underlying, resolution, timeZone, fillForward, leverage);
         }
 
         /// <summary>
@@ -2426,11 +2426,11 @@ namespace QuantConnect.Algorithm
         /// <param name="properties">The properties of this new custom data</param>
         /// <param name="exchangeHours">The Exchange hours of this symbol</param>
         /// <param name="resolution">Resolution of the Data Required</param>
-        /// <param name="fillDataForward">When no data available on a tradebar, return the last data that was generated</param>
+        /// <param name="fillForward">When no data available on a tradebar, return the last data that was generated</param>
         /// <param name="leverage">Custom leverage per security</param>
         /// <returns>The new <see cref="Security"/></returns>
         [DocumentationAttribute(AddingData)]
-        public Security AddData<T>(string ticker, SymbolProperties properties, SecurityExchangeHours exchangeHours, Resolution? resolution = null, bool fillDataForward = false, decimal leverage = 1.0m)
+        public Security AddData<T>(string ticker, SymbolProperties properties, SecurityExchangeHours exchangeHours, Resolution? resolution = null, bool fillForward = false, decimal leverage = 1.0m)
             where T : IBaseData, new()
         {
             // Get the right key for storage of base type symbols
@@ -2440,7 +2440,7 @@ namespace QuantConnect.Algorithm
             SetDatabaseEntries(key, properties, exchangeHours);
 
             // Then add the data
-            return AddData(typeof(T), ticker, resolution, null, fillDataForward, leverage);
+            return AddData(typeof(T), ticker, resolution, null, fillForward, leverage);
         }
 
         /// <summary>
@@ -2651,7 +2651,7 @@ namespace QuantConnect.Algorithm
         /// Creates and adds a new <see cref="Security"/> to the algorithm
         /// </summary>
         [DocumentationAttribute(AddingData)]
-        private T AddSecurity<T>(SecurityType securityType, string ticker, Resolution? resolution, string market, bool fillDataForward, decimal leverage, bool extendedMarketHours,
+        private T AddSecurity<T>(SecurityType securityType, string ticker, Resolution? resolution, string market, bool fillForward, decimal leverage, bool extendedMarketHours,
             DataMappingMode? mappingMode = null, DataNormalizationMode? normalizationMode = null)
             where T : Security
         {
@@ -2671,7 +2671,7 @@ namespace QuantConnect.Algorithm
                 symbol = QuantConnect.Symbol.Create(ticker, securityType, market);
             }
 
-            var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillDataForward, extendedMarketHours,
+            var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillForward, extendedMarketHours,
                 dataNormalizationMode: normalizationMode ?? UniverseSettings.DataNormalizationMode,
                 dataMappingMode: mappingMode ?? UniverseSettings.DataMappingMode);
             var security = Securities.CreateSecurity(symbol, configs, leverage);

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -458,39 +458,39 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// <param name="symbol">Symbol Representation of the MarketType, e.g. AAPL</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily.</param>
         /// <param name="market">The market the requested security belongs to, such as 'usa' or 'fxcm'</param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice.</param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice.</param>
         /// <param name="leverage">leverage for this security</param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security</param>
         /// <param name="dataNormalizationMode">The price scaling mode to use for the security</param>
-        public Security AddSecurity(SecurityType securityType, string symbol, Resolution? resolution, string market, bool fillDataForward, decimal leverage, bool extendedMarketHours,
+        public Security AddSecurity(SecurityType securityType, string symbol, Resolution? resolution, string market, bool fillForward, decimal leverage, bool extendedMarketHours,
             DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null)
-            => _baseAlgorithm.AddSecurity(securityType, symbol, resolution, market, fillDataForward, leverage, extendedMarketHours, dataMappingMode, dataNormalizationMode);
+            => _baseAlgorithm.AddSecurity(securityType, symbol, resolution, market, fillForward, leverage, extendedMarketHours, dataMappingMode, dataNormalizationMode);
 
         /// <summary>
         /// Creates and adds a new single <see cref="Future"/> contract to the algorithm
         /// </summary>
         /// <param name="symbol">The futures contract symbol</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
         /// <returns>The new <see cref="Future"/> security</returns>
-        public Future AddFutureContract(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true, decimal leverage = 0m,
+        public Future AddFutureContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true, decimal leverage = 0m,
             bool extendedMarketHours = false)
-            => _baseAlgorithm.AddFutureContract(symbol, resolution, fillDataForward, leverage, extendedMarketHours);
+            => _baseAlgorithm.AddFutureContract(symbol, resolution, fillForward, leverage, extendedMarketHours);
 
         /// <summary>
         /// Creates and adds a new single <see cref="Option"/> contract to the algorithm
         /// </summary>
         /// <param name="symbol">The option contract symbol</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
         /// <returns>The new <see cref="Option"/> security</returns>
-        public Option AddOptionContract(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true, decimal leverage = 0m, bool extendedMarketHours = false)
-            => _baseAlgorithm.AddOptionContract(symbol, resolution, fillDataForward, leverage, extendedMarketHours);
+        public Option AddOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true, decimal leverage = 0m, bool extendedMarketHours = false)
+            => _baseAlgorithm.AddOptionContract(symbol, resolution, fillForward, leverage, extendedMarketHours);
 
         /// <summary>
         /// Invoked at the end of every time step. This allows the algorithm

--- a/Common/Data/HistoryRequestFactory.cs
+++ b/Common/Data/HistoryRequestFactory.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -45,6 +45,8 @@ namespace QuantConnect.Data
         /// <param name="endAlgoTz">History request end time in algorithm time zone</param>
         /// <param name="exchangeHours">Security exchange hours</param>
         /// <param name="resolution">The resolution to use. If null will use <see cref="SubscriptionDataConfig.Resolution"/></param>
+        /// <param name="fillForward">True to fill forward missing data, false otherwise</param>
+        /// <param name="extendedMarket">True to include extended market hours data, false otherwise</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security history request</param>
         /// <param name="dataNormalizationMode">The price scaling mode to use for the securities history</param>
         /// <param name="contractDepthOffset">The continuous contract desired offset from the current front month.
@@ -55,6 +57,8 @@ namespace QuantConnect.Data
             DateTime endAlgoTz,
             SecurityExchangeHours exchangeHours,
             Resolution? resolution,
+            bool? fillForward = null,
+            bool? extendedMarket = null,
             DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null,
             int? contractDepthOffset = null)
@@ -70,6 +74,12 @@ namespace QuantConnect.Data
                 dataType = LeanData.GetDataType(resolution.Value, subscription.TickType);
             }
 
+            var fillForwardResolution = subscription.FillDataForward ? resolution : null;
+            if (fillForward != null)
+            {
+                fillForwardResolution = fillForward.Value ? resolution : null;
+            }
+
             var request = new HistoryRequest(subscription,
                 exchangeHours,
                 startAlgoTz.ConvertToUtc(_algorithm.TimeZone),
@@ -77,9 +87,14 @@ namespace QuantConnect.Data
             {
                 DataType = dataType,
                 Resolution = resolution.Value,
-                FillForwardResolution = subscription.FillDataForward ? resolution : null,
+                FillForwardResolution = fillForwardResolution,
                 TickType = subscription.TickType
             };
+
+            if (extendedMarket != null)
+            {
+                request.IncludeExtendedMarketHours = extendedMarket.Value;
+            }
 
             if (dataMappingMode != null)
             {

--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -65,7 +65,7 @@ namespace QuantConnect.Data
         ///     is this output time zone, that is, the time zone that will be used on BaseData instances
         /// </param>
         /// <param name="isCustomData">True if this is custom user supplied data, false for normal QC data</param>
-        /// <param name="fillDataForward">when there is no data pass the last tradebar forward</param>
+        /// <param name="fillForward">when there is no data pass the last tradebar forward</param>
         /// <param name="extendedMarketHours">Request premarket data as well when true </param>
         /// <returns>
         ///     The newly created <see cref="SubscriptionDataConfig" /> or existing instance if it already existed
@@ -76,7 +76,7 @@ namespace QuantConnect.Data
             DateTimeZone timeZone,
             DateTimeZone exchangeTimeZone,
             bool isCustomData = false,
-            bool fillDataForward = true,
+            bool fillForward = true,
             bool extendedMarketHours = false
             )
         {
@@ -88,7 +88,7 @@ namespace QuantConnect.Data
             }
 
             var tickType = LeanData.GetCommonTickTypeForCommonDataTypes(dataType, symbol.SecurityType);
-            return Add(dataType, tickType, symbol, resolution, timeZone, exchangeTimeZone, isCustomData, fillDataForward,
+            return Add(dataType, tickType, symbol, resolution, timeZone, exchangeTimeZone, isCustomData, fillForward,
                 extendedMarketHours);
         }
 
@@ -105,7 +105,7 @@ namespace QuantConnect.Data
         ///     is this output time zone, that is, the time zone that will be used on BaseData instances
         /// </param>
         /// <param name="isCustomData">True if this is custom user supplied data, false for normal QC data</param>
-        /// <param name="fillDataForward">when there is no data pass the last tradebar forward</param>
+        /// <param name="fillForward">when there is no data pass the last tradebar forward</param>
         /// <param name="extendedMarketHours">Request premarket data as well when true </param>
         /// <param name="isInternalFeed">
         ///     Set to true to prevent data from this subscription from being sent into the algorithm's
@@ -127,14 +127,14 @@ namespace QuantConnect.Data
             DateTimeZone dataTimeZone,
             DateTimeZone exchangeTimeZone,
             bool isCustomData,
-            bool fillDataForward = true,
+            bool fillForward = true,
             bool extendedMarketHours = false,
             bool isInternalFeed = false,
             bool isFilteredSubscription = true,
             DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted
             )
         {
-            return SubscriptionDataConfigService.Add(symbol, resolution, fillDataForward,
+            return SubscriptionDataConfigService.Add(symbol, resolution, fillForward,
                 extendedMarketHours, isFilteredSubscription, isInternalFeed, isCustomData,
                 new List<Tuple<Type, TickType>> {new Tuple<Type, TickType>(dataType, tickType)},
                 dataNormalizationMode).First();

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -598,12 +598,12 @@ namespace QuantConnect.Interfaces
         /// <param name="symbol">Symbol Representation of the MarketType, e.g. AAPL</param>
         /// <param name="resolution">Resolution of the MarketType required: MarketData, Second or Minute</param>
         /// <param name="market">The market the requested security belongs to, such as 'usa' or 'fxcm'</param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice.</param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice.</param>
         /// <param name="leverage">leverage for this security</param>
         /// <param name="extendedMarketHours">ExtendedMarketHours send in data from 4am - 8pm, not used for FOREX</param>
         /// <param name="dataMappingMode">The contract mapping mode to use for the security</param>
         /// <param name="dataNormalizationMode">The price scaling mode to use for the security</param>
-        Security AddSecurity(SecurityType securityType, string symbol, Resolution? resolution, string market, bool fillDataForward, decimal leverage, bool extendedMarketHours,
+        Security AddSecurity(SecurityType securityType, string symbol, Resolution? resolution, string market, bool fillForward, decimal leverage, bool extendedMarketHours,
             DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null);
 
         /// <summary>
@@ -611,22 +611,22 @@ namespace QuantConnect.Interfaces
         /// </summary>
         /// <param name="symbol">The futures contract symbol</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">Show the after market data as well</param>
         /// <returns>The new <see cref="Future"/> security</returns>
-        Future AddFutureContract(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true, decimal leverage = 0m, bool extendedMarketHours = false);
+        Future AddFutureContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true, decimal leverage = 0m, bool extendedMarketHours = false);
 
         /// <summary>
         /// Creates and adds a new single <see cref="Option"/> contract to the algorithm
         /// </summary>
         /// <param name="symbol">The option contract symbol</param>
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
-        /// <param name="fillDataForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">Show the after market data as well</param>
         /// <returns>The new <see cref="Option"/> security</returns>
-        Option AddOptionContract(Symbol symbol, Resolution? resolution = null, bool fillDataForward = true, decimal leverage = 0m, bool extendedMarketHours = false);
+        Option AddOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true, decimal leverage = 0m, bool extendedMarketHours = false);
 
         /// <summary>
         /// Removes the security with the specified symbol. This will cancel all

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -364,22 +364,22 @@ namespace QuantConnect.Research
                     if (symbol.Underlying.SecurityType == SecurityType.Equity)
                     {
                         // only add underlying if not present
-                        AddEquity(symbol.Underlying.Value, resolutionToUseForUnderlying, fillDataForward: fillForward,
+                        AddEquity(symbol.Underlying.Value, resolutionToUseForUnderlying, fillForward: fillForward,
                             extendedMarketHours: extendedMarket);
                     }
                     else if (symbol.Underlying.SecurityType == SecurityType.Index)
                     {
                         // only add underlying if not present
-                        AddIndex(symbol.Underlying.Value, resolutionToUseForUnderlying, fillDataForward: fillForward);
+                        AddIndex(symbol.Underlying.Value, resolutionToUseForUnderlying, fillForward: fillForward);
                     }
                     else if(symbol.Underlying.SecurityType == SecurityType.Future && symbol.Underlying.IsCanonical())
                     {
-                        AddFuture(symbol.Underlying.ID.Symbol, resolutionToUseForUnderlying, fillDataForward: fillForward,
+                        AddFuture(symbol.Underlying.ID.Symbol, resolutionToUseForUnderlying, fillForward: fillForward,
                             extendedMarketHours: extendedMarket);
                     }
                     else if (symbol.Underlying.SecurityType == SecurityType.Future)
                     {
-                        AddFutureContract(symbol.Underlying, resolutionToUseForUnderlying, fillDataForward: fillForward,
+                        AddFutureContract(symbol.Underlying, resolutionToUseForUnderlying, fillForward: fillForward,
                             extendedMarketHours: extendedMarket);
                     }
                 }

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -400,7 +400,7 @@ def getTickHistory(algorithm, symbol, start, end):
             if (language == Language.CSharp)
             {
                 _algorithm.History(new [] {Symbols.SPY}, new DateTime(1,1,1,1,1,1), new DateTime(1, 1, 1, 1, 1, 2), Resolution.Tick,
-                    fillDataForward: true);
+                    fillForward: true);
             }
             else
             {
@@ -409,7 +409,7 @@ def getTickHistory(algorithm, symbol, start, end):
                     _algorithm.SetPandasConverter();
                     using var symbols = new PyList(new [] {Symbols.SPY.ToPython()});
                     _algorithm.History(symbols, new DateTime(1,1,1,1,1,1), new DateTime(1, 1, 1, 1, 1, 2),
-                        Resolution.Tick, fillDataForward: true);
+                        Resolution.Tick, fillForward: true);
                 }
             }
 
@@ -671,7 +671,7 @@ def getOpenInterestHistory(algorithm, symbol, start, end, resolution):
 
             if (language == Language.CSharp)
             {
-                var result = _algorithm.History(new[] { optionSymbol }, start, end, historyResolution, fillDataForward:false).ToList();
+                var result = _algorithm.History(new[] { optionSymbol }, start, end, historyResolution, fillForward:false).ToList();
 
                 Assert.AreEqual(53, result.Count);
                 Assert.IsTrue(result.Any(slice => slice.ContainsKey(optionSymbol)));
@@ -720,7 +720,7 @@ def getOpenInterestHistory(algorithm, symbol, start, end, resolution):
 
             if (language == Language.CSharp)
             {
-                var result = _algorithm.History(new[] { optionSymbol, optionSymbol2 }, start, end, historyResolution, fillDataForward: false).ToList();
+                var result = _algorithm.History(new[] { optionSymbol, optionSymbol2 }, start, end, historyResolution, fillForward: false).ToList();
 
                 Assert.AreEqual(415, result.Count);
                 Assert.IsTrue(result.Any(slice => slice.ContainsKey(optionSymbol)));
@@ -1578,43 +1578,43 @@ def getOpenInterestHistory(algorithm, symbol, start, end):
             if (language == Language.CSharp)
             {
                 // No symbol, time span
-                var noSymbolTimeSpanHistory = algorithm.History(timeSpan, resolution, fillDataForward: fillForward).ToList();
+                var noSymbolTimeSpanHistory = algorithm.History(timeSpan, resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(noSymbolTimeSpanHistory, expectedHistoryCount, resolution, fillForward);
 
                 // No symbol, periods
-                var noSymbolPeriodBasedHistory = algorithm.History(periods, resolution, fillDataForward: fillForward).ToList();
+                var noSymbolPeriodBasedHistory = algorithm.History(periods, resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(noSymbolPeriodBasedHistory, expectedHistoryCount, resolution, fillForward);
 
                 // No symbol, date range
                 // TODO: to be implemented
 
                 // Single symbol, time span
-                var singleSymbolTimeSpanHistory = algorithm.History(symbol, timeSpan, resolution, fillDataForward: fillForward).ToList();
+                var singleSymbolTimeSpanHistory = algorithm.History(symbol, timeSpan, resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(singleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Single symbol, periods
-                var singleSymbolPeriodBasedHistory = algorithm.History(symbol, periods, resolution, fillDataForward: fillForward).ToList();
+                var singleSymbolPeriodBasedHistory = algorithm.History(symbol, periods, resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(singleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Single symbol, date range
                 var singleSymbolDateRangeHistory = algorithm.History(symbol, start, end,
-                    resolution, fillDataForward: fillForward).ToList();
+                    resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(singleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Symbol array, time span
-                var symbolsTimeSpanHistory = algorithm.History(new[] { symbol }, timeSpan, resolution, fillDataForward: fillForward).ToList();
+                var symbolsTimeSpanHistory = algorithm.History(new[] { symbol }, timeSpan, resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(symbolsTimeSpanHistory, expectedHistoryCount, resolution, fillForward);
 
                 // Symbol array, periods
-                var symbolsPeriodBasedHistory = algorithm.History(new[] { symbol }, periods, resolution, fillDataForward: fillForward).ToList();
+                var symbolsPeriodBasedHistory = algorithm.History(new[] { symbol }, periods, resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(symbolsPeriodBasedHistory, expectedHistoryCount, resolution, fillForward);
 
                 // Symbol array, date range
-                var symbolsdateRangeHistory = algorithm.History(new[] { symbol }, start, end, resolution, fillDataForward: fillForward).ToList();
+                var symbolsdateRangeHistory = algorithm.History(new[] { symbol }, start, end, resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(symbolsdateRangeHistory, expectedHistoryCount, resolution, fillForward);
 
                 // Generic, no symbol, time span
-                var typedNoSymbolTimeSpanHistory = algorithm.History<TradeBar>(timeSpan, resolution, fillDataForward: fillForward).ToList();
+                var typedNoSymbolTimeSpanHistory = algorithm.History<TradeBar>(timeSpan, resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(typedNoSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, no symbol, periods
@@ -1625,32 +1625,32 @@ def getOpenInterestHistory(algorithm, symbol, start, end):
 
                 // Generic, single symbol, time span
                 var typedSingleSymbolTimeSpanHistory = algorithm.History<TradeBar>(symbol, timeSpan,
-                    resolution, fillDataForward: fillForward).ToList();
+                    resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(typedSingleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, single symbol, periods
                 var typedSingleSymbolPeriodBasedHistory = algorithm.History<TradeBar>(symbol, periods,
-                    resolution, fillDataForward: fillForward).ToList();
+                    resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(typedSingleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, single symbol, date range
                 var typedSingleSymbolDateRangeHistory = algorithm.History<TradeBar>(symbol, start, end,
-                    resolution, fillDataForward: fillForward).ToList();
+                    resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(typedSingleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, symbol array, time span
                 var typedSymbolsTimeSpanHistory = algorithm.History<TradeBar>(new[] { symbol }, timeSpan,
-                    resolution, fillDataForward: fillForward).ToList();
+                    resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(typedSymbolsTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, symbol array, periods
                 var typedSymbolsPeriodBasedHistory = algorithm.History<TradeBar>(new[] { symbol }, periods,
-                    resolution, fillDataForward: fillForward).ToList();
+                    resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(typedSymbolsPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, symbol array, date range
                 var typedSymbolsDateRangeHistory = algorithm.History<TradeBar>(new[] { symbol }, start, end,
-                    resolution, fillDataForward: fillForward).ToList();
+                    resolution, fillForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(typedSymbolsDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
             }
             else
@@ -1669,71 +1669,71 @@ tradeBar = TradeBar
                     using var pyTradeBarType = testModule.GetAttr("tradeBar");
 
                     // Single symbol, time span
-                    var singleSymbolTimeSpanHistory = algorithm.History(pySymbol, timeSpan, resolution, fillDataForward: fillForward);
+                    var singleSymbolTimeSpanHistory = algorithm.History(pySymbol, timeSpan, resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(singleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Single symbol, periods
-                    var singleSymbolPeriodBasedHistory = algorithm.History(pySymbol, periods, resolution, fillDataForward: fillForward);
+                    var singleSymbolPeriodBasedHistory = algorithm.History(pySymbol, periods, resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(singleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Single symbol, date range
-                    var singleSymbolDateRangeHistory = algorithm.History(pySymbol, start, end, resolution, fillDataForward: fillForward);
+                    var singleSymbolDateRangeHistory = algorithm.History(pySymbol, start, end, resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(singleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Symbol array, time span
-                    var symbolsTimeSpanHistory = algorithm.History(pySymbols, timeSpan, resolution, fillDataForward: fillForward);
+                    var symbolsTimeSpanHistory = algorithm.History(pySymbols, timeSpan, resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(symbolsTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Symbol array, periods
-                    var symbolsPeriodBasedHistory = algorithm.History(pySymbols, periods, resolution, fillDataForward: fillForward);
+                    var symbolsPeriodBasedHistory = algorithm.History(pySymbols, periods, resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(symbolsPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Symbol array, date range
-                    var symbolsDateRangeHistory = algorithm.History(pySymbols, start, end, resolution, fillDataForward: fillForward);
+                    var symbolsDateRangeHistory = algorithm.History(pySymbols, start, end, resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(symbolsDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, single symbol, time span
                     var typedSingleSymbolTimeSpanHistory = algorithm.History(pyTradeBarType, pySymbol, timeSpan,
-                        resolution, fillDataForward: fillForward);
+                        resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(typedSingleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Same as previous but using a Symbol instead of pySymbol
-                    typedSingleSymbolTimeSpanHistory = algorithm.History(pyTradeBarType, symbol, timeSpan, resolution, fillDataForward: fillForward);
+                    typedSingleSymbolTimeSpanHistory = algorithm.History(pyTradeBarType, symbol, timeSpan, resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(typedSingleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, single symbol, periods
                     var typedSingleSymbolPeriodBasedHistory = algorithm.History(pyTradeBarType, pySymbol, periods,
-                        resolution, fillDataForward: fillForward);
+                        resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(typedSingleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Same as previous but using a Symbol instead of pySymbol
                     typedSingleSymbolPeriodBasedHistory = algorithm.History(pyTradeBarType, symbol, periods,
-                        resolution, fillDataForward: fillForward);
+                        resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(typedSingleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, single symbol, date range
                     var typedSingleSymbolDateRangeHistory = algorithm.History(pyTradeBarType, pySymbol, start, end,
-                        resolution, fillDataForward: fillForward);
+                        resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(typedSingleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Same as previous but using a Symbol instead of pySymbol
                     typedSingleSymbolDateRangeHistory = algorithm.History(pyTradeBarType, symbol, start, end,
-                        resolution, fillDataForward: fillForward);
+                        resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(typedSingleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, symbol array, time span
                     var typedSymbolsTimeSpanHistory = algorithm.History(pyTradeBarType, pySymbols, timeSpan,
-                        resolution, fillDataForward: fillForward);
+                        resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(typedSymbolsTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, symbol array, periods
                     var typedSymbolsPeriodBasedHistory = algorithm.History(pyTradeBarType, pySymbols, periods,
-                        resolution, fillDataForward: fillForward);
+                        resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(typedSymbolsPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, symbol array, date range
                     var typedSymbolsDateRangeHistory = algorithm.History(pyTradeBarType, pySymbols, start, end,
-                        resolution, fillDataForward: fillForward);
+                        resolution, fillForward: fillForward);
                     AssertFillForwardHistoryResults(typedSymbolsDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
                 }
             }

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -1554,131 +1554,68 @@ def getOpenInterestHistory(algorithm, symbol, start, end):
             }
         }
 
-        [TestCase(Language.CSharp, Resolution.Second, 46800, 22884, 46800, 16093)]
-        [TestCase(Language.Python, Resolution.Second, 46800, 22884, 46800, 16093)]
-        [TestCase(Language.CSharp, Resolution.Minute, 780, 390, 780, 390)]
-        [TestCase(Language.Python, Resolution.Minute, 780, 390, 780, 390)]
-        public void HistoryRequestWithFillForward(Language language, Resolution resolution,
-            int historyWithFillForwardExpectedCount, int historyWithoutFillForwardExpectedCount,
-            int tradeBarOnlyHistoryWithFillForwardExpectedCount, int tradeBarOnlyHistoryWithoutFillForwardExpectedCount)
+        // C#
+        [TestCase(Language.CSharp, Resolution.Second, true, 46800, 46800, 46800)]
+        [TestCase(Language.CSharp, Resolution.Second, false, 46800, 22884, 16093)]
+        [TestCase(Language.CSharp, Resolution.Minute, true, 780, 780, 780)]
+        [TestCase(Language.CSharp, Resolution.Minute, false, 780, 390, 390)]
+        // Python
+        [TestCase(Language.Python, Resolution.Second, true, 46800, 46800, 46800)]
+        [TestCase(Language.Python, Resolution.Second, false, 46800, 22884, 16093)]
+        [TestCase(Language.Python, Resolution.Minute, true, 780, 780, 780)]
+        [TestCase(Language.Python, Resolution.Minute, false, 780, 390, 390)]
+        public void HistoryRequestWithFillForward(Language language, Resolution resolution, bool fillForward, int periods,
+            int expectedHistoryCount, int expectedTradeBarOnlyHistoryCount)
         {
             // Theres data only for 2013-10-07 to 2013-10-11 for SPY. Data should be fill forwarded till the 15th.
             var start = new DateTime(2013, 10, 11);
             var end = new DateTime(2013, 10, 15);
+            var timeSpan = end - start;
+
             var algorithm = GetAlgorithm(end);
             var symbol = algorithm.AddEquity("SPY").Symbol;
-
-            var periods = historyWithFillForwardExpectedCount;
-            var timeSpan = end - start;
 
             if (language == Language.CSharp)
             {
                 // No symbol, time span
-                var noSymbolTimeSpanHistoryWithFillForward = algorithm.History(timeSpan, resolution, fillForward: true).ToList();
-                var noSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(timeSpan, resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    noSymbolTimeSpanHistoryWithFillForward,
-                    noSymbolTimeSpanHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount,
-                    resolution);
+                var noSymbolTimeSpanHistory = algorithm.History(timeSpan, resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(noSymbolTimeSpanHistory, expectedHistoryCount, resolution, fillForward);
 
                 // No symbol, periods
-                var noSymbolPeriodBasedHistoryWithFillForward = algorithm.History(periods, resolution, fillForward: true).ToList();
-                var noSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(periods, resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    noSymbolPeriodBasedHistoryWithFillForward,
-                    noSymbolPeriodBasedHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount,
-                    resolution);
+                var noSymbolPeriodBasedHistory = algorithm.History(periods, resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(noSymbolPeriodBasedHistory, expectedHistoryCount, resolution, fillForward);
 
                 // No symbol, date range
                 // TODO: to be implemented
 
                 // Single symbol, time span
-                var singleSymbolTimeSpanHistoryWithFillForward = algorithm.History(symbol, timeSpan,
-                    resolution, fillForward: true).ToList();
-                var singleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(symbol, timeSpan,
-                    resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    singleSymbolTimeSpanHistoryWithFillForward,
-                    singleSymbolTimeSpanHistoryWithoutFillForward,
-                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                    resolution);
+                var singleSymbolTimeSpanHistory = algorithm.History(symbol, timeSpan, resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(singleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Single symbol, periods
-                var singleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(symbol, periods,
-                    resolution, fillForward: true).ToList();
-                var singleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(symbol, periods,
-                    resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    singleSymbolPeriodBasedHistoryWithFillForward,
-                    singleSymbolPeriodBasedHistoryWithoutFillForward,
-                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                    resolution);
+                var singleSymbolPeriodBasedHistory = algorithm.History(symbol, periods, resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(singleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Single symbol, date range
-                var singleSymbolDateRangeHistoryWithFillForward = algorithm.History(symbol, start, end,
-                    resolution, fillForward: true).ToList();
-                var singleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(symbol, start, end,
-                    resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    singleSymbolDateRangeHistoryWithFillForward,
-                    singleSymbolDateRangeHistoryWithoutFillForward,
-                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                    resolution);
+                var singleSymbolDateRangeHistory = algorithm.History(symbol, start, end,
+                    resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(singleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Symbol array, time span
-                var symbolsTimeSpanHistoryWithFillForward = algorithm.History(new[] { symbol }, timeSpan,
-                    resolution, fillForward: true).ToList();
-                var symbolsTimeSpanHistoryWithoutFillForward = algorithm.History(new[] { symbol }, timeSpan,
-                    resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    symbolsTimeSpanHistoryWithFillForward,
-                    symbolsTimeSpanHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount,
-                    resolution);
+                var symbolsTimeSpanHistory = algorithm.History(new[] { symbol }, timeSpan, resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(symbolsTimeSpanHistory, expectedHistoryCount, resolution, fillForward);
 
                 // Symbol array, periods
-                var symbolsPeriodBasedHistoryWithFillForward = algorithm.History(new[] { symbol }, periods,
-                    resolution, fillForward: true).ToList();
-                var symbolsPeriodBasedHistoryWithoutFillForward = algorithm.History(new[] { symbol }, periods,
-                    resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    symbolsPeriodBasedHistoryWithFillForward,
-                    symbolsPeriodBasedHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount,
-                    resolution);
+                var symbolsPeriodBasedHistory = algorithm.History(new[] { symbol }, periods, resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(symbolsPeriodBasedHistory, expectedHistoryCount, resolution, fillForward);
 
                 // Symbol array, date range
-                var symbolsdateRangeHistoryWithFillForward = algorithm.History(new[] { symbol }, start, end,
-                    resolution, fillForward: true).ToList();
-                var symbolsdateRangeHistoryWithoutFillForward = algorithm.History(new[] { symbol }, start, end,
-                    resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    symbolsdateRangeHistoryWithFillForward,
-                    symbolsdateRangeHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount,
-                    resolution);
+                var symbolsdateRangeHistory = algorithm.History(new[] { symbol }, start, end, resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(symbolsdateRangeHistory, expectedHistoryCount, resolution, fillForward);
 
                 // Generic, no symbol, time span
-                var typedNoSymbolTimeSpanHistoryWithFillForward = algorithm.History<TradeBar>(timeSpan,
-                    resolution, fillForward: true).ToList();
-                var typedNoSymbolTimeSpanHistoryWithoutFillForward = algorithm.History<TradeBar>(timeSpan,
-                    resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    typedNoSymbolTimeSpanHistoryWithFillForward,
-                    typedNoSymbolTimeSpanHistoryWithoutFillForward,
-                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                    resolution);
+                var typedNoSymbolTimeSpanHistory = algorithm.History<TradeBar>(timeSpan, resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(typedNoSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, no symbol, periods
                 // TODO: to be implemented
@@ -1687,76 +1624,33 @@ def getOpenInterestHistory(algorithm, symbol, start, end):
                 // TODO: to be implemented
 
                 // Generic, single symbol, time span
-                var typedSingleSymbolTimeSpanHistoryWithFillForward = algorithm.History<TradeBar>(symbol, timeSpan,
-                    resolution, fillForward: true).ToList();
-                var typedSingleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History<TradeBar>(symbol, timeSpan,
-                    resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    typedSingleSymbolTimeSpanHistoryWithFillForward,
-                    typedSingleSymbolTimeSpanHistoryWithoutFillForward,
-                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                    resolution);
+                var typedSingleSymbolTimeSpanHistory = algorithm.History<TradeBar>(symbol, timeSpan, resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(typedSingleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, single symbol, periods
-                var typedSingleSymbolPeriodBasedHistoryWithFillForward = algorithm.History<TradeBar>(symbol, periods,
-                    resolution, fillForward: true).ToList();
-                var typedSingleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History<TradeBar>(symbol, periods,
-                    resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    typedSingleSymbolPeriodBasedHistoryWithFillForward,
-                    typedSingleSymbolPeriodBasedHistoryWithoutFillForward,
-                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                    resolution);
+                var typedSingleSymbolPeriodBasedHistory = algorithm.History<TradeBar>(symbol, periods,
+                    resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(typedSingleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, single symbol, date range
-                var typedSingleSymbolDateRangeHistoryWithFillForward = algorithm.History<TradeBar>(symbol, start, end,
-                    resolution, fillForward: true).ToList();
-                var typedSingleSymbolDateRangeHistoryWithoutFillForward = algorithm.History<TradeBar>(symbol, start, end,
-                    resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    typedSingleSymbolDateRangeHistoryWithFillForward,
-                    typedSingleSymbolDateRangeHistoryWithoutFillForward,
-                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                    resolution);
+                var typedSingleSymbolDateRangeHistory = algorithm.History<TradeBar>(symbol, start, end,
+                    resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(typedSingleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, symbol array, time span
-                var typedSymbolsTimeSpanHistoryWithFillForward = algorithm.History<TradeBar>(new[] { symbol }, timeSpan,
-                    resolution, fillForward: true).ToList();
-                var typedSymbolsTimeSpanHistoryWithoutFillForward = algorithm.History<TradeBar>(new[] { symbol }, timeSpan,
-                    resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    typedSymbolsTimeSpanHistoryWithFillForward,
-                    typedSymbolsTimeSpanHistoryWithoutFillForward,
-                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                    resolution);
+                var typedSymbolsTimeSpanHistory = algorithm.History<TradeBar>(new[] { symbol }, timeSpan,
+                    resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(typedSymbolsTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, symbol array, periods
-                var typedSymbolsPeriodBasedHistoryWithFillForward = algorithm.History<TradeBar>(new[] { symbol }, periods,
-                    resolution, fillForward: true).ToList();
-                var typedSymbolsPeriodBasedHistoryWithoutFillForward = algorithm.History<TradeBar>(new[] { symbol }, periods,
-                    resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    typedSymbolsPeriodBasedHistoryWithFillForward,
-                    typedSymbolsPeriodBasedHistoryWithoutFillForward,
-                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                    resolution);
+                var typedSymbolsPeriodBasedHistory = algorithm.History<TradeBar>(new[] { symbol }, periods,
+                    resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(typedSymbolsPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, symbol array, date range
-                var typedSymbolsDateRangeHistoryWithFillForward = algorithm.History<TradeBar>(new[] { symbol }, start, end,
-                    resolution, fillForward: true).ToList();
-                var typedSymbolsDateRangeHistoryWithoutFillForward = algorithm.History<TradeBar>(new[] { symbol }, start, end,
-                    resolution, fillForward: false).ToList();
-                AssertFillForwardHistoryResults(
-                    typedSymbolsDateRangeHistoryWithFillForward,
-                    typedSymbolsDateRangeHistoryWithoutFillForward,
-                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                    resolution);
+                var typedSymbolsDateRangeHistory = algorithm.History<TradeBar>(new[] { symbol }, start, end,
+                    resolution, fillForward: fillForward).ToList();
+                AssertFillForwardHistoryResults(typedSymbolsDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
             }
             else
             {
@@ -1774,172 +1668,68 @@ tradeBar = TradeBar
                     using var pyTradeBarType = testModule.GetAttr("tradeBar");
 
                     // Single symbol, time span
-                    var singleSymbolTimeSpanHistoryWithFillForward = algorithm.History(pySymbol, timeSpan, resolution, fillForward: true);
-                    var singleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(pySymbol, timeSpan, resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        singleSymbolTimeSpanHistoryWithFillForward,
-                        singleSymbolTimeSpanHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    var singleSymbolTimeSpanHistory = algorithm.History(pySymbol, timeSpan, resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(singleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Single symbol, periods
-                    var singleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(pySymbol, periods, resolution, fillForward: true);
-                    var singleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(pySymbol, periods, resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        singleSymbolPeriodBasedHistoryWithFillForward,
-                        singleSymbolPeriodBasedHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    var singleSymbolPeriodBasedHistory = algorithm.History(pySymbol, periods, resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(singleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Single symbol, date range
-                    var singleSymbolDateRangeHistoryWithFillForward = algorithm.History(pySymbol, start, end, resolution, fillForward: true);
-                    var singleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(pySymbol, start, end, resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        singleSymbolDateRangeHistoryWithFillForward,
-                        singleSymbolDateRangeHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    var singleSymbolDateRangeHistory = algorithm.History(pySymbol, start, end, resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(singleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Symbol array, time span
-                    var symbolsTimeSpanHistoryWithFillForward = algorithm.History(pySymbols, timeSpan, resolution, fillForward: true);
-                    var symbolsTimeSpanHistoryWithoutFillForward = algorithm.History(pySymbols, timeSpan, resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        symbolsTimeSpanHistoryWithFillForward,
-                        symbolsTimeSpanHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    var symbolsTimeSpanHistory = algorithm.History(pySymbols, timeSpan, resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(symbolsTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Symbol array, periods
-                    var symbolsPeriodBasedHistoryWithFillForward = algorithm.History(pySymbols, periods, resolution, fillForward: true);
-                    var symbolsPeriodBasedHistoryWithoutFillForward = algorithm.History(pySymbols, periods, resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        symbolsPeriodBasedHistoryWithFillForward,
-                        symbolsPeriodBasedHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    var symbolsPeriodBasedHistory = algorithm.History(pySymbols, periods, resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(symbolsPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Symbol array, date range
-                    var symbolsDateRangeHistoryWithFillForward = algorithm.History(pySymbols, start, end, resolution, fillForward: true);
-                    var symbolsDateRangeHistoryWithoutFillForward = algorithm.History(pySymbols, start, end, resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        symbolsDateRangeHistoryWithFillForward,
-                        symbolsDateRangeHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    var symbolsDateRangeHistory = algorithm.History(pySymbols, start, end, resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(symbolsDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, single symbol, time span
-                    var typedSingleSymbolTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbol, timeSpan,
-                        resolution, fillForward: true);
-                    var typedSingleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbol, timeSpan,
-                        resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        typedSingleSymbolTimeSpanHistoryWithFillForward,
-                        typedSingleSymbolTimeSpanHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    var typedSingleSymbolTimeSpanHistory = algorithm.History(pyTradeBarType, pySymbol, timeSpan,
+                        resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(typedSingleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Same as previous but using a Symbol instead of pySymbol
-                    typedSingleSymbolTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, symbol, timeSpan,
-                        resolution, fillForward: true);
-                    typedSingleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(pyTradeBarType, symbol, timeSpan,
-                        resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        typedSingleSymbolTimeSpanHistoryWithFillForward,
-                        typedSingleSymbolTimeSpanHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    typedSingleSymbolTimeSpanHistory = algorithm.History(pyTradeBarType, symbol, timeSpan, resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(typedSingleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, single symbol, periods
-                    var typedSingleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbol, periods,
-                        resolution, fillForward: true);
-                    var typedSingleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbol, periods,
-                        resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        typedSingleSymbolPeriodBasedHistoryWithFillForward,
-                        typedSingleSymbolPeriodBasedHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    var typedSingleSymbolPeriodBasedHistory = algorithm.History(pyTradeBarType, pySymbol, periods,
+                        resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(typedSingleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Same as previous but using a Symbol instead of pySymbol
-                    typedSingleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(pyTradeBarType, symbol, periods,
-                        resolution, fillForward: true);
-                    typedSingleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(pyTradeBarType, symbol, periods,
-                        resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        typedSingleSymbolPeriodBasedHistoryWithFillForward,
-                        typedSingleSymbolPeriodBasedHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    typedSingleSymbolPeriodBasedHistory = algorithm.History(pyTradeBarType, symbol, periods, resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(typedSingleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, single symbol, date range
-                    var typedSingleSymbolDateRangeHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbol, start, end,
-                        resolution, fillForward: true);
-                    var typedSingleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbol, start, end,
-                        resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        typedSingleSymbolDateRangeHistoryWithFillForward,
-                        typedSingleSymbolDateRangeHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    var typedSingleSymbolDateRangeHistory = algorithm.History(pyTradeBarType, pySymbol, start, end,
+                        resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(typedSingleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Same as previous but using a Symbol instead of pySymbol
-                    typedSingleSymbolDateRangeHistoryWithFillForward = algorithm.History(pyTradeBarType, symbol, start, end,
-                        resolution, fillForward: true);
-                    typedSingleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(pyTradeBarType, symbol, start, end,
-                        resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        typedSingleSymbolDateRangeHistoryWithFillForward,
-                        typedSingleSymbolDateRangeHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    typedSingleSymbolDateRangeHistory = algorithm.History(pyTradeBarType, symbol, start, end, resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(typedSingleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, symbol array, time span
-                    var typedSymbolsTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbols, timeSpan,
-                        resolution, fillForward: true);
-                    var typedSymbolsTimeSpanHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbols, timeSpan,
-                        resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        typedSymbolsTimeSpanHistoryWithFillForward,
-                        typedSymbolsTimeSpanHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    var typedSymbolsTimeSpanHistory = algorithm.History(pyTradeBarType, pySymbols, timeSpan, resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(typedSymbolsTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, symbol array, periods
-                    var typedSymbolsPeriodBasedHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbols, periods,
-                        resolution, fillForward: true);
-                    var typedSymbolsPeriodBasedHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbols, periods,
-                        resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        typedSymbolsPeriodBasedHistoryWithFillForward,
-                        typedSymbolsPeriodBasedHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    var typedSymbolsPeriodBasedHistory = algorithm.History(pyTradeBarType, pySymbols, periods, resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(typedSymbolsPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, symbol array, date range
-                    var typedSymbolsDateRangeHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbols, start, end,
-                        resolution, fillForward: true);
-                    var typedSymbolsDateRangeHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbols, start, end,
-                        resolution, fillForward: false);
-                    AssertFillForwardHistoryResults(
-                        typedSymbolsDateRangeHistoryWithFillForward,
-                        typedSymbolsDateRangeHistoryWithoutFillForward,
-                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
-                        resolution);
+                    var typedSymbolsDateRangeHistory = algorithm.History(pyTradeBarType, pySymbols, start, end,
+                        resolution, fillForward: fillForward);
+                    AssertFillForwardHistoryResults(typedSymbolsDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
                 }
             }
         }
@@ -2139,17 +1929,10 @@ tradeBar = TradeBar
         /// Asserts that history result has more data when called with fillForward set to true.
         /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
         /// </summary>
-        private static void AssertFillForwardHistoryResultsCount<T>(
-            List<T> historyWithFillForward,
-            List<T> historyWithoutFillForward,
-            int expectedHistoryWithFillForwardCount,
-            int expectedHistoryWithoutFillForwardCount)
+        private static void AssertFillForwardHistoryResultsCount<T>(List<T> history, int expectedCount)
         {
-            Assert.IsNotEmpty(historyWithFillForward);
-            Assert.IsNotEmpty(historyWithoutFillForward);
-            Assert.AreEqual(expectedHistoryWithFillForwardCount, historyWithFillForward.Count);
-            Assert.AreEqual(expectedHistoryWithoutFillForwardCount, historyWithoutFillForward.Count);
-            Assert.Less(historyWithoutFillForward.Count, historyWithFillForward.Count);
+            Assert.IsNotEmpty(history);
+            Assert.AreEqual(expectedCount, history.Count);
         }
 
         /// <summary>
@@ -2159,23 +1942,24 @@ tradeBar = TradeBar
         {
             var hours = MarketHoursDatabase.FromDataFolder().GetEntry(symbol.ID.Market, symbol, symbol.ID.SecurityType).ExchangeHours;
 
-            for (var i = 0; i < times.Count;)
+            // We are assuming one regular segment per day for the test security
+            var periodMultiplier = 0;
+            var baseSegmentTimeIndex = 0;
+            for (var i = 0; i < times.Count; i++)
             {
-                var currentDayHours = hours.GetMarketHours(times[i]);
-                var regularMarketSegments = currentDayHours.Segments.Where(x => x.State == MarketHoursState.Market).ToList();
-                var firstSegmentOfDayIndex = i > 0
-                    ? 0
-                    : regularMarketSegments
-                        .FindIndex(x => times[i].TimeOfDay > x.Start && times[i].TimeOfDay <= x.End);
-
-                foreach (var segment in regularMarketSegments.Skip(firstSegmentOfDayIndex))
+                var currentTime = times[i];
+                if (i > 0 && currentTime.DayOfWeek != times[i - 1].DayOfWeek)
                 {
-                    var start = i > 0 ? segment.Start + period : times[i].TimeOfDay;
-                    for (var time = start; time <= segment.End; time += period, i++)
-                    {
-                        Assert.AreEqual(time, times[i].TimeOfDay);
-                    }
+                    baseSegmentTimeIndex = i;
+                    periodMultiplier = 0;
                 }
+
+                var expectedCurrentTime = times[baseSegmentTimeIndex] + periodMultiplier++ * period;
+                Assert.AreEqual(expectedCurrentTime, currentTime);
+                Assert.IsTrue(
+                    // subtract `period` since the times list has the EndTime
+                    hours.IsOpen(currentTime - period, extendedMarket: false),
+                    $"Current time {currentTime} is not open");
             }
         }
 
@@ -2183,125 +1967,95 @@ tradeBar = TradeBar
         /// Asserts that history data, when called with fillForward set to true, has a period that is equal to the resolution used.
         /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
         /// </summary>
-        private static void AssertFillForwardHistoryData(
-            List<TradeBar> historyWithFillForward,
-            List<TradeBar> historyWithoutFillForward,
-            Resolution resolution)
+        private static void AssertFillForwardHistoryData(List<TradeBar> history, Resolution resolution, bool fillForward)
         {
             var expectedPeriod = resolution.ToTimeSpan();
-            Assert.IsTrue(historyWithFillForward.All(bar => bar.Period == expectedPeriod));
-            Assert.IsTrue(historyWithoutFillForward.All(bar => bar.Period == expectedPeriod));
+            Assert.IsTrue(history.All(bar => bar.Period == expectedPeriod));
 
-            var symbol = historyWithFillForward.First().Symbol;
-            var times = historyWithFillForward.Select(bar => bar.EndTime).ToList();
-            AssertFillForwardedHistoryTimes(symbol, times, expectedPeriod);
+            if (fillForward)
+            {
+                var symbol = history.First().Symbol;
+                var times = history.Select(bar => bar.EndTime).ToList();
+                AssertFillForwardedHistoryTimes(symbol, times, expectedPeriod);
+            }
         }
 
         /// <summary>
         /// Asserts that history data, when called with fillForward set to true, has a period that is equal to the resolution used.
         /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
         /// </summary>
-        private static void AssertFillForwardHistoryData(
-            List<Slice> historyWithFillForward,
-            List<Slice> historyWithoutFillForward,
-            Resolution resolution)
+        private static void AssertFillForwardHistoryData(List<Slice> history, Resolution resolution, bool fillForward)
         {
             AssertFillForwardHistoryData(
-                historyWithFillForward.Select(slice => slice.Bars.Values.SingleOrDefault((TradeBar)null)).Where(bar => bar != null).ToList(),
-                historyWithoutFillForward.Select(slice => slice.Bars.Values.SingleOrDefault((TradeBar)null)).Where(bar => bar != null).ToList(),
-                resolution);
+                history.Select(slice => slice.Bars.Values.SingleOrDefault((TradeBar)null)).Where(bar => bar != null).ToList(),
+                resolution,
+                fillForward);
         }
 
         ///// <summary>
         /// Asserts that history data, when called with fillForward set to true, has a period that is equal to the resolution used.
         /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
         /// </summary>
-        private static void AssertFillForwardHistoryData(
-            List<DataDictionary<TradeBar>> historyWithFillForward,
-            List<DataDictionary<TradeBar>> historyWithoutFillForward,
-            Resolution resolution)
+        private static void AssertFillForwardHistoryData(List<DataDictionary<TradeBar>> history, Resolution resolution, bool fillForward)
         {
             AssertFillForwardHistoryData(
-                historyWithFillForward.Select(x => x.Values.SingleOrDefault((TradeBar)null)).Where(bar => bar != null).ToList(),
-                historyWithoutFillForward.Select(x => x.Values.SingleOrDefault((TradeBar)null)).Where(bar => bar != null).ToList(),
-                resolution);
+                history.Select(x => x.Values.SingleOrDefault((TradeBar)null)).Where(bar => bar != null).ToList(),
+                resolution,
+                fillForward);
         }
 
         /// <summary>
         /// Asserts that history result has more data when called with fillForward set to true.
         /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
         /// </summary>
-        private static void AssertFillForwardHistoryResults(
-            List<TradeBar> historyWithFillForward,
-            List<TradeBar> historyWithoutFillForward,
-            int expectedHistoryWithFillForwardCount,
-            int expectedHistoryWithoutFillForwardCount,
-            Resolution resolution)
+        private static void AssertFillForwardHistoryResults(List<TradeBar> history, int expectedCount, Resolution resolution, bool fillForward)
         {
-            AssertFillForwardHistoryResultsCount(historyWithFillForward, historyWithoutFillForward,
-                expectedHistoryWithFillForwardCount, expectedHistoryWithoutFillForwardCount);
-            AssertFillForwardHistoryData(historyWithFillForward, historyWithoutFillForward, resolution);
+            AssertFillForwardHistoryResultsCount(history, expectedCount);
+            AssertFillForwardHistoryData(history, resolution, fillForward);
         }
 
         /// <summary>
         /// Asserts that history result has more data when called with fillForward set to true.
         /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
         /// </summary>
-        private static void AssertFillForwardHistoryResults(
-            List<Slice> historyWithFillForward,
-            List<Slice> historyWithoutFillForward,
-            int expectedHistoryWithFillForwardCount,
-            int expectedHistoryWithoutFillForwardCount,
-            Resolution resolution)
+        private static void AssertFillForwardHistoryResults(List<Slice> history, int expectedCount, Resolution resolution, bool fillForward)
         {
-            AssertFillForwardHistoryResultsCount(historyWithFillForward, historyWithoutFillForward,
-                expectedHistoryWithFillForwardCount, expectedHistoryWithoutFillForwardCount);
-            AssertFillForwardHistoryData(historyWithFillForward, historyWithoutFillForward, resolution);
+            AssertFillForwardHistoryResultsCount(history, expectedCount);
+            AssertFillForwardHistoryData(history, resolution, fillForward);
         }
 
         /// <summary>
         /// Asserts that history result has more data when called with fillForward set to true.
         /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
         /// </summary>
-        private static void AssertFillForwardHistoryResults(
-            List<DataDictionary<TradeBar>> historyWithFillForward,
-            List<DataDictionary<TradeBar>> historyWithoutFillForward,
-            int expectedHistoryWithFillForwardCount,
-            int expectedHistoryWithoutFillForwardCount,
-            Resolution resolution)
+        private static void AssertFillForwardHistoryResults(List<DataDictionary<TradeBar>> history, int expectedCount,
+            Resolution resolution, bool fillForward)
         {
-            AssertFillForwardHistoryResultsCount(historyWithFillForward, historyWithoutFillForward,
-                expectedHistoryWithFillForwardCount, expectedHistoryWithoutFillForwardCount);
-            AssertFillForwardHistoryData(historyWithFillForward, historyWithoutFillForward, resolution);
+            AssertFillForwardHistoryResultsCount(history, expectedCount);
+            AssertFillForwardHistoryData(history, resolution, fillForward);
         }
 
         /// <summary>
         /// Asserts that history result has more data when called with fillForward set to true.
         /// Used in the test <see cref="HistoryRequestWithFillForward"/> for Python cases.
         /// </summary>
-        private static void AssertFillForwardHistoryResults(
-            PyObject historyWithFillForward,
-            PyObject historyWithoutFillForward,
-            int expectedHistoryWithFillForwardCount,
-            int expectedHistoryWithoutFillForwardCount,
-            Resolution resolution)
+        private static void AssertFillForwardHistoryResults(PyObject history, int expectedCount, Resolution resolution, bool fillForward)
         {
-            var historyWithFillForwardCount = historyWithFillForward.GetAttr("shape")[0].As<int>();
-            var historyWithoutFillForwardCount = historyWithoutFillForward.GetAttr("shape")[0].As<int>();
-            Assert.Greater(historyWithFillForwardCount, 0);
-            Assert.Greater(historyWithoutFillForwardCount, 0);
-            Assert.AreEqual(expectedHistoryWithFillForwardCount, historyWithFillForwardCount);
-            Assert.AreEqual(expectedHistoryWithoutFillForwardCount, historyWithoutFillForwardCount);
-            Assert.Less(historyWithoutFillForwardCount, historyWithFillForwardCount);
+            var historyCount = history.GetAttr("shape")[0].As<int>();
+            Assert.Greater(historyCount, 0);
+            Assert.AreEqual(expectedCount, historyCount);
 
-            var index = historyWithFillForward
-                .GetAttr("index")
-                .GetAttr("to_flat_index").Invoke()
-                .GetAttr("tolist").Invoke()
-                .As<List<PyObject>>();
-            var symbol = index.First()[0].As<Symbol>();
-            var times = index.Select(x => x[1].As<DateTime>()).ToList();
-            AssertFillForwardedHistoryTimes(symbol, times, resolution.ToTimeSpan());
+            if (fillForward)
+            {
+                var index = history
+                    .GetAttr("index")
+                    .GetAttr("to_flat_index").Invoke()
+                    .GetAttr("tolist").Invoke()
+                    .As<List<PyObject>>();
+                var symbol = index.First()[0].As<Symbol>();
+                var times = index.Select(x => x[1].As<DateTime>()).ToList();
+                AssertFillForwardedHistoryTimes(symbol, times, resolution.ToTimeSpan());
+            }
         }
     }
 }

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -1554,121 +1554,131 @@ def getOpenInterestHistory(algorithm, symbol, start, end):
             }
         }
 
-        [TestCase(Language.CSharp)]
-        [TestCase(Language.Python)]
-        public void HistoryRequestWithFillForward(Language language)
+        [TestCase(Language.CSharp, Resolution.Second, 46800, 22884, 46800, 16093)]
+        [TestCase(Language.Python, Resolution.Second, 46800, 22884, 46800, 16093)]
+        [TestCase(Language.CSharp, Resolution.Minute, 780, 390, 780, 390)]
+        [TestCase(Language.Python, Resolution.Minute, 780, 390, 780, 390)]
+        public void HistoryRequestWithFillForward(Language language, Resolution resolution,
+            int historyWithFillForwardExpectedCount, int historyWithoutFillForwardExpectedCount,
+            int tradeBarOnlyHistoryWithFillForwardExpectedCount, int tradeBarOnlyHistoryWithoutFillForwardExpectedCount)
         {
-            // Theres data only for 2014-06-09 for AAPL with minute resolution. Data should be fill forwarded till the 11th.
-            var start = new DateTime(2014, 06, 09);
-            var end = new DateTime(2014, 06, 11);
+            // Theres data only for 2013-10-07 to 2013-10-11 for SPY. Data should be fill forwarded till the 15th.
+            var start = new DateTime(2013, 10, 11);
+            var end = new DateTime(2013, 10, 15);
             var algorithm = GetAlgorithm(end);
-            var aaplSymbol = algorithm.AddEquity("AAPL", Resolution.Daily).Symbol;
-
-            var historyWithFillForwardExpectedCount = 780;
-            var historyWithoutFillForwardExpectedCount = 390;
+            var symbol = algorithm.AddEquity("SPY").Symbol;
 
             var periods = historyWithFillForwardExpectedCount;
-            var dateRange = end - start;
+            var timeSpan = end - start;
 
             if (language == Language.CSharp)
             {
                 // No symbol, time span
-                var noSymbolTimeSpanHistoryWithFillForward = algorithm.History(dateRange, Resolution.Minute, fillForward: true).ToList();
-                var noSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(dateRange, Resolution.Minute, fillForward: false).ToList();
+                var noSymbolTimeSpanHistoryWithFillForward = algorithm.History(timeSpan, resolution, fillForward: true).ToList();
+                var noSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(timeSpan, resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     noSymbolTimeSpanHistoryWithFillForward,
                     noSymbolTimeSpanHistoryWithoutFillForward,
                     historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    historyWithoutFillForwardExpectedCount,
+                    resolution);
 
                 // No symbol, periods
-                var noSymbolPeriodBasedHistoryWithFillForward = algorithm.History(periods, Resolution.Minute, fillForward: true).ToList();
-                var noSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(periods, Resolution.Minute, fillForward: false).ToList();
+                var noSymbolPeriodBasedHistoryWithFillForward = algorithm.History(periods, resolution, fillForward: true).ToList();
+                var noSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(periods, resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     noSymbolPeriodBasedHistoryWithFillForward,
                     noSymbolPeriodBasedHistoryWithoutFillForward,
                     historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    historyWithoutFillForwardExpectedCount,
+                    resolution);
 
                 // No symbol, date range
                 // TODO: to be implemented
 
                 // Single symbol, time span
-                var singleSymbolTimeSpanHistoryWithFillForward = algorithm.History(aaplSymbol, dateRange,
-                    Resolution.Minute, fillForward: true).ToList();
-                var singleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(aaplSymbol, dateRange,
-                    Resolution.Minute, fillForward: false).ToList();
+                var singleSymbolTimeSpanHistoryWithFillForward = algorithm.History(symbol, timeSpan,
+                    resolution, fillForward: true).ToList();
+                var singleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(symbol, timeSpan,
+                    resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     singleSymbolTimeSpanHistoryWithFillForward,
                     singleSymbolTimeSpanHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                    resolution);
 
                 // Single symbol, periods
-                var singleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(aaplSymbol, periods,
-                    Resolution.Minute, fillForward: true).ToList();
-                var singleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(aaplSymbol, periods,
-                    Resolution.Minute, fillForward: false).ToList();
+                var singleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(symbol, periods,
+                    resolution, fillForward: true).ToList();
+                var singleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(symbol, periods,
+                    resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     singleSymbolPeriodBasedHistoryWithFillForward,
                     singleSymbolPeriodBasedHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                    resolution);
 
                 // Single symbol, date range
-                var singleSymbolDateRangeHistoryWithFillForward = algorithm.History(aaplSymbol, start, end,
-                    Resolution.Minute, fillForward: true).ToList();
-                var singleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(aaplSymbol, start, end,
-                    Resolution.Minute, fillForward: false).ToList();
+                var singleSymbolDateRangeHistoryWithFillForward = algorithm.History(symbol, start, end,
+                    resolution, fillForward: true).ToList();
+                var singleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(symbol, start, end,
+                    resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     singleSymbolDateRangeHistoryWithFillForward,
                     singleSymbolDateRangeHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                    resolution);
 
                 // Symbol array, time span
-                var symbolsTimeSpanHistoryWithFillForward = algorithm.History(new[] { aaplSymbol }, dateRange,
-                    Resolution.Minute, fillForward: true).ToList();
-                var symbolsTimeSpanHistoryWithoutFillForward = algorithm.History(new[] { aaplSymbol }, dateRange,
-                    Resolution.Minute, fillForward: false).ToList();
+                var symbolsTimeSpanHistoryWithFillForward = algorithm.History(new[] { symbol }, timeSpan,
+                    resolution, fillForward: true).ToList();
+                var symbolsTimeSpanHistoryWithoutFillForward = algorithm.History(new[] { symbol }, timeSpan,
+                    resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     symbolsTimeSpanHistoryWithFillForward,
                     symbolsTimeSpanHistoryWithoutFillForward,
                     historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    historyWithoutFillForwardExpectedCount,
+                    resolution);
 
                 // Symbol array, periods
-                var symbolsPeriodBasedHistoryWithFillForward = algorithm.History(new[] { aaplSymbol }, periods,
-                    Resolution.Minute, fillForward: true).ToList();
-                var symbolsPeriodBasedHistoryWithoutFillForward = algorithm.History(new[] { aaplSymbol }, periods,
-                    Resolution.Minute, fillForward: false).ToList();
+                var symbolsPeriodBasedHistoryWithFillForward = algorithm.History(new[] { symbol }, periods,
+                    resolution, fillForward: true).ToList();
+                var symbolsPeriodBasedHistoryWithoutFillForward = algorithm.History(new[] { symbol }, periods,
+                    resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     symbolsPeriodBasedHistoryWithFillForward,
                     symbolsPeriodBasedHistoryWithoutFillForward,
                     historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    historyWithoutFillForwardExpectedCount,
+                    resolution);
 
                 // Symbol array, date range
-                var symbolsdateRangeHistoryWithFillForward = algorithm.History(new[] { aaplSymbol }, start, end,
-                    Resolution.Minute, fillForward: true).ToList();
-                var symbolsdateRangeHistoryWithoutFillForward = algorithm.History(new[] { aaplSymbol }, start, end,
-                    Resolution.Minute, fillForward: false).ToList();
+                var symbolsdateRangeHistoryWithFillForward = algorithm.History(new[] { symbol }, start, end,
+                    resolution, fillForward: true).ToList();
+                var symbolsdateRangeHistoryWithoutFillForward = algorithm.History(new[] { symbol }, start, end,
+                    resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     symbolsdateRangeHistoryWithFillForward,
                     symbolsdateRangeHistoryWithoutFillForward,
                     historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    historyWithoutFillForwardExpectedCount,
+                    resolution);
 
                 // Generic, no symbol, time span
-                var typedNoSymbolTimeSpanHistoryWithFillForward = algorithm.History<TradeBar>(dateRange,
-                    Resolution.Minute, fillForward: true).ToList();
-                var typedNoSymbolTimeSpanHistoryWithoutFillForward = algorithm.History<TradeBar>(dateRange,
-                    Resolution.Minute, fillForward: false).ToList();
+                var typedNoSymbolTimeSpanHistoryWithFillForward = algorithm.History<TradeBar>(timeSpan,
+                    resolution, fillForward: true).ToList();
+                var typedNoSymbolTimeSpanHistoryWithoutFillForward = algorithm.History<TradeBar>(timeSpan,
+                    resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     typedNoSymbolTimeSpanHistoryWithFillForward,
                     typedNoSymbolTimeSpanHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                    resolution);
 
                 // Generic, no symbol, periods
                 // TODO: to be implemented
@@ -1677,70 +1687,76 @@ def getOpenInterestHistory(algorithm, symbol, start, end):
                 // TODO: to be implemented
 
                 // Generic, single symbol, time span
-                var typedSingleSymbolTimeSpanHistoryWithFillForward = algorithm.History<TradeBar>(aaplSymbol, dateRange,
-                    Resolution.Minute, fillForward: true).ToList();
-                var typedSingleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History<TradeBar>(aaplSymbol, dateRange,
-                    Resolution.Minute, fillForward: false).ToList();
+                var typedSingleSymbolTimeSpanHistoryWithFillForward = algorithm.History<TradeBar>(symbol, timeSpan,
+                    resolution, fillForward: true).ToList();
+                var typedSingleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History<TradeBar>(symbol, timeSpan,
+                    resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     typedSingleSymbolTimeSpanHistoryWithFillForward,
                     typedSingleSymbolTimeSpanHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                    resolution);
 
                 // Generic, single symbol, periods
-                var typedSingleSymbolPeriodBasedHistoryWithFillForward = algorithm.History<TradeBar>(aaplSymbol, periods,
-                    Resolution.Minute, fillForward: true).ToList();
-                var typedSingleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History<TradeBar>(aaplSymbol, periods,
-                    Resolution.Minute, fillForward: false).ToList();
+                var typedSingleSymbolPeriodBasedHistoryWithFillForward = algorithm.History<TradeBar>(symbol, periods,
+                    resolution, fillForward: true).ToList();
+                var typedSingleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History<TradeBar>(symbol, periods,
+                    resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     typedSingleSymbolPeriodBasedHistoryWithFillForward,
                     typedSingleSymbolPeriodBasedHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                    resolution);
 
                 // Generic, single symbol, date range
-                var typedSingleSymbolDateRangeHistoryWithFillForward = algorithm.History<TradeBar>(aaplSymbol, start, end,
-                    Resolution.Minute, fillForward: true).ToList();
-                var typedSingleSymbolDateRangeHistoryWithoutFillForward = algorithm.History<TradeBar>(aaplSymbol, start, end,
-                    Resolution.Minute, fillForward: false).ToList();
+                var typedSingleSymbolDateRangeHistoryWithFillForward = algorithm.History<TradeBar>(symbol, start, end,
+                    resolution, fillForward: true).ToList();
+                var typedSingleSymbolDateRangeHistoryWithoutFillForward = algorithm.History<TradeBar>(symbol, start, end,
+                    resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     typedSingleSymbolDateRangeHistoryWithFillForward,
                     typedSingleSymbolDateRangeHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                    resolution);
 
                 // Generic, symbol array, time span
-                var typedSymbolsTimeSpanHistoryWithFillForward = algorithm.History<TradeBar>(new[] { aaplSymbol }, dateRange,
-                    Resolution.Minute, fillForward: true).ToList();
-                var typedSymbolsTimeSpanHistoryWithoutFillForward = algorithm.History<TradeBar>(new[] { aaplSymbol }, dateRange,
-                    Resolution.Minute, fillForward: false).ToList();
+                var typedSymbolsTimeSpanHistoryWithFillForward = algorithm.History<TradeBar>(new[] { symbol }, timeSpan,
+                    resolution, fillForward: true).ToList();
+                var typedSymbolsTimeSpanHistoryWithoutFillForward = algorithm.History<TradeBar>(new[] { symbol }, timeSpan,
+                    resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     typedSymbolsTimeSpanHistoryWithFillForward,
                     typedSymbolsTimeSpanHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                    resolution);
 
                 // Generic, symbol array, periods
-                var typedSymbolsPeriodBasedHistoryWithFillForward = algorithm.History<TradeBar>(new[] { aaplSymbol }, periods,
-                    Resolution.Minute, fillForward: true).ToList();
-                var typedSymbolsPeriodBasedHistoryWithoutFillForward = algorithm.History<TradeBar>(new[] { aaplSymbol }, periods,
-                    Resolution.Minute, fillForward: false).ToList();
+                var typedSymbolsPeriodBasedHistoryWithFillForward = algorithm.History<TradeBar>(new[] { symbol }, periods,
+                    resolution, fillForward: true).ToList();
+                var typedSymbolsPeriodBasedHistoryWithoutFillForward = algorithm.History<TradeBar>(new[] { symbol }, periods,
+                    resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     typedSymbolsPeriodBasedHistoryWithFillForward,
                     typedSymbolsPeriodBasedHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                    resolution);
 
                 // Generic, symbol array, date range
-                var typedSymbolsDateRangeHistoryWithFillForward = algorithm.History<TradeBar>(new[] { aaplSymbol }, start, end,
-                    Resolution.Minute, fillForward: true).ToList();
-                var typedSymbolsDateRangeHistoryWithoutFillForward = algorithm.History<TradeBar>(new[] { aaplSymbol }, start, end,
-                    Resolution.Minute, fillForward: false).ToList();
+                var typedSymbolsDateRangeHistoryWithFillForward = algorithm.History<TradeBar>(new[] { symbol }, start, end,
+                    resolution, fillForward: true).ToList();
+                var typedSymbolsDateRangeHistoryWithoutFillForward = algorithm.History<TradeBar>(new[] { symbol }, start, end,
+                    resolution, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     typedSymbolsDateRangeHistoryWithFillForward,
                     typedSymbolsDateRangeHistoryWithoutFillForward,
-                    historyWithFillForwardExpectedCount,
-                    historyWithoutFillForwardExpectedCount);
+                    tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                    tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                    resolution);
             }
             else
             {
@@ -1753,162 +1769,162 @@ tradeBar = TradeBar
                     ");
 
                     algorithm.SetPandasConverter();
-                    using var pySymbol = aaplSymbol.ToPython();
+                    using var pySymbol = symbol.ToPython();
                     using var pySymbols = new PyList(new[] { pySymbol });
                     using var pyTradeBarType = testModule.GetAttr("tradeBar");
 
                     // Single symbol, time span
-                    var singleSymbolTimeSpanHistoryWithFillForward = algorithm.History(pySymbol, end - start, Resolution.Minute, fillForward: true);
-                    var singleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(pySymbol, end - start, Resolution.Minute, fillForward: false);
+                    var singleSymbolTimeSpanHistoryWithFillForward = algorithm.History(pySymbol, timeSpan, resolution, fillForward: true);
+                    var singleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(pySymbol, timeSpan, resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         singleSymbolTimeSpanHistoryWithFillForward,
                         singleSymbolTimeSpanHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
 
                     // Single symbol, periods
-                    var singleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(pySymbol, periods, Resolution.Minute, fillForward: true);
-                    var singleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(pySymbol, periods, Resolution.Minute, fillForward: false);
+                    var singleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(pySymbol, periods, resolution, fillForward: true);
+                    var singleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(pySymbol, periods, resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         singleSymbolPeriodBasedHistoryWithFillForward,
                         singleSymbolPeriodBasedHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
 
                     // Single symbol, date range
-                    var singleSymbolDateRangeHistoryWithFillForward = algorithm.History(pySymbol, start, end, Resolution.Minute, fillForward: true);
-                    var singleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(pySymbol, start, end, Resolution.Minute, fillForward: false);
+                    var singleSymbolDateRangeHistoryWithFillForward = algorithm.History(pySymbol, start, end, resolution, fillForward: true);
+                    var singleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(pySymbol, start, end, resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         singleSymbolDateRangeHistoryWithFillForward,
                         singleSymbolDateRangeHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
 
                     // Symbol array, time span
-                    var symbolsTimeSpanHistoryWithFillForward = algorithm.History(pySymbols, end - start, Resolution.Minute, fillForward: true);
-                    var symbolsTimeSpanHistoryWithoutFillForward = algorithm.History(pySymbols, end - start, Resolution.Minute, fillForward: false);
+                    var symbolsTimeSpanHistoryWithFillForward = algorithm.History(pySymbols, timeSpan, resolution, fillForward: true);
+                    var symbolsTimeSpanHistoryWithoutFillForward = algorithm.History(pySymbols, timeSpan, resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         symbolsTimeSpanHistoryWithFillForward,
                         symbolsTimeSpanHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
 
                     // Symbol array, periods
-                    var symbolsPeriodBasedHistoryWithFillForward = algorithm.History(pySymbols, periods, Resolution.Minute, fillForward: true);
-                    var symbolsPeriodBasedHistoryWithoutFillForward = algorithm.History(pySymbols, periods, Resolution.Minute, fillForward: false);
+                    var symbolsPeriodBasedHistoryWithFillForward = algorithm.History(pySymbols, periods, resolution, fillForward: true);
+                    var symbolsPeriodBasedHistoryWithoutFillForward = algorithm.History(pySymbols, periods, resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         symbolsPeriodBasedHistoryWithFillForward,
                         symbolsPeriodBasedHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
 
                     // Symbol array, date range
-                    var symbolsDateRangeHistoryWithFillForward = algorithm.History(pySymbols, start, end, Resolution.Minute, fillForward: true);
-                    var symbolsDateRangeHistoryWithoutFillForward = algorithm.History(pySymbols, start, end, Resolution.Minute, fillForward: false);
+                    var symbolsDateRangeHistoryWithFillForward = algorithm.History(pySymbols, start, end, resolution, fillForward: true);
+                    var symbolsDateRangeHistoryWithoutFillForward = algorithm.History(pySymbols, start, end, resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         symbolsDateRangeHistoryWithFillForward,
                         symbolsDateRangeHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
 
                     // Generic, single symbol, time span
-                    var typedSingleSymbolTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbol, end - start,
-                        Resolution.Minute, fillForward: true);
-                    var typedSingleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbol, end - start,
-                        Resolution.Minute, fillForward: false);
+                    var typedSingleSymbolTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbol, timeSpan,
+                        resolution, fillForward: true);
+                    var typedSingleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbol, timeSpan,
+                        resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         typedSingleSymbolTimeSpanHistoryWithFillForward,
                         typedSingleSymbolTimeSpanHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
 
                     // Same as previous but using a Symbol instead of pySymbol
-                    typedSingleSymbolTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, aaplSymbol, end - start,
-                        Resolution.Minute, fillForward: true);
-                    typedSingleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(pyTradeBarType, aaplSymbol, end - start,
-                        Resolution.Minute, fillForward: false);
+                    typedSingleSymbolTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, symbol, timeSpan,
+                        resolution, fillForward: true);
+                    typedSingleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(pyTradeBarType, symbol, timeSpan,
+                        resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         typedSingleSymbolTimeSpanHistoryWithFillForward,
                         typedSingleSymbolTimeSpanHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
 
                     // Generic, single symbol, periods
                     var typedSingleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbol, periods,
-                        Resolution.Minute, fillForward: true);
+                        resolution, fillForward: true);
                     var typedSingleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbol, periods,
-                        Resolution.Minute, fillForward: false);
+                        resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         typedSingleSymbolPeriodBasedHistoryWithFillForward,
                         typedSingleSymbolPeriodBasedHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
 
                     // Same as previous but using a Symbol instead of pySymbol
-                    typedSingleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(pyTradeBarType, aaplSymbol, periods,
-                        Resolution.Minute, fillForward: true);
-                    typedSingleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(pyTradeBarType, aaplSymbol, periods,
-                        Resolution.Minute, fillForward: false);
+                    typedSingleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(pyTradeBarType, symbol, periods,
+                        resolution, fillForward: true);
+                    typedSingleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(pyTradeBarType, symbol, periods,
+                        resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         typedSingleSymbolPeriodBasedHistoryWithFillForward,
                         typedSingleSymbolPeriodBasedHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
 
                     // Generic, single symbol, date range
                     var typedSingleSymbolDateRangeHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbol, start, end,
-                        Resolution.Minute, fillForward: true);
+                        resolution, fillForward: true);
                     var typedSingleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbol, start, end,
-                        Resolution.Minute, fillForward: false);
+                        resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         typedSingleSymbolDateRangeHistoryWithFillForward,
                         typedSingleSymbolDateRangeHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
 
                     // Same as previous but using a Symbol instead of pySymbol
-                    typedSingleSymbolDateRangeHistoryWithFillForward = algorithm.History(pyTradeBarType, aaplSymbol, start, end,
-                        Resolution.Minute, fillForward: true);
-                    typedSingleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(pyTradeBarType, aaplSymbol, start, end,
-                        Resolution.Minute, fillForward: false);
+                    typedSingleSymbolDateRangeHistoryWithFillForward = algorithm.History(pyTradeBarType, symbol, start, end,
+                        resolution, fillForward: true);
+                    typedSingleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(pyTradeBarType, symbol, start, end,
+                        resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         typedSingleSymbolDateRangeHistoryWithFillForward,
                         typedSingleSymbolDateRangeHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
 
                     // Generic, symbol array, time span
-                    var typedSymbolsTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbols, end - start,
-                        Resolution.Minute, fillForward: true);
-                    var typedSymbolsTimeSpanHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbols, end - start,
-                        Resolution.Minute, fillForward: false);
+                    var typedSymbolsTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbols, timeSpan,
+                        resolution, fillForward: true);
+                    var typedSymbolsTimeSpanHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbols, timeSpan,
+                        resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         typedSymbolsTimeSpanHistoryWithFillForward,
                         typedSymbolsTimeSpanHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
 
                     // Generic, symbol array, periods
                     var typedSymbolsPeriodBasedHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbols, periods,
-                        Resolution.Minute, fillForward: true);
+                        resolution, fillForward: true);
                     var typedSymbolsPeriodBasedHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbols, periods,
-                        Resolution.Minute, fillForward: false);
+                        resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         typedSymbolsPeriodBasedHistoryWithFillForward,
                         typedSymbolsPeriodBasedHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
 
                     // Generic, symbol array, date range
                     var typedSymbolsDateRangeHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbols, start, end,
-                        Resolution.Minute, fillForward: true);
+                        resolution, fillForward: true);
                     var typedSymbolsDateRangeHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbols, start, end,
-                        Resolution.Minute, fillForward: false);
+                        resolution, fillForward: false);
                     AssertFillForwardHistoryResults(
                         typedSymbolsDateRangeHistoryWithFillForward,
                         typedSymbolsDateRangeHistoryWithoutFillForward,
-                        historyWithFillForwardExpectedCount,
-                        historyWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithFillForwardExpectedCount,
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
                 }
             }
         }
@@ -2108,7 +2124,7 @@ tradeBar = TradeBar
         /// Asserts that history result has more data when called with fillForward set to true.
         /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
         /// </summary>
-        private static void AssertFillForwardHistoryResults<T>(
+        private static void AssertFillForwardHistoryResultsCount<T>(
             List<T> historyWithFillForward,
             List<T> historyWithoutFillForward,
             int expectedHistoryWithFillForwardCount,
@@ -2119,6 +2135,98 @@ tradeBar = TradeBar
             Assert.AreEqual(expectedHistoryWithFillForwardCount, historyWithFillForward.Count);
             Assert.AreEqual(expectedHistoryWithoutFillForwardCount, historyWithoutFillForward.Count);
             Assert.Less(historyWithoutFillForward.Count, historyWithFillForward.Count);
+        }
+
+        /// <summary>
+        /// Asserts that history data, when called with fillForward set to true, has a period that is equal to the resolution used.
+        /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
+        /// </summary>
+        private static void AssertFillForwardHistoryData(
+            List<TradeBar> historyWithFillForward,
+            List<TradeBar> historyWithoutFillForward,
+            Resolution resolution)
+        {
+            var expectedPeriod = resolution.ToTimeSpan();
+            Assert.IsTrue(historyWithFillForward.All(bar => bar.Period == expectedPeriod));
+            Assert.IsTrue(historyWithoutFillForward.All(bar => bar.Period == expectedPeriod));
+        }
+
+        /// <summary>
+        /// Asserts that history data, when called with fillForward set to true, has a period that is equal to the resolution used.
+        /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
+        /// </summary>
+        private static void AssertFillForwardHistoryData(
+            List<Slice> historyWithFillForward,
+            List<Slice> historyWithoutFillForward,
+            Resolution resolution)
+        {
+            AssertFillForwardHistoryData(
+                historyWithFillForward.Select(slice => slice.Bars.Values.SingleOrDefault((TradeBar)null)).Where(bar => bar != null).ToList(),
+                historyWithoutFillForward.Select(slice => slice.Bars.Values.SingleOrDefault((TradeBar)null)).Where(bar => bar != null).ToList(),
+                resolution);
+        }
+
+        ///// <summary>
+        /// Asserts that history data, when called with fillForward set to true, has a period that is equal to the resolution used.
+        /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
+        /// </summary>
+        private static void AssertFillForwardHistoryData(
+            List<DataDictionary<TradeBar>> historyWithFillForward,
+            List<DataDictionary<TradeBar>> historyWithoutFillForward,
+            Resolution resolution)
+        {
+            AssertFillForwardHistoryData(
+                historyWithFillForward.Select(x => x.Values.SingleOrDefault((TradeBar)null)).Where(bar => bar != null).ToList(),
+                historyWithoutFillForward.Select(x => x.Values.SingleOrDefault((TradeBar)null)).Where(bar => bar != null).ToList(),
+                resolution);
+        }
+
+        /// <summary>
+        /// Asserts that history result has more data when called with fillForward set to true.
+        /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
+        /// </summary>
+        private static void AssertFillForwardHistoryResults(
+            List<TradeBar> historyWithFillForward,
+            List<TradeBar> historyWithoutFillForward,
+            int expectedHistoryWithFillForwardCount,
+            int expectedHistoryWithoutFillForwardCount,
+            Resolution resolution)
+        {
+            AssertFillForwardHistoryResultsCount(historyWithFillForward, historyWithoutFillForward,
+                expectedHistoryWithFillForwardCount, expectedHistoryWithoutFillForwardCount);
+            AssertFillForwardHistoryData(historyWithFillForward, historyWithoutFillForward, resolution);
+        }
+
+        /// <summary>
+        /// Asserts that history result has more data when called with fillForward set to true.
+        /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
+        /// </summary>
+        private static void AssertFillForwardHistoryResults(
+            List<Slice> historyWithFillForward,
+            List<Slice> historyWithoutFillForward,
+            int expectedHistoryWithFillForwardCount,
+            int expectedHistoryWithoutFillForwardCount,
+            Resolution resolution)
+        {
+            AssertFillForwardHistoryResultsCount(historyWithFillForward, historyWithoutFillForward,
+                expectedHistoryWithFillForwardCount, expectedHistoryWithoutFillForwardCount);
+            AssertFillForwardHistoryData(historyWithFillForward, historyWithoutFillForward, resolution);
+        }
+
+        /// <summary>
+        /// Asserts that history result has more data when called with fillForward set to true.
+        /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
+        /// </summary>
+        private static void AssertFillForwardHistoryResults(
+            List<DataDictionary<TradeBar>> historyWithFillForward,
+            List<DataDictionary<TradeBar>> historyWithoutFillForward,
+            int expectedHistoryWithFillForwardCount,
+            int expectedHistoryWithoutFillForwardCount,
+            Resolution resolution)
+        {
+            AssertFillForwardHistoryResultsCount(historyWithFillForward, historyWithoutFillForward,
+                expectedHistoryWithFillForwardCount, expectedHistoryWithoutFillForwardCount);
+            AssertFillForwardHistoryData(historyWithFillForward, historyWithoutFillForward, resolution);
         }
 
         /// <summary>

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -1554,6 +1554,369 @@ def getOpenInterestHistory(algorithm, symbol, start, end):
             }
         }
 
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void HistoryRequestWithFillForward(Language language)
+        {
+            // Theres data only for 2014-06-09 for AAPL with minute resolution. Data should be fill forwarded till the 11th.
+            var start = new DateTime(2014, 06, 09);
+            var end = new DateTime(2014, 06, 11);
+            var algorithm = GetAlgorithm(end);
+            var aaplSymbol = algorithm.AddEquity("AAPL", Resolution.Daily).Symbol;
+
+            var historyWithFillForwardExpectedCount = 780;
+            var historyWithoutFillForwardExpectedCount = 390;
+
+            var periods = historyWithFillForwardExpectedCount;
+            var dateRange = end - start;
+
+            if (language == Language.CSharp)
+            {
+                // No symbol, time span
+                var noSymbolTimeSpanHistoryWithFillForward = algorithm.History(dateRange, Resolution.Minute, fillForward: true)
+                    .Where(x => x.ContainsKey(aaplSymbol)).ToList();
+                var noSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(dateRange, Resolution.Minute, fillForward: false)
+                    .Where(x => x.ContainsKey(aaplSymbol)).ToList();
+                AssertFillForwardHistoryResults(
+                    noSymbolTimeSpanHistoryWithFillForward,
+                    noSymbolTimeSpanHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+
+                // No symbol, periods
+                var noSymbolPeriodBasedHistoryWithFillForward = algorithm.History(periods, Resolution.Minute, fillForward: true)
+                    .Where(x => x.ContainsKey(aaplSymbol)).ToList();
+                var noSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(periods, Resolution.Minute, fillForward: false)
+                    .Where(x => x.ContainsKey(aaplSymbol)).ToList();
+                AssertFillForwardHistoryResults(
+                    noSymbolPeriodBasedHistoryWithFillForward,
+                    noSymbolPeriodBasedHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+
+                // No symbol, date range
+                // TODO: to be implemented
+
+                // Single symbol, time span
+                var singleSymbolTimeSpanHistoryWithFillForward = algorithm.History(aaplSymbol, dateRange,
+                    Resolution.Minute, fillForward: true).ToList();
+                var singleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(aaplSymbol, dateRange,
+                    Resolution.Minute, fillForward: false).ToList();
+                AssertFillForwardHistoryResults(
+                    singleSymbolTimeSpanHistoryWithFillForward,
+                    singleSymbolTimeSpanHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+
+                // Single symbol, periods
+                var singleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(aaplSymbol, periods,
+                    Resolution.Minute, fillForward: true).ToList();
+                var singleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(aaplSymbol, periods,
+                    Resolution.Minute, fillForward: false).ToList();
+                AssertFillForwardHistoryResults(
+                    singleSymbolPeriodBasedHistoryWithFillForward,
+                    singleSymbolPeriodBasedHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+
+                // Single symbol, date range
+                var singleSymbolDateRangeHistoryWithFillForward = algorithm.History(aaplSymbol, start, end,
+                    Resolution.Minute, fillForward: true).ToList();
+                var singleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(aaplSymbol, start, end,
+                    Resolution.Minute, fillForward: false).ToList();
+                AssertFillForwardHistoryResults(
+                    singleSymbolDateRangeHistoryWithFillForward,
+                    singleSymbolDateRangeHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+
+                // Symbol array, time span
+                var symbolsTimeSpanHistoryWithFillForward = algorithm.History(new[] { aaplSymbol }, dateRange,
+                    Resolution.Minute, fillForward: true).ToList();
+                var symbolsTimeSpanHistoryWithoutFillForward = algorithm.History(new[] { aaplSymbol }, dateRange,
+                    Resolution.Minute, fillForward: false).ToList();
+                AssertFillForwardHistoryResults(
+                    symbolsTimeSpanHistoryWithFillForward,
+                    symbolsTimeSpanHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+
+                // Symbol array, periods
+                var symbolsPeriodBasedHistoryWithFillForward = algorithm.History(new[] { aaplSymbol }, periods,
+                    Resolution.Minute, fillForward: true).ToList();
+                var symbolsPeriodBasedHistoryWithoutFillForward = algorithm.History(new[] { aaplSymbol }, periods,
+                    Resolution.Minute, fillForward: false).ToList();
+                AssertFillForwardHistoryResults(
+                    symbolsPeriodBasedHistoryWithFillForward,
+                    symbolsPeriodBasedHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+
+                // Symbol array, date range
+                var symbolsdateRangeHistoryWithFillForward = algorithm.History(new[] { aaplSymbol }, start, end,
+                    Resolution.Minute, fillForward: true).ToList();
+                var symbolsdateRangeHistoryWithoutFillForward = algorithm.History(new[] { aaplSymbol }, start, end,
+                    Resolution.Minute, fillForward: false).ToList();
+                AssertFillForwardHistoryResults(
+                    symbolsdateRangeHistoryWithFillForward,
+                    symbolsdateRangeHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+
+                // Generic, no symbol, time span
+                var typedNoSymbolTimeSpanHistoryWithFillForward = algorithm.History<TradeBar>(dateRange,
+                    Resolution.Minute, fillForward: true).ToList();
+                var typedNoSymbolTimeSpanHistoryWithoutFillForward = algorithm.History<TradeBar>(dateRange,
+                    Resolution.Minute, fillForward: false).ToList();
+                AssertFillForwardHistoryResults(
+                    typedNoSymbolTimeSpanHistoryWithFillForward,
+                    typedNoSymbolTimeSpanHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+
+                // Generic, no symbol, periods
+                // TODO: to be implemented
+
+                // Generic, no symbol, date range
+                // TODO: to be implemented
+
+                // Generic, single symbol, time span
+                var typedSingleSymbolTimeSpanHistoryWithFillForward = algorithm.History<TradeBar>(aaplSymbol, dateRange,
+                    Resolution.Minute, fillForward: true).ToList();
+                var typedSingleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History<TradeBar>(aaplSymbol, dateRange,
+                    Resolution.Minute, fillForward: false).ToList();
+                AssertFillForwardHistoryResults(
+                    typedSingleSymbolTimeSpanHistoryWithFillForward,
+                    typedSingleSymbolTimeSpanHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+
+                // Generic, single symbol, periods
+                var typedSingleSymbolPeriodBasedHistoryWithFillForward = algorithm.History<TradeBar>(aaplSymbol, periods,
+                    Resolution.Minute, fillForward: true).ToList();
+                var typedSingleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History<TradeBar>(aaplSymbol, periods,
+                    Resolution.Minute, fillForward: false).ToList();
+                AssertFillForwardHistoryResults(
+                    typedSingleSymbolPeriodBasedHistoryWithFillForward,
+                    typedSingleSymbolPeriodBasedHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+
+                // Generic, single symbol, date range
+                var typedSingleSymbolDateRangeHistoryWithFillForward = algorithm.History<TradeBar>(aaplSymbol, start, end,
+                    Resolution.Minute, fillForward: true).ToList();
+                var typedSingleSymbolDateRangeHistoryWithoutFillForward = algorithm.History<TradeBar>(aaplSymbol, start, end,
+                    Resolution.Minute, fillForward: false).ToList();
+                AssertFillForwardHistoryResults(
+                    typedSingleSymbolDateRangeHistoryWithFillForward,
+                    typedSingleSymbolDateRangeHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+
+                // Generic, symbol array, time span
+                var typedSymbolsTimeSpanHistoryWithFillForward = algorithm.History<TradeBar>(new[] { aaplSymbol }, dateRange,
+                    Resolution.Minute, fillForward: true).ToList();
+                var typedSymbolsTimeSpanHistoryWithoutFillForward = algorithm.History<TradeBar>(new[] { aaplSymbol }, dateRange,
+                    Resolution.Minute, fillForward: false).ToList();
+                AssertFillForwardHistoryResults(
+                    typedSymbolsTimeSpanHistoryWithFillForward,
+                    typedSymbolsTimeSpanHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+
+                // Generic, symbol array, periods
+                var typedSymbolsPeriodBasedHistoryWithFillForward = algorithm.History<TradeBar>(new[] { aaplSymbol }, periods,
+                    Resolution.Minute, fillForward: true).ToList();
+                var typedSymbolsPeriodBasedHistoryWithoutFillForward = algorithm.History<TradeBar>(new[] { aaplSymbol }, periods,
+                    Resolution.Minute, fillForward: false).ToList();
+                AssertFillForwardHistoryResults(
+                    typedSymbolsPeriodBasedHistoryWithFillForward,
+                    typedSymbolsPeriodBasedHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+
+                // Generic, symbol array, date range
+                var typedSymbolsDateRangeHistoryWithFillForward = algorithm.History<TradeBar>(new[] { aaplSymbol }, start, end,
+                    Resolution.Minute, fillForward: true).ToList();
+                var typedSymbolsDateRangeHistoryWithoutFillForward = algorithm.History<TradeBar>(new[] { aaplSymbol }, start, end,
+                    Resolution.Minute, fillForward: false).ToList();
+                AssertFillForwardHistoryResults(
+                    typedSymbolsDateRangeHistoryWithFillForward,
+                    typedSymbolsDateRangeHistoryWithoutFillForward,
+                    historyWithFillForwardExpectedCount,
+                    historyWithoutFillForwardExpectedCount);
+            }
+            else
+            {
+                using (Py.GIL())
+                {
+                    var testModule = PyModule.FromString("testModule", @"
+from AlgorithmImports import *
+
+tradeBar = TradeBar
+                    ");
+
+                    algorithm.SetPandasConverter();
+                    using var pySymbol = aaplSymbol.ToPython();
+                    using var pySymbols = new PyList(new[] { pySymbol });
+                    using var pyTradeBarType = testModule.GetAttr("tradeBar");
+
+                    // Single symbol, time span
+                    var singleSymbolTimeSpanHistoryWithFillForward = algorithm.History(pySymbol, end - start, Resolution.Minute, fillForward: true);
+                    var singleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(pySymbol, end - start, Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        singleSymbolTimeSpanHistoryWithFillForward,
+                        singleSymbolTimeSpanHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+
+                    // Single symbol, periods
+                    var singleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(pySymbol, periods, Resolution.Minute, fillForward: true);
+                    var singleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(pySymbol, periods, Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        singleSymbolPeriodBasedHistoryWithFillForward,
+                        singleSymbolPeriodBasedHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+
+                    // Single symbol, date range
+                    var singleSymbolDateRangeHistoryWithFillForward = algorithm.History(pySymbol, start, end, Resolution.Minute, fillForward: true);
+                    var singleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(pySymbol, start, end, Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        singleSymbolDateRangeHistoryWithFillForward,
+                        singleSymbolDateRangeHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+
+                    // Symbol array, time span
+                    var symbolsTimeSpanHistoryWithFillForward = algorithm.History(pySymbols, end - start, Resolution.Minute, fillForward: true);
+                    var symbolsTimeSpanHistoryWithoutFillForward = algorithm.History(pySymbols, end - start, Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        symbolsTimeSpanHistoryWithFillForward,
+                        symbolsTimeSpanHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+
+                    // Symbol array, periods
+                    var symbolsPeriodBasedHistoryWithFillForward = algorithm.History(pySymbols, periods, Resolution.Minute, fillForward: true);
+                    var symbolsPeriodBasedHistoryWithoutFillForward = algorithm.History(pySymbols, periods, Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        symbolsPeriodBasedHistoryWithFillForward,
+                        symbolsPeriodBasedHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+
+                    // Symbol array, date range
+                    var symbolsDateRangeHistoryWithFillForward = algorithm.History(pySymbols, start, end, Resolution.Minute, fillForward: true);
+                    var symbolsDateRangeHistoryWithoutFillForward = algorithm.History(pySymbols, start, end, Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        symbolsDateRangeHistoryWithFillForward,
+                        symbolsDateRangeHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+
+                    // Generic, single symbol, time span
+                    var typedSingleSymbolTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbol, end - start,
+                        Resolution.Minute, fillForward: true);
+                    var typedSingleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbol, end - start,
+                        Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        typedSingleSymbolTimeSpanHistoryWithFillForward,
+                        typedSingleSymbolTimeSpanHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+
+                    // Same as previous but using a Symbol instead of pySymbol
+                    typedSingleSymbolTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, aaplSymbol, end - start,
+                        Resolution.Minute, fillForward: true);
+                    typedSingleSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(pyTradeBarType, aaplSymbol, end - start,
+                        Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        typedSingleSymbolTimeSpanHistoryWithFillForward,
+                        typedSingleSymbolTimeSpanHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+
+                    // Generic, single symbol, periods
+                    var typedSingleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbol, periods,
+                        Resolution.Minute, fillForward: true);
+                    var typedSingleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbol, periods,
+                        Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        typedSingleSymbolPeriodBasedHistoryWithFillForward,
+                        typedSingleSymbolPeriodBasedHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+
+                    // Same as previous but using a Symbol instead of pySymbol
+                    typedSingleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(pyTradeBarType, aaplSymbol, periods,
+                        Resolution.Minute, fillForward: true);
+                    typedSingleSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(pyTradeBarType, aaplSymbol, periods,
+                        Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        typedSingleSymbolPeriodBasedHistoryWithFillForward,
+                        typedSingleSymbolPeriodBasedHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+
+                    // Generic, single symbol, date range
+                    var typedSingleSymbolDateRangeHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbol, start, end,
+                        Resolution.Minute, fillForward: true);
+                    var typedSingleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbol, start, end,
+                        Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        typedSingleSymbolDateRangeHistoryWithFillForward,
+                        typedSingleSymbolDateRangeHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+
+                    // Same as previous but using a Symbol instead of pySymbol
+                    typedSingleSymbolDateRangeHistoryWithFillForward = algorithm.History(pyTradeBarType, aaplSymbol, start, end,
+                        Resolution.Minute, fillForward: true);
+                    typedSingleSymbolDateRangeHistoryWithoutFillForward = algorithm.History(pyTradeBarType, aaplSymbol, start, end,
+                        Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        typedSingleSymbolDateRangeHistoryWithFillForward,
+                        typedSingleSymbolDateRangeHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+
+                    // Generic, symbol array, time span
+                    var typedSymbolsTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbols, end - start,
+                        Resolution.Minute, fillForward: true);
+                    var typedSymbolsTimeSpanHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbols, end - start,
+                        Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        typedSymbolsTimeSpanHistoryWithFillForward,
+                        typedSymbolsTimeSpanHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+
+                    // Generic, symbol array, periods
+                    var typedSymbolsPeriodBasedHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbols, periods,
+                        Resolution.Minute, fillForward: true);
+                    var typedSymbolsPeriodBasedHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbols, periods,
+                        Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        typedSymbolsPeriodBasedHistoryWithFillForward,
+                        typedSymbolsPeriodBasedHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+
+                    // Generic, symbol array, date range
+                    var typedSymbolsDateRangeHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbols, start, end,
+                        Resolution.Minute, fillForward: true);
+                    var typedSymbolsDateRangeHistoryWithoutFillForward = algorithm.History(pyTradeBarType, pySymbols, start, end,
+                        Resolution.Minute, fillForward: false);
+                    AssertFillForwardHistoryResults(
+                        typedSymbolsDateRangeHistoryWithFillForward,
+                        typedSymbolsDateRangeHistoryWithoutFillForward,
+                        historyWithFillForwardExpectedCount,
+                        historyWithoutFillForwardExpectedCount);
+                }
+            }
+        }
+
         private QCAlgorithm GetAlgorithm(DateTime dateTime)
         {
             var algorithm = new QCAlgorithm();
@@ -1743,6 +2106,42 @@ def getOpenInterestHistory(algorithm, symbol, start, end):
         private static DataNormalizationMode[] GetAllDataNormalizationModes()
         {
             return (DataNormalizationMode[])Enum.GetValues(typeof(DataNormalizationMode));
+        }
+
+        /// <summary>
+        /// Asserts that history result has more data when called with fillForward set to true.
+        /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
+        /// </summary>
+        private static void AssertFillForwardHistoryResults<T>(
+            List<T> historyWithFillForward,
+            List<T> historyWithoutFillForward,
+            int expectedHistoryWithFillForwardCount,
+            int expectedHistoryWithoutFillForwardCount)
+        {
+            Assert.IsNotEmpty(historyWithFillForward);
+            Assert.IsNotEmpty(historyWithoutFillForward);
+            Assert.AreEqual(expectedHistoryWithFillForwardCount, historyWithFillForward.Count);
+            Assert.AreEqual(expectedHistoryWithoutFillForwardCount, historyWithoutFillForward.Count);
+            Assert.Less(historyWithoutFillForward.Count, historyWithFillForward.Count);
+        }
+
+        /// <summary>
+        /// Asserts that history result has more data when called with fillForward set to true.
+        /// Used in the test <see cref="HistoryRequestWithFillForward"/> for Python cases.
+        /// </summary>
+        private static void AssertFillForwardHistoryResults(
+            PyObject historyWithFillForward,
+            PyObject historyWithoutFillForward,
+            int expectedHistoryWithFillForwardCount,
+            int expectedHistoryWithoutFillForwardCount)
+        {
+            var historyWithFillForwardCount = historyWithFillForward.GetAttr("shape")[0].As<int>();
+            var historyWithoutFillForwardCount = historyWithoutFillForward.GetAttr("shape")[0].As<int>();
+            Assert.Greater(historyWithFillForwardCount, 0);
+            Assert.Greater(historyWithoutFillForwardCount, 0);
+            Assert.AreEqual(expectedHistoryWithFillForwardCount, historyWithFillForwardCount);
+            Assert.AreEqual(expectedHistoryWithoutFillForwardCount, historyWithoutFillForwardCount);
+            Assert.Less(historyWithoutFillForwardCount, historyWithFillForwardCount);
         }
     }
 }

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -400,7 +400,7 @@ def getTickHistory(algorithm, symbol, start, end):
             if (language == Language.CSharp)
             {
                 _algorithm.History(new [] {Symbols.SPY}, new DateTime(1,1,1,1,1,1), new DateTime(1, 1, 1, 1, 1, 2), Resolution.Tick,
-                    fillForward: true);
+                    fillDataForward: true);
             }
             else
             {
@@ -409,7 +409,7 @@ def getTickHistory(algorithm, symbol, start, end):
                     _algorithm.SetPandasConverter();
                     using var symbols = new PyList(new [] {Symbols.SPY.ToPython()});
                     _algorithm.History(symbols, new DateTime(1,1,1,1,1,1), new DateTime(1, 1, 1, 1, 1, 2),
-                        Resolution.Tick, fillForward: true);
+                        Resolution.Tick, fillDataForward: true);
                 }
             }
 
@@ -671,7 +671,7 @@ def getOpenInterestHistory(algorithm, symbol, start, end, resolution):
 
             if (language == Language.CSharp)
             {
-                var result = _algorithm.History(new[] { optionSymbol }, start, end, historyResolution, fillForward:false).ToList();
+                var result = _algorithm.History(new[] { optionSymbol }, start, end, historyResolution, fillDataForward:false).ToList();
 
                 Assert.AreEqual(53, result.Count);
                 Assert.IsTrue(result.Any(slice => slice.ContainsKey(optionSymbol)));
@@ -720,7 +720,7 @@ def getOpenInterestHistory(algorithm, symbol, start, end, resolution):
 
             if (language == Language.CSharp)
             {
-                var result = _algorithm.History(new[] { optionSymbol, optionSymbol2 }, start, end, historyResolution, fillForward: false).ToList();
+                var result = _algorithm.History(new[] { optionSymbol, optionSymbol2 }, start, end, historyResolution, fillDataForward: false).ToList();
 
                 Assert.AreEqual(415, result.Count);
                 Assert.IsTrue(result.Any(slice => slice.ContainsKey(optionSymbol)));
@@ -1578,43 +1578,43 @@ def getOpenInterestHistory(algorithm, symbol, start, end):
             if (language == Language.CSharp)
             {
                 // No symbol, time span
-                var noSymbolTimeSpanHistory = algorithm.History(timeSpan, resolution, fillForward: fillForward).ToList();
+                var noSymbolTimeSpanHistory = algorithm.History(timeSpan, resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(noSymbolTimeSpanHistory, expectedHistoryCount, resolution, fillForward);
 
                 // No symbol, periods
-                var noSymbolPeriodBasedHistory = algorithm.History(periods, resolution, fillForward: fillForward).ToList();
+                var noSymbolPeriodBasedHistory = algorithm.History(periods, resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(noSymbolPeriodBasedHistory, expectedHistoryCount, resolution, fillForward);
 
                 // No symbol, date range
                 // TODO: to be implemented
 
                 // Single symbol, time span
-                var singleSymbolTimeSpanHistory = algorithm.History(symbol, timeSpan, resolution, fillForward: fillForward).ToList();
+                var singleSymbolTimeSpanHistory = algorithm.History(symbol, timeSpan, resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(singleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Single symbol, periods
-                var singleSymbolPeriodBasedHistory = algorithm.History(symbol, periods, resolution, fillForward: fillForward).ToList();
+                var singleSymbolPeriodBasedHistory = algorithm.History(symbol, periods, resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(singleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Single symbol, date range
                 var singleSymbolDateRangeHistory = algorithm.History(symbol, start, end,
-                    resolution, fillForward: fillForward).ToList();
+                    resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(singleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Symbol array, time span
-                var symbolsTimeSpanHistory = algorithm.History(new[] { symbol }, timeSpan, resolution, fillForward: fillForward).ToList();
+                var symbolsTimeSpanHistory = algorithm.History(new[] { symbol }, timeSpan, resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(symbolsTimeSpanHistory, expectedHistoryCount, resolution, fillForward);
 
                 // Symbol array, periods
-                var symbolsPeriodBasedHistory = algorithm.History(new[] { symbol }, periods, resolution, fillForward: fillForward).ToList();
+                var symbolsPeriodBasedHistory = algorithm.History(new[] { symbol }, periods, resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(symbolsPeriodBasedHistory, expectedHistoryCount, resolution, fillForward);
 
                 // Symbol array, date range
-                var symbolsdateRangeHistory = algorithm.History(new[] { symbol }, start, end, resolution, fillForward: fillForward).ToList();
+                var symbolsdateRangeHistory = algorithm.History(new[] { symbol }, start, end, resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(symbolsdateRangeHistory, expectedHistoryCount, resolution, fillForward);
 
                 // Generic, no symbol, time span
-                var typedNoSymbolTimeSpanHistory = algorithm.History<TradeBar>(timeSpan, resolution, fillForward: fillForward).ToList();
+                var typedNoSymbolTimeSpanHistory = algorithm.History<TradeBar>(timeSpan, resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(typedNoSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, no symbol, periods
@@ -1624,32 +1624,33 @@ def getOpenInterestHistory(algorithm, symbol, start, end):
                 // TODO: to be implemented
 
                 // Generic, single symbol, time span
-                var typedSingleSymbolTimeSpanHistory = algorithm.History<TradeBar>(symbol, timeSpan, resolution, fillForward: fillForward).ToList();
+                var typedSingleSymbolTimeSpanHistory = algorithm.History<TradeBar>(symbol, timeSpan,
+                    resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(typedSingleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, single symbol, periods
                 var typedSingleSymbolPeriodBasedHistory = algorithm.History<TradeBar>(symbol, periods,
-                    resolution, fillForward: fillForward).ToList();
+                    resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(typedSingleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, single symbol, date range
                 var typedSingleSymbolDateRangeHistory = algorithm.History<TradeBar>(symbol, start, end,
-                    resolution, fillForward: fillForward).ToList();
+                    resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(typedSingleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, symbol array, time span
                 var typedSymbolsTimeSpanHistory = algorithm.History<TradeBar>(new[] { symbol }, timeSpan,
-                    resolution, fillForward: fillForward).ToList();
+                    resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(typedSymbolsTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, symbol array, periods
                 var typedSymbolsPeriodBasedHistory = algorithm.History<TradeBar>(new[] { symbol }, periods,
-                    resolution, fillForward: fillForward).ToList();
+                    resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(typedSymbolsPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                 // Generic, symbol array, date range
                 var typedSymbolsDateRangeHistory = algorithm.History<TradeBar>(new[] { symbol }, start, end,
-                    resolution, fillForward: fillForward).ToList();
+                    resolution, fillDataForward: fillForward).ToList();
                 AssertFillForwardHistoryResults(typedSymbolsDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
             }
             else
@@ -1668,67 +1669,71 @@ tradeBar = TradeBar
                     using var pyTradeBarType = testModule.GetAttr("tradeBar");
 
                     // Single symbol, time span
-                    var singleSymbolTimeSpanHistory = algorithm.History(pySymbol, timeSpan, resolution, fillForward: fillForward);
+                    var singleSymbolTimeSpanHistory = algorithm.History(pySymbol, timeSpan, resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(singleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Single symbol, periods
-                    var singleSymbolPeriodBasedHistory = algorithm.History(pySymbol, periods, resolution, fillForward: fillForward);
+                    var singleSymbolPeriodBasedHistory = algorithm.History(pySymbol, periods, resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(singleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Single symbol, date range
-                    var singleSymbolDateRangeHistory = algorithm.History(pySymbol, start, end, resolution, fillForward: fillForward);
+                    var singleSymbolDateRangeHistory = algorithm.History(pySymbol, start, end, resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(singleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Symbol array, time span
-                    var symbolsTimeSpanHistory = algorithm.History(pySymbols, timeSpan, resolution, fillForward: fillForward);
+                    var symbolsTimeSpanHistory = algorithm.History(pySymbols, timeSpan, resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(symbolsTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Symbol array, periods
-                    var symbolsPeriodBasedHistory = algorithm.History(pySymbols, periods, resolution, fillForward: fillForward);
+                    var symbolsPeriodBasedHistory = algorithm.History(pySymbols, periods, resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(symbolsPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Symbol array, date range
-                    var symbolsDateRangeHistory = algorithm.History(pySymbols, start, end, resolution, fillForward: fillForward);
+                    var symbolsDateRangeHistory = algorithm.History(pySymbols, start, end, resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(symbolsDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, single symbol, time span
                     var typedSingleSymbolTimeSpanHistory = algorithm.History(pyTradeBarType, pySymbol, timeSpan,
-                        resolution, fillForward: fillForward);
+                        resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(typedSingleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Same as previous but using a Symbol instead of pySymbol
-                    typedSingleSymbolTimeSpanHistory = algorithm.History(pyTradeBarType, symbol, timeSpan, resolution, fillForward: fillForward);
+                    typedSingleSymbolTimeSpanHistory = algorithm.History(pyTradeBarType, symbol, timeSpan, resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(typedSingleSymbolTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, single symbol, periods
                     var typedSingleSymbolPeriodBasedHistory = algorithm.History(pyTradeBarType, pySymbol, periods,
-                        resolution, fillForward: fillForward);
+                        resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(typedSingleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Same as previous but using a Symbol instead of pySymbol
-                    typedSingleSymbolPeriodBasedHistory = algorithm.History(pyTradeBarType, symbol, periods, resolution, fillForward: fillForward);
+                    typedSingleSymbolPeriodBasedHistory = algorithm.History(pyTradeBarType, symbol, periods,
+                        resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(typedSingleSymbolPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, single symbol, date range
                     var typedSingleSymbolDateRangeHistory = algorithm.History(pyTradeBarType, pySymbol, start, end,
-                        resolution, fillForward: fillForward);
+                        resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(typedSingleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Same as previous but using a Symbol instead of pySymbol
-                    typedSingleSymbolDateRangeHistory = algorithm.History(pyTradeBarType, symbol, start, end, resolution, fillForward: fillForward);
+                    typedSingleSymbolDateRangeHistory = algorithm.History(pyTradeBarType, symbol, start, end,
+                        resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(typedSingleSymbolDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, symbol array, time span
-                    var typedSymbolsTimeSpanHistory = algorithm.History(pyTradeBarType, pySymbols, timeSpan, resolution, fillForward: fillForward);
+                    var typedSymbolsTimeSpanHistory = algorithm.History(pyTradeBarType, pySymbols, timeSpan,
+                        resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(typedSymbolsTimeSpanHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, symbol array, periods
-                    var typedSymbolsPeriodBasedHistory = algorithm.History(pyTradeBarType, pySymbols, periods, resolution, fillForward: fillForward);
+                    var typedSymbolsPeriodBasedHistory = algorithm.History(pyTradeBarType, pySymbols, periods,
+                        resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(typedSymbolsPeriodBasedHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
 
                     // Generic, symbol array, date range
                     var typedSymbolsDateRangeHistory = algorithm.History(pyTradeBarType, pySymbols, start, end,
-                        resolution, fillForward: fillForward);
+                        resolution, fillDataForward: fillForward);
                     AssertFillForwardHistoryResults(typedSymbolsDateRangeHistory, expectedTradeBarOnlyHistoryCount, resolution, fillForward);
                 }
             }

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -1573,10 +1573,8 @@ def getOpenInterestHistory(algorithm, symbol, start, end):
             if (language == Language.CSharp)
             {
                 // No symbol, time span
-                var noSymbolTimeSpanHistoryWithFillForward = algorithm.History(dateRange, Resolution.Minute, fillForward: true)
-                    .Where(x => x.ContainsKey(aaplSymbol)).ToList();
-                var noSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(dateRange, Resolution.Minute, fillForward: false)
-                    .Where(x => x.ContainsKey(aaplSymbol)).ToList();
+                var noSymbolTimeSpanHistoryWithFillForward = algorithm.History(dateRange, Resolution.Minute, fillForward: true).ToList();
+                var noSymbolTimeSpanHistoryWithoutFillForward = algorithm.History(dateRange, Resolution.Minute, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     noSymbolTimeSpanHistoryWithFillForward,
                     noSymbolTimeSpanHistoryWithoutFillForward,
@@ -1584,10 +1582,8 @@ def getOpenInterestHistory(algorithm, symbol, start, end):
                     historyWithoutFillForwardExpectedCount);
 
                 // No symbol, periods
-                var noSymbolPeriodBasedHistoryWithFillForward = algorithm.History(periods, Resolution.Minute, fillForward: true)
-                    .Where(x => x.ContainsKey(aaplSymbol)).ToList();
-                var noSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(periods, Resolution.Minute, fillForward: false)
-                    .Where(x => x.ContainsKey(aaplSymbol)).ToList();
+                var noSymbolPeriodBasedHistoryWithFillForward = algorithm.History(periods, Resolution.Minute, fillForward: true).ToList();
+                var noSymbolPeriodBasedHistoryWithoutFillForward = algorithm.History(periods, Resolution.Minute, fillForward: false).ToList();
                 AssertFillForwardHistoryResults(
                     noSymbolPeriodBasedHistoryWithFillForward,
                     noSymbolPeriodBasedHistoryWithoutFillForward,

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -1780,7 +1780,8 @@ tradeBar = TradeBar
                         singleSymbolTimeSpanHistoryWithFillForward,
                         singleSymbolTimeSpanHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
 
                     // Single symbol, periods
                     var singleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(pySymbol, periods, resolution, fillForward: true);
@@ -1789,7 +1790,8 @@ tradeBar = TradeBar
                         singleSymbolPeriodBasedHistoryWithFillForward,
                         singleSymbolPeriodBasedHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
 
                     // Single symbol, date range
                     var singleSymbolDateRangeHistoryWithFillForward = algorithm.History(pySymbol, start, end, resolution, fillForward: true);
@@ -1798,7 +1800,8 @@ tradeBar = TradeBar
                         singleSymbolDateRangeHistoryWithFillForward,
                         singleSymbolDateRangeHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
 
                     // Symbol array, time span
                     var symbolsTimeSpanHistoryWithFillForward = algorithm.History(pySymbols, timeSpan, resolution, fillForward: true);
@@ -1807,7 +1810,8 @@ tradeBar = TradeBar
                         symbolsTimeSpanHistoryWithFillForward,
                         symbolsTimeSpanHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
 
                     // Symbol array, periods
                     var symbolsPeriodBasedHistoryWithFillForward = algorithm.History(pySymbols, periods, resolution, fillForward: true);
@@ -1816,7 +1820,8 @@ tradeBar = TradeBar
                         symbolsPeriodBasedHistoryWithFillForward,
                         symbolsPeriodBasedHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
 
                     // Symbol array, date range
                     var symbolsDateRangeHistoryWithFillForward = algorithm.History(pySymbols, start, end, resolution, fillForward: true);
@@ -1825,7 +1830,8 @@ tradeBar = TradeBar
                         symbolsDateRangeHistoryWithFillForward,
                         symbolsDateRangeHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
 
                     // Generic, single symbol, time span
                     var typedSingleSymbolTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbol, timeSpan,
@@ -1836,7 +1842,8 @@ tradeBar = TradeBar
                         typedSingleSymbolTimeSpanHistoryWithFillForward,
                         typedSingleSymbolTimeSpanHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
 
                     // Same as previous but using a Symbol instead of pySymbol
                     typedSingleSymbolTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, symbol, timeSpan,
@@ -1847,7 +1854,8 @@ tradeBar = TradeBar
                         typedSingleSymbolTimeSpanHistoryWithFillForward,
                         typedSingleSymbolTimeSpanHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
 
                     // Generic, single symbol, periods
                     var typedSingleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbol, periods,
@@ -1858,7 +1866,8 @@ tradeBar = TradeBar
                         typedSingleSymbolPeriodBasedHistoryWithFillForward,
                         typedSingleSymbolPeriodBasedHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
 
                     // Same as previous but using a Symbol instead of pySymbol
                     typedSingleSymbolPeriodBasedHistoryWithFillForward = algorithm.History(pyTradeBarType, symbol, periods,
@@ -1869,7 +1878,8 @@ tradeBar = TradeBar
                         typedSingleSymbolPeriodBasedHistoryWithFillForward,
                         typedSingleSymbolPeriodBasedHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
 
                     // Generic, single symbol, date range
                     var typedSingleSymbolDateRangeHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbol, start, end,
@@ -1880,7 +1890,8 @@ tradeBar = TradeBar
                         typedSingleSymbolDateRangeHistoryWithFillForward,
                         typedSingleSymbolDateRangeHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
 
                     // Same as previous but using a Symbol instead of pySymbol
                     typedSingleSymbolDateRangeHistoryWithFillForward = algorithm.History(pyTradeBarType, symbol, start, end,
@@ -1891,7 +1902,8 @@ tradeBar = TradeBar
                         typedSingleSymbolDateRangeHistoryWithFillForward,
                         typedSingleSymbolDateRangeHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
 
                     // Generic, symbol array, time span
                     var typedSymbolsTimeSpanHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbols, timeSpan,
@@ -1902,7 +1914,8 @@ tradeBar = TradeBar
                         typedSymbolsTimeSpanHistoryWithFillForward,
                         typedSymbolsTimeSpanHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
 
                     // Generic, symbol array, periods
                     var typedSymbolsPeriodBasedHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbols, periods,
@@ -1913,7 +1926,8 @@ tradeBar = TradeBar
                         typedSymbolsPeriodBasedHistoryWithFillForward,
                         typedSymbolsPeriodBasedHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
 
                     // Generic, symbol array, date range
                     var typedSymbolsDateRangeHistoryWithFillForward = algorithm.History(pyTradeBarType, pySymbols, start, end,
@@ -1924,7 +1938,8 @@ tradeBar = TradeBar
                         typedSymbolsDateRangeHistoryWithFillForward,
                         typedSymbolsDateRangeHistoryWithoutFillForward,
                         tradeBarOnlyHistoryWithFillForwardExpectedCount,
-                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount);
+                        tradeBarOnlyHistoryWithoutFillForwardExpectedCount,
+                        resolution);
                 }
             }
         }
@@ -2138,6 +2153,33 @@ tradeBar = TradeBar
         }
 
         /// <summary>
+        /// Asserts that fill forwarded history results has data for every period in the requested time span
+        /// </summary>
+        private static void AssertFillForwardedHistoryTimes(Symbol symbol, List<DateTime> times, TimeSpan period)
+        {
+            var hours = MarketHoursDatabase.FromDataFolder().GetEntry(symbol.ID.Market, symbol, symbol.ID.SecurityType).ExchangeHours;
+
+            for (var i = 0; i < times.Count;)
+            {
+                var currentDayHours = hours.GetMarketHours(times[i]);
+                var regularMarketSegments = currentDayHours.Segments.Where(x => x.State == MarketHoursState.Market).ToList();
+                var firstSegmentOfDayIndex = i > 0
+                    ? 0
+                    : regularMarketSegments
+                        .FindIndex(x => times[i].TimeOfDay > x.Start && times[i].TimeOfDay <= x.End);
+
+                foreach (var segment in regularMarketSegments.Skip(firstSegmentOfDayIndex))
+                {
+                    var start = i > 0 ? segment.Start + period : times[i].TimeOfDay;
+                    for (var time = start; time <= segment.End; time += period, i++)
+                    {
+                        Assert.AreEqual(time, times[i].TimeOfDay);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Asserts that history data, when called with fillForward set to true, has a period that is equal to the resolution used.
         /// Used in the test <see cref="HistoryRequestWithFillForward"/>.
         /// </summary>
@@ -2150,27 +2192,9 @@ tradeBar = TradeBar
             Assert.IsTrue(historyWithFillForward.All(bar => bar.Period == expectedPeriod));
             Assert.IsTrue(historyWithoutFillForward.All(bar => bar.Period == expectedPeriod));
 
-            // Check that fill-forwarded history has data for every period in the requested time span
             var symbol = historyWithFillForward.First().Symbol;
-            var hours = MarketHoursDatabase.FromDataFolder().GetEntry(symbol.ID.Market, symbol, symbol.ID.SecurityType).ExchangeHours;
-            for (var i = 0; i < historyWithFillForward.Count;)
-            {
-                var currentDayHours = hours.GetMarketHours(historyWithFillForward[i].Time);
-                var regularMarketSegments = currentDayHours.Segments.Where(x => x.State == MarketHoursState.Market).ToList();
-                var firstSegmentOfDayIndex = i > 0
-                    ? 0
-                    : regularMarketSegments
-                        .FindIndex(x => historyWithFillForward[i].Time.TimeOfDay >= x.Start && historyWithFillForward[i].Time.TimeOfDay < x.End);
-
-                foreach (var segment in regularMarketSegments.Skip(firstSegmentOfDayIndex))
-                {
-                    var start = i > 0 ? segment.Start : historyWithFillForward[i].Time.TimeOfDay;
-                    for (var time = start; time < segment.End; time += expectedPeriod, i++)
-                    {
-                        Assert.AreEqual(time, historyWithFillForward[i].Time.TimeOfDay);
-                    }
-                }
-            }
+            var times = historyWithFillForward.Select(bar => bar.EndTime).ToList();
+            AssertFillForwardedHistoryTimes(symbol, times, expectedPeriod);
         }
 
         /// <summary>
@@ -2259,7 +2283,8 @@ tradeBar = TradeBar
             PyObject historyWithFillForward,
             PyObject historyWithoutFillForward,
             int expectedHistoryWithFillForwardCount,
-            int expectedHistoryWithoutFillForwardCount)
+            int expectedHistoryWithoutFillForwardCount,
+            Resolution resolution)
         {
             var historyWithFillForwardCount = historyWithFillForward.GetAttr("shape")[0].As<int>();
             var historyWithoutFillForwardCount = historyWithoutFillForward.GetAttr("shape")[0].As<int>();
@@ -2268,6 +2293,15 @@ tradeBar = TradeBar
             Assert.AreEqual(expectedHistoryWithFillForwardCount, historyWithFillForwardCount);
             Assert.AreEqual(expectedHistoryWithoutFillForwardCount, historyWithoutFillForwardCount);
             Assert.Less(historyWithoutFillForwardCount, historyWithFillForwardCount);
+
+            var index = historyWithFillForward
+                .GetAttr("index")
+                .GetAttr("to_flat_index").Invoke()
+                .GetAttr("tolist").Invoke()
+                .As<List<PyObject>>();
+            var symbol = index.First()[0].As<Symbol>();
+            var times = index.Select(x => x[1].As<DateTime>()).ToList();
+            AssertFillForwardedHistoryTimes(symbol, times, resolution.ToTimeSpan());
         }
     }
 }

--- a/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/FileSystemDataFeedTests.cs
@@ -181,7 +181,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             synchronizer.Initialize(algorithm, algorithm.DataManager);
 
             feed.Initialize(algorithm, job, resultHandler, TestGlobals.MapFileProvider, TestGlobals.FactorFileProvider, TestGlobals.DataProvider, algorithm.DataManager, synchronizer, dataPermissionManager.DataChannelProvider);
-            var option = algorithm.AddOption("AAPL", fillDataForward: fillForward);
+            var option = algorithm.AddOption("AAPL", fillForward: fillForward);
             option.SetFilter(filter => filter.FrontMonth());
             algorithm.PostInitialize();
 
@@ -232,7 +232,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             feed.Initialize(algorithm, job, resultHandler, TestGlobals.MapFileProvider, TestGlobals.FactorFileProvider, TestGlobals.DataProvider,
                 algorithm.DataManager, synchronizer, dataPermissionManager.DataChannelProvider);
-            var future = algorithm.AddFuture("ES", fillDataForward: fillForward, extendedMarketHours: true);
+            var future = algorithm.AddFuture("ES", fillForward: fillForward, extendedMarketHours: true);
             future.SetFilter(0, 300);
             algorithm.PostInitialize();
 

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -844,7 +844,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var feed = RunDataFeed();
             for (int i = 0; i < 100; i++)
             {
-                _algorithm.AddData<CustomMockedFileBaseData>((100 + i).ToStringInvariant(), Resolution.Second, fillDataForward: false);
+                _algorithm.AddData<CustomMockedFileBaseData>((100 + i).ToStringInvariant(), Resolution.Second, fillForward: false);
             }
 
             int count = 0;
@@ -892,7 +892,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var feed = RunDataFeed();
 
-            _algorithm.AddData<TestCustomData>("Pinocho", Resolution.Minute, fillDataForward: false);
+            _algorithm.AddData<TestCustomData>("Pinocho", Resolution.Minute, fillForward: false);
 
             TestCustomData.ReturnNull = returnsNull;
             TestCustomData.ThrowException = throwsException;
@@ -2308,12 +2308,12 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             {
                 case SecurityType.Base:
                     algorithm.AddEquity(symbol.Underlying.Value, resolution, symbol.ID.Market,
-                        fillDataForward: false);
+                        fillForward: false);
 
                     if (customDataType.RequiresMapping())
                     {
                         security = algorithm.AddData<T>(symbol.Value, resolution,
-                            fillDataForward: false);
+                            fillForward: false);
                     }
                     else
                     {
@@ -2322,11 +2322,11 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                     break;
 
                 case SecurityType.Future:
-                    security = algorithm.AddFutureContract(symbol, resolution, fillDataForward: false, extendedMarketHours: true);
+                    security = algorithm.AddFutureContract(symbol, resolution, fillForward: false, extendedMarketHours: true);
                     break;
 
                 case SecurityType.Option:
-                    security = algorithm.AddOptionContract(symbol, resolution, fillDataForward: false);
+                    security = algorithm.AddOptionContract(symbol, resolution, fillForward: false);
                     break;
 
                 default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

In an effort to add all the configuration parameters (fill forward, extended market hours, data mapping and normalization mode, and contract depth offset) to the `History` API, this is the first step towards that goal. Parameters will be added one by one, being `fillForward` the first one.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Part of #6750 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

It could require updating the `History` API documentation.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
