### PR TITLE
Security cache dynamic collection for custom properties

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -34,7 +34,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.18" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Fuzzy" Version="3.6.0" />
     <PackageReference Include="Accord.MachineLearning" Version="3.6.0" />

--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -34,7 +34,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.20" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Fuzzy" Version="3.6.0" />
     <PackageReference Include="Accord.MachineLearning" Version="3.6.0" />

--- a/Algorithm.CSharp/SecurityCustomPropertiesAlgorithm.cs
+++ b/Algorithm.CSharp/SecurityCustomPropertiesAlgorithm.cs
@@ -1,0 +1,116 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities.Equity;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Demonstration of how to use custom security properties.
+    /// In this algorithm we trade a security based on the values of a slow and fast EMAs which are stored in the security itself.
+    /// </summary>
+    public class SecurityCustomPropertiesAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Equity _spy;
+        private dynamic _dynamicSpy;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 11);
+            SetCash(100000);
+
+            _spy = AddEquity("SPY", Resolution.Minute);
+
+            _dynamicSpy = _spy;
+            // Using the dynamic interface to store our indicator as a custom property
+            _dynamicSpy.SlowEma = EMA(_spy.Symbol, 30, Resolution.Minute);
+            // Using the generic interface to store our indicator as a custom property
+            _spy.Set("FastEma", EMA(_spy.Symbol, 60, Resolution.Minute));
+        }
+
+        public override void OnData(Slice data)
+        {
+            if (!Portfolio.Invested)
+            {
+                // Using the dynamic interface to access the custom properties
+                if (_dynamicSpy.SlowEma > _dynamicSpy.FastEma)
+                {
+                    SetHoldings(_spy.Symbol, 1);
+                }
+            }
+            // Using the generic interface to access the custom properties
+            else if (_spy.Get<IndicatorBase>("SlowEma") < _spy.Get<IndicatorBase>("FastEma"))
+            {
+                Liquidate(_spy.Symbol);
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 3943;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "30"},
+            {"Average Win", "0.38%"},
+            {"Average Loss", "-0.08%"},
+            {"Compounding Annual Return", "127.177%"},
+            {"Drawdown", "0.800%"},
+            {"Expectancy", "0.838"},
+            {"Net Profit", "1.055%"},
+            {"Sharpe Ratio", "11.681"},
+            {"Probabilistic Sharpe Ratio", "88.147%"},
+            {"Loss Rate", "67%"},
+            {"Win Rate", "33%"},
+            {"Profit-Loss Ratio", "4.51"},
+            {"Alpha", "0.226"},
+            {"Beta", "0.341"},
+            {"Annual Standard Deviation", "0.077"},
+            {"Annual Variance", "0.006"},
+            {"Information Ratio", "-7.331"},
+            {"Tracking Error", "0.147"},
+            {"Treynor Ratio", "2.647"},
+            {"Total Fees", "$103.40"},
+            {"Estimated Strategy Capacity", "$7700000.00"},
+            {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
+            {"Portfolio Turnover", "597.28%"},
+            {"OrderListHash", "eb583d25c08cef6046cc1bbc01e5c440"}
+        };
+    }
+}

--- a/Algorithm.CSharp/SecurityCustomPropertiesAlgorithm.cs
+++ b/Algorithm.CSharp/SecurityCustomPropertiesAlgorithm.cs
@@ -76,7 +76,7 @@ namespace QuantConnect.Algorithm.CSharp
                 }
             }
             // Using the generic interface to access the custom properties
-            else if (_spy.Get<IndicatorBase>("SlowEma") < _spy.Get<IndicatorBase>("FastEma"))
+            else if (_spy.Get<ExponentialMovingAverage>("SlowEma") < _spy.Get<ExponentialMovingAverage>("FastEma"))
             {
                 Liquidate(_spy.Symbol);
             }

--- a/Algorithm.CSharp/SecurityCustomPropertiesAlgorithm.cs
+++ b/Algorithm.CSharp/SecurityCustomPropertiesAlgorithm.cs
@@ -38,15 +38,25 @@ namespace QuantConnect.Algorithm.CSharp
 
             _spy = AddEquity("SPY", Resolution.Minute);
 
-            _dynamicSpy = _spy;
             // Using the dynamic interface to store our indicator as a custom property
+            _dynamicSpy = _spy;
             _dynamicSpy.SlowEma = EMA(_spy.Symbol, 30, Resolution.Minute);
+
             // Using the generic interface to store our indicator as a custom property
             _spy.Set("FastEma", EMA(_spy.Symbol, 60, Resolution.Minute));
+
+            // Using the indexer to store our indicator as a custom property
+            _spy["BB"] = BB(_spy.Symbol, 20, 1, MovingAverageType.Simple, Resolution.Minute);
+
         }
 
         public override void OnData(Slice data)
         {
+            if (!_dynamicSpy.FastEma.IsReady)
+            {
+                return;
+            }
+
             if (!Portfolio.Invested)
             {
                 // Using the dynamic interface to access the custom properties
@@ -60,6 +70,10 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 Liquidate(_spy.Symbol);
             }
+
+            // Using the indexer to access the custom properties
+            var bb = _spy["BB"] as BollingerBands;
+            Plot("BB", bb.UpperBand, bb.MiddleBand, bb.LowerBand);
         }
 
         /// <summary>
@@ -88,29 +102,29 @@ namespace QuantConnect.Algorithm.CSharp
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
             {"Total Trades", "30"},
-            {"Average Win", "0.38%"},
-            {"Average Loss", "-0.08%"},
-            {"Compounding Annual Return", "127.177%"},
+            {"Average Win", "0.42%"},
+            {"Average Loss", "-0.09%"},
+            {"Compounding Annual Return", "78.519%"},
             {"Drawdown", "0.800%"},
-            {"Expectancy", "0.838"},
-            {"Net Profit", "1.055%"},
-            {"Sharpe Ratio", "11.681"},
-            {"Probabilistic Sharpe Ratio", "88.147%"},
-            {"Loss Rate", "67%"},
-            {"Win Rate", "33%"},
-            {"Profit-Loss Ratio", "4.51"},
-            {"Alpha", "0.226"},
+            {"Expectancy", "0.574"},
+            {"Net Profit", "0.744%"},
+            {"Sharpe Ratio", "11.684"},
+            {"Probabilistic Sharpe Ratio", "88.148%"},
+            {"Loss Rate", "73%"},
+            {"Win Rate", "27%"},
+            {"Profit-Loss Ratio", "4.90"},
+            {"Alpha", "0.227"},
             {"Beta", "0.341"},
             {"Annual Standard Deviation", "0.077"},
             {"Annual Variance", "0.006"},
-            {"Information Ratio", "-7.331"},
+            {"Information Ratio", "-7.329"},
             {"Tracking Error", "0.147"},
-            {"Treynor Ratio", "2.647"},
-            {"Total Fees", "$103.40"},
-            {"Estimated Strategy Capacity", "$7700000.00"},
+            {"Treynor Ratio", "2.648"},
+            {"Total Fees", "$103.09"},
+            {"Estimated Strategy Capacity", "$7300000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
-            {"Portfolio Turnover", "597.28%"},
-            {"OrderListHash", "eb583d25c08cef6046cc1bbc01e5c440"}
+            {"Portfolio Turnover", "597.39%"},
+            {"OrderListHash", "5c28d5191259b2eb26f8e9694200c5c6"}
         };
     }
 }

--- a/Algorithm.CSharp/SecurityCustomPropertiesAlgorithm.cs
+++ b/Algorithm.CSharp/SecurityCustomPropertiesAlgorithm.cs
@@ -43,7 +43,7 @@ namespace QuantConnect.Algorithm.CSharp
             _dynamicSpy.SlowEma = EMA(_spy.Symbol, 30, Resolution.Minute);
 
             // Using the generic interface to store our indicator as a custom property
-            _spy.Set("FastEma", EMA(_spy.Symbol, 60, Resolution.Minute));
+            _spy.Add("FastEma", EMA(_spy.Symbol, 60, Resolution.Minute));
 
             // Using the indexer to store our indicator as a custom property
             _spy["BB"] = BB(_spy.Symbol, 20, 1, MovingAverageType.Simple, Resolution.Minute);

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -29,7 +29,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.20" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Math" Version="3.6.0" />
     <PackageReference Include="Accord.Statistics" Version="3.6.0" />

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -29,7 +29,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.18" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Math" Version="3.6.0" />
     <PackageReference Include="Accord.Statistics" Version="3.6.0" />

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -39,7 +39,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.20" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="AccumulativeInsightPortfolioRegressionAlgorithm.py" />

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -39,7 +39,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.18" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="AccumulativeInsightPortfolioRegressionAlgorithm.py" />

--- a/Algorithm.Python/SecurityCustomPropertiesAlgorithm.py
+++ b/Algorithm.Python/SecurityCustomPropertiesAlgorithm.py
@@ -34,10 +34,21 @@ class SecurityCustomPropertiesAlgorithm(QCAlgorithm):
         # Using the generic interface to store our indicator as a custom property.
         self.spy.Set("FastEma", self.EMA(self.spy.Symbol, 60, Resolution.Minute))
 
+        # Using the indexer to store our indicator as a custom property
+        self.spy["BB"] = self.BB(self.spy.Symbol, 20, 1, MovingAverageType.Simple, Resolution.Minute);
+
     def OnData(self, data):
+        if not self.spy.Get[IndicatorBase]("FastEma").IsReady:
+            return
+
         if not self.Portfolio.Invested:
+            # Using the property and the generic interface to access our indicator
             if self.spy.SlowEma > self.spy.Get[IndicatorBase]("FastEma"):
                 self.SetHoldings(self.spy.Symbol, 1)
         else:
             if self.spy.SlowEma < self.spy.Get[IndicatorBase]("FastEma"):
                 self.Liquidate(self.spy.Symbol)
+
+        # Using the indexer to access our indicator
+        bb: BollingerBands = self.spy["BB"]
+        self.Plot("BB", bb.UpperBand, bb.MiddleBand, bb.LowerBand)

--- a/Algorithm.Python/SecurityCustomPropertiesAlgorithm.py
+++ b/Algorithm.Python/SecurityCustomPropertiesAlgorithm.py
@@ -32,7 +32,7 @@ class SecurityCustomPropertiesAlgorithm(QCAlgorithm):
         self.spy.SlowEma = self.EMA(self.spy.Symbol, 30, Resolution.Minute)
 
         # Using the generic interface to store our indicator as a custom property.
-        self.spy.Set("FastEma", self.EMA(self.spy.Symbol, 60, Resolution.Minute))
+        self.spy.Add("FastEma", self.EMA(self.spy.Symbol, 60, Resolution.Minute))
 
         # Using the indexer to store our indicator as a custom property
         self.spy["BB"] = self.BB(self.spy.Symbol, 20, 1, MovingAverageType.Simple, Resolution.Minute);

--- a/Algorithm.Python/SecurityCustomPropertiesAlgorithm.py
+++ b/Algorithm.Python/SecurityCustomPropertiesAlgorithm.py
@@ -54,7 +54,7 @@ class SecurityCustomPropertiesAlgorithm(QCAlgorithm):
             if self.spy.SlowEma > self.spy.FastEma:
                 self.SetHoldings(self.spy.Symbol, 1)
         else:
-            if self.spy.Get[IndicatorBase]("SlowEma") < self.spy.Get[IndicatorBase]("FastEma"):
+            if self.spy.Get[ExponentialMovingAverage]("SlowEma") < self.spy.Get[ExponentialMovingAverage]("FastEma"):
                 self.Liquidate(self.spy.Symbol)
 
         # Using the indexer to access our indicator

--- a/Algorithm.Python/SecurityCustomPropertiesAlgorithm.py
+++ b/Algorithm.Python/SecurityCustomPropertiesAlgorithm.py
@@ -1,0 +1,43 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Demonstration of how to use custom security properties.
+### In this algorithm we trade a security based on the values of a slow and fast EMAs which are stored in the security itself.
+### </summary>
+class SecurityCustomPropertiesAlgorithm(QCAlgorithm):
+    '''Demonstration of how to use custom security properties.
+    In this algorithm we trade a security based on the values of a slow and fast EMAs which are stored in the security itself.'''
+
+    def Initialize(self):
+        self.SetStartDate(2013,10, 7)
+        self.SetEndDate(2013,10,11)
+        self.SetCash(100000)
+
+        self.spy = self.AddEquity("SPY", Resolution.Minute)
+
+        # Using the dynamic interface to store our indicator as a custom property.
+        self.spy.SlowEma = self.EMA(self.spy.Symbol, 30, Resolution.Minute)
+
+        # Using the generic interface to store our indicator as a custom property.
+        self.spy.Set("FastEma", self.EMA(self.spy.Symbol, 60, Resolution.Minute))
+
+    def OnData(self, data):
+        if not self.Portfolio.Invested:
+            if self.spy.SlowEma > self.spy.Get[IndicatorBase]("FastEma"):
+                self.SetHoldings(self.spy.Symbol, 1)
+        else:
+            if self.spy.SlowEma < self.spy.Get[IndicatorBase]("FastEma"):
+                self.Liquidate(self.spy.Symbol)

--- a/Algorithm/QuantConnect.Algorithm.csproj
+++ b/Algorithm/QuantConnect.Algorithm.csproj
@@ -29,7 +29,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.20" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NodaTime" Version="3.0.5" />

--- a/Algorithm/QuantConnect.Algorithm.csproj
+++ b/Algorithm/QuantConnect.Algorithm.csproj
@@ -29,7 +29,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.18" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NodaTime" Version="3.0.5" />

--- a/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
+++ b/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
@@ -28,7 +28,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.18" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
+++ b/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
@@ -28,7 +28,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.20" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -34,7 +34,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.20" />
     <PackageReference Include="CloneExtensions" Version="1.3.0" />
     <PackageReference Include="fasterflect" Version="3.0.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -34,7 +34,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.18" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
     <PackageReference Include="CloneExtensions" Version="1.3.0" />
     <PackageReference Include="fasterflect" Version="3.0.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -939,7 +939,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// AD the specified custom property.
+        /// Adds the specified custom property.
         /// This allows us to use the security object as a dynamic object for quick storage.
         /// </summary>
         /// <param name="key">The property key</param>

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -939,12 +939,12 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Sets the specified custom property on this object to the specified value.
+        /// AD the specified custom property.
         /// This allows us to use the security object as a dynamic object for quick storage.
         /// </summary>
         /// <param name="key">The property key</param>
         /// <param name="value">The property value</param>
-        public void Set(string key, object value)
+        public void Add(string key, object value)
         {
             Cache.Properties[key] = value;
         }
@@ -1016,7 +1016,7 @@ namespace QuantConnect.Securities
 
         /// <summary>
         /// Gets or sets the specified custom property through the indexer.
-        /// This is a wrapper around the <see cref="Get{T}(string)"/> and <see cref="Set(string,object)"/> methods.
+        /// This is a wrapper around the <see cref="Get{T}(string)"/> and <see cref="Add(string,object)"/> methods.
         /// </summary>
         /// <param name="key">The property key</param>
         public object this[string key]
@@ -1027,7 +1027,7 @@ namespace QuantConnect.Securities
             }
             set
             {
-                Set(key, value);
+                Add(key, value);
             }
         }
 

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -1014,6 +1014,23 @@ namespace QuantConnect.Securities
             Cache.Properties.Clear();
         }
 
+        /// <summary>
+        /// Gets or sets the specified custom property through the indexer.
+        /// This is a wrapper around the <see cref="Get{T}(string)"/> and <see cref="Set(string,object)"/> methods.
+        /// </summary>
+        /// <param name="key">The property key</param>
+        public object this[string key]
+        {
+            get
+            {
+                return Get<object>(key);
+            }
+            set
+            {
+                Set(key, value);
+            }
+        }
+
         #endregion
 
         /// <summary>

--- a/Common/Securities/SecurityCache.cs
+++ b/Common/Securities/SecurityCache.cs
@@ -40,6 +40,9 @@ namespace QuantConnect.Securities
         private IReadOnlyList<BaseData> _lastTickTrades = _empty;
         private Dictionary<Type, IReadOnlyList<BaseData>> _dataByType;
 
+        private readonly object _propertiesLock = new();
+        private Dictionary<string, object> _properties;
+
         /// <summary>
         /// Gets the most recent price submitted to this cache
         /// </summary>
@@ -98,7 +101,21 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Collection of keyed custom properties
         /// </summary>
-        public Dictionary<string, object> Properties { get; } = new();
+        public Dictionary<string, object> Properties
+        {
+            get
+            {
+                lock(_propertiesLock)
+                {
+                    if (_properties == null)
+                    {
+                        _properties = new Dictionary<string, object>();
+                    }
+                }
+
+                return _properties;
+            }
+        }
 
         /// <summary>
         /// Add a list of market data points to the local security cache for the current market price.

--- a/Common/Securities/SecurityCache.cs
+++ b/Common/Securities/SecurityCache.cs
@@ -40,7 +40,6 @@ namespace QuantConnect.Securities
         private IReadOnlyList<BaseData> _lastTickTrades = _empty;
         private Dictionary<Type, IReadOnlyList<BaseData>> _dataByType;
 
-        private readonly object _propertiesLock = new();
         private Dictionary<string, object> _properties;
 
         /// <summary>
@@ -105,14 +104,10 @@ namespace QuantConnect.Securities
         {
             get
             {
-                lock(_propertiesLock)
+                if (_properties == null)
                 {
-                    if (_properties == null)
-                    {
-                        _properties = new Dictionary<string, object>();
-                    }
+                    _properties = new Dictionary<string, object>();
                 }
-
                 return _properties;
             }
         }

--- a/Common/Securities/SecurityCache.cs
+++ b/Common/Securities/SecurityCache.cs
@@ -95,7 +95,10 @@ namespace QuantConnect.Securities
         /// </summary>
         public long OpenInterest { get; private set; }
 
-        public Dictionary<string, object> CustomProperties = new();
+        /// <summary>
+        /// Collection of keyed custom properties
+        /// </summary>
+        public Dictionary<string, object> Properties { get; } = new();
 
         /// <summary>
         /// Add a list of market data points to the local security cache for the current market price.

--- a/Common/Securities/SecurityCache.cs
+++ b/Common/Securities/SecurityCache.cs
@@ -23,12 +23,8 @@ using System.Runtime.CompilerServices;
 namespace QuantConnect.Securities
 {
     /// <summary>
-    /// Base class caching caching spot for security data and any other temporary properties.
+    /// Base class caching spot for security data and any other temporary properties.
     /// </summary>
-    /// <remarks>
-    /// This class is virtually unused and will soon be made obsolete.
-    /// This comment made in a remark to prevent obsolete errors in all users algorithms
-    /// </remarks>
     public class SecurityCache
     {
         // let's share the empty readonly version, so we don't need null checks
@@ -98,6 +94,8 @@ namespace QuantConnect.Securities
         /// Gets the most recent open interest submitted to this cache
         /// </summary>
         public long OpenInterest { get; private set; }
+
+        public Dictionary<string, object> CustomProperties = new();
 
         /// <summary>
         /// Add a list of market data points to the local security cache for the current market price.

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -42,7 +42,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.20" />
     <PackageReference Include="fasterflect" Version="3.0.0" />
     <PackageReference Include="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -42,7 +42,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.18" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
     <PackageReference Include="fasterflect" Version="3.0.0" />
     <PackageReference Include="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -31,7 +31,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.18" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -31,7 +31,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.20" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Report/QuantConnect.Report.csproj
+++ b/Report/QuantConnect.Report.csproj
@@ -41,7 +41,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.18" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
     <PackageReference Include="Deedle" Version="2.1.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/Report/QuantConnect.Report.csproj
+++ b/Report/QuantConnect.Report.csproj
@@ -41,7 +41,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.20" />
     <PackageReference Include="Deedle" Version="2.1.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/Research/QuantConnect.Research.csproj
+++ b/Research/QuantConnect.Research.csproj
@@ -31,7 +31,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.18" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/Research/QuantConnect.Research.csproj
+++ b/Research/QuantConnect.Research.csproj
@@ -31,7 +31,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.20" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Common/Securities/SecurityTests.cs
+++ b/Tests/Common/Securities/SecurityTests.cs
@@ -300,7 +300,13 @@ namespace QuantConnect.Tests.Common.Securities
         public void SetsAndGetsDynamicCustomPropertiesUsingCacheInterface()
         {
             var security = GetSecurity();
-            SetUpSecurityCustomProperties(security);
+            security.Cache.Properties.Add("Bool", true);
+            security.Cache.Properties.Add("Integer", 1);
+            security.Cache.Properties.Add("Double", 2.0);
+            security.Cache.Properties.Add("Decimal", 3.0m);
+            security.Cache.Properties.Add("String", "4");
+            security.Cache.Properties.Add("DateTime", DateTime.UtcNow);
+            security.Cache.Properties.Add("EMA", new ExponentialMovingAverage(10));
 
             Assert.AreEqual(7, security.Cache.Properties.Count);
             Assert.IsTrue(security.Cache.Properties.ContainsKey("Bool"));
@@ -318,9 +324,14 @@ namespace QuantConnect.Tests.Common.Securities
         public void SetsAndGetsDynamicCustomPropertiesUsingDynamicInterface()
         {
             var security = GetSecurity();
-            SetUpSecurityCustomProperties(security);
-
             dynamic dynamicSecurity = security;
+            dynamicSecurity.Bool = true;
+            dynamicSecurity.Integer = 1;
+            dynamicSecurity.Double = 2.0;
+            dynamicSecurity.Decimal = 3.0m;
+            dynamicSecurity.String = "string";
+            dynamicSecurity.DateTime = new DateTime(2023, 06, 20);
+            dynamicSecurity.EMA = new ExponentialMovingAverage(10);
 
             Assert.AreEqual(true, dynamicSecurity.Bool);
             Assert.AreEqual(1, dynamicSecurity.Integer);
@@ -337,7 +348,13 @@ namespace QuantConnect.Tests.Common.Securities
         public void SetsAndGetsDynamicCustomPropertiesUsingGenericInterface()
         {
             var security = GetSecurity();
-            SetUpSecurityCustomProperties(security);
+            security.Set("Bool", true);
+            security.Set("Integer", 1);
+            security.Set("Double", 2.0);
+            security.Set("Decimal", 3.0m);
+            security.Set("String", "string");
+            security.Set("DateTime", new DateTime(2023, 06, 20));
+            security.Set("EMA", new ExponentialMovingAverage(10));
 
             Assert.AreEqual(true, security.TryGet<bool>("Bool", out var boolValue));
             Assert.AreEqual(true, boolValue);
@@ -375,10 +392,34 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
+        public void SetsAndGetsDynamicCustomPropertiesUsingIndexer()
+        {
+            var security = GetSecurity();
+            security["Bool"] = true;
+            security["Integer"] = 1;
+            security["Double"] = 2.0;
+            security["Decimal"] = 3.0m;
+            security["String"] = "string";
+            security["DateTime"] = new DateTime(2023, 06, 20);
+            security["EMA"] = new ExponentialMovingAverage(10);
+
+            Assert.AreEqual(true, security["Bool"]);
+            Assert.AreEqual(1, security["Integer"]);
+            Assert.AreEqual(2.0, security["Double"]);
+            Assert.AreEqual(3.0m, security["Decimal"]);
+            Assert.AreEqual("string", security["String"]);
+            Assert.AreEqual(new DateTime(2023, 06, 20), security["DateTime"]);
+            Assert.AreEqual(new ExponentialMovingAverage(10), security["EMA"]);
+
+            Assert.Throws<KeyNotFoundException>(() => { var notAProperty = security["NotAProperty"]; });
+        }
+
+        [Test]
         public void RemovesCustomProperties()
         {
             var security = GetSecurity();
-            SetUpSecurityCustomProperties(security);
+            security.Set("Bool", true);
+            security.Set("DateTime", new DateTime(2023, 06, 20));
 
             Assert.IsTrue(security.Remove("Bool"));
             Assert.IsFalse(security.TryGet<bool>("Bool", out _));
@@ -394,33 +435,16 @@ namespace QuantConnect.Tests.Common.Securities
         public void ClearsCustomProperties()
         {
             var security = GetSecurity();
-            SetUpSecurityCustomProperties(security);
+            security.Set("Decimal", 3.0m);
+            security.Set("DateTime", new DateTime(2023, 06, 20));
 
-            Assert.AreEqual(7, security.Cache.Properties.Count);
+            Assert.AreEqual(2, security.Cache.Properties.Count);
 
             security.Clear();
             Assert.AreEqual(0, security.Cache.Properties.Count);
-            Assert.IsFalse(security.TryGet<bool>("Bool", out _));
-            Assert.IsFalse(security.TryGet<int>("Integer", out _));
-            Assert.IsFalse(security.TryGet<double>("Double", out _));
             Assert.IsFalse(security.TryGet<decimal>("Decimal", out _));
-            Assert.IsFalse(security.TryGet<string>("String", out _));
             Assert.IsFalse(security.TryGet<DateTime>("DateTime", out _));
-            Assert.IsFalse(security.TryGet<ExponentialMovingAverage>("EMA", out _));
 
-        }
-
-        private static void SetUpSecurityCustomProperties(Security security)
-        {
-            dynamic dynamicSecurity = security;
-
-            dynamicSecurity.Bool = true;
-            dynamicSecurity.Integer = 1;
-            dynamicSecurity.Double = 2.0;
-            dynamicSecurity.Decimal = 3.0m;
-            dynamicSecurity.String = "string";
-            dynamicSecurity.DateTime = new DateTime(2023, 06, 20);
-            dynamicSecurity.EMA = new ExponentialMovingAverage(10);
         }
 
         #endregion

--- a/Tests/Common/Securities/SecurityTests.cs
+++ b/Tests/Common/Securities/SecurityTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -25,6 +25,8 @@ using QuantConnect.Orders.Fills;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Orders.Slippage;
 using QuantConnect.Securities.Option;
+using QuantConnect.Indicators;
+using Microsoft.CSharp.RuntimeBinder;
 
 namespace QuantConnect.Tests.Common.Securities
 {
@@ -291,6 +293,84 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(tradeBars[0].Close, fromDynamicSecurityData.Close);
             Assert.AreEqual(tradeBars[0].Volume, fromDynamicSecurityData.Volume);
         }
+
+        #region Custom properties tests
+
+        [Test]
+        public void SetsAndGetsDynamicCustomPropertiesUsingCacheInterface()
+        {
+            var security = GetSecurity();
+            SetUpSecurityCustomProperties(security);
+
+            Assert.AreEqual(7, security.Cache.CustomProperties.Count);
+            Assert.IsTrue(security.Cache.CustomProperties.ContainsKey("Bool"));
+            Assert.IsTrue(security.Cache.CustomProperties.ContainsKey("Integer"));
+            Assert.IsTrue(security.Cache.CustomProperties.ContainsKey("Double"));
+            Assert.IsTrue(security.Cache.CustomProperties.ContainsKey("Decimal"));
+            Assert.IsTrue(security.Cache.CustomProperties.ContainsKey("String"));
+            Assert.IsTrue(security.Cache.CustomProperties.ContainsKey("DateTime"));
+            Assert.IsTrue(security.Cache.CustomProperties.ContainsKey("EMA"));
+
+            Assert.IsFalse(security.Cache.CustomProperties.ContainsKey("NotAProperty"));
+        }
+
+        [Test]
+        public void SetsAndGetsDynamicCustomPropertiesUsingDynamicInterface()
+        {
+            var security = GetSecurity();
+            SetUpSecurityCustomProperties(security);
+
+            dynamic dynamicSecurity = security;
+
+            Assert.AreEqual(true, dynamicSecurity.Bool);
+            Assert.AreEqual(1, dynamicSecurity.Integer);
+            Assert.AreEqual(2.0, dynamicSecurity.Double);
+            Assert.AreEqual(3.0m, dynamicSecurity.Decimal);
+            Assert.AreEqual("string", dynamicSecurity.String);
+            Assert.AreEqual(new DateTime(2023, 06, 20), dynamicSecurity.DateTime);
+            Assert.AreEqual(new ExponentialMovingAverage(10), dynamicSecurity.EMA);
+
+            Assert.Throws<RuntimeBinderException>(() => { var notAProperty = dynamicSecurity.NotAProperty; });
+        }
+
+        [Test]
+        public void SetsAndGetsDynamicCustomPropertiesUsingGenericInterface()
+        {
+            var security = GetSecurity();
+            SetUpSecurityCustomProperties(security);
+
+            Assert.AreEqual(true, security.TryGet<bool>("Bool", out var boolValue));
+            Assert.AreEqual(true, boolValue);
+            Assert.AreEqual(true, security.TryGet<int>("Integer", out var intValue));
+            Assert.AreEqual(1, intValue);
+            Assert.AreEqual(true, security.TryGet<double>("Double", out var doubleValue));
+            Assert.AreEqual(2.0, doubleValue);
+            Assert.AreEqual(true, security.TryGet<decimal>("Decimal", out var decimalValue));
+            Assert.AreEqual(3.0m, decimalValue);
+            Assert.AreEqual(true, security.TryGet<string>("String", out var stringValue));
+            Assert.AreEqual("string", stringValue);
+            Assert.AreEqual(true, security.TryGet<DateTime>("DateTime", out var dateTimeValue));
+            Assert.AreEqual(new DateTime(2023, 06, 20), dateTimeValue);
+            Assert.AreEqual(true, security.TryGet<ExponentialMovingAverage>("EMA", out var emaValue));
+            Assert.AreEqual(new ExponentialMovingAverage(10), emaValue);
+
+            Assert.AreEqual(false, security.TryGet<bool>("NotAProperty", out _));
+        }
+
+        private static void SetUpSecurityCustomProperties(Security security)
+        {
+            dynamic dynamicSecurity = security;
+
+            dynamicSecurity.Bool = true;
+            dynamicSecurity.Integer = 1;
+            dynamicSecurity.Double = 2.0;
+            dynamicSecurity.Decimal = 3.0m;
+            dynamicSecurity.String = "string";
+            dynamicSecurity.DateTime = new DateTime(2023, 06, 20);
+            dynamicSecurity.EMA = new ExponentialMovingAverage(10);
+        }
+
+        #endregion
 
         internal static Security GetSecurity(bool isMarketAlwaysOpen = true)
         {

--- a/Tests/Common/Securities/SecurityTests.cs
+++ b/Tests/Common/Securities/SecurityTests.cs
@@ -302,16 +302,16 @@ namespace QuantConnect.Tests.Common.Securities
             var security = GetSecurity();
             SetUpSecurityCustomProperties(security);
 
-            Assert.AreEqual(7, security.Cache.CustomProperties.Count);
-            Assert.IsTrue(security.Cache.CustomProperties.ContainsKey("Bool"));
-            Assert.IsTrue(security.Cache.CustomProperties.ContainsKey("Integer"));
-            Assert.IsTrue(security.Cache.CustomProperties.ContainsKey("Double"));
-            Assert.IsTrue(security.Cache.CustomProperties.ContainsKey("Decimal"));
-            Assert.IsTrue(security.Cache.CustomProperties.ContainsKey("String"));
-            Assert.IsTrue(security.Cache.CustomProperties.ContainsKey("DateTime"));
-            Assert.IsTrue(security.Cache.CustomProperties.ContainsKey("EMA"));
+            Assert.AreEqual(7, security.Cache.Properties.Count);
+            Assert.IsTrue(security.Cache.Properties.ContainsKey("Bool"));
+            Assert.IsTrue(security.Cache.Properties.ContainsKey("Integer"));
+            Assert.IsTrue(security.Cache.Properties.ContainsKey("Double"));
+            Assert.IsTrue(security.Cache.Properties.ContainsKey("Decimal"));
+            Assert.IsTrue(security.Cache.Properties.ContainsKey("String"));
+            Assert.IsTrue(security.Cache.Properties.ContainsKey("DateTime"));
+            Assert.IsTrue(security.Cache.Properties.ContainsKey("EMA"));
 
-            Assert.IsFalse(security.Cache.CustomProperties.ContainsKey("NotAProperty"));
+            Assert.IsFalse(security.Cache.Properties.ContainsKey("NotAProperty"));
         }
 
         [Test]
@@ -341,20 +341,73 @@ namespace QuantConnect.Tests.Common.Securities
 
             Assert.AreEqual(true, security.TryGet<bool>("Bool", out var boolValue));
             Assert.AreEqual(true, boolValue);
+            Assert.AreEqual(true, security.Get<bool>("Bool"));
+
             Assert.AreEqual(true, security.TryGet<int>("Integer", out var intValue));
             Assert.AreEqual(1, intValue);
+            Assert.AreEqual(1, security.Get<int>("Integer"));
+
             Assert.AreEqual(true, security.TryGet<double>("Double", out var doubleValue));
             Assert.AreEqual(2.0, doubleValue);
+            Assert.AreEqual(2.0, security.Get<double>("Double"));
+
             Assert.AreEqual(true, security.TryGet<decimal>("Decimal", out var decimalValue));
             Assert.AreEqual(3.0m, decimalValue);
+            Assert.AreEqual(3.0m, security.Get<decimal>("Decimal"));
+
             Assert.AreEqual(true, security.TryGet<string>("String", out var stringValue));
             Assert.AreEqual("string", stringValue);
+            Assert.AreEqual("string", security.Get<string>("String"));
+
             Assert.AreEqual(true, security.TryGet<DateTime>("DateTime", out var dateTimeValue));
             Assert.AreEqual(new DateTime(2023, 06, 20), dateTimeValue);
+            Assert.AreEqual(new DateTime(2023, 06, 20), security.Get<DateTime>("DateTime"));
+
             Assert.AreEqual(true, security.TryGet<ExponentialMovingAverage>("EMA", out var emaValue));
             Assert.AreEqual(new ExponentialMovingAverage(10), emaValue);
+            Assert.AreEqual(new ExponentialMovingAverage(10), security.Get<ExponentialMovingAverage>("EMA"));
 
             Assert.AreEqual(false, security.TryGet<bool>("NotAProperty", out _));
+            Assert.Throws<KeyNotFoundException>(() => security.Get<bool>("NotAProperty"));
+
+            Assert.Throws<InvalidCastException>(() => security.TryGet<SimpleMovingAverage>("EMA", out _));
+            Assert.Throws<InvalidCastException>(() => security.Get<SimpleMovingAverage>("EMA"));
+        }
+
+        [Test]
+        public void RemovesCustomProperties()
+        {
+            var security = GetSecurity();
+            SetUpSecurityCustomProperties(security);
+
+            Assert.IsTrue(security.Remove("Bool"));
+            Assert.IsFalse(security.TryGet<bool>("Bool", out _));
+            Assert.IsFalse(security.Remove("Bool"));
+
+            Assert.IsTrue(security.Remove("DateTime", out DateTime dateTime));
+            Assert.AreEqual(new DateTime(2023, 06, 20), dateTime);
+            Assert.IsFalse(security.TryGet<DateTime>("DateTime", out _));
+            Assert.IsFalse(security.Remove<DateTime>("DateTime", out _));
+        }
+
+        [Test]
+        public void ClearsCustomProperties()
+        {
+            var security = GetSecurity();
+            SetUpSecurityCustomProperties(security);
+
+            Assert.AreEqual(7, security.Cache.Properties.Count);
+
+            security.Clear();
+            Assert.AreEqual(0, security.Cache.Properties.Count);
+            Assert.IsFalse(security.TryGet<bool>("Bool", out _));
+            Assert.IsFalse(security.TryGet<int>("Integer", out _));
+            Assert.IsFalse(security.TryGet<double>("Double", out _));
+            Assert.IsFalse(security.TryGet<decimal>("Decimal", out _));
+            Assert.IsFalse(security.TryGet<string>("String", out _));
+            Assert.IsFalse(security.TryGet<DateTime>("DateTime", out _));
+            Assert.IsFalse(security.TryGet<ExponentialMovingAverage>("EMA", out _));
+
         }
 
         private static void SetUpSecurityCustomProperties(Security security)

--- a/Tests/Common/Securities/SecurityTests.cs
+++ b/Tests/Common/Securities/SecurityTests.cs
@@ -348,13 +348,13 @@ namespace QuantConnect.Tests.Common.Securities
         public void SetsAndGetsDynamicCustomPropertiesUsingGenericInterface()
         {
             var security = GetSecurity();
-            security.Set("Bool", true);
-            security.Set("Integer", 1);
-            security.Set("Double", 2.0);
-            security.Set("Decimal", 3.0m);
-            security.Set("String", "string");
-            security.Set("DateTime", new DateTime(2023, 06, 20));
-            security.Set("EMA", new ExponentialMovingAverage(10));
+            security.Add("Bool", true);
+            security.Add("Integer", 1);
+            security.Add("Double", 2.0);
+            security.Add("Decimal", 3.0m);
+            security.Add("String", "string");
+            security.Add("DateTime", new DateTime(2023, 06, 20));
+            security.Add("EMA", new ExponentialMovingAverage(10));
 
             Assert.AreEqual(true, security.TryGet<bool>("Bool", out var boolValue));
             Assert.AreEqual(true, boolValue);
@@ -418,8 +418,8 @@ namespace QuantConnect.Tests.Common.Securities
         public void RemovesCustomProperties()
         {
             var security = GetSecurity();
-            security.Set("Bool", true);
-            security.Set("DateTime", new DateTime(2023, 06, 20));
+            security.Add("Bool", true);
+            security.Add("DateTime", new DateTime(2023, 06, 20));
 
             Assert.IsTrue(security.Remove("Bool"));
             Assert.IsFalse(security.TryGet<bool>("Bool", out _));
@@ -435,8 +435,8 @@ namespace QuantConnect.Tests.Common.Securities
         public void ClearsCustomProperties()
         {
             var security = GetSecurity();
-            security.Set("Decimal", 3.0m);
-            security.Set("DateTime", new DateTime(2023, 06, 20));
+            security.Add("Decimal", 3.0m);
+            security.Add("DateTime", new DateTime(2023, 06, 20));
 
             Assert.AreEqual(2, security.Cache.Properties.Count);
 
@@ -445,6 +445,31 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.IsFalse(security.TryGet<decimal>("Decimal", out _));
             Assert.IsFalse(security.TryGet<DateTime>("DateTime", out _));
 
+        }
+
+        [Test]
+        public void OverwritesCustomProperties()
+        {
+            var security = GetSecurity();
+            dynamic dynamicSecurity = security;
+
+            dynamicSecurity.DateTime = new DateTime(2023, 06, 20);
+            Assert.AreEqual(new DateTime(2023, 06, 20), dynamicSecurity.DateTime);
+
+            dynamicSecurity.DateTime = new DateTime(2024, 06, 20);
+            Assert.AreEqual(new DateTime(2024, 06, 20), dynamicSecurity.DateTime);
+        }
+
+        [Test]
+        public void InvokesCustomPropertyMethod()
+        {
+            var security = GetSecurity();
+            dynamic dynamicSecurity = security;
+
+            dynamicSecurity.MakeEma = new Func<int, decimal, ExponentialMovingAverage>(
+                (period, smoothingFactor) => new ExponentialMovingAverage(period, smoothingFactor));
+
+            Assert.AreEqual(new ExponentialMovingAverage(10, 0.5m), dynamicSecurity.MakeEma(10, 0.5m));
         }
 
         #endregion

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.18" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Math" Version="3.6.0" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.20" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Math" Version="3.6.0" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -39,7 +39,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.20" />
     <PackageReference Include="CoinAPI.WebSocket.V1" Version="1.6.7" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />
     <PackageReference Include="Common.Logging.Core" Version="3.4.1" />

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -39,7 +39,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.18" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.19" />
     <PackageReference Include="CoinAPI.WebSocket.V1" Version="1.6.7" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />
     <PackageReference Include="Common.Logging.Core" Version="3.4.1" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This adds a custom properties collection carried by `SecurityCache` and helper methods and mechanism to make it accessible from `Security` instances:
- Using `Security.Get<T>/Try<T>Get/Set` methods or the indexer (`Security[]`), the custom properties can be set/accessed by key.
    - `Get/TryGet/Set` allow to set and get (casting to the desired/expected type) the dynamic properties. C# users might use these methods and -- if performance is not that big of an issue -- they could use the dynamic object capabilities (see next point).
- Using `dynamic` the properties can be set/accessed dynamically by property name (e.g. `security.SlowEma`) instead of by key. C# users can rely un this for easy dynamic properties access. Python users can also use this since it will be no different than setting custom Python attributes to a given instance.

`BasicTemplateBenchmark` benchmark algorithm was ran using both QuantConnect/pythonnet version 2.0.18 and 2.0.19. No real difference was found:

Master:

```
Algorithm Id:(BasicTemplateBenchmark) completed in 34.06 seconds at 106k data points per second. Processing total of 3,617,396 data points.

Algorithm Id:(BasicTemplateBenchmark) completed in 34.00 seconds at 106k data points per second. Processing total of 3,617,396 data points.

Algorithm Id:(BasicTemplateBenchmark) completed in 34.05 seconds at 106k data points per second. Processing total of 3,617,396 data points.
```

PR:

```
Algorithm Id:(BasicTemplateBenchmark) completed in 33.44 seconds at 108k data points per second. Processing total of 3,617,396 data points.

Algorithm Id:(BasicTemplateBenchmark) completed in 33.99 seconds at 106k data points per second. Processing total of 3,617,396 data points.

Algorithm Id:(BasicTemplateBenchmark) completed in 33.69 seconds at 107k data points per second. Processing total of 3,617,396 data points.
```

The algorithm was also modified to access several properties of the security objects in `OnData`. Again, no meaningful difference was observed.

```python
class BasicTemplateBenchmark(QCAlgorithm):

    def Initialize(self):
        self.SetStartDate(2000, 1, 1)
        self.SetEndDate(2022, 1, 1)
        self.SetBenchmark(lambda x: 1)
        self.AddEquity("SPY")

    def OnData(self, data):
        # Accessing security properties
        spy = self.Securities["SPY"]
        _open = spy.Open
        close = spy.Close
        high = spy.High
        low = spy.Low
        volume = spy.Volume
        symbol = spy.Symbol
        quote_currency = spy.QuoteCurrency
        symbol_properties = spy.SymbolProperties
        exchange = spy.Exchange
        _type = spy.Type

        if not spy.Holdings.Invested:
            self.SetHoldings("SPY", 1)
            self.Debug("Purchased Stock")
```

Master:
```
Algorithm Id:(BasicTemplateBenchmark) completed in 41.89 seconds at 86k data points per second. Processing total of 3,617,396 data points.

Algorithm Id:(BasicTemplateBenchmark) completed in 40.59 seconds at 89k data points per second. Processing total of 3,617,396 data points.

Algorithm Id:(BasicTemplateBenchmark) completed in 40.99 seconds at 88k data points per second. Processing total of 3,617,396 data points.
```

PR:

```
Algorithm Id:(BasicTemplateBenchmark) completed in 38.90 seconds at 93k data points per second. Processing total of 3,617,396 data points.

Algorithm Id:(BasicTemplateBenchmark) completed in 40.55 seconds at 89k data points per second. Processing total of 3,617,396 data points.

Algorithm Id:(BasicTemplateBenchmark) completed in 39.53 seconds at 92k data points per second. Processing total of 3,617,396 data points.
```

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #6809 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Reducing some of the boiler plate scaffolding required building multi asset strategies.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests and regression algorithms.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
