### PR TITLE
Expire Instead of Clear Insights In Base PCM In OnSecuritiesChanged

### DIFF
--- a/Algorithm.CSharp/PortfolioRebalanceOnSecurityChangesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/PortfolioRebalanceOnSecurityChangesRegressionAlgorithm.cs
@@ -108,7 +108,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 5568;
+        public long DataPoints => 5500;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -121,29 +121,29 @@ namespace QuantConnect.Algorithm.CSharp
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "74"},
-            {"Average Win", "2.44%"},
-            {"Average Loss", "-2.28%"},
-            {"Compounding Annual Return", "-4.581%"},
-            {"Drawdown", "30.500%"},
-            {"Expectancy", "-0.081"},
-            {"Net Profit", "-8.951%"},
-            {"Sharpe Ratio", "-0.137"},
-            {"Probabilistic Sharpe Ratio", "2.627%"},
+            {"Average Win", "2.37%"},
+            {"Average Loss", "-2.26%"},
+            {"Compounding Annual Return", "-4.832%"},
+            {"Drawdown", "29.700%"},
+            {"Expectancy", "-0.089"},
+            {"Net Profit", "-9.431%"},
+            {"Sharpe Ratio", "-0.176"},
+            {"Probabilistic Sharpe Ratio", "2.229%"},
             {"Loss Rate", "56%"},
             {"Win Rate", "44%"},
-            {"Profit-Loss Ratio", "1.07"},
-            {"Alpha", "-0.071"},
-            {"Beta", "0.978"},
-            {"Annual Standard Deviation", "0.152"},
-            {"Annual Variance", "0.023"},
-            {"Information Ratio", "-0.748"},
-            {"Tracking Error", "0.097"},
-            {"Treynor Ratio", "-0.021"},
-            {"Total Fees", "$264.99"},
-            {"Estimated Strategy Capacity", "$55000000.00"},
+            {"Profit-Loss Ratio", "1.05"},
+            {"Alpha", "-0.064"},
+            {"Beta", "0.768"},
+            {"Annual Standard Deviation", "0.139"},
+            {"Annual Variance", "0.019"},
+            {"Information Ratio", "-0.709"},
+            {"Tracking Error", "0.108"},
+            {"Treynor Ratio", "-0.032"},
+            {"Total Fees", "$262.70"},
+            {"Estimated Strategy Capacity", "$54000000.00"},
             {"Lowest Capacity Asset", "IBM R735QTJ8XC9X"},
-            {"Portfolio Turnover", "5.06%"},
-            {"OrderListHash", "bdb23325dc6c1fa04f63a329346be794"}
+            {"Portfolio Turnover", "5.05%"},
+            {"OrderListHash", "f8384f12fbcd59d3ad6e70bf86c97cbf"}
         };
     }
 }

--- a/Algorithm/Portfolio/PortfolioConstructionModel.cs
+++ b/Algorithm/Portfolio/PortfolioConstructionModel.cs
@@ -163,7 +163,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             _securityChanges = changes != SecurityChanges.None;
             // Get removed symbol and invalidate them in the insight collection
             _removedSymbols = changes.RemovedSecurities.Select(x => x.Symbol).ToList();
-            algorithm?.Insights.Clear(_removedSymbols.ToArray());
+            algorithm?.Insights.Expire(_removedSymbols.ToArray());
         }
 
         /// <summary>

--- a/Algorithm/Portfolio/PortfolioConstructionModel.cs
+++ b/Algorithm/Portfolio/PortfolioConstructionModel.cs
@@ -30,7 +30,6 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
     public class PortfolioConstructionModel : IPortfolioConstructionModel
     {
         private Func<DateTime, DateTime?> _rebalancingFunc;
-        private List<Symbol> _removedSymbols;
         private DateTime? _rebalancingTime;
         private bool _securityChanges;
 
@@ -103,14 +102,6 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
 
             var targets = new List<IPortfolioTarget>();
 
-            // Create flatten target for each security that was removed from the universe
-            if (_removedSymbols != null)
-            {
-                var universeDeselectionTargets = _removedSymbols.Select(symbol => new PortfolioTarget(symbol, 0));
-                targets.AddRange(universeDeselectionTargets);
-                _removedSymbols = null;
-            }
-
             var lastActiveInsights = PythonWrapper?.GetTargetInsights()
                                                  ?? GetTargetInsights();
 
@@ -162,8 +153,8 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
 
             _securityChanges = changes != SecurityChanges.None;
             // Get removed symbol and invalidate them in the insight collection
-            _removedSymbols = changes.RemovedSecurities.Select(x => x.Symbol).ToList();
-            algorithm?.Insights.Expire(_removedSymbols.ToArray());
+            var removedSymbols = changes.RemovedSecurities.Select(x => x.Symbol);
+            algorithm?.Insights.Expire(removedSymbols);
         }
 
         /// <summary>


### PR DESCRIPTION
#### Description
Expire instead of Clear insights In PortfolioConstrcutionModel.OnSecuritiesChanged

The regression was incorrect because `_removedSymbols` didn't retain the removed symbols from previous `OnSecuritiesChanged` calls, and the algorithm rebalances once per month. E.g. On day 1, SPY and FB were removed, on day 3 AAPL and IBM were removed and `removedSymbols` would only include AAPL and IBM.

We should heve fixed this problem before with:

```csharp
if (_removedSymbols == null) _removedSymbols = new List<Symbol>();
_removedSymbols.AddRange(changes.RemovedSecurities.Select(x => x.Symbol));
```

#### Related Issue
Closes #7250

#### Motivation and Context
Bug fix

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Regression tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`