### PR TITLE
Remove EnableAutomaticWarmUp and IIndicatorWarmUpPeriodProvider impl from RVA

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -1452,7 +1452,7 @@ namespace QuantConnect.Algorithm
         {
             var name = CreateIndicatorName(symbol, $"RDV({period})", resolution);
             var relativeDailyVolume = new RelativeDailyVolume(name, period);
-            InitializeIndicator(symbol, relativeDailyVolume, resolution, selector);
+            RegisterIndicator(symbol, relativeDailyVolume, resolution, selector);
 
             return relativeDailyVolume;
         }

--- a/Indicators/RelativeDailyVolume.cs
+++ b/Indicators/RelativeDailyVolume.cs
@@ -26,22 +26,18 @@ namespace QuantConnect.Indicators
     /// 
     /// Current volume from open to current time of day / Average over the past x days from open to current time of day
     /// </summary>
-    public class RelativeDailyVolume : TradeBarIndicator, IIndicatorWarmUpPeriodProvider
+    public class RelativeDailyVolume : TradeBarIndicator
     {
         private readonly SortedDictionary<TimeSpan, SimpleMovingAverage> _relativeData;
         private readonly Dictionary<DateTime, decimal> _currentData;
         private int _previousDay;
         private int _days;
+        private int _period;
 
         /// <summary>
         /// Gets a flag indicating when the indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady => _days >= WarmUpPeriod;
-
-        /// <summary>
-        /// Required period, in data points, for the indicator to be ready and fully initialized.
-        /// </summary>
-        public int WarmUpPeriod { get; }
+        public override bool IsReady => _days >= _period;
 
         /// <summary>
         /// Initializes a new instance of the RelativeDailyVolume class using the specified period
@@ -62,7 +58,7 @@ namespace QuantConnect.Indicators
         {
             _relativeData = new SortedDictionary<TimeSpan, SimpleMovingAverage>();
             _currentData = new Dictionary<DateTime, decimal>();
-            WarmUpPeriod = period;
+            _period = period;
             _previousDay = -1; // No calendar day can be -1, thus default is not a calendar day
             _days = -1; // Will increment by one after first TradeBar, then will increment by one every new day
         }
@@ -84,7 +80,7 @@ namespace QuantConnect.Indicators
                     cumulativeVolume += pair.Value;
                     if (!_relativeData.TryGetValue(timeBar, out daysAverage))
                     {
-                        daysAverage = _relativeData[timeBar] = new SimpleMovingAverage(WarmUpPeriod);
+                        daysAverage = _relativeData[timeBar] = new SimpleMovingAverage(_period);
                     }
                     daysAverage.Update(pair.Key, cumulativeVolume);
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Since `RelativeDailyVolume` is a daily indicator, in order to `WarmUp` it we need to provide it enough data points(the number of the period) in either daily resolution or an equivalent amount of datapoints in other resolution. To find the number of required data points, in certain given resolution, to warm up this indicator depends not only on the resolution and the `period` but also on the market hours for the indicator symbol, since this define the amount of data points, at certain resolution, we can obtain from certain day of the week. Therefore, the computations to find this value are complex and fragile. That's why we remove this feature from this indicator.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5835 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, when users have set `EnableAutomaticWarmUp` to true and instantiated a `RelativeVolumeAverage` indicator, this indicator will not be warmed up.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change may require a change to documentation to inform the users, this indicator cannot be warmed up.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All the tests were run and it was asserted no one of them failed
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
