### PR TITLE
Change misleading error message while registering an indicator in Python

### DIFF
--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -578,42 +578,40 @@ namespace QuantConnect.Algorithm
         {
             // First check if this is just a regular IDataConsolidator
             IDataConsolidator dataConsolidator;
-            PythonConsolidator customPythonConsolidator = null;
-            if (pyObject.TryConvert(out dataConsolidator) || Extensions.TryConvert<PythonConsolidator>(pyObject, out customPythonConsolidator, allowPythonDerivative: true))
+            if (pyObject.TryConvert(out dataConsolidator))
             {
-                if (customPythonConsolidator != null)
-                {
-                    dataConsolidator = new DataConsolidatorPythonWrapper(pyObject);
-                }
-
-                try
-                {
-                    RegisterIndicator(symbol, indicator, dataConsolidator, selector);
-                    return;
-                }catch (Exception e)
-                {
-                    throw new ArgumentException("An exception was thrown while trying to register the indicator: ", e);
-                }
+                RegisterIndicator(symbol, indicator, dataConsolidator, selector);
+                return;
             }
 
-            // Finally, since above didn't work, just try it as a timespan
-            // Issue #4668 Fix
-            using (Py.GIL())
+            try
             {
-                try
+                dataConsolidator = new DataConsolidatorPythonWrapper(pyObject);
+            }
+            catch
+            {
+                // Finally, since above didn't work, just try it as a timespan
+                // Issue #4668 Fix
+                using (Py.GIL())
                 {
-                    // tryConvert does not work for timespan
-                    TimeSpan? timeSpan = pyObject.As<TimeSpan>();
-                    if (timeSpan != default(TimeSpan))
+                    try
                     {
-                        RegisterIndicator(symbol, indicator, timeSpan, selector);
+                        // tryConvert does not work for timespan
+                        TimeSpan? timeSpan = pyObject.As<TimeSpan>();
+                        if (timeSpan != default(TimeSpan))
+                        {
+                            RegisterIndicator(symbol, indicator, timeSpan, selector);
+                            return;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        throw new ArgumentException("Invalid third argument, should be either a valid consolidator or timedelta object. The following exception was thrown: ", e);
                     }
                 }
-                catch (Exception e)
-                {
-                    throw new ArgumentException("Invalid third argument, should be either a valid consolidator or timedelta object. The following exception was thrown: ", e);
-                }
             }
+
+            RegisterIndicator(symbol, indicator, dataConsolidator, selector);
         }
 
         /// <summary>

--- a/Tests/Indicators/PythonIndicatorTests.cs
+++ b/Tests/Indicators/PythonIndicatorTests.cs
@@ -31,6 +31,12 @@ namespace QuantConnect.Tests.Indicators
     [TestFixture]
     public class PythonIndicatorTests : CommonIndicatorTests<IBaseData>
     {
+        [SetUp]
+        public void SetUp()
+        {
+            SymbolCache.Clear();
+        }
+
         private static PyObject CreatePythonIndicator(int period = 14)
         {
             using (Py.GIL())

--- a/Tests/Indicators/PythonIndicatorTests.cs
+++ b/Tests/Indicators/PythonIndicatorTests.cs
@@ -260,6 +260,58 @@ class BadCustomIndicator(PythonIndicator):
         }
 
         [Test]
+        public void AllPythonRegisterIndicatorBadCases()
+        {
+            //This test covers all three bad cases of registering a indicator through Python
+
+            //Setup algorithm and Equity
+            var algorithm = new QCAlgorithm();
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
+            algorithm.AddData<TradeBar>("SPY", Resolution.Daily);
+            var spy = "SPY";
+
+            //Setup Python Indicator and Consolidator
+            using (Py.GIL())
+            {
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
+                    "from AlgorithmImports import *\n" +
+                    "consolidator = QuoteBarConsolidator(timedelta(days = 5)) \n" +
+                    "class CustomIndicator(PythonIndicator):\n" +
+                    "   def __init__(self):\n" +
+                    "       self.Value = 0\n" +
+                    "   def Update(self, input):\n" +
+                    "       self.Value = input.Value\n" +
+                    "       return True\n" +
+                    "class CustomConsolidator(PythonConsolidator):\n" +
+                    "   def __init__(self):\n" +
+                    "       self.InputType = QuoteBar\n" +
+                    "       self.OutputType = QuoteBar\n" +
+                    "       self.Consolidated = None\n" +
+                    "       self.WorkingData = None\n" +
+                    "class InvalidConsolidator:\n" +
+                    "   pass\n"
+                );
+
+                //Get our variables from Python
+                var PyIndicator = module.GetAttr("CustomIndicator").Invoke();
+                var PyConsolidator = module.GetAttr("CustomConsolidator").Invoke();
+                var Consolidator = module.GetAttr("consolidator");
+                var InvalidConsolidator = module.GetAttr("InvalidConsolidator");
+
+                //Test 1: Using a C# Consolidator; Should convert consolidator into IDataConsolidator and fail because of the InputType
+                var exception = Assert.Throws<ArgumentException>(() => algorithm.RegisterIndicator(spy, PyIndicator, Consolidator));
+                Assert.That(exception.Message, Is.EqualTo("An exception was thrown while trying to register the indicator: "));
+                //Test 2: Using a Python Consolidator; Should wrap consolidator and fail because of the InputType
+                exception = Assert.Throws<ArgumentException>(() => algorithm.RegisterIndicator(spy, PyIndicator, PyConsolidator));
+                Assert.That(exception.Message, Is.EqualTo("An exception was thrown while trying to register the indicator: "));
+
+                //Test 3: Using an invalid consolidator; Should try to convert into C#, Python Consolidator and timedelta and fail as the type is invalid
+                exception = Assert.Throws<ArgumentException>(() => algorithm.RegisterIndicator(spy, PyIndicator, InvalidConsolidator));
+                Assert.That(exception.Message, Is.EqualTo("Invalid third argument, should be either a valid consolidator or timedelta object. The following exception was thrown: "));
+            }
+        }
+
+        [Test]
         public void WarmsUpProperlyPythonIndicator()
         {
             using (Py.GIL())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The bug was raised because if something went wrong trying to register an indicator, with a C# or a custom consolidator, the exception raised was lost, because the catch sentence didn't return it with another exception
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5849 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change users will receive an informative error message when something went wrong while registering an indicator
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require updates to documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- A unit test was added asserting an exception with a related message was raised each time something went wrong with the consolidator
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
