### PR TITLE
Equity MOO/MOC orders fill on opening/closing trade ticks

### DIFF
--- a/Algorithm.CSharp/MarketOnCloseOrderFillsOnCloseTradeWithTickResolutionAlgorithm.cs
+++ b/Algorithm.CSharp/MarketOnCloseOrderFillsOnCloseTradeWithTickResolutionAlgorithm.cs
@@ -1,0 +1,140 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Algorithm asserting that MarketOnClose orders are filled with official close price.
+    /// </summary>
+    public class MarketOnCloseOrderFillsOnCloseTradeWithTickResolutionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _symbol;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 7);
+            SetEndDate(2013, 10, 8);
+            SetCash(1000000);
+
+            _symbol = AddEquity("SPY", Resolution.Tick, extendedMarketHours: true, dataNormalizationMode: DataNormalizationMode.Raw).Symbol;
+
+            Schedule.On(DateRules.EveryDay(_symbol),
+                TimeRules.BeforeMarketClose(_symbol, 20),
+                () => MarketOnCloseOrder(_symbol, 1));
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            if (orderEvent.Status == OrderStatus.Filled)
+            {
+                Debug(orderEvent.ToString());
+
+                if (orderEvent.Message != "")
+                {
+                    throw new Exception($"OrderEvent.Message should be empty, but is '{orderEvent.Message}'");
+                }
+
+                var order = Transactions.GetOrderById(orderEvent.OrderId);
+                if (order.Tag != "")
+                {
+                    throw new Exception($"Order.Tag should be empty, but is '{order.Tag}'");
+                }
+
+                var expectedFillPrice = orderEvent.UtcTime.Date == StartDate.Date ? 167.42m : 165.48m;
+                if (orderEvent.FillPrice != expectedFillPrice)
+                {
+                    throw new Exception(
+                        $"Expected {orderEvent.UtcTime.Date} order fill price to be {expectedFillPrice} but was {orderEvent.FillPrice}");
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            var orders = Transactions.GetOrders().ToList();
+
+            // We expect 2 orders, one for each day
+            var expectedOrdersCount = 2;
+            if (orders.Count != expectedOrdersCount)
+            {
+                throw new Exception($"Expected {expectedOrdersCount} orders, but found {orders.Count}");
+            }
+
+            if (orders.Any(x => x.Status != OrderStatus.Filled))
+            {
+                throw new Exception(
+                    $"Expected all orders to be filled, but found {orders.Count(x => x.Status != OrderStatus.Filled)} unfilled orders");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 7077871;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new()
+        {
+            {"Total Trades", "2"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$2.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
+            {"Portfolio Turnover", "0.02%"},
+            {"OrderListHash", "9d31f1f6d35cee039174809cf24092db"}
+        };
+    }
+}

--- a/Algorithm.CSharp/MarketOnOpenOrderFillsOnOpenTradeWithTickResolutionAlgorithm.cs
+++ b/Algorithm.CSharp/MarketOnOpenOrderFillsOnOpenTradeWithTickResolutionAlgorithm.cs
@@ -1,0 +1,140 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Algorithm asserting that MarketOnOpen orders are filled with official open price.
+    /// </summary>
+    public class MarketOnOpenOrderFillsOnOpenTradeWithTickResolutionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _symbol;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 7);
+            SetEndDate(2013, 10, 8);
+            SetCash(1000000);
+
+            _symbol = AddEquity("SPY", Resolution.Tick, extendedMarketHours: true, dataNormalizationMode: DataNormalizationMode.Raw).Symbol;
+
+            Schedule.On(DateRules.EveryDay(_symbol),
+                TimeRules.At(new TimeSpan(6, 0, 0), TimeZone),
+                () => MarketOnOpenOrder(_symbol, 1));
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            if (orderEvent.Status == OrderStatus.Filled)
+            {
+                Log(orderEvent.ToString());
+
+                if (orderEvent.Message != "")
+                {
+                    throw new Exception($"OrderEvent.Message should be empty, but is '{orderEvent.Message}'");
+                }
+
+                var order = Transactions.GetOrderById(orderEvent.OrderId);
+                if (order.Tag != "")
+                {
+                    throw new Exception($"Order.Tag should be empty, but is '{order.Tag}'");
+                }
+
+                var expectedFillPrice = orderEvent.UtcTime.Date == StartDate.Date ? 167.43m : 167.45m;
+                if (orderEvent.FillPrice != expectedFillPrice)
+                {
+                    throw new Exception(
+                        $"Expected {orderEvent.UtcTime.Date} order fill price to be {expectedFillPrice} but was {orderEvent.FillPrice}");
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            var orders = Transactions.GetOrders().ToList();
+
+            // We expect 2 orders, one for each day
+            var expectedOrdersCount = 2;
+            if (orders.Count != expectedOrdersCount)
+            {
+                throw new Exception($"Expected {expectedOrdersCount} orders, but found {orders.Count}");
+            }
+
+            if (orders.Any(x => x.Status != OrderStatus.Filled))
+            {
+                throw new Exception(
+                    $"Expected all orders to be filled, but found {orders.Count(x => x.Status != OrderStatus.Filled)} unfilled orders");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 7077871;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new()
+        {
+            {"Total Trades", "2"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$2.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
+            {"Portfolio Turnover", "0.02%"},
+            {"OrderListHash", "3e5a12f7b2c5609d65d3f2a132dc0de5"}
+        };
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Properly selecting the official open/close and opening/closing prints trade condition flags from trade ticks in order to fill MOO and MOC orders with the right prices.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6770 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests and regression algorithms.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
