### PR TITLE
Change misleading message when order is not large enough for Binance brokerage

### DIFF
--- a/Common/Brokerages/BinanceBrokerageModel.cs
+++ b/Common/Brokerages/BinanceBrokerageModel.cs
@@ -117,10 +117,12 @@ namespace QuantConnect.Brokerages
             // Binance API provides minimum order size in quote currency
             // and hence we have to check current order size using available price and order quantity
             var quantityIsValid = true;
+            var price = 0m;
             switch (order)
             {
                 case LimitOrder limitOrder:
                     quantityIsValid &= IsOrderSizeLargeEnough(limitOrder.LimitPrice);
+                    price = limitOrder.Price;
                     break;
                 case MarketOrder:
                     if (!security.HasData)
@@ -131,7 +133,7 @@ namespace QuantConnect.Brokerages
                         return false;
                     }
 
-                    var price = order.Direction == OrderDirection.Buy ? security.AskPrice : security.BidPrice;
+                    price = order.Direction == OrderDirection.Buy ? security.AskPrice : security.BidPrice;
                     quantityIsValid &= IsOrderSizeLargeEnough(price);
                     break;
                 case StopLimitOrder stopLimitOrder:
@@ -144,6 +146,7 @@ namespace QuantConnect.Brokerages
                     quantityIsValid &= IsOrderSizeLargeEnough(stopLimitOrder.LimitPrice);
                     // Binance Trading UI requires this check too...
                     quantityIsValid &= IsOrderSizeLargeEnough(stopLimitOrder.StopPrice);
+                    price = stopLimitOrder.StopPrice;
                     break;
                 case StopMarketOrder:
                     // despite Binance API allows you to post STOP_LOSS and TAKE_PROFIT order types
@@ -164,7 +167,7 @@ namespace QuantConnect.Brokerages
             if (!quantityIsValid)
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
-                    Messages.DefaultBrokerageModel.InvalidOrderQuantity(security, order.Quantity));
+                    Messages.DefaultBrokerageModel.InvalidOrderQuantity(security, order.Quantity * price));
 
                 return false;
             }

--- a/Common/Brokerages/BinanceBrokerageModel.cs
+++ b/Common/Brokerages/BinanceBrokerageModel.cs
@@ -117,7 +117,7 @@ namespace QuantConnect.Brokerages
             // Binance API provides minimum order size in quote currency
             // and hence we have to check current order size using available price and order quantity
             var quantityIsValid = true;
-            var price = 1m;
+            decimal price;
             switch (order)
             {
                 case LimitOrder limitOrder:

--- a/Common/Brokerages/BinanceBrokerageModel.cs
+++ b/Common/Brokerages/BinanceBrokerageModel.cs
@@ -117,7 +117,7 @@ namespace QuantConnect.Brokerages
             // Binance API provides minimum order size in quote currency
             // and hence we have to check current order size using available price and order quantity
             var quantityIsValid = true;
-            var price = 0m;
+            var price = 1m;
             switch (order)
             {
                 case LimitOrder limitOrder:
@@ -143,10 +143,16 @@ namespace QuantConnect.Brokerages
                             Messages.BinanceBrokerageModel.UnsupportedOrderTypeForSecurityType(order, security));
                         return false;
                     }
+                    price = stopLimitOrder.LimitPrice;
                     quantityIsValid &= IsOrderSizeLargeEnough(stopLimitOrder.LimitPrice);
+                    if (!quantityIsValid)
+                    {
+                        break;
+                    }
+
                     // Binance Trading UI requires this check too...
                     quantityIsValid &= IsOrderSizeLargeEnough(stopLimitOrder.StopPrice);
-                    price = stopLimitOrder.LimitPrice;
+                    price = stopLimitOrder.StopPrice;
                     break;
                 case StopMarketOrder:
                     // despite Binance API allows you to post STOP_LOSS and TAKE_PROFIT order types

--- a/Common/Brokerages/BinanceBrokerageModel.cs
+++ b/Common/Brokerages/BinanceBrokerageModel.cs
@@ -122,7 +122,7 @@ namespace QuantConnect.Brokerages
             {
                 case LimitOrder limitOrder:
                     quantityIsValid &= IsOrderSizeLargeEnough(limitOrder.LimitPrice);
-                    price = limitOrder.Price;
+                    price = limitOrder.LimitPrice;
                     break;
                 case MarketOrder:
                     if (!security.HasData)
@@ -146,7 +146,7 @@ namespace QuantConnect.Brokerages
                     quantityIsValid &= IsOrderSizeLargeEnough(stopLimitOrder.LimitPrice);
                     // Binance Trading UI requires this check too...
                     quantityIsValid &= IsOrderSizeLargeEnough(stopLimitOrder.StopPrice);
-                    price = stopLimitOrder.StopPrice;
+                    price = stopLimitOrder.LimitPrice;
                     break;
                 case StopMarketOrder:
                     // despite Binance API allows you to post STOP_LOSS and TAKE_PROFIT order types
@@ -167,7 +167,7 @@ namespace QuantConnect.Brokerages
             if (!quantityIsValid)
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
-                    Messages.DefaultBrokerageModel.InvalidOrderQuantity(security, order.Quantity * price));
+                    Messages.DefaultBrokerageModel.InvalidOrderSize(security, order.Quantity, price));
 
                 return false;
             }

--- a/Common/Messages/Messages.Brokerages.cs
+++ b/Common/Messages/Messages.Brokerages.cs
@@ -59,7 +59,7 @@ namespace QuantConnect
             public static string InvalidOrderQuantity(Securities.Security security, decimal quantity)
             {
                 return Invariant($@"The minimum order size (in quote currency) for {security.Symbol.Value} is {
-                    security.SymbolProperties.MinimumOrderSize}. Order quantity was {quantity}.");
+                    security.SymbolProperties.MinimumOrderSize}. Order size was {quantity}.");
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Common/Messages/Messages.Brokerages.cs
+++ b/Common/Messages/Messages.Brokerages.cs
@@ -59,7 +59,13 @@ namespace QuantConnect
             public static string InvalidOrderQuantity(Securities.Security security, decimal quantity)
             {
                 return Invariant($@"The minimum order size (in quote currency) for {security.Symbol.Value} is {
-                    security.SymbolProperties.MinimumOrderSize}. Order size was {quantity}.");
+                    security.SymbolProperties.MinimumOrderSize}. Order quantity was {quantity}.");
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string InvalidOrderSize(Securities.Security security, decimal quantity, decimal price)
+            {
+                return Invariant($@"The minimum order size (in quote currency) for {security.Symbol.Value} is {security.SymbolProperties.MinimumOrderSize}. Order size was {quantity * price}.");
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Tests/Common/Brokerages/BinanceBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/BinanceBrokerageModelTests.cs
@@ -115,7 +115,7 @@ namespace QuantConnect.Tests.Common.Brokerages
             Assert.AreEqual(isValidOrderQuantity, message == null);
             if (!isValidOrderQuantity)
             {
-                Assert.AreEqual(Messages.DefaultBrokerageModel.InvalidOrderSize(_security, order.Object.Quantity, order.Object.LimitPrice), message.Message);
+                Assert.AreEqual(Messages.DefaultBrokerageModel.InvalidOrderSize(_security, order.Object.Quantity, Math.Min(order.Object.LimitPrice, order.Object.StopPrice)), message.Message);
             }
         }
 

--- a/Tests/Common/Brokerages/BinanceBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/BinanceBrokerageModelTests.cs
@@ -65,6 +65,11 @@ namespace QuantConnect.Tests.Common.Brokerages
 
             Assert.AreEqual(isValidOrderQuantity, BinanceBrokerageModel.CanSubmitOrder(_security, order.Object, out var message));
             Assert.AreEqual(isValidOrderQuantity, message == null);
+            if (!isValidOrderQuantity)
+            {
+                var price = order.Object.Direction == OrderDirection.Buy ? _security.AskPrice : _security.BidPrice;
+                Assert.AreEqual(Messages.DefaultBrokerageModel.InvalidOrderSize(_security, order.Object.Quantity, price), message.Message);
+            }
         }
 
         [TestCase(0.002, 5500, true)]
@@ -83,6 +88,10 @@ namespace QuantConnect.Tests.Common.Brokerages
 
             Assert.AreEqual(isValidOrderQuantity, BinanceBrokerageModel.CanSubmitOrder(_security, order.Object, out var message));
             Assert.AreEqual(isValidOrderQuantity, message == null);
+            if (!isValidOrderQuantity)
+            {
+                Assert.AreEqual(Messages.DefaultBrokerageModel.InvalidOrderSize(_security, order.Object.Quantity, order.Object.LimitPrice), message.Message);
+            }
         }
 
         [TestCase(0.002, 5500, 5500, true)]
@@ -104,6 +113,10 @@ namespace QuantConnect.Tests.Common.Brokerages
 
             Assert.AreEqual(isValidOrderQuantity, BinanceBrokerageModel.CanSubmitOrder(_security, order.Object, out var message));
             Assert.AreEqual(isValidOrderQuantity, message == null);
+            if (!isValidOrderQuantity)
+            {
+                Assert.AreEqual(Messages.DefaultBrokerageModel.InvalidOrderSize(_security, order.Object.Quantity, order.Object.LimitPrice), message.Message);
+            }
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Change misleading message in BinanceBrokerageModel for one in which the minimum order size is expressed in volume, not quantity
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7215 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change if the user submits an order to Binance with a size less than the allowed, LEAN throws an informative and correct message pointing to the error
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require updates to documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In each unit test related with method `CanSubmitOrder()` in BinanceBrokerageModelTests.cs, it was asserted the method not only returned false were expected, but also the type of message related to the error.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
