### PR TITLE
Unit tests for `OptionStrategyPositionGroupBuyingPowerModelTests`

### DIFF
--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -62,6 +62,257 @@ namespace QuantConnect.Tests.Common.Securities
             Log.DebuggingEnabled = true;
         }
 
+        /// <summary>
+        /// All these test cases are based on test done on local IB TWS and assuming an initial cash of 1,000,000
+        /// </summary>
+        // option strategy definition, initial quantity, order quantity, expected result
+        private static readonly TestCaseData[] HasSufficientBuyingPowerForOrderTestCases = new[]
+        {
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, 50, true).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, 60, false),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -40, true),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -50, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, 50 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, 60 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -40 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -50 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, -50 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, -60 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, 50 - -20, true).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, 60 - -20, false),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, 80, true).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, 90, false),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -90, true).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -100, false),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, 80 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, 90 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -90 - 20, true).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -100 - 20, false),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -90 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -100 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 80 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 90 - -20, false),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, 1000, true),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, 1010, false),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -980, true),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -990, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, 1000 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, 1010 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -980 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -990 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, -980 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, -990 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, 1000 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, 1010 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, 1000, true),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, 10000, true),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, -1000, true),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, -1010, false),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, 1000 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, 10000 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -1000 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -1010 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, -1000 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, -1010 - -20, false),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, 1000 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, 10000 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, 970, true),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, 990, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, -990, true),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, -1010, false),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, 970 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, 990 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -990 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -1010 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, -990 - -20, true).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, -1010 - -20, false),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, 970 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, 990 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, 990, true),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, 1010, false),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, -1000, true),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, -10000, true),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, 990 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, 1010 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -1000 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -10000 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, -1000 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, -10000 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, 990 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, 1010 - -20, false),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, 85, true),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, 90, false),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, -50, true).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, -55, false),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, 85 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, 90 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -50 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -55 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, -50 - -20, true).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, -55 - -20, false),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, 85 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, 90 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, 90, true),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, 110, false),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, -50, true).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, -60, false),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, 90 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, 110 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -50 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -60 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, -50 - -20, true).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, -60 - -20, false),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, 90 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, 110 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, 700, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, 720, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, -640, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, -660, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, 700 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, 720 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -640 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -660 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, -640 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, -660 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, 700 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, 720 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, 640, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, 660, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, -700, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, -720, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, 640 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, 660 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -700 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -720 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, -700 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, -720 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, 640 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, 660 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, 1000, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, 10000, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, -990, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, -1010, false),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, 1000 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, 10000 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -990 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -1010 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, -990 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, -1010 - -20, false),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, 1000 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, 10000 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, 990, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, 1010, false),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, -1000, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, -10000, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, 990 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, 1010 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -1000 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -10000 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, -1000 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, -10000 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, 990 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, 1010 - -20, false),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, 1300, true),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, 1310, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, -40, true),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, -60, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, 1300 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, 1310 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -40 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -60 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, -40 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, -60 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, 1300 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, 1310 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, 1000, true),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, 10000, true),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, -310, true),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, -330, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, 1000 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, 10000 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -310 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -330 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, -310 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, -330 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, 1000 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, 10000 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, 980, true),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, 1000, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, -980, true),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, -1000, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, 980 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, 1000 - 20, false),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -980 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -1000 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, -980 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, -1000 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, 980 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, 1000 - -20, false).Explicit(),
+        };
+
+        [TestCaseSource(nameof(HasSufficientBuyingPowerForOrderTestCases))]
+        public void HasSufficientBuyingPowerForOrder(OptionStrategyDefinition optionStrategy, int initialPositionQuantity, int orderQuantity,
+            bool expectedResult)
+        {
+            _algorithm.SetCash(1000000);
+
+            IPositionGroup initialPositionGroup = null;
+            var templatePositionGroupQuantity = initialPositionQuantity;
+            if (initialPositionQuantity != 0)
+            {
+                initialPositionGroup = SetUpOptionStrategy(optionStrategy, initialPositionQuantity);
+            }
+            else
+            {
+                templatePositionGroupQuantity = 1;
+                initialPositionGroup = SetUpOptionStrategy(optionStrategy, templatePositionGroupQuantity);
+                foreach (var position in initialPositionGroup.Positions)
+                {
+                    var security = _algorithm.Securities[position.Symbol];
+                    security.Holdings.SetHoldings(0, 0);
+                }
+                Assert.AreEqual(0, _portfolio.PositionGroups.Count);
+            }
+
+            var orders = GetPositionGroupOrders(initialPositionGroup, templatePositionGroupQuantity, orderQuantity);
+            var ordersPositionGroup = _portfolio.Positions.CreatePositionGroup(orders);
+
+            var result = ordersPositionGroup.BuyingPowerModel.HasSufficientBuyingPowerForOrder(
+                new HasSufficientPositionGroupBuyingPowerForOrderParameters(_portfolio, ordersPositionGroup, orders));
+
+            Assert.AreEqual(expectedResult, result.IsSufficient, result.Reason);
+        }
+
         [Test]
         public void HasSufficientBuyingPowerForStrategyOrder([Values] bool withInitialHoldings)
         {
@@ -854,7 +1105,7 @@ namespace QuantConnect.Tests.Common.Securities
             var finalQuantity = initialPositionQuantity + newGroupQuantity;
 
             var buyingPowerImpact = positionGroup.BuyingPowerModel.GetReservedBuyingPowerImpact(new ReservedBuyingPowerImpactParameters(_portfolio,
-                positionGroup, GetPositionGroupOrders(positionGroup, newGroupQuantity)));
+                positionGroup, GetPositionGroupOrders(initialPositionGroup, initialPositionQuantity, newGroupQuantity)));
 
             var initialUsedMargin = initialPositionGroup.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(
                 new ReservedBuyingPowerForPositionGroupParameters(_portfolio, initialPositionGroup)).AbsoluteUsedBuyingPower;
@@ -920,14 +1171,14 @@ namespace QuantConnect.Tests.Common.Securities
             };
         }
 
-        private List<Order> GetPositionGroupOrders(IPositionGroup positionGroup, decimal quantity)
+        private List<Order> GetPositionGroupOrders(IPositionGroup positionGroup, decimal initialPositionGroupQuantity, decimal quantity)
         {
             var groupOrderManager = new GroupOrderManager(1, positionGroup.Count, quantity);
             return positionGroup.Positions.Select(position => Order.CreateOrder(new SubmitOrderRequest(
                 OrderType.ComboMarket,
                 position.Symbol.SecurityType,
                 position.Symbol,
-                position.Quantity,
+                (position.Quantity / initialPositionGroupQuantity).GetOrderLegGroupQuantity(groupOrderManager),
                 0,
                 0,
                 _algorithm.Time,

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -419,125 +419,115 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(expectedQuantity, quantity);
         }
 
+        // option strategy definition, initial position quantity, target buying power percent, expected quantity
         private static readonly TestCaseData[] OrderQuantityForTargetBuyingPowerTestCases = new[]
         {
-            // option strategy definition, initial position quantity, final position quantity
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 11),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 9),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 0),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 0),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 0),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 0),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 0),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 0),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 11),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 9),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 11),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 9),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 11),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 9),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 0),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 9),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 0),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 0).Explicit(),
+            // Initial margin requirement for CoveredCall with quantity 10 is 205000
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 205000m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 205000m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 0m, -10),
+            // Initial margin requirement for CoveredCall with quantity -10 is 112000
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 112000m * 11 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 112000m * 9 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 0m, +10),
+            // Initial margin requirement for CoveredPut with quantity 10 is 205000
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 205000m * 11 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 205000m * 9 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 0m, -10),
+            // Initial margin requirement for CoveredPut with quantity -10 is 205000
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 205000m * 11 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 205000m * 9 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 0m, +10),
+            // Initial margin requirement for BearCallSpread with quantity 10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 11 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 9 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 0m, -10),
+            // Initial margin requirement for BearCallSpread with quantity -10 is 0
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 0m, 0).Explicit(),
+            // Initial margin requirement for BearPutSpread with quantity 10 is 0
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 0m, 0).Explicit(),
+            // Initial margin requirement for BearPutSpread with quantity -10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 10000m * 11 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 10000m * 9 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 0m, +10).Explicit(),
+            // Initial margin requirement for BullCallSpread with quantity 10 is 0
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 0m, 0).Explicit(),
+            // Initial margin requirement for BullCallSpread with quantity -10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 10000m * 11 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 10000m * 9 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 0m, +10).Explicit(),
+            // Initial margin requirement for BullPutSpread with quantity 10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 10000m * 11 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 10000m * 9 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 0m, -10),
+            // Initial margin requirement for BullPutSpread with quantity -10 is 0
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 0m, 0).Explicit(),
+            // Initial margin requirement for Straddle with quantity 10 is 112020
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 112020m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 112020m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 0m, -10).Explicit(),
+            // Initial margin requirement for Straddle with quantity -10 is 235019
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 235019m * 11 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 235019m * 9 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 0m, +10).Explicit(),
+            // Initial margin requirement for Strangle with quantity 10 is 102020
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 102020m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 102020m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 0m, -10).Explicit(),
+            // Initial margin requirement for Strangle with quantity -10 is 225020
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 225020m * 11 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 225020m * 9 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 0m, +10).Explicit(),
+            // Initial margin requirement for ButterflyCall with quantity 10 is 0
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 0m, 0).Explicit(),
+            // Initial margin requirement for ButterflyCall with quantity -10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 10000m * 11 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 10000m * 9 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 0m, +10).Explicit(),
+            // Initial margin requirement for ShortButterflyCall with quantity 10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 10000m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 10000m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 0m, -10),
+            // Initial margin requirement for ShortButterflyCall with quantity -10 is 0
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 0m, 0).Explicit(),
+            // Initial margin requirement for ButterflyPut with quantity 10 is 0
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 0m, 0).Explicit(),
+            // Initial margin requirement for ButterflyPut with quantity -10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 10000m * 11 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 10000m * 9 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 0m, +10).Explicit(),
+            // Initial margin requirement for ShortButterflyPut with quantity 10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 10000m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 10000m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 0m, -10),
+            // Initial margin requirement for ShortButterflyPut with quantity -10 is 0
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 0m, 0).Explicit(),
+            // Initial margin requirement for CallCalendarSpread with quantity 10 is 0
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 0m, 0).Explicit(),
+            // Initial margin requirement for CallCalendarSpread with quantity -10 is 0
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 0m, 0).Explicit(),
+            // Initial margin requirement for PutCalendarSpread with quantity 10 is 0
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 0m, 0).Explicit(),
+            // Initial margin requirement for PutCalendarSpread with quantity -10 is 0
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 0m, 0).Explicit(),
+            // Initial margin requirement for IronCondor with quantity 10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 10000m * 11 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 10000m * 9 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 0m, -10).Explicit(),
+            // Initial margin requirement for IronCondor with quantity -10 is 0
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 0m, 0).Explicit(),
         };
 
         [TestCaseSource(nameof(OrderQuantityForTargetBuyingPowerTestCases))]
         public void PositionGroupOrderQuantityCalculationForTargetBuyingPower(OptionStrategyDefinition optionStrategyDefinition,
-            int initialPositionQuantity, int expectedFinalQuantity)
+            int initialPositionQuantity, decimal targetBuyingPower, int expectedQuantity)
         {
             var positionGroup = SetUpOptionStrategy(optionStrategyDefinition, initialPositionQuantity);
 
-            var initialUsedMargin = positionGroup.BuyingPowerModel.GetInitialMarginRequirement(
-                new PositionGroupInitialMarginParameters(_portfolio, positionGroup));
-
-            var deltaBuyingPower = GetDeltaBuyingPower(initialUsedMargin.Value, initialPositionQuantity, expectedFinalQuantity,
-                out var expectedQuantity);
-            var targetBuyingPower = initialUsedMargin + deltaBuyingPower;
-            var targetBuyingPowerPercent = _portfolio.TotalPortfolioValue != 0 ? targetBuyingPower / _portfolio.TotalPortfolioValue : 0;
-
-            Log.Trace($"Initial used margin: {initialUsedMargin.Value}");
-            Log.Trace($"Delta buying power: {deltaBuyingPower}");
-            Log.Trace($"Target buying power: {targetBuyingPower}");
-            Log.Trace($"Target buying power percent: {targetBuyingPowerPercent}");
+            var targetBuyingPowerPercent = targetBuyingPower / _portfolio.TotalPortfolioValue;
 
             var quantity = positionGroup.BuyingPowerModel.GetMaximumLotsForTargetBuyingPower(new GetMaximumLotsForTargetBuyingPowerParameters(
                 _portfolio, positionGroup, targetBuyingPowerPercent, minimumOrderMarginPortfolioPercentage: 0)).NumberOfLots;
-
-            Log.Trace($"Expected quantity: {expectedQuantity}");
-            Log.Trace($"Computed quantity: {quantity}");
 
             Assert.AreEqual(expectedQuantity, quantity);
         }
@@ -696,9 +686,9 @@ namespace QuantConnect.Tests.Common.Securities
             var initialUsedMargin = _portfolio.TotalMarginUsed;
             var initialPositionInitialMargin = initialPositionGroup.BuyingPowerModel.GetInitialMarginRequirement(
                 new PositionGroupInitialMarginParameters(_portfolio, initialPositionGroup));
-            Log.Trace($"Initial used margin: {initialUsedMargin}");
-            Log.Trace($"Initial position initial margin requirement: {initialPositionInitialMargin}");
-            Log.Trace($"Final quantity: {finalQuantity}");
+            Log.Debug($"Initial used margin: {initialUsedMargin}");
+            Log.Debug($"Initial position initial margin requirement: {initialPositionInitialMargin}");
+            Log.Debug($"Final quantity: {finalQuantity}");
 
             // Initial and final positions are in the same side
             if (Math.Sign(finalQuantity) == Math.Sign(initialPositionQuantity))
@@ -854,52 +844,6 @@ namespace QuantConnect.Tests.Common.Securities
         public void ReservedBuyingPowerImpactCalculation(OptionStrategyDefinition optionStrategyDefinition, int initialPositionQuantity,
             int newGroupQuantity)
         {
-            // starting long
-            if (initialPositionQuantity > 0)
-            {
-                // going longer
-                if (newGroupQuantity > 0)
-                {
-                    //Assert.Ignore();
-                }
-                // reducing long
-                else if (initialPositionQuantity + newGroupQuantity > 0)
-                {
-                    //Assert.Ignore();
-                }
-                // liquidating long position
-                else if (initialPositionQuantity + newGroupQuantity == 0)
-                {
-                    //Assert.Ignore();
-                }
-                // switching to short
-                else
-                {
-                    //Assert.Ignore();
-                }
-            }
-            // starting short
-            // going shorter
-            else if (newGroupQuantity < 0)
-            {
-                //Assert.Ignore();
-            }
-            // reducing short
-            else if (initialPositionQuantity + newGroupQuantity < 0)
-            {
-                //Assert.Ignore();
-            }
-            // liquidating short position
-            else if (initialPositionQuantity + newGroupQuantity == 0)
-            {
-                //Assert.Ignore();
-            }
-            // switching to long
-            else
-            {
-                //Assert.Ignore();
-            }
-
             var initialMargin = _portfolio.MarginRemaining;
             var initialPositionGroup = SetUpOptionStrategy(optionStrategyDefinition, initialPositionQuantity);
 
@@ -914,8 +858,8 @@ namespace QuantConnect.Tests.Common.Securities
 
             var initialUsedMargin = initialPositionGroup.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(
                 new ReservedBuyingPowerForPositionGroupParameters(_portfolio, initialPositionGroup)).AbsoluteUsedBuyingPower;
-            Log.Trace($"Initial used margin: {initialUsedMargin}");
-            Log.Trace($"Final quantity: {finalQuantity}");
+            Log.Debug($"Initial used margin: {initialUsedMargin}");
+            Log.Debug($"Final quantity: {finalQuantity}");
 
             foreach (var contemplatedChangePosition in buyingPowerImpact.ContemplatedChanges)
             {
@@ -1187,20 +1131,6 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(expectedPositionGroupBPMStrategy, positionGroup.BuyingPowerModel.ToString());
 
             return positionGroup;
-        }
-
-        private static decimal GetDeltaBuyingPower(decimal initialUsedMargin, int initialPositionQuantity, int expectedFinalQuantity,
-            out int expectedQuantity)
-        {
-            expectedQuantity = 0;
-            if (initialUsedMargin != 0)
-            {
-                expectedQuantity = expectedFinalQuantity - initialPositionQuantity;
-            }
-
-            // If reducing the position, we are reducing the buying power used by the strategy, so the delta buying power is negative
-            var direction = Math.Abs(expectedFinalQuantity) < Math.Abs(initialPositionQuantity) ? -1 : +1;
-            return direction * Math.Abs(expectedQuantity * initialUsedMargin / initialPositionQuantity);
         }
     }
 }

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -308,121 +308,113 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(expectedMaintenanceMargin, maintenanceMargin.Value);
         }
 
+        // option strategy definition, initial position quantity, final position quantity
         private static readonly TestCaseData[] OrderQuantityForDeltaBuyingPowerTestCases = new[]
         {
-            // option strategy definition, initial position quantity, final position quantity
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 0),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 11),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 9),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 11),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 9),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 0).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -9).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -11).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 0).Explicit(),
+            // Initial margin for CoveredCall with quantity 10 is 205000
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 205000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -205000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -205000m, -10).Explicit(),
+            // Initial margin for CoveredCall with quantity -10 is 112000
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 112000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -112000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -112000m, +10).Explicit(),
+            // Initial margin for CoveredPut with quantity 10 is 205000
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 205000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -205000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -205000m, -10).Explicit(),
+            // Initial margin for CoveredPut with quantity -10 is 205000
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 205000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -205000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -205000m, +10),
+            // Initial margin for BullCallSpread with quantity 10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 1000m, 1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -1000m, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10000m, 10).Explicit(),
+            // Initial margin for BullCallSpread with quantity -10 is 0
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 0m, 0).Explicit(),
+            // Initial margin for BearPutSpread with quantity 10 is 0
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 0m, 0).Explicit(),
+            // Initial margin for BearPutSpread with quantity -10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 10000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -10000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -10000m, +10).Explicit(),
+            // Initial margin for BullCallSpread with quantity 10 is 0
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 0m, 0).Explicit(),
+            // Initial margin for BullCallSpread with quantity -10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 10000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -10000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -10000m, +10).Explicit(),
+            // Initial margin for BullPutSpread with quantity 10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 10000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10000m, -10).Explicit(),
+            // Initial margin for BullPutSpread with quantity -10 is 0
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 0m, 0).Explicit(),
+            // Initial margin for Straddle with quantity 10 is 112020
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 112020m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -112020m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -112020m, -10).Explicit(),
+            // Initial margin for Straddle with quantity -10 is 235019
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 235019m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -235019m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -235019m, +10).Explicit(),
+            // Initial margin for Strangle with quantity 10 is 102020
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 102020m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -102020m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -102020m, -10).Explicit(),
+            // Initial margin for Strangle with quantity -10 is 225020
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 225020m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -225020m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -225020m, +10).Explicit(),
+            // Initial margin for ButterflyCall with quantity 10 is 0
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 0m, 0).Explicit(),
+            // Initial margin for ButterflyCall with quantity -10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 10000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -10000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -10000m, +10).Explicit(),
+            // Initial margin for ShortButterflyCall with quantity 10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 10000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -10000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -10000m, -10).Explicit(),
+            // Initial margin for ShortButterflyCall with quantity -10 is 0
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 0m, 0).Explicit(),
+            // Initial margin for ButterflyPut with quantity 10 is 0
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 0m, 0).Explicit(),
+            // Initial margin for ButterflyPut with quantity -10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 10000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -10000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -10000m, +10).Explicit(),
+            // Initial margin for ShortButterflyPut with quantity 10 is 1000
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 10000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10000m, -10).Explicit(),
+            // Initial margin for ShortButterflyPut with quantity -10 is 0
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 0m, 0).Explicit(),
+            // Initial margin for CallCalendarSpread with quantity 10 is 0
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 0m, 0).Explicit(),
+            // Initial margin for CallCalendarSpread with quantity -10 is 0
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 0m, 0).Explicit(),
+            // Initial margin for PutCalendarSpread with quantity 10 is 0
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 0m, 0).Explicit(),
+            // Initial margin for PutCalendarSpread with quantity -10 is 0
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 0m, 0).Explicit(),
+            // Initial margin for IronCondor with quantity 10 is 10000
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 10000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10000m, -10).Explicit(),
+            // Initial margin for IronCondor with quantity -10 is 0
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 0m, 0).Explicit(),
         };
 
         [TestCaseSource(nameof(OrderQuantityForDeltaBuyingPowerTestCases))]
         public void PositionGroupOrderQuantityCalculationForDeltaBuyingPower(OptionStrategyDefinition optionStrategyDefinition,
-            int initialPositionQuantity, int expectedFinalQuantity)
+            int initialPositionQuantity, decimal deltaBuyingPower, int expectedQuantity)
         {
             var positionGroup = SetUpOptionStrategy(optionStrategyDefinition, initialPositionQuantity);
 
-            var initialUsedMargin = positionGroup.BuyingPowerModel.GetInitialMarginRequirement(
-                new PositionGroupInitialMarginParameters(_portfolio, positionGroup));
-
-            var deltaBuyingPower = GetDeltaBuyingPower(initialUsedMargin.Value, initialPositionQuantity, expectedFinalQuantity,
-                out var expectedQuantity);
-
-            Log.Trace($"Initial used margin: {initialUsedMargin.Value}");
-            Log.Trace($"Delta buying power: {deltaBuyingPower}");
-
             var quantity = positionGroup.BuyingPowerModel.GetMaximumLotsForDeltaBuyingPower(new GetMaximumLotsForDeltaBuyingPowerParameters(
                 _portfolio, positionGroup, deltaBuyingPower, minimumOrderMarginPortfolioPercentage: 0)).NumberOfLots;
-
-            Log.Trace($"Expected quantity: {expectedQuantity}");
-            Log.Trace($"Computed quantity: {quantity}");
 
             Assert.AreEqual(expectedQuantity, quantity);
         }

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -197,6 +197,50 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.IsTrue(hasSufficientBuyingPowerResult.IsSufficient);
         }
 
+        /// <summary>
+        /// Test cases for the <see cref="OptionStrategyPositionGroupBuyingPowerModel.GetInitialMarginRequirement"/> method.
+        ///
+        /// TODO: We should come back and revisit these test cases to make sure they are correct.
+        /// The approximate values from IB for the prices used in the test are in the comments.
+        /// For instance, see the test case for the CoveredCall strategy. The margin values do not match IB's values.
+        ///
+        /// Test cases marked as explicit will fail if ran, they have an approximate expected value based on IB's margin requirements.
+        /// </summary>
+        private static readonly TestCaseData[] InitialMarginRequirementsTestCases = new[]
+        {
+            // OptionStrategyDefinition, initialHoldingsQuantity, expectedInitialMarginRequirement
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 1, 10000m).Explicit(),          // IB:  10282.15
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -1, 11200m),                    // IB:  12338.58
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 1, 12000m).Explicit(),           // IB:  12331.38
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -1, 10000m).Explicit(),          // IB:  10276.15
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 0m).Explicit(),           // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                     // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 1, 0m),                       // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -1, 1000m),                   // IB:  1000
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 1, 0m),                      // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -1, 0m).Explicit(),          // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 1, 1000m),                    // IB:  1000
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -1, 0m),                      // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 1, 0m).Explicit(),                 // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -1, 3000m).Explicit(),             // IB:  3001.60
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 1, 0m).Explicit(),                 // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -1, 3000m).Explicit(),             // IB:  3001.60
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 1, 0m),                       // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -1, 0m).Explicit(),           // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 1, 0m).Explicit(),       // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -1, 0m),                 // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 1, 0m),                        // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -1, 1000m),                    // IB:  1000
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 1, 1000m),                // IB:  1000
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -1, 0m),                  // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 1, 0m),                  // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -1, 0m),                 // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 1, 0m),                   // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -1, 3000m).Explicit(),    // IB:  3001.6
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 1, 1000m),                       // IB:  1017.62
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -1, 0m),                         // IB:  0
+        };
+
         [TestCaseSource(nameof(InitialMarginRequirementsTestCases))]
         public void GetsInitialMarginRequirement(OptionStrategyDefinition optionStrategyDefinition, int quantity,
             decimal expectedInitialMarginRequirement)
@@ -209,6 +253,50 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(expectedInitialMarginRequirement, initialMarginRequirement.Value);
         }
 
+        /// <summary>
+        /// Test cases for the <see cref="OptionStrategyPositionGroupBuyingPowerModel.GetMaintenanceMargin"/> method.
+        ///
+        /// TODO: We should come back and revisit these test cases to make sure they are correct.
+        /// The approximate values from IB for the prices used in the test are in the comments.
+        /// For instance, see the test case for the CoveredCall strategy. The margin values do not match IB's values.
+        ///
+        /// Test cases marked as explicit will fail if ran, they have an approximate expected value based on IB's margin requirements.
+        /// </summary>
+        private static readonly TestCaseData[] MaintenanceMarginTestCases = new[]
+        {
+            // OptionStrategyDefinition, initialHoldingsQuantity, expectedMaintenanceMargin
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 1, 10000m).Explicit(),          // IB:  10282.15
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -1, 3000m).Explicit(),          // IB:  3000
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 1, 3000m).Explicit(),            // IB:  3000
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -1, 1000m).Explicit(),           // IB:  10276.15
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 0m).Explicit(),           // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                     // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 1, 0m),                       // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -1, 1000m),                   // IB:  1000
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 1, 0m),                      // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -1, 0m).Explicit(),          // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 1, 1000m),                    // IB:  1000
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -1, 0m),                      // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 1, 0m).Explicit(),                 // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -1, 3000m).Explicit(),             // IB:  3001.60
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 1, 0m).Explicit(),                 // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -1, 3000m).Explicit(),             // IB:  3001.60
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 1, 0m),                       // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -1, 0m).Explicit(),           // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 1, 0m).Explicit(),       // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -1, 0m),                 // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 1, 0m),                        // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -1, 1000m),                    // IB:  1000
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 1, 1000m),                // IB:  1000
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -1, 0m),                  // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 1, 0m),                  // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -1, 0m),                 // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 1, 0m),                   // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -1, 3000m).Explicit(),    // IB:  3001.6
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 1, 1000m),                       // IB:  1017.62
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -1, 0m),                         // IB:  0
+        };
+
         [TestCaseSource(nameof(MaintenanceMarginTestCases))]
         public void GetsMaintenanceMargin(OptionStrategyDefinition optionStrategyDefinition, int quantity, decimal expectedMaintenanceMargin)
         {
@@ -220,21 +308,102 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(expectedMaintenanceMargin, maintenanceMargin.Value);
         }
 
-        private static decimal GetDeltaBuyingPower(decimal initialUsedMargin, int initialPositionQuantity, int expectedFinalQuantity,
-            out int expectedQuantity)
+        private static readonly TestCaseData[] OrderQuantityForDeltaBuyingPowerTestCases = new[]
         {
-            expectedQuantity = 0;
-            if (initialUsedMargin != 0)
-            {
-                expectedQuantity = expectedFinalQuantity - initialPositionQuantity;
-            }
+            // option strategy definition, initial position quantity, final position quantity
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 0),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 11),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 9),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 11),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 9),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 0).Explicit(),
+        };
 
-            // If reducing the position, we are reducing the buying power used by the strategy, so the delta buying power is negative
-            var direction = Math.Abs(expectedFinalQuantity) < Math.Abs(initialPositionQuantity) ? -1 : +1;
-            return direction * Math.Abs(expectedQuantity * initialUsedMargin / initialPositionQuantity);
-        }
-
-        [TestCaseSource(nameof(GetOrderQuantityForDeltaBuyingPowerTestCases))]
+        [TestCaseSource(nameof(OrderQuantityForDeltaBuyingPowerTestCases))]
         public void PositionGroupOrderQuantityCalculationForDeltaBuyingPower(OptionStrategyDefinition optionStrategyDefinition,
             int initialPositionQuantity, int expectedFinalQuantity)
         {
@@ -258,7 +427,102 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(expectedQuantity, quantity);
         }
 
-        [TestCaseSource(nameof(GetOrderQuantityForTargetBuyingPowerTestCases))]
+        private static readonly TestCaseData[] OrderQuantityForTargetBuyingPowerTestCases = new[]
+        {
+            // option strategy definition, initial position quantity, final position quantity
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 11),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 9),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 0),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 0),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 0),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 0),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 0),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 0),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 11),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 9),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 11),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 9),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 11),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 9),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 0),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 9),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 0),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 0).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -9).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -11).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 0).Explicit(),
+        };
+
+        [TestCaseSource(nameof(OrderQuantityForTargetBuyingPowerTestCases))]
         public void PositionGroupOrderQuantityCalculationForTargetBuyingPower(OptionStrategyDefinition optionStrategyDefinition,
             int initialPositionQuantity, int expectedFinalQuantity)
         {
@@ -286,7 +550,134 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(expectedQuantity, quantity);
         }
 
-        [TestCaseSource(nameof(GetPositionGroupBuyingPowerTestCases))]
+        private static readonly TestCaseData[] PositionGroupBuyingPowerTestCases = new[]
+        {
+            // option strategy definition, initial position quantity, new position quantity
+            // Starting from the "initial position quantity", we want to get the buying power available for an order that would get us to
+            // the "new position quantity" (if we don't take into account the initial position).
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 1), // Going from 10 to 11
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -1), // Going from 10 to 9
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -10).Explicit(), // Going from 10 to 0
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -20).Explicit(), // Going from 10 to -10
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 20),
+        };
+
+        [TestCaseSource(nameof(PositionGroupBuyingPowerTestCases))]
         public void BuyingPowerForPositionGroupCalculation(OptionStrategyDefinition optionStrategyDefinition, int initialPositionQuantity,
             int newGroupQuantity)
         {
@@ -340,10 +731,183 @@ namespace QuantConnect.Tests.Common.Securities
             }
         }
 
-        [TestCaseSource(nameof(GetReservedBuyingPowerImpactTestCases))]
+        private static readonly TestCaseData[] ReservedBuyingPowerImpactTestCases = new[]
+        {
+            // option strategy definition, initial position quantity, new position quantity
+            // Starting from the "initial position quantity", we want to get the buying power available for an order that would get us to
+            // the "new position quantity" (if we don't take into account the initial position).
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 1), // Going from 10 to 11
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -1), // Going from 10 to 9
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -10), // Going from 10 to 0
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -20), // Going from 10 to -10
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 20),
+        };
+
+        [TestCaseSource(nameof(ReservedBuyingPowerImpactTestCases))]
         public void ReservedBuyingPowerImpactCalculation(OptionStrategyDefinition optionStrategyDefinition, int initialPositionQuantity,
             int newGroupQuantity)
         {
+            // starting long
+            if (initialPositionQuantity > 0)
+            {
+                // going longer
+                if (newGroupQuantity > 0)
+                {
+                    //Assert.Ignore();
+                }
+                // reducing long
+                else if (initialPositionQuantity + newGroupQuantity > 0)
+                {
+                    //Assert.Ignore();
+                }
+                // liquidating long position
+                else if (initialPositionQuantity + newGroupQuantity == 0)
+                {
+                    //Assert.Ignore();
+                }
+                // switching to short
+                else
+                {
+                    //Assert.Ignore();
+                }
+            }
+            // starting short
+            // going shorter
+            else if (newGroupQuantity < 0)
+            {
+                //Assert.Ignore();
+            }
+            // reducing short
+            else if (initialPositionQuantity + newGroupQuantity < 0)
+            {
+                //Assert.Ignore();
+            }
+            // liquidating short position
+            else if (initialPositionQuantity + newGroupQuantity == 0)
+            {
+                //Assert.Ignore();
+            }
+            // switching to long
+            else
+            {
+                //Assert.Ignore();
+            }
+
             var initialMargin = _portfolio.MarginRemaining;
             var initialPositionGroup = SetUpOptionStrategy(optionStrategyDefinition, initialPositionQuantity);
 
@@ -633,548 +1197,18 @@ namespace QuantConnect.Tests.Common.Securities
             return positionGroup;
         }
 
-        /// <summary>
-        /// Test cases for the <see cref="OptionStrategyPositionGroupBuyingPowerModel.GetInitialMarginRequirement"/> method.
-        ///
-        /// TODO: We should come back and revisit these test cases to make sure they are correct.
-        /// The approximate values from IB for the prices used in the test are in the comments.
-        /// For instance, see the test case for the CoveredCall strategy. The margin values do not match IB's values.
-        ///
-        /// Test cases marked as explicit will fail if ran, they have an approximate expected value based on IB's margin requirements.
-        /// </summary>
-        private static TestCaseData[] InitialMarginRequirementsTestCases = new[]
+        private static decimal GetDeltaBuyingPower(decimal initialUsedMargin, int initialPositionQuantity, int expectedFinalQuantity,
+            out int expectedQuantity)
         {
-            // OptionStrategyDefinition, initialHoldingsQuantity, expectedInitialMarginRequirement
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 1, 10000m).Explicit(),                          // IB:  10282.15
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -1, 11200m),                                    // IB:  12338.58
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 1, 12000m).Explicit(),                           // IB:  12331.38
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -1, 10000m).Explicit(),                          // IB:  10276.15
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 0m).Explicit(),                           // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                                     // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 1, 0m),                                       // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -1, 1000m),                                   // IB:  1000
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 1, 0m),                                      // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -1, 0m).Explicit(),                          // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 1, 1000m),                                    // IB:  1000
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -1, 0m),                                      // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 1, 0m).Explicit(),                                 // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -1, 3000m).Explicit(),                             // IB:  3001.60
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 1, 0m).Explicit(),                                 // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -1, 3000m).Explicit(),                             // IB:  3001.60
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 1, 0m),                                       // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -1, 0m).Explicit(),                           // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 1, 0m).Explicit(),                       // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -1, 0m),                                 // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 1, 0m),                                        // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -1, 1000m),                                    // IB:  1000
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 1, 1000m),                                // IB:  1000
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -1, 0m),                                  // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 1, 0m),                                  // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -1, 0m),                                 // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 1, 0m),                                   // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -1, 3000m).Explicit(),                    // IB:  3001.6
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 1, 1000m),                                       // IB:  1017.62
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -1, 0m),                                         // IB:  0
-        };
-
-        /// <summary>
-        /// Test cases for the <see cref="OptionStrategyPositionGroupBuyingPowerModel.GetMaintenanceMargin"/> method.
-        ///
-        /// TODO: We should come back and revisit these test cases to make sure they are correct.
-        /// The approximate values from IB for the prices used in the test are in the comments.
-        /// For instance, see the test case for the CoveredCall strategy. The margin values do not match IB's values.
-        ///
-        /// Test cases marked as explicit will fail if ran, they have an approximate expected value based on IB's margin requirements.
-        /// </summary>
-        private static TestCaseData[] MaintenanceMarginTestCases = new[]
-        {
-            // OptionStrategyDefinition, initialHoldingsQuantity, expectedMaintenanceMargin
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 1, 10000m).Explicit(),                          // IB:  10282.15
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -1, 3000m).Explicit(),                          // IB:  3000
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 1, 3000m).Explicit(),                            // IB:  3000
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -1, 1000m).Explicit(),                           // IB:  10276.15
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 0m).Explicit(),                           // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                                     // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 1, 0m),                                       // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -1, 1000m),                                   // IB:  1000
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 1, 0m),                                      // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -1, 0m).Explicit(),                          // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 1, 1000m),                                    // IB:  1000
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -1, 0m),                                      // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 1, 0m).Explicit(),                                 // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -1, 3000m).Explicit(),                             // IB:  3001.60
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 1, 0m).Explicit(),                                 // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -1, 3000m).Explicit(),                             // IB:  3001.60
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 1, 0m),                                       // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -1, 0m).Explicit(),                           // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 1, 0m).Explicit(),                       // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -1, 0m),                                 // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 1, 0m),                                        // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -1, 1000m),                                    // IB:  1000
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 1, 1000m),                                // IB:  1000
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -1, 0m),                                  // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 1, 0m),                                  // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -1, 0m),                                 // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 1, 0m),                                   // IB:  0
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -1, 3000m).Explicit(),                    // IB:  3001.6
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 1, 1000m),                                       // IB:  1017.62
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -1, 0m),                                         // IB:  0
-        };
-
-        private static TestCaseData[] GetOrderQuantityForDeltaBuyingPowerTestCases()
-        {
-            return new[]
+            expectedQuantity = 0;
+            if (initialUsedMargin != 0)
             {
-                // option strategy definition, initial position quantity, final position quantity
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 0),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 11),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 9),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 11),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 9),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 0).Explicit(),
-            };
-        }
+                expectedQuantity = expectedFinalQuantity - initialPositionQuantity;
+            }
 
-        private static TestCaseData[] GetOrderQuantityForTargetBuyingPowerTestCases()
-        {
-            return new[]
-            {
-                // option strategy definition, initial position quantity, final position quantity
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 11),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 9),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 0),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 0),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 0),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 0),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 0),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 0),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 11),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 9),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 11),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 9),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 11),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 9),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 0),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 9),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 0),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 0).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -9).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -11).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 0).Explicit(),
-            };
-        }
-
-        private static TestCaseData[] GetPositionGroupBuyingPowerTestCases()
-        {
-            return new[]
-            {
-                // option strategy definition, initial position quantity, new position quantity
-                // Starting from the "initial position quantity", we want to get the buying power available for an order that would get us to
-                // the "new position quantity" (if we don't take into account the initial position).
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 1), // Going from 10 to 11
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -1), // Going from 10 to 9
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -10).Explicit(), // Going from 10 to 0
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -20).Explicit(), // Going from 10 to -10
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -1).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 1).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -1).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 1).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -1).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 1).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -1).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 1).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -20).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 10).Explicit(),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 20),
-            };
-        }
-
-        private static TestCaseData[] GetReservedBuyingPowerImpactTestCases()
-        {
-            return new[]
-            {
-                // option strategy definition, initial position quantity, new position quantity
-                // Starting from the "initial position quantity", we want to get the buying power available for an order that would get us to
-                // the "new position quantity" (if we don't take into account the initial position).
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 1), // Going from 10 to 11
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -1), // Going from 10 to 9
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -10), // Going from 10 to 0
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -20), // Going from 10 to -10
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 20),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 1),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -1),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -20),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -1),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 1),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 10),
-                new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 20),
-            };
+            // If reducing the position, we are reducing the buying power used by the strategy, so the delta buying power is negative
+            var direction = Math.Abs(expectedFinalQuantity) < Math.Abs(initialPositionQuantity) ? -1 : +1;
+            return direction * Math.Abs(expectedQuantity * initialUsedMargin / initialPositionQuantity);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This extends the unit tests for the `OptionStrategyPositionGroupBuyingPowerModelTests` to cover several methods and option strategies. The idea is to have the tests without fixing any bugs yet, and use them as expected behavior when tackling bugs.

Tests marked as _explicit_ are failing and the explicit flag should be removed when fixing the bugs that cause the failure.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

This spawned from https://github.com/QuantConnect/Lean/pull/7230 and https://github.com/QuantConnect/Lean/pull/7231

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Having a colection of tests that allow us to indentify where the BPM is failing.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
