### PR TITLE
Indicators history rolling window

### DIFF
--- a/Algorithm.CSharp/IndicatorHistoryAlgorithm.cs
+++ b/Algorithm.CSharp/IndicatorHistoryAlgorithm.cs
@@ -58,6 +58,12 @@ namespace QuantConnect.Algorithm.CSharp
                 if (_sma[0] < _sma[_sma.WindowCount - 1])
                 {
                     Buy(_symbol, 100);
+
+                    // Let's log the SMA values for the last 14 days, for demonstration purposes on how it can be enumerated
+                    foreach (var dataPoint in _sma)
+                    {
+                        Log($"SMA @{dataPoint.EndTime}: {dataPoint.Value}");
+                    }
                 }
             }
         }

--- a/Algorithm.CSharp/IndicatorHistoryAlgorithm.cs
+++ b/Algorithm.CSharp/IndicatorHistoryAlgorithm.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 
 using QuantConnect.Data;
@@ -44,39 +43,38 @@ namespace QuantConnect.Algorithm.CSharp
 
             _bollingerBands = BB(_symbol, 20, 2.0m, resolution: Resolution.Daily);
             // Let's keep BB values for a 20 day period
-            _bollingerBands.Window = 20;
+            _bollingerBands.Window.Size = 20;
             // Also keep the same period of data for the middle band
-            _bollingerBands.MiddleBand.Window = 20;
+            _bollingerBands.MiddleBand.Window.Size = 20;
         }
 
         public void OnData(Slice slice)
         {
             if (!_bollingerBands.IsReady) return;
 
-            // The window is filled up, we have 20 days worth of BB values to use at our convenience
-            if (_bollingerBands.WindowCount == _bollingerBands.Window)
+            // We can access the current and oldest (in our period) values of the indicator
+            Log($"Current BB value: {_bollingerBands[0].EndTime} - {_bollingerBands[0].Value}");
+            Log($@"Oldest BB value: {_bollingerBands[_bollingerBands.Window.Count - 1].EndTime} - {
+                _bollingerBands[_bollingerBands.Window.Count - 1].Value}");
+
+            // Let's log the BB values for the last 20 days, for demonstration purposes on how it can be enumerated
+            foreach (var dataPoint in _bollingerBands)
             {
-                // We can access the current and oldest (in our period) values of the indicator
-                Log($"Current BB value: {_bollingerBands[0].EndTime} - {_bollingerBands[0].Value}");
-                Log($@"Oldest BB value: {
-                    _bollingerBands[_bollingerBands.WindowCount - 1].EndTime} - {_bollingerBands[_bollingerBands.WindowCount - 1].Value}");
-
-                // Let's log the BB values for the last 20 days, for demonstration purposes on how it can be enumerated
-                foreach (var dataPoint in _bollingerBands)
-                {
-                    Log($"BB @{dataPoint.EndTime}: {dataPoint.Value}");
-                }
-
-                // We can also do the same for internal indicators:
-                var middleBand = _bollingerBands.MiddleBand;
-                Log($"Current BB Middle Band value: {middleBand[0].EndTime} - {middleBand[0].Value}");
-                Log($@"Oldest BB Middle Band value: {
-                    middleBand[middleBand.WindowCount - 1].EndTime} - {middleBand[middleBand.WindowCount - 1].Value}");
-                foreach (var dataPoint in middleBand)
-                {
-                    Log($"BB Middle Band @{dataPoint.EndTime}: {dataPoint.Value}");
-                }
+                Log($"BB @{dataPoint.EndTime}: {dataPoint.Value}");
             }
+
+            // We can also do the same for internal indicators:
+            var middleBand = _bollingerBands.MiddleBand;
+            Log($"Current BB Middle Band value: {middleBand[0].EndTime} - {middleBand[0].Value}");
+            Log($@"Oldest BB Middle Band value: {middleBand[middleBand.Window.Count - 1].EndTime} - {
+                middleBand[middleBand.Window.Count - 1].Value}");
+            foreach (var dataPoint in middleBand)
+            {
+                Log($"BB Middle Band @{dataPoint.EndTime}: {dataPoint.Value}");
+            }
+
+            // We are done now!
+            Quit();
         }
 
         /// <summary>
@@ -92,7 +90,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 4031;
+        public long DataPoints => 161;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -120,8 +118,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "0"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-1.66"},
-            {"Tracking Error", "0.094"},
+            {"Information Ratio", "-7.674"},
+            {"Tracking Error", "0.085"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},

--- a/Algorithm.CSharp/IndicatorHistoryAlgorithm.cs
+++ b/Algorithm.CSharp/IndicatorHistoryAlgorithm.cs
@@ -50,7 +50,8 @@ namespace QuantConnect.Algorithm.CSharp
 
         public void OnData(Slice slice)
         {
-            if (!_bollingerBands.IsReady) return;
+            // Let's wait for our indicator to fully initialize and have a full window of history data
+            if (!_bollingerBands.Window.IsReady) return;
 
             // We can access the current and oldest (in our period) values of the indicator
             Log($"Current BB value: {_bollingerBands[0].EndTime} - {_bollingerBands[0].Value}");
@@ -90,7 +91,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 161;
+        public long DataPoints => 153;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -118,8 +119,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "0"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-7.674"},
-            {"Tracking Error", "0.085"},
+            {"Information Ratio", "-7.209"},
+            {"Tracking Error", "0.087"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},

--- a/Algorithm.CSharp/IndicatorHistoryAlgorithm.cs
+++ b/Algorithm.CSharp/IndicatorHistoryAlgorithm.cs
@@ -1,0 +1,124 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Demonstration algorithm of indicators history window usage
+    /// </summary>
+    public class IndicatorHistoryAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _symbol;
+
+        private IndicatorBase<IndicatorDataPoint> _sma;
+
+        /// <summary>
+        /// Initialize the data and resolution you require for your strategy
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 1, 1);
+            SetEndDate(2014, 12, 31);
+            SetCash(25000);
+
+            _symbol = AddEquity("SPY", Resolution.Daily).Symbol;
+
+            _sma = SMA(_symbol, 14, Resolution.Daily);
+            // Let's keep SMA values for a 14 day period
+            _sma.Window = 14;
+        }
+
+        public void OnData(Slice slice)
+        {
+            if (!_sma.IsReady || Portfolio.Invested) return;
+
+            // The window is filled up, we have 14 days worth of SMA values to use at our convenience
+            if (_sma.WindowCount == _sma.Window)
+            {
+                // Let's say that hypothetically, we want to buy shares of the equity when the SMA is less than its 14 days old value
+                if (_sma[0] < _sma[_sma.WindowCount - 1])
+                {
+                    Buy(_symbol, 100);
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!Portfolio.Invested)
+            {
+                throw new Exception("Expected the portfolio to be invested at the end of the algorithm");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 4031;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "7.998%"},
+            {"Drawdown", "4.500%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "16.635%"},
+            {"Sharpe Ratio", "1.144"},
+            {"Probabilistic Sharpe Ratio", "57.499%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "-0.015"},
+            {"Beta", "0.455"},
+            {"Annual Standard Deviation", "0.049"},
+            {"Annual Variance", "0.002"},
+            {"Information Ratio", "-1.769"},
+            {"Tracking Error", "0.056"},
+            {"Treynor Ratio", "0.123"},
+            {"Total Fees", "$1.00"},
+            {"Estimated Strategy Capacity", "$1500000000.00"},
+            {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
+            {"Portfolio Turnover", "0.08%"},
+            {"OrderListHash", "337525763b81bead1e0ca6f4e40115f3"}
+        };
+    }
+}

--- a/Algorithm.Python/IndicatorHistoryAlgorithm.py
+++ b/Algorithm.Python/IndicatorHistoryAlgorithm.py
@@ -34,7 +34,8 @@ class IndicatorHistoryAlgorithm(QCAlgorithm):
         self.bollingerBands.MiddleBand.Window.Size = 20;
 
     def OnData(self, slice: Slice):
-        if not self.bollingerBands.IsReady: return
+        # Let's wait for our indicator to fully initialize and have a full window of history data
+        if not self.bollingerBands.Window.IsReady: return
 
         # We can access the current and oldest (in our period) values of the indicator
         self.Log(f"Current BB value: {self.bollingerBands[0].EndTime} - {self.bollingerBands[0].Value}")

--- a/Algorithm.Python/IndicatorHistoryAlgorithm.py
+++ b/Algorithm.Python/IndicatorHistoryAlgorithm.py
@@ -27,23 +27,30 @@ class IndicatorHistoryAlgorithm(QCAlgorithm):
 
         self.symbol = self.AddEquity("SPY", Resolution.Daily).Symbol
 
-        self.sma = self.SMA(self.symbol, 14, Resolution.Daily)
-        # Let's keep SMA values for a 14 day period
-        self.sma.Window = 14
+        self.bollingerBands = self.BB(self.symbol, 20, 2.0, resolution=Resolution.Daily)
+        # Let's keep BB values for a 20 day period
+        self.bollingerBands.Window = 20
+        # Also keep the same period of data for the middle band
+        self.bollingerBands.MiddleBand.Window = 20;
 
     def OnData(self, slice: Slice):
-        if not self.sma.IsReady or self.Portfolio.Invested: return
+        if not self.bollingerBands.IsReady: return
 
-        # The window is filled up, we have 14 days worth of SMA values to use at our convenience
-        if self.sma.WindowCount == self.sma.Window:
-            # Let's say that hypothetically, we want to buy shares of the equity when the SMA is less than its 14 days old value
-            if self.sma[0] < self.sma[self.sma.WindowCount - 1]:
-                self.Buy(self.symbol, 100)
+        # The window is filled up, we have 20 days worth of BB values to use at our convenience
+        if self.bollingerBands.WindowCount == self.bollingerBands.Window:
+            # We can access the current and oldest (in our period) values of the indicator
+            self.Log(f"Current BB value: {self.bollingerBands[0].EndTime} - {self.bollingerBands[0].Value}")
+            self.Log(f"Oldest BB value: {self.bollingerBands[self.bollingerBands.WindowCount - 1].EndTime} - "
+                     f"{self.bollingerBands[self.bollingerBands.WindowCount - 1].Value}")
 
-                # Let's log the SMA values for the last 14 days, for demonstration purposes on how it can be enumerated
-                for dataPoint in self.sma:
-                    self.Log(f"SMA @{dataPoint.EndTime}: {dataPoint.Value}")
+            # Let's log the BB values for the last 20 days, for demonstration purposes on how it can be enumerated
+            for dataPoint in self.bollingerBands:
+                self.Log(f"BB @{dataPoint.EndTime}: {dataPoint.Value}")
 
-    def OnEndOfAlgorithm(self):
-        if not self.Portfolio.Invested:
-            raise Exception("Expected the portfolio to be invested at the end of the algorithm")
+            # We can also do the same for internal indicators:
+            middleBand = self.bollingerBands.MiddleBand
+            self.Log(f"Current BB Middle Band value: {middleBand[0].EndTime} - {middleBand[0].Value}")
+            self.Log(f"Oldest BB Middle Band value: {middleBand[middleBand.WindowCount - 1].EndTime} - "
+                     f"{middleBand[middleBand.WindowCount - 1].Value}")
+            for dataPoint in middleBand:
+                self.Log(f"BB Middle Band @{dataPoint.EndTime}: {dataPoint.Value}")

--- a/Algorithm.Python/IndicatorHistoryAlgorithm.py
+++ b/Algorithm.Python/IndicatorHistoryAlgorithm.py
@@ -1,0 +1,45 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Demonstration algorithm of indicators history window usage
+### </summary>
+class IndicatorHistoryAlgorithm(QCAlgorithm):
+    '''Demonstration algorithm of indicators history window usage.'''
+
+    def Initialize(self):
+        '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+        self.SetStartDate(2013, 1, 1)
+        self.SetEndDate(2014, 12, 31)
+        self.SetCash(25000)
+
+        self.symbol = self.AddEquity("SPY", Resolution.Daily).Symbol
+
+        self.sma = self.SMA(self.symbol, 14, Resolution.Daily)
+        # Let's keep SMA values for a 14 day period
+        self.sma.Window = 14
+
+    def OnData(self, slice: Slice):
+        if not self.sma.IsReady or self.Portfolio.Invested: return
+
+        # The window is filled up, we have 14 days worth of SMA values to use at our convenience
+        if self.sma.WindowCount == self.sma.Window:
+            # Let's say that hypothetically, we want to buy shares of the equity when the SMA is less than its 14 days old value
+            if self.sma[0] < self.sma[self.sma.WindowCount - 1]:
+                self.Buy(self.symbol, 100)
+
+    def OnEndOfAlgorithm(self):
+        if not self.Portfolio.Invested:
+            raise Exception("Expected the portfolio to be invested at the end of the algorithm")

--- a/Algorithm.Python/IndicatorHistoryAlgorithm.py
+++ b/Algorithm.Python/IndicatorHistoryAlgorithm.py
@@ -40,6 +40,10 @@ class IndicatorHistoryAlgorithm(QCAlgorithm):
             if self.sma[0] < self.sma[self.sma.WindowCount - 1]:
                 self.Buy(self.symbol, 100)
 
+                # Let's log the SMA values for the last 14 days, for demonstration purposes on how it can be enumerated
+                for dataPoint in self.sma:
+                    self.Log(f"SMA @{dataPoint.EndTime}: {dataPoint.Value}")
+
     def OnEndOfAlgorithm(self):
         if not self.Portfolio.Invested:
             raise Exception("Expected the portfolio to be invested at the end of the algorithm")

--- a/Algorithm.Python/IndicatorHistoryAlgorithm.py
+++ b/Algorithm.Python/IndicatorHistoryAlgorithm.py
@@ -29,28 +29,29 @@ class IndicatorHistoryAlgorithm(QCAlgorithm):
 
         self.bollingerBands = self.BB(self.symbol, 20, 2.0, resolution=Resolution.Daily)
         # Let's keep BB values for a 20 day period
-        self.bollingerBands.Window = 20
+        self.bollingerBands.Window.Size = 20
         # Also keep the same period of data for the middle band
-        self.bollingerBands.MiddleBand.Window = 20;
+        self.bollingerBands.MiddleBand.Window.Size = 20;
 
     def OnData(self, slice: Slice):
         if not self.bollingerBands.IsReady: return
 
-        # The window is filled up, we have 20 days worth of BB values to use at our convenience
-        if self.bollingerBands.WindowCount == self.bollingerBands.Window:
-            # We can access the current and oldest (in our period) values of the indicator
-            self.Log(f"Current BB value: {self.bollingerBands[0].EndTime} - {self.bollingerBands[0].Value}")
-            self.Log(f"Oldest BB value: {self.bollingerBands[self.bollingerBands.WindowCount - 1].EndTime} - "
-                     f"{self.bollingerBands[self.bollingerBands.WindowCount - 1].Value}")
+        # We can access the current and oldest (in our period) values of the indicator
+        self.Log(f"Current BB value: {self.bollingerBands[0].EndTime} - {self.bollingerBands[0].Value}")
+        self.Log(f"Oldest BB value: {self.bollingerBands[self.bollingerBands.Window.Count - 1].EndTime} - "
+                 f"{self.bollingerBands[self.bollingerBands.Window.Count - 1].Value}")
 
-            # Let's log the BB values for the last 20 days, for demonstration purposes on how it can be enumerated
-            for dataPoint in self.bollingerBands:
-                self.Log(f"BB @{dataPoint.EndTime}: {dataPoint.Value}")
+        # Let's log the BB values for the last 20 days, for demonstration purposes on how it can be enumerated
+        for dataPoint in self.bollingerBands:
+            self.Log(f"BB @{dataPoint.EndTime}: {dataPoint.Value}")
 
-            # We can also do the same for internal indicators:
-            middleBand = self.bollingerBands.MiddleBand
-            self.Log(f"Current BB Middle Band value: {middleBand[0].EndTime} - {middleBand[0].Value}")
-            self.Log(f"Oldest BB Middle Band value: {middleBand[middleBand.WindowCount - 1].EndTime} - "
-                     f"{middleBand[middleBand.WindowCount - 1].Value}")
-            for dataPoint in middleBand:
-                self.Log(f"BB Middle Band @{dataPoint.EndTime}: {dataPoint.Value}")
+        # We can also do the same for internal indicators:
+        middleBand = self.bollingerBands.MiddleBand
+        self.Log(f"Current BB Middle Band value: {middleBand[0].EndTime} - {middleBand[0].Value}")
+        self.Log(f"Oldest BB Middle Band value: {middleBand[middleBand.Window.Count - 1].EndTime} - "
+                 f"{middleBand[middleBand.Window.Count - 1].Value}")
+        for dataPoint in middleBand:
+            self.Log(f"BB Middle Band @{dataPoint.EndTime}: {dataPoint.Value}")
+
+        # We are done now!
+        self.Quit()

--- a/Common/Indicators/IReadOnlyWindow.cs
+++ b/Common/Indicators/IReadOnlyWindow.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,7 +36,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         ///     Gets the number of samples that have been added to this window over its lifetime
         /// </summary>
-        decimal Samples { get; }
+        int Samples { get; }
 
         /// <summary>
         ///     Indexes into this window, where index 0 is the most recently

--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using QuantConnect.Api;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -192,9 +192,13 @@ namespace QuantConnect.Indicators
                         throw new ArgumentOutOfRangeException(nameof(i), i, Messages.RollingWindow.IndexOutOfSizeRange);
                     }
 
-                    if (i > _size - 1)
+                    if (i > _list.Count - 1)
                     {
-                        Resize(i + 1);
+                        if (i > _size - 1)
+                        {
+                            Resize(i + 1);
+                        }
+
                         var count = _list.Count;
                         for (var j = 0; j < i - count + 1; j++)
                         {
@@ -327,11 +331,8 @@ namespace QuantConnect.Indicators
             {
                 _listLock.EnterWriteLock();
 
-                if (size > _list.Capacity)
-                {
-                    _list.Capacity = size;
-                }
-                else if (size < _list.Count)
+                _list.EnsureCapacity(size);
+                if (size < _list.Count)
                 {
                     _list.RemoveRange(0, _list.Count - size);
                 }

--- a/Common/Messages/Messages.Indicators.cs
+++ b/Common/Messages/Messages.Indicators.cs
@@ -58,25 +58,7 @@ namespace QuantConnect
 
             public static string NoItemsRemovedYet = "No items have been removed yet!";
 
-            public static string WindowIsEmpty = "Rolling window is empty";
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static string IndexOutOfSizeRange(int size)
-            {
-                return Invariant($"Index must be between 0 and {size - 1} (rolling window is of size {size})");
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static string IndexOutOfCountRange(int count, int index)
-            {
-                return Invariant($"Index must be between 0 and {count - 1} (entry {index} does not exist yet)");
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static string SetIndexOutOfRange(int count)
-            {
-                return Invariant($"Must be between 0 and {count - 1}");
-            }
+            public static string IndexOutOfSizeRange = "Index must be a non-negative integer";
         }
     }
 }

--- a/Indicators/Indicator.cs
+++ b/Indicators/Indicator.cs
@@ -1,11 +1,11 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,10 +22,15 @@ namespace QuantConnect.Indicators
     public abstract class Indicator : IndicatorBase<IndicatorDataPoint>
     {
         /// <summary>
+        /// The default size of the history window for the indicator
+        /// </summary>
+        public static int DefaultWindowSize { get; } = 2;
+
+        /// <summary>
         /// Initializes a new instance of the Indicator class using the specified name.
         /// </summary>
         /// <param name="name">The name of this indicator</param>
-        protected Indicator(string name) 
+        protected Indicator(string name)
             : base(name)
         {
         }

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -863,7 +863,7 @@ namespace QuantConnect.Research
             var name = indicator.GetType().Name;
 
             var properties = indicator.GetType().GetProperties()
-                .Where(x => x.PropertyType.IsGenericType && x.Name != "Consolidators")
+                .Where(x => x.PropertyType.IsGenericType && x.Name != "Consolidators" && x.Name != "Window")
                 .ToDictionary(x => x.Name, y => new List<IndicatorDataPoint>());
             properties.Add(name, new List<IndicatorDataPoint>());
 

--- a/Tests/Indicators/IndicatorTests.cs
+++ b/Tests/Indicators/IndicatorTests.cs
@@ -227,6 +227,49 @@ namespace QuantConnect.Tests.Indicators
             Assert.AreEqual(3, indicatorTimeList.Count(x => x.Minute == 32));
         }
 
+        [TestCase(2)]
+        [TestCase(5)]
+        [TestCase(10)]
+        public void IndicatorKeepsHistory(int historyWindow)
+        {
+            var indicator = new TestIndicator("Test indicator");
+            indicator.Window = historyWindow;
+
+            var points = new List<IndicatorDataPoint>(100);
+            var referenceDate = new DateTime(2023, 06, 12, 9, 0, 0);
+            for (int i = 0; i < 100; i++)
+            {
+                // The first iteration will not update the indicator. By default, first value is IndicatorDataPoint(DateTime.MinValue, 0)
+                if (i == 0)
+                {
+                    var defaultValue = new IndicatorDataPoint(DateTime.MinValue, 0);
+                    Assert.AreEqual(defaultValue, indicator.Current);
+                    Assert.AreEqual(defaultValue, indicator[0]);
+                }
+                else
+                {
+                    var dateTime = referenceDate.AddMinutes(i);
+                    indicator.Update(dateTime, i);
+                    var expected = new IndicatorDataPoint(dateTime, i);
+
+                    Assert.AreEqual(expected, indicator.Current);
+                    Assert.AreEqual(expected, indicator[0]);
+                }
+
+                points.Insert(0, indicator[0]);
+                var startIndex = Math.Max(0, i - historyWindow + 1);
+                for (int j = startIndex; j <= i; j++)
+                {
+                    Assert.AreEqual(points[i - j], indicator[i - j]);
+                }
+
+                // Check the enumerator
+                var windowPoints = indicator.ToList();
+                var count = i - startIndex < historyWindow ? i - startIndex + 1 : historyWindow;
+                CollectionAssert.AreEqual(points.GetRange(0, count), windowPoints);
+            }
+        }
+
         private static void TestComparisonOperators<TValue>()
         {
             var indicator = new TestIndicator();

--- a/Tests/Indicators/IndicatorTests.cs
+++ b/Tests/Indicators/IndicatorTests.cs
@@ -233,7 +233,7 @@ namespace QuantConnect.Tests.Indicators
         public void IndicatorKeepsHistory(int historyWindow)
         {
             var indicator = new TestIndicator("Test indicator");
-            indicator.Window = historyWindow;
+            indicator.Window.Size = historyWindow;
 
             var points = new List<IndicatorDataPoint>(100);
             var referenceDate = new DateTime(2023, 06, 12, 9, 0, 0);
@@ -271,116 +271,52 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        public void HistoryWindowCanBeIndexedOutsideCount()
-        {
-            var indicator = new TestIndicator("Test indicator");
-            Assert.AreEqual(IndicatorBase.DefaultWindowSize, indicator.Window);
-
-            const int windowSize = 10;
-            indicator.Window = windowSize;
-            Assert.AreEqual(windowSize, indicator.Window);
-            Assert.AreEqual(1, indicator.WindowCount);
-
-            // Update the indicator a few times
-            var referenceDate = new DateTime(2023, 06, 12, 9, 0, 0);
-            // Start from 1 because the indicator has a value by default (DateTime.Min, 0)
-            for (var i = 1; i < windowSize / 2; i++)
-            {
-                indicator.Update(referenceDate.AddMinutes(i - 1), i);
-                Assert.AreEqual(i + 1, indicator.WindowCount);
-            }
-
-            // Index the indicator outside the current count but within its size
-            for (var i = indicator.WindowCount; i < indicator.Window; i++)
-            {
-                Assert.GreaterOrEqual(i, indicator.WindowCount);
-
-                Assert.IsNull(indicator[i]);
-                Assert.AreEqual(windowSize, indicator.Window);
-            }
-        }
-
-        [Test]
-        public void HistoryWindowCanBeIndexedOutsideSize()
-        {
-            var indicator = new TestIndicator("Test indicator");
-            Assert.AreEqual(IndicatorBase.DefaultWindowSize, indicator.Window);
-
-            // Index the indicator outside the current size
-            var initialSize = indicator.Window;
-            for (var i = initialSize; i < initialSize + 10; i++)
-            {
-                Assert.IsNull(indicator[i]);
-                Assert.AreEqual(i + 1, indicator.Window);
-            }
-        }
-
-        [Test]
-        public void HistoryWindowResizingUpKeepsCurrentValues()
-        {
-            var indicator = new TestIndicator("Test indicator");
-            indicator.Window = 5;
-
-            // Update the indicator to fill up the window
-            var referenceDate = new DateTime(2023, 06, 12, 9, 0, 0);
-            var dataPoints = new List<IndicatorDataPoint>(indicator.Window);
-            for (var i = 0; i < indicator.Window; i++)
-            {
-                indicator.Update(referenceDate.AddMinutes(i), i);
-                dataPoints.Insert(0, indicator.Current);
-            }
-
-            indicator.Window = indicator.Window * 2;
-            Assert.AreEqual(dataPoints.Count, indicator.WindowCount);
-            CollectionAssert.AreEqual(dataPoints, indicator.Take(dataPoints.Count));
-        }
-
-        [Test]
-        public void HistoryWindowResizingDownKeepsCurrentValuesWithinNewSize()
-        {
-            var indicator = new TestIndicator("Test indicator");
-            indicator.Window = 10;
-
-            // Update the indicator to fill up the window
-            var referenceDate = new DateTime(2023, 06, 12, 9, 0, 0);
-            var dataPoints = new List<IndicatorDataPoint>(indicator.Window);
-            for (var i = 0; i < indicator.Window; i++)
-            {
-                indicator.Update(referenceDate.AddMinutes(i), i);
-                dataPoints.Insert(0, indicator.Current);
-            }
-
-            var smallerSize = indicator.Window / 2;
-            indicator.Window = smallerSize;
-            Assert.AreEqual(smallerSize, indicator.Window);
-            Assert.AreEqual(indicator.WindowCount, indicator.Window);
-            CollectionAssert.AreEqual(dataPoints.Take(indicator.WindowCount), indicator);
-        }
-
-        [Test]
         public void HistoryWindowIsCorrectlyReset()
         {
             var indicator = new TestIndicator("Test indicator");
-            indicator.Window = 20;
+            indicator.Window.Size = 20;
 
             // Update the indicator a few times
             var referenceDate = new DateTime(2023, 06, 12, 9, 0, 0);
-            for (var i = 1; i < indicator.Window; i++)
+            for (var i = 1; i < indicator.Window.Size; i++)
             {
                 indicator.Update(referenceDate.AddMinutes(i - 1), i);
             }
 
-            Assert.AreEqual(indicator.Window, indicator.WindowCount);
+            Assert.AreEqual(indicator.Window.Size, indicator.Window.Count);
 
             indicator.Reset();
 
             // Window size is kept
-            Assert.AreEqual(20, indicator.Window);
+            Assert.AreEqual(20, indicator.Window.Size);
 
             // Window values are removed
-            Assert.AreEqual(1, indicator.WindowCount);
+            Assert.AreEqual(1, indicator.Window.Count);
             Assert.AreEqual(new IndicatorDataPoint(DateTime.MinValue, 0), indicator[0]);
             Assert.IsNull(indicator[1]);
+        }
+
+        [Test]
+        public void CanAccessCurrentAndPreviousState()
+        {
+            var indicator = new TestIndicator("Test indicator");
+            indicator.Window.Size = 10;
+
+            // Update the indicator a few times
+            var referenceDate = new DateTime(2023, 06, 12, 9, 0, 0);
+            var dataPoints = new List<IndicatorDataPoint>(indicator.Window.Size);
+            for (var i = 0; i < indicator.Window.Size; i++)
+            {
+                var dateTime = referenceDate.AddMinutes(i);
+                indicator.Update(dateTime, i);
+                dataPoints.Add(new IndicatorDataPoint(dateTime, i));
+            }
+
+            Assert.AreEqual(dataPoints[^1], indicator.Current);
+            Assert.AreEqual(dataPoints[^1], indicator[0]);
+
+            Assert.AreEqual(dataPoints[^2], indicator.Previous);
+            Assert.AreEqual(dataPoints[^2], indicator[1]);
         }
 
         private static void TestComparisonOperators<TValue>()

--- a/Tests/Indicators/RollingWindowTests.cs
+++ b/Tests/Indicators/RollingWindowTests.cs
@@ -1,11 +1,11 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Indicators;
@@ -172,19 +173,113 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        public void ThrowsWhenIndexingOutOfRange()
+        public void ThrowsWhenIndexIsNegative()
         {
             var window = new RollingWindow<int>(1);
             Assert.IsFalse(window.IsReady);
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => { var x = window[0]; });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { var x = window[-1]; });
+        }
 
-            window.Add(0);
-            Assert.AreEqual(1, window.Count);
-            Assert.AreEqual(0, window[0]);
-            Assert.IsTrue(window.IsReady);
+        [Test]
+        public void WindowCanBeIndexedOutsideCount()
+        {
+            const int windowSize = 10;
+            var window = new RollingWindow<int>(windowSize);
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => { var x = window[1]; });
+            // Add some data to the window
+            const int count = windowSize / 2;
+            for (var i = 0; i < count; i++)
+            {
+                window.Add(i);
+            }
+            Assert.AreEqual(count, window.Count);
+
+            // Index the indicator outside the current count but within its size
+            for (var i = window.Count; i < window.Size; i++)
+            {
+                Assert.AreEqual(default(int), window[i]);
+                Assert.AreEqual(windowSize, window.Size);
+            }
+        }
+
+        [Test]
+        public void WindowCanBeIndexedOutsideSizeAndGetsResized()
+        {
+            const int windowSize = 10;
+            var window = new RollingWindow<int>(windowSize);
+
+            // Index the indicator outside the current size
+            for (var i = windowSize; i < windowSize + 10; i++)
+            {
+                Assert.AreEqual(default(int), window[i]);
+                Assert.AreEqual(i + 1, window.Size);
+            }
+        }
+
+        [Test]
+        public void HistoryWindowResizingUpKeepsCurrentValues()
+        {
+            const int windowSize = 10;
+            var window = new RollingWindow<int>(windowSize);
+
+            // Fill the window up
+            var values = new List<int>(window.Size);
+            for (var i = 0; i < window.Size; i++)
+            {
+                window.Add(i);
+                values.Insert(0, i);
+            }
+
+            // Resize up
+            window.Size = window.Size * 2;
+            Assert.AreEqual(values.Count, window.Count);
+            CollectionAssert.AreEqual(values, window.Take(values.Count));
+        }
+
+        [Test]
+        public void HistoryWindowResizingDownKeepsCurrentValuesWithinNewSizeBelowCurrentCount()
+        {
+            const int windowSize = 20;
+            const int smallerSize = 10;
+
+            var window = new RollingWindow<int>(windowSize);
+
+            // Fill the window up
+            var values = new List<int>(window.Size);
+            for (var i = 0; i < window.Size; i++)
+            {
+                window.Add(i);
+                values.Insert(0, i);
+            }
+
+            window.Size = smallerSize;
+            Assert.AreEqual(smallerSize, window.Size);
+            Assert.AreEqual(smallerSize, window.Count);
+            CollectionAssert.AreEqual(values.Take(smallerSize), window);
+        }
+
+        [Test]
+        public void HistoryWindowResizingDownKeepsCurrentValuesWithinNewSizeAboveCurrentCount()
+        {
+            const int windowSize = 20;
+            const int dataCount = 5;
+            const int smallerSize = 10;
+
+            var window = new RollingWindow<int>(windowSize);
+
+            // Add some data to the window
+            var values = new List<int>(window.Size);
+            for (var i = 0; i < dataCount; i++)
+            {
+                window.Add(i);
+                values.Insert(0, i);
+            }
+
+            window.Size = smallerSize;
+            Assert.AreEqual(smallerSize, window.Size);
+            Assert.AreEqual(dataCount, window.Count);
+            CollectionAssert.AreEqual(values.Take(smallerSize), window);
         }
     }
 }

--- a/Tests/Indicators/RollingWindowTests.cs
+++ b/Tests/Indicators/RollingWindowTests.cs
@@ -204,6 +204,36 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
+        public void WindowCanBeIndexedOutsideCountUsingSetter()
+        {
+            const int windowSize = 20;
+            const int initialElementsCount = 5;
+            const int indexingStart = 10;
+            var window = new RollingWindow<int>(windowSize);
+
+            // Add some data to the window
+            for (var i = 0; i < initialElementsCount; i++)
+            {
+                window.Add(i);
+            }
+            Assert.AreEqual(initialElementsCount, window.Count);
+
+            // Index the indicator outside the current count but within its size
+            for (var i = indexingStart; i < window.Size; i++)
+            {
+                window[i] = i;
+                Assert.AreEqual(i, window[i]);
+                Assert.AreEqual(windowSize, window.Size);
+            }
+
+            // The middle indexes that were not touched should have the default value
+            for (var i = initialElementsCount; i < indexingStart; i++)
+            {
+                Assert.AreEqual(default(int), window[i]);
+            }
+        }
+
+        [Test]
         public void WindowCanBeIndexedOutsideSizeAndGetsResized()
         {
             const int windowSize = 10;

--- a/Tests/Indicators/RollingWindowTests.cs
+++ b/Tests/Indicators/RollingWindowTests.cs
@@ -245,6 +245,14 @@ namespace QuantConnect.Tests.Indicators
                 Assert.AreEqual(default(int), window[i]);
                 Assert.AreEqual(i + 1, window.Size);
             }
+
+            // Explicitly resize the window
+            var oldSize = window.Size;
+            window.Size = window.Size + 10;
+            for (var i = oldSize; i < window.Size; i++)
+            {
+                Assert.AreEqual(default(int), window[i]);
+            }
         }
 
         [Test]
@@ -259,6 +267,20 @@ namespace QuantConnect.Tests.Indicators
                 window[i] = i;
                 Assert.AreEqual(i, window[i]);
                 Assert.AreEqual(i + 1, window.Size);
+            }
+        }
+
+        [Test]
+        public void NewElementsHaveDefaultValuesWhenResizingUp()
+        {
+            var window = new RollingWindow<int>(10);
+
+            // Explicitly resize the window
+            var oldSize = window.Size;
+            window.Size = window.Size * 2;
+            for (var i = oldSize; i < window.Size; i++)
+            {
+                Assert.AreEqual(default(int), window[i]);
             }
         }
 

--- a/Tests/Indicators/RollingWindowTests.cs
+++ b/Tests/Indicators/RollingWindowTests.cs
@@ -218,6 +218,21 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
+        public void WindowCanBeIndexedOutsideSizeUsingSetterAndGetsResized()
+        {
+            const int windowSize = 10;
+            var window = new RollingWindow<int>(windowSize);
+
+            // Index the indicator outside the current size
+            for (var i = windowSize; i < windowSize + 10; i++)
+            {
+                window[i] = i;
+                Assert.AreEqual(i, window[i]);
+                Assert.AreEqual(i + 1, window.Size);
+            }
+        }
+
+        [Test]
         public void HistoryWindowResizingUpKeepsCurrentValues()
         {
             const int windowSize = 10;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Implement a rolling window in `IndicatorBase` to keep track of indicator's history for a user-defined period.

- The window size can be set/overriden using `indicator.Window = <value>;`.
- The number of currently store history points in the window can be accessed through `indicator.WindowCount`.
- Indicators are now enumerables, so the latest indicator value can be found on index 0 (`indicator[0]`) and the oldest value on index `indicator.WindowCount - 1`.
- Indexing an indicator history outside the current count `null`.
- Indexing an indicator history outside the window size (`indicator[i]` where `i >= indicator.Window`) will return null and resize the window to `i + 1`.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #3372 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

We may need to add documentation for this new indicator's feature.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests and regression algorithms.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
