### PR TITLE
Fix bug in VolumeWeightedAveragePriceIndicator

### DIFF
--- a/Indicators/CompositeIndicator.cs
+++ b/Indicators/CompositeIndicator.cs
@@ -76,7 +76,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="name">The name of this indicator</param>
         /// <param name="left">The left indicator for the 'composer'</param>
-        /// <param name="right">The right indidcator for the 'composoer'</param>
+        /// <param name="right">The right indicator for the 'composer'</param>
         /// <param name="composer">Function used to compose the left and right indicators</param>
         public CompositeIndicator(string name, IndicatorBase left, IndicatorBase right, IndicatorComposer composer)
             : base(name)
@@ -92,7 +92,7 @@ namespace QuantConnect.Indicators
         /// and producing a new value via the composer delegate specified
         /// </summary>
         /// <param name="left">The left indicator for the 'composer'</param>
-        /// <param name="right">The right indidcator for the 'composoer'</param>
+        /// <param name="right">The right indicator for the 'composer'</param>
         /// <param name="composer">Function used to compose the left and right indicators</param>
         public CompositeIndicator(IndicatorBase left, IndicatorBase right, IndicatorComposer composer)
             : this($"COMPOSE({left.Name},{right.Name})", left, right, composer)

--- a/Indicators/CompositeIndicator.cs
+++ b/Indicators/CompositeIndicator.cs
@@ -40,6 +40,11 @@ namespace QuantConnect.Indicators
         /// <returns>And indicator result representing the composition of the two indicators</returns>
         public delegate IndicatorResult IndicatorComposer(IndicatorBase left, IndicatorBase right);
 
+        /// <summary>
+        /// Event handler type for the CompositeIndicator.Reset event
+        /// </summary>
+        public delegate void ResetHandler();
+
         /// <summary>function used to compose the individual indicators</summary>
         private readonly IndicatorComposer _composer;
 
@@ -52,6 +57,11 @@ namespace QuantConnect.Indicators
         /// Gets the 'right' indicator for the delegate
         /// </summary>
         public IndicatorBase Right { get; private set; }
+
+        /// <summary>
+        /// Event handler that fires after this indicator is reset
+        /// </summary>
+        public event ResetHandler IsReset;
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
@@ -67,6 +77,7 @@ namespace QuantConnect.Indicators
         public override void Reset() {
             Left.Reset();
             Right.Reset();
+            IsReset.Invoke();
             base.Reset();
         }
 

--- a/Indicators/CompositeIndicator.cs
+++ b/Indicators/CompositeIndicator.cs
@@ -40,11 +40,6 @@ namespace QuantConnect.Indicators
         /// <returns>And indicator result representing the composition of the two indicators</returns>
         public delegate IndicatorResult IndicatorComposer(IndicatorBase left, IndicatorBase right);
 
-        /// <summary>
-        /// Event handler type for the CompositeIndicator.Reset event
-        /// </summary>
-        public delegate void ResetHandler();
-
         /// <summary>function used to compose the individual indicators</summary>
         private readonly IndicatorComposer _composer;
 
@@ -57,11 +52,6 @@ namespace QuantConnect.Indicators
         /// Gets the 'right' indicator for the delegate
         /// </summary>
         public IndicatorBase Right { get; private set; }
-
-        /// <summary>
-        /// Event handler that fires after this indicator is reset
-        /// </summary>
-        public event ResetHandler IsReset;
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
@@ -77,7 +67,6 @@ namespace QuantConnect.Indicators
         public override void Reset() {
             Left.Reset();
             Right.Reset();
-            IsReset.Invoke();
             base.Reset();
         }
 

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Indicators
         /// <param name="weight">Indicator that provides the average weights</param>
         /// <param name="period">Average period</param>
         /// <returns>Indicator that results of the average of first by weights given by second</returns>
-        public static CompositeIndicator WeightedBy<T, TWeight>(this IndicatorBase<T> value, TWeight weight, int period)
+        public static ResetCompositeIndicator WeightedBy<T, TWeight>(this IndicatorBase<T> value, TWeight weight, int period)
             where T : IBaseData
             where TWeight : IndicatorBase<IndicatorDataPoint>
         {
@@ -99,15 +99,14 @@ namespace QuantConnect.Indicators
             };
 
             var compositeIndicator = numerator.Over(denominator);
-            compositeIndicator.IsReset += () =>
-            {
+            var resetCompositeIndicator = new ResetCompositeIndicator(compositeIndicator, () => {
                 x.Reset();
                 y.Reset();
                 numerator.Reset();
                 denominator.Reset();
-            };
+            });
 
-            return compositeIndicator;
+            return resetCompositeIndicator;
         }
 
         /// <summary>

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -101,8 +101,6 @@ namespace QuantConnect.Indicators
             var resetCompositeIndicator = new ResetCompositeIndicator(numerator, denominator, GetOverIndicatorComposer(), () => {
                 x.Reset();
                 y.Reset();
-                numerator.Reset();
-                denominator.Reset();
             });
 
             return resetCompositeIndicator;

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -98,7 +98,16 @@ namespace QuantConnect.Indicators
                 denominator.Update(consolidated);
             };
 
-            return numerator.Over(denominator);
+            var compositeIndicator = numerator.Over(denominator);
+            compositeIndicator.IsReset += () =>
+            {
+                x.Reset();
+                y.Reset();
+                numerator.Reset();
+                denominator.Reset();
+            };
+
+            return compositeIndicator;
         }
 
         /// <summary>

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -222,7 +222,7 @@ namespace QuantConnect.Indicators
         /// <returns>The ratio of the left to the right indicator</returns>
         public static CompositeIndicator Over(this IndicatorBase left, IndicatorBase right)
         {
-            return new(left, right, GetOverIndicatorComposer());
+            return new (left, right, GetOverIndicatorComposer());
         }
 
         /// <summary>
@@ -575,6 +575,10 @@ namespace QuantConnect.Indicators
             return indicator.SafeAsManagedObject();
         }
 
+        /// <summary>
+        /// Gets the IndicatorComposer for a CompositeIndicator whose result is the ratio of the left to the right
+        /// </summary>
+        /// <returns>The IndicatorComposer for a CompositeIndicator whose result is the ratio of the left to the right</returns>
         private static CompositeIndicator.IndicatorComposer GetOverIndicatorComposer()
         {
             return (l, r) => r.Current.Value == 0m ? new IndicatorResult(0m, IndicatorStatus.MathError) : new IndicatorResult(l.Current.Value / r.Current.Value);

--- a/Indicators/ResetCompositeIndicator.cs
+++ b/Indicators/ResetCompositeIndicator.cs
@@ -23,7 +23,7 @@ namespace QuantConnect.Indicators
     public class ResetCompositeIndicator : CompositeIndicator
     {
         /// <summary>
-        /// Action to execute once the given CompositeIndicator is reset
+        /// Action to execute once this indicator is reset
         /// </summary>
         private Action _extraResetAction;
 
@@ -32,12 +32,13 @@ namespace QuantConnect.Indicators
         /// and producing a new value via the composer delegate specified
         /// </summary>
         /// <param name="left">The left indicator for the 'composer'</param>
-        /// <param name="right">The right indidcator for the 'composoer'</param>
+        /// <param name="right">The right indicator for the 'composer'</param>
         /// <param name="composer">Function used to compose the left and right indicators</param>
         /// <param name="extraResetAction">Action to execute once the composite indicator is reset</param>
         public ResetCompositeIndicator(IndicatorBase left, IndicatorBase right, IndicatorComposer composer, Action extraResetAction)
             : this($"RESET_COMPOSE({left.Name},{right.Name})", left, right, composer, extraResetAction)
-        { }
+        {
+        }
 
         /// <summary>
         /// Creates a new CompositeIndicator capable of taking the output from the left and right indicators
@@ -45,16 +46,17 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="name">The name of this indicator</param>
         /// <param name="left">The left indicator for the 'composer'</param>
-        /// <param name="right">The right indidcator for the 'composoer'</param>
+        /// <param name="right">The right indicator for the 'composer'</param>
         /// <param name="composer">Function used to compose the left and right indicators</param>
         /// <param name="extraResetAction">Action to execute once the indicator is reset</param>
-        public ResetCompositeIndicator(string name, IndicatorBase left, IndicatorBase right, IndicatorComposer composer, Action extraResetAction) : base(name, left, right, composer)
+        public ResetCompositeIndicator(string name, IndicatorBase left, IndicatorBase right, IndicatorComposer composer, Action extraResetAction)
+            : base(name, left, right, composer)
         {
             _extraResetAction = extraResetAction;
         }
 
         /// <summary>
-        /// Resets the given CompositeIndicator and invokes the given action
+        /// Resets this indicator and invokes the given reset action
         /// </summary>
         public override void Reset()
         {

--- a/Indicators/ResetCompositeIndicator.cs
+++ b/Indicators/ResetCompositeIndicator.cs
@@ -1,0 +1,104 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data;
+using System;
+
+namespace QuantConnect.Indicators
+{
+    /// <summary>
+    /// Class that extends CompositeIndicator to execute a given action once is reset
+    /// </summary>
+    public class ResetCompositeIndicator : IndicatorBase
+    {
+        /// <summary>
+        /// Action to execute once the given CompositeIndicator is reset
+        /// </summary>
+        private Action _extraResetAction;
+
+        /// <summary>
+        /// The CompositeIndicator that will fire the given action once is reset
+        /// </summary>
+        private CompositeIndicator _compositeIndicator;
+
+        /// <summary>
+        /// Gets current value of the given CompositeIndicator
+        /// </summary>
+        public IndicatorDataPoint Current => _compositeIndicator.Current;
+
+        /// <summary>
+        /// Gets a flag indicating when the given CompositeIndicator is ready
+        /// </summary>
+        public override bool IsReady => _compositeIndicator.IsReady;
+
+        /// <summary>
+        /// Creates a new ResetCompositeIndicator with the given CompositeIndicator and Action
+        /// </summary>
+        /// <param name="compositeIndicator">The CompositeIndicator that will fire the given action once is reset</param>
+        /// <param name="extraResetAction">Action to be executed once the given CompositeIndicator is reset</param>
+        public ResetCompositeIndicator(CompositeIndicator compositeIndicator, Action extraResetAction)
+        {
+            _extraResetAction = extraResetAction;
+            _compositeIndicator = compositeIndicator;
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <returns>
+        /// true if the specified object  is equal to the current object; otherwise, false.
+        /// </returns>
+        /// <param name="obj">The object to compare with the current object. </param>
+        public override bool Equals(object obj)
+        {
+            if (_compositeIndicator.Equals(obj))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Get Hash Code for this Object
+        /// </summary>
+        /// <returns>Integer Hash Code</returns>
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        /// <summary>
+        /// Resets the given CompositeIndicator and invokes the given action
+        /// </summary>
+        public override void Reset()
+        {
+            _compositeIndicator.Reset();
+            _extraResetAction.Invoke();
+        }
+
+        /// <summary>
+        /// Updates the given CompositeIndicator
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public override bool Update(IBaseData input)
+        {
+            return _compositeIndicator.Update(input);
+        }
+    }
+}

--- a/Indicators/ResetCompositeIndicator.cs
+++ b/Indicators/ResetCompositeIndicator.cs
@@ -63,23 +63,7 @@ namespace QuantConnect.Indicators
         /// <param name="obj">The object to compare with the current object. </param>
         public override bool Equals(object obj)
         {
-            if (_compositeIndicator.Equals(obj))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Get Hash Code for this Object
-        /// </summary>
-        /// <returns>Integer Hash Code</returns>
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
+            return _compositeIndicator.Equals(obj);
         }
 
         /// <summary>

--- a/Indicators/ResetCompositeIndicator.cs
+++ b/Indicators/ResetCompositeIndicator.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
 */
 
-using QuantConnect.Data;
 using System;
 
 namespace QuantConnect.Indicators
@@ -21,7 +20,7 @@ namespace QuantConnect.Indicators
     /// <summary>
     /// Class that extends CompositeIndicator to execute a given action once is reset
     /// </summary>
-    public class ResetCompositeIndicator : IndicatorBase
+    public class ResetCompositeIndicator : CompositeIndicator
     {
         /// <summary>
         /// Action to execute once the given CompositeIndicator is reset
@@ -29,41 +28,29 @@ namespace QuantConnect.Indicators
         private Action _extraResetAction;
 
         /// <summary>
-        /// The CompositeIndicator that will fire the given action once is reset
+        /// Creates a new ResetCompositeIndicator capable of taking the output from the left and right indicators
+        /// and producing a new value via the composer delegate specified
         /// </summary>
-        private CompositeIndicator _compositeIndicator;
+        /// <param name="left">The left indicator for the 'composer'</param>
+        /// <param name="right">The right indidcator for the 'composoer'</param>
+        /// <param name="composer">Function used to compose the left and right indicators</param>
+        /// <param name="extraResetAction">Action to execute once the composite indicator is reset</param>
+        public ResetCompositeIndicator(IndicatorBase left, IndicatorBase right, IndicatorComposer composer, Action extraResetAction)
+            : this($"RESET_COMPOSE({left.Name},{right.Name})", left, right, composer, extraResetAction)
+        { }
 
         /// <summary>
-        /// Gets current value of the given CompositeIndicator
+        /// Creates a new CompositeIndicator capable of taking the output from the left and right indicators
+        /// and producing a new value via the composer delegate specified
         /// </summary>
-        public IndicatorDataPoint Current => _compositeIndicator.Current;
-
-        /// <summary>
-        /// Gets a flag indicating when the given CompositeIndicator is ready
-        /// </summary>
-        public override bool IsReady => _compositeIndicator.IsReady;
-
-        /// <summary>
-        /// Creates a new ResetCompositeIndicator with the given CompositeIndicator and Action
-        /// </summary>
-        /// <param name="compositeIndicator">The CompositeIndicator that will fire the given action once is reset</param>
-        /// <param name="extraResetAction">Action to be executed once the given CompositeIndicator is reset</param>
-        public ResetCompositeIndicator(CompositeIndicator compositeIndicator, Action extraResetAction)
+        /// <param name="name">The name of this indicator</param>
+        /// <param name="left">The left indicator for the 'composer'</param>
+        /// <param name="right">The right indidcator for the 'composoer'</param>
+        /// <param name="composer">Function used to compose the left and right indicators</param>
+        /// <param name="extraResetAction">Action to execute once the indicator is reset</param>
+        public ResetCompositeIndicator(string name, IndicatorBase left, IndicatorBase right, IndicatorComposer composer, Action extraResetAction) : base(name, left, right, composer)
         {
             _extraResetAction = extraResetAction;
-            _compositeIndicator = compositeIndicator;
-        }
-
-        /// <summary>
-        /// Determines whether the specified object is equal to the current object.
-        /// </summary>
-        /// <returns>
-        /// true if the specified object  is equal to the current object; otherwise, false.
-        /// </returns>
-        /// <param name="obj">The object to compare with the current object. </param>
-        public override bool Equals(object obj)
-        {
-            return _compositeIndicator.Equals(obj);
         }
 
         /// <summary>
@@ -71,18 +58,8 @@ namespace QuantConnect.Indicators
         /// </summary>
         public override void Reset()
         {
-            _compositeIndicator.Reset();
+            base.Reset();
             _extraResetAction.Invoke();
-        }
-
-        /// <summary>
-        /// Updates the given CompositeIndicator
-        /// </summary>
-        /// <param name="input"></param>
-        /// <returns></returns>
-        public override bool Update(IBaseData input)
-        {
-            return _compositeIndicator.Update(input);
         }
     }
 }

--- a/Indicators/VolumeWeightedAveragePriceIndicator.cs
+++ b/Indicators/VolumeWeightedAveragePriceIndicator.cs
@@ -76,7 +76,7 @@ namespace QuantConnect.Indicators
         {
             _price.Reset();
             _volume.Reset();
-            _vwap = _price.WeightedBy(_volume, _period);
+            _vwap.Reset();
             base.Reset();
         }
 

--- a/Indicators/VolumeWeightedAveragePriceIndicator.cs
+++ b/Indicators/VolumeWeightedAveragePriceIndicator.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Indicators
         private readonly int _period;
         private readonly Identity _price;
         private readonly Identity _volume;
-        private ResetCompositeIndicator _vwap;
+        protected ResetCompositeIndicator VWAP;
 
         /// <summary>
         /// Initializes a new instance of the VWAP class with the default name and period
@@ -56,13 +56,13 @@ namespace QuantConnect.Indicators
             _volume = new Identity("Volume");
 
             // This class will be using WeightedBy indicator extension
-            _vwap = _price.WeightedBy(_volume, period);
+            VWAP = _price.WeightedBy(_volume, period);
         }
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady => _vwap.IsReady;
+        public override bool IsReady => VWAP.IsReady;
 
         /// <summary>
         /// Required period, in data points, for the indicator to be ready and fully initialized.
@@ -76,7 +76,7 @@ namespace QuantConnect.Indicators
         {
             _price.Reset();
             _volume.Reset();
-            _vwap.Reset();
+            VWAP.Reset();
             base.Reset();
         }
 
@@ -89,7 +89,7 @@ namespace QuantConnect.Indicators
         {
             _price.Update(input.EndTime, GetTimeWeightedAveragePrice(input));
             _volume.Update(input.EndTime, input.Volume);
-            return _vwap.Current.Value;
+            return VWAP.Current.Value;
         }
 
         /// <summary>

--- a/Indicators/VolumeWeightedAveragePriceIndicator.cs
+++ b/Indicators/VolumeWeightedAveragePriceIndicator.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Indicators
         private readonly int _period;
         private readonly Identity _price;
         private readonly Identity _volume;
-        private CompositeIndicator _vwap;
+        private ResetCompositeIndicator _vwap;
 
         /// <summary>
         /// Initializes a new instance of the VWAP class with the default name and period

--- a/Indicators/VolumeWeightedAveragePriceIndicator.cs
+++ b/Indicators/VolumeWeightedAveragePriceIndicator.cs
@@ -29,8 +29,8 @@ namespace QuantConnect.Indicators
         /// In this VWAP calculation, typical price is defined by (O + H + L + C) / 4
         /// </summary>
         private readonly int _period;
-        private readonly Identity _price;
-        private readonly Identity _volume;
+        protected readonly Identity Price;
+        protected readonly Identity Volume;
         protected CompositeIndicator VWAP;
 
         /// <summary>
@@ -52,11 +52,11 @@ namespace QuantConnect.Indicators
         {
             _period = period;
 
-            _price = new Identity("Price");
-            _volume = new Identity("Volume");
+            Price = new Identity("Price");
+            Volume = new Identity("Volume");
 
             // This class will be using WeightedBy indicator extension
-            VWAP = _price.WeightedBy(_volume, period);
+            VWAP = Price.WeightedBy(Volume, period);
         }
 
         /// <summary>
@@ -74,6 +74,8 @@ namespace QuantConnect.Indicators
         /// </summary>
         public override void Reset()
         {
+            Price.Reset();
+            Volume.Reset();
             VWAP.Reset();
             base.Reset();
         }
@@ -85,8 +87,8 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(TradeBar input)
         {
-            _price.Update(input.EndTime, GetTimeWeightedAveragePrice(input));
-            _volume.Update(input.EndTime, input.Volume);
+            Price.Update(input.EndTime, GetTimeWeightedAveragePrice(input));
+            Volume.Update(input.EndTime, input.Volume);
             return VWAP.Current.Value;
         }
 

--- a/Indicators/VolumeWeightedAveragePriceIndicator.cs
+++ b/Indicators/VolumeWeightedAveragePriceIndicator.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Indicators
         private readonly int _period;
         private readonly Identity _price;
         private readonly Identity _volume;
-        protected ResetCompositeIndicator VWAP;
+        protected CompositeIndicator VWAP;
 
         /// <summary>
         /// Initializes a new instance of the VWAP class with the default name and period
@@ -74,8 +74,6 @@ namespace QuantConnect.Indicators
         /// </summary>
         public override void Reset()
         {
-            _price.Reset();
-            _volume.Reset();
             VWAP.Reset();
             base.Reset();
         }

--- a/Tests/Indicators/CompositeIndicatorTests.cs
+++ b/Tests/Indicators/CompositeIndicatorTests.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Tests.Indicators
         {
             var left = new Delay(1);
             var right = new Delay(2);
-            var composite = new CompositeIndicator(left, right, (l, r) => l.Current.Value + r.Current.Value);
+            var composite = CreateCompositeIndicator(left, right, (l, r) => l.Current.Value + r.Current.Value);
 
             left.Update(DateTime.Today.AddSeconds(0), 1m);
             right.Update(DateTime.Today.AddSeconds(0), 1m);
@@ -59,7 +59,7 @@ namespace QuantConnect.Tests.Indicators
         {
             var left = new Identity("left");
             var right = new Identity("right");
-            var composite = new CompositeIndicator(left, right, (l, r) =>
+            var composite = CreateCompositeIndicator(left, right, (l, r) =>
             {
                 Assert.AreEqual(left, l);
                 Assert.AreEqual(right, r);
@@ -72,10 +72,10 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        public void ResetsProperly() {
+        public virtual void ResetsProperly() {
             var left = new Maximum("left", 2);
             var right = new Minimum("right", 2);
-            var composite = new CompositeIndicator(left, right, (l, r) => l.Current.Value + r.Current.Value);
+            var composite = CreateCompositeIndicator(left, right, (l, r) => l.Current.Value + r.Current.Value);
 
             left.Update(DateTime.Today, 1m);
             right.Update(DateTime.Today,-1m);
@@ -92,6 +92,11 @@ namespace QuantConnect.Tests.Indicators
             TestHelper.AssertIndicatorIsInDefaultState(right);
             Assert.AreEqual(left.PeriodsSinceMaximum, 0);
             Assert.AreEqual(right.PeriodsSinceMinimum, 0);
+        }
+
+        protected virtual CompositeIndicator CreateCompositeIndicator(IndicatorBase left, IndicatorBase right, QuantConnect.Indicators.CompositeIndicator.IndicatorComposer composer)
+        {
+            return new CompositeIndicator(left, right, composer);
         }
     }
 }

--- a/Tests/Indicators/ResetCompositeIndicatorTests.cs
+++ b/Tests/Indicators/ResetCompositeIndicatorTests.cs
@@ -1,0 +1,59 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using QuantConnect.Indicators;
+using System;
+
+namespace QuantConnect.Tests.Indicators
+{
+    public class ResetCompositeIndicatorTests : CompositeIndicatorTests
+    {
+        [Test]
+        public override void ResetsProperly()
+        {
+            var left = new Maximum("left", 2);
+            var right = new Minimum("right", 2);
+            var resetActionExectuted = false;
+            var resetAction = () =>
+            {
+                resetActionExectuted = true;
+            };
+            var composite = new ResetCompositeIndicator(left, right, (l, r) => l.Current.Value + r.Current.Value, resetAction);
+
+            left.Update(DateTime.Today, 1m);
+            right.Update(DateTime.Today, -1m);
+
+            left.Update(DateTime.Today.AddDays(1), -1m);
+            right.Update(DateTime.Today.AddDays(1), 1m);
+
+            Assert.AreEqual(left.PeriodsSinceMaximum, 1);
+            Assert.AreEqual(right.PeriodsSinceMinimum, 1);
+
+            composite.Reset();
+            TestHelper.AssertIndicatorIsInDefaultState(composite);
+            TestHelper.AssertIndicatorIsInDefaultState(left);
+            TestHelper.AssertIndicatorIsInDefaultState(right);
+            Assert.AreEqual(left.PeriodsSinceMaximum, 0);
+            Assert.AreEqual(right.PeriodsSinceMinimum, 0);
+            Assert.IsTrue(resetActionExectuted);
+        }
+
+        protected override CompositeIndicator CreateCompositeIndicator(IndicatorBase left, IndicatorBase right, CompositeIndicator.IndicatorComposer composer)
+        {
+            return new ResetCompositeIndicator(left, right, composer, () => { });
+        }
+    }
+}

--- a/Tests/Indicators/VolumeWeightedAveragePriceIndicatorTests.cs
+++ b/Tests/Indicators/VolumeWeightedAveragePriceIndicatorTests.cs
@@ -109,7 +109,7 @@ namespace QuantConnect.Tests.Indicators
 
         public ResetCompositeIndicator GetVolumeWeightedAveragePrice()
         {
-            return _vwap;
+            return VWAP;
         }
     }
 }

--- a/Tests/Indicators/VolumeWeightedAveragePriceIndicatorTests.cs
+++ b/Tests/Indicators/VolumeWeightedAveragePriceIndicatorTests.cs
@@ -82,5 +82,34 @@ namespace QuantConnect.Tests.Indicators
             ind.Update(new TradeBar(DateTime.UtcNow, Symbols.SPY, 2m, 2m, 2m, 2m, 1));
             Assert.AreEqual(ind.Current.Value, 2m);
         }
+
+        [Test]
+        public void ResetsVolumeWeightedAveragePriceProperly()
+        {
+            var ind = new TestVolumeWeightedAveragePriceIndicator(50);
+
+            foreach (var data in TestHelper.GetTradeBarStream(TestFileName))
+            {
+                ind.Update(data);
+            }
+            Assert.IsTrue(ind.IsReady);
+
+            var lastVWAP = ind.GetVolumeWeightedAveragePrice();
+            ind.Reset();
+            var newVWAP = ind.GetVolumeWeightedAveragePrice();
+            Assert.IsTrue(Object.ReferenceEquals(lastVWAP, newVWAP));
+        }
+    }
+
+    public class TestVolumeWeightedAveragePriceIndicator : VolumeWeightedAveragePriceIndicator
+    {
+        public TestVolumeWeightedAveragePriceIndicator(int period) : base(period)
+        {
+        }
+
+        public ResetCompositeIndicator GetVolumeWeightedAveragePrice()
+        {
+            return _vwap;
+        }
     }
 }

--- a/Tests/Indicators/VolumeWeightedAveragePriceIndicatorTests.cs
+++ b/Tests/Indicators/VolumeWeightedAveragePriceIndicatorTests.cs
@@ -84,7 +84,7 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        public void ResetsVolumeWeightedAveragePriceProperly()
+        public void ResetsInnerVolumeWeightedAveragePriceIndicatorProperly()
         {
             var indicator = new TestVolumeWeightedAveragePriceIndicator(50);
 
@@ -92,16 +92,74 @@ namespace QuantConnect.Tests.Indicators
             {
                 indicator.Update(data);
             }
+
             Assert.IsTrue(indicator.IsReady);
 
-            var lastVWAP = indicator.GetVolumeWeightedAveragePrice();
+            var lastVWAPIndicator = indicator.GetInnerVolumeWeightedAveragePriceIndicator();
+
+            Assert.AreNotEqual(0, lastVWAPIndicator.Samples);
+            Assert.AreNotEqual(0, lastVWAPIndicator.Left.Samples);
+            Assert.AreNotEqual(0, lastVWAPIndicator.Right.Samples);
+            Assert.IsTrue(lastVWAPIndicator.IsReady);
+            Assert.IsTrue(lastVWAPIndicator.Left.IsReady);
+            Assert.IsTrue(lastVWAPIndicator.Right.IsReady);
+
             indicator.Reset();
-            var newVWAP = indicator.GetVolumeWeightedAveragePrice();
-            Assert.IsTrue(Object.ReferenceEquals(lastVWAP, newVWAP));
-            Assert.AreEqual(0, newVWAP.Left.Samples);
-            Assert.AreEqual(0, newVWAP.Right.Samples);
-            Assert.IsFalse(newVWAP.Left.IsReady);
-            Assert.IsFalse(newVWAP.Right.IsReady);
+            var newVWAPIndicator = indicator.GetInnerVolumeWeightedAveragePriceIndicator();
+
+            Assert.IsTrue(Object.ReferenceEquals(lastVWAPIndicator, newVWAPIndicator));
+            Assert.AreEqual(0, newVWAPIndicator.Samples);
+            Assert.AreEqual(0, newVWAPIndicator.Left.Samples);
+            Assert.AreEqual(0, newVWAPIndicator.Right.Samples);
+            Assert.IsFalse(newVWAPIndicator.IsReady);
+            Assert.IsFalse(newVWAPIndicator.Left.IsReady);
+            Assert.IsFalse(newVWAPIndicator.Right.IsReady);
+        }
+
+        [Test]
+        public void ResetsInnerPriceIndicatorProperly()
+        {
+            var indicator = new TestVolumeWeightedAveragePriceIndicator(50);
+
+            foreach (var data in TestHelper.GetTradeBarStream(TestFileName))
+            {
+                indicator.Update(data);
+            }
+
+            Assert.IsTrue(indicator.IsReady);
+
+            var lastPriceIndicator = indicator.GetInnerPriceIndicator();
+            Assert.AreNotEqual(0, lastPriceIndicator.Samples);
+            Assert.IsTrue(lastPriceIndicator.IsReady);
+
+            indicator.Reset();
+
+            var newPriceIndicator = indicator.GetInnerPriceIndicator();
+            Assert.AreEqual(0, newPriceIndicator.Samples);
+            Assert.IsFalse(newPriceIndicator.IsReady);
+        }
+
+        [Test]
+        public void ResetsInnerVolumeIndicatorProperly()
+        {
+            var indicator = new TestVolumeWeightedAveragePriceIndicator(50);
+
+            foreach (var data in TestHelper.GetTradeBarStream(TestFileName))
+            {
+                indicator.Update(data);
+            }
+
+            Assert.IsTrue(indicator.IsReady);
+
+            var lastVolumeIndicator = indicator.GetInnerVolumeIndicator();
+            Assert.AreNotEqual(0, lastVolumeIndicator.Samples);
+            Assert.IsTrue(lastVolumeIndicator.IsReady);
+
+            indicator.Reset();
+
+            var newVolumeIndicator = indicator.GetInnerVolumeIndicator();
+            Assert.AreEqual(0, newVolumeIndicator.Samples);
+            Assert.IsFalse(newVolumeIndicator.IsReady);
         }
     }
 
@@ -111,9 +169,19 @@ namespace QuantConnect.Tests.Indicators
         {
         }
 
-        public CompositeIndicator GetVolumeWeightedAveragePrice()
+        public CompositeIndicator GetInnerVolumeWeightedAveragePriceIndicator()
         {
             return VWAP;
+        }
+
+        public IndicatorBase GetInnerPriceIndicator()
+        {
+            return Price;
+        }
+
+        public IndicatorBase GetInnerVolumeIndicator()
+        {
+            return Volume;
         }
     }
 }

--- a/Tests/Indicators/VolumeWeightedAveragePriceIndicatorTests.cs
+++ b/Tests/Indicators/VolumeWeightedAveragePriceIndicatorTests.cs
@@ -86,17 +86,17 @@ namespace QuantConnect.Tests.Indicators
         [Test]
         public void ResetsVolumeWeightedAveragePriceProperly()
         {
-            var ind = new TestVolumeWeightedAveragePriceIndicator(50);
+            var indicator = new TestVolumeWeightedAveragePriceIndicator(50);
 
             foreach (var data in TestHelper.GetTradeBarStream(TestFileName))
             {
-                ind.Update(data);
+                indicator.Update(data);
             }
-            Assert.IsTrue(ind.IsReady);
+            Assert.IsTrue(indicator.IsReady);
 
-            var lastVWAP = ind.GetVolumeWeightedAveragePrice();
-            ind.Reset();
-            var newVWAP = ind.GetVolumeWeightedAveragePrice();
+            var lastVWAP = indicator.GetVolumeWeightedAveragePrice();
+            indicator.Reset();
+            var newVWAP = indicator.GetVolumeWeightedAveragePrice();
             Assert.IsTrue(Object.ReferenceEquals(lastVWAP, newVWAP));
         }
     }

--- a/Tests/Indicators/VolumeWeightedAveragePriceIndicatorTests.cs
+++ b/Tests/Indicators/VolumeWeightedAveragePriceIndicatorTests.cs
@@ -98,6 +98,10 @@ namespace QuantConnect.Tests.Indicators
             indicator.Reset();
             var newVWAP = indicator.GetVolumeWeightedAveragePrice();
             Assert.IsTrue(Object.ReferenceEquals(lastVWAP, newVWAP));
+            Assert.AreEqual(0, newVWAP.Left.Samples);
+            Assert.AreEqual(0, newVWAP.Right.Samples);
+            Assert.IsFalse(newVWAP.Left.IsReady);
+            Assert.IsFalse(newVWAP.Right.IsReady);
         }
     }
 
@@ -107,7 +111,7 @@ namespace QuantConnect.Tests.Indicators
         {
         }
 
-        public ResetCompositeIndicator GetVolumeWeightedAveragePrice()
+        public CompositeIndicator GetVolumeWeightedAveragePrice()
         {
             return VWAP;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
When this indicator was reset, instead of reset its VolumeWeightedAveragePrice composite indicator, it created a new one. So the previous was never disposed. In order to fix this, there was created a new indicator called `ResetCompositeIndicator.cs` that takes a composite indicator and an action to execute once the given indicator is reset. Therefore, when `Reset()` method is called in `VolumeWeightedAveragePriceIndicator`, the `VolumeWeightedAveragePriceIndicator` is reset instead of re-assigned. Immediately after , this `ResetCompositeIndicator` executes the given action to reset variables used in `IndicatorExtensions.WeightedBy()` method.

On the other hand, `IndicatorExtensions.cs` was reviewed to ensure this bug was not in other usages of `CompositeIndicator`
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4964 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, LEAN will no create a new composite indicator once `VolumeWeightedAveragePriceIndicator` is reset. Additionally, users will be able to assign an action to execute once certain indicator is reset.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change does not require updates to documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There was created a unit test that asserted `VolumeWeightedAveragePrice` field in `VolumeWeightedAveragePriceIndicator.cs` was the same before and after the indicator was reset
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
