### PR TITLE
Fix potential bug in KrakenOrderProperties

### DIFF
--- a/Common/Orders/KrakenOrderProperties.cs
+++ b/Common/Orders/KrakenOrderProperties.cs
@@ -19,16 +19,6 @@ namespace QuantConnect.Orders
     /// <summary>
     /// Kraken order properties
     /// </summary>
-    /// <remarks>
-    /// Kraken lets you set you preference for the currency
-    /// in which your trading fees are determined if the
-    /// order is filled. But it won't necessarily give you
-    /// you choice (for example, if set it to a currency in
-    /// which you have zero balance). Also, fee currency
-    /// selection does not to opening and rollover fees.
-    /// See (https://support.kraken.com/hc/en-us/articles/202966956#howclosingtransactionswork)
-    /// for more information about the currency selection.
-    /// </remarks>
     public class KrakenOrderProperties : OrderProperties
     {
         private bool _feeInQuote;
@@ -40,10 +30,9 @@ namespace QuantConnect.Orders
         public bool PostOnly { get; set; }
         
         /// <summary>
-        /// Prefer fee in base currency (default if selling. Source: https://docs.kraken.com/rest/#tag/User-Trading/operation/addOrder).
-        /// It's set here: https://github.com/QuantConnect/Lean.Brokerages.Kraken/blob/master/QuantConnect.KrakenBrokerage/KrakenBrokerage.cs#L141
-        /// and used to create a Kraken order here: https://github.com/QuantConnect/Lean.Brokerages.Kraken/blob/master/QuantConnect.KrakenBrokerage/KrakenBrokerage.Messaging.cs#L353
+        /// If true or by default when selling, fees will be charged in base currency. If false will be ignored. Mutually exclusive with FeeInQuote.
         /// </summary>
+        /// <remarks>See (https://support.kraken.com/hc/en-us/articles/202966956#howclosingtransactionswork) for more information about the currency selection.</remarks>
         public bool FeeInBase
         {
             get
@@ -61,10 +50,9 @@ namespace QuantConnect.Orders
         }
 
         /// <summary>
-        /// Prefer fee in quote currency (default if buying, mutually exclusive with FeeInBase. Source: https://docs.kraken.com/rest/#tag/User-Trading/operation/addOrder)
-        /// It's set here: https://github.com/QuantConnect/Lean.Brokerages.Kraken/blob/master/QuantConnect.KrakenBrokerage/KrakenBrokerage.cs#L145
-        /// and used to create a Kraken order here: https://github.com/QuantConnect/Lean.Brokerages.Kraken/blob/master/QuantConnect.KrakenBrokerage/KrakenBrokerage.Messaging.cs#L358
+        /// If true or by default when buying, fees will be charged in quote currency. If false will be ignored. Mutually exclusive with FeeInBase.
         /// </summary>
+        /// <remarks>See (https://support.kraken.com/hc/en-us/articles/202966956#howclosingtransactionswork) for more information about the currency selection.</remarks>
         public bool FeeInQuote
         {
             get

--- a/Common/Orders/KrakenOrderProperties.cs
+++ b/Common/Orders/KrakenOrderProperties.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Orders
         /// Post-only order (available when ordertype = limit)
         /// </summary>
         public bool PostOnly { get; set; }
-
+        
         /// <summary>
         /// Prefer fee in base currency (default if selling. Source: https://docs.kraken.com/rest/#tag/User-Trading/operation/addOrder).
         /// It's set here: https://github.com/QuantConnect/Lean.Brokerages.Kraken/blob/master/QuantConnect.KrakenBrokerage/KrakenBrokerage.cs#L141

--- a/Common/Orders/KrakenOrderProperties.cs
+++ b/Common/Orders/KrakenOrderProperties.cs
@@ -19,22 +19,67 @@ namespace QuantConnect.Orders
     /// <summary>
     /// Kraken order properties
     /// </summary>
+    /// <remarks>
+    /// Kraken lets you set you preference for the currency
+    /// in which your trading fees are determined if the
+    /// order is filled. But it won't necessarily give you
+    /// you choice (for example, if set it to a currency in
+    /// which you have zero balance). Also, fee currency
+    /// selection does not to opening and rollover fees.
+    /// See (https://support.kraken.com/hc/en-us/articles/202966956#howclosingtransactionswork)
+    /// for more information about the currency selection.
+    /// </remarks>
     public class KrakenOrderProperties : OrderProperties
     {
+        private bool _feeInQuote;
+        private bool _feeInBase;
+
         /// <summary>
         /// Post-only order (available when ordertype = limit)
         /// </summary>
         public bool PostOnly { get; set; }
-        
+
         /// <summary>
-        /// Prefer fee in base currency (default if selling)
+        /// Prefer fee in base currency (default if selling. Source: https://docs.kraken.com/rest/#tag/User-Trading/operation/addOrder).
+        /// It's set here: https://github.com/QuantConnect/Lean.Brokerages.Kraken/blob/master/QuantConnect.KrakenBrokerage/KrakenBrokerage.cs#L141
+        /// and used to create a Kraken order here: https://github.com/QuantConnect/Lean.Brokerages.Kraken/blob/master/QuantConnect.KrakenBrokerage/KrakenBrokerage.Messaging.cs#L353
         /// </summary>
-        public bool FeeInBase { get; set; }
-        
+        public bool FeeInBase
+        {
+            get
+            {
+                return _feeInBase;
+            }
+            set
+            {
+                if (value)
+                {
+                    _feeInBase = value;
+                    _feeInQuote = !_feeInBase;
+                }
+            }
+        }
+
         /// <summary>
-        /// Prefer fee in quote currency (default if buying, mutually exclusive with FeeInBase)
+        /// Prefer fee in quote currency (default if buying, mutually exclusive with FeeInBase. Source: https://docs.kraken.com/rest/#tag/User-Trading/operation/addOrder)
+        /// It's set here: https://github.com/QuantConnect/Lean.Brokerages.Kraken/blob/master/QuantConnect.KrakenBrokerage/KrakenBrokerage.cs#L145
+        /// and used to create a Kraken order here: https://github.com/QuantConnect/Lean.Brokerages.Kraken/blob/master/QuantConnect.KrakenBrokerage/KrakenBrokerage.Messaging.cs#L358
         /// </summary>
-        public bool FeeInQuote { get; set; }
+        public bool FeeInQuote
+        {
+            get
+            {
+                return _feeInQuote;
+            }
+            set
+            {
+                if (value)
+                {
+                    _feeInQuote = value;
+                    _feeInBase = !_feeInQuote;
+                }
+            }
+        }
         
         /// <summary>
         /// https://support.kraken.com/hc/en-us/articles/201648183-Market-Price-Protection


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Enhance `FeeInBase` and `FeeInQuote` implementations to make them mutually exclusive even when one has already been set to true.
- Add XML docs 
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #6875 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, users will be able to change the fees currency for Kraken orders, from base to quote and vice versa.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require changes nor updates to documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
