### PR TITLE
Minor fix for automatically added option underlying

### DIFF
--- a/Algorithm.CSharp/AddOptionWithOnMarketOpenOnlyFilterRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddOptionWithOnMarketOpenOnlyFilterRegressionAlgorithm.cs
@@ -88,7 +88,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all time slices of algorithm
         /// </summary>
-        public long DataPoints => 5956900;
+        public long DataPoints => 5952220;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/BacktestingBrokerageRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/BacktestingBrokerageRegressionAlgorithm.cs
@@ -296,7 +296,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 1272651;
+        public long DataPoints => 1272232;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionStrategyAlgorithm.cs
@@ -112,7 +112,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 476196;
+        public long DataPoints => 475777;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/CoveredAndProtectiveCallStrategiesAlgorithm.cs
+++ b/Algorithm.CSharp/CoveredAndProtectiveCallStrategiesAlgorithm.cs
@@ -97,7 +97,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 4494;
+        public override long DataPoints => 4490;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/CoveredAndProtectivePutStrategiesAlgorithm.cs
+++ b/Algorithm.CSharp/CoveredAndProtectivePutStrategiesAlgorithm.cs
@@ -97,7 +97,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 4494;
+        public override long DataPoints => 4490;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/FillForwardUntilExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FillForwardUntilExpiryRegressionAlgorithm.cs
@@ -122,7 +122,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 1293451;
+        public long DataPoints => 1291113;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/IronCondorStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/IronCondorStrategyAlgorithm.cs
@@ -119,7 +119,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 4494;
+        public override long DataPoints => 4490;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/LiquidatingMultipleOptionStrategiesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LiquidatingMultipleOptionStrategiesRegressionAlgorithm.cs
@@ -147,7 +147,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 527613;
+        public long DataPoints => 526804;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/LongAndShortButterflyCallStrategiesAlgorithm.cs
+++ b/Algorithm.CSharp/LongAndShortButterflyCallStrategiesAlgorithm.cs
@@ -119,7 +119,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 4494;
+        public override long DataPoints => 4490;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/LongAndShortButterflyPutStrategiesAlgorithm.cs
+++ b/Algorithm.CSharp/LongAndShortButterflyPutStrategiesAlgorithm.cs
@@ -119,7 +119,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 4494;
+        public override long DataPoints => 4490;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/LongAndShortCallCalendarSpreadStrategiesAlgorithm.cs
+++ b/Algorithm.CSharp/LongAndShortCallCalendarSpreadStrategiesAlgorithm.cs
@@ -102,7 +102,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 4494;
+        public override long DataPoints => 4490;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/LongAndShortPutCalendarSpreadStrategiesAlgorithm.cs
+++ b/Algorithm.CSharp/LongAndShortPutCalendarSpreadStrategiesAlgorithm.cs
@@ -102,7 +102,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 4494;
+        public override long DataPoints => 4490;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/LongAndShortStraddleStrategiesAlgorithm.cs
+++ b/Algorithm.CSharp/LongAndShortStraddleStrategiesAlgorithm.cs
@@ -99,7 +99,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 4494;
+        public override long DataPoints => 4490;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/LongAndShortStrangleStrategiesAlgorithm.cs
+++ b/Algorithm.CSharp/LongAndShortStrangleStrategiesAlgorithm.cs
@@ -109,7 +109,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 4494;
+        public override long DataPoints => 4490;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/NakedCallStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/NakedCallStrategyAlgorithm.cs
@@ -88,7 +88,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 4494;
+        public override long DataPoints => 4490;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/NakedPutStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/NakedPutStrategyAlgorithm.cs
@@ -88,7 +88,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 4494;
+        public override long DataPoints => 4490;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/NakedShortOptionStrategyOverMarginAlgorithm.cs
+++ b/Algorithm.CSharp/NakedShortOptionStrategyOverMarginAlgorithm.cs
@@ -131,7 +131,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 476196;
+        public long DataPoints => 475777;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionChainedAndUniverseSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionChainedAndUniverseSelectionRegressionAlgorithm.cs
@@ -95,7 +95,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 3549746;
+        public long DataPoints => 3547404;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionExpiryDateTodayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExpiryDateTodayRegressionAlgorithm.cs
@@ -107,7 +107,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 8628279;
+        public long DataPoints => 8626717;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionNoTimeInUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionNoTimeInUniverseRegressionAlgorithm.cs
@@ -80,7 +80,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 471644;
+        public long DataPoints => 471225;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionOpenInterestRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionOpenInterestRegressionAlgorithm.cs
@@ -117,7 +117,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 400889;
+        public long DataPoints => 399332;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionRegressionAlgorithm.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 866464;
+        public override long DataPoints => 865679;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionTimeSpanWarmupRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedAmericanOptionTimeSpanWarmupRegressionAlgorithm.cs
@@ -35,6 +35,6 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 3549743;
+        public override long DataPoints => 3547401;
     }
 }

--- a/Algorithm.CSharp/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedEuropeanOptionRegressionAlgorithm.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 133;
+        public override long DataPoints => 132;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionPriceModelForSupportedEuropeanOptionTimeSpanWarmupRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForSupportedEuropeanOptionTimeSpanWarmupRegressionAlgorithm.cs
@@ -36,6 +36,6 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 1401;
+        public override long DataPoints => 1387;
     }
 }

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedAmericanOptionRegressionAlgorithm.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 866464;
+        public override long DataPoints => 865679;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedAmericanOptionTimeSpanWarmupRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedAmericanOptionTimeSpanWarmupRegressionAlgorithm.cs
@@ -34,6 +34,6 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 3549743;
+        public override long DataPoints => 3547401;
     }
 }

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionRegressionAlgorithm.cs
@@ -42,7 +42,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 133;
+        public override long DataPoints => 132;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionTimeSpanWarmupRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionPriceModelForUnsupportedEuropeanOptionTimeSpanWarmupRegressionAlgorithm.cs
@@ -36,6 +36,6 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 1401;
+        public override long DataPoints => 1387;
     }
 }

--- a/Algorithm.CSharp/OptionRenameDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionRenameDailyRegressionAlgorithm.cs
@@ -153,7 +153,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 1008;
+        public long DataPoints => 1002;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionRenameRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionRenameRegressionAlgorithm.cs
@@ -141,7 +141,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 268330;
+        public long DataPoints => 265988;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionSplitRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionSplitRegressionAlgorithm.cs
@@ -124,7 +124,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 1976132;
+        public long DataPoints => 1974570;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionsExpiredContractRegression.cs
+++ b/Algorithm.CSharp/OptionsExpiredContractRegression.cs
@@ -80,7 +80,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 13168362;
+        public long DataPoints => 13167553;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/RollOutFrontMonthToBackMonthOptionUsingCalendarSpreadRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RollOutFrontMonthToBackMonthOptionUsingCalendarSpreadRegressionAlgorithm.cs
@@ -137,7 +137,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 467798;
+        public long DataPoints => 467379;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/WarmupLowerResolutionOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WarmupLowerResolutionOptionRegressionAlgorithm.cs
@@ -126,7 +126,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 983246;
+        public long DataPoints => 982462;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/WarmupOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WarmupOptionRegressionAlgorithm.cs
@@ -113,7 +113,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public virtual long DataPoints => 631732;
+        public virtual long DataPoints => 630923;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/WarmupOptionResolutionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WarmupOptionResolutionRegressionAlgorithm.cs
@@ -50,6 +50,6 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 557243;
+        public override long DataPoints => 556822;
     }
 }

--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -103,9 +103,10 @@ namespace QuantConnect.Algorithm
                                 underlyingSymbol.Value,
                                 resolution,
                                 underlyingSymbol.ID.Market,
-                                false,
-                                0,
-                                configs.IsExtendedMarketHours());
+                                configs.IsFillForward(),
+                                Security.NullLeverage,
+                                configs.IsExtendedMarketHours(),
+                                dataNormalizationMode: DataNormalizationMode.Raw);
                         }
 
                         // set data mode raw and default volatility model


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Lean engine will automatically add an options underlying if not present, but in most cases the option chain will select the underlying too, so let's make sure the configurations match. Previous to this change 'fill forward' setting could be different causing the underlying to be duplicated in the data stack

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Found while working on https://github.com/QuantConnect/Lean/issues/6735
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
N/A
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
