### PR TITLE
Fix bug in MarketProfile indicator

### DIFF
--- a/Indicators/MarketProfile.cs
+++ b/Indicators/MarketProfile.cs
@@ -161,16 +161,9 @@ namespace QuantConnect.Indicators
         /// <returns>A a value for this indicator, Point of Control (POC) price</returns>
         protected override decimal ComputeNextValue(TradeBar input)
         {
-            // If the point is fill forward it has zero volume, then it could pop a real point
-            // from _oldDataPoints
-            if (input.IsFillForward)
-            {
-                return 0m;
-            }
-
             // Define Volume and add it to _volumePerPrice and _oldDataPoints
             var VolumeQuantity = GetVolume(input);
-            Add(input,VolumeQuantity);
+            Add(input, VolumeQuantity);
 
             // Get the index of the close price with maximum volume
             _pointOfControl = GetMax();

--- a/Indicators/MarketProfile.cs
+++ b/Indicators/MarketProfile.cs
@@ -219,10 +219,16 @@ namespace QuantConnect.Indicators
             {
                 var RemovedDataPoint = _oldDataPoints.MostRecentlyRemoved;
                 ClosePrice = Round(RemovedDataPoint.Item1);
-                _volumePerPrice[ClosePrice] -= RemovedDataPoint.Item2;
-                if (_volumePerPrice[ClosePrice] == 0)
+                // Two equal points can be inserted in _oldDataPoints, where the volume of the second one is zero. Then
+                // when the first one is removed from _oldDataPoints, its value in _volumePerPrice is also removed as
+                // the remaining value is zero.
+                if (_volumePerPrice.ContainsKey(ClosePrice))
                 {
-                    _volumePerPrice.Remove(ClosePrice);
+                    _volumePerPrice[ClosePrice] -= RemovedDataPoint.Item2;
+                    if (_volumePerPrice[ClosePrice] == 0)
+                    {
+                        _volumePerPrice.Remove(ClosePrice);
+                    }
                 }
             }
         }

--- a/Tests/Indicators/VolumeProfileTests.cs
+++ b/Tests/Indicators/VolumeProfileTests.cs
@@ -76,7 +76,7 @@ namespace QuantConnect.Tests.Indicators
                 CreateIndicator(),
                 TestFileName,
                 "VA",
-                (ind, expected) => Assert.AreEqual(expected, (double)((VolumeProfile)ind).ValueAreaVolume,0.01)
+                (ind, expected) => Assert.AreEqual(expected, (double)((VolumeProfile)ind).ValueAreaVolume, 0.01)
                 );
         }
 
@@ -110,13 +110,13 @@ namespace QuantConnect.Tests.Indicators
             Assert.IsFalse(vp.IsReady);
             for (int i = 0; i < 3; i++)
             {
-                vp.Update(new TradeBar() { Symbol = Symbols.IBM, Close = 1,Volume=1, Time = reference.AddDays(1 + i) });
+                vp.Update(new TradeBar() { Symbol = Symbols.IBM, Close = 1, Volume = 1, Time = reference.AddDays(1 + i) });
             }
             Assert.IsTrue(vp.IsReady);
             vp.Reset();
 
             TestHelper.AssertIndicatorIsInDefaultState(vp);
-            vp.Update(new TradeBar() { Symbol = Symbols.IBM, Close = 1, Volume=1, Time = reference.AddDays(1) });
+            vp.Update(new TradeBar() { Symbol = Symbols.IBM, Close = 1, Volume = 1, Time = reference.AddDays(1) });
             Assert.AreEqual(vp.Current.Value, 1m);
         }
 
@@ -133,6 +133,19 @@ namespace QuantConnect.Tests.Indicators
             {
                 vp.Update(new TradeBar() { Symbol = Symbols.AAPL, Low = 1, High = 2, Volume = 100, Time = reference.AddDays(1 + i) });
                 Assert.AreEqual(i == period - 1, vp.IsReady);
+            }
+        }
+
+        [Test]
+        public void DoesNotFailWithRepeatedInputCloseValues()
+        {
+            var closeValues = new double[] { 313.25, 313.248, 313.241, 313.249, 313.243, 314.245, 315.241 };
+            var vp = new VolumeProfile(2);
+            var reference = new DateTime(2000, 1, 1);
+            var period = ((IIndicatorWarmUpPeriodProvider)vp).WarmUpPeriod;
+            for (var i = 0; i < closeValues.Length; i++)
+            {
+                Assert.DoesNotThrow(() => vp.Update(new TradeBar() { Symbol = Symbols.AAPL, Close = (decimal)closeValues[i], Volume = closeValues[i] != 313.243 ? 100 : 0, Time = reference.AddDays(1 + i) }));
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
If two inputs points with repeated close values were inserted, with the second one being a Fill Forward bar,  when the first one was removed from _oldDataPoints, as the reamaining value of it in _volumePerPrice would be zero, that entry would be also removed from _volumePerPrice. Therefore, when the second input point was removed from _oldDataPoints, this entry
would not be found in _volumePerPrice. Then the changes made were:

- Modify MarketProfile to check every removed data point is still in `_volumePerPrice`
- Modify MarketProfile to check `_volumePerPrice` is not empty, before trying to access some of its elements
- Add unit tests to covert this change
- Nit changes in VolumeProfileTests.cs
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7025 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change Fill Forward bars inserted into Market Profile indicator won't raise exceptions
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require updates to documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There was created a unit test asserting the bars inserted into the market profile indicator didn't generate exceptions in different scenarios
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
