### PR TITLE
Fix indicator name generation method

### DIFF
--- a/Algorithm.CSharp/IndicatorSuiteAlgorithm.cs
+++ b/Algorithm.CSharp/IndicatorSuiteAlgorithm.cs
@@ -33,9 +33,11 @@ namespace QuantConnect.Algorithm.CSharp
     public class IndicatorSuiteAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private string _ticker = "SPY";
+        private string _ticker2 = "GOOG";
         private string _customTicker = "IBM";
 
         private Symbol _symbol;
+        private Symbol _symbol2;
         private Symbol _customSymbol;
 
         private Indicators _indicators;
@@ -61,6 +63,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             //Add as many securities as you like. All the data will be passed into the event handler:
             _symbol = AddSecurity(SecurityType.Equity, _ticker, Resolution.Daily).Symbol;
+            _symbol2 = AddSecurity(SecurityType.Equity, _ticker2, Resolution.Daily).Symbol;
 
             //Add the Custom Data:
             _customSymbol = AddData<CustomData>(_customTicker, Resolution.Daily).Symbol;
@@ -79,7 +82,8 @@ namespace QuantConnect.Algorithm.CSharp
                 MOMP = MOMP(_symbol, 20, Resolution.Daily),
                 STD = STD(_symbol, 20, Resolution.Daily),
                 MIN = MIN(_symbol, 14, Resolution.Daily), // by default if the symbol is a tradebar type then it will be the min of the low property
-                MAX = MAX(_symbol, 14, Resolution.Daily)  // by default if the symbol is a tradebar type then it will be the max of the high property
+                MAX = MAX(_symbol, 14, Resolution.Daily),  // by default if the symbol is a tradebar type then it will be the max of the high property
+                B = B(_symbol, _symbol2, 14),
             };
 
             // Here we're going to define indicators using 'selector' functions. These 'selector' functions will define what data gets sent into the indicator
@@ -204,6 +208,7 @@ namespace QuantConnect.Algorithm.CSharp
             public MovingAverageConvergenceDivergence MACD;
             public Minimum MIN;
             public Maximum MAX;
+            public Beta B;
         }
 
         /// <summary>
@@ -240,7 +245,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 4537;
+        public long DataPoints => 4733;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.Python/IndicatorSuiteAlgorithm.py
+++ b/Algorithm.Python/IndicatorSuiteAlgorithm.py
@@ -28,6 +28,7 @@ class IndicatorSuiteAlgorithm(QCAlgorithm):
         '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
 
         self.symbol = "SPY"
+        self.symbol2 = "GOOG"
         self.customSymbol = "IBM"
         self.price = None
 
@@ -37,6 +38,7 @@ class IndicatorSuiteAlgorithm(QCAlgorithm):
         # Find more symbols here: http://quantconnect.com/data
 
         self.AddEquity(self.symbol, Resolution.Daily)
+        self.AddEquity(self.symbol2, Resolution.Daily)
         self.AddData(CustomData, self.customSymbol, Resolution.Daily)
 
         # Set up default Indicators, these indicators are defined on the Value property of incoming data (except ATR and AROON which use the full TradeBar object)
@@ -54,7 +56,8 @@ class IndicatorSuiteAlgorithm(QCAlgorithm):
                             # by default if the symbol is a tradebar type then it will be the max of the high property
                             'MAX' : self.MAX(self.symbol, 14, Resolution.Daily),
                             'ATR' : self.ATR(self.symbol, 14, MovingAverageType.Simple, Resolution.Daily),
-                            'AROON' : self.AROON(self.symbol, 20, Resolution.Daily)
+                            'AROON' : self.AROON(self.symbol, 20, Resolution.Daily),
+                            'B' : self.B(self.symbol, self.symbol2, 14)
                           }
 
         #  Here we're going to define indicators using 'selector' functions. These 'selector' functions will define what data gets sent into the indicator

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -318,7 +318,7 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(Indicators)]
         public Beta B(Symbol target, Symbol reference, int period, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
         {
-            var name = CreateIndicatorName(QuantConnect.Symbol.None, "B", resolution);
+            var name = CreateIndicatorName(QuantConnect.Symbol.None, $"B({period})", resolution);
             var beta = new Beta(name, period, target, reference);
             InitializeIndicator(target, beta, resolution, selector);
             InitializeIndicator(reference, beta, resolution, selector);

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -2131,7 +2131,9 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(Indicators)]
         public string CreateIndicatorName(Symbol symbol, string type, Resolution? resolution)
         {
-            if (!resolution.HasValue)
+            var symbolIsNotEmpty = symbol != QuantConnect.Symbol.None && symbol != QuantConnect.Symbol.Empty;
+
+            if (!resolution.HasValue && symbolIsNotEmpty)
             {
                 resolution = GetSubscription(symbol).Resolution;
             }
@@ -2168,7 +2170,7 @@ namespace QuantConnect.Algorithm
 
             var parts = new List<string>();
 
-            if (symbol != QuantConnect.Symbol.None && symbol != QuantConnect.Symbol.Empty)
+            if (symbolIsNotEmpty)
             {
                 parts.Add(symbol.ToString());
             }

--- a/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
+++ b/Tests/Algorithm/AlgorithmRegisterIndicatorTests.cs
@@ -97,11 +97,13 @@ namespace QuantConnect.Tests.Algorithm
             new TestCaseData(Symbols.SPY, "TEST", Resolution.Hour, "TEST(SPY_hr)"),
             new TestCaseData(Symbols.SPY, "TEST", Resolution.Daily, "TEST(SPY_day)"),
             new TestCaseData(Symbol.Empty, "TEST", Resolution.Minute, "TEST(min)"),
-            new TestCaseData(Symbol.None, "TEST", Resolution.Minute, "TEST(min)")
+            new TestCaseData(Symbol.None, "TEST", Resolution.Minute, "TEST(min)"),
+            new TestCaseData(Symbol.Empty, "TEST", null, "TEST()"),
+            new TestCaseData(Symbol.None, "TEST", null, "TEST()")
         };
 
         [Test, TestCaseSource(nameof(IndicatorNameParameters))]
-        public void CreateIndicatorName(Symbol symbol, string baseName, Resolution resolution, string expectation)
+        public void CreateIndicatorName(Symbol symbol, string baseName, Resolution? resolution, string expectation)
         {
             Assert.AreEqual(expectation, _algorithm.CreateIndicatorName(symbol, baseName, resolution));
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Detecting None/Empty symbol when trying to the subscription resolution in indicator name generation in order to avoid unwanted exceptions.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #7326 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests and regression algorithm

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
