### PR TITLE
Account for premium in options strategies margin

### DIFF
--- a/Algorithm.CSharp/NullBuyingPowerOptionBullCallSpreadAlgorithm.cs
+++ b/Algorithm.CSharp/NullBuyingPowerOptionBullCallSpreadAlgorithm.cs
@@ -20,6 +20,7 @@ using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
+using QuantConnect.Securities.Positions;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -40,6 +41,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(200000);
 
             SetSecurityInitializer(security => security.MarginModel = SecurityMarginModel.Null);
+            Portfolio.SetPositions(SecurityPositionGroupModel.Null);
 
             var equity = AddEquity("GOOG");
             var option = AddOption(equity.Symbol);

--- a/Algorithm.CSharp/SingleOptionPositionGroupBuyingPowerModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SingleOptionPositionGroupBuyingPowerModelRegressionAlgorithm.cs
@@ -87,7 +87,8 @@ namespace QuantConnect.Algorithm.CSharp
         private void TestQuantityForDeltaBuyingPowerForPositionGroup(IPositionGroup positionGroup, Security security)
         {
             var absQuantity = Math.Abs(positionGroup.Quantity);
-            var initialMarginPerUnit = positionGroup.BuyingPowerModel.GetInitialMarginRequirement(Portfolio, positionGroup) / absQuantity;
+            var initialMarginPerUnit = ((OptionInitialMargin)positionGroup.BuyingPowerModel.GetInitialMarginRequirement(
+                new PositionGroupInitialMarginParameters(Portfolio, positionGroup))).TotalValue / absQuantity;
             var maintenanceMarginPerUnit = positionGroup.BuyingPowerModel.GetMaintenanceMargin(Portfolio, positionGroup) / absQuantity;
 
             for (var expectedQuantity = 1; expectedQuantity <= absQuantity; expectedQuantity++)
@@ -116,7 +117,7 @@ namespace QuantConnect.Algorithm.CSharp
         {
             // We use the custom TestPositionGroupBuyingPowerModel class here because the default buying power model for position groups is the
             // OptionStrategyPositionGroupBuyingPowerModel, which does not support single-leg positions yet.
-            var positionQuantityForDeltaWithPositionGroupBuyingPowerModel = new TestPositionGroupBuyingPowerModel()
+            var positionQuantityForDeltaWithPositionGroupBuyingPowerModel = positionGroup.BuyingPowerModel
                 .GetMaximumLotsForDeltaBuyingPower(new GetMaximumLotsForDeltaBuyingPowerParameters(Portfolio, positionGroup, deltaBuyingPower,
                     minimumOrderMarginPortfolioPercentage: 0)).NumberOfLots;
 

--- a/Algorithm.CSharp/SingleOptionPositionGroupBuyingPowerModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SingleOptionPositionGroupBuyingPowerModelRegressionAlgorithm.cs
@@ -87,8 +87,7 @@ namespace QuantConnect.Algorithm.CSharp
         private void TestQuantityForDeltaBuyingPowerForPositionGroup(IPositionGroup positionGroup, Security security)
         {
             var absQuantity = Math.Abs(positionGroup.Quantity);
-            var initialMarginPerUnit = ((OptionInitialMargin)positionGroup.BuyingPowerModel.GetInitialMarginRequirement(
-                new PositionGroupInitialMarginParameters(Portfolio, positionGroup))).TotalValue / absQuantity;
+            var initialMarginPerUnit = positionGroup.BuyingPowerModel.GetInitialMarginRequirement(Portfolio, positionGroup) / absQuantity;
             var maintenanceMarginPerUnit = positionGroup.BuyingPowerModel.GetMaintenanceMargin(Portfolio, positionGroup) / absQuantity;
 
             for (var expectedQuantity = 1; expectedQuantity <= absQuantity; expectedQuantity++)

--- a/Algorithm.Python/NullBuyingPowerOptionBullCallSpreadAlgorithm.py
+++ b/Algorithm.Python/NullBuyingPowerOptionBullCallSpreadAlgorithm.py
@@ -27,6 +27,7 @@ class NullBuyingPowerOptionBullCallSpreadAlgorithm(QCAlgorithm):
         self.SetCash(200000)
 
         self.SetSecurityInitializer(lambda security: security.SetMarginModel(SecurityMarginModel.Null))
+        self.Portfolio.SetPositions(SecurityPositionGroupModel.Null);
 
         equity = self.AddEquity("GOOG")
         option = self.AddOption(equity.Symbol)

--- a/Common/Securities/Option/OptionStrategyPositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Option/OptionStrategyPositionGroupBuyingPowerModel.cs
@@ -234,8 +234,9 @@ namespace QuantConnect.Securities.Option
                 var security = (Option)parameters.Portfolio.Securities[option.Symbol];
                 result = Math.Abs(security.BuyingPowerModel.GetInitialMarginRequirement(security, option.Quantity));
 
-                // Premium is already accounted for in the initial margin requirement for naked options
-                return new InitialMargin(result);
+                // Naked options are a especial case, because they already have the premium included in the margin.
+                var optionValue = security.Holdings.GetQuantityValue(option.Quantity).InAccountCurrency;
+                result -= Math.Max(optionValue, 0);
             }
             else if (_optionStrategy.Name == OptionStrategyDefinitions.BearCallSpread.Name
                 || _optionStrategy.Name == OptionStrategyDefinitions.BullCallSpread.Name)
@@ -294,7 +295,7 @@ namespace QuantConnect.Securities.Option
                 premium += option.Holdings.GetQuantityValue(position.Quantity).InAccountCurrency;
             }
 
-            return new InitialMargin(result + Math.Max(premium, 0));
+            return new OptionInitialMargin(result, premium);
         }
 
         /// <summary>

--- a/Common/Securities/Option/OptionStrategyPositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Option/OptionStrategyPositionGroupBuyingPowerModel.cs
@@ -232,7 +232,10 @@ namespace QuantConnect.Securities.Option
             {
                 var option = parameters.PositionGroup.Positions.Single();
                 var security = (Option)parameters.Portfolio.Securities[option.Symbol];
-                result = security.BuyingPowerModel.GetInitialMarginRequirement(security, option.Quantity);
+                result = Math.Abs(security.BuyingPowerModel.GetInitialMarginRequirement(security, option.Quantity));
+
+                // Premium is already accounted for in the initial margin requirement for naked options
+                return new InitialMargin(result);
             }
             else if (_optionStrategy.Name == OptionStrategyDefinitions.BearCallSpread.Name
                 || _optionStrategy.Name == OptionStrategyDefinitions.BullCallSpread.Name)

--- a/Common/Securities/OptionInitialMargin.cs
+++ b/Common/Securities/OptionInitialMargin.cs
@@ -33,9 +33,9 @@ namespace QuantConnect.Securities
         public decimal Premium { get; }
 
         /// <summary>
-        /// The initial margin value in account currency, including the premium in cases that apply (premium debited)
+        /// The initial margin value in account currency, not including the premium in cases that apply (premium debited)
         /// </summary>
-        public decimal TotalValue { get; }
+        public decimal ValueWithoutPremium { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OptionInitialMargin"/> class
@@ -43,10 +43,10 @@ namespace QuantConnect.Securities
         /// <param name="value">The initial margin</param
         /// <param name="premium">The premium of the option/option strategy</param>
         public OptionInitialMargin(decimal value, decimal premium)
-            : base(value)
+            : base(value + Math.Max(premium, 0))
         {
             Premium = premium;
-            TotalValue = Value + Math.Max(Premium, 0);
+            ValueWithoutPremium = value;
         }
     }
 }

--- a/Common/Securities/OptionInitialMargin.cs
+++ b/Common/Securities/OptionInitialMargin.cs
@@ -1,0 +1,53 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.Securities
+{
+    /// <summary>
+    /// Result type for <see cref="IBuyingPowerModel.GetInitialMarginRequirement"/>
+    /// and <see cref="IBuyingPowerModel.GetInitialMarginRequiredForOrder"/>
+    /// </summary>
+    public class OptionInitialMargin : InitialMargin
+    {
+        /// <summary>
+        /// Gets an instance of <see cref="OptionInitialMargin"/> with zero values
+        /// </summary>
+        public static OptionInitialMargin Zero { get; } = new OptionInitialMargin(0m, 0m);
+
+        /// <summary>
+        /// The option/strategy premium value in account currency
+        /// </summary>
+        public decimal Premium { get; }
+
+        /// <summary>
+        /// The initial margin value in account currency, including the premium in cases that apply (premium debited)
+        /// </summary>
+        public decimal TotalValue { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OptionInitialMargin"/> class
+        /// </summary>
+        /// <param name="value">The initial margin</param
+        /// <param name="premium">The premium of the option/option strategy</param>
+        public OptionInitialMargin(decimal value, decimal premium)
+            : base(value)
+        {
+            Premium = premium;
+            TotalValue = Value + Math.Max(Premium, 0);
+        }
+    }
+}

--- a/Common/Securities/OptionInitialMargin.cs
+++ b/Common/Securities/OptionInitialMargin.cs
@@ -18,8 +18,7 @@ using System;
 namespace QuantConnect.Securities
 {
     /// <summary>
-    /// Result type for <see cref="IBuyingPowerModel.GetInitialMarginRequirement"/>
-    /// and <see cref="IBuyingPowerModel.GetInitialMarginRequiredForOrder"/>
+    /// Result type for <see cref="Option.OptionStrategyPositionGroupBuyingPowerModel.GetInitialMarginRequirement"/>
     /// </summary>
     public class OptionInitialMargin : InitialMargin
     {

--- a/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
@@ -129,6 +129,22 @@ namespace QuantConnect.Securities.Positions
                 );
             }
 
+            var orderGroups = positionManager.ResolvePositionGroups(new PositionCollection(positions));
+            // This should always return a single group since it is a single order/combo
+            foreach (var orderGroup in orderGroups)
+            {
+                var initialMargin = orderGroup.BuyingPowerModel.GetInitialMarginRequirement(new PositionGroupInitialMarginParameters(
+                    parameters.Portfolio, orderGroup));
+                var optionInitialMargin = initialMargin as OptionInitialMargin;
+
+                if (optionInitialMargin != null)
+                {
+                    // We need to add the premium paid for the order. We use the TotalValue-Value difference instead of Premium
+                    // to add it only when needed -- when it is debited from the account
+                    contemplated += optionInitialMargin.TotalValue - optionInitialMargin.Value;
+                }
+            }
+
             return new ReservedBuyingPowerImpact(
                 current, contemplated, impactedGroups, parameters.ContemplatedChanges, contemplatedGroups
             );
@@ -206,6 +222,12 @@ namespace QuantConnect.Securities.Positions
             )
         {
             return this.GetMaintenanceMargin(parameters.Portfolio, parameters.PositionGroup);
+        }
+
+        private static decimal GetInitialMarginValue(InitialMargin initialMargin)
+        {
+            var optionInitialMargin = initialMargin as OptionInitialMargin;
+            return optionInitialMargin?.TotalValue ?? initialMargin.Value;
         }
 
         /// <summary>
@@ -287,7 +309,8 @@ namespace QuantConnect.Securities.Positions
             var currentUsedMargin = 0m;
             if (currentPositionGroup.Quantity != 0)
             {
-                currentUsedMargin = Math.Abs(currentPositionGroup.BuyingPowerModel.GetInitialMarginRequirement(portfolio, currentPositionGroup));
+                currentUsedMargin = Math.Abs(GetInitialMarginValue(currentPositionGroup.BuyingPowerModel.GetInitialMarginRequirement(
+                    new PositionGroupInitialMarginParameters(portfolio, currentPositionGroup))));
             }
 
             // 4. Check that the change of margin is above our models minimum percentage change
@@ -308,7 +331,8 @@ namespace QuantConnect.Securities.Positions
             var groupUnit = currentPositionGroup.CreateUnitGroup(parameters.Portfolio.Positions);
 
             // 5a. Compute initial margin requirement for a single unit
-            var unitMargin = Math.Abs(groupUnit.BuyingPowerModel.GetInitialMarginRequirement(portfolio, groupUnit));
+            var unitMargin= Math.Abs(GetInitialMarginValue(groupUnit.BuyingPowerModel.GetInitialMarginRequirement(
+                new PositionGroupInitialMarginParameters(portfolio, groupUnit))));
             if (unitMargin == 0m)
             {
                 // likely due to missing price data
@@ -437,8 +461,8 @@ namespace QuantConnect.Securities.Positions
                 buyingPower += existing.Key.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(parameters.Portfolio, existing);
 
                 // 2b. Rebate the initial margin equivalent of current position
-                // this interface doesn't have a concept of initial margin as it's an impl detail of the BuyingPowerModel base class
-                buyingPower += Math.Abs(existing.Key.BuyingPowerModel.GetInitialMarginRequirement(parameters.Portfolio, existing));
+                buyingPower += Math.Abs(GetInitialMarginValue(existing.Key.BuyingPowerModel.GetInitialMarginRequirement(
+                    new PositionGroupInitialMarginParameters(parameters.Portfolio, existing))));
             }
 
             return buyingPower;
@@ -588,7 +612,8 @@ namespace QuantConnect.Securities.Positions
 
             // Calculate the initial value for the wanted final margin after the delta is applied.
             var finalPositionGroup = currentPositionGroup.WithQuantity(currentGroupAbsQuantity + positionGroupQuantity, portfolio.Positions);
-            finalMargin = Math.Abs(finalPositionGroup.BuyingPowerModel.GetInitialMarginRequirement(portfolio, finalPositionGroup));
+            finalMargin = Math.Abs(GetInitialMarginValue(finalPositionGroup.BuyingPowerModel.GetInitialMarginRequirement(
+                new PositionGroupInitialMarginParameters(portfolio, finalPositionGroup))));
 
             // Keep the previous calculated final margin we would get after the delta is applied.
             // This is useful for the cases were the final group gets us with final margin greater than the target.
@@ -604,7 +629,8 @@ namespace QuantConnect.Securities.Positions
             {
                 positionGroupQuantity += quantityStep;
                 finalPositionGroup = currentPositionGroup.WithQuantity(currentGroupAbsQuantity + positionGroupQuantity, portfolio.Positions);
-                finalMargin = Math.Abs(finalPositionGroup.BuyingPowerModel.GetInitialMarginRequirement(portfolio, finalPositionGroup));
+                finalMargin = Math.Abs(GetInitialMarginValue(finalPositionGroup.BuyingPowerModel.GetInitialMarginRequirement(
+                    new PositionGroupInitialMarginParameters(portfolio, finalPositionGroup))));
 
                 var newMarginDifference = getMarginDifference(finalMargin);
                 if (UnableToConverge(newMarginDifference, marginDifference, groupUnit, portfolio, positionGroupQuantity,

--- a/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
@@ -317,7 +317,7 @@ namespace QuantConnect.Securities.Positions
             var groupUnit = currentPositionGroup.CreateUnitGroup(parameters.Portfolio.Positions);
 
             // 5a. Compute initial margin requirement for a single unit
-            var unitMargin= Math.Abs(groupUnit.BuyingPowerModel.GetInitialMarginRequirement(portfolio, groupUnit));
+            var unitMargin = Math.Abs(groupUnit.BuyingPowerModel.GetInitialMarginRequirement(portfolio, groupUnit));
             if (unitMargin == 0m)
             {
                 // likely due to missing price data

--- a/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
@@ -121,7 +121,7 @@ namespace QuantConnect.Securities.Positions
             var contemplatedGroups = positionManager.ResolvePositionGroups(new PositionCollection(impactedPositions.Values));
 
             // 5. Compute contemplated margin
-            var contemplated = GetContemplatedGroupsInitialMargin(parameters.Portfolio, contemplatedGroups);
+            var contemplated = GetContemplatedGroupsInitialMargin(parameters.Portfolio, contemplatedGroups, positions);
 
             return new ReservedBuyingPowerImpact(current, contemplated, impactedGroups, parameters.ContemplatedChanges, contemplatedGroups);
         }
@@ -130,7 +130,8 @@ namespace QuantConnect.Securities.Positions
         /// Gets the initial margin required for the specified contemplated position group.
         /// Used by <see cref="GetReservedBuyingPowerImpact"/> to get the contemplated groups margin.
         /// </summary>
-        protected virtual decimal GetContemplatedGroupsInitialMargin(SecurityPortfolioManager portfolio, PositionGroupCollection contemplatedGroups)
+        protected virtual decimal GetContemplatedGroupsInitialMargin(SecurityPortfolioManager portfolio, PositionGroupCollection contemplatedGroups,
+            List<IPosition> ordersPositions)
         {
             var contemplatedMargin = 0m;
             foreach (var contemplatedGroup in contemplatedGroups)

--- a/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
@@ -224,12 +224,6 @@ namespace QuantConnect.Securities.Positions
             return this.GetMaintenanceMargin(parameters.Portfolio, parameters.PositionGroup);
         }
 
-        private static decimal GetInitialMarginValue(InitialMargin initialMargin)
-        {
-            var optionInitialMargin = initialMargin as OptionInitialMargin;
-            return optionInitialMargin?.TotalValue ?? initialMargin.Value;
-        }
-
         /// <summary>
         /// Get the maximum position group order quantity to obtain a position with a given buying power
         /// percentage. Will not take into account free buying power.
@@ -651,6 +645,16 @@ namespace QuantConnect.Securities.Positions
             }
 
             return positionGroupQuantity;
+        }
+
+        /// <summary>
+        /// Gets the initial margin total value, including premium in case the <paramref name="initialMargin"/>
+        /// is an <see cref="OptionInitialMargin"/>
+        /// </summary>
+        private static decimal GetInitialMarginValue(InitialMargin initialMargin)
+        {
+            var optionInitialMargin = initialMargin as OptionInitialMargin;
+            return optionInitialMargin?.TotalValue ?? initialMargin.Value;
         }
     }
 }

--- a/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
@@ -124,7 +124,7 @@ namespace QuantConnect.Securities.Positions
             var contemplated = 0m;
             foreach (var contemplatedGroup in contemplatedGroups)
             {
-                contemplated += contemplatedGroup.BuyingPowerModel.GetMaintenanceMargin(
+                contemplated += contemplatedGroup.BuyingPowerModel.GetInitialMarginRequirement(
                     parameters.Portfolio, contemplatedGroup
                 );
             }

--- a/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Positions/PositionGroupBuyingPowerModel.cs
@@ -446,6 +446,7 @@ namespace QuantConnect.Securities.Positions
                 buyingPower += existing.Key.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(parameters.Portfolio, existing);
 
                 // 2b. Rebate the initial margin equivalent of current position
+                // this interface doesn't have a concept of initial margin as it's an impl detail of the BuyingPowerModel base class
                 buyingPower += Math.Abs(existing.Key.BuyingPowerModel.GetInitialMarginRequirement(parameters.Portfolio, existing));
             }
 

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -61,6 +61,10 @@ namespace QuantConnect.Tests.Common.Securities
 
         /// <summary>
         /// All these test cases are based on the assumption that the initial cash is 1,000,000.
+        ///
+        /// The formula used for the order quantity is:
+        ///     - Staying in the same position side: (cash - initial quantity * unit initial margin) / (unit initial margin + premium)
+        ///     - Reversing the position side: (cash + initial quantity * unit initial margin) / (unit initial margin + premium)
         /// </summary>
         // option strategy definition, initial quantity, order quantity, expected result
         private static readonly TestCaseData[] HasSufficientBuyingPowerForOrderTestCases = new[]
@@ -68,30 +72,30 @@ namespace QuantConnect.Tests.Common.Securities
             // Initial margin requirement|premium for CoveredCall with quantities 1 and -1 are 19210|0 and 10250|11200 respectively
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, (1000000 - 0 * 19210) / (19210 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, (1000000 - 0 * 19210) / (19210 + 0) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -(1000000 - -0 * 10250) / (10250 + 11200), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -(1000000 - -0 * 10250) / (10250 + 11200) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -(1000000 + 0 * 10250) / (10250 + 11200), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -(1000000 + 0 * 10250) / (10250 + 11200) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, (1000000 - 20 * 19210) / (19210 + 0), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, (1000000 - 20 * 19210) / (19210 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -(1000000 - -20 * 10250) / (10250 + 11200), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -(1000000 - -20 * 10250) / (10250 + 11200) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, (1000000 - -20 * 19210) / (19210 + 0), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, (1000000 - -20 * 19210) / (19210 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -(1000000 + 20 * 10250) / (10250 + 11200), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -(1000000 + 20 * 10250) / (10250 + 11200) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, (1000000 + 20 * 19210) / (19210 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, (1000000 + 20 * 19210) / (19210 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, -(1000000 - 20 * 10250) / (10250 + 11200), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, -(1000000 - 20 * 10250) / (10250 + 11200) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for ProtectiveCall with quantities 1 and -1 are 10250|11200 and 19210|0 respectively
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, (1000000 - 0 * 10250) / (10250 + 11200), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, (1000000 - 0 * 10250) / (10250 + 11200) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, -(1000000 - -0 * 19210) / (19210 + 0), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, -(1000000 - -0 * 19210) / (19210 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, -(1000000 + 0 * 19210) / (19210 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, -(1000000 + 0 * 19210) / (19210 + 0) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, (1000000 - 20 * 10250) / (10250 + 11200), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, (1000000 - 20 * 10250) / (10250 + 11200) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -(1000000 - -20 * 19210) / (19210 + 0), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -(1000000 - -20 * 19210) / (19210 + 0) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, (1000000 - -20 * 10250) / (10250 + 11200), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, (1000000 - -20 * 10250) / (10250 + 11200) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -(1000000 + 20 * 19210) / (19210 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -(1000000 + 20 * 19210) / (19210 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, (1000000 + 20 * 10250) / (10250 + 11200), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, (1000000 + 20 * 10250) / (10250 + 11200) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, -(1000000 - 20 * 19210) / (19210 + 0), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, -(1000000 - 20 * 19210) / (19210 + 0) - 1, false),  // -20 to max short + 1
@@ -103,280 +107,280 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, (1000000 - 20 * 10250) / (10250 + 0), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, (1000000 - 20 * 10250) / (10250 + 0) + 1, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -(1000000 - -20 * 10250) / (10250 + 2), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -(1000000 - -20 * 10250) / (10250 + 2) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, (1000000 - -20 * 10250) / (10250 + 0), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, (1000000 - -20 * 10250) / (10250 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -(1000000 + 20 * 10250) / (10250 + 2), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -(1000000 + 20 * 10250) / (10250 + 2) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, (1000000 + 20 * 10250) / (10250 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, (1000000 + 20 * 10250) / (10250 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -(1000000 - 20 * 10250) / (10250 + 2), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -(1000000 - 20 * 10250) / (10250 + 2) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for ProtectivePut with quantities 1 and -1 are 10250|2 and 10250|0 respectively
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, (1000000 - 0 * 10250) / (10250 + 2), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, (1000000 - 0 * 10250) / (10250 + 2) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, -(1000000 - -0 * 10250) / (10250 + 0), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, -(1000000 - -0 * 10250) / (10250 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, -(1000000 + 0 * 10250) / (10250 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, -(1000000 + 0 * 10250) / (10250 + 0) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, (1000000 - 20 * 10250) / (10250 + 2), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, (1000000 - 20 * 10250) / (10250 + 2) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -(1000000 - -20 * 10250) / (10250 + 0), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -(1000000 - -20 * 10250) / (10250 + 0) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, (1000000 - -20 * 10250) / (10250 + 2), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, (1000000 - -20 * 10250) / (10250 + 2) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -(1000000 + 20 * 10250) / (10250 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -(1000000 + 20 * 10250) / (10250 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, (1000000 + 20 * 10250) / (10250 + 2), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, (1000000 + 20 * 10250) / (10250 + 2) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, -(1000000 - 20 * 10250) / (10250 + 0), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, -(1000000 - 20 * 10250) / (10250 + 0) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for BearCallSpread with quantities 1 and -1 are 1000|0 and 0|1200 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, (1000000 - 0 * 1000) / (1000 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, (1000000 - 0 * 1000) / (1000 + 0) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -(1000000 - -0 * 0) / (0 + 1200), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -(1000000 - -0 * 0) / (0 + 1200) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -(1000000 + 0 * 0) / (0 + 1200), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -(1000000 + 0 * 0) / (0 + 1200) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, (1000000 - 20 * 1000) / (1000 + 0), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, (1000000 - 20 * 1000) / (1000 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -(1000000 - -20 * 0) / (0 + 1200), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -(1000000 - -20 * 0) / (0 + 1200) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, (1000000 - -20 * 1000) / (1000 + 0), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, (1000000 - -20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -(1000000 + 20 * 0) / (0 + 1200), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -(1000000 + 20 * 0) / (0 + 1200) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, (1000000 + 20 * 1000) / (1000 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, (1000000 + 20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, -(1000000 - 20 * 0) / (0 + 1200), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, -(1000000 - 20 * 0) / (0 + 1200) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for BearPutSpread with quantities 1 and -1 are 0|1 and 1000|0 respectively
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, (1000000 - 0 * 0) / (0 + 1), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, (1000000 - 0 * 0) / (0 + 1) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, -(1000000 - -0 * 1000) / (1000 + 0), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, -(1000000 - -0 * 1000) / (1000 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, -(1000000 + 0 * 1000) / (1000 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, -(1000000 + 0 * 1000) / (1000 + 0) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, (1000000 - 20 * 0) / (0 + 1), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, (1000000 - 20 * 0) / (0 + 1) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -(1000000 - -20 * 1000) / (1000 + 0), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -(1000000 - -20 * 1000) / (1000 + 0) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, (1000000 - -20 * 0) / (0 + 1), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, (1000000 - -20 * 0) / (0 + 1) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -(1000000 + 20 * 1000) / (1000 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -(1000000 + 20 * 1000) / (1000 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, (1000000 + 20 * 0) / (0 + 1), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, (1000000 + 20 * 0) / (0 + 1) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, -(1000000 - 20 * 1000) / (1000 + 0), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, -(1000000 - 20 * 1000) / (1000 + 0) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for BullCallSpread with quantities 1 and -1 are 0|1200 and 1000|0 respectively
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, (1000000 - 0 * 0) / (0 + 1200), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, (1000000 - 0 * 0) / (0 + 1200) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, -(1000000 - -0 * 1000) / (1000 + 0), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, -(1000000 - -0 * 1000) / (1000 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, -(1000000 + 0 * 1000) / (1000 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, -(1000000 + 0 * 1000) / (1000 + 0) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, (1000000 - 20 * 0) / (0 + 1200), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, (1000000 - 20 * 0) / (0 + 1200) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -(1000000 - -20 * 1000) / (1000 + 0), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -(1000000 - -20 * 1000) / (1000 + 0) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, (1000000 - -20 * 0) / (0 + 1200), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, (1000000 - -20 * 0) / (0 + 1200) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -(1000000 + 20 * 1000) / (1000 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -(1000000 + 20 * 1000) / (1000 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, (1000000 + 20 * 0) / (0 + 1200), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, (1000000 + 20 * 0) / (0 + 1200) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, -(1000000 - 20 * 1000) / (1000 + 0), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, -(1000000 - 20 * 1000) / (1000 + 0) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for BullPutSpread with quantities 1 and -1 are 1000|0 and 0|1 respectively
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, (1000000 - 0 * 1000) / (1000 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, (1000000 - 0 * 1000) / (1000 + 0) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, -(1000000 - -0 * 0) / (0 + 1), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, -(1000000 - -0 * 0) / (0 + 1) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, -(1000000 + 0 * 0) / (0 + 1), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, -(1000000 + 0 * 0) / (0 + 1) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, (1000000 - 20 * 1000) / (1000 + 0), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, (1000000 - 20 * 1000) / (1000 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -(1000000 - -20 * 0) / (0 + 1), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -(1000000 - -20 * 0) / (0 + 1) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, (1000000 - -20 * 1000) / (1000 + 0), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, (1000000 - -20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -(1000000 + 20 * 0) / (0 + 1), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -(1000000 + 20 * 0) / (0 + 1) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, (1000000 + 20 * 1000) / (1000 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, (1000000 + 20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, -(1000000 - 20 * 0) / (0 + 1), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, -(1000000 - 20 * 0) / (0 + 1) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for Straddle with quantities 1 and -1 are 0|11202 and 19402|0 respectively
             new TestCaseData(OptionStrategyDefinitions.Straddle, 0, (1000000 - 0 * 0) / (0 + 11202), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.Straddle, 0, (1000000 - 0 * 0) / (0 + 11202) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, -(1000000 - -0 * 19402) / (19402 + 0), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, -(1000000 - -0 * 19402) / (19402 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, -(1000000 + 0 * 19402) / (19402 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, -(1000000 + 0 * 19402) / (19402 + 0) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.Straddle, 20, (1000000 - 20 * 0) / (0 + 11202), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.Straddle, 20, (1000000 - 20 * 0) / (0 + 11202) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -(1000000 - -20 * 19402) / (19402 + 0), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -(1000000 - -20 * 19402) / (19402 + 0) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, (1000000 - -20 * 0) / (0 + 11202), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, (1000000 - -20 * 0) / (0 + 11202) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -(1000000 + 20 * 19402) / (19402 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -(1000000 + 20 * 19402) / (19402 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, (1000000 + 20 * 0) / (0 + 11202), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, (1000000 + 20 * 0) / (0 + 11202) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.Straddle, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.Straddle, -20, -(1000000 - 20 * 19402) / (19402 + 0), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.Straddle, -20, -(1000000 - 20 * 19402) / (19402 + 0) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for ShortStraddle with quantities 1 and -1 are 19402|0 and 0|11202 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, (1000000 - 0 * 19402) / (19402 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, (1000000 - 0 * 19402) / (19402 + 0) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, -(1000000 - -0 * 0) / (0 + 11202), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, -(1000000 - -0 * 0) / (0 + 11202) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, -(1000000 + 0 * 0) / (0 + 11202), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, -(1000000 + 0 * 0) / (0 + 11202) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, (1000000 - 20 * 19402) / (19402 + 0), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, (1000000 - 20 * 19402) / (19402 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -(1000000 - -20 * 0) / (0 + 11202), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -(1000000 - -20 * 0) / (0 + 11202) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, (1000000 - -20 * 19402) / (19402 + 0), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, (1000000 - -20 * 19402) / (19402 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -(1000000 + 20 * 0) / (0 + 11202), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -(1000000 + 20 * 0) / (0 + 11202) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, (1000000 + 20 * 19402) / (19402 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, (1000000 + 20 * 19402) / (19402 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, -(1000000 - 20 * 0) / (0 + 11202), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, -(1000000 - 20 * 0) / (0 + 11202) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for Strangle with quantities 1 and -1 are 0|10002 and 18202|0 respectively
             new TestCaseData(OptionStrategyDefinitions.Strangle, 0, (1000000 - 0 * 0) / (0 + 10002), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.Strangle, 0, (1000000 - 0 * 0) / (0 + 10002) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, -(1000000 - -0 * 18202) / (18202 + 0), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, -(1000000 - -0 * 18202) / (18202 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, -(1000000 + 0 * 18202) / (18202 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, -(1000000 + 0 * 18202) / (18202 + 0) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.Strangle, 20, (1000000 - 20 * 0) / (0 + 10002), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.Strangle, 20, (1000000 - 20 * 0) / (0 + 10002) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -(1000000 - -20 * 18202) / (18202 + 0), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -(1000000 - -20 * 18202) / (18202 + 0) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, (1000000 - -20 * 0) / (0 + 10002), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, (1000000 - -20 * 0) / (0 + 10002) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -(1000000 + 20 * 18202) / (18202 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -(1000000 + 20 * 18202) / (18202 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, (1000000 + 20 * 0) / (0 + 10002), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, (1000000 + 20 * 0) / (0 + 10002) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.Strangle, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.Strangle, -20, -(1000000 - 20 * 18202) / (18202 + 0), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.Strangle, -20, -(1000000 - 20 * 18202) / (18202 + 0) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for ShortStrangle with quantities 1 and -1 are 18202|0 and 0|10002 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, (1000000 - 0 * 18202) / (18202 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, (1000000 - 0 * 18202) / (18202 + 0) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, -(1000000 - -0 * 0) / (0 + 10002), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, -(1000000 - -0 * 0) / (0 + 10002) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, -(1000000 + 0 * 0) / (0 + 10002), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, -(1000000 + 0 * 0) / (0 + 10002) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, (1000000 - 20 * 18202) / (18202 + 0), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, (1000000 - 20 * 18202) / (18202 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -(1000000 - -20 * 0) / (0 + 10002), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -(1000000 - -20 * 0) / (0 + 10002) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, (1000000 - -20 * 18202) / (18202 + 0), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, (1000000 - -20 * 18202) / (18202 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -(1000000 + 20 * 0) / (0 + 10002), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -(1000000 + 20 * 0) / (0 + 10002) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, (1000000 + 20 * 18202) / (18202 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, (1000000 + 20 * 18202) / (18202 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, -(1000000 - 20 * 0) / (0 + 10002), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, -(1000000 - 20 * 0) / (0 + 10002) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for ButterflyCall with quantities 1 and -1 are 0|400 and 1000|0 respectively
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, (1000000 - 0 * 0) / (0 + 400), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, (1000000 - 0 * 0) / (0 + 400) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, -(1000000 - -0 * 1000) / (1000 + 0), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, -(1000000 - -0 * 1000) / (1000 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, -(1000000 + 0 * 1000) / (1000 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, -(1000000 + 0 * 1000) / (1000 + 0) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, (1000000 - 20 * 0) / (0 + 400), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, (1000000 - 20 * 0) / (0 + 400) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -(1000000 - -20 * 1000) / (1000 + 0), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -(1000000 - -20 * 1000) / (1000 + 0) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, (1000000 - -20 * 0) / (0 + 400), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, (1000000 - -20 * 0) / (0 + 400) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -(1000000 + 20 * 1000) / (1000 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -(1000000 + 20 * 1000) / (1000 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, (1000000 + 20 * 0) / (0 + 400), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, (1000000 + 20 * 0) / (0 + 400) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, -(1000000 - 20 * 1000) / (1000 + 0), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, -(1000000 - 20 * 1000) / (1000 + 0) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for ShortButterflyCall with quantities 1 and -1 are 1000|0 and 0|400 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, (1000000 - 0 * 1000) / (1000 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, (1000000 - 0 * 1000) / (1000 + 0) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, -(1000000 - -0 * 0) / (0 + 400), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, -(1000000 - -0 * 0) / (0 + 400) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, -(1000000 + 0 * 0) / (0 + 400), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, -(1000000 + 0 * 0) / (0 + 400) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, (1000000 - 20 * 1000) / (1000 + 0), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, (1000000 - 20 * 1000) / (1000 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -(1000000 - -20 * 0) / (0 + 400), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -(1000000 - -20 * 0) / (0 + 400) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, (1000000 - -20 * 1000) / (1000 + 0), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, (1000000 - -20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -(1000000 + 20 * 0) / (0 + 400), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -(1000000 + 20 * 0) / (0 + 400) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, (1000000 + 20 * 1000) / (1000 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, (1000000 + 20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, -(1000000 - 20 * 0) / (0 + 400), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, -(1000000 - 20 * 0) / (0 + 400) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for ButterflyPut with quantities 1 and -1 are 0|1 and 1000|0 respectively
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, (1000000 - 0 * 0) / (0 + 1), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, (1000000 - 0 * 0) / (0 + 1) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, -(1000000 - -0 * 1000) / (1000 + 0), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, -(1000000 - -0 * 1000) / (1000 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, -(1000000 + 0 * 1000) / (1000 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, -(1000000 + 0 * 1000) / (1000 + 0) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, (1000000 - 20 * 0) / (0 + 1), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, (1000000 - 20 * 0) / (0 + 1) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -(1000000 - -20 * 1000) / (1000 + 0), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -(1000000 - -20 * 1000) / (1000 + 0) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, (1000000 - -20 * 0) / (0 + 1), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, (1000000 - -20 * 0) / (0 + 1) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -(1000000 + 20 * 1000) / (1000 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -(1000000 + 20 * 1000) / (1000 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, (1000000 + 20 * 0) / (0 + 1), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, (1000000 + 20 * 0) / (0 + 1) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, -(1000000 - 20 * 1000) / (1000 + 0), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, -(1000000 - 20 * 1000) / (1000 + 0) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for ShortButterflyPut with quantities 1 and -1 are 1000|0 and 0|1 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, (1000000 - 0 * 1000) / (1000 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, (1000000 - 0 * 1000) / (1000 + 0) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, -(1000000 - -0 * 0) / (0 + 1), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, -(1000000 - -0 * 0) / (0 + 1) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, -(1000000 + 0 * 0) / (0 + 1), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, -(1000000 + 0 * 0) / (0 + 1) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, (1000000 - 20 * 1000) / (1000 + 0), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, (1000000 - 20 * 1000) / (1000 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -(1000000 - -20 * 0) / (0 + 1), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -(1000000 - -20 * 0) / (0 + 1) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, (1000000 - -20 * 1000) / (1000 + 0), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, (1000000 - -20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -(1000000 + 20 * 0) / (0 + 1), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -(1000000 + 20 * 0) / (0 + 1) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, (1000000 + 20 * 1000) / (1000 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, (1000000 + 20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, -(1000000 - 20 * 0) / (0 + 1), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, -(1000000 - 20 * 0) / (0 + 1) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for CallCalendarSpread with quantities 1 and -1 are 0|200 and 19400|0 respectively
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, (1000000 - 0 * 0) / (0 + 200), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, (1000000 - 0 * 0) / (0 + 200) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, -(1000000 - -0 * 19400) / (19400 + 0), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, -(1000000 - -0 * 19400) / (19400 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, -(1000000 + 0 * 19400) / (19400 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, -(1000000 + 0 * 19400) / (19400 + 0) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, (1000000 - 20 * 0) / (0 + 200), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, (1000000 - 20 * 0) / (0 + 200) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -(1000000 - -20 * 19400) / (19400 + 0), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -(1000000 - -20 * 19400) / (19400 + 0) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, (1000000 - -20 * 0) / (0 + 200), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, (1000000 - -20 * 0) / (0 + 200) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -(1000000 + 20 * 19400) / (19400 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -(1000000 + 20 * 19400) / (19400 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, (1000000 + 20 * 0) / (0 + 200), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, (1000000 + 20 * 0) / (0 + 200) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, -(1000000 - 20 * 19400) / (19400 + 0), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, -(1000000 - 20 * 19400) / (19400 + 0) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for ShortCallCalendarSpread with quantities 1 and -1 are 19400|0 and 0|200 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, (1000000 - 0 * 19400) / (19400 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, (1000000 - 0 * 19400) / (19400 + 0) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, -(1000000 - -0 * 0) / (0 + 200), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, -(1000000 - -0 * 0) / (0 + 200) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, -(1000000 + 0 * 0) / (0 + 200), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, -(1000000 + 0 * 0) / (0 + 200) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, (1000000 - 20 * 19400) / (19400 + 0), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, (1000000 - 20 * 19400) / (19400 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -(1000000 - -20 * 0) / (0 + 200), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -(1000000 - -20 * 0) / (0 + 200) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, (1000000 - -20 * 19400) / (19400 + 0), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, (1000000 - -20 * 19400) / (19400 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -(1000000 + 20 * 0) / (0 + 200), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -(1000000 + 20 * 0) / (0 + 200) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, (1000000 + 20 * 19400) / (19400 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, (1000000 + 20 * 19400) / (19400 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, -(1000000 - 20 * 0) / (0 + 200), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, -(1000000 - 20 * 0) / (0 + 200) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for PutCalendarSpread with quantities 1 and -1 are 0|1 and 3002|0 respectively
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, (1000000 - 0 * 0) / (0 + 1), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, (1000000 - 0 * 0) / (0 + 1) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, -(1000000 - -0 * 3002) / (3002 + 0), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, -(1000000 - -0 * 3002) / (3002 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, -(1000000 + 0 * 3002) / (3002 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, -(1000000 + 0 * 3002) / (3002 + 0) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, (1000000 - 20 * 0) / (0 + 1), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, (1000000 - 20 * 0) / (0 + 1) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -(1000000 - -20 * 3002) / (3002 + 0), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -(1000000 - -20 * 3002) / (3002 + 0) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, (1000000 - -20 * 0) / (0 + 1), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, (1000000 - -20 * 0) / (0 + 1) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -(1000000 + 20 * 3002) / (3002 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -(1000000 + 20 * 3002) / (3002 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, (1000000 + 20 * 0) / (0 + 1), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, (1000000 + 20 * 0) / (0 + 1) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, -(1000000 - 20 * 3002) / (3002 + 0), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, -(1000000 - 20 * 3002) / (3002 + 0) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for ShortPutCalendarSpread with quantities 1 and -1 are 3002|0 and 0|1 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, (1000000 - 0 * 3002) / (3002 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, (1000000 - 0 * 3002) / (3002 + 0) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, -(1000000 - -0 * 0) / (0 + 1), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, -(1000000 - -0 * 0) / (0 + 1) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, -(1000000 + 0 * 0) / (0 + 1), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, -(1000000 + 0 * 0) / (0 + 1) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, (1000000 - 20 * 3002) / (3002 + 0), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, (1000000 - 20 * 3002) / (3002 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -(1000000 - -20 * 0) / (0 + 1), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -(1000000 - -20 * 0) / (0 + 1) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, (1000000 - -20 * 3002) / (3002 + 0), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, (1000000 - -20 * 3002) / (3002 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -(1000000 + 20 * 0) / (0 + 1), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -(1000000 + 20 * 0) / (0 + 1) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, (1000000 + 20 * 3002) / (3002 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, (1000000 + 20 * 3002) / (3002 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, -(1000000 - 20 * 0) / (0 + 1), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, -(1000000 - 20 * 0) / (0 + 1) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for IronCondor with quantities 1 and -1 are 1000|0 and 0|1001 respectively
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, (1000000 - 0 * 1000) / (1000 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, (1000000 - 0 * 1000) / (1000 + 0) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, -(1000000 - -0 * 0) / (0 + 1001), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, -(1000000 - -0 * 0) / (0 + 1001) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, -(1000000 + 0 * 0) / (0 + 1001), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, -(1000000 + 0 * 0) / (0 + 1001) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, (1000000 - 20 * 1000) / (1000 + 0), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, (1000000 - 20 * 1000) / (1000 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -(1000000 - -20 * 0) / (0 + 1001), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -(1000000 - -20 * 0) / (0 + 1001) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, (1000000 - -20 * 1000) / (1000 + 0), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, (1000000 - -20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -(1000000 + 20 * 0) / (0 + 1001), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -(1000000 + 20 * 0) / (0 + 1001) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, (1000000 + 20 * 1000) / (1000 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, (1000000 + 20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, -(1000000 - 20 * 0) / (0 + 1001), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, -(1000000 - 20 * 0) / (0 + 1001) - 1, false),  // -20 to max short + 1
@@ -628,7 +632,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var initialMarginRequirement = positionGroup.BuyingPowerModel.GetInitialMarginRequirement(
                 new PositionGroupInitialMarginParameters(_portfolio, positionGroup));
-            
+
             Assert.AreEqual((double)expectedInitialMarginRequirement, (double)initialMarginRequirement.Value, (double)(0.2m * expectedInitialMarginRequirement));
         }
 
@@ -726,7 +730,7 @@ namespace QuantConnect.Tests.Common.Securities
         // option strategy definition, initial position quantity, final position quantity
         private static readonly TestCaseData[] OrderQuantityForDeltaBuyingPowerTestCases = new[]
         {
-            // Initial margin requirement for CoveredCall with quantity 10 and -10 is 192100 and 214500 respectively
+            // Initial margin requirement (including premium) for CoveredCall with quantity 10 and -10 is 192100 and 214500 respectively
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 192100m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -192100m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -192100m, -10),
@@ -735,7 +739,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -214500m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -214500m, -10),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -214500m - 192100m, -20),   // Going from -10 to 10
-            // Initial margin requirement for ProtectiveCall with quantity 10 and -10 is 214500 and 192100 respectively
+            // Initial margin requirement (including premium) for ProtectiveCall with quantity 10 and -10 is 214500 and 192100 respectively
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 214500m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -214500m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -214500m, -10),
@@ -744,7 +748,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, -192100m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, -192100m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, -192100m - 214500m, -20),
-            // Initial margin requirement for CoveredPut with quantity 10 and -10 is 102500 and 102520 respectively
+            // Initial margin requirement (including premium) for CoveredPut with quantity 10 and -10 is 102500 and 102520 respectively
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 102500m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -102500m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -102500m, -10),
@@ -753,7 +757,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -102520m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -102520m, -10),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -102520m - 102500m, -20),
-            // Initial margin requirement for ProtectivePut with quantity 10 and -10 is 102520 and 102500 respectively
+            // Initial margin requirement (including premium) for ProtectivePut with quantity 10 and -10 is 102520 and 102500 respectively
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 102520m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -102520m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -102520m, -10),
@@ -762,7 +766,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102500m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102500m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102500m - 102520m, -20),
-            // Initial margin requirement for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively
+            // Initial margin requirement (including premium) for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10000m, -10),
@@ -771,7 +775,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -12000m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -12000m, -10).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -12000m - 10000m, -20).Explicit(),
-            // Initial margin requirement for BearPutSpread with quantity 10 and -10 is 10 and 10000 respectively
+            // Initial margin requirement (including premium) for BearPutSpread with quantity 10 and -10 is 10 and 10000 respectively
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 10m / 10, +1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -10m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -10m, -10).Explicit(),
@@ -780,7 +784,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -10000m, -10),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -10000m - 10m, -20),
-            // Initial margin requirement for BullCallSpread with quantity 10 and -10 is 12000 and 10000 respectively
+            // Initial margin requirement (including premium) for BullCallSpread with quantity 10 and -10 is 12000 and 10000 respectively
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 12000m / 10, +1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -12000m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -12000m, -10).Explicit(),
@@ -789,7 +793,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -10000m, -10),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -10000m - 12000m, -20),
-            // Initial margin requirement for BullPutSpread with quantity 10 and -10 is 10000 and 10 respectively
+            // Initial margin requirement (including premium) for BullPutSpread with quantity 10 and -10 is 10000 and 10 respectively
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10000m, -10),
@@ -798,7 +802,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -10m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -10m, -10).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -10m - 10000m, -20).Explicit(),
-            // Initial margin requirement for Straddle with quantity 10 and -10 is 112020 and 194020 respectively
+            // Initial margin requirement (including premium) for Straddle with quantity 10 and -10 is 112020 and 194020 respectively
             new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 112020m / 10, +1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -112020m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -112020m, -10).Explicit(),
@@ -807,7 +811,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -194020m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -194020m, -10),
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -194020m - 112020m, -20),
-            // Initial margin requirement for ShortStraddle with quantity 10 and -10 is 194020 and 112020 respectively
+            // Initial margin requirement (including premium) for ShortStraddle with quantity 10 and -10 is 194020 and 112020 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, 194020m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, -194020m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, -194020m, -10),
@@ -816,7 +820,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, -112020m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, -112020m, -10).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, -112020m - 194020m, -20).Explicit(),
-            // Initial margin requirement for Strangle with quantity 10 and -10 is 100020 and 182020 respectively
+            // Initial margin requirement (including premium) for Strangle with quantity 10 and -10 is 100020 and 182020 respectively
             new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 100020m / 10, +1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -100020m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -100020m, -10).Explicit(),
@@ -825,7 +829,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -182020m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -182020m, -10),
             new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -182020m - 100020m, -20),
-            // Initial margin requirement for ShortStrangle with quantity 10 and -10 is 182020 and 100020 respectively
+            // Initial margin requirement (including premium) for ShortStrangle with quantity 10 and -10 is 182020 and 100020 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, 182020m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -182020m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -182020m, -10),
@@ -834,7 +838,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, -100020m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, -100020m, -10).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, -100020m - 182020m, -20).Explicit(),
-            // Initial margin requirement for ButterflyCall with quantity 10 and -10 is 4000 and 10000 respectively
+            // Initial margin requirement (including premium) for ButterflyCall with quantity 10 and -10 is 4000 and 10000 respectively
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 4000m / 10, +1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -4000m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -4000m, -10).Explicit(),
@@ -843,7 +847,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -10000m, -10),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -10000m - 4000m, -20),
-            // Initial margin requirement for ShortButterflyCall with quantity 10 and -10 is 10000 and 4000 respectively
+            // Initial margin requirement (including premium) for ShortButterflyCall with quantity 10 and -10 is 10000 and 4000 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -10000m, -10),
@@ -852,7 +856,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -4000m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -4000m, -10).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -4000m - 10000m, -20).Explicit(),
-            // Initial margin requirement for ButterflyPut with quantity 10 and -10 is 10 and 10000 respectively
+            // Initial margin requirement (including premium) for ButterflyPut with quantity 10 and -10 is 10 and 10000 respectively
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 10m / 10, +1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -10m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -10m, -10).Explicit(),
@@ -861,7 +865,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -10000m, -10),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -10000m - 10m, -20),
-            // Initial margin requirement for ShortButterflyPut with quantity 10 and -10 is 10000 and 10 respectively
+            // Initial margin requirement (including premium) for ShortButterflyPut with quantity 10 and -10 is 10000 and 10 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10000m, -10),
@@ -870,7 +874,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -10m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -10m, -10).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -10m - 10000m, -20).Explicit(),
-            // Initial margin requirement for CallCalendarSpread with quantity 10 and -10 is 2000 and 194000 respectively
+            // Initial margin requirement (including premium) for CallCalendarSpread with quantity 10 and -10 is 2000 and 194000 respectively
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 2000m / 10, +1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -2000m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -2000m, -10).Explicit(),
@@ -879,7 +883,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -194000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -194000m, -10),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -194000m - 2000m, -20),
-            // Initial margin requirement for ShortCallCalendarSpread with quantity 10 and -10 is 194000 and 2000 respectively
+            // Initial margin requirement (including premium) for ShortCallCalendarSpread with quantity 10 and -10 is 194000 and 2000 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, 194000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, -194000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, -194000m, -10),
@@ -888,7 +892,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, -2000m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, -2000m, -10).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, -2000m - 194000m, -20).Explicit(),
-            // Initial margin requirement for PutCalendarSpread with quantity 10 and -10 is 10 and 30020 respectively
+            // Initial margin requirement (including premium) for PutCalendarSpread with quantity 10 and -10 is 10 and 30020 respectively
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 10m / 10, +1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -10m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -10m, -10).Explicit(),
@@ -897,7 +901,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -30020m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -30020m, -10),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -30020m - 10m, -20),
-            // Initial margin requirement for ShortPutCalendarSpread with quantity 10 and -10 is 30020 and 10 respectively
+            // Initial margin requirement (including premium) for ShortPutCalendarSpread with quantity 10 and -10 is 30020 and 10 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, 30020m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, -30020m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, -30020m, -10),
@@ -906,7 +910,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, -10m / 10, -1).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, -10m, -10).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, -10m - 30020m, -20).Explicit(),
-            // Initial margin requirement for IronCondor with quantity 10 and -10 is 10000 and 10010 respectively
+            // Initial margin requirement (including premium) for IronCondor with quantity 10 and -10 is 10000 and 10010 respectively
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10000m, -10),
@@ -1034,7 +1038,7 @@ namespace QuantConnect.Tests.Common.Securities
         // option strategy definition, initial position quantity, target buying power percent, expected quantity
         private static readonly TestCaseData[] OrderQuantityForTargetBuyingPowerTestCases = new[]
         {
-            // Initial margin requirement for CoveredCall with quantity 10 and -10 is 192100m and 214500m respectively
+            // Initial margin requirement (including premium) for CoveredCall with quantity 10 and -10 is 192100m and 214500m respectively
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 192100m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 192100m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 0m, -10),
@@ -1043,7 +1047,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 214500m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -192100m, -20),    // Going from -10 to 10
-            // Initial margin requirement for ProtectiveCall with quantity 10 and -10 is 214500m and 192100m respectively
+            // Initial margin requirement (including premium) for ProtectiveCall with quantity 10 and -10 is 214500m and 192100m respectively
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 214500m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 214500m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 0m, -10),
@@ -1052,7 +1056,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 192100m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, -214500m, -20),
-            // Initial margin requirement for CoveredPut with quantity 10 and -10 is 102500m and 102520m respectively
+            // Initial margin requirement (including premium) for CoveredPut with quantity 10 and -10 is 102500m and 102520m respectively
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 102500m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 102500m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 0m, -10),
@@ -1061,7 +1065,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 102520m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -102500m, -20),
-            // Initial margin requirement for ProtectivePut with quantity 10 and -10 is 102520m and 102500m respectively
+            // Initial margin requirement (including premium) for ProtectivePut with quantity 10 and -10 is 102520m and 102500m respectively
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 102520m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 102520m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 0m, -10),
@@ -1070,7 +1074,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 102500m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102520m, -20),
-            // Initial margin requirement for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively
+            // Initial margin requirement (including premium) for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 0m, -10),
@@ -1079,7 +1083,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 12000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -10000m, -20),
-            // Initial margin requirement for BearPutSpread with quantity 10 and -10 is 10 and 10000 respectively
+            // Initial margin requirement (including premium) for BearPutSpread with quantity 10 and -10 is 10 and 10000 respectively
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 10m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 10m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 0m, -10),
@@ -1088,7 +1092,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -10m, -20),
-            // Initial margin requirement for BullCallSpread with quantity 10 and -10 is 12000 and 10000 respectively
+            // Initial margin requirement (including premium) for BullCallSpread with quantity 10 and -10 is 12000 and 10000 respectively
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 12000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 12000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 0m, -10),
@@ -1097,7 +1101,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -12000m, -20),
-            // Initial margin requirement for BullPutSpread with quantity 10 and -10 is 10000 and 10 respectively
+            // Initial margin requirement (including premium) for BullPutSpread with quantity 10 and -10 is 10000 and 10 respectively
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 0m, -10),
@@ -1106,7 +1110,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 10m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -10000m, -20),
-            // Initial margin requirement for Straddle with quantity 10 and -10 is 112020 and 194020 respectively
+            // Initial margin requirement (including premium) for Straddle with quantity 10 and -10 is 112020 and 194020 respectively
             new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 112020m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 112020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 0m, -10),
@@ -1115,7 +1119,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 194020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -112020m, -20),
-            // Initial margin requirement for ShortStraddle with quantity 10 and -10 is 194020 and 112020 respectively
+            // Initial margin requirement (including premium) for ShortStraddle with quantity 10 and -10 is 194020 and 112020 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, 194020m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, 194020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, 0m, -10),
@@ -1124,7 +1128,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, 112020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, -194020m, -20),
-            // Initial margin requirement for Strangle with quantity 10 and -10 is 100020 and 182020 respectively
+            // Initial margin requirement (including premium) for Strangle with quantity 10 and -10 is 100020 and 182020 respectively
             new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 100020m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 100020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 0m, -10),
@@ -1133,7 +1137,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 182020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -100020m, -20),
-            // Initial margin requirement for ShortStrangle with quantity 10 and -10 is 182020 and 100020 respectively
+            // Initial margin requirement (including premium) for ShortStrangle with quantity 10 and -10 is 182020 and 100020 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, 182020m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, 182020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, 0m, -10),
@@ -1142,7 +1146,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, 100020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, -182020m, -20),
-            // Initial margin requirement for ButterflyCall with quantity 10 and -10 is 4000 and 10000 respectively
+            // Initial margin requirement (including premium) for ButterflyCall with quantity 10 and -10 is 4000 and 10000 respectively
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 4000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 4000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 0m, -10),
@@ -1151,7 +1155,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -4000m, -20),
-            // Initial margin requirement for ShortButterflyCall with quantity 10 and -10 is 10000 and 4000 respectively
+            // Initial margin requirement (including premium) for ShortButterflyCall with quantity 10 and -10 is 10000 and 4000 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 0m, -10),
@@ -1160,7 +1164,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 4000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -10000m, -20),
-            // Initial margin requirement for ButterflyPut with quantity 10 and -10 is 10 and 10000 respectively
+            // Initial margin requirement (including premium) for ButterflyPut with quantity 10 and -10 is 10 and 10000 respectively
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 10m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 10m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 0m, -10),
@@ -1169,7 +1173,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -10m, -20),
-            // Initial margin requirement for ShortButterflyPut with quantity 10 and -10 is 10000 and 10 respectively
+            // Initial margin requirement (including premium) for ShortButterflyPut with quantity 10 and -10 is 10000 and 10 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 0m, -10),
@@ -1178,7 +1182,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 10m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -10000m, -20),
-            // Initial margin requirement for CallCalendarSpread with quantity 10 and -10 is 2000 and 194000 respectively
+            // Initial margin requirement (including premium) for CallCalendarSpread with quantity 10 and -10 is 2000 and 194000 respectively
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 2000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 2000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 0m, -10),
@@ -1187,7 +1191,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 194000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -2000m, -20),
-            // Initial margin requirement for ShortCallCalendarSpread with quantity 10 and -10 is 194000 and 2000 respectively
+            // Initial margin requirement (including premium) for ShortCallCalendarSpread with quantity 10 and -10 is 194000 and 2000 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, 194000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, 194000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, 0m, -10),
@@ -1196,7 +1200,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, 2000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, -194000m, -20),
-            // Initial margin requirement for PutCalendarSpread with quantity 10 and -10 is 10 and 30020 respectively
+            // Initial margin requirement (including premium) for PutCalendarSpread with quantity 10 and -10 is 10 and 30020 respectively
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 10m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 10m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 0m, -10),
@@ -1205,7 +1209,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 30020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -10m, -20),
-            // Initial margin requirement for ShortPutCalendarSpread with quantity 10 and -10 is 30020 and 10 respectively
+            // Initial margin requirement (including premium) for ShortPutCalendarSpread with quantity 10 and -10 is 30020 and 10 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, 30020m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, 30020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, 0m, -10),
@@ -1214,7 +1218,7 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, 10m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, -30020m, -20),
-            // Initial margin requirement for IronCondor with quantity 10 and -10 is 10000 and 10010 respectively
+            // Initial margin requirement (including premium) for IronCondor with quantity 10 and -10 is 10000 and 10010 respectively
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 0m, -10),

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -62,327 +62,325 @@ namespace QuantConnect.Tests.Common.Securities
 
         /// <summary>
         /// All these test cases are based on the assumption that the initial cash is 1,000,000.
-        ///
-        /// Cases where maintenance margin is 0, it means there is always going to be available buying power.
         /// </summary>
         // option strategy definition, initial quantity, order quantity, expected result
         private static readonly TestCaseData[] HasSufficientBuyingPowerForOrderTestCases = new[]
         {
-            // Maintenance margin for CoveredCall with quantities 1 and -1 are 18500 and 3000 respectively
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, 1000000 / 18500, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, 1000000 / 18500 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -(1000000 / 3000), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -(1000000 / 3000 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, (1000000 / 18500) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, (1000000 / 18500 + 1) - 20, false), // 20 to max long + 1
+            // Initial margin requirement (with premium) for CoveredCall with quantities 1 and -1 are 19210 and 21450 respectively
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, 1000000 / (19210 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, 1000000 / (19210 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -(1000000 / 21450), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -(1000000 / 21450 + 1), false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, (1000000 / 19210) - 20, true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, (1000000 / 19210 + 1) - 20, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -(1000000 / 3000) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -(1000000 / 3000 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, (1000000 / 18500) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, (1000000 / 18500 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -(1000000 / 21450) - 20, true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -(1000000 / 21450 + 1) - 20, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, (1000000 / 19210) - -20, true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, (1000000 / 19210 + 1) - -20, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, -(1000000 / 3000) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, -(1000000 / 3000 + 1) - -20, false),  // -20 to max short + 1
-            // Maintenance margin for ProtectiveCall with quantities 1 and -1 are 3000 and 18500 respectively
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, 1000000 / 3000, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, 1000000 / 3000 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, -(1000000 / 18500), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, -(1000000 / 18500 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, (1000000 / 3000) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, (1000000 / 3000 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, -(1000000 / 21450) - -20, true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, -(1000000 / 21450 + 1) - -20, false),  // -20 to max short + 1
+            // Initial margin requirement (with premium) for ProtectiveCall with quantities 1 and -1 are 21450 and 19210 respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, 1000000 / 21450, true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, 1000000 / 21450 + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, -(1000000 / 19210), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, -(1000000 / 19210 + 1), false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, (1000000 / 21450) - 20, true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, (1000000 / 21450 + 1) - 20, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -(1000000 / 18500) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -(1000000 / 18500 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, (1000000 / 3000) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, (1000000 / 3000 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -(1000000 / 19210) - 20, true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -(1000000 / 19210 + 1) - 20, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, (1000000 / 21450) - -20, true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, (1000000 / 21450 + 1) - -20, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, -(1000000 / 18500) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, -(1000000 / 18500 + 1) - -20, false),  // -20 to max short + 1
-            // Maintenance margin for CoveredPut with quantities 1 and -1 are 10250 and 10250 respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, -(1000000 / 19210) - -20, true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, -(1000000 / 19210 + 1) - -20, false),  // -20 to max short + 1
+            // Initial margin requirement (with premium) for CoveredPut with quantities 1 and -1 are 10250 and 10252 respectively
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, 1000000 / 10250, true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, 1000000 / 10250 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -(1000000 / 10250), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -(1000000 / 10250 + 1), false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -(1000000 / 10252), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -(1000000 / 10252 + 1), false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, (1000000 / 10250) - 20, true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, (1000000 / 10250 + 1) - 20, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -(1000000 / 10250) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -(1000000 / 10250 + 1) - 20, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -(1000000 / 10252) - 20, true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -(1000000 / 10252 + 1) - 20, false),  // 20 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, (1000000 / 10250) - -20, true),   // -20 to max long
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, (1000000 / 10250 + 1) - -20, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -(1000000 / 10250) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -(1000000 / 10250 + 1) - -20, false),  // -20 to max short + 1
-            // Maintenance margin for ProtectivePut with quantities 1 and -1 are 10250 and 10250 respectively
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, 1000000 / 10250, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, 1000000 / 10250 + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -(1000000 / 10252) - -20, true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -(1000000 / 10252 + 1) - -20, false),  // -20 to max short + 1
+            // Initial margin requirement (with premium) for ProtectivePut with quantities 1 and -1 are 10252 and 10250 respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, 1000000 / 10252, true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, 1000000 / 10252 + 1, false), // 0 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, -(1000000 / 10250), true), // 0 to max short
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, -(1000000 / 10250 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, (1000000 / 10250) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, (1000000 / 10250 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, (1000000 / 10252) - 20, true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, (1000000 / 10252 + 1) - 20, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -20, true), // 20 to 0
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -(1000000 / 10250) - 20, true), // 20 to max short
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -(1000000 / 10250 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, (1000000 / 10250) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, (1000000 / 10250 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, (1000000 / 10252) - -20, true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, (1000000 / 10252 + 1) - -20, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, -(1000000 / 10250) - -20, true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, -(1000000 / 10250 + 1) - -20, false),  // -20 to max short + 1
-            // Maintenance margin for BearCallSpread with quantities 1 and -1 are 1000 and 0 respectively
+            // Initial margin requirement (with premium) for BearCallSpread with quantities 1 and -1 are 1000 and 1200 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, 1000000 / 1000, true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, 1000000 / 1000 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -100, true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -1000, true),    // 0 to greater short
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -(1000000 / 1200), true), // 0 to short
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -(1000000 / 1200 + 1), false),    // 0 to greater short
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, (1000000 / 1000) - 20, true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, (1000000 / 1000 + 1) - 20, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -100 - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -1000 - 20, true),  // 20 to greater short
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -(1000000 / 1200) - 20, true), // 20 to short
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -(1000000 / 1200 + 1) - 20, false),  // 20 to greater short
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, (1000000 / 1000) - -20, true),   // -20 to max long
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, (1000000 / 1000 + 1) - -20, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, -100 - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, -1000 - -20, true),  // -20 to greater short
-            // Maintenance margin for BearPutSpread with quantities 1 and -1 are 0 and 1000 respectively
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, 100, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, 1000, true), // 0 to greater long
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, -(1000000 / 1200) - -20, true),    // -20 to short
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, -(1000000 / 1200 + 1) - -20, false),  // -20 to greater short
+            // Initial margin requirement (with premium) for BearPutSpread with quantities 1 and -1 are 1 and 1000 respectively
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, 1000000 / 1, true), // 0 to long
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, 1000000 / 1 + 1, false), // 0 to greater long
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, -(1000000 / 1000), true), // 0 to max short
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, -(1000000 / 1000 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, 100 - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, 1000 - 20, true), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, (1000000 / 1) - 20, true),    // 20 to long
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, (1000000 / 1 + 1) - 20, false), // 20 to greater long
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -20, true), // 20 to 0
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -(1000000 / 1000) - 20, true), // 20 to max short
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -(1000000 / 1000 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, 100 - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, 1000 - -20, true),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, (1000000 / 1) - -20, true),   // -20 to long
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, (1000000 / 1 + 1) - -20, false),   // -20 to greater long
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, -(1000000 / 1000) - -20, true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, -(1000000 / 1000 + 1) - -20, false),  // -20 to max short + 1
-            // Maintenance margin for BullCallSpread with quantities 1 and -1 are 0 and 1000 respectively
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, 100, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, 1000, true), // 0 to greater long
+            // Initial margin requirement (with premium) for BullCallSpread with quantities 1 and -1 are 1200 and 1000 respectively
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, 1000000 / 1200, true), // 0 to long
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, 1000000 / 1200 + 1, false), // 0 to greater long
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, -(1000000 / 1000), true), // 0 to max short
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, -(1000000 / 1000 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, 100 - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, 1000 - 20, true), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, (1000000 / 1200) - 20, true),    // 20 to long
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, (1000000 / 1200 + 1) - 20, false), // 20 to greater long
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -20, true), // 20 to 0
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -(1000000 / 1000) - 20, true), // 20 to max short
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -(1000000 / 1000 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, 100 - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, 1000 - -20, true),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, (1000000 / 1200) - -20, true),   // -20 to long
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, (1000000 / 1200 + 1) - -20, false),   // -20 to greater long
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, -(1000000 / 1000) - -20, true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, -(1000000 / 1000 + 1) - -20, false),  // -20 to max short + 1
-            // Maintenance margin for BullPutSpread with quantities 1 and -1 are 1000 and 0 respectively
+            // Initial margin requirement (with premium) for BullPutSpread with quantities 1 and -1 are 1000 and 1 respectively
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, 1000000 / 1000, true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, 1000000 / 1000 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, -100, true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, -1000, true),    // 0 to greater short
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, -(1000000 / 1), true), // 0 to short
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, -(1000000 / 1 + 1), false),    // 0 to greater short
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, (1000000 / 1000) - 20, true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, (1000000 / 1000 + 1) - 20, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -100 - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -1000 - 20, true),  // 20 to greater short
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -(1000000 / 1) - 20, true), // 20 to short
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -(1000000 / 1 + 1) - 20, false),  // 20 to greater short
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, (1000000 / 1000) - -20, true),   // -20 to max long
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, (1000000 / 1000 + 1) - -20, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, -100 - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, -1000 - -20, true),  // -20 to greater short
-            // Maintenance margin for Straddle with quantities 1 and -1 are 0 and 19402 respectively
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, 100, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, 1000, true), // 0 to greater long
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, -(1000000 / 1) - -20, true),    // -20 to short
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, -(1000000 / 1 + 1) - -20, false),  // -20 to greater short
+            // Initial margin requirement (with premium) for Straddle with quantities 1 and -1 are 11202 and 19402 respectively
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, 1000000 / 11202, true), // 0 to long
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, 1000000 / 11202 + 1, false), // 0 to greater long
             new TestCaseData(OptionStrategyDefinitions.Straddle, 0, -(1000000 / 19402), true), // 0 to max short
             new TestCaseData(OptionStrategyDefinitions.Straddle, 0, -(1000000 / 19402 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, 100 - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, 1000 - 20, true), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, (1000000 / 11202) - 20, true),    // 20 to long
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, (1000000 / 11202 + 1) - 20, false), // 20 to greater long
             new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -20, true), // 20 to 0
             new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -(1000000 / 19402) - 20, true), // 20 to max short
             new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -(1000000 / 19402 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, 100 - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, 1000 - -20, true),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, (1000000 / 11202) - -20, true),   // -20 to long
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, (1000000 / 11202 + 1) - -20, false),   // -20 to greater long
             new TestCaseData(OptionStrategyDefinitions.Straddle, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.Straddle, -20, -(1000000 / 19402) - -20, true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.Straddle, -20, -(1000000 / 19402 + 1) - -20, false),  // -20 to max short + 1
-            // Maintenance margin for ShortStraddle with quantities 1 and -1 are 19402 and 0 respectively
+            // Initial margin requirement (with premium) for ShortStraddle with quantities 1 and -1 are 19402 and 11202 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, 1000000 / 19402, true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, 1000000 / 19402 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, -100, true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, -1000, true),    // 0 to greater short
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, -(1000000 / 11202), true), // 0 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, -(1000000 / 11202 + 1), false),    // 0 to greater short
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, (1000000 / 19402) - 20, true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, (1000000 / 19402 + 1) - 20, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -100 - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -1000 - 20, true),  // 20 to greater short
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -(1000000 / 11202) - 20, true), // 20 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -(1000000 / 11202 + 1) - 20, false),  // 20 to greater short
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, (1000000 / 19402) - -20, true),   // -20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, (1000000 / 19402 + 1) - -20, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, -100 - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, -1000 - -20, true),  // -20 to greater short
-            // Maintenance margin for Strangle with quantities 1 and -1 are 0 and 18402 respectively
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, 100, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, 1000, true), // 0 to greater long
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, -(1000000 / 18402), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, -(1000000 / 18402 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, 100 - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, 1000 - 20, true), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, -(1000000 / 11202) - -20, true),    // -20 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, -(1000000 / 11202 + 1) - -20, false),  // -20 to greater short
+            // Initial margin requirement (with premium) for Strangle with quantities 1 and -1 are 10002 and 18202 respectively
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, 1000000 / 10002, true), // 0 to long
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, 1000000 / 10002 + 1, false), // 0 to greater long
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, -(1000000 / 18202), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, -(1000000 / 18202 + 1), false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, (1000000 / 10002) - 20, true),    // 20 to long
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, (1000000 / 10002 + 1) - 20, false), // 20 to greater long
             new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -(1000000 / 18402) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -(1000000 / 18402 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, 100 - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, 1000 - -20, true),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -(1000000 / 18202) - 20, true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -(1000000 / 18202 + 1) - 20, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, (1000000 / 10002) - -20, true),   // -20 to long
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, (1000000 / 10002 + 1) - -20, false),   // -20 to greater long
             new TestCaseData(OptionStrategyDefinitions.Strangle, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, -(1000000 / 18402) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, -(1000000 / 18402 + 1) - -20, false),  // -20 to max short + 1
-            // Maintenance margin for ShortStrangle with quantities 1 and -1 are 18402 and 0 respectively
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, 1000000 / 18402, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, 1000000 / 18402 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, -100, true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, -1000, true),    // 0 to greater short
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, (1000000 / 18402) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, (1000000 / 18402 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, -(1000000 / 18202) - -20, true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, -(1000000 / 18202 + 1) - -20, false),  // -20 to max short + 1
+            // Initial margin requirement (with premium) for ShortStrangle with quantities 1 and -1 are 18202 and 10002 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, 1000000 / 18202, true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, 1000000 / 18202 + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, -(1000000 / 11202), true), // 0 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, -(1000000 / 10002 + 1), false),    // 0 to greater short
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, (1000000 / 18202) - 20, true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, (1000000 / 18202 + 1) - 20, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -100 - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -1000 - 20, true),  // 20 to greater short
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, (1000000 / 18402) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, (1000000 / 18402 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -(1000000 / 10002) - 20, true), // 20 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -(1000000 / 10002 + 1) - 20, false),  // 20 to greater short
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, (1000000 / 18202) - -20, true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, (1000000 / 18202 + 1) - -20, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, -100 - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, -1000 - -20, true),  // -20 to greater short
-            // Maintenance margin for ButterflyCall with quantities 1 and -1 are 0 and 1000 respectively
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, 100, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, 1000, true), // 0 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, -(1000000 / 10002) - -20, true),    // -20 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, -(1000000 / 10002 + 1) - -20, false),  // -20 to greater short
+            // Initial margin requirement (with premium) for ButterflyCall with quantities 1 and -1 are 400 and 1000 respectively
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, 1000000/ 400, true), // 0 to long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, 1000000/ 400 + 1, false), // 0 to greater long
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, -(1000000 / 1000), true), // 0 to max short
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, -(1000000 / 1000 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, 100 - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, 1000 - 20, true), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, (1000000/ 400) - 20, true),    // 20 to long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, (1000000/ 400 + 1) - 20, false), // 20 to greater long
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -20, true), // 20 to 0
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -(1000000 / 1000) - 20, true), // 20 to max short
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -(1000000 / 1000 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, 100 - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, 1000 - -20, true),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, (1000000/ 400) - -20, true),   // -20 to long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, (1000000/ 400 + 1) - -20, false),   // -20 to greater long
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, -(1000000 / 1000) - -20, true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, -(1000000 / 1000 + 1) - -20, false),  // -20 to max short + 1
-            // Maintenance margin for ShortButterflyCall with quantities 1 and -1 are 1000 and 0 respectively
+            // Initial margin requirement (with premium) for ShortButterflyCall with quantities 1 and -1 are 1000 and 0 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, 1000000 / 1000, true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, 1000000 / 1000 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, -100, true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, -1000, true),    // 0 to greater short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, -(1000000 / 10202), true), // 0 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, -(1000000/ 400 + 1), false),    // 0 to greater short
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, (1000000 / 1000) - 20, true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, (1000000 / 1000 + 1) - 20, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -100 - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -1000 - 20, true),  // 20 to greater short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -(1000000/ 400) - 20, true), // 20 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -(1000000/ 400 + 1) - 20, false),  // 20 to greater short
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, (1000000 / 1000) - -20, true),   // -20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, (1000000 / 1000 + 1) - -20, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, -100 - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, -1000 - -20, true),  // -20 to greater short
-            // Maintenance margin for ButterflyPut with quantities 1 and -1 are 0 and 1000 respectively
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, 100, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, 1000, true), // 0 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, -(1000000/ 400) - -20, true),    // -20 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, -(1000000/ 400 + 1) - -20, false),  // -20 to greater short
+            // Initial margin requirement (with premium) for ButterflyPut with quantities 1 and -1 are 1 and 1000 respectively
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, 1000000 / 1, true), // 0 to long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, 1000000 / 1 + 1, false), // 0 to greater long
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, -(1000000 / 1000), true), // 0 to max short
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, -(1000000 / 1000 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, 100 - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, 1000 - 20, true), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, (1000000 / 1) - 20, true),    // 20 to long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, (1000000 / 1 + 1) - 20, false), // 20 to greater long
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -20, true), // 20 to 0
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -(1000000 / 1000) - 20, true), // 20 to max short
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -(1000000 / 1000 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, 100 - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, 1000 - -20, true),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, (1000000 / 1) - -20, true),   // -20 to long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, (1000000 / 1 + 1) - -20, false),   // -20 to greater long
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, -(1000000 / 1000) - -20, true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, -(1000000 / 1000 + 1) - -20, false),  // -20 to max short + 1
-            // Maintenance margin for ShortButterflyPut with quantities 1 and -1 are 1000 and 0 respectively
+            // Initial margin requirement (with premium) for ShortButterflyPut with quantities 1 and -1 are 1000 and 1 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, 1000000 / 1000, true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, 1000000 / 1000 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, -100, true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, -1000, true),    // 0 to greater short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, -(1000000 / 1), true), // 0 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, -(1000000 / 1 + 1), false),    // 0 to greater short
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, (1000000 / 1000) - 20, true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, (1000000 / 1000 + 1) - 20, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -100 - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -1000 - 20, true),  // 20 to greater short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -(1000000 / 1) - 20, true), // 20 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -(1000000 / 1 + 1) - 20, false),  // 20 to greater short
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, (1000000 / 1000) - -20, true),   // -20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, (1000000 / 1000 + 1) - -20, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, -100 - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, -1000 - -20, true),  // -20 to greater short
-            // Maintenance margin for CallCalendarSpread with quantities 1 and -1 are 0 and 19400 respectively
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, 100, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, 1000, true), // 0 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, -(1000000 / 1) - -20, true),    // -20 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, -(1000000 / 1 + 1) - -20, false),  // -20 to greater short
+            // Initial margin requirement (with premium) for CallCalendarSpread with quantities 1 and -1 are 200 and 19400 respectively
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, 1000000 / 200, true), // 0 to long
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, 1000000 / 200 + 1, false), // 0 to greater long
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, -(1000000 / 19400), true), // 0 to max short
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, -(1000000 / 19400 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, 100 - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, 1000 - 20, true), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, (1000000 / 200) - 20, true),    // 20 to long
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, (1000000 / 200 + 1) - 20, false), // 20 to greater long
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -20, true), // 20 to 0
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -(1000000 / 19400) - 20, true), // 20 to max short
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -(1000000 / 19400 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, 100 - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, 1000 - -20, true),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, (1000000 / 200) - -20, true),   // -20 to long
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, (1000000 / 200 + 1) - -20, false),   // -20 to greater long
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, -(1000000 / 19400) - -20, true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, -(1000000 / 19400 + 1) - -20, false),  // -20 to max short + 1
-            // Maintenance margin for ShortCallCalendarSpread with quantities 1 and -1 are 19400 and 0 respectively
+            // Initial margin requirement (with premium) for ShortCallCalendarSpread with quantities 1 and -1 are 19400 and 400 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, 1000000 / 19400, true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, 1000000 / 19400 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, -100, true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, -1000, true),    // 0 to greater short
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, -(1000000 / 200), true), // 0 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, -(1000000 / 200 + 1), false),    // 0 to greater short
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, (1000000 / 19400) - 20, true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, (1000000 / 19400 + 1) - 20, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -100 - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -1000 - 20, true),  // 20 to greater short
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -(1000000 / 200) - 20, true), // 20 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -(1000000 / 200 + 1) - 20, false),  // 20 to greater short
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, (1000000 / 19400) - -20, true),   // -20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, (1000000 / 19400 + 1) - -20, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, -100 - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, -1000 - -20, true),  // -20 to greater short
-            // Maintenance margin for PutCalendarSpread with quantities 1 and -1 are 0 and 3002 respectively
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, 100, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, 1000, true), // 0 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, -(1000000 / 200) - -20, true),    // -20 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, -(1000000 / 200 + 1) - -20, false),  // -20 to greater short
+            // Initial margin requirement (with premium) for PutCalendarSpread with quantities 1 and -1 are 1 and 3002 respectively
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, 1000000 / 1, true), // 0 to long
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, 1000000 / 1 + 1, false), // 0 to greater long
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, -(1000000 / 3002), true), // 0 to max short
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, -(1000000 / 3002 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, 100 - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, 1000 - 20, true), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, (1000000 / 1) - 20, true),    // 20 to long
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, (1000000 / 1 + 1) - 20, false), // 20 to greater long
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -20, true), // 20 to 0
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -(1000000 / 3002) - 20, true), // 20 to max short
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -(1000000 / 3002 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, 100 - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, 1000 - -20, true),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, (1000000 / 1) - -20, true),   // -20 to long
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, (1000000 / 1 + 1) - -20, false),   // -20 to greater long
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, -(1000000 / 3002) - -20, true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, -(1000000 / 3002 + 1) - -20, false),  // -20 to max short + 1
-            // Maintenance margin for ShortPutCalendarSpread with quantities 1 and -1 are 3002 and 0 respectively
+            // Initial margin requirement (with premium) for ShortPutCalendarSpread with quantities 1 and -1 are 3002 and 1 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, 1000000 / 3002, true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, 1000000 / 3002 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, -100, true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, -1000, true),    // 0 to greater short
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, -(1000000 / 1), true), // 0 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, -(1000000 / 1 + 1), false),    // 0 to greater short
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, (1000000 / 3002) - 20, true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, (1000000 / 3002 + 1) - 20, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -100 - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -1000 - 20, true),  // 20 to greater short
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -(1000000 / 1) - 20, true), // 20 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -(1000000 / 1 + 1) - 20, false),  // 20 to greater short
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, (1000000 / 3002) - -20, true),   // -20 to max long
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, (1000000 / 3002 + 1) - -20, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, -100 - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, -1000 - -20, true),  // -20 to greater short
-            // Maintenance margin for IronCondor with quantities 1 and -1 are 1000 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, -(1000000 / 1) - -20, true),    // -20 to short
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, -(1000000 / 1 + 1) - -20, false),  // -20 to greater short
+            // Initial margin requirement (with premium) for IronCondor with quantities 1 and -1 are 1000 and 1001 respectively
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, 1000000 / 1000, true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, 1000000 / 1000 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, -100, true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, -1000, true),    // 0 to greater short
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, -(1000000 / 1001), true), // 0 to short
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, -(1000000 / 1001 + 1), false),    // 0 to greater short
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, (1000000 / 1000) - 20, true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, (1000000 / 1000 + 1) - 20, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -100 - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -1000 - 20, true),  // 20 to greater short
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -(1000000 / 1001) - 20, true), // 20 to short
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -(1000000 / 1001 + 1) - 20, false),  // 20 to greater short
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, (1000000 / 1000) - -20, true),   // -20 to max long
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, (1000000 / 1000 + 1) - -20, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, -100 - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, -1000 - -20, true),  // -20 to greater short
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, -(1000000 / 1001) - -20, true),    // -20 to short
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, -(1000000 / 1001 + 1) - -20, false),  // -20 to greater short
         };
 
         [TestCaseSource(nameof(HasSufficientBuyingPowerForOrderTestCases))]
@@ -719,6 +717,16 @@ namespace QuantConnect.Tests.Common.Securities
             var initialMarginRequirement = positionGroup.BuyingPowerModel.GetInitialMarginRequirement(
                 new PositionGroupInitialMarginParameters(_portfolio, positionGroup));
 
+            Console.WriteLine(initialMarginRequirement.Value);
+
+            var premium = 0m;
+            foreach (var position in positionGroup.Positions.Where(position => position.Symbol.SecurityType.IsOption()))
+            {
+                var option = (Option)_portfolio.Securities[position.Symbol];
+                premium += option.Holdings.GetQuantityValue(position.Quantity).InAccountCurrency;
+            }
+            initialMarginRequirement -= Math.Max(0, premium);
+
             Assert.AreEqual((double)expectedInitialMarginRequirement, (double)initialMarginRequirement.Value, (double)(0.2m * expectedInitialMarginRequirement));
         }
 
@@ -816,146 +824,195 @@ namespace QuantConnect.Tests.Common.Securities
         // option strategy definition, initial position quantity, final position quantity
         private static readonly TestCaseData[] OrderQuantityForDeltaBuyingPowerTestCases = new[]
         {
-            // Initial margin requirement for CoveredCall with quantity 10 and -10 is 192100 and 102500 respectively
+            // Initial margin requirement for CoveredCall with quantity 10 and -10 is 192100 and 214500 respectively
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 192100m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -192100m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -192100m, -10),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -192100m - 102500m, -20),    // Going from 10 to -10
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 102500m / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -102500m / 10, -1),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -102500m, -10),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -102500m - 192100m, -20),   // Going from -10 to 10
-            // Initial margin requirement for ProtectiveCall with quantity 10 and -10 is 102500 and 192100 respectively
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 102500m / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -102500m / 10, -1),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -102500m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -102500m - 192100m, -20),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -192100m - 214500m, -20),    // Going from 10 to -10
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 214500m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -214500m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -214500m, -10),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -214500m - 192100m, -20),   // Going from -10 to 10
+            // Initial margin requirement for ProtectiveCall with quantity 10 and -10 is 214500 and 192100 respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 214500m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -214500m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -214500m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -214500m - 192100m, -20),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 192100m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, -192100m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, -192100m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, -192100m - 102500m, -20),
-            // Initial margin requirement for CoveredPut with quantity 10 and -10 is 102500 and 102500 respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, -192100m - 214500m, -20),
+            // Initial margin requirement for CoveredPut with quantity 10 and -10 is 102500 and 102520 respectively
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 102500m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -102500m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -102500m, -10),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -102500m - 102500m, -20),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 102500m / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -102500m / 10, -1),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -102500m, -10),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -102500m - 102500m, -20),
-            // Initial margin requirement for ProtectivePut with quantity 10 and -10 is 102500 and 102500 respectively
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 102500m / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -102500m / 10, -1),
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -102500m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -102500m - 102500m, -20),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -102500m - 102520m, -20),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 102520m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -102520m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -102520m, -10),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -102520m - 102500m, -20),
+            // Initial margin requirement for ProtectivePut with quantity 10 and -10 is 102520 and 102500 respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 102520m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -102520m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -102520m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -102520m - 102500m, -20),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 102500m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102500m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102500m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102500m - 102500m, -20),
-            // Initial margin requirement for BearCallSpread with quantity 10 and -10 is 10000 and 0 respectively
-            // The assumed 10000 margin for short test is not correct.
-            // It should be replaced when margin for short takes premium into account making it non-zero.
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 1000m, +1),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -1000m, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102500m - 102520m, -20),
+            // Initial margin requirement for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10000m, -10),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10000m - 10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 0m - 10000m, -20).Explicit(),
-            // Initial margin requirement for BearPutSpread with quantity 10 and -10 is 0 and 10000 respectively
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 0m - 10000m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10000m - 12000m, -20),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 12000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -12000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -12000m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -12000m - 10000m, -20).Explicit(),
+            // Initial margin requirement for BearPutSpread with quantity 10 and -10 is 10 and 10000 respectively
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 10m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -10m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -10m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -10m - 10000m, -20).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -10000m, -10),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -10000m - 10000m, -20).Explicit(),
-            // Initial margin requirement for BullCallSpread with quantity 10 and -10 is 0 and 10000 respectively
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 0m - 10000m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -10000m - 10m, -20),
+            // Initial margin requirement for BullCallSpread with quantity 10 and -10 is 12000 and 10000 respectively
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 12000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -12000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -12000m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -12000m - 10000m, -20).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -10000m, -10),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -10000m - 10000m, -20).Explicit(),
-            // Initial margin requirement for BullPutSpread with quantity 10 and -10 is 10000 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -10000m - 12000m, -20),
+            // Initial margin requirement for BullPutSpread with quantity 10 and -10 is 10000 and 10 respectively
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10000m, -10),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10000m - 10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 0m - 10000m, -20).Explicit(),
-            // Initial margin requirement for Straddle with quantity 10 and -10 is 0 and 194020 respectively
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 0m - 194020m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10000m - 10m, -20),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 10m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -10m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -10m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -10m - 10000m, -20).Explicit(),
+            // Initial margin requirement for Straddle with quantity 10 and -10 is 112020 and 194020 respectively
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 112020m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -112020m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -112020m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -112020m - 194020m, -20).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 194020m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -194020m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -194020m, -10),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -194020m - 10000m, -20).Explicit(),
-            // Initial margin requirement for ShortStraddle with quantity 10 and -10 is 194020 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -194020m - 112020m, -20),
+            // Initial margin requirement for ShortStraddle with quantity 10 and -10 is 194020 and 112020 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, 194020m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, -194020m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, -194020m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, -194020m - 10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, 0m - 194020m, -20).Explicit(),
-            // Initial margin requirement for Strangle with quantity 10 -10 is 0 and 184020 respectively
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 0m - 184020m , -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 184020m / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -184020m / 10, -1),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -184020m, -10),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -184020m - 10000m, -20).Explicit(),
-            // Initial margin requirement for ShortStrangle with quantity 10 and -10 is 184020 and 0 respectively
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, 184020m / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -184020m / 10, -1),
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -184020m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -184020m - 10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, 0m - 184020m, -20).Explicit(),
-            // Initial margin requirement for ButterflyCall with quantity 10 and -10 is 0 and 10000 respectively
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 0m - 10000m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, -194020m - 112020m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, 112020m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, -112020m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, -112020m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, -112020m - 194020m, -20).Explicit(),
+            // Initial margin requirement for Strangle with quantity 10 and -10 is 100020 and 182020 respectively
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 100020m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -100020m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -100020m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -100020m - 182020m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 182020m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -182020m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -182020m, -10),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -182020m - 100020m, -20),
+            // Initial margin requirement for ShortStrangle with quantity 10 and -10 is 182020 and 100020 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, 182020m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -182020m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -182020m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -182020m - 100020m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, 100020m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, -100020m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, -100020m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, -100020m - 182020m, -20).Explicit(),
+            // Initial margin requirement for ButterflyCall with quantity 10 and -10 is 4000 and 10000 respectively
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 4000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -4000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -4000m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -4000m - 10000m, -20).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -10000m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -10000m - 10000m, -20).Explicit(),
-            // Initial margin requirement for ShortButterflyCall with quantity 10 and -10 is 10000 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -10000m - 4000m, -20),
+            // Initial margin requirement for ShortButterflyCall with quantity 10 and -10 is 10000 and 4000 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -10000m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -10000m - 10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 0m - 10000m, -20).Explicit(),
-            // Initial margin requirement for ButterflyPut with quantity 10 and -10 is 0 and 10000 respectively
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 0m - 10000m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -10000m - 4000m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 4000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -4000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -4000m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -4000m - 10000m, -20).Explicit(),
+            // Initial margin requirement for ButterflyPut with quantity 10 and -10 is 10 and 10000 respectively
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 10m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -10m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -10m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -10m - 10000m, -20).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -10000m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -10000m - 1000m, -20).Explicit(),
-            // Initial margin requirement for ShortButterflyPut with quantity 10 and -10 is 1000 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -10000m - 10m, -20),
+            // Initial margin requirement for ShortButterflyPut with quantity 10 and -10 is 10000 and 10 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10000m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10000m - 10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 0m - 10000m, -20).Explicit(),
-            // Initial margin requirement for CallCalendarSpread with quantity 10 and -10 is 0 and 194000 respectively
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 0m - 194000m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10000m - 10m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 10m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -10m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -10m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -10m - 10000m, -20).Explicit(),
+            // Initial margin requirement for CallCalendarSpread with quantity 10 and -10 is 2000 and 194000 respectively
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 2000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -2000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -2000m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -2000m - 194000m, -20).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 194000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -194000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -194000m, -10),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -194000m - 10000m, -20).Explicit(),
-            // Initial margin requirement for ShortCallCalendarSpread with quantity 10 and -10 is 194000 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -194000m - 2000m, -20),
+            // Initial margin requirement for ShortCallCalendarSpread with quantity 10 and -10 is 194000 and 2000 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, 194000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, -194000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, -194000m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, -194000m - 10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, 0m - 194000m, -20).Explicit(),
-            // Initial margin requirement for PutCalendarSpread with quantity 10 and -10 is 0 and 30020 respectively
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 0m - 30020m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, -194000m - 2000m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, 2000m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, -2000m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, -2000m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, -2000m - 194000m, -20).Explicit(),
+            // Initial margin requirement for PutCalendarSpread with quantity 10 and -10 is 10 and 30020 respectively
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 10m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -10m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -10m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -10m - 30020m, -20).Explicit(),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 30020m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -30020m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -30020m, -10),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -30020m - 10000m, -20).Explicit(),
-            // Initial margin requirement for ShortPutCalendarSpread with quantity 10 and -10 is 30020 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -30020m - 10m, -20),
+            // Initial margin requirement for ShortPutCalendarSpread with quantity 10 and -10 is 30020 and 10 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, 30020m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, -30020m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, -30020m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, -30020m - 10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, 0m - 30020m, -20).Explicit(),
-            // Initial margin requirement for IronCondor with quantity 10 and -10 is 10000 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, -30020m - 10m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, 10m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, -10m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, -10m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, -10m - 30020m, -20).Explicit(),
+            // Initial margin requirement for IronCondor with quantity 10 and -10 is 10000 and 10010 respectively
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10000m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10000m, -10),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10000m - 10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 0m - 10000m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10000m - 10010m, -20),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 10010m / 10, +1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -10010m / 10, -1).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -10010m, -10).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -10010m - 10000m, -20).Explicit(),
         };
 
         [TestCaseSource(nameof(OrderQuantityForDeltaBuyingPowerTestCases))]
@@ -977,9 +1034,8 @@ namespace QuantConnect.Tests.Common.Securities
             {
                 // Add a small buffer to avoid rounding errors
                 var usedMargin = _portfolio.TotalMarginUsed;
-                deltaBuyingPower *= deltaBuyingPower > 0 || Math.Abs(deltaBuyingPower) > usedMargin ? 1.001m : 0.999m;
+                deltaBuyingPower *= deltaBuyingPower > 0 || Math.Abs(deltaBuyingPower) > usedMargin ? 1.00001m : 0.99999m;
             }
-
 
             var result = positionGroup.BuyingPowerModel.GetMaximumLotsForDeltaBuyingPower(new GetMaximumLotsForDeltaBuyingPowerParameters(
                 _portfolio, positionGroup, deltaBuyingPower, minimumOrderMarginPortfolioPercentage: 0));
@@ -1046,7 +1102,7 @@ namespace QuantConnect.Tests.Common.Securities
             {
                 // Add a small buffer to avoid rounding errors
                 var usedMargin = _portfolio.TotalMarginUsed;
-                deltaBuyingPower *= deltaBuyingPower > 0 || Math.Abs(deltaBuyingPower) > usedMargin ? 1.001m : 0.999m;
+                deltaBuyingPower *= deltaBuyingPower > 0 || Math.Abs(deltaBuyingPower) > usedMargin ? 1.00001m : 0.99999m;
             }
 
             // Using a reference position with in the same position side as the one in the portfolio
@@ -1074,146 +1130,195 @@ namespace QuantConnect.Tests.Common.Securities
         // option strategy definition, initial position quantity, target buying power percent, expected quantity
         private static readonly TestCaseData[] OrderQuantityForTargetBuyingPowerTestCases = new[]
         {
-            // Initial margin requirement for CoveredCall with quantity 10 and -10 is 192100m and 102500m respectively
+            // Initial margin requirement for CoveredCall with quantity 10 and -10 is 192100m and 214500m respectively
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 192100m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 192100m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -102500m, -20),  // Going from 10 to -10
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 102500m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 102500m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 10, -214500m, -20),  // Going from 10 to -10
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 214500m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 214500m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -192100m, -20),    // Going from -10 to 10
-            // Initial margin requirement for ProtectiveCall with quantity 10 and -10 is 102500m and 192100m respectively
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 102500m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 102500m * 9 / 10, -1),
+            // Initial margin requirement for ProtectiveCall with quantity 10 and -10 is 214500m and 192100m respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 214500m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 214500m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -192100m, -20),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 192100m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 192100m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, -102500m, -20),
-            // Initial margin requirement for CoveredPut with quantity 10 and -10 is 102500m and 102500m respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, -214500m, -20),
+            // Initial margin requirement for CoveredPut with quantity 10 and -10 is 102500m and 102520m respectively
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 102500m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 102500m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -102500m, -20),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 102500m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 102500m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -102520m, -20),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 102520m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 102520m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -102500m, -20),
-            // Initial margin requirement for ProtectivePut with quantity 10 and -10 is 102500m and 102500m respectively
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 102500m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 102500m * 9 / 10, -1),
+            // Initial margin requirement for ProtectivePut with quantity 10 and -10 is 102520m and 102500m respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 102520m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 102520m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -102500m, -20),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 102500m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 102500m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102500m, -20),
-            // Initial margin requirement for BearCallSpread with quantity 10 and -10 is 10000 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102520m, -20),
+            // Initial margin requirement for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 0m, -10),
-            // The following case won't converge until margin for short bear call takes premium into account.
-            // The target buying power of -10000 should be replaced with the actual margin requirement for -10.
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -10000m, -20).Explicit(),
-            // Initial margin requirement for BearPutSpread with quantity 10 and -10 is 0 and 10000 respectively
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -10000m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -12000m, -20),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 12000m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 12000m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -10000m, -20),
+            // Initial margin requirement for BearPutSpread with quantity 10 and -10 is 10 and 10000 respectively
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 10m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 10m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -10000m, -20),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -10000m, -20).Explicit(),
-            // Initial margin requirement for BullCallSpread with quantity 10 and -10 is 0 and 10000 respectively
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -10000m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -10m, -20),
+            // Initial margin requirement for BullCallSpread with quantity 10 and -10 is 12000 and 10000 respectively
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 12000m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 12000m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -10000m, -20),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -10000m, -20).Explicit(),
-            // Initial margin requirement for BullPutSpread with quantity 10 and -10 is 10000 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -12000m, -20),
+            // Initial margin requirement for BullPutSpread with quantity 10 and -10 is 10000 and 10 respectively
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -10000m, -20).Explicit(),
-            // Initial margin requirement for Straddle with quantity 10 and -10 is 0 and 194020 respectively
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -194020m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10m, -20),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 10m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 10m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -10000m, -20),
+            // Initial margin requirement for Straddle with quantity 10 and -10 is 112020 and 194020 respectively
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 112020m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 112020m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -194020m, -20),
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 194020m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 194020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -10000m, -20).Explicit(),
-            // Initial margin requirement for ShortStraddle with quantity 10 and -10 is 194020 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -112020m, -20),
+            // Initial margin requirement for ShortStraddle with quantity 10 and -10 is 194020 and 112020 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, 194020m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, 194020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, -10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, -194020m, -20).Explicit(),
-            // Initial margin requirement for Strangle with quantity 10 and -10 is 0 and 184020 respectively
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -184020m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 184020m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 184020m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, -112020m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, 112020m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, 112020m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, -194020m, -20),
+            // Initial margin requirement for Strangle with quantity 10 and -10 is 100020 and 182020 respectively
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 100020m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 100020m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -182020m, -20),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 182020m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 182020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -10000m, -20).Explicit(),
-            // Initial margin requirement for ShortStrangle with quantity 10 and -10 is 184020 and 0 respectively
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, 184020m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, 184020m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -100020m, -20),
+            // Initial margin requirement for ShortStrangle with quantity 10 and -10 is 182020 and 100020 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, 182020m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, 182020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, -184020m, -20).Explicit(),
-            // Initial margin requirement for ButterflyCall with quantity 10 and -10 is 0 and 10000 respectively
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -10000m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -100020m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, 100020m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, 100020m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, -182020m, -20),
+            // Initial margin requirement for ButterflyCall with quantity 10 and -10 is 4000 and 10000 respectively
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 4000m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 4000m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -10000m, -20),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -10000m, -20).Explicit(),
-            // Initial margin requirement for ShortButterflyCall with quantity 10 and -10 is 10000 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -4000m, -20),
+            // Initial margin requirement for ShortButterflyCall with quantity 10 and -10 is 10000 and 4000 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -10000m, -20).Explicit(),
-            // Initial margin requirement for ButterflyPut with quantity 10 and -10 is 0 and 10000 respectively
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -10000m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -4000m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 4000m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 4000m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -10000m, -20),
+            // Initial margin requirement for ButterflyPut with quantity 10 and -10 is 10 and 10000 respectively
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 10m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 10m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -10000m, -20),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -10000m, -20).Explicit(),
-            // Initial margin requirement for ShortButterflyPut with quantity 10 and -10 is 10000 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -10m, -20),
+            // Initial margin requirement for ShortButterflyPut with quantity 10 and -10 is 10000 and 10 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -10000m, -20).Explicit(),
-            // Initial margin requirement for CallCalendarSpread with quantity 10 and -10 is 0 and 194000 respectively
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -194000m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 10m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 10m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -10000m, -20),
+            // Initial margin requirement for CallCalendarSpread with quantity 10 and -10 is 2000 and 194000 respectively
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 2000m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 2000m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -194000m, -20),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 194000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 194000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -10000m, -20).Explicit(),
-            // Initial margin requirement for ShortCallCalendarSpread with quantity 10 and -10 is 194000 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -2000m, -20),
+            // Initial margin requirement for ShortCallCalendarSpread with quantity 10 and -10 is 194000 and 2000 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, 194000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, 194000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, -10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, -10000m, -20).Explicit(),
-            // Initial margin requirement for PutCalendarSpread with quantity 10 and -10 is 0 and 30020 respectively
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -30020m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, -2000m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, 2000m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, 2000m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, -194000m, -20),
+            // Initial margin requirement for PutCalendarSpread with quantity 10 and -10 is 10 and 30020 respectively
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 10m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 10m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -30020m, -20),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 30020m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 30020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -10000m, -20).Explicit(),
-            // Initial margin requirement for ShortPutCalendarSpread with quantity 10 and -10 is 30020 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -10m, -20),
+            // Initial margin requirement for ShortPutCalendarSpread with quantity 10 and -10 is 30020 and 10 respectively
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, 30020m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, 30020m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, -10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, -30020m, -20).Explicit(),
-            // Initial margin requirement for IronCondor with quantity 10 and -10 is 10000 and 0 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, -10m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, 10m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, 10m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, -30020m, -20),
+            // Initial margin requirement for IronCondor with quantity 10 and -10 is 10000 and 10010 respectively
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 10000m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10000m, -20).Explicit(),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -10000m, -20).Explicit(),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10010m, -20),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 10010m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 10010m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -10000m, -20),
         };
 
         [TestCaseSource(nameof(OrderQuantityForTargetBuyingPowerTestCases))]
@@ -1308,13 +1413,13 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, -1, 1000000m - 30000m),
             // Expected buying power for reducing, closing or going long:
             // (1000000 initial cash - 30000 used margin) margin remaining + 30000 used margin + 102500 initial margin requirement
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 1, (1000000m - 30000m) + 30000m + 102500m),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 10, (1000000m - 30000m) + 30000m + 102500m),
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 20, (1000000m - 30000m) + 30000m + 102500m),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 1, (1000000m - 30000m) + 30000m + 214500m),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 10, (1000000m - 30000m) + 30000m + 214500m),
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -10, 20, (1000000m - 30000m) + 30000m + 214500m),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, +1, 1000000m - 30000m),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -1, (1000000m - 30000m) + 30000m + 102500m),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -10, (1000000m - 30000m) + 30000m + 102500m),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -20, (1000000m - 30000m) + 30000m + 102500m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -1, (1000000m - 30000m) + 30000m + 214500m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -10, (1000000m - 30000m) + 30000m + 214500m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 10, -20, (1000000m - 30000m) + 30000m + 214500m),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, -1, 1000000m - 185000m),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 1, (1000000m - 185000m) + 185000m + 192100m),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -10, 10, (1000000m - 185000m) + 185000m + 192100m),
@@ -1324,13 +1429,13 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -10, (1000000m - 102500m) + 102500m + 102500m),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 10, -20, (1000000m - 102500m) + 102500m + 102500m),
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, -1, 1000000m - 102500m),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 1, (1000000m - 102500m) + 102500m + 102500m),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 10, (1000000m - 102500m) + 102500m + 102500m),
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 20, (1000000m - 102500m) + 102500m + 102500m),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 1, (1000000m - 102500m) + 102500m + 102520m),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 10, (1000000m - 102500m) + 102500m + 102520m),
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -10, 20, (1000000m - 102500m) + 102500m + 102520m),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, 1, 1000000m - 102500m),
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -1, (1000000m - 102500m) + 102500m + 102500m),
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -10, (1000000m - 102500m) + 102500m + 102500m),
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -20, (1000000m - 102500m) + 102500m + 102500m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -1, (1000000m - 102500m) + 102500m + 102520m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -10, (1000000m - 102500m) + 102500m + 102520m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 10, -20, (1000000m - 102500m) + 102500m + 102520m),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -1, 1000000m - 102500m),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 1, (1000000m - 102500m) + 102500m + 102500m),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 10, (1000000m - 102500m) + 102500m + 102500m),
@@ -1340,21 +1445,21 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -20, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, -1, 1000000m - 0),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 1, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 10, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 20, (1000000m - 0) + 0 + 0),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 1, (1000000m - 0) + 0 + 12000m),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 10, (1000000m - 0) + 0 + 12000m),
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -10, 20, (1000000m - 0) + 0 + 12000m),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, 1, 1000000m - 0),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -1, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -10, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -20, (1000000m - 0) + 0 + 0),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -1, (1000000m - 0) + 0 + 10m),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -10, (1000000m - 0) + 0 + 10m),
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 10, -20, (1000000m - 0) + 0 + 10m),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, -1, 1000000m - 10000m),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 1, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 10, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -10, 20, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, 1, 1000000m - 0),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -1, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -10, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -20, (1000000m - 0) + 0 + 0),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -1, (1000000m - 0) + 0 + 12000m),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -10, (1000000m - 0) + 0 + 12000m),
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 10, -20, (1000000m - 0) + 0 + 12000m),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, -1, 1000000m - 10000m),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 1, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -10, 10, (1000000m - 10000m) + 10000m + 10000m),
@@ -1364,13 +1469,13 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -10, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 10, -20, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, -1, 1000000m - 0),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 1, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 10, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 20, (1000000m - 0) + 0 + 0),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 1, (1000000m - 0) + 0 + 10m),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 10, (1000000m - 0) + 0 + 10m),
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -10, 20, (1000000m - 0) + 0 + 10m),
             new TestCaseData(OptionStrategyDefinitions.Straddle, 10, 1, 1000000m - 0m),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -1, (1000000m - 0m) + 0m + 0m),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -10, (1000000m - 0m) + 0m + 0m),
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -20, (1000000m - 0m) + 0m + 0m),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -1, (1000000m - 0m) + 0m + 112020m),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -10, (1000000m - 0m) + 0m + 112020m),
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 10, -20, (1000000m - 0m) + 0m + 112020m),
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, -1, 1000000m - 194020m),
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 1, (1000000m - 194020m) + 194020m + 194020m),
             new TestCaseData(OptionStrategyDefinitions.Straddle, -10, 10, (1000000m - 194020m) + 194020m + 194020m),
@@ -1380,29 +1485,29 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, -10, (1000000m - 194020m) + 194020m + 194020m),
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 10, -20, (1000000m - 194020m) + 194020m + 194020m),
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, -1, 1000000m - 0m),
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, 1, (1000000m - 0m) + 0m + 0m),
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, 10, (1000000m - 0m) + 0m + 0m),
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, 20, (1000000m - 0m) + 0m + 0m),
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, 1, (1000000m - 0m) + 0m + 112020m),
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, 10, (1000000m - 0m) + 0m + 112020m),
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -10, 20, (1000000m - 0m) + 0m + 112020m),
             new TestCaseData(OptionStrategyDefinitions.Strangle, 10, 1, 1000000m - 0m),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -1, (1000000m - 0m) + 0m + 0m),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -10, (1000000m - 0m) + 0m + 0m),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -20, (1000000m - 0m) + 0m + 0m),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -1, 1000000m - 184020m),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 1, (1000000m - 184020m) + 184020m + 184020m),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 10, (1000000m - 184020m) + 184020m + 184020m),
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 20, (1000000m - 184020m) + 184020m + 184020m),
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, 1, 1000000m - 184020m),
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -1, (1000000m - 184020m) + 184020m + 184020m),
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -10, (1000000m - 184020m) + 184020m + 184020m),
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -20, (1000000m - 184020m) + 184020m + 184020m),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -1, (1000000m - 0m) + 0m + 100020m),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -10, (1000000m - 0m) + 0m + 100020m),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 10, -20, (1000000m - 0m) + 0m + 100020m),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, -1, 1000000m - 182020m),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 1, (1000000m - 182020m) + 182020m + 182020m),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 10, (1000000m - 182020m) + 182020m + 182020m),
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -10, 20, (1000000m - 182020m) + 182020m + 182020m),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, 1, 1000000m - 182020m),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -1, (1000000m - 182020m) + 182020m + 182020m),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -10, (1000000m - 182020m) + 182020m + 182020m),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 10, -20, (1000000m - 182020m) + 182020m + 182020m),
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, -1, 1000000m - 0m),
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, 1, (1000000m - 0m) + 0m + 0m),
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, 10, (1000000m - 0m) + 0m + 0m),
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, 20, (1000000m - 0m) + 0m + 0m),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, 1, (1000000m - 0m) + 0m + 100020m),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, 10, (1000000m - 0m) + 0m + 100020m),
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -10, 20, (1000000m - 0m) + 0m + 100020m),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, 1, 1000000m - 0m),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -1, (1000000m - 0m) + 0m + 0),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -10, (1000000m - 0m) + 0m + 0),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -20, (1000000m - 0m) + 0m + 0),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -1, (1000000m - 0m) + 0m + 4000m),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -10, (1000000m - 0m) + 0m + 4000m),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 10, -20, (1000000m - 0m) + 0m + 4000m),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, -1, 1000000m - 10000m),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 1, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -10, 10, (1000000m - 10000m) + 10000m + 10000m),
@@ -1412,13 +1517,13 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -10, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 10, -20, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, -1, 1000000m - 0),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 1, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 10, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 20, (1000000m - 0) + 0 + 0),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 1, (1000000m - 0) + 0 + 4000m),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 10, (1000000m - 0) + 0 + 4000m),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -10, 20, (1000000m - 0) + 0 + 4000m),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, 1, 1000000m - 0),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -1, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -10, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -20, (1000000m - 0) + 0 + 0),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -1, (1000000m - 0) + 0 + 10m),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -10, (1000000m - 0) + 0 + 10m),
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 10, -20, (1000000m - 0) + 0 + 10m),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, -1, 1000000m - 10000m),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 1, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -10, 10, (1000000m - 10000m) + 10000m + 10000m),
@@ -1428,13 +1533,13 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -10, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 10, -20, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, -1, 1000000m - 0),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 1, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 10, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 20, (1000000m - 0) + 0 + 0),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 1, (1000000m - 0) + 0 + 10m),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 10, (1000000m - 0) + 0 + 10m),
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -10, 20, (1000000m - 0) + 0 + 10m),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, 1, 1000000m - 0),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -1, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -10, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -20, (1000000m - 0) + 0 + 0),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -1, (1000000m - 0) + 0 + 2000m),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -10, (1000000m - 0) + 0 + 2000m),
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 10, -20, (1000000m - 0) + 0 + 2000m),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, -1, 1000000m - 194000m),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 1, (1000000m - 194000m) + 194000m + 194000m),
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -10, 10, (1000000m - 194000m) + 194000m + 194000m),
@@ -1444,13 +1549,13 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, -10, (1000000m - 194000m) + 194000m + 194000m),
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 10, -20, (1000000m - 194000m) + 194000m + 194000m),
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, -1, 1000000m - 0),
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, 1, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, 10, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, 20, (1000000m - 0) + 0 + 0),
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, 1, (1000000m - 0) + 0 + 2000m),
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, 10, (1000000m - 0) + 0 + 2000m),
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -10, 20, (1000000m - 0) + 0 + 2000m),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, 1, 1000000m - 0),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -1, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -10, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -20, (1000000m - 0) + 0 + 0),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -1, (1000000m - 0) + 0 + 10m),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -10, (1000000m - 0) + 0 + 10m),
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 10, -20, (1000000m - 0) + 0 + 10m),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, -1, 1000000m - 30020m),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 1, (1000000m - 30020m) + 30020m + 30020m),
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -10, 10, (1000000m - 30020m) + 30020m + 30020m),
@@ -1460,17 +1565,17 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, -10, (1000000m - 30020m) + 30020m + 30020m),
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 10, -20, (1000000m - 30020m) + 30020m + 30020m),
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, -1, 1000000m - 0),
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, 1, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, 10, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, 20, (1000000m - 0) + 0 + 0),
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, 1, (1000000m - 0) + 0 + 10m),
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, 10, (1000000m - 0) + 0 + 10m),
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -10, 20, (1000000m - 0) + 0 + 10m),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, 1, 1000000m - 10000m),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -1, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -10, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 10, -20, (1000000m - 10000m) + 10000m + 10000m),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -1, 1000000m - 0),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 1, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 10, (1000000m - 0) + 0 + 0),
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 20, (1000000m - 0) + 0 + 0),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 1, (1000000m - 0) + 0 + 10010m),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 10, (1000000m - 0) + 0 + 10010m),
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 20, (1000000m - 0) + 0 + 10010m),
         };
 
         [TestCaseSource(nameof(PositionGroupBuyingPowerTestCases))]
@@ -1703,49 +1808,32 @@ namespace QuantConnect.Tests.Common.Securities
             var initialMargin = _portfolio.MarginRemaining;
             var initialPositionGroup = SetUpOptionStrategy(optionStrategyDefinition, initialPositionQuantity);
 
-            var positionGroup = _portfolio.Positions.ResolvePositionGroups(new PositionCollection(
-                initialPositionGroup.Positions.Select(position => new Position(position.Symbol,
-                    position.Quantity / initialPositionQuantity * newGroupQuantity, position.UnitQuantity)))).Single();
-
             var finalQuantity = initialPositionQuantity + newGroupQuantity;
+            var sign = Math.Sign(finalQuantity) == Math.Sign(initialPositionQuantity) ? 1 : -1;
+            var finalPositionGroup = finalQuantity != 0
+                ? initialPositionGroup.WithQuantity(sign * Math.Abs(finalQuantity), _portfolio.Positions)
+                : PositionGroup.Empty(null);
 
-            var buyingPowerImpact = positionGroup.BuyingPowerModel.GetReservedBuyingPowerImpact(new ReservedBuyingPowerImpactParameters(_portfolio,
-                positionGroup, GetPositionGroupOrders(initialPositionGroup, initialPositionQuantity, newGroupQuantity)));
+            var buyingPowerImpact = initialPositionGroup.BuyingPowerModel.GetReservedBuyingPowerImpact(new ReservedBuyingPowerImpactParameters(_portfolio,
+                finalPositionGroup, GetPositionGroupOrders(initialPositionGroup, initialPositionQuantity, newGroupQuantity)));
 
-            var initialUsedMargin = initialPositionGroup.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(
+            var usedMargin = initialPositionGroup.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(
                 new ReservedBuyingPowerForPositionGroupParameters(_portfolio, initialPositionGroup)).AbsoluteUsedBuyingPower;
-            Log.Debug($"Initial used margin: {initialUsedMargin}");
-            Log.Debug($"Final quantity: {finalQuantity}");
 
             foreach (var contemplatedChangePosition in buyingPowerImpact.ContemplatedChanges)
             {
-                var position = positionGroup.SingleOrDefault(p => contemplatedChangePosition.Symbol == p.Symbol);
+                var position = finalPositionGroup.SingleOrDefault(p => contemplatedChangePosition.Symbol == p.Symbol);
                 Assert.IsNotNull(position);
                 Assert.AreEqual(position.Quantity, contemplatedChangePosition.Quantity);
             }
 
-            Assert.That(buyingPowerImpact.Current, Is.EqualTo(initialUsedMargin).Within(1e-18));
-
-            // Either initial and final positions are in the same side or we are liquidating
-            if (Math.Sign(finalQuantity) == Math.Sign(initialPositionQuantity) || finalQuantity == 0)
-            {
-                var expectedDelta = Math.Abs(newGroupQuantity * initialUsedMargin / initialPositionQuantity)
-                    * (Math.Abs(finalQuantity) < Math.Abs(initialPositionQuantity) ? -1 : +1);
-                Assert.That(buyingPowerImpact.Delta, Is.EqualTo(expectedDelta).Within(1e-18));
-                Assert.That(buyingPowerImpact.Contemplated, Is.EqualTo(initialUsedMargin + expectedDelta).Within(1e-18));
-            }
-            // Switching position side
-            else
-            {
-                var finalPositionGroup = _portfolio.Positions.ResolvePositionGroups(new PositionCollection(
-                    initialPositionGroup.Positions.Select(position =>
-                        position.Combine(positionGroup.Positions.Single(x => x.Symbol == position.Symbol))))).Single();
-                var finalPositionGroupMargin = finalPositionGroup.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(
-                    new ReservedBuyingPowerForPositionGroupParameters(_portfolio, finalPositionGroup)).AbsoluteUsedBuyingPower;
-                var expectedDelta = finalPositionGroupMargin - initialUsedMargin;
-                Assert.That(buyingPowerImpact.Delta, Is.EqualTo(expectedDelta).Within(1e-18));
-                Assert.That(buyingPowerImpact.Contemplated, Is.EqualTo(finalPositionGroupMargin).Within(1e-18));
-            }
+            var newGroupInitialMarginRequirement = finalQuantity != 0
+                ? finalPositionGroup.BuyingPowerModel.GetInitialMarginRequirement(_portfolio, finalPositionGroup)
+                : 0m;
+            var expectedDelta = newGroupInitialMarginRequirement - usedMargin;
+            Assert.That(buyingPowerImpact.Delta, Is.EqualTo(expectedDelta).Within(1e-18));
+            Assert.That(buyingPowerImpact.Current, Is.EqualTo(usedMargin).Within(1e-18));
+            Assert.That(buyingPowerImpact.Contemplated, Is.EqualTo(newGroupInitialMarginRequirement).Within(1e-18));
         }
 
         private List<Order> GetStrategyOrders(decimal quantity)
@@ -1846,7 +1934,7 @@ namespace QuantConnect.Tests.Common.Securities
             var spyMay19_300Call = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Call, 300, may192023));
             spyMay19_300Call.SetMarketPrice(new Tick { Value = 112m });
             var spyMay19_310Call = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Call, 310, may192023));
-            spyMay19_310Call.SetMarketPrice(new Tick { Value = 102m });
+            spyMay19_310Call.SetMarketPrice(new Tick { Value = 100m });
             var spyMay19_320Call = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Call, 320, may192023));
             spyMay19_320Call.SetMarketPrice(new Tick { Value = 92m });
             var spyMay19_330Call = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Call, 330, may192023));
@@ -1857,16 +1945,16 @@ namespace QuantConnect.Tests.Common.Securities
             var spyMay17_400Call = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Call, 400, may172023));
             spyMay17_400Call.SetMarketPrice(new Tick { Value = 28m });
             var spyMay17_300Call = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Call, 300, may172023));
-            spyMay17_300Call.SetMarketPrice(new Tick { Value = 112m });
+            spyMay17_300Call.SetMarketPrice(new Tick { Value = 110m });
             var spyMay17_500Call = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Call, 500, may172023));
             spyMay17_500Call.SetMarketPrice(new Tick { Value = 0.04m });
 
             var spyMay19_300Put = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Put, 300, may192023));
             spyMay19_300Put.SetMarketPrice(new Tick { Value = 0.02m });
             var spyMay19_310Put = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Put, 310, may192023));
-            spyMay19_310Put.SetMarketPrice(new Tick { Value = 0.02m });
+            spyMay19_310Put.SetMarketPrice(new Tick { Value = 0.03m });
             var spyMay19_320Put = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Put, 320, may192023));
-            spyMay19_320Put.SetMarketPrice(new Tick { Value = 0.03m });
+            spyMay19_320Put.SetMarketPrice(new Tick { Value = 0.05m });
             var spyMay17_300Put = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Put, 300, may172023));
             spyMay17_300Put.SetMarketPrice(new Tick { Value = 0.01m });
 
@@ -1880,7 +1968,7 @@ namespace QuantConnect.Tests.Common.Securities
                 _equity.Holdings.SetHoldings(_equity.Price, initialHoldingsQuantity * _callOption.ContractMultiplier);
 
                 var optionContract = spyMay19_300Call;
-                if(strike.HasValue)
+                if (strike.HasValue)
                 {
                     switch (strike.Value)
                     {

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -26,7 +26,6 @@ using QuantConnect.Securities;
 using QuantConnect.Securities.Option;
 using QuantConnect.Securities.Option.StrategyMatcher;
 using QuantConnect.Securities.Positions;
-using QuantConnect.Logging;
 using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Common.Securities
@@ -66,321 +65,321 @@ namespace QuantConnect.Tests.Common.Securities
         // option strategy definition, initial quantity, order quantity, expected result
         private static readonly TestCaseData[] HasSufficientBuyingPowerForOrderTestCases = new[]
         {
-            // Initial margin requirement (with premium) for CoveredCall with quantities 1 and -1 are 19210 and 21450 respectively
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, 1000000 / (19210 + 0), true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, 1000000 / (19210 + 0) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -(1000000 / 21450), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -(1000000 / 21450 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, (1000000 / 19210) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, (1000000 / 19210 + 1) - 20, false), // 20 to max long + 1
+            // Initial margin requirement|premium for CoveredCall with quantities 1 and -1 are 19210|0 and 10250|11200 respectively
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, (1000000 - 0 * 19210) / (19210 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, (1000000 - 0 * 19210) / (19210 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -(1000000 - -0 * 10250) / (10250 + 11200), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 0, -(1000000 - -0 * 10250) / (10250 + 11200) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, (1000000 - 20 * 19210) / (19210 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, (1000000 - 20 * 19210) / (19210 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -(1000000 / 21450) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -(1000000 / 21450 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, (1000000 / 19210) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, (1000000 / 19210 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -(1000000 - -20 * 10250) / (10250 + 11200), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, 20, -(1000000 - -20 * 10250) / (10250 + 11200) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, (1000000 - -20 * 19210) / (19210 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, (1000000 - -20 * 19210) / (19210 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, -(1000000 / 21450) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, -(1000000 / 21450 + 1) - -20, false),  // -20 to max short + 1
-            // Initial margin requirement (with premium) for ProtectiveCall with quantities 1 and -1 are 21450 and 19210 respectively
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, 1000000 / 21450, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, 1000000 / 21450 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, -(1000000 / 19210), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, -(1000000 / 19210 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, (1000000 / 21450) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, (1000000 / 21450 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, -(1000000 - 20 * 10250) / (10250 + 11200), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredCall, -20, -(1000000 - 20 * 10250) / (10250 + 11200) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for ProtectiveCall with quantities 1 and -1 are 10250|11200 and 19210|0 respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, (1000000 - 0 * 10250) / (10250 + 11200), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, (1000000 - 0 * 10250) / (10250 + 11200) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, -(1000000 - -0 * 19210) / (19210 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 0, -(1000000 - -0 * 19210) / (19210 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, (1000000 - 20 * 10250) / (10250 + 11200), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, (1000000 - 20 * 10250) / (10250 + 11200) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -(1000000 / 19210) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -(1000000 / 19210 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, (1000000 / 21450) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, (1000000 / 21450 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -(1000000 - -20 * 19210) / (19210 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, 20, -(1000000 - -20 * 19210) / (19210 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, (1000000 - -20 * 10250) / (10250 + 11200), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, (1000000 - -20 * 10250) / (10250 + 11200) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, -(1000000 / 19210) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, -(1000000 / 19210 + 1) - -20, false),  // -20 to max short + 1
-            // Initial margin requirement (with premium) for CoveredPut with quantities 1 and -1 are 10250 and 10252 respectively
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, 1000000 / 10250, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, 1000000 / 10250 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -(1000000 / 10252), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -(1000000 / 10252 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, (1000000 / 10250) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, (1000000 / 10250 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, -(1000000 - 20 * 19210) / (19210 + 0), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCall, -20, -(1000000 - 20 * 19210) / (19210 + 0) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for CoveredPut with quantities 1 and -1 are 10250|0 and 10250|2 respectively
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, (1000000 - 0 * 10250) / (10250 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, (1000000 - 0 * 10250) / (10250 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -(1000000 - 0 * 10250) / (10250 + 2), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 0, -(1000000 - 0 * 10250) / (10250 + 2) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, (1000000 - 20 * 10250) / (10250 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, (1000000 - 20 * 10250) / (10250 + 0) + 1, false), // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -(1000000 / 10252) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -(1000000 / 10252 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, (1000000 / 10250) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, (1000000 / 10250 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -(1000000 - -20 * 10250) / (10250 + 2), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, 20, -(1000000 - -20 * 10250) / (10250 + 2) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, (1000000 - -20 * 10250) / (10250 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, (1000000 - -20 * 10250) / (10250 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -(1000000 / 10252) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -(1000000 / 10252 + 1) - -20, false),  // -20 to max short + 1
-            // Initial margin requirement (with premium) for ProtectivePut with quantities 1 and -1 are 10252 and 10250 respectively
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, 1000000 / 10252, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, 1000000 / 10252 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, -(1000000 / 10250), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, -(1000000 / 10250 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, (1000000 / 10252) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, (1000000 / 10252 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -(1000000 - 20 * 10250) / (10250 + 2), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.CoveredPut, -20, -(1000000 - 20 * 10250) / (10250 + 2) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for ProtectivePut with quantities 1 and -1 are 10250|2 and 10250|0 respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, (1000000 - 0 * 10250) / (10250 + 2), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, (1000000 - 0 * 10250) / (10250 + 2) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, -(1000000 - -0 * 10250) / (10250 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 0, -(1000000 - -0 * 10250) / (10250 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, (1000000 - 20 * 10250) / (10250 + 2), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, (1000000 - 20 * 10250) / (10250 + 2) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -(1000000 / 10250) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -(1000000 / 10250 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, (1000000 / 10252) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, (1000000 / 10252 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -(1000000 - -20 * 10250) / (10250 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 20, -(1000000 - -20 * 10250) / (10250 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, (1000000 - -20 * 10250) / (10250 + 2), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, (1000000 - -20 * 10250) / (10250 + 2) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, -(1000000 / 10250) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, -(1000000 / 10250 + 1) - -20, false),  // -20 to max short + 1
-            // Initial margin requirement (with premium) for BearCallSpread with quantities 1 and -1 are 1000 and 1200 respectively
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, 1000000 / 1000, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, 1000000 / 1000 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -(1000000 / 1200), true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -(1000000 / 1200 + 1), false),    // 0 to greater short
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, (1000000 / 1000) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, (1000000 / 1000 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, -(1000000 - 20 * 10250) / (10250 + 0), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, -(1000000 - 20 * 10250) / (10250 + 0) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for BearCallSpread with quantities 1 and -1 are 1000|0 and 0|1200 respectively
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, (1000000 - 0 * 1000) / (1000 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, (1000000 - 0 * 1000) / (1000 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -(1000000 - -0 * 0) / (0 + 1200), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, -(1000000 - -0 * 0) / (0 + 1200) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, (1000000 - 20 * 1000) / (1000 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, (1000000 - 20 * 1000) / (1000 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -(1000000 / 1200) - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -(1000000 / 1200 + 1) - 20, false),  // 20 to greater short
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, (1000000 / 1000) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, (1000000 / 1000 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -(1000000 - -20 * 0) / (0 + 1200), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 20, -(1000000 - -20 * 0) / (0 + 1200) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, (1000000 - -20 * 1000) / (1000 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, (1000000 - -20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, -(1000000 / 1200) - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, -(1000000 / 1200 + 1) - -20, false),  // -20 to greater short
-            // Initial margin requirement (with premium) for BearPutSpread with quantities 1 and -1 are 1 and 1000 respectively
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, 1000000 / 1, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, 1000000 / 1 + 1, false), // 0 to greater long
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, -(1000000 / 1000), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, -(1000000 / 1000 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, (1000000 / 1) - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, (1000000 / 1 + 1) - 20, false), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, -(1000000 - 20 * 0) / (0 + 1200), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -20, -(1000000 - 20 * 0) / (0 + 1200) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for BearPutSpread with quantities 1 and -1 are 0|1 and 1000|0 respectively
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, (1000000 - 0 * 0) / (0 + 1), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, (1000000 - 0 * 0) / (0 + 1) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, -(1000000 - -0 * 1000) / (1000 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 0, -(1000000 - -0 * 1000) / (1000 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, (1000000 - 20 * 0) / (0 + 1), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, (1000000 - 20 * 0) / (0 + 1) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -(1000000 / 1000) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -(1000000 / 1000 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, (1000000 / 1) - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, (1000000 / 1 + 1) - -20, false),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -(1000000 - -20 * 1000) / (1000 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 20, -(1000000 - -20 * 1000) / (1000 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, (1000000 - -20 * 0) / (0 + 1), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, (1000000 - -20 * 0) / (0 + 1) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, -(1000000 / 1000) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, -(1000000 / 1000 + 1) - -20, false),  // -20 to max short + 1
-            // Initial margin requirement (with premium) for BullCallSpread with quantities 1 and -1 are 1200 and 1000 respectively
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, 1000000 / 1200, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, 1000000 / 1200 + 1, false), // 0 to greater long
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, -(1000000 / 1000), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, -(1000000 / 1000 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, (1000000 / 1200) - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, (1000000 / 1200 + 1) - 20, false), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, -(1000000 - 20 * 1000) / (1000 + 0), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.BearPutSpread, -20, -(1000000 - 20 * 1000) / (1000 + 0) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for BullCallSpread with quantities 1 and -1 are 0|1200 and 1000|0 respectively
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, (1000000 - 0 * 0) / (0 + 1200), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, (1000000 - 0 * 0) / (0 + 1200) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, -(1000000 - -0 * 1000) / (1000 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 0, -(1000000 - -0 * 1000) / (1000 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, (1000000 - 20 * 0) / (0 + 1200), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, (1000000 - 20 * 0) / (0 + 1200) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -(1000000 / 1000) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -(1000000 / 1000 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, (1000000 / 1200) - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, (1000000 / 1200 + 1) - -20, false),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -(1000000 - -20 * 1000) / (1000 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, 20, -(1000000 - -20 * 1000) / (1000 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, (1000000 - -20 * 0) / (0 + 1200), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, (1000000 - -20 * 0) / (0 + 1200) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, -(1000000 / 1000) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, -(1000000 / 1000 + 1) - -20, false),  // -20 to max short + 1
-            // Initial margin requirement (with premium) for BullPutSpread with quantities 1 and -1 are 1000 and 1 respectively
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, 1000000 / 1000, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, 1000000 / 1000 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, -(1000000 / 1), true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, -(1000000 / 1 + 1), false),    // 0 to greater short
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, (1000000 / 1000) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, (1000000 / 1000 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, -(1000000 - 20 * 1000) / (1000 + 0), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.BullCallSpread, -20, -(1000000 - 20 * 1000) / (1000 + 0) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for BullPutSpread with quantities 1 and -1 are 1000|0 and 0|1 respectively
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, (1000000 - 0 * 1000) / (1000 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, (1000000 - 0 * 1000) / (1000 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, -(1000000 - -0 * 0) / (0 + 1), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 0, -(1000000 - -0 * 0) / (0 + 1) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, (1000000 - 20 * 1000) / (1000 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, (1000000 - 20 * 1000) / (1000 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -(1000000 / 1) - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -(1000000 / 1 + 1) - 20, false),  // 20 to greater short
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, (1000000 / 1000) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, (1000000 / 1000 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -(1000000 - -20 * 0) / (0 + 1), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, 20, -(1000000 - -20 * 0) / (0 + 1) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, (1000000 - -20 * 1000) / (1000 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, (1000000 - -20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, -(1000000 / 1) - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, -(1000000 / 1 + 1) - -20, false),  // -20 to greater short
-            // Initial margin requirement (with premium) for Straddle with quantities 1 and -1 are 11202 and 19402 respectively
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, 1000000 / 11202, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, 1000000 / 11202 + 1, false), // 0 to greater long
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, -(1000000 / 19402), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, -(1000000 / 19402 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, (1000000 / 11202) - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, (1000000 / 11202 + 1) - 20, false), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, -(1000000 - 20 * 0) / (0 + 1), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.BullPutSpread, -20, -(1000000 - 20 * 0) / (0 + 1) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for Straddle with quantities 1 and -1 are 0|11202 and 19402|0 respectively
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, (1000000 - 0 * 0) / (0 + 11202), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, (1000000 - 0 * 0) / (0 + 11202) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, -(1000000 - -0 * 19402) / (19402 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 0, -(1000000 - -0 * 19402) / (19402 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, (1000000 - 20 * 0) / (0 + 11202), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, (1000000 - 20 * 0) / (0 + 11202) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -(1000000 / 19402) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -(1000000 / 19402 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, (1000000 / 11202) - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, (1000000 / 11202 + 1) - -20, false),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -(1000000 - -20 * 19402) / (19402 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.Straddle, 20, -(1000000 - -20 * 19402) / (19402 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, (1000000 - -20 * 0) / (0 + 11202), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, (1000000 - -20 * 0) / (0 + 11202) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.Straddle, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, -(1000000 / 19402) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, -(1000000 / 19402 + 1) - -20, false),  // -20 to max short + 1
-            // Initial margin requirement (with premium) for ShortStraddle with quantities 1 and -1 are 19402 and 11202 respectively
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, 1000000 / 19402, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, 1000000 / 19402 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, -(1000000 / 11202), true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, -(1000000 / 11202 + 1), false),    // 0 to greater short
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, (1000000 / 19402) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, (1000000 / 19402 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, -(1000000 - 20 * 19402) / (19402 + 0), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.Straddle, -20, -(1000000 - 20 * 19402) / (19402 + 0) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for ShortStraddle with quantities 1 and -1 are 19402|0 and 0|11202 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, (1000000 - 0 * 19402) / (19402 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, (1000000 - 0 * 19402) / (19402 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, -(1000000 - -0 * 0) / (0 + 11202), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 0, -(1000000 - -0 * 0) / (0 + 11202) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, (1000000 - 20 * 19402) / (19402 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, (1000000 - 20 * 19402) / (19402 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -(1000000 / 11202) - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -(1000000 / 11202 + 1) - 20, false),  // 20 to greater short
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, (1000000 / 19402) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, (1000000 / 19402 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -(1000000 - -20 * 0) / (0 + 11202), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, 20, -(1000000 - -20 * 0) / (0 + 11202) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, (1000000 - -20 * 19402) / (19402 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, (1000000 - -20 * 19402) / (19402 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, -(1000000 / 11202) - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, -(1000000 / 11202 + 1) - -20, false),  // -20 to greater short
-            // Initial margin requirement (with premium) for Strangle with quantities 1 and -1 are 10002 and 18202 respectively
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, 1000000 / 10002, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, 1000000 / 10002 + 1, false), // 0 to greater long
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, -(1000000 / 18202), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, -(1000000 / 18202 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, (1000000 / 10002) - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, (1000000 / 10002 + 1) - 20, false), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, -(1000000 - 20 * 0) / (0 + 11202), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortStraddle, -20, -(1000000 - 20 * 0) / (0 + 11202) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for Strangle with quantities 1 and -1 are 0|10002 and 18202|0 respectively
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, (1000000 - 0 * 0) / (0 + 10002), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, (1000000 - 0 * 0) / (0 + 10002) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, -(1000000 - -0 * 18202) / (18202 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 0, -(1000000 - -0 * 18202) / (18202 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, (1000000 - 20 * 0) / (0 + 10002), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, (1000000 - 20 * 0) / (0 + 10002) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -(1000000 / 18202) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -(1000000 / 18202 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, (1000000 / 10002) - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, (1000000 / 10002 + 1) - -20, false),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -(1000000 - -20 * 18202) / (18202 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.Strangle, 20, -(1000000 - -20 * 18202) / (18202 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, (1000000 - -20 * 0) / (0 + 10002), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, (1000000 - -20 * 0) / (0 + 10002) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.Strangle, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, -(1000000 / 18202) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, -(1000000 / 18202 + 1) - -20, false),  // -20 to max short + 1
-            // Initial margin requirement (with premium) for ShortStrangle with quantities 1 and -1 are 18202 and 10002 respectively
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, 1000000 / 18202, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, 1000000 / 18202 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, -(1000000 / 11202), true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, -(1000000 / 10002 + 1), false),    // 0 to greater short
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, (1000000 / 18202) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, (1000000 / 18202 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, -(1000000 - 20 * 18202) / (18202 + 0), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.Strangle, -20, -(1000000 - 20 * 18202) / (18202 + 0) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for ShortStrangle with quantities 1 and -1 are 18202|0 and 0|10002 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, (1000000 - 0 * 18202) / (18202 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, (1000000 - 0 * 18202) / (18202 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, -(1000000 - -0 * 0) / (0 + 10002), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 0, -(1000000 - -0 * 0) / (0 + 10002) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, (1000000 - 20 * 18202) / (18202 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, (1000000 - 20 * 18202) / (18202 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -(1000000 / 10002) - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -(1000000 / 10002 + 1) - 20, false),  // 20 to greater short
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, (1000000 / 18202) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, (1000000 / 18202 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -(1000000 - -20 * 0) / (0 + 10002), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, 20, -(1000000 - -20 * 0) / (0 + 10002) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, (1000000 - -20 * 18202) / (18202 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, (1000000 - -20 * 18202) / (18202 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, -(1000000 / 10002) - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, -(1000000 / 10002 + 1) - -20, false),  // -20 to greater short
-            // Initial margin requirement (with premium) for ButterflyCall with quantities 1 and -1 are 400 and 1000 respectively
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, 1000000/ 400, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, 1000000/ 400 + 1, false), // 0 to greater long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, -(1000000 / 1000), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, -(1000000 / 1000 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, (1000000/ 400) - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, (1000000/ 400 + 1) - 20, false), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, -(1000000 - 20 * 0) / (0 + 10002), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortStrangle, -20, -(1000000 - 20 * 0) / (0 + 10002) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for ButterflyCall with quantities 1 and -1 are 0|400 and 1000|0 respectively
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, (1000000 - 0 * 0) / (0 + 400), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, (1000000 - 0 * 0) / (0 + 400) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, -(1000000 - -0 * 1000) / (1000 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 0, -(1000000 - -0 * 1000) / (1000 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, (1000000 - 20 * 0) / (0 + 400), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, (1000000 - 20 * 0) / (0 + 400) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -(1000000 / 1000) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -(1000000 / 1000 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, (1000000/ 400) - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, (1000000/ 400 + 1) - -20, false),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -(1000000 - -20 * 1000) / (1000 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, 20, -(1000000 - -20 * 1000) / (1000 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, (1000000 - -20 * 0) / (0 + 400), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, (1000000 - -20 * 0) / (0 + 400) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, -(1000000 / 1000) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, -(1000000 / 1000 + 1) - -20, false),  // -20 to max short + 1
-            // Initial margin requirement (with premium) for ShortButterflyCall with quantities 1 and -1 are 1000 and 0 respectively
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, 1000000 / 1000, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, 1000000 / 1000 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, -(1000000 / 10202), true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, -(1000000/ 400 + 1), false),    // 0 to greater short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, (1000000 / 1000) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, (1000000 / 1000 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, -(1000000 - 20 * 1000) / (1000 + 0), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ButterflyCall, -20, -(1000000 - 20 * 1000) / (1000 + 0) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for ShortButterflyCall with quantities 1 and -1 are 1000|0 and 0|400 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, (1000000 - 0 * 1000) / (1000 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, (1000000 - 0 * 1000) / (1000 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, -(1000000 - -0 * 0) / (0 + 400), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 0, -(1000000 - -0 * 0) / (0 + 400) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, (1000000 - 20 * 1000) / (1000 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, (1000000 - 20 * 1000) / (1000 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -(1000000/ 400) - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -(1000000/ 400 + 1) - 20, false),  // 20 to greater short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, (1000000 / 1000) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, (1000000 / 1000 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -(1000000 - -20 * 0) / (0 + 400), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, 20, -(1000000 - -20 * 0) / (0 + 400) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, (1000000 - -20 * 1000) / (1000 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, (1000000 - -20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, -(1000000/ 400) - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, -(1000000/ 400 + 1) - -20, false),  // -20 to greater short
-            // Initial margin requirement (with premium) for ButterflyPut with quantities 1 and -1 are 1 and 1000 respectively
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, 1000000 / 1, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, 1000000 / 1 + 1, false), // 0 to greater long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, -(1000000 / 1000), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, -(1000000 / 1000 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, (1000000 / 1) - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, (1000000 / 1 + 1) - 20, false), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, -(1000000 - 20 * 0) / (0 + 400), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyCall, -20, -(1000000 - 20 * 0) / (0 + 400) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for ButterflyPut with quantities 1 and -1 are 0|1 and 1000|0 respectively
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, (1000000 - 0 * 0) / (0 + 1), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, (1000000 - 0 * 0) / (0 + 1) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, -(1000000 - -0 * 1000) / (1000 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 0, -(1000000 - -0 * 1000) / (1000 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, (1000000 - 20 * 0) / (0 + 1), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, (1000000 - 20 * 0) / (0 + 1) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -(1000000 / 1000) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -(1000000 / 1000 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, (1000000 / 1) - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, (1000000 / 1 + 1) - -20, false),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -(1000000 - -20 * 1000) / (1000 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, 20, -(1000000 - -20 * 1000) / (1000 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, (1000000 - -20 * 0) / (0 + 1), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, (1000000 - -20 * 0) / (0 + 1) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, -(1000000 / 1000) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, -(1000000 / 1000 + 1) - -20, false),  // -20 to max short + 1
-            // Initial margin requirement (with premium) for ShortButterflyPut with quantities 1 and -1 are 1000 and 1 respectively
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, 1000000 / 1000, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, 1000000 / 1000 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, -(1000000 / 1), true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, -(1000000 / 1 + 1), false),    // 0 to greater short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, (1000000 / 1000) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, (1000000 / 1000 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, -(1000000 - 20 * 1000) / (1000 + 0), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ButterflyPut, -20, -(1000000 - 20 * 1000) / (1000 + 0) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for ShortButterflyPut with quantities 1 and -1 are 1000|0 and 0|1 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, (1000000 - 0 * 1000) / (1000 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, (1000000 - 0 * 1000) / (1000 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, -(1000000 - -0 * 0) / (0 + 1), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 0, -(1000000 - -0 * 0) / (0 + 1) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, (1000000 - 20 * 1000) / (1000 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, (1000000 - 20 * 1000) / (1000 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -(1000000 / 1) - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -(1000000 / 1 + 1) - 20, false),  // 20 to greater short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, (1000000 / 1000) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, (1000000 / 1000 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -(1000000 - -20 * 0) / (0 + 1), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, 20, -(1000000 - -20 * 0) / (0 + 1) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, (1000000 - -20 * 1000) / (1000 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, (1000000 - -20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, -(1000000 / 1) - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, -(1000000 / 1 + 1) - -20, false),  // -20 to greater short
-            // Initial margin requirement (with premium) for CallCalendarSpread with quantities 1 and -1 are 200 and 19400 respectively
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, 1000000 / 200, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, 1000000 / 200 + 1, false), // 0 to greater long
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, -(1000000 / 19400), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, -(1000000 / 19400 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, (1000000 / 200) - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, (1000000 / 200 + 1) - 20, false), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, -(1000000 - 20 * 0) / (0 + 1), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortButterflyPut, -20, -(1000000 - 20 * 0) / (0 + 1) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for CallCalendarSpread with quantities 1 and -1 are 0|200 and 19400|0 respectively
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, (1000000 - 0 * 0) / (0 + 200), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, (1000000 - 0 * 0) / (0 + 200) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, -(1000000 - -0 * 19400) / (19400 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 0, -(1000000 - -0 * 19400) / (19400 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, (1000000 - 20 * 0) / (0 + 200), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, (1000000 - 20 * 0) / (0 + 200) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -(1000000 / 19400) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -(1000000 / 19400 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, (1000000 / 200) - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, (1000000 / 200 + 1) - -20, false),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -(1000000 - -20 * 19400) / (19400 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, 20, -(1000000 - -20 * 19400) / (19400 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, (1000000 - -20 * 0) / (0 + 200), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, (1000000 - -20 * 0) / (0 + 200) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, -(1000000 / 19400) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, -(1000000 / 19400 + 1) - -20, false),  // -20 to max short + 1
-            // Initial margin requirement (with premium) for ShortCallCalendarSpread with quantities 1 and -1 are 19400 and 400 respectively
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, 1000000 / 19400, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, 1000000 / 19400 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, -(1000000 / 200), true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, -(1000000 / 200 + 1), false),    // 0 to greater short
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, (1000000 / 19400) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, (1000000 / 19400 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, -(1000000 - 20 * 19400) / (19400 + 0), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.CallCalendarSpread, -20, -(1000000 - 20 * 19400) / (19400 + 0) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for ShortCallCalendarSpread with quantities 1 and -1 are 19400|0 and 0|200 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, (1000000 - 0 * 19400) / (19400 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, (1000000 - 0 * 19400) / (19400 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, -(1000000 - -0 * 0) / (0 + 200), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 0, -(1000000 - -0 * 0) / (0 + 200) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, (1000000 - 20 * 19400) / (19400 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, (1000000 - 20 * 19400) / (19400 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -(1000000 / 200) - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -(1000000 / 200 + 1) - 20, false),  // 20 to greater short
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, (1000000 / 19400) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, (1000000 / 19400 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -(1000000 - -20 * 0) / (0 + 200), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, 20, -(1000000 - -20 * 0) / (0 + 200) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, (1000000 - -20 * 19400) / (19400 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, (1000000 - -20 * 19400) / (19400 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, -(1000000 / 200) - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, -(1000000 / 200 + 1) - -20, false),  // -20 to greater short
-            // Initial margin requirement (with premium) for PutCalendarSpread with quantities 1 and -1 are 1 and 3002 respectively
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, 1000000 / 1, true), // 0 to long
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, 1000000 / 1 + 1, false), // 0 to greater long
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, -(1000000 / 3002), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, -(1000000 / 3002 + 1), false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, (1000000 / 1) - 20, true),    // 20 to long
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, (1000000 / 1 + 1) - 20, false), // 20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, -(1000000 - 20 * 0) / (0 + 200), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortCallCalendarSpread, -20, -(1000000 - 20 * 0) / (0 + 200) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for PutCalendarSpread with quantities 1 and -1 are 0|1 and 3002|0 respectively
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, (1000000 - 0 * 0) / (0 + 1), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, (1000000 - 0 * 0) / (0 + 1) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, -(1000000 - -0 * 3002) / (3002 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 0, -(1000000 - -0 * 3002) / (3002 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, (1000000 - 20 * 0) / (0 + 1), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, (1000000 - 20 * 0) / (0 + 1) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -(1000000 / 3002) - 20, true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -(1000000 / 3002 + 1) - 20, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, (1000000 / 1) - -20, true),   // -20 to long
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, (1000000 / 1 + 1) - -20, false),   // -20 to greater long
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -(1000000 - -20 * 3002) / (3002 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, 20, -(1000000 - -20 * 3002) / (3002 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, (1000000 - -20 * 0) / (0 + 1), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, (1000000 - -20 * 0) / (0 + 1) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, -(1000000 / 3002) - -20, true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, -(1000000 / 3002 + 1) - -20, false),  // -20 to max short + 1
-            // Initial margin requirement (with premium) for ShortPutCalendarSpread with quantities 1 and -1 are 3002 and 1 respectively
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, 1000000 / 3002, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, 1000000 / 3002 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, -(1000000 / 1), true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, -(1000000 / 1 + 1), false),    // 0 to greater short
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, (1000000 / 3002) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, (1000000 / 3002 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, -(1000000 - 20 * 3002) / (3002 + 0), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.PutCalendarSpread, -20, -(1000000 - 20 * 3002) / (3002 + 0) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for ShortPutCalendarSpread with quantities 1 and -1 are 3002|0 and 0|1 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, (1000000 - 0 * 3002) / (3002 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, (1000000 - 0 * 3002) / (3002 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, -(1000000 - -0 * 0) / (0 + 1), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 0, -(1000000 - -0 * 0) / (0 + 1) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, (1000000 - 20 * 3002) / (3002 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, (1000000 - 20 * 3002) / (3002 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -(1000000 / 1) - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -(1000000 / 1 + 1) - 20, false),  // 20 to greater short
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, (1000000 / 3002) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, (1000000 / 3002 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -(1000000 - -20 * 0) / (0 + 1), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, 20, -(1000000 - -20 * 0) / (0 + 1) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, (1000000 - -20 * 3002) / (3002 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, (1000000 - -20 * 3002) / (3002 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, -(1000000 / 1) - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, -(1000000 / 1 + 1) - -20, false),  // -20 to greater short
-            // Initial margin requirement (with premium) for IronCondor with quantities 1 and -1 are 1000 and 1001 respectively
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, 1000000 / 1000, true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, 1000000 / 1000 + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, -(1000000 / 1001), true), // 0 to short
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, -(1000000 / 1001 + 1), false),    // 0 to greater short
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, (1000000 / 1000) - 20, true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, (1000000 / 1000 + 1) - 20, false), // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, -(1000000 - 20 * 0) / (0 + 1), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -20, -(1000000 - 20 * 0) / (0 + 1) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for IronCondor with quantities 1 and -1 are 1000|0 and 0|1001 respectively
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, (1000000 - 0 * 1000) / (1000 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, (1000000 - 0 * 1000) / (1000 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, -(1000000 - -0 * 0) / (0 + 1001), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 0, -(1000000 - -0 * 0) / (0 + 1001) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, (1000000 - 20 * 1000) / (1000 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, (1000000 - 20 * 1000) / (1000 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -(1000000 / 1001) - 20, true), // 20 to short
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -(1000000 / 1001 + 1) - 20, false),  // 20 to greater short
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, (1000000 / 1000) - -20, true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, (1000000 / 1000 + 1) - -20, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -(1000000 - -20 * 0) / (0 + 1001), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, 20, -(1000000 - -20 * 0) / (0 + 1001) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, (1000000 - -20 * 1000) / (1000 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, (1000000 - -20 * 1000) / (1000 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, -(1000000 / 1001) - -20, true),    // -20 to short
-            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, -(1000000 / 1001 + 1) - -20, false),  // -20 to greater short
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, -(1000000 - 20 * 0) / (0 + 1001), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, -(1000000 - 20 * 0) / (0 + 1001) - 1, false),  // -20 to max short + 1
         };
 
         [TestCaseSource(nameof(HasSufficientBuyingPowerForOrderTestCases))]
@@ -398,96 +397,6 @@ namespace QuantConnect.Tests.Common.Securities
                 new HasSufficientPositionGroupBuyingPowerForOrderParameters(_portfolio, ordersPositionGroup, orders));
 
             Assert.AreEqual(expectedResult, result.IsSufficient, result.Reason);
-        }
-
-        [Test]
-        public void HasSufficientBuyingPowerForStrategyOrder([Values] bool withInitialHoldings)
-        {
-            const decimal price = 1.2345m;
-            const decimal underlyingPrice = 200m;
-
-            _algorithm.SetCash(100000);
-            var initialMargin = _portfolio.MarginRemaining;
-
-            _equity.SetMarketPrice(new Tick { Value = underlyingPrice });
-            _callOption.SetMarketPrice(new Tick { Value = price });
-            _putOption.SetMarketPrice(new Tick { Value = price });
-
-            var initialHoldingsQuantity = withInitialHoldings ? -10 : 0;
-            _callOption.Holdings.SetHoldings(1.5m, initialHoldingsQuantity);
-            _putOption.Holdings.SetHoldings(1m, initialHoldingsQuantity);
-
-            var sufficientCaseConsidered = false;
-            var insufficientCaseConsidered = false;
-
-            // make sure these cases are considered:
-            // 1. liquidating part of the position
-            var partialLiquidationCaseConsidered = false;
-            // 2. liquidating the whole position
-            var fullLiquidationCaseConsidered = false;
-            // 3. shorting more, but with margin left
-            var furtherShortingWithMarginRemainingCaseConsidered = false;
-            // 4. shorting even more to the point margin is no longer enough
-            var furtherShortingWithNoMarginRemainingCaseConsidered = false;
-
-            for (var strategyQuantity = Math.Abs(initialHoldingsQuantity); strategyQuantity > -30; strategyQuantity--)
-            {
-                var orders = GetStrategyOrders(strategyQuantity);
-                Assert.IsTrue(_portfolio.Positions.TryCreatePositionGroup(orders, out var positionGroup));
-                var buyingPowerModel = positionGroup.BuyingPowerModel;
-
-                var maintenanceMargin = buyingPowerModel.GetMaintenanceMargin(
-                    new PositionGroupMaintenanceMarginParameters(_portfolio, positionGroup));
-
-                var hasSufficientBuyingPowerResult = buyingPowerModel.HasSufficientBuyingPowerForOrder(
-                    new HasSufficientPositionGroupBuyingPowerForOrderParameters(_portfolio, positionGroup, orders));
-
-                Assert.AreEqual(maintenanceMargin < initialMargin, hasSufficientBuyingPowerResult.IsSufficient);
-
-                if (hasSufficientBuyingPowerResult.IsSufficient)
-                {
-                    sufficientCaseConsidered = true;
-                }
-                else
-                {
-                    Assert.IsTrue(sufficientCaseConsidered, "All 'sufficient buying power' case should have been before the 'insufficient' ones");
-
-                    insufficientCaseConsidered = true;
-                }
-
-                var newPositionQuantity = positionGroup.Quantity;
-                if (newPositionQuantity == 0)
-                {
-                    fullLiquidationCaseConsidered = true;
-                }
-                else if (initialHoldingsQuantity + strategyQuantity < 0)
-                {
-                    if (newPositionQuantity < Math.Abs(initialHoldingsQuantity))
-                    {
-                        partialLiquidationCaseConsidered = true;
-                    }
-                    else if (hasSufficientBuyingPowerResult.IsSufficient)
-                    {
-                        furtherShortingWithMarginRemainingCaseConsidered = true;
-                    }
-                    else
-                    {
-                        furtherShortingWithNoMarginRemainingCaseConsidered = true;
-                    }
-                }
-            }
-
-            Assert.IsTrue(sufficientCaseConsidered, "The 'sufficient buying power' case was not considered");
-            Assert.IsTrue(insufficientCaseConsidered, "The 'insufficient buying power' case was not considered");
-
-            if (withInitialHoldings)
-            {
-                Assert.IsTrue(partialLiquidationCaseConsidered, "The 'partial liquidation' case was not considered");
-                Assert.IsTrue(fullLiquidationCaseConsidered, "The 'full liquidation' case was not considered");
-            }
-
-            Assert.IsTrue(furtherShortingWithMarginRemainingCaseConsidered, "The 'further shorting with margin remaining' case was not considered");
-            Assert.IsTrue(furtherShortingWithNoMarginRemainingCaseConsidered, "The 'further shorting with no margin remaining' case was not considered");
         }
 
         [Test]
@@ -603,10 +512,12 @@ namespace QuantConnect.Tests.Common.Securities
             //   -1: short will go towards long and vice-versa
 
             var positionGroup = SetUpOptionStrategy(OptionStrategyDefinitions.CoveredCall, initialHoldingsQuantity);
-            var currentUsedMargin = Math.Abs(positionGroup.BuyingPowerModel.GetInitialMarginRequirement(_portfolio, positionGroup));
+            var currentUsedMargin = Math.Abs(((OptionInitialMargin)positionGroup.BuyingPowerModel.GetInitialMarginRequirement(
+                new PositionGroupInitialMarginParameters(_portfolio, positionGroup))).TotalValue);
 
             var longUnitGroup = positionGroup.CreateUnitGroup(_portfolio.Positions);
-            var longUnitMargin = Math.Abs(longUnitGroup.BuyingPowerModel.GetInitialMarginRequirement(_portfolio, longUnitGroup));
+            var longUnitMargin = Math.Abs(((OptionInitialMargin)longUnitGroup.BuyingPowerModel.GetInitialMarginRequirement(
+                new PositionGroupInitialMarginParameters(_portfolio, longUnitGroup))).TotalValue);
 
             var expectedQuantity = 0m;
             var finalPositionQuantity = 0m;
@@ -615,7 +526,8 @@ namespace QuantConnect.Tests.Common.Securities
             if (targetMarginPercent > 1 && targetMarginDirection == -1)
             {
                 var shortUnitGroup = positionGroup.WithQuantity(-1, _portfolio.Positions);
-                var shortUnitMargin = Math.Abs(shortUnitGroup.BuyingPowerModel.GetInitialMarginRequirement(_portfolio, shortUnitGroup));
+                var shortUnitMargin = Math.Abs(((OptionInitialMargin)shortUnitGroup.BuyingPowerModel.GetInitialMarginRequirement(
+                    new PositionGroupInitialMarginParameters(_portfolio, shortUnitGroup))).TotalValue);
                 finalPositionQuantity = Math.Floor(-currentUsedMargin / shortUnitMargin);
                 expectedQuantity = -Math.Abs(initialHoldingsQuantity) + finalPositionQuantity;
 
@@ -716,17 +628,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var initialMarginRequirement = positionGroup.BuyingPowerModel.GetInitialMarginRequirement(
                 new PositionGroupInitialMarginParameters(_portfolio, positionGroup));
-
-            Console.WriteLine(initialMarginRequirement.Value);
-
-            var premium = 0m;
-            foreach (var position in positionGroup.Positions.Where(position => position.Symbol.SecurityType.IsOption()))
-            {
-                var option = (Option)_portfolio.Securities[position.Symbol];
-                premium += option.Holdings.GetQuantityValue(position.Quantity).InAccountCurrency;
-            }
-            initialMarginRequirement -= Math.Max(0, premium);
-
+            
             Assert.AreEqual((double)expectedInitialMarginRequirement, (double)initialMarginRequirement.Value, (double)(0.2m * expectedInitialMarginRequirement));
         }
 
@@ -1021,14 +923,15 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var positionGroup = SetUpOptionStrategy(optionStrategyDefinition, initialPositionQuantity);
 
-            var initialMarginRequirement = positionGroup.BuyingPowerModel.GetInitialMarginRequirement(_portfolio, positionGroup);
+            var initialMarginRequirement = (OptionInitialMargin)positionGroup.BuyingPowerModel.GetInitialMarginRequirement(
+                new PositionGroupInitialMarginParameters(_portfolio, positionGroup));
             var maintenanceMargin = positionGroup.BuyingPowerModel.GetMaintenanceMargin(_portfolio, positionGroup);
             // Adjust the delta buying power:
             // GetMaximumLotsForDeltaBuyingPower will add the delta buying power to the maintenance margin and used that as a target margin,
             // but then GetMaximumLotsForTargetBuyingPower will work with initial margin requirement so we make sure the resulting quantity
             // can be ordered. In order to match this, we need to adjust the delta buying power by the difference between the initial margin
             // requirement  and maintenance margin.
-            deltaBuyingPower += initialMarginRequirement - maintenanceMargin;
+            deltaBuyingPower += initialMarginRequirement.TotalValue - maintenanceMargin;
 
             if (expectedQuantity != -Math.Abs(initialPositionQuantity)) // Not liquidating
             {
@@ -1089,14 +992,15 @@ namespace QuantConnect.Tests.Common.Securities
         {
             var currentPositionGroup = SetUpOptionStrategy(optionStrategyDefinition, initialPositionQuantity);
 
-            var initialMarginRequirement = currentPositionGroup.BuyingPowerModel.GetInitialMarginRequirement(_portfolio, currentPositionGroup);
+            var initialMarginRequirement = (OptionInitialMargin)currentPositionGroup.BuyingPowerModel.GetInitialMarginRequirement(
+                new PositionGroupInitialMarginParameters(_portfolio, currentPositionGroup));
             var maintenanceMargin = currentPositionGroup.BuyingPowerModel.GetMaintenanceMargin(_portfolio, currentPositionGroup);
             // Adjust the delta buying power:
             // GetMaximumLotsForDeltaBuyingPower will add the delta buying power to the maintenance margin and used that as a target margin,
             // but then GetMaximumLotsForTargetBuyingPower will work with initial margin requirement so we make sure the resulting quantity
             // can be ordered. In order to match this, we need to adjust the delta buying power by the difference between the initial margin
             // requirement  and maintenance margin.
-            deltaBuyingPower += initialMarginRequirement - maintenanceMargin;
+            deltaBuyingPower += initialMarginRequirement.TotalValue - maintenanceMargin;
 
             if (expectedQuantity != -Math.Abs(initialPositionQuantity)) // Not liquidating
             {
@@ -1814,8 +1718,9 @@ namespace QuantConnect.Tests.Common.Securities
                 ? initialPositionGroup.WithQuantity(sign * Math.Abs(finalQuantity), _portfolio.Positions)
                 : PositionGroup.Empty(null);
 
+            var orders = GetPositionGroupOrders(initialPositionGroup, initialPositionQuantity, newGroupQuantity);
             var buyingPowerImpact = initialPositionGroup.BuyingPowerModel.GetReservedBuyingPowerImpact(new ReservedBuyingPowerImpactParameters(_portfolio,
-                finalPositionGroup, GetPositionGroupOrders(initialPositionGroup, initialPositionQuantity, newGroupQuantity)));
+                finalPositionGroup, orders));
 
             var usedMargin = initialPositionGroup.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(
                 new ReservedBuyingPowerForPositionGroupParameters(_portfolio, initialPositionGroup)).AbsoluteUsedBuyingPower;
@@ -1827,13 +1732,21 @@ namespace QuantConnect.Tests.Common.Securities
                 Assert.AreEqual(position.Quantity, contemplatedChangePosition.Quantity);
             }
 
-            var newGroupInitialMarginRequirement = finalQuantity != 0
+            var expectedContemplatedInitialMarginRequirement = finalQuantity != 0
                 ? finalPositionGroup.BuyingPowerModel.GetInitialMarginRequirement(_portfolio, finalPositionGroup)
                 : 0m;
-            var expectedDelta = newGroupInitialMarginRequirement - usedMargin;
+            var ordersPositions = orders.Select(o => o.CreatePositions(_portfolio.Securities)).SelectMany(p => p);
+            var orderGroup = _portfolio.Positions.ResolvePositionGroups(new PositionCollection(ordersPositions)).Single();
+            var orderGroupInitialMargin = (OptionInitialMargin)orderGroup.BuyingPowerModel.GetInitialMarginRequirement(
+                new PositionGroupInitialMarginParameters(_portfolio, orderGroup));
+            // Use TotalValue - Value difference instead of Premium because when premium is negative, it is not added to initial margin requirements
+            // since it is credited to the account
+            expectedContemplatedInitialMarginRequirement += orderGroupInitialMargin.TotalValue - orderGroupInitialMargin.Value;
+
+            var expectedDelta = expectedContemplatedInitialMarginRequirement - usedMargin;
             Assert.That(buyingPowerImpact.Delta, Is.EqualTo(expectedDelta).Within(1e-18));
             Assert.That(buyingPowerImpact.Current, Is.EqualTo(usedMargin).Within(1e-18));
-            Assert.That(buyingPowerImpact.Contemplated, Is.EqualTo(newGroupInitialMarginRequirement).Within(1e-18));
+            Assert.That(buyingPowerImpact.Contemplated, Is.EqualTo(expectedContemplatedInitialMarginRequirement).Within(1e-18));
         }
 
         private List<Order> GetStrategyOrders(decimal quantity)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Premium is now accounted for in option strategies initial margin calculation.

- About explicit `OptionStrategyPositionGroupBuyingPowerModelTests.OrderQuantityForDeltaBuyingPowerTestCases` test cases: `GetMaximumLotsForTargetBuyingPower` gets the maximum quantity that can be ordered to get a given target buying power, so it works with initial margin requirements. `GetMaximumLotsForDeltaBuyingPower` on the other hand, adds the passed delta to the curent maintenance margin, so strategies with zero maintenance margin always return 0. This is expected to be addressed on a separate PR.
- About how IB determines whether there is enough available buying power:
Among other things, IB uses the order quantity premium and the whole resulting position initial margin requirement to determine whether the order is accepted. In the following screenshot, we already sold 1 covered call and try to sell 40 more, outside of the available buying power. 
![image](https://github.com/QuantConnect/Lean/assets/25215064/6678dafa-157c-4b21-a776-07864be59776)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
