### PR TITLE
Fix bug in RandomDataGenerator for Option data at Minute resolution

### DIFF
--- a/Tests/ToolBox/RandomDataGenerator/OptionSymbolGeneratorTests.cs
+++ b/Tests/ToolBox/RandomDataGenerator/OptionSymbolGeneratorTests.cs
@@ -140,5 +140,35 @@ namespace QuantConnect.Tests.ToolBox.RandomDataGenerator
                 Assert.GreaterOrEqual(_underlyingPrice + maximumDeviation, strikePrice);
             }
         }
+
+        [Test]
+        [TestCase("2021, 6, 2 00:00:00", "2021, 6, 4 00:00:00")]
+        [TestCase("2021, 6, 2 00:00:00", "2021, 6, 5 00:00:00")]
+        [TestCase("2021, 6, 2 00:00:00", "2021, 7, 2 00:00:00")]
+        [TestCase("2021, 6, 2 00:00:00", "2021, 6, 10 00:00:00")]
+        [TestCase("2021, 6, 2 00:00:00", "2021, 6, 11 00:00:00")]
+        [TestCase("2021, 6, 2 00:00:00", "2021, 8, 2 00:00:00")]
+        [TestCase("2021, 6, 2 00:00:00", "2021, 6, 15 00:00:00")]
+        public void OptionSymbolGeneratorCreatesOptionSymbol_WithExpirationDateAtLeastThreeDaysAfterMinExpiryDate(DateTime minExpiry, DateTime maxExpiry)
+        {
+            var symbolGenerator = new OptionSymbolGenerator(
+                new RandomDataGeneratorSettings()
+                {
+                    Market = Market.USA,
+                    Start = minExpiry,
+                    End = maxExpiry
+                },
+                new RandomValueGenerator(),
+                _underlyingPrice,
+                _maximumStrikePriceDeviation);
+            var symbols = BaseSymbolGeneratorTests.GenerateAsset(symbolGenerator).ToList();
+            Assert.AreEqual(3, symbols.Count);
+
+            foreach (var option in new[] { symbols[1], symbols[2] })
+            {
+                var expiration = option.ID.Date;
+                Assert.LessOrEqual(minExpiry.AddDays(3), expiration);
+            }
+        }
     }
 }

--- a/Tests/ToolBox/RandomDataGenerator/TickGeneratorTests.cs
+++ b/Tests/ToolBox/RandomDataGenerator/TickGeneratorTests.cs
@@ -37,8 +37,8 @@ namespace QuantConnect.Tests.ToolBox.RandomDataGenerator
         [SetUp]
         public void Setup()
         {
-            var start = new DateTime(2020, 1, 1);
-            var end = new DateTime(2020, 1, 2);
+            var start = new DateTime(2020, 1, 6);
+            var end = new DateTime(2020, 1, 10);
 
             // initialize using a seed for deterministic tests
             _symbol = Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
@@ -66,7 +66,7 @@ namespace QuantConnect.Tests.ToolBox.RandomDataGenerator
                     Start = start,
                     End = end
                 },
-                _tickTypesPerSecurityType[_symbol.SecurityType].ToArray(),
+                new TickType[3] { TickType.Trade, TickType.Quote, TickType.OpenInterest },
                 _security,
                 new RandomValueGenerator());
 
@@ -135,6 +135,7 @@ namespace QuantConnect.Tests.ToolBox.RandomDataGenerator
 
             Assert.AreEqual(dateTime, tick.Time);
             Assert.AreEqual(TickType.OpenInterest, tick.TickType);
+            Assert.AreEqual(typeof(OpenInterest), tick.GetType());
             Assert.AreEqual(_symbol, tick.Symbol);
             Assert.GreaterOrEqual(tick.Quantity, 9000);
             Assert.LessOrEqual(tick.Quantity, 11000);
@@ -212,6 +213,26 @@ namespace QuantConnect.Tests.ToolBox.RandomDataGenerator
             var history = _tickGenerator.GenerateTicks().ToList();
             Assert.IsNotEmpty(history);
             Assert.That(history.Select(s => s.Symbol), Is.All.EqualTo(_symbol));
+        }
+
+        [Test]
+        public void HistoryIsBetweenStartAndEndDate()
+        {
+            var start = new DateTime(2020, 1, 6);
+            var end = new DateTime(2020, 1, 10);
+            var history = _tickGenerator.GenerateTicks().ToList();
+            Assert.IsNotEmpty(history);
+            Assert.That(history.All(s => start <= s.Time && s.Time <= end));
+        }
+
+        [Test]
+        public void HistoryGeneratesOpenInterestDataAsExpected()
+        {
+            var start = new DateTime(2020, 1, 6);
+            var end = new DateTime(2020, 1, 10);
+            var history = _tickGenerator.GenerateTicks().ToList();
+            Assert.IsNotEmpty(history);
+            Assert.AreEqual(3, history.Where(s => s.TickType == TickType.OpenInterest).Count());
         }
     }
 }

--- a/ToolBox/RandomDataGenerator/OptionSymbolGenerator.cs
+++ b/ToolBox/RandomDataGenerator/OptionSymbolGenerator.cs
@@ -34,6 +34,9 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
         public OptionSymbolGenerator(RandomDataGeneratorSettings settings, IRandomValueGenerator random, decimal underlyingPrice, decimal maximumStrikePriceDeviation)
             : base(settings, random)
         {
+            // We add seven days more because TickGenerator for options needs first three underlying data points to warm up
+            // the price generator, so if the expiry date is before settings.Start plus three days no quote or trade data is
+            // generated for this option
             _minExpiry = (settings.Start).AddDays(7);
             _maxExpiry = (settings.End).AddDays(7);
             _market = settings.Market;

--- a/ToolBox/RandomDataGenerator/OptionSymbolGenerator.cs
+++ b/ToolBox/RandomDataGenerator/OptionSymbolGenerator.cs
@@ -34,8 +34,8 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
         public OptionSymbolGenerator(RandomDataGeneratorSettings settings, IRandomValueGenerator random, decimal underlyingPrice, decimal maximumStrikePriceDeviation)
             : base(settings, random)
         {
-            _minExpiry = settings.Start;
-            _maxExpiry = settings.End;
+            _minExpiry = (settings.Start).AddDays(7);
+            _maxExpiry = (settings.End).AddDays(7);
             _market = settings.Market;
             _underlyingPrice = underlyingPrice;
             _symbolChainSize = settings.ChainSymbolCount;

--- a/ToolBox/RandomDataGenerator/TickGenerator.cs
+++ b/ToolBox/RandomDataGenerator/TickGenerator.cs
@@ -76,6 +76,8 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
             {
 
                 var next = NextTickTime(current, _settings.Resolution, _settings.DataDensity);
+                // The current date can be the last one of the last day before the market closes
+                // so the next date could be beyond de end date
                 if (next > _settings.End)
                 {
                     break;

--- a/ToolBox/RandomDataGenerator/TickGenerator.cs
+++ b/ToolBox/RandomDataGenerator/TickGenerator.cs
@@ -76,6 +76,11 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
             {
 
                 var next = NextTickTime(current, _settings.Resolution, _settings.DataDensity);
+                if (next > _settings.End)
+                {
+                    break;
+                }
+
                 if (_tickTypes.Contains(TickType.OpenInterest))
                 {
                     if (next.Date != current.Date)
@@ -190,7 +195,7 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
         public Tick NextOpenInterest(DateTime dateTime, decimal previousValue, decimal maximumPercentDeviation)
         {
             var next = (long)_random.NextPrice(Symbol.SecurityType, Symbol.ID.Market, previousValue, maximumPercentDeviation);
-            return new Tick
+            return new OpenInterest
             {
                 Time = dateTime,
                 Symbol = Symbol,

--- a/ToolBox/TickAggregator.cs
+++ b/ToolBox/TickAggregator.cs
@@ -145,7 +145,7 @@ namespace QuantConnect.ToolBox
     }
 
     /// <summary>
-    /// Use <see cref="OpenInterestConsolidator"/> to consolidate open interest ticks daily.
+    /// Use <see cref="OpenInterestConsolidator"/> to consolidate open interest ticks into a specified resolution
     /// </summary>
     public class OpenInterestTickAggregator : TickAggregator
     {

--- a/ToolBox/TickAggregator.cs
+++ b/ToolBox/TickAggregator.cs
@@ -77,7 +77,7 @@ namespace QuantConnect.ToolBox
                     // OI is special
                     if (tickType == TickType.OpenInterest)
                     {
-                        yield return new OpenInterestTickAggregator();
+                        yield return new OpenInterestTickAggregator(resolution);
                         continue;
                     }
 
@@ -100,7 +100,7 @@ namespace QuantConnect.ToolBox
                         break;
 
                     case TickType.OpenInterest:
-                        yield return new OpenInterestTickAggregator();
+                        yield return new OpenInterestTickAggregator(resolution);
                         break;
 
                     default:
@@ -149,11 +149,11 @@ namespace QuantConnect.ToolBox
     /// </summary>
     public class OpenInterestTickAggregator : TickAggregator
     {
-        public OpenInterestTickAggregator()
-            : base(Resolution.Daily, TickType.OpenInterest)
+        public OpenInterestTickAggregator(Resolution resolution)
+            : base(resolution, TickType.OpenInterest)
         {
             Consolidated = new List<BaseData>();
-            Consolidator = new OpenInterestConsolidator(Time.OneDay);
+            Consolidator = new OpenInterestConsolidator(resolution.ToTimeSpan());
             Consolidator.DataConsolidated += (sender, consolidated) =>
             {
                 Consolidated.Add(consolidated as OpenInterest);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This bug was raised by different conditions.

- First, the tick created in TickGenerator for Open Interest was not of type Open Interest, so open interest ticks could actually update the volatility model in `Security.UpdateConsumersMarketPrice()`.
- Second, TickAggregator.cs was made to use daily resolution for OpenInterest always.
- Third, the RandomValueGenerator generated a random Friday as an expiration date for the option created but TickGenerator needed first three underlying data points to warm up option's price generator, so if the expiration date was before the start date plus 3 days, RandomDataGenerator just generated OpenInterest data for the option.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5871 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, users will be able to generate option data at minute resolution
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require updates to documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- To test no option was generated with expiry date before the start day plus three days, there was created a unit test that created an option with a new OptionSymbolGenerator for each different end date, then it asserted the option generated expiry date was appropriate.
- To test option open interest data was generated, it was created a test that asserted the data generated by TickGenerator contained the expected amount of Open Interest data.
- Finally, it was generated KAQ and GBE option data at minute resolution from 2021-06-01 to 2021-07-01, IZF option data was generated at minute resolution from 2021-06-01 to 2021-08-01 and BTC Future data was generated from 2021-06-01 to 2021-08-01 at minute resolution
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
