### PR TITLE
Add TriggerPrice field when applying a split

### DIFF
--- a/Algorithm.CSharp/SplitEquityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SplitEquityRegressionAlgorithm.cs
@@ -1,0 +1,136 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using System.Collections.Generic;
+using QuantConnect.Orders;
+using QuantConnect.Util;
+using System;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Simple regression algorithm asserting certain order fields update properly when a
+    /// split in the data happens
+    /// </summary>
+    public class SplitEquityRegressionAlgorithm: QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _aapl;
+        private List<OrderTicket> _tickets = new();
+
+        public override void Initialize()
+        {
+            SetStartDate(2014, 6, 5);
+            SetEndDate(2014, 6, 11);
+            SetCash(100000);
+
+            _aapl = AddEquity("AAPL", Resolution.Hour, dataNormalizationMode: DataNormalizationMode.Raw).Symbol;
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (Transactions.GetOrders().IsNullOrEmpty())
+            {
+                _tickets.Add(LimitIfTouchedOrder(_aapl, 10, 10, 10));
+                _tickets.Add(LimitOrder(_aapl, 10, 5));
+                _tickets.Add(StopLimitOrder(_aapl, 10, 15, 15));
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            foreach (var ticket in _tickets)
+            {
+                if (ticket.Quantity != 69.0m)
+                {
+                    throw new Exception($"The Quantity of order with ID: {ticket.OrderId} should be 69, but was {ticket.Quantity}");
+                }
+                switch (ticket.OrderType)
+                {
+                    case OrderType.LimitIfTouched:
+                        if (ticket.Get(OrderField.TriggerPrice) != 1.43m)
+                        {
+                            throw new Exception($"Order with ID: {ticket.OrderId} should have a Trigger Price equal to 1.43, but was {ticket.Get(OrderField.TriggerPrice)}");
+                        }
+                        break;
+                    case OrderType.Limit:
+                        if (ticket.Get(OrderField.LimitPrice) != 0.7143m)
+                        {
+                            throw new Exception($"Order with ID: {ticket.OrderId} should have a Limit Price equal to 0.7143, but was {ticket.Get(OrderField.LimitPrice)}");
+                        }
+                        break;
+                    case OrderType.StopLimit:
+                        if (ticket.Get(OrderField.StopPrice) != 2.14m)
+                        {
+                            throw new Exception($"Order with ID: {ticket.OrderId} should have a Stop Price equal to 2.14, but was {ticket.Get(OrderField.StopPrice)}");
+                        }
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 80;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-2.491"},
+            {"Tracking Error", "0.042"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "0f8f82f4f9a4960816b73daa148af272"}
+        };
+    }
+}

--- a/Algorithm.CSharp/SplitEquityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SplitEquityRegressionAlgorithm.cs
@@ -65,6 +65,11 @@ namespace QuantConnect.Algorithm.CSharp
                         {
                             throw new Exception($"Order with ID: {ticket.OrderId} should have a Trigger Price equal to 1.43, but was {ticket.Get(OrderField.TriggerPrice)}");
                         }
+
+                        if (ticket.Get(OrderField.LimitPrice) != 1.43m)
+                        {
+                            throw new Exception($"Order with ID: {ticket.OrderId} should have a Limit Price equal to 1.43, but was {ticket.Get(OrderField.LimitPrice)}");
+                        }
                         break;
                     case OrderType.Limit:
                         if (ticket.Get(OrderField.LimitPrice) != 0.7143m)
@@ -130,7 +135,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", ""},
             {"Portfolio Turnover", "0%"},
-            {"OrderListHash", "0f8f82f4f9a4960816b73daa148af272"}
+            {"OrderListHash", "fb7383d38257493fe4f3427e781d9a34"}
         };
     }
 }

--- a/Common/Brokerages/DefaultBrokerageModel.cs
+++ b/Common/Brokerages/DefaultBrokerageModel.cs
@@ -172,7 +172,8 @@ namespace QuantConnect.Brokerages
             {
                 Quantity = (int?) (ticket.Quantity/splitFactor),
                 LimitPrice = ticket.OrderType.IsLimitOrder() ? ticket.Get(OrderField.LimitPrice)*splitFactor : (decimal?) null,
-                StopPrice = ticket.OrderType.IsStopOrder() ? ticket.Get(OrderField.StopPrice)*splitFactor : (decimal?) null
+                StopPrice = ticket.OrderType.IsStopOrder() ? ticket.Get(OrderField.StopPrice)*splitFactor : (decimal?) null,
+                TriggerPrice = ticket.OrderType == OrderType.LimitIfTouched ? ticket.Get(OrderField.TriggerPrice) * splitFactor : (decimal?) null
             }));
         }
 

--- a/Common/Orders/OrderExtensions.cs
+++ b/Common/Orders/OrderExtensions.cs
@@ -62,14 +62,9 @@ namespace QuantConnect.Orders
         /// <returns>True if the order is a limit order, false otherwise</returns>
         public static bool IsLimitOrder(this OrderType orderType)
         {
-            var limitOrderTypes = new HashSet<OrderType>()
-            {
-                OrderType.Limit,
-                OrderType.StopLimit,
-                OrderType.LimitIfTouched
-            };
-
-            return limitOrderTypes.Contains(orderType);
+            return orderType == OrderType.Limit
+                || orderType == OrderType.StopLimit
+                || orderType == OrderType.LimitIfTouched;
         }
 
         /// <summary>

--- a/Common/Orders/OrderExtensions.cs
+++ b/Common/Orders/OrderExtensions.cs
@@ -13,6 +13,8 @@
  * limitations under the License.
 */
 
+using System.Collections.Generic;
+
 namespace QuantConnect.Orders
 {
     /// <summary>
@@ -60,7 +62,14 @@ namespace QuantConnect.Orders
         /// <returns>True if the order is a limit order, false otherwise</returns>
         public static bool IsLimitOrder(this OrderType orderType)
         {
-            return orderType == OrderType.Limit || orderType == OrderType.StopLimit;
+            var limitOrderTypes = new HashSet<OrderType>()
+            {
+                OrderType.Limit,
+                OrderType.StopLimit,
+                OrderType.LimitIfTouched
+            };
+
+            return limitOrderTypes.Contains(orderType);
         }
 
         /// <summary>

--- a/Tests/Common/Brokerages/DefaultBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/DefaultBrokerageModelTests.cs
@@ -110,7 +110,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                         orderRequest = new SubmitOrderRequest(OrderType.StopLimit, SecurityType.Equity, "IBM", 100, 10, 0, 0, DateTime.UtcNow, "");
                         break;
                     case OrderType.LimitIfTouched:
-                        orderRequest = new SubmitOrderRequest(OrderType.LimitIfTouched, SecurityType.Equity, "IBM", 100, 0, 0, 12, DateTime.UtcNow, "");
+                        orderRequest = new SubmitOrderRequest(OrderType.LimitIfTouched, SecurityType.Equity, "IBM", 100, 0, 14, 12, DateTime.UtcNow, "");
                         break;
                 }
                 algorithm.Transactions.AddOrder(orderRequest);
@@ -135,6 +135,7 @@ namespace QuantConnect.Tests.Common.Brokerages
                         break;
                     case OrderType.LimitIfTouched:
                         Assert.AreEqual(6, order.GetPropertyValue("TriggerPrice"));
+                        Assert.AreEqual(7, order.GetPropertyValue("LimitPrice"));
                         break;
                 }
             }

--- a/Tests/Common/Brokerages/DefaultBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/DefaultBrokerageModelTests.cs
@@ -20,6 +20,14 @@ using QuantConnect.Tests.Brokerages;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Orders.Fills;
+using System.Collections.Generic;
+using QuantConnect.Data.Market;
+using Fasterflect;
+using QuantConnect.Lean.Engine.TransactionHandlers;
+using System;
+using QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests;
+using QuantConnect.Brokerages.Backtesting;
+using QuantConnect.Tests.Engine;
 
 namespace QuantConnect.Tests.Common.Brokerages
 {
@@ -68,6 +76,68 @@ namespace QuantConnect.Tests.Common.Brokerages
             var security = TestsHelpers.GetSecurity(securityType: securityType, market: Market.USA);
             var fillModel = _defaultBrokerageModel.GetFillModel(security);
             Assert.AreEqual(expectedFillModel, fillModel.GetType().Name);
+        }
+
+        [Test]
+        public void ApplySplitWorksAsExpected()
+        {
+            var orderTypes = new List<OrderType>()
+            {
+                OrderType.Limit,
+                OrderType.StopLimit,
+                OrderType.LimitIfTouched
+            };
+
+            var algorithm = new BrokerageTransactionHandlerTests.TestAlgorithm
+            {
+                HistoryProvider = new BrokerageTransactionHandlerTests.EmptyHistoryProvider()
+            };
+            var transactionHandler = new BacktestingTransactionHandler();
+            transactionHandler.Initialize(algorithm, new BacktestingBrokerage(algorithm), new TestResultHandler(Console.WriteLine));
+
+            algorithm.Transactions.SetOrderProcessor(transactionHandler);
+            algorithm.AddEquity("IBM");
+            var tickets = new List<OrderTicket>();
+            foreach (var type in orderTypes)
+            {
+                SubmitOrderRequest orderRequest = null;
+                switch (type)
+                {
+                    case OrderType.Limit:
+                        orderRequest = new SubmitOrderRequest(OrderType.Limit, SecurityType.Equity, "IBM", 100, 0, 8, 0, DateTime.UtcNow, "");
+                        break;
+                    case OrderType.StopLimit:
+                        orderRequest = new SubmitOrderRequest(OrderType.StopLimit, SecurityType.Equity, "IBM", 100, 10, 0, 0, DateTime.UtcNow, "");
+                        break;
+                    case OrderType.LimitIfTouched:
+                        orderRequest = new SubmitOrderRequest(OrderType.LimitIfTouched, SecurityType.Equity, "IBM", 100, 0, 0, 12, DateTime.UtcNow, "");
+                        break;
+                }
+                algorithm.Transactions.AddOrder(orderRequest);
+                var ticket = new OrderTicket(algorithm.Transactions, orderRequest);
+                tickets.Add(ticket);
+            }
+
+            var split = new Split("IBM", DateTime.UtcNow, 1, 0.5m, SplitType.SplitOccurred);
+            _defaultBrokerageModel.ApplySplit(tickets, split);
+            transactionHandler.ProcessSynchronousEvents();
+            foreach (var order in algorithm.Transactions.GetOrders())
+            {
+                Assert.AreEqual(200, order.Quantity);
+                var orderType = order.Type;
+                switch (orderType)
+                {
+                    case OrderType.Limit:
+                        Assert.AreEqual(4, order.GetPropertyValue("LimitPrice"));
+                        break;
+                    case OrderType.StopLimit:
+                        Assert.AreEqual(5, order.GetPropertyValue("StopPrice"));
+                        break;
+                    case OrderType.LimitIfTouched:
+                        Assert.AreEqual(6, order.GetPropertyValue("TriggerPrice"));
+                        break;
+                }
+            }
         }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
If one stock is split in k parts, the new TriggerPrice in an order for that stock should be also scaled by a factor of 1/k.
Changes:
- Modify `DefaultBrokerageModel.ApplySplit()` to adjust `TriggerPrice` field, if the ticket order comes from a LimitIfTouched order
- Regression and unit test were added
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #6933 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, `TriggerPrice` field in LimitIfTouched orders will be adjusted when a split in the data happens
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require updates to documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There was created a regression algorithm in which there was a split in the data between the start and end date. At then end of the algorithm, it was asserted certain order fields were adjusted as expected. The unit test created have a similar behavior.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
