### PR TITLE
Support overriding position group margin requirements

### DIFF
--- a/Algorithm.CSharp/DefaultMarginComboOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DefaultMarginComboOrderRegressionAlgorithm.cs
@@ -1,0 +1,79 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Orders;
+using System.Collections.Generic;
+using System;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting the behavior of the default position group Not allowing us to fill a combo order above our margin available
+    /// </summary>
+    public class DefaultMarginComboOrderRegressionAlgorithm : NullMarginComboOrderRegressionAlgorithm
+    {
+        protected override void OverrideMarginModels()
+        {
+            // we use the default
+        }
+
+        protected override void AssertState(OrderTicket ticket, int expectedGroupCount, int expectedMarginUsed)
+        {
+            if (ticket.Status != OrderStatus.Invalid)
+            {
+                throw new Exception($"Unexpected order status {ticket.Status} for symbol {ticket.Symbol} and quantity {ticket.Quantity}");
+            }
+            if (Portfolio.Positions.Groups.Count != 0)
+            {
+                throw new Exception($"Unexpected position group count {Portfolio.Positions.Groups.Count} for symbol {ticket.Symbol} and quantity {ticket.Quantity}");
+            }
+            if (Portfolio.TotalMarginUsed != 0)
+            {
+                throw new Exception($"Unexpected margin used {Portfolio.TotalMarginUsed} for symbol {ticket.Symbol} and quantity {ticket.Quantity}");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "71db757e317ae4499311f712048a937b"}
+        };
+    }
+}

--- a/Algorithm.CSharp/DefaultMarginComboOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DefaultMarginComboOrderRegressionAlgorithm.cs
@@ -13,9 +13,9 @@
  * limitations under the License.
 */
 
+using System;
 using QuantConnect.Orders;
 using System.Collections.Generic;
-using System;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -44,6 +44,11 @@ namespace QuantConnect.Algorithm.CSharp
                 throw new Exception($"Unexpected margin used {Portfolio.TotalMarginUsed} for symbol {ticket.Symbol} and quantity {ticket.Quantity}");
             }
         }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public override Language[] Languages { get; } = { Language.CSharp };
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/DefaultMarginMultipleOrdersRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DefaultMarginMultipleOrdersRegressionAlgorithm.cs
@@ -1,0 +1,79 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting the behavior of the default position group Not allowing us to fill orders above our margin available
+    /// </summary>
+    public class DefaultMarginMultipleOrdersRegressionAlgorithm : NullMarginMultipleOrdersRegressionAlgorithm
+    {
+        protected override void OverrideMarginModels()
+        {
+            // we use the default
+        }
+
+        protected override void AssertState(OrderTicket ticket, int expectedGroupCount, int expectedMarginUsed)
+        {
+            if (ticket.Status != OrderStatus.Invalid)
+            {
+                throw new Exception($"Unexpected order status {ticket.Status} for symbol {ticket.Symbol} and quantity {ticket.Quantity}");
+            }
+            if (Portfolio.Positions.Groups.Count != 0)
+            {
+                throw new Exception($"Unexpected position group count {Portfolio.Positions.Groups.Count} for symbol {ticket.Symbol} and quantity {ticket.Quantity}");
+            }
+            if (Portfolio.TotalMarginUsed != 0)
+            {
+                throw new Exception($"Unexpected margin used {Portfolio.TotalMarginUsed} for symbol {ticket.Symbol} and quantity {ticket.Quantity}");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "51db0792b2caf4f739303df2c106ccb2"}
+        };
+    }
+}

--- a/Algorithm.CSharp/DefaultMarginMultipleOrdersRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DefaultMarginMultipleOrdersRegressionAlgorithm.cs
@@ -14,8 +14,8 @@
 */
 
 using System;
-using System.Collections.Generic;
 using QuantConnect.Orders;
+using System.Collections.Generic;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -44,6 +44,11 @@ namespace QuantConnect.Algorithm.CSharp
                 throw new Exception($"Unexpected margin used {Portfolio.TotalMarginUsed} for symbol {ticket.Symbol} and quantity {ticket.Quantity}");
             }
         }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public override Language[] Languages { get; } = { Language.CSharp };
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/LiquidatingMultipleOptionStrategiesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LiquidatingMultipleOptionStrategiesRegressionAlgorithm.cs
@@ -92,7 +92,7 @@ namespace QuantConnect.Algorithm.CSharp
             else
             {
                 // Let's check that we have the right position groups, just to make sure we are good.
-                var positionGroups = Portfolio.PositionGroups;
+                var positionGroups = Portfolio.Positions.Groups;
                 if (positionGroups.Count != 2)
                 {
                     throw new Exception($"Expected 2 position groups, one for each spread, but found {positionGroups.Count}");

--- a/Algorithm.CSharp/NakedShortOptionStrategyOverMarginAlgorithm.cs
+++ b/Algorithm.CSharp/NakedShortOptionStrategyOverMarginAlgorithm.cs
@@ -111,7 +111,7 @@ namespace QuantConnect.Algorithm.CSharp
             }
 
             var expectedQuantity = Math.Abs(_quantity - _quantityToLiquidate);
-            var positionGroup = Portfolio.PositionGroups.Single();
+            var positionGroup = Portfolio.Positions.Groups.Single();
             if (positionGroup.Quantity != expectedQuantity)
             {
                 throw new Exception($"Expected position quantity to be {expectedQuantity} but was {positionGroup.Quantity}");

--- a/Algorithm.CSharp/NullMarginComboOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/NullMarginComboOrderRegressionAlgorithm.cs
@@ -1,0 +1,72 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Linq;
+using QuantConnect.Orders;
+using QuantConnect.Data.Market;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting the behavior of specifying a null position group allowing us to fill a combo order which would be invalid if not
+    /// </summary>
+    public class NullMarginComboOrderRegressionAlgorithm : NullMarginMultipleOrdersRegressionAlgorithm
+    {
+        protected override void PlaceTrades(List<OptionContract> symbols)
+        {
+            var orderLegs = new List<Leg>()
+            {
+                Leg.Create(symbols[0].Symbol, -1),
+                Leg.Create(symbols[0].Symbol.Underlying, 100),
+            };
+            var tickets = ComboMarketOrder(orderLegs, 10).ToList();
+
+            AssertState(tickets[0], 2, 1010);
+            AssertState(tickets[1], 2, 1010);
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "2"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$50.00"},
+            {"Estimated Strategy Capacity", "$8800000.00"},
+            {"Lowest Capacity Asset", "GOOCV VP83T1ZUHROL"},
+            {"Portfolio Turnover", "7608.10%"},
+            {"OrderListHash", "d6b151001e65ab2baa0bc31720733876"}
+        };
+    }
+}

--- a/Algorithm.CSharp/NullMarginComboOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/NullMarginComboOrderRegressionAlgorithm.cs
@@ -25,18 +25,23 @@ namespace QuantConnect.Algorithm.CSharp
     /// </summary>
     public class NullMarginComboOrderRegressionAlgorithm : NullMarginMultipleOrdersRegressionAlgorithm
     {
-        protected override void PlaceTrades(List<OptionContract> symbols)
+        protected override void PlaceTrades(OptionContract optionContract)
         {
             var orderLegs = new List<Leg>()
             {
-                Leg.Create(symbols[0].Symbol, -1),
-                Leg.Create(symbols[0].Symbol.Underlying, 100),
+                Leg.Create(optionContract.Symbol, -1),
+                Leg.Create(optionContract.Symbol.Underlying, 100),
             };
             var tickets = ComboMarketOrder(orderLegs, 10).ToList();
 
             AssertState(tickets[0], 2, 1010);
             AssertState(tickets[1], 2, 1010);
         }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public override Language[] Languages { get; } = { Language.CSharp };
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/NullMarginMultipleOrdersRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/NullMarginMultipleOrdersRegressionAlgorithm.cs
@@ -73,8 +73,7 @@ namespace QuantConnect.Algorithm.CSharp
                         .Where(contract => contract.Right == OptionRight.Call)
                         .OrderByDescending(x => x.Expiry)
                         .ThenBy(x => x.Strike)
-                        .Take(2)
-                        .ToList();
+                        .First();
 
                     if(!_placedTrades)
                     {
@@ -85,10 +84,10 @@ namespace QuantConnect.Algorithm.CSharp
             }
         }
 
-        protected virtual void PlaceTrades(List<OptionContract> symbols)
+        protected virtual void PlaceTrades(OptionContract optionContract)
         {
-            AssertState(MarketOrder(symbols[1].Symbol.Underlying, 1000), 1, 1000);
-            AssertState(MarketOrder(symbols[0].Symbol, -10), 2, 1010);
+            AssertState(MarketOrder(optionContract.Symbol.Underlying, 1000), 1, 1000);
+            AssertState(MarketOrder(optionContract.Symbol, -10), 2, 1010);
         }
 
         protected virtual void AssertState(OrderTicket ticket, int expectedGroupCount, int expectedMarginUsed)
@@ -115,7 +114,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public virtual Language[] Languages { get; } = { Language.CSharp };
+        public virtual Language[] Languages { get; } = { Language.CSharp, Language.Python };
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm

--- a/Algorithm.CSharp/NullMarginMultipleOrdersRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/NullMarginMultipleOrdersRegressionAlgorithm.cs
@@ -1,0 +1,161 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Orders;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+using QuantConnect.Data.Market;
+using System.Collections.Generic;
+using QuantConnect.Securities.Positions;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting the behavior of specifying a null position group allowing us to fill orders which would be invalid if not
+    /// </summary>
+    public class NullMarginMultipleOrdersRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private bool _placedTrades;
+        protected Symbol OptionSymbol { get; private set; }
+
+        public override void Initialize()
+        {
+            SetStartDate(2015, 12, 24);
+            SetEndDate(2015, 12, 24);
+            SetCash(10000);
+
+            OverrideMarginModels();
+
+            var equity = AddEquity("GOOG", leverage: 4);
+            var option = AddOption(equity.Symbol);
+            OptionSymbol = option.Symbol;
+
+            option.SetFilter(u => u.Strikes(-2, +2).Expiration(0, 180));
+        }
+
+        protected virtual void OverrideMarginModels()
+        {
+            Portfolio.SetPositions(SecurityPositionGroupModel.Null);
+            SetSecurityInitializer(security =>
+            {
+                security.SetBuyingPowerModel(new ConstantBuyingPowerModel(1));
+            });
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
+        {
+            if (!Portfolio.Invested)
+            {
+                OptionChain chain;
+                if (IsMarketOpen(OptionSymbol) && slice.OptionChains.TryGetValue(OptionSymbol, out chain))
+                {
+                    // we find at the money (ATM) call contract with farthest expiration
+                    var atmContracts = chain
+                        .Where(contract => contract.Right == OptionRight.Call)
+                        .OrderByDescending(x => x.Expiry)
+                        .ThenBy(x => x.Strike)
+                        .Take(2)
+                        .ToList();
+
+                    if(!_placedTrades)
+                    {
+                        _placedTrades = true;
+                        PlaceTrades(atmContracts);
+                    }
+                }
+            }
+        }
+
+        protected virtual void PlaceTrades(List<OptionContract> symbols)
+        {
+            AssertState(MarketOrder(symbols[1].Symbol.Underlying, 1000), 1, 1000);
+            AssertState(MarketOrder(symbols[0].Symbol, -10), 2, 1010);
+        }
+
+        protected virtual void AssertState(OrderTicket ticket, int expectedGroupCount, int expectedMarginUsed)
+        {
+            if (ticket.Status != OrderStatus.Filled)
+            {
+                throw new Exception($"Unexpected order status {ticket.Status} for symbol {ticket.Symbol} and quantity {ticket.Quantity}");
+            }
+            if (Portfolio.Positions.Groups.Count != expectedGroupCount)
+            {
+                throw new Exception($"Unexpected position group count {Portfolio.Positions.Groups.Count} for symbol {ticket.Symbol} and quantity {ticket.Quantity}");
+            }
+            if(Portfolio.TotalMarginUsed != expectedMarginUsed)
+            {
+                throw new Exception($"Unexpected margin used {expectedMarginUsed}");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public virtual bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public virtual Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public virtual long DataPoints => 475788;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public virtual int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public virtual Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "2"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$7.50"},
+            {"Estimated Strategy Capacity", "$8800000.00"},
+            {"Lowest Capacity Asset", "GOOCV VP83T1ZUHROL"},
+            {"Portfolio Turnover", "7577.77%"},
+            {"OrderListHash", "765d3f0c58d5c90a226763e9c69e8ddf"}
+        };
+    }
+}

--- a/Algorithm.CSharp/OptionEquityBaseStrategyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionEquityBaseStrategyRegressionAlgorithm.cs
@@ -51,7 +51,7 @@ namespace QuantConnect.Algorithm.CSharp
 
         protected void AssertOptionStrategyIsPresent(string name, int? quantity = null)
         {
-            if (Portfolio.PositionGroups.Where(group => group.BuyingPowerModel is OptionStrategyPositionGroupBuyingPowerModel)
+            if (Portfolio.Positions.Groups.Where(group => group.BuyingPowerModel is OptionStrategyPositionGroupBuyingPowerModel)
                 .Count(group => ((OptionStrategyPositionGroupBuyingPowerModel)@group.BuyingPowerModel).ToString() == name
                     && (!quantity.HasValue || Math.Abs(group.Quantity) == quantity)) != 1)
             {
@@ -61,7 +61,7 @@ namespace QuantConnect.Algorithm.CSharp
 
         protected void AssertDefaultGroup(Symbol symbol, decimal quantity)
         {
-            if (Portfolio.PositionGroups.Where(group => group.BuyingPowerModel is SecurityPositionGroupBuyingPowerModel)
+            if (Portfolio.Positions.Groups.Where(group => group.BuyingPowerModel is SecurityPositionGroupBuyingPowerModel)
                 .Count(group => group.Positions.Any(position => position.Symbol == symbol && position.Quantity == quantity)) != 1)
             {
                 throw new Exception($"Default groupd for symbol '{symbol}' and quantity '{quantity}' was not found!");

--- a/Algorithm.CSharp/OptionStrategyMarginCallEventsAlgorithm.cs
+++ b/Algorithm.CSharp/OptionStrategyMarginCallEventsAlgorithm.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.Algorithm.CSharp
         {
             base.OnMarginCall(requests);
 
-            var positionGroup = Portfolio.PositionGroups.Single();
+            var positionGroup = Portfolio.Positions.Groups.Single();
             foreach (var request in requests)
             {
                 var position = positionGroup.GetPosition(request.Symbol);

--- a/Algorithm.CSharp/OptionsMarginCallEventsAlgorithmBase.cs
+++ b/Algorithm.CSharp/OptionsMarginCallEventsAlgorithmBase.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Algorithm.CSharp
                 throw new Exception("All orders should be filled");
             }
 
-            var finalStrategyQuantity = Portfolio.PositionGroups.First().Quantity;
+            var finalStrategyQuantity = Portfolio.Positions.Groups.First().Quantity;
             if (Math.Abs(OriginalQuantity) <= Math.Abs(finalStrategyQuantity))
             {
                 throw new Exception($@"Strategy position group quantity should have been decreased from the original quantity {OriginalQuantity

--- a/Algorithm.CSharp/RollOutFrontMonthToBackMonthOptionUsingCalendarSpreadRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RollOutFrontMonthToBackMonthOptionUsingCalendarSpreadRegressionAlgorithm.cs
@@ -105,12 +105,12 @@ namespace QuantConnect.Algorithm.CSharp
                 throw new Exception("Expected the algorithm to have bought and sold a Bull Call Spread and a Bear Put Spread.");
             }
 
-            if (Portfolio.PositionGroups.Count != 1)
+            if (Portfolio.Positions.Groups.Count != 1)
             {
-                throw new Exception($"Expected 1 position group, found {Portfolio.PositionGroups.Count}");
+                throw new Exception($"Expected 1 position group, found {Portfolio.Positions.Groups.Count}");
             }
 
-            var positions = Portfolio.PositionGroups.Single().Positions.ToList();
+            var positions = Portfolio.Positions.Groups.Single().Positions.ToList();
             if (positions.Count != 1)
             {
                 throw new Exception($"Expected 1 position in the position group, found {positions.Count()}");

--- a/Algorithm.CSharp/SingleOptionPositionGroupBuyingPowerModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SingleOptionPositionGroupBuyingPowerModelRegressionAlgorithm.cs
@@ -67,7 +67,7 @@ namespace QuantConnect.Algorithm.CSharp
             MarketOrder(contractSymbol, quantity);
 
             var security = Securities[contractSymbol];
-            var positionGroup = Portfolio.PositionGroups.Single();
+            var positionGroup = Portfolio.Positions.Groups.Single();
 
             TestQuantityForDeltaBuyingPowerForPositionGroup(positionGroup, security);
 
@@ -75,7 +75,7 @@ namespace QuantConnect.Algorithm.CSharp
             quantity = -10;
             MarketOrder(contractSymbol, quantity - positionGroup.Quantity);
 
-            positionGroup = Portfolio.PositionGroups.Single();
+            positionGroup = Portfolio.Positions.Groups.Single();
             if (positionGroup.Positions.Single().Quantity != quantity)
             {
                 throw new Exception($@"Expected position group quantity to be {quantity} but was {positionGroup.Quantity}");

--- a/Algorithm.Python/NullMarginMultipleOrdersRegressionAlgorithm.py
+++ b/Algorithm.Python/NullMarginMultipleOrdersRegressionAlgorithm.py
@@ -1,0 +1,50 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression algorithm asserting the behavior of specifying a null position group allowing us to fill orders which would be invalid if not
+### </summary>
+class NullMarginMultipleOrdersRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetStartDate(2015, 12, 24)
+        self.SetEndDate(2015, 12, 24)
+        self.SetCash(10000)
+
+        # override security position group model
+        self.Portfolio.SetPositions(SecurityPositionGroupModel.Null)
+        # override margin requirements
+        self.SetSecurityInitializer(lambda security: security.SetBuyingPowerModel(ConstantBuyingPowerModel(1)))
+
+        equity = self.AddEquity("GOOG", leverage=4, fillForward=True)
+        option = self.AddOption(equity.Symbol, fillForward=True)
+        self._optionSymbol = option.Symbol
+
+        option.SetFilter(lambda u: u.Strikes(-2, +2).Expiration(0, 180))
+
+    def OnData(self, data: Slice):
+        if not self.Portfolio.Invested:
+            if self.IsMarketOpen(self._optionSymbol):
+                chain = data.OptionChains.GetValue(self._optionSymbol)
+                if chain is not None:
+                    callContracts = [contract for contract in chain if contract.Right == OptionRight.Call]
+                    callContracts.sort(key=lambda x: (x.Expiry, 1/ x.Strike), reverse=True)
+
+                    optionContract = callContracts[0]
+                    self.MarketOrder(optionContract.Symbol.Underlying, 1000)
+                    self.MarketOrder(optionContract.Symbol, -10)
+
+                    if self.Portfolio.TotalMarginUsed != 1010:
+                        raise ValueError(f"Unexpected margin used {self.Portfolio.TotalMarginUsed}")

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -293,10 +293,7 @@ namespace QuantConnect.Brokerages.Backtesting
                     HasSufficientBuyingPowerForOrderResult hasSufficientBuyingPowerResult;
                     try
                     {
-                        var group = Algorithm.Portfolio.Positions.CreatePositionGroup(orders);
-                        hasSufficientBuyingPowerResult = group.BuyingPowerModel.HasSufficientBuyingPowerForOrder(
-                            new HasSufficientPositionGroupBuyingPowerForOrderParameters(Algorithm.Portfolio, group, orders)
-                        );
+                        hasSufficientBuyingPowerResult = Algorithm.Portfolio.HasSufficientBuyingPowerForOrder(orders);
                     }
                     catch (Exception err)
                     {

--- a/Common/AlgorithmImports.py
+++ b/Common/AlgorithmImports.py
@@ -68,6 +68,7 @@ from QuantConnect.Securities.Future import *
 from QuantConnect.Data.Consolidators import *
 from QuantConnect.Orders.TimeInForces import *
 from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Securities.Positions import *
 from QuantConnect.Orders.OptionExercise import *
 from QuantConnect.Securities.Volatility import *
 from QuantConnect.Securities.Interfaces import *

--- a/Common/Securities/DefaultMarginCallModel.cs
+++ b/Common/Securities/DefaultMarginCallModel.cs
@@ -99,7 +99,7 @@ namespace QuantConnect.Securities
             {
                 if (totalMarginUsed > totalPortfolioValue * (1 + _marginBuffer))
                 {
-                    foreach (var positionGroup in Portfolio.PositionGroups)
+                    foreach (var positionGroup in Portfolio.Positions.Groups)
                     {
                         var positionMarginCallOrders = GenerateMarginCallOrders(
                             new MarginCallOrdersParameters(positionGroup, totalPortfolioValue, totalMarginUsed)).ToList();

--- a/Common/Securities/Positions/NullSecurityPositionGroupModel.cs
+++ b/Common/Securities/Positions/NullSecurityPositionGroupModel.cs
@@ -1,0 +1,33 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.Positions
+{
+    /// <summary>
+    /// Responsible for managing the resolution of position groups for an algorithm.
+    /// Will only resolve single position groups
+    /// </summary>
+    public class NullSecurityPositionGroupModel : SecurityPositionGroupModel
+    {
+        /// <summary>
+        /// Get the position group resolver instance to use
+        /// </summary>
+        /// <returns>The position group resolver instance</returns>
+        protected override IPositionGroupResolver GetPositionGroupResolver()
+        {
+            return new CompositePositionGroupResolver(new SecurityPositionGroupResolver(PositionGroupBuyingPowerModel));
+        }
+    }
+}

--- a/Common/Securities/Positions/PositionGroupExtensions.cs
+++ b/Common/Securities/Positions/PositionGroupExtensions.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Securities.Positions
         /// <param name="groupQuantity">The quantity of the new group</param>
         /// <param name="positionMananger">The position manager to use to resolve positions</param>
         /// <returns>A position group with the same position ratios as the template but with the specified group quantity</returns>
-        public static IPositionGroup WithQuantity(this IPositionGroup template, decimal groupQuantity, PositionManager positionMananger)
+        public static IPositionGroup WithQuantity(this IPositionGroup template, decimal groupQuantity, SecurityPositionGroupModel positionMananger)
         {
             var positions = template.ToArray(p => p.WithLots(groupQuantity));
 
@@ -66,7 +66,7 @@ namespace QuantConnect.Securities.Positions
         /// </summary>
         /// <param name="template">The group template</param>
         /// <returns>A position group with the same position ratios as the template but with the specified group quantity</returns>
-        public static IPositionGroup CreateUnitGroup(this IPositionGroup template, PositionManager positionMananger)
+        public static IPositionGroup CreateUnitGroup(this IPositionGroup template, SecurityPositionGroupModel positionMananger)
         {
             return template.WithQuantity(1, positionMananger);
         }

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -793,10 +793,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             HasSufficientBuyingPowerForOrderResult hasSufficientBuyingPowerResult;
             try
             {
-                var group = _algorithm.Portfolio.Positions.CreatePositionGroup(orders);
-                hasSufficientBuyingPowerResult = group.BuyingPowerModel.HasSufficientBuyingPowerForOrder(
-                    _algorithm.Portfolio, group, orders
-                );
+                hasSufficientBuyingPowerResult = _algorithm.Portfolio.HasSufficientBuyingPowerForOrder(orders);
             }
             catch (Exception err)
             {

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -394,7 +394,7 @@ namespace QuantConnect.Tests.Common.Securities
             var initialPositionGroup = SetUpOptionStrategy(optionStrategy, initialPositionQuantity);
 
             var orders = GetPositionGroupOrders(initialPositionGroup, initialPositionQuantity != 0 ? initialPositionQuantity : 1, orderQuantity);
-            var ordersPositionGroup = _portfolio.Positions.CreatePositionGroup(orders);
+            Assert.IsTrue(_portfolio.Positions.TryCreatePositionGroup(orders, out var ordersPositionGroup));
 
             var result = ordersPositionGroup.BuyingPowerModel.HasSufficientBuyingPowerForOrder(
                 new HasSufficientPositionGroupBuyingPowerForOrderParameters(_portfolio, ordersPositionGroup, orders));
@@ -435,7 +435,7 @@ namespace QuantConnect.Tests.Common.Securities
             for (var strategyQuantity = Math.Abs(initialHoldingsQuantity); strategyQuantity > -30; strategyQuantity--)
             {
                 var orders = GetStrategyOrders(strategyQuantity);
-                var positionGroup = _portfolio.Positions.CreatePositionGroup(orders);
+                Assert.IsTrue(_portfolio.Positions.TryCreatePositionGroup(orders, out var positionGroup));
                 var buyingPowerModel = positionGroup.BuyingPowerModel;
 
                 var maintenanceMargin = buyingPowerModel.GetMaintenanceMargin(
@@ -511,7 +511,7 @@ namespace QuantConnect.Tests.Common.Securities
             var quantity = -initialHoldingsQuantity / 2;
             var orders = GetStrategyOrders(quantity);
 
-            var positionGroup = _portfolio.Positions.CreatePositionGroup(orders);
+            Assert.IsTrue(_portfolio.Positions.TryCreatePositionGroup(orders, out var positionGroup));
 
             var hasSufficientBuyingPowerResult = positionGroup.BuyingPowerModel.HasSufficientBuyingPowerForOrder(
                 new HasSufficientPositionGroupBuyingPowerForOrderParameters(_portfolio, positionGroup, orders));
@@ -533,7 +533,7 @@ namespace QuantConnect.Tests.Common.Securities
             initialHoldingsQuantity = -absQuantity;
 
             SetUpOptionStrategy(initialHoldingsQuantity);
-            var positionGroup = _portfolio.PositionGroups.Single();
+            var positionGroup = _portfolio.Positions.Groups.Single();
 
             var expectedQuantity = initialHoldingsQuantity - finalPositionQuantity;
             var usedMargin = _portfolio.TotalMarginUsed;
@@ -1788,9 +1788,9 @@ namespace QuantConnect.Tests.Common.Securities
             _callOption.Holdings.SetHoldings(1m, initialHoldingsQuantity);
             _putOption.Holdings.SetHoldings(1m, initialHoldingsQuantity);
 
-            Assert.AreEqual(1, _portfolio.PositionGroups.Count);
+            Assert.AreEqual(1, _portfolio.Positions.Groups.Count);
 
-            var positionGroup = _portfolio.PositionGroups.First();
+            var positionGroup = _portfolio.Positions.Groups.First();
             Assert.AreEqual(initialHoldingsQuantity < 0 ? OptionStrategyDefinitions.ShortStraddle.Name : OptionStrategyDefinitions.Straddle.Name,
                 positionGroup.BuyingPowerModel.ToString());
 
@@ -1835,7 +1835,7 @@ namespace QuantConnect.Tests.Common.Securities
                     var security = _algorithm.Securities[position.Symbol];
                     security.Holdings.SetHoldings(0, 0);
                 }
-                Assert.AreEqual(0, _portfolio.PositionGroups.Count);
+                Assert.AreEqual(0, _portfolio.Positions.Groups.Count);
 
                 return group;
             }
@@ -2153,7 +2153,7 @@ namespace QuantConnect.Tests.Common.Securities
                 longCallOption.Holdings.SetHoldings(longCallOption.Price, initialHoldingsQuantity);
             }
 
-            var positionGroup = _portfolio.PositionGroups.Single();
+            var positionGroup = _portfolio.Positions.Groups.Single();
             Assert.AreEqual(expectedPositionGroupBPMStrategy, positionGroup.BuyingPowerModel.ToString());
 
             if (updateCashbook)

--- a/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
@@ -247,7 +247,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var expected = -(int)(Math.Round((totalMargin - netLiquidationValue) / securityPrice, MidpointRounding.AwayFromZero) * 4m);
             var actual = (portfolio.MarginCallModel as TestDefaultMarginCallModel).GenerateMarginCallOrders(
-                new MarginCallOrdersParameters(portfolio.PositionGroups.Single(), netLiquidationValue, totalMargin)).Single().Quantity;
+                new MarginCallOrdersParameters(portfolio.Positions.Groups.Single(), netLiquidationValue, totalMargin)).Single().Quantity;
 
             Assert.AreEqual(expected, actual);
         }
@@ -275,7 +275,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var expected = -(int)(Math.Round((totalMargin - netLiquidationValue) / securityPrice, MidpointRounding.AwayFromZero) * 2m);
             var actual = (portfolio.MarginCallModel as TestDefaultMarginCallModel).GenerateMarginCallOrders(
-                new MarginCallOrdersParameters(portfolio.PositionGroups.Single(), netLiquidationValue, totalMargin)).Single().Quantity;
+                new MarginCallOrdersParameters(portfolio.Positions.Groups.Single(), netLiquidationValue, totalMargin)).Single().Quantity;
 
             Assert.AreEqual(expected, actual);
         }
@@ -302,7 +302,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var expected = (int)(Math.Round((totalMargin - netLiquidationValue) / securityPrice, MidpointRounding.AwayFromZero) * 4m);
             var actual = (portfolio.MarginCallModel as TestDefaultMarginCallModel).GenerateMarginCallOrders(
-                new MarginCallOrdersParameters(portfolio.PositionGroups.Single(), netLiquidationValue, totalMargin)).Single().Quantity;
+                new MarginCallOrdersParameters(portfolio.Positions.Groups.Single(), netLiquidationValue, totalMargin)).Single().Quantity;
 
             Assert.AreEqual(expected, actual);
         }
@@ -329,7 +329,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var expected = (int)(Math.Round((totalMargin - netLiquidationValue) / securityPrice, MidpointRounding.AwayFromZero) * 2m);
             var actual = (portfolio.MarginCallModel as TestDefaultMarginCallModel).GenerateMarginCallOrders(
-                new MarginCallOrdersParameters(portfolio.PositionGroups.Single(), netLiquidationValue, totalMargin)).Single().Quantity;
+                new MarginCallOrdersParameters(portfolio.Positions.Groups.Single(), netLiquidationValue, totalMargin)).Single().Quantity;
 
             Assert.AreEqual(expected, actual);
         }

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -408,7 +408,7 @@ namespace QuantConnect.Tests.Engine.Setup
                 transactionHandler.Object, realTimeHandler.Object, objectStore.Object, TestGlobals.DataCacheProvider, TestGlobals.MapFileProvider)));
 
             // let's assert be detect the covered call option strategy for existing position correctly
-            if (algorithm.Portfolio.PositionGroups.Where(group => group.BuyingPowerModel is OptionStrategyPositionGroupBuyingPowerModel)
+            if (algorithm.Portfolio.Positions.Groups.Where(group => group.BuyingPowerModel is OptionStrategyPositionGroupBuyingPowerModel)
                 .Count(group => ((OptionStrategyPositionGroupBuyingPowerModel)@group.BuyingPowerModel).ToString() == OptionStrategyDefinitions.CoveredCall.Name
                     && (Math.Abs(group.Quantity) == 1)) != 1)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Add support for algorithms to set the null security position group model which will not group securities together but rather return the single group buying power model. Adding regression algorithms
- Cleanup unrequired check in `OptionStrategyPositionGroupResolver`
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allow overriding position group margin requirements
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added regression algorithms
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
