### PR TITLE
Covered and protective call put

### DIFF
--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -324,6 +324,7 @@ namespace QuantConnect.Securities.Option
         {
             return Math.Max(0.0m, GetPayOff(underlyingPrice));
         }
+
         /// <summary>
         /// Option payoff function at expiration time
         /// </summary>
@@ -332,6 +333,16 @@ namespace QuantConnect.Securities.Option
         public decimal GetPayOff(decimal underlyingPrice)
         {
             return Right == OptionRight.Call ? underlyingPrice - StrikePrice : StrikePrice - underlyingPrice;
+        }
+
+        /// <summary>
+        /// Option out of the money function
+        /// </summary>
+        /// <param name="underlyingPrice">The price of the underlying</param>
+        /// <returns></returns>
+        public decimal OutOfTheMoneyAmount(decimal underlyingPrice)
+        {
+            return Math.Max(0, Right == OptionRight.Call ? StrikePrice - underlyingPrice : underlyingPrice - StrikePrice);
         }
 
         /// <summary>

--- a/Common/Securities/Option/OptionStrategyPositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Option/OptionStrategyPositionGroupBuyingPowerModel.cs
@@ -60,12 +60,13 @@ namespace QuantConnect.Securities.Option
                 var optionSecurity = (Option)parameters.Portfolio.Securities[optionPosition.Symbol];
                 var underlyingSecurity = parameters.Portfolio.Securities[underlyingPosition.Symbol];
 
-                var outOfTheMoneyAmount = optionSecurity.OutOfTheMoneyAmount(underlyingSecurity.Price) * optionSecurity.ContractUnitOfTrade * Math.Abs(optionPosition.Quantity);
+                var absOptionQuantity = Math.Abs(optionPosition.Quantity);
+                var outOfTheMoneyAmount = optionSecurity.OutOfTheMoneyAmount(underlyingSecurity.Price) * optionSecurity.ContractUnitOfTrade * absOptionQuantity;
 
                 var underlyingMarginRequired = Math.Abs(underlyingSecurity.BuyingPowerModel.GetMaintenanceMargin(MaintenanceMarginParameters.ForQuantityAtCurrentPrice(
                     underlyingSecurity, underlyingPosition.Quantity)));
 
-                var result = Math.Min(0.1m * optionSecurity.StrikePrice * optionSecurity.ContractUnitOfTrade + outOfTheMoneyAmount, underlyingMarginRequired);
+                var result = Math.Min(0.1m * optionSecurity.StrikePrice * optionSecurity.ContractUnitOfTrade * absOptionQuantity + outOfTheMoneyAmount, underlyingMarginRequired);
                 var inAccountCurrency = parameters.Portfolio.CashBook.ConvertToAccountCurrency(result, optionSecurity.QuoteCurrency.Symbol);
 
                 return new MaintenanceMargin(inAccountCurrency);

--- a/Common/Securities/Option/StrategyMatcher/OptionStrategyDefinitions.cs
+++ b/Common/Securities/Option/StrategyMatcher/OptionStrategyDefinitions.cs
@@ -71,17 +71,37 @@ namespace QuantConnect.Securities.Option.StrategyMatcher
         /// <summary>
         /// Hold 1 lot of the underlying and sell 1 call contract
         /// </summary>
+        /// <remarks>Inverse of the <see cref="ProtectiveCall"/></remarks>
         public static OptionStrategyDefinition CoveredCall { get; }
             = OptionStrategyDefinition.Create("Covered Call", 1,
                 OptionStrategyDefinition.CallLeg(-1)
             );
 
         /// <summary>
+        /// Hold -1 lot of the underlying and buy 1 call contract
+        /// </summary>
+        /// <remarks>Inverse of the <see cref="CoveredCall"/></remarks>
+        public static OptionStrategyDefinition ProtectiveCall { get; }
+            = OptionStrategyDefinition.Create("Protective Call", -1,
+                OptionStrategyDefinition.CallLeg(1)
+            );
+
+        /// <summary>
         /// Hold -1 lot of the underlying and sell 1 put contract
         /// </summary>
+        /// <remarks>Inverse of the <see cref="ProtectivePut"/></remarks>
         public static OptionStrategyDefinition CoveredPut { get; }
             = OptionStrategyDefinition.Create("Covered Put", -1,
                 OptionStrategyDefinition.PutLeg(-1)
+            );
+
+        /// <summary>
+        /// Hold 1 lot of the underlying and buy 1 put contract
+        /// </summary>
+        /// <remarks>Inverse of the <see cref="CoveredPut"/></remarks>
+        public static OptionStrategyDefinition ProtectivePut { get; }
+            = OptionStrategyDefinition.Create("Protective Put", 1,
+                OptionStrategyDefinition.PutLeg(1)
             );
 
         /// <summary>

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -66,6 +66,20 @@ namespace QuantConnect.Tests.Common.Securities
         // option strategy definition, initial quantity, order quantity, expected result
         private static readonly TestCaseData[] HasSufficientBuyingPowerForOrderTestCases = new[]
         {
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, -50, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, -60, false),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, 40, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, 50, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -50 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -60 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, +40 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, +50 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, -50 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, -60 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, 40 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, 50 - -20, false).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, 50, true).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, 60, false),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -40, true),
@@ -80,6 +94,20 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, 20, true),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, 50 - -20, true).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, 60 - -20, false),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, -80, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, -1000000 / 10250 + 1, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, 90, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, 100, false),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -80 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -90 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, +90 - 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, +100 - 20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, +90 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, +100 - -20, false).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, 20, true),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, -1000000 / 10250 - -20, true).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, -1000000 / 10250 + 1 - -20, false).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, 80, true).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, 1000000 / 10250 + 1, false),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -90, true).Explicit(),
@@ -572,6 +600,15 @@ namespace QuantConnect.Tests.Common.Securities
         // option strategy definition, initial position quantity, final position quantity
         private static readonly TestCaseData[] OrderQuantityForDeltaBuyingPowerTestCases = new[]
         {
+            // Initial margin for ProtectiveCall with quantity 10 is 125000m
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 125000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -125000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -125000m, -10).Explicit(),
+            // Initial margin for ProtectivePut with quantity 10 is 104000m
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 100000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -100000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -100000m, -10).Explicit(),
+
             // Initial margin for CoveredCall with quantity 10 is 192100m
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 192100m / 10, +1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -192100m / 10, -1).Explicit(),
@@ -683,21 +720,37 @@ namespace QuantConnect.Tests.Common.Securities
         // option strategy definition, initial position quantity, target buying power percent, expected quantity
         private static readonly TestCaseData[] OrderQuantityForTargetBuyingPowerTestCases = new[]
         {
+            // Initial margin requirement for ProtectiveCall with quantity 10 is 125000m
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 125000m * 11 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 125000m * 9 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 0m, -10).Explicit(),
+            // Initial margin requirement for CoveredCall with quantity -10 is 192100m
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 192100m * 11 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 192100m * 9 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 0m, +10).Explicit(),
+            // Initial margin requirement for ProtectivePut with quantity 10 is 100000m
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 100000m * 11 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 100000m * 9 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 0m, -10).Explicit(),
+            // Initial margin requirement for CoveredPut with quantity -10 is 205000
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 205000m * 11 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 205000m * 9 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 0m, +10).Explicit(),
             // Initial margin requirement for CoveredCall with quantity 10 is 192100m
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 192100m * 11 / 10, +1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 192100m * 9 / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 0m, -10),
-            // Initial margin requirement for CoveredCall with quantity -10 is 112000
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 112000m * 11 / 10, -1).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 112000m * 9 / 10, +1).Explicit(),
+            // Initial margin requirement for CoveredCall with quantity -10 is 125000m
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 125000m * 11 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 125000m * 9 / 10, +1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 0m, +10),
             // Initial margin requirement for CoveredPut with quantity 10 is 205000
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 205000m * 11 / 10, +1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 205000m * 9 / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 0m, -10),
-            // Initial margin requirement for CoveredPut with quantity -10 is 205000
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 205000m * 11 / 10, -1).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 205000m * 9 / 10, +1).Explicit(),
+            // Initial margin requirement for CoveredPut with quantity -10 is 100000m
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 100000m * 11 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 100000m * 9 / 10, +1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 0m, +10),
             // Initial margin requirement for BearCallSpread with quantity 10 is 10000
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 11 / 10, +1).Explicit(),
@@ -806,6 +859,14 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 1),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 10).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 20).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 1),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -10).Explicit(),
@@ -814,6 +875,14 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 1),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 10).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 20).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10),
@@ -1099,6 +1168,22 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 1),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 10),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 20),
         };
 
         [TestCaseSource(nameof(ReservedBuyingPowerImpactTestCases))]

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, 50 - -20, true).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, 60 - -20, false),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, 80, true).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, 90, false),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, 1000000 / 12000 + 1, false),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -90, true).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -100, false),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, 80 - 20, true),
@@ -92,8 +92,8 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -90 - -20, true),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -100 - -20, false).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 20, true),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 80 - -20, true),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 90 - -20, false),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 1000000 / 12000 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 1000000 / 12000 + 1 - -20, false),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, 1000, true),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, 1010, false),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -980, true),
@@ -441,10 +441,10 @@ namespace QuantConnect.Tests.Common.Securities
         private static readonly TestCaseData[] InitialMarginRequirementsTestCases = new[]
         {
             // OptionStrategyDefinition, initialHoldingsQuantity, expectedInitialMarginRequirement
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 1, 10000m).Explicit(),          // IB:  10282.15
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -1, 11200m),                    // IB:  12338.58
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 1, 12000m).Explicit(),           // IB:  12331.38
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -1, 10000m).Explicit(),          // IB:  10276.15
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 1, 19000m),                     // IB:  19325
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -1, 12000m),                    // IB:  12338.58
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 1, 12000m),                      // IB:  12331.38
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -1, 10000m),                     // IB:  10276.15
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 0m).Explicit(),           // IB:  0
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                     // IB:  0
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 1, 0m),                       // IB:  0
@@ -471,6 +471,10 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -1, 3000m).Explicit(),    // IB:  3001.6
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 1, 1000m),                       // IB:  1017.62
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -1, 0m),                         // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 1, 12000m),                  // IB:  inverted covered call
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -1, 19000m),                 // IB:  inverted covered call
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 1, 10000m),                   // IB:  inverted covered put
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -1, 12000m),                  // IB:  inverted covered put
         };
 
         [TestCaseSource(nameof(InitialMarginRequirementsTestCases))]
@@ -482,7 +486,28 @@ namespace QuantConnect.Tests.Common.Securities
             var initialMarginRequirement = positionGroup.BuyingPowerModel.GetInitialMarginRequirement(
                 new PositionGroupInitialMarginParameters(_portfolio, positionGroup));
 
-            Assert.AreEqual(expectedInitialMarginRequirement, initialMarginRequirement.Value);
+            Assert.AreEqual((double)expectedInitialMarginRequirement, (double)initialMarginRequirement.Value, (double)(0.2m * expectedInitialMarginRequirement));
+        }
+
+        private static readonly TestCaseData[] CoveredCallInitialMarginRequirementsTestCases = new[]
+        {
+            // OptionStrategyDefinition, initialHoldingsQuantity, expectedInitialMarginRequirement, option strike
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 2, 53700m, 200),                     // IB: 53,714
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 2, 38000m, 300),                     // IB: 38,756
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 2, 23000m, 400),                     // IB: 23,752
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 2, 21000m, 500),                     // IB: 20,939
+        };
+
+        [TestCaseSource(nameof(CoveredCallInitialMarginRequirementsTestCases))]
+        public void CoveredCallInitialMarginRequirement(OptionStrategyDefinition optionStrategyDefinition, int quantity,
+            decimal expectedInitialMarginRequirement, int strike)
+        {
+            var positionGroup = SetUpOptionStrategy(optionStrategyDefinition, quantity, strike);
+
+            var initialMarginRequirement = positionGroup.BuyingPowerModel.GetInitialMarginRequirement(
+                new PositionGroupInitialMarginParameters(_portfolio, positionGroup));
+
+            Assert.AreEqual((double)expectedInitialMarginRequirement, (double)initialMarginRequirement.Value, (double)(0.2m * expectedInitialMarginRequirement));
         }
 
         /// <summary>
@@ -497,10 +522,10 @@ namespace QuantConnect.Tests.Common.Securities
         private static readonly TestCaseData[] MaintenanceMarginTestCases = new[]
         {
             // OptionStrategyDefinition, initialHoldingsQuantity, expectedMaintenanceMargin
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 1, 10000m).Explicit(),          // IB:  10282.15
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -1, 3000m).Explicit(),          // IB:  3000
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 1, 3000m).Explicit(),            // IB:  3000
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -1, 1000m).Explicit(),           // IB:  10276.15
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 1, 19000m),                     // IB:  19325
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -1, 3000m),                     // IB:  3000
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 1, 12000m),                      // IB:  12000m
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -1, 10000m),                     // IB:  10276
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 0m).Explicit(),           // IB:  0
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                     // IB:  0
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 1, 0m),                       // IB:  0
@@ -527,6 +552,10 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -1, 3000m).Explicit(),    // IB:  3001.6
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 1, 1000m),                       // IB:  1017.62
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -1, 0m),                         // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 1, 3000m),                   // IB:  inverted covered call
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -1, 19000m),                 // IB:  inverted covered call
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 1, 10000m),                   // IB:  inverted covered Put
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -1, 12000m),                  // IB:  inverted covered Put
         };
 
         [TestCaseSource(nameof(MaintenanceMarginTestCases))]
@@ -537,7 +566,7 @@ namespace QuantConnect.Tests.Common.Securities
             var maintenanceMargin = positionGroup.BuyingPowerModel.GetMaintenanceMargin(
                 new PositionGroupMaintenanceMarginParameters(_portfolio, positionGroup));
 
-            Assert.AreEqual(expectedMaintenanceMargin, maintenanceMargin.Value);
+            Assert.AreEqual((double)expectedMaintenanceMargin, (double)maintenanceMargin.Value, (double)(0.2m * expectedMaintenanceMargin));
         }
 
         // option strategy definition, initial position quantity, final position quantity
@@ -1167,7 +1196,7 @@ namespace QuantConnect.Tests.Common.Securities
                 groupOrderManager: groupOrderManager))).ToList();
         }
 
-        private IPositionGroup SetUpOptionStrategy(OptionStrategyDefinition optionStrategyDefinition, int initialHoldingsQuantity)
+        private IPositionGroup SetUpOptionStrategy(OptionStrategyDefinition optionStrategyDefinition, int initialHoldingsQuantity, int? strike = null)
         {
             if (initialHoldingsQuantity == 0)
             {
@@ -1193,8 +1222,15 @@ namespace QuantConnect.Tests.Common.Securities
             spyMay19_320Call.SetMarketPrice(new Tick { Value = 92m });
             var spyMay19_330Call = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Call, 330, may192023));
             spyMay19_330Call.SetMarketPrice(new Tick { Value = 82m });
+
+            var spyMay17_200Call = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Call, 200, may172023));
+            spyMay17_200Call.SetMarketPrice(new Tick { Value = 220m });
+            var spyMay17_400Call = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Call, 400, may172023));
+            spyMay17_400Call.SetMarketPrice(new Tick { Value = 28m });
             var spyMay17_300Call = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Call, 300, may172023));
             spyMay17_300Call.SetMarketPrice(new Tick { Value = 112m });
+            var spyMay17_500Call = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Call, 500, may172023));
+            spyMay17_500Call.SetMarketPrice(new Tick { Value = 0.04m });
 
             var spyMay19_300Put = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Put, 300, may192023));
             spyMay19_300Put.SetMarketPrice(new Tick { Value = 0.02m });
@@ -1206,18 +1242,70 @@ namespace QuantConnect.Tests.Common.Securities
             spyMay17_300Put.SetMarketPrice(new Tick { Value = 0.01m });
 
             _equity.SetMarketPrice(new Tick { Value = 410m });
+            _equity.SetLeverage(4);
 
             var expectedPositionGroupBPMStrategy = optionStrategyDefinition.Name;
 
             if (optionStrategyDefinition.Name == OptionStrategyDefinitions.CoveredCall.Name)
             {
                 _equity.Holdings.SetHoldings(_equity.Price, initialHoldingsQuantity * _callOption.ContractMultiplier);
-                spyMay19_300Call.Holdings.SetHoldings(spyMay19_300Call.Price, -initialHoldingsQuantity);
+
+                var optionContract = spyMay19_300Call;
+                if(strike.HasValue)
+                {
+                    switch (strike.Value)
+                    {
+                        case 200:
+                            optionContract = spyMay17_200Call;
+                            break;
+                        case 300:
+                            optionContract = spyMay17_300Call;
+                            break;
+                        case 400:
+                            optionContract = spyMay17_400Call;
+                            break;
+                        case 500:
+                            optionContract = spyMay17_500Call;
+                            break;
+                    }
+                }
+
+                optionContract.Holdings.SetHoldings(optionContract.Price, -initialHoldingsQuantity);
+
+                if (initialHoldingsQuantity < 0)
+                {
+                    expectedPositionGroupBPMStrategy = OptionStrategyDefinitions.ProtectiveCall.Name;
+                }
+            }
+            else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.ProtectiveCall.Name)
+            {
+                _equity.Holdings.SetHoldings(_equity.Price, -initialHoldingsQuantity * _callOption.ContractMultiplier);
+                spyMay19_300Call.Holdings.SetHoldings(spyMay19_300Call.Price, initialHoldingsQuantity);
+
+                if (initialHoldingsQuantity < 0)
+                {
+                    expectedPositionGroupBPMStrategy = OptionStrategyDefinitions.CoveredCall.Name;
+                }
             }
             else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.CoveredPut.Name)
             {
                 _equity.Holdings.SetHoldings(_equity.Price, -initialHoldingsQuantity * _putOption.ContractMultiplier);
                 spyMay19_300Put.Holdings.SetHoldings(spyMay19_300Put.Price, -initialHoldingsQuantity);
+
+                if (initialHoldingsQuantity < 0)
+                {
+                    expectedPositionGroupBPMStrategy = OptionStrategyDefinitions.ProtectivePut.Name;
+                }
+            }
+            else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.ProtectivePut.Name)
+            {
+                _equity.Holdings.SetHoldings(_equity.Price, initialHoldingsQuantity * _putOption.ContractMultiplier);
+                spyMay19_300Put.Holdings.SetHoldings(spyMay19_300Put.Price, initialHoldingsQuantity);
+
+                if (initialHoldingsQuantity < 0)
+                {
+                    expectedPositionGroupBPMStrategy = OptionStrategyDefinitions.CoveredPut.Name;
+                }
             }
             else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.BearCallSpread.Name)
             {

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, 50 - -20, true).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, 60 - -20, false),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, 80, true).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, 1000000 / 12000 + 1, false),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, 1000000 / 10250 + 1, false),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -90, true).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -100, false),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, 80 - 20, true),
@@ -92,8 +92,8 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -90 - -20, true),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -100 - -20, false).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 20, true),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 1000000 / 12000 - -20, true),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 1000000 / 12000 + 1 - -20, false),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 1000000 / 10250 - -20, true),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 1000000 / 10250 + 1 - -20, false).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, 1000, true),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, 1010, false),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -980, true),
@@ -472,9 +472,9 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 1, 1000m),                       // IB:  1017.62
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -1, 0m),                         // IB:  0
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 1, 12000m),                  // IB:  inverted covered call
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -1, 19000m),                 // IB:  inverted covered call
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -1, 19000m),                 // IB:  covered call
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 1, 10000m),                   // IB:  inverted covered put
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -1, 12000m),                  // IB:  inverted covered put
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -1, 12000m),                  // IB:  covered put
         };
 
         [TestCaseSource(nameof(InitialMarginRequirementsTestCases))]
@@ -524,7 +524,7 @@ namespace QuantConnect.Tests.Common.Securities
             // OptionStrategyDefinition, initialHoldingsQuantity, expectedMaintenanceMargin
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 1, 19000m),                     // IB:  19325
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -1, 3000m),                     // IB:  3000
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 1, 12000m),                      // IB:  12000m
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 1, 10250m),                      // IB:  12000m
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -1, 10000m),                     // IB:  10276
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 0m).Explicit(),           // IB:  0
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                     // IB:  0
@@ -553,9 +553,9 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 1, 1000m),                       // IB:  1017.62
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -1, 0m),                         // IB:  0
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 1, 3000m),                   // IB:  inverted covered call
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -1, 19000m),                 // IB:  inverted covered call
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -1, 19000m),                 // IB:  covered call
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 1, 10000m),                   // IB:  inverted covered Put
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -1, 12000m),                  // IB:  inverted covered Put
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -1, 10250m),                  // IB:  covered Put
         };
 
         [TestCaseSource(nameof(MaintenanceMarginTestCases))]
@@ -572,22 +572,22 @@ namespace QuantConnect.Tests.Common.Securities
         // option strategy definition, initial position quantity, final position quantity
         private static readonly TestCaseData[] OrderQuantityForDeltaBuyingPowerTestCases = new[]
         {
-            // Initial margin for CoveredCall with quantity 10 is 205000
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 205000m / 10, +1).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -205000m / 10, -1).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -205000m, -10).Explicit(),
+            // Initial margin for CoveredCall with quantity 10 is 192100m
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 192100m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -192100m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -192100m, -10).Explicit(),
             // Initial margin for CoveredCall with quantity -10 is 112000
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 112000m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -112000m / 10, +1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -112000m, +10).Explicit(),
-            // Initial margin for CoveredPut with quantity 10 is 205000
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 205000m / 10, +1).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -205000m / 10, -1).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -205000m, -10).Explicit(),
-            // Initial margin for CoveredPut with quantity -10 is 205000
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 205000m / 10, -1).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -205000m / 10, +1).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -205000m, +10),
+            // Initial margin for CoveredPut with quantity 10 is 102500
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 102500 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -102500 / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -102500, -10).Explicit(),
+            // Initial margin for CoveredPut with quantity -10 is 102500
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 102500m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -102500m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -102500m, +10),
             // Initial margin for BullCallSpread with quantity 10 is 10000
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 1000m, 1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -1000m, -1).Explicit(),
@@ -683,9 +683,9 @@ namespace QuantConnect.Tests.Common.Securities
         // option strategy definition, initial position quantity, target buying power percent, expected quantity
         private static readonly TestCaseData[] OrderQuantityForTargetBuyingPowerTestCases = new[]
         {
-            // Initial margin requirement for CoveredCall with quantity 10 is 205000
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 205000m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 205000m * 9 / 10, -1),
+            // Initial margin requirement for CoveredCall with quantity 10 is 192100m
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 192100m * 11 / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 192100m * 9 / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 0m, -10),
             // Initial margin requirement for CoveredCall with quantity -10 is 112000
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 112000m * 11 / 10, -1).Explicit(),
@@ -945,7 +945,7 @@ namespace QuantConnect.Tests.Common.Securities
                 positionGroup, direction));
 
             var initialUsedMargin = _portfolio.TotalMarginUsed;
-            var initialPositionInitialMargin = initialPositionGroup.BuyingPowerModel.GetInitialMarginRequirement(
+            var initialPositionInitialMargin = positionGroup.BuyingPowerModel.GetInitialMarginRequirement(
                 new PositionGroupInitialMarginParameters(_portfolio, initialPositionGroup));
             Log.Debug($"Initial used margin: {initialUsedMargin}");
             Log.Debug($"Initial position initial margin requirement: {initialPositionInitialMargin}");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fixes for covered call. Adding new and updating existing unit tests
- Adding protective call & put strategies, which are the inverse of covered call/put but with different margin requirement

Coauthored with @jhonabreul 

**Reference values from IB:**

**Long covered call:**
![image](https://github.com/QuantConnect/Lean/assets/25215064/98617d3d-d2df-447a-88c0-8961e9cd084b)

**Short covered call/protective call:**
![image](https://github.com/QuantConnect/Lean/assets/25215064/fbfbff8a-fe55-4f28-ba0a-f5956c1ce403)

**Long covered put:**
![image](https://github.com/QuantConnect/Lean/assets/25215064/ebdd6ec7-b22d-4d4a-9315-cd7fdd4ffe2c)

**Short covered put/protective put:**
![image](https://github.com/QuantConnect/Lean/assets/25215064/180c3230-f5e6-4359-93aa-b6648e0c476b)

**Long covered call, quantity=2, strike=200:**
![image](https://github.com/QuantConnect/Lean/assets/25215064/c1e36daa-f52d-4a81-b17b-9b9d76a513d4)

**Long covered call, quantity=2, strike=300:**
![image](https://github.com/QuantConnect/Lean/assets/25215064/7d6916e3-1e6d-4f30-86af-fef4b4f7a243)

**Long covered call, quantity=2, strike=400:**
![image](https://github.com/QuantConnect/Lean/assets/25215064/194dc56c-4827-489f-837e-999995dbdec7)

**Long covered call, quantity=2, strike=500:**
![image](https://github.com/QuantConnect/Lean/assets/25215064/ebbb00d5-b26c-4114-a968-ac93382b9b56)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See related https://github.com/QuantConnect/Lean/pull/7230
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve initial/maintenance margin requirement
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added and existing unit tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
