### PR TITLE
Solve Report Generation Conversion Rate Error bug

### DIFF
--- a/Report/PortfolioLooper/PortfolioLooper.cs
+++ b/Report/PortfolioLooper/PortfolioLooper.cs
@@ -139,17 +139,14 @@ namespace QuantConnect.Report
             // Begin setting up the currency conversion feed if needed
             var coreSecurities = Algorithm.Securities.Values.ToList();
 
-            if (coreSecurities.Any(x => x.Symbol.SecurityType == SecurityType.Forex || x.Symbol.SecurityType == SecurityType.Crypto))
-            {
-                BaseSetupHandler.SetupCurrencyConversions(Algorithm, _dataManager.UniverseSelection);
-                var conversionSecurities = Algorithm.Securities.Values.Where(s => !coreSecurities.Contains(s)).ToList();
+            BaseSetupHandler.SetupCurrencyConversions(Algorithm, _dataManager.UniverseSelection);
+            var conversionSecurities = Algorithm.Securities.Values.Where(s => !coreSecurities.Contains(s)).ToList();
 
-                // Skip the history request if we don't need to convert anything
-                if (conversionSecurities.Any())
-                {
-                    // Point-in-time Slices to convert FX and Crypto currencies to the portfolio currency
-                    _conversionSlices = GetHistory(Algorithm, conversionSecurities, resolution);
-                }
+            // Skip the history request if we don't need to convert anything
+            if (conversionSecurities.Any())
+            {
+                // Point-in-time Slices to convert FX and Crypto currencies to the portfolio currency
+                _conversionSlices = GetHistory(Algorithm, conversionSecurities, resolution);
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
`Report.PortfolioLooper` constructor didn't set up currency conversion for CryptoFutures securities (See https://github.com/QuantConnect/Lean/blob/master/Report/PortfolioLooper/PortfolioLooper.cs#L142), so when the backtest result used that kind of security types it never found a conversion for them so it was assigned zero conversion rate, raising an exception when a conversion was tried to be made. Making a git blame for Report.PortfolioLooper constructor it was found the if sentence was not needed so it was removed. On the other hand, once that if sentence was removed, the Report for `BasicTemplateCryptoFutureAlgorithm.cs` still failed, because Report was looking for BTCBUSD data at daily resolution in Cache, though BTCUSD CryptoFuture was at minute resolution in the regression algorithm.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7170 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change users will be able to generate reports for backtest results that used CryptoFutures
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require updates to documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Different reports were made for algorithms that used security types as Equity, Future and Option to check `conversionSecurities` list was empty, meaning the if sentence was unnecessary for that kind of security types. See https://github.com/QuantConnect/Lean/blob/master/Report/PortfolioLooper/PortfolioLooper.cs#L145
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
