### PR TITLE
Fix bug in Insight Weighted PCM

### DIFF
--- a/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.cs
@@ -150,6 +150,6 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// </summary>
         /// <param name="insight">The insight to create a target for</param>
         /// <returns>The value of the selected insight member</returns>
-        protected virtual double GetValue(Insight insight) => insight.Weight != null ? (double)Math.Abs((decimal)insight.Weight) : 0;
+        protected virtual double GetValue(Insight insight) => insight.Weight != null ? Math.Abs((double)insight.Weight) : 0;
     }
 }

--- a/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.cs
@@ -150,6 +150,6 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         /// </summary>
         /// <param name="insight">The insight to create a target for</param>
         /// <returns>The value of the selected insight member</returns>
-        protected virtual double GetValue(Insight insight) => insight.Weight ?? 0;
+        protected virtual double GetValue(Insight insight) => insight.Weight != null ? (double)Math.Abs((decimal)insight.Weight) : 0;
     }
 }

--- a/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/InsightWeightingPortfolioConstructionModel.py
@@ -64,4 +64,4 @@ class InsightWeightingPortfolioConstructionModel(EqualWeightingPortfolioConstruc
             insight: The insight to create a target for
         Returns:
             The value of the selected insight member'''
-        return insight.Weight
+        return abs(insight.Weight)

--- a/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
@@ -195,7 +195,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(Language.Python, InsightDirection.Down, -1)]
         [TestCase(Language.Python, InsightDirection.Flat, 1)]
         [TestCase(Language.Python, InsightDirection.Flat, -1)]
-        public virtual void InsightsReturnsTargetsConsistentWithDirection(Language language, InsightDirection direction, double weightSign)
+        public virtual void InsightsReturnsTargetsConsistentWithDirection(Language language, InsightDirection direction, int weightSign)
         {
             SetPortfolioConstruction(language);
 

--- a/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/EqualWeightingPortfolioConstructionModelTests.cs
@@ -183,13 +183,19 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         }
 
         [Test]
-        [TestCase(Language.CSharp, InsightDirection.Up)]
-        [TestCase(Language.CSharp, InsightDirection.Down)]
-        [TestCase(Language.CSharp, InsightDirection.Flat)]
-        [TestCase(Language.Python, InsightDirection.Up)]
-        [TestCase(Language.Python, InsightDirection.Down)]
-        [TestCase(Language.Python, InsightDirection.Flat)]
-        public virtual void InsightsReturnsTargetsConsistentWithDirection(Language language, InsightDirection direction)
+        [TestCase(Language.CSharp, InsightDirection.Up, 1)]
+        [TestCase(Language.CSharp, InsightDirection.Up, -1)]
+        [TestCase(Language.CSharp, InsightDirection.Down, 1)]
+        [TestCase(Language.CSharp, InsightDirection.Down, -1)]
+        [TestCase(Language.CSharp, InsightDirection.Flat, 1)]
+        [TestCase(Language.CSharp, InsightDirection.Flat, -1)]
+        [TestCase(Language.Python, InsightDirection.Up, 1)]
+        [TestCase(Language.Python, InsightDirection.Up, -1)]
+        [TestCase(Language.Python, InsightDirection.Down, 1)]
+        [TestCase(Language.Python, InsightDirection.Down, -1)]
+        [TestCase(Language.Python, InsightDirection.Flat, 1)]
+        [TestCase(Language.Python, InsightDirection.Flat, -1)]
+        public virtual void InsightsReturnsTargetsConsistentWithDirection(Language language, InsightDirection direction, double weightSign)
         {
             SetPortfolioConstruction(language);
 
@@ -203,7 +209,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             var expectedTargets = Algorithm.Securities
                 .Select(x => new PortfolioTarget(x.Key, (int)direction * Math.Floor(amount / x.Value.Price)));
 
-            var insights = Algorithm.Securities.Keys.Select(x => GetInsight(x, direction, Algorithm.UtcTime));
+            var insights = Algorithm.Securities.Keys.Select(x => GetInsight(x, direction, Algorithm.UtcTime, weight: weightSign * Weight));
             var actualTargets = Algorithm.PortfolioConstruction.CreateTargets(Algorithm, insights.ToArray());
 
             AssertTargets(expectedTargets, actualTargets);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Modify `InsightWeightingPortfolioConstructionModel.cs/py` to take the
  absolute value in its `GetValue()` method.
- Modifiy `InsightsReturnsTargetsConsistentWithDirection()` unit test to
  consider also the case where the direction is Down and the weight is
  negative.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #6337 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change if we emit a down insight with a weight(negative/positive), the InsightWeightingPortfolioConstructionModel will create a target to sell the security.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require changes to documentation.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The unit tests `InsightsReturnsTargetsConsistentWithDirection()` were modified to consider also the case where the direction is Down and the weight is negative,
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
