### PR TITLE
Custom data universe selection market hours

### DIFF
--- a/Algorithm.CSharp/CustomDataUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataUniverseRegressionAlgorithm.cs
@@ -1,0 +1,137 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using System.Collections.Generic;
+using QuantConnect.Data.UniverseSelection;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Custom data universe selection regression algorithm asserting it's behavior. See GH issue #6396
+    /// </summary>
+    public class CustomDataUniverseRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Queue<DateTime> _selectionTime = new (new[] {
+            new DateTime(2014, 03, 24, 0, 0, 0),
+            new DateTime(2014, 03, 25, 0, 0, 0),
+            new DateTime(2014, 03, 26, 0, 0, 0),
+            new DateTime(2014, 03, 27, 0, 0, 0),
+            new DateTime(2014, 03, 28, 0, 0, 0),
+            new DateTime(2014, 03, 29, 0, 0, 0),
+            new DateTime(2014, 03, 30, 0, 0, 0),
+            new DateTime(2014, 03, 31, 0, 0, 0)
+        });
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2014, 03, 24);
+            SetEndDate(2014, 03, 31);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+            var universe = AddUniverse<CoarseFundamental>("custom-data-universe", (coarse) =>
+            {
+                Debug($"Universe selection called: {Time} Count: {coarse.Count()}");
+
+                var expectedTime = _selectionTime.Dequeue();
+                if (expectedTime != Time)
+                {
+                    throw new Exception($"Unexpected selection time {Time}");
+                }
+                return coarse.OrderByDescending(x => x.DollarVolume).Select(x => x.Symbol).Take(10);
+            });
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (!Portfolio.Invested)
+            {
+                foreach (var symbol in data.Keys)
+                {
+                    SetHoldings(symbol, 1m / data.Keys.Count);
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_selectionTime.Count != 0)
+            {
+                throw new Exception($"Unexpected selection times, missing {_selectionTime.Count}");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 42574;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "7"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "-65.130%"},
+            {"Drawdown", "2.900%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "-2.283%"},
+            {"Sharpe Ratio", "-4.241"},
+            {"Probabilistic Sharpe Ratio", "5.388%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "-1.065"},
+            {"Beta", "1.336"},
+            {"Annual Standard Deviation", "0.132"},
+            {"Annual Variance", "0.018"},
+            {"Information Ratio", "-12.03"},
+            {"Tracking Error", "0.078"},
+            {"Treynor Ratio", "-0.42"},
+            {"Total Fees", "$13.87"},
+            {"Estimated Strategy Capacity", "$430000000.00"},
+            {"Lowest Capacity Asset", "NB R735QTJ8XC9X"},
+            {"Portfolio Turnover", "12.54%"},
+            {"OrderListHash", "c9e692926d2798b28f78192fb69f0a29"}
+        };
+    }
+}

--- a/Algorithm.CSharp/DropboxBaseDataUniverseSelectionAlgorithm.cs
+++ b/Algorithm.CSharp/DropboxBaseDataUniverseSelectionAlgorithm.cs
@@ -186,7 +186,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 5300;
+        public long DataPoints => 5301;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -221,7 +221,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$320000.00"},
             {"Lowest Capacity Asset", "BNO UN3IMQ2JU1YD"},
             {"Portfolio Turnover", "135.26%"},
-            {"OrderListHash", "df66ec72bb4332b14bbe31ec9bea7ffc"}
+            {"OrderListHash", "4e9dbe6c2640427a5f3e510b57c7155f"}
         };
     }
 }

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -491,12 +491,7 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(Universes)]
         public Universe AddUniverse(Type dataType, SecurityType securityType, string name, Resolution resolution, string market, UniverseSettings universeSettings, PyObject pySelector)
         {
-            var marketHoursDbEntry = MarketHoursDatabase.GetEntry(market, name, securityType);
-            var dataTimeZone = marketHoursDbEntry.DataTimeZone;
-            var exchangeTimeZone = marketHoursDbEntry.ExchangeHours.TimeZone;
-            var symbol = QuantConnect.Symbol.Create(name, securityType, market, baseDataType: dataType);
-            var config = new SubscriptionDataConfig(dataType, symbol, resolution, dataTimeZone, exchangeTimeZone, false, false, true, true, isFilteredSubscription: false);
-
+            var config = GetCustomUniverseConfiguration(dataType, name, resolution, market);
             var selector = pySelector.ConvertToDelegate<Func<IEnumerable<IBaseData>, object>>();
 
             return AddUniverse(new FuncUniverse(config, universeSettings, baseDatas =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Custom data universe selection market hours. Adding regression test asserting the behavior. Updating existing tests due to market hours change, triggering selection always, even the 4th of July 2018

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/6396
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Normalize custom universe with custom data market hours behavior
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added and existing tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
