### PR TITLE
Make indicators work with RenkoBars and VolumeRenkoBars

### DIFF
--- a/Algorithm.CSharp/IndicatorWithRenkoBarsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndicatorWithRenkoBarsRegressionAlgorithm.cs
@@ -1,0 +1,139 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.Market;
+using QuantConnect.Indicators;
+using QuantConnect.Interfaces;
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm to assert we can update indicators that inherit from <see cref="IndicatorBase"/> with RenkoBar's
+    /// </summary>
+    public class IndicatorWithRenkoBarsRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private MassIndex _mi;
+        private WilderAccumulativeSwingIndex _wasi;
+        private WilderSwingIndex _wsi;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 09);
+
+            var spy = AddEquity("SPY").Symbol;
+
+            var renkoBarConsolidator = new RenkoConsolidator<TradeBar>(0.1m);
+            renkoBarConsolidator.DataConsolidated += OnDataConsolidated;
+
+            SubscriptionManager.AddConsolidator("SPY", renkoBarConsolidator);
+            _mi = new MassIndex("MI", 9, 25);
+            _wasi = new WilderAccumulativeSwingIndex(8);
+            _wsi = new WilderSwingIndex(8);
+        }
+
+        public void OnDataConsolidated(object sender, RenkoBar renkoBar)
+        {
+            _mi.Update(renkoBar);
+            _wasi.Update(renkoBar);
+            _wsi.Update(renkoBar);
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_mi.IsReady)
+            {
+                throw new Exception($"Mass Index indicator should be ready");
+            }
+            else if (_mi.Current.Value == 0)
+            {
+                throw new Exception($"The current value of the Mass Index indicator should be different than zero");
+            }
+
+            if (!_wasi.IsReady)
+            {
+                throw new Exception($"WilderAccumulativeSwingIndex indicator should be ready");
+            }
+            else if (_wasi.Current.Value == 0)
+            {
+                throw new Exception($"The current value of the WilderAccumulativeSwingIndex indicator should be different than zero");
+            }
+
+            if (!_wsi.IsReady)
+            {
+                throw new Exception($"WilderSwingIndex indicator should be ready");
+            }
+            else if (_wsi.Current.Value == 0)
+            {
+                throw new Exception($"The current value of the WilderSwingIndex indicator should be different than zeros");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp};
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 2369;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "5.524"},
+            {"Tracking Error", "0.136"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/IndicatorWithRenkoBarsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndicatorWithRenkoBarsRegressionAlgorithm.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetStartDate(2013, 10, 07);
             SetEndDate(2013, 10, 09);
 
-            var spy = AddEquity("SPY").Symbol;
+            AddEquity("SPY");
 
             var renkoBarConsolidator = new RenkoConsolidator<TradeBar>(0.1m);
             renkoBarConsolidator.DataConsolidated += OnDataConsolidated;
@@ -59,29 +59,29 @@ namespace QuantConnect.Algorithm.CSharp
         {
             if (!_mi.IsReady)
             {
-                throw new Exception($"Mass Index indicator should be ready");
+                throw new Exception("Mass Index indicator should be ready");
             }
             else if (_mi.Current.Value == 0)
             {
-                throw new Exception($"The current value of the Mass Index indicator should be different than zero");
+                throw new Exception("The current value of the Mass Index indicator should be different than zero");
             }
 
             if (!_wasi.IsReady)
             {
-                throw new Exception($"WilderAccumulativeSwingIndex indicator should be ready");
+                throw new Exception("WilderAccumulativeSwingIndex indicator should be ready");
             }
             else if (_wasi.Current.Value == 0)
             {
-                throw new Exception($"The current value of the WilderAccumulativeSwingIndex indicator should be different than zero");
+                throw new Exception("The current value of the WilderAccumulativeSwingIndex indicator should be different than zero");
             }
 
             if (!_wsi.IsReady)
             {
-                throw new Exception($"WilderSwingIndex indicator should be ready");
+                throw new Exception("WilderSwingIndex indicator should be ready");
             }
             else if (_wsi.Current.Value == 0)
             {
-                throw new Exception($"The current value of the WilderSwingIndex indicator should be different than zeros");
+                throw new Exception("The current value of the WilderSwingIndex indicator should be different than zeros");
             }
         }
 
@@ -93,7 +93,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public Language[] Languages { get; } = { Language.CSharp};
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python};
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm

--- a/Algorithm.Python/IndicatorWithRenkoBarsRegressionAlgorithm.py
+++ b/Algorithm.Python/IndicatorWithRenkoBarsRegressionAlgorithm.py
@@ -1,0 +1,57 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regrssion algorithm to assert we can update indicators that inherit from IndicatorBase<TradeBar> with RenkoBar's
+### </summary>
+### <meta name="tag" content="renko" />
+### <meta name="tag" content="indicators" />
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="consolidating data" />
+class IndicatorWithRenkoBarsRegressionAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        self.SetStartDate(2013, 10, 7)
+        self.SetEndDate(2013, 10, 9)
+
+        self.AddEquity("SPY");
+
+        renkoConsolidator = RenkoConsolidator(0.1)
+        renkoConsolidator.DataConsolidated += self.OnDataConsolidated;
+
+        self.SubscriptionManager.AddConsolidator("SPY", renkoConsolidator)
+        self.mi = MassIndex("MI", 9, 25)
+        self.wasi = WilderAccumulativeSwingIndex(8)
+        self.wsi = WilderSwingIndex(8)
+
+    def OnDataConsolidated(self, sender, renkoBar):
+        self.mi.Update(renkoBar)
+        self.wasi.Update(renkoBar)
+        self.wsi.Update(renkoBar)
+
+    def OnEndOfAlgorithm(self):
+        if not self.mi.IsReady:
+            raise Exception("Mass Index indicator should be ready")
+        elif self.mi.Current.Value == 0:
+            raise Exception("The current value of the Mass Index indicator should be different than zero")
+
+        if not self.wasi.IsReady:
+            raise Exception("WilderAccumulativeSwingIndex indicator should be ready")
+        elif self.wasi.Current.Value == 0:
+            raise Exception("The current value of the WilderAccumulativeSwingIndex indicator should be different than zero")
+
+        if not self.wsi.IsReady:
+            raise Exception("WilderSwingIndex indicator should be ready")
+        if self.wsi.Current.Value == 0:
+            raise Exception("The current value of the WilderSwingIndex indicator should be different than zeros")

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -37,6 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
+    <Compile Include="IndicatorWithRenkoBarsRegressionAlgorithm.py" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="QuantConnect.pythonnet" Version="2.0.20" />

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -37,7 +37,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
-    <Compile Include="IndicatorWithRenkoBarsRegressionAlgorithm.py" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="QuantConnect.pythonnet" Version="2.0.20" />
@@ -56,6 +55,7 @@
     <Content Include="CustomPartialFillModelAlgorithm.py" />
     <Content Include="AddRiskManagementAlgorithm.py" />
     <Content Include="AddUniverseSelectionModelAlgorithm.py" />
+    <Compile Include="IndicatorWithRenkoBarsRegressionAlgorithm.py" />
     <Content Include="Alphas\ContingentClaimsAnalysisDefaultPredictionAlpha.py" />
     <Content Include="Alphas\GasAndCrudeOilEnergyCorrelationAlpha.py" />
     <Content Include="Alphas\GlobalEquityMeanReversionIBSAlpha.py" />

--- a/Common/Data/Market/BaseRenkoBar.cs
+++ b/Common/Data/Market/BaseRenkoBar.cs
@@ -38,11 +38,6 @@ namespace QuantConnect.Data.Market
         public decimal BrickSize  { get; protected set; }
 
         /// <summary>
-        /// Gets the volume of trades during the bar.
-        /// </summary>
-        public decimal Volume { get; protected set; }
-
-        /// <summary>
         /// Gets the end time of this renko bar or the most recent update time if it <see cref="IsClosed"/>
         /// </summary>
         public override DateTime EndTime { get; set; }

--- a/Common/Data/Market/BaseRenkoBar.cs
+++ b/Common/Data/Market/BaseRenkoBar.cs
@@ -20,7 +20,7 @@ namespace QuantConnect.Data.Market
     /// <summary>
     /// Represents a bar sectioned not by time, but by some amount of movement in a set field
     /// </summary>
-    public abstract class BaseRenkoBar : BaseData, IBaseDataBar
+    public abstract class BaseRenkoBar : TradeBar, IBaseDataBar
     {
         /// <summary>
         /// Gets the kind of the bar

--- a/Common/Data/Market/BaseRenkoBar.cs
+++ b/Common/Data/Market/BaseRenkoBar.cs
@@ -18,7 +18,12 @@ using System;
 namespace QuantConnect.Data.Market
 {
     /// <summary>
-    /// Represents a bar sectioned not by time, but by some amount of movement in a set field
+    /// Represents a bar sectioned not by time, but by some amount of movement in a set field,
+    /// where:
+    /// - Open : Gets the opening value that started this bar
+    /// - Close : Gets the closing value or the current value if the bar has not yet closed.
+    /// - High : Gets the highest value encountered during this bar
+    /// - Low : Gets the lowest value encountered during this bar
     /// </summary>
     public abstract class BaseRenkoBar : TradeBar, IBaseDataBar
     {
@@ -31,30 +36,6 @@ namespace QuantConnect.Data.Market
         /// The preset size of the consolidated bar
         /// </summary>
         public decimal BrickSize  { get; protected set; }
-
-        /// <summary>
-        /// Gets the opening value that started this bar.
-        /// </summary>
-        public decimal Open { get; protected set; }
-
-        /// <summary>
-        /// Gets the closing value or the current value if the bar has not yet closed.
-        /// </summary>
-        public decimal Close
-        {
-            get { return Value; }
-            protected set { Value = value; }
-        }
-
-        /// <summary>
-        /// Gets the highest value encountered during this bar
-        /// </summary>
-        public decimal High { get; protected set; }
-
-        /// <summary>
-        /// Gets the lowest value encountered during this bar
-        /// </summary>
-        public decimal Low { get; protected set; }
 
         /// <summary>
         /// Gets the volume of trades during the bar.

--- a/Common/Data/Market/RenkoBar.cs
+++ b/Common/Data/Market/RenkoBar.cs
@@ -23,12 +23,6 @@ namespace QuantConnect.Data.Market
     public class RenkoBar : BaseRenkoBar
     {
         /// <summary>
-        /// Throws an exception when accessed, since RenkoBar's do not have Volume.
-        /// If you want to use Volume in a BaseRenkoBar see <see cref="VolumeRenkoBar"></see>
-        /// </summary>
-        public override decimal Volume => throw new Exception("RenkoBar's don't have Volume");
-
-        /// <summary>
         /// Gets the end time of this renko bar or the most recent update time if it <see cref="BaseRenkoBar.IsClosed"/>
         /// </summary>
         [Obsolete("RenkoBar.End is obsolete. Please use RenkoBar.EndTime property instead.")]

--- a/Common/Data/Market/RenkoBar.cs
+++ b/Common/Data/Market/RenkoBar.cs
@@ -23,6 +23,12 @@ namespace QuantConnect.Data.Market
     public class RenkoBar : BaseRenkoBar
     {
         /// <summary>
+        /// Throws an exception when accessed, since RenkoBar's do not have Volume.
+        /// If you want to use Volume in a BaseRenkoBar see <see cref="VolumeRenkoBar"></see>
+        /// </summary>
+        public override decimal Volume => throw new Exception("RenkoBar's don't have Volume");
+
+        /// <summary>
         /// Gets the end time of this renko bar or the most recent update time if it <see cref="BaseRenkoBar.IsClosed"/>
         /// </summary>
         [Obsolete("RenkoBar.End is obsolete. Please use RenkoBar.EndTime property instead.")]

--- a/Tests/Common/Data/RenkoConsolidatorTests.cs
+++ b/Tests/Common/Data/RenkoConsolidatorTests.cs
@@ -713,17 +713,6 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual("BarSize must be strictly greater than zero", message.Message);
         }
 
-        [Test]
-        public void AccessToVolumePropertyOfRenkoBarsThrowsException()
-        {
-            var start = new DateTime(2019, 1, 1);
-            var renkoBar = new RenkoBar("", start, start, 0.9m, 1, 1, 1, 1);
-            Assert.Throws<Exception>(() =>
-            {
-                var volume = renkoBar.Volume;
-            });
-        }
-
         private class TestRenkoConsolidator : RenkoConsolidator
         {
             public TestRenkoConsolidator(decimal barSize)

--- a/Tests/Common/Data/RenkoConsolidatorTests.cs
+++ b/Tests/Common/Data/RenkoConsolidatorTests.cs
@@ -713,6 +713,17 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual("BarSize must be strictly greater than zero", message.Message);
         }
 
+        [Test]
+        public void AccessToVolumePropertyOfRenkoBarsThrowsException()
+        {
+            var start = new DateTime(2019, 1, 1);
+            var renkoBar = new RenkoBar("", start, start, 0.9m, 1, 1, 1, 1);
+            Assert.Throws<Exception>(() =>
+            {
+                var volume = renkoBar.Volume;
+            });
+        }
+
         private class TestRenkoConsolidator : RenkoConsolidator
         {
             public TestRenkoConsolidator(decimal barSize)

--- a/Tests/Indicators/AccelerationBandsTests.cs
+++ b/Tests/Indicators/AccelerationBandsTests.cs
@@ -1,4 +1,19 @@
-﻿using NUnit.Framework;
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
 
@@ -9,6 +24,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 0.5m;
             return new AccelerationBands(period: 20, width: 4m);
         }
 

--- a/Tests/Indicators/AccumulationDistributionOscillatorTests.cs
+++ b/Tests/Indicators/AccumulationDistributionOscillatorTests.cs
@@ -36,5 +36,15 @@ namespace QuantConnect.Tests.Indicators
         {
             get { return "AdOsc_3_10"; }
         }
+
+        /// <summary>
+        /// The final value of this indicator is zero because it uses the Volume of the bars it receives.
+        /// Since RenkoBar's don't always have Volume, the final current value is zero. Therefore we
+        /// skip this test
+        /// </summary>
+        /// <param name="indicator"></param>
+        protected override void IndicatorValueIsNotZeroAfterReceiveRenkoBars(IndicatorBase indicator)
+        {
+        }
     }
 }

--- a/Tests/Indicators/AccumulationDistributionTests.cs
+++ b/Tests/Indicators/AccumulationDistributionTests.cs
@@ -36,5 +36,15 @@ namespace QuantConnect.Tests.Indicators
         {
             get { return "AD"; }
         }
+
+        /// <summary>
+        /// The final value of this indicator is zero because it uses the Volume of the bars it receives.
+        /// Since RenkoBar's don't always have Volume, the final current value is zero. Therefore we
+        /// skip this test
+        /// </summary>
+        /// <param name="indicator"></param>
+        protected override void IndicatorValueIsNotZeroAfterReceiveRenkoBars(IndicatorBase indicator)
+        {
+        }
     }
 }

--- a/Tests/Indicators/AdvanceDeclineDifferenceTests.cs
+++ b/Tests/Indicators/AdvanceDeclineDifferenceTests.cs
@@ -14,8 +14,10 @@
 */
 
 using NUnit.Framework;
+using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
+using static QuantConnect.Tests.Indicators.TestHelper;
 
 namespace QuantConnect.Tests.Indicators
 {
@@ -154,6 +156,106 @@ namespace QuantConnect.Tests.Indicators
 
             Assert.IsTrue(indicator.IsReady);
             Assert.AreEqual(1m, indicator.Current.Value);
+        }
+
+        [Test]
+        public override void AcceptsRenkoBarsAsInput()
+        {
+            var indicator = CreateIndicator();
+            if (indicator is IndicatorBase<TradeBar>)
+            {
+                var aaplRenkoConsolidator = new RenkoConsolidator(10000m);
+                aaplRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                var googRenkoConsolidator = new RenkoConsolidator(100000m);
+                googRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                var ibmRenkoConsolidator = new RenkoConsolidator(10000m);
+                ibmRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                foreach (var parts in GetCsvFileStream(TestFileName))
+                {
+                    var tradebar = parts.GetTradeBar();
+                    if (tradebar.Symbol.Value == "AAPL")
+                    {
+                        aaplRenkoConsolidator.Update(tradebar);
+                    }
+                    else if (tradebar.Symbol.Value == "GOOG")
+                    {
+                        googRenkoConsolidator.Update(tradebar);
+                    }
+                    else
+                    {
+                        ibmRenkoConsolidator.Update(tradebar);
+                    }
+                }
+
+                Assert.IsTrue(indicator.IsReady);
+                Assert.AreNotEqual(0, indicator.Samples);
+                IndicatorValueIsNotZeroAfterReceiveVolumeRenkoBars(indicator);
+                aaplRenkoConsolidator.Dispose();
+                googRenkoConsolidator.Dispose();
+                ibmRenkoConsolidator.Dispose();
+            }
+        }
+
+        [Test]
+        public override void AcceptsVolumeRenkoBarsAsInput()
+        {
+            var indicator = CreateIndicator();
+            if (indicator is IndicatorBase<TradeBar>)
+            {
+                var aaplRenkoConsolidator = new VolumeRenkoConsolidator(10000000m);
+                aaplRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                var googRenkoConsolidator = new VolumeRenkoConsolidator(500000m);
+                googRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                var ibmRenkoConsolidator = new VolumeRenkoConsolidator(500000m);
+                ibmRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                foreach (var parts in GetCsvFileStream(TestFileName))
+                {
+                    var tradebar = parts.GetTradeBar();
+                    if (tradebar.Symbol.Value == "AAPL")
+                    {
+                        aaplRenkoConsolidator.Update(tradebar);
+                    }
+                    else if (tradebar.Symbol.Value == "GOOG")
+                    {
+                        googRenkoConsolidator.Update(tradebar);
+                    }
+                    else
+                    {
+                        ibmRenkoConsolidator.Update(tradebar);
+                    }
+                }
+
+                Assert.IsTrue(indicator.IsReady);
+                Assert.AreNotEqual(0, indicator.Samples);
+                IndicatorValueIsNotZeroAfterReceiveVolumeRenkoBars(indicator);
+                aaplRenkoConsolidator.Dispose();
+                googRenkoConsolidator.Dispose();
+                ibmRenkoConsolidator.Dispose();
+            }
         }
 
         protected override string TestFileName => "arms_data.txt";

--- a/Tests/Indicators/AdvanceDeclineDifferenceTests.cs
+++ b/Tests/Indicators/AdvanceDeclineDifferenceTests.cs
@@ -28,6 +28,7 @@ namespace QuantConnect.Tests.Indicators
             adDifference.AddStock(Symbols.AAPL);
             adDifference.AddStock(Symbols.IBM);
             adDifference.AddStock(Symbols.GOOG);
+            RenkoBarSize = 5000000;
             return adDifference;
         }
 

--- a/Tests/Indicators/AdvanceDeclineDifferenceTests.cs
+++ b/Tests/Indicators/AdvanceDeclineDifferenceTests.cs
@@ -138,7 +138,7 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        public void WarmsUpOrdered()
+        public virtual void WarmsUpOrdered()
         {
             var indicator = CreateIndicator();
             var reference = System.DateTime.Today;
@@ -201,7 +201,7 @@ namespace QuantConnect.Tests.Indicators
 
                 Assert.IsTrue(indicator.IsReady);
                 Assert.AreNotEqual(0, indicator.Samples);
-                IndicatorValueIsNotZeroAfterReceiveVolumeRenkoBars(indicator);
+                IndicatorValueIsNotZeroAfterReceiveRenkoBars(indicator);
                 aaplRenkoConsolidator.Dispose();
                 googRenkoConsolidator.Dispose();
                 ibmRenkoConsolidator.Dispose();

--- a/Tests/Indicators/AdvanceDeclineRatioTests.cs
+++ b/Tests/Indicators/AdvanceDeclineRatioTests.cs
@@ -14,15 +14,13 @@
 */
 
 using NUnit.Framework;
-using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
-using static QuantConnect.Tests.Indicators.TestHelper;
 
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class AdvanceDeclineRatioTests : CommonIndicatorTests<TradeBar>
+    public class AdvanceDeclineRatioTests : AdvanceDeclineDifferenceTests
     {
         protected override IndicatorBase<TradeBar> CreateIndicator()
         {
@@ -35,7 +33,7 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        public virtual void ShouldIgnoreRemovedStocks()
+        public override void ShouldIgnoreRemovedStocks()
         {
             var adr = (AdvanceDeclineRatio)CreateIndicator();
             var reference = System.DateTime.Today;
@@ -70,7 +68,7 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        public virtual void IgnorePeriodIfAnyStockMissed()
+        public override void IgnorePeriodIfAnyStockMissed()
         {
             var adr = (AdvanceDeclineRatio)CreateIndicator();
             adr.Add(Symbols.MSFT);
@@ -138,107 +136,7 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        public override void AcceptsRenkoBarsAsInput()
-        {
-            var indicator = CreateIndicator();
-            if (indicator is IndicatorBase<TradeBar>)
-            {
-                var aaplRenkoConsolidator = new RenkoConsolidator(10000m);
-                aaplRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
-                {
-                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
-                };
-
-                var googRenkoConsolidator = new RenkoConsolidator(100000m);
-                googRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
-                {
-                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
-                };
-
-                var ibmRenkoConsolidator = new RenkoConsolidator(10000m);
-                ibmRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
-                {
-                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
-                };
-
-                foreach (var parts in GetCsvFileStream(TestFileName))
-                {
-                    var tradebar = parts.GetTradeBar();
-                    if (tradebar.Symbol.Value == "AAPL")
-                    {
-                        aaplRenkoConsolidator.Update(tradebar);
-                    }
-                    else if (tradebar.Symbol.Value == "GOOG")
-                    {
-                        googRenkoConsolidator.Update(tradebar);
-                    }
-                    else
-                    {
-                        ibmRenkoConsolidator.Update(tradebar);
-                    }
-                }
-
-                Assert.IsTrue(indicator.IsReady);
-                Assert.AreNotEqual(0, indicator.Samples);
-                IndicatorValueIsNotZeroAfterReceiveVolumeRenkoBars(indicator);
-                aaplRenkoConsolidator.Dispose();
-                googRenkoConsolidator.Dispose();
-                ibmRenkoConsolidator.Dispose();
-            }
-        }
-
-        [Test]
-        public override void AcceptsVolumeRenkoBarsAsInput()
-        {
-            var indicator = CreateIndicator();
-            if (indicator is IndicatorBase<TradeBar>)
-            {
-                var aaplRenkoConsolidator = new VolumeRenkoConsolidator(10000000m);
-                aaplRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
-                {
-                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
-                };
-
-                var googRenkoConsolidator = new VolumeRenkoConsolidator(500000m);
-                googRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
-                {
-                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
-                };
-
-                var ibmRenkoConsolidator = new VolumeRenkoConsolidator(500000m);
-                ibmRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
-                {
-                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
-                };
-
-                foreach (var parts in GetCsvFileStream(TestFileName))
-                {
-                    var tradebar = parts.GetTradeBar();
-                    if (tradebar.Symbol.Value == "AAPL")
-                    {
-                        aaplRenkoConsolidator.Update(tradebar);
-                    }
-                    else if (tradebar.Symbol.Value == "GOOG")
-                    {
-                        googRenkoConsolidator.Update(tradebar);
-                    }
-                    else
-                    {
-                        ibmRenkoConsolidator.Update(tradebar);
-                    }
-                }
-
-                Assert.IsTrue(indicator.IsReady);
-                Assert.AreNotEqual(0, indicator.Samples);
-                IndicatorValueIsNotZeroAfterReceiveVolumeRenkoBars(indicator);
-                aaplRenkoConsolidator.Dispose();
-                googRenkoConsolidator.Dispose();
-                ibmRenkoConsolidator.Dispose();
-            }
-        }
-
-        [Test]
-        public void WarmsUpOrdered()
+        public override void WarmsUpOrdered()
         {
             var indicator = CreateIndicator();
             var reference = System.DateTime.Today;

--- a/Tests/Indicators/AdvanceDeclineRatioTests.cs
+++ b/Tests/Indicators/AdvanceDeclineRatioTests.cs
@@ -14,9 +14,10 @@
 */
 
 using NUnit.Framework;
+using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
-using System;
+using static QuantConnect.Tests.Indicators.TestHelper;
 
 namespace QuantConnect.Tests.Indicators
 {
@@ -134,6 +135,106 @@ namespace QuantConnect.Tests.Indicators
             Assert.IsTrue(indicator.IsReady);
             Assert.AreEqual(2m, indicator.Current.Value);
             Assert.AreEqual(6, indicator.Samples);
+        }
+
+        [Test]
+        public override void AcceptsRenkoBarsAsInput()
+        {
+            var indicator = CreateIndicator();
+            if (indicator is IndicatorBase<TradeBar>)
+            {
+                var aaplRenkoConsolidator = new RenkoConsolidator(10000m);
+                aaplRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                var googRenkoConsolidator = new RenkoConsolidator(100000m);
+                googRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                var ibmRenkoConsolidator = new RenkoConsolidator(10000m);
+                ibmRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                foreach (var parts in GetCsvFileStream(TestFileName))
+                {
+                    var tradebar = parts.GetTradeBar();
+                    if (tradebar.Symbol.Value == "AAPL")
+                    {
+                        aaplRenkoConsolidator.Update(tradebar);
+                    }
+                    else if (tradebar.Symbol.Value == "GOOG")
+                    {
+                        googRenkoConsolidator.Update(tradebar);
+                    }
+                    else
+                    {
+                        ibmRenkoConsolidator.Update(tradebar);
+                    }
+                }
+
+                Assert.IsTrue(indicator.IsReady);
+                Assert.AreNotEqual(0, indicator.Samples);
+                IndicatorValueIsNotZeroAfterReceiveVolumeRenkoBars(indicator);
+                aaplRenkoConsolidator.Dispose();
+                googRenkoConsolidator.Dispose();
+                ibmRenkoConsolidator.Dispose();
+            }
+        }
+
+        [Test]
+        public override void AcceptsVolumeRenkoBarsAsInput()
+        {
+            var indicator = CreateIndicator();
+            if (indicator is IndicatorBase<TradeBar>)
+            {
+                var aaplRenkoConsolidator = new VolumeRenkoConsolidator(10000000m);
+                aaplRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                var googRenkoConsolidator = new VolumeRenkoConsolidator(500000m);
+                googRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                var ibmRenkoConsolidator = new VolumeRenkoConsolidator(500000m);
+                ibmRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                foreach (var parts in GetCsvFileStream(TestFileName))
+                {
+                    var tradebar = parts.GetTradeBar();
+                    if (tradebar.Symbol.Value == "AAPL")
+                    {
+                        aaplRenkoConsolidator.Update(tradebar);
+                    }
+                    else if (tradebar.Symbol.Value == "GOOG")
+                    {
+                        googRenkoConsolidator.Update(tradebar);
+                    }
+                    else
+                    {
+                        ibmRenkoConsolidator.Update(tradebar);
+                    }
+                }
+
+                Assert.IsTrue(indicator.IsReady);
+                Assert.AreNotEqual(0, indicator.Samples);
+                IndicatorValueIsNotZeroAfterReceiveVolumeRenkoBars(indicator);
+                aaplRenkoConsolidator.Dispose();
+                googRenkoConsolidator.Dispose();
+                ibmRenkoConsolidator.Dispose();
+            }
         }
 
         [Test]

--- a/Tests/Indicators/AdvanceDeclineRatioTests.cs
+++ b/Tests/Indicators/AdvanceDeclineRatioTests.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Tests.Indicators
             adr.Add(Symbols.AAPL);
             adr.Add(Symbols.IBM);
             adr.Add(Symbols.GOOG);
+            RenkoBarSize = 5000000;
             return adr;
         }
 

--- a/Tests/Indicators/AdvanceDeclineRatioVolumeTests.cs
+++ b/Tests/Indicators/AdvanceDeclineRatioVolumeTests.cs
@@ -28,6 +28,7 @@ namespace QuantConnect.Tests.Indicators
             advr.Add(Symbols.AAPL);
             advr.Add(Symbols.IBM);
             advr.Add(Symbols.GOOG);
+            RenkoBarSize = 5000000;
             return advr;
         }
 

--- a/Tests/Indicators/ArmsIndexTests.cs
+++ b/Tests/Indicators/ArmsIndexTests.cs
@@ -14,16 +14,14 @@
 */
 
 using NUnit.Framework;
-using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
-using static QuantConnect.Tests.Indicators.TestHelper;
 using System;
 
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class ArmsIndexTests : CommonIndicatorTests<TradeBar>
+    public class ArmsIndexTests : AdvanceDeclineDifferenceTests
     {
         protected override IndicatorBase<TradeBar> CreateIndicator()
         {
@@ -36,7 +34,7 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        public virtual void ShouldIgnoreRemovedStocks()
+        public override void ShouldIgnoreRemovedStocks()
         {
             var trin = (ArmsIndex) CreateIndicator();
             var reference = System.DateTime.Today;
@@ -71,7 +69,7 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        public virtual void IgnorePeriodIfAnyStockMissed()
+        public override void IgnorePeriodIfAnyStockMissed()
         {
             var adr = (ArmsIndex)CreateIndicator();
             adr.Add(Symbols.MSFT);
@@ -139,7 +137,7 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        public void WarmsUpOrdered()
+        public override void WarmsUpOrdered()
         {
             var indicator = CreateIndicator();
             var reference = System.DateTime.Today;
@@ -214,56 +212,6 @@ namespace QuantConnect.Tests.Indicators
             }
 
             Assert.AreEqual(30, indicator.Samples);
-        }
-
-        [Test]
-        public override void AcceptsVolumeRenkoBarsAsInput()
-        {
-            var indicator = CreateIndicator();
-            if (indicator is IndicatorBase<TradeBar>)
-            {
-                var aaplRenkoConsolidator = new VolumeRenkoConsolidator(10000000m);
-                aaplRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
-                {
-                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
-                };
-
-                var googRenkoConsolidator = new VolumeRenkoConsolidator(500000m);
-                googRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
-                {
-                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
-                };
-
-                var ibmRenkoConsolidator = new VolumeRenkoConsolidator(500000m);
-                ibmRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
-                {
-                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
-                };
-
-                foreach (var parts in GetCsvFileStream(TestFileName))
-                {
-                    var tradebar = parts.GetTradeBar();
-                    if (tradebar.Symbol.Value == "AAPL")
-                    {
-                        aaplRenkoConsolidator.Update(tradebar);
-                    }
-                    else if (tradebar.Symbol.Value == "GOOG")
-                    {
-                        googRenkoConsolidator.Update(tradebar);
-                    }
-                    else
-                    {
-                        ibmRenkoConsolidator.Update(tradebar);
-                    }
-                }
-
-                Assert.IsTrue(indicator.IsReady);
-                Assert.AreNotEqual(0, indicator.Samples);
-                IndicatorValueIsNotZeroAfterReceiveVolumeRenkoBars(indicator);
-                aaplRenkoConsolidator.Dispose();
-                googRenkoConsolidator.Dispose();
-                ibmRenkoConsolidator.Dispose();
-            }
         }
 
         protected override string TestFileName => "arms_data.txt";

--- a/Tests/Indicators/ArmsIndexTests.cs
+++ b/Tests/Indicators/ArmsIndexTests.cs
@@ -14,8 +14,10 @@
 */
 
 using NUnit.Framework;
+using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
+using static QuantConnect.Tests.Indicators.TestHelper;
 using System;
 
 namespace QuantConnect.Tests.Indicators
@@ -214,8 +216,68 @@ namespace QuantConnect.Tests.Indicators
             Assert.AreEqual(30, indicator.Samples);
         }
 
+        [Test]
+        public override void AcceptsVolumeRenkoBarsAsInput()
+        {
+            var indicator = CreateIndicator();
+            if (indicator is IndicatorBase<TradeBar>)
+            {
+                var aaplRenkoConsolidator = new VolumeRenkoConsolidator(10000000m);
+                aaplRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                var googRenkoConsolidator = new VolumeRenkoConsolidator(500000m);
+                googRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                var ibmRenkoConsolidator = new VolumeRenkoConsolidator(500000m);
+                ibmRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+                {
+                    Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+                };
+
+                foreach (var parts in GetCsvFileStream(TestFileName))
+                {
+                    var tradebar = parts.GetTradeBar();
+                    if (tradebar.Symbol.Value == "AAPL")
+                    {
+                        aaplRenkoConsolidator.Update(tradebar);
+                    }
+                    else if (tradebar.Symbol.Value == "GOOG")
+                    {
+                        googRenkoConsolidator.Update(tradebar);
+                    }
+                    else
+                    {
+                        ibmRenkoConsolidator.Update(tradebar);
+                    }
+                }
+
+                Assert.IsTrue(indicator.IsReady);
+                Assert.AreNotEqual(0, indicator.Samples);
+                IndicatorValueIsNotZeroAfterReceiveVolumeRenkoBars(indicator);
+                aaplRenkoConsolidator.Dispose();
+                googRenkoConsolidator.Dispose();
+                ibmRenkoConsolidator.Dispose();
+            }
+        }
+
         protected override string TestFileName => "arms_data.txt";
 
         protected override string TestColumnName => "TRIN";
+
+        /// <summary>
+        /// The final value of this indicator is zero because it uses the Volume of the bars it receives.
+        /// Since RenkoBar's don't always have Volume, the final current value is zero. Therefore we
+        /// skip this test
+        /// </summary>
+        /// <param name="indicator"></param>
+        protected override void IndicatorValueIsNotZeroAfterReceiveRenkoBars(IndicatorBase indicator)
+        {
+        }
     }
 }

--- a/Tests/Indicators/ArmsIndexTests.cs
+++ b/Tests/Indicators/ArmsIndexTests.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Tests.Indicators
             indicator.Add(Symbols.AAPL);
             indicator.Add(Symbols.IBM);
             indicator.Add(Symbols.GOOG);
+            RenkoBarSize = 5000000;
             return indicator;
         }
 

--- a/Tests/Indicators/AroonOscillatorTests.cs
+++ b/Tests/Indicators/AroonOscillatorTests.cs
@@ -25,6 +25,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 0.5m;
             return new AroonOscillator(14, 14);
         }
 

--- a/Tests/Indicators/AverageDirectionalIndexTests.cs
+++ b/Tests/Indicators/AverageDirectionalIndexTests.cs
@@ -24,6 +24,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 0.5m;
             return new AverageDirectionalIndex(14);
         }
 

--- a/Tests/Indicators/AverageDirectionalMovementIndexRatingTests.cs
+++ b/Tests/Indicators/AverageDirectionalMovementIndexRatingTests.cs
@@ -25,6 +25,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 0.5m;
             return new AverageDirectionalMovementIndexRating(14);
         }
 

--- a/Tests/Indicators/AverageTrueRangeTests.cs
+++ b/Tests/Indicators/AverageTrueRangeTests.cs
@@ -25,6 +25,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 0.5m;
             return new AverageTrueRange(14);
         }
 

--- a/Tests/Indicators/AwesomeOscillatorTests.cs
+++ b/Tests/Indicators/AwesomeOscillatorTests.cs
@@ -24,6 +24,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 100000000m;
             return new AwesomeOscillator(5, 34);
         }
 

--- a/Tests/Indicators/BalanceOfPowerTests.cs
+++ b/Tests/Indicators/BalanceOfPowerTests.cs
@@ -24,6 +24,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 100000000m;
             return new BalanceOfPower();
         }
 

--- a/Tests/Indicators/BetaIndicatorTests.cs
+++ b/Tests/Indicators/BetaIndicatorTests.cs
@@ -14,9 +14,11 @@
 */
 
 using NUnit.Framework;
+using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
 using System;
+using static QuantConnect.Tests.Indicators.TestHelper;
 
 namespace QuantConnect.Tests.Indicators
 {
@@ -31,7 +33,6 @@ namespace QuantConnect.Tests.Indicators
 
         protected override IndicatorBase<TradeBar> CreateIndicator()
         {
-            VolumeRenkoBarSize = 100000;
             var indicator = new Beta("testBetaIndicator", 5, "AMZN 2T", "SPX 2T");
             return indicator;
         }
@@ -69,6 +70,76 @@ namespace QuantConnect.Tests.Indicators
             }
 
             Assert.AreEqual(2*period.Value, indicator.Samples);
+        }
+
+        [Test]
+        public override void AcceptsRenkoBarsAsInput()
+        {
+            var indicator = CreateIndicator();
+            var firstRenkoConsolidator = new RenkoConsolidator(10m);
+            var secondRenkoConsolidator = new RenkoConsolidator(10m);
+            firstRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+            {
+                Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+            };
+
+            secondRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+            {
+                Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+            };
+
+            foreach (var parts in GetCsvFileStream(TestFileName))
+            {
+                var tradebar = parts.GetTradeBar();
+                if (tradebar.Symbol.Value == "AMZN")
+                {
+                    firstRenkoConsolidator.Update(tradebar);
+                }
+                else
+                {
+                    secondRenkoConsolidator.Update(tradebar);
+                }
+            }
+
+            Assert.IsTrue(indicator.IsReady);
+            Assert.AreNotEqual(0, indicator.Samples);
+            firstRenkoConsolidator.Dispose();
+            secondRenkoConsolidator.Dispose();
+        }
+
+        [Test]
+        public override void AcceptsVolumeRenkoBarsAsInput()
+        {
+            var indicator = CreateIndicator();
+            var firstVolumeRenkoConsolidator = new VolumeRenkoConsolidator(1000000);
+            var secondVolumeRenkoConsolidator = new VolumeRenkoConsolidator(1000000000);
+            firstVolumeRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+            {
+                Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+            };
+
+            secondVolumeRenkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+            {
+                Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+            };
+
+            foreach (var parts in GetCsvFileStream(TestFileName))
+            {
+                var tradebar = parts.GetTradeBar();
+                if (tradebar.Symbol.Value == "AMZN")
+                {
+                    firstVolumeRenkoConsolidator.Update(tradebar);
+                }
+                else
+                {
+                    secondVolumeRenkoConsolidator.Update(tradebar);
+                }
+            }
+
+            Assert.IsTrue(indicator.IsReady);
+            Assert.AreNotEqual(0, indicator.Samples);
+            firstVolumeRenkoConsolidator.Dispose();
+            secondVolumeRenkoConsolidator.Dispose();
         }
 
         [Test]

--- a/Tests/Indicators/BetaIndicatorTests.cs
+++ b/Tests/Indicators/BetaIndicatorTests.cs
@@ -32,7 +32,6 @@ namespace QuantConnect.Tests.Indicators
         protected override IndicatorBase<TradeBar> CreateIndicator()
         {
             var indicator = new Beta("testBetaIndicator", 5, "AMZN 2T", "SPX 2T");
-            Ticker = "AMZN 2T";
             return indicator;
         }
 

--- a/Tests/Indicators/BetaIndicatorTests.cs
+++ b/Tests/Indicators/BetaIndicatorTests.cs
@@ -32,6 +32,7 @@ namespace QuantConnect.Tests.Indicators
         protected override IndicatorBase<TradeBar> CreateIndicator()
         {
             var indicator = new Beta("testBetaIndicator", 5, "AMZN 2T", "SPX 2T");
+            Ticker = "AMZN 2T";
             return indicator;
         }
 

--- a/Tests/Indicators/BetaIndicatorTests.cs
+++ b/Tests/Indicators/BetaIndicatorTests.cs
@@ -31,6 +31,7 @@ namespace QuantConnect.Tests.Indicators
 
         protected override IndicatorBase<TradeBar> CreateIndicator()
         {
+            VolumeRenkoBarSize = 100000;
             var indicator = new Beta("testBetaIndicator", 5, "AMZN 2T", "SPX 2T");
             return indicator;
         }

--- a/Tests/Indicators/ChaikinMoneyFlowTests.cs
+++ b/Tests/Indicators/ChaikinMoneyFlowTests.cs
@@ -69,6 +69,16 @@ namespace QuantConnect.Tests.Indicators
             }
             Assert.AreEqual(cmf.Current.Value, 0m);
         }
+
+        /// <summary>
+        /// The final value of this indicator is zero because it uses the Volume of the bars it receives.
+        /// Since RenkoBar's don't always have Volume, the final current value is zero. Therefore we
+        /// skip this test
+        /// </summary>
+        /// <param name="indicator"></param>
+        protected override void IndicatorValueIsNotZeroAfterReceiveRenkoBars(IndicatorBase indicator)
+        {
+        }
     }
 }
       

--- a/Tests/Indicators/CommodityChannelIndexTests.cs
+++ b/Tests/Indicators/CommodityChannelIndexTests.cs
@@ -25,6 +25,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 0.5m;
             return new CommodityChannelIndex(14);
         }
 

--- a/Tests/Indicators/CommonIndicatorTests.cs
+++ b/Tests/Indicators/CommonIndicatorTests.cs
@@ -99,7 +99,10 @@ namespace QuantConnect.Tests.Indicators
         public virtual void AcceptsRenkoBarsAsInput()
         {
             var indicator = CreateIndicator();
-            if (indicator is IndicatorBase<TradeBar>)
+            if (indicator is IndicatorBase<TradeBar> ||
+                indicator is IndicatorBase<IBaseData> ||
+                indicator is BarIndicator ||
+                indicator is IndicatorBase<IBaseDataBar>)
             {
                 var renkoConsolidator = new RenkoConsolidator(RenkoBarSize);
                 renkoConsolidator.DataConsolidated += (sender, renkoBar) =>
@@ -119,7 +122,10 @@ namespace QuantConnect.Tests.Indicators
         public virtual void AcceptsVolumeRenkoBarsAsInput()
         {
             var indicator = CreateIndicator();
-            if (indicator is IndicatorBase<TradeBar>)
+            if (indicator is IndicatorBase<TradeBar> ||
+                indicator is IndicatorBase<IBaseData> ||
+                indicator is BarIndicator ||
+                indicator is IndicatorBase<IBaseDataBar>)
             {
                 var volumeRenkoConsolidator = new VolumeRenkoConsolidator(VolumeRenkoBarSize);
                 volumeRenkoConsolidator.DataConsolidated += (sender, volumeRenkoBar) =>

--- a/Tests/Indicators/CommonIndicatorTests.cs
+++ b/Tests/Indicators/CommonIndicatorTests.cs
@@ -108,6 +108,7 @@ namespace QuantConnect.Tests.Indicators
                 };
 
                 TestHelper.UpdateRenkoConsolidator(renkoConsolidator, TestFileName);
+                Assert.IsTrue(indicator.IsReady);
                 Assert.AreNotEqual(0, indicator.Samples);
                 renkoConsolidator.Dispose();
             }
@@ -126,6 +127,7 @@ namespace QuantConnect.Tests.Indicators
                 };
 
                 TestHelper.UpdateRenkoConsolidator(volumeRenkoConsolidator, TestFileName);
+                Assert.IsTrue(indicator.IsReady);
                 Assert.AreNotEqual(0, indicator.Samples);
                 volumeRenkoConsolidator.Dispose();
             }

--- a/Tests/Indicators/CommonIndicatorTests.cs
+++ b/Tests/Indicators/CommonIndicatorTests.cs
@@ -107,7 +107,8 @@ namespace QuantConnect.Tests.Indicators
                     Assert.DoesNotThrow(() => indicator.Update(renkoBar));
                 };
 
-                TestHelper.RunRenkoTestIndicator(indicator as IndicatorBase<TradeBar>, renkoConsolidator, TestFileName);
+                TestHelper.UpdateRenkoConsolidator(renkoConsolidator, TestFileName);
+                Assert.AreNotEqual(0, indicator.Samples);
                 renkoConsolidator.Dispose();
             }
         }
@@ -118,14 +119,15 @@ namespace QuantConnect.Tests.Indicators
             var indicator = CreateIndicator();
             if (indicator is IndicatorBase<TradeBar>)
             {
-                var renkoConsolidator = new VolumeRenkoConsolidator(RenkoBarSize);
-                renkoConsolidator.DataConsolidated += (sender, volumeRenkoBar) =>
+                var volumeRenkoConsolidator = new VolumeRenkoConsolidator(VolumeRenkoBarSize);
+                volumeRenkoConsolidator.DataConsolidated += (sender, volumeRenkoBar) =>
                 {
                     Assert.DoesNotThrow(() => indicator.Update(volumeRenkoBar));
                 };
 
-                TestHelper.RunRenkoTestIndicator(indicator as IndicatorBase<TradeBar>, renkoConsolidator, TestFileName);
-                renkoConsolidator.Dispose();
+                TestHelper.UpdateRenkoConsolidator(volumeRenkoConsolidator, TestFileName);
+                Assert.AreNotEqual(0, indicator.Samples);
+                volumeRenkoConsolidator.Dispose();
             }
         }
 
@@ -213,8 +215,13 @@ namespace QuantConnect.Tests.Indicators
         protected abstract string TestColumnName { get; }
 
         /// <summary>
-        /// Returns the BarSize for the RenkoBar tests, namely, AcceptsVolumeRenkoBarsAsInput() and AcceptsRenkoBarsAsInput()
+        /// Returns the BarSize for the RenkoBar test, namely, AcceptsRenkoBarsAsInput()
         /// </summary>
         protected decimal RenkoBarSize = 10m;
+
+        /// <summary>
+        /// Returns the BarSize for the VolumeRenkoBar test, namely, AcceptsVolumeRenkoBarsAsInput()
+        /// </summary>
+        protected decimal VolumeRenkoBarSize = 500000m;
     }
 }

--- a/Tests/Indicators/CommonIndicatorTests.cs
+++ b/Tests/Indicators/CommonIndicatorTests.cs
@@ -131,28 +131,38 @@ namespace QuantConnect.Tests.Indicators
         protected virtual void RunTestIndicator(IndicatorBase<T> indicator)
         {
             if (indicator is IndicatorBase<IndicatorDataPoint>)
+            {
                 TestHelper.TestIndicator(
                     indicator as IndicatorBase<IndicatorDataPoint>,
                     TestFileName,
                     TestColumnName,
                     Assertion as Action<IndicatorBase<IndicatorDataPoint>, double>
                 );
+            }
             else if (indicator is IndicatorBase<IBaseDataBar>)
+            {
                 TestHelper.TestIndicator(
                     indicator as IndicatorBase<IBaseDataBar>,
                     TestFileName,
                     TestColumnName,
                     Assertion as Action<IndicatorBase<IBaseDataBar>, double>
                 );
+            }
             else if (indicator is IndicatorBase<TradeBar>)
+            {
                 TestHelper.TestIndicator(
                     indicator as IndicatorBase<TradeBar>,
                     TestFileName,
                     TestColumnName,
-                    Assertion as Action<IndicatorBase<TradeBar>, double>
-                );
+                    Assertion as Action<IndicatorBase<TradeBar>, double>);
+                TestHelper.RenkoTestIndicator(
+                    indicator as IndicatorBase<TradeBar>,
+                    TestFileName);
+            }
             else
+            {
                 throw new NotSupportedException("RunTestIndicator: Unsupported indicator data type: " + typeof(T));
+            }
         }
 
         /// <summary>

--- a/Tests/Indicators/CommonIndicatorTests.cs
+++ b/Tests/Indicators/CommonIndicatorTests.cs
@@ -110,6 +110,7 @@ namespace QuantConnect.Tests.Indicators
                 TestHelper.UpdateRenkoConsolidator(renkoConsolidator, TestFileName);
                 Assert.IsTrue(indicator.IsReady);
                 Assert.AreNotEqual(0, indicator.Samples);
+                IndicatorValueIsNotZeroAfterReceiveRenkoBars(indicator);
                 renkoConsolidator.Dispose();
             }
         }
@@ -129,8 +130,19 @@ namespace QuantConnect.Tests.Indicators
                 TestHelper.UpdateRenkoConsolidator(volumeRenkoConsolidator, TestFileName);
                 Assert.IsTrue(indicator.IsReady);
                 Assert.AreNotEqual(0, indicator.Samples);
+                IndicatorValueIsNotZeroAfterReceiveVolumeRenkoBars(indicator);
                 volumeRenkoConsolidator.Dispose();
             }
+        }
+
+        protected virtual void IndicatorValueIsNotZeroAfterReceiveRenkoBars(IndicatorBase indicator)
+        {
+            Assert.AreNotEqual(0, indicator.Current.Value);
+        }
+
+        protected virtual void IndicatorValueIsNotZeroAfterReceiveVolumeRenkoBars(IndicatorBase indicator)
+        {
+            Assert.AreNotEqual(0, indicator.Current.Value);
         }
 
         protected static IBaseData GetInput(DateTime startDate, int value) => GetInput(Symbols.SPY, startDate, value);

--- a/Tests/Indicators/CommonIndicatorTests.cs
+++ b/Tests/Indicators/CommonIndicatorTests.cs
@@ -94,6 +94,18 @@ namespace QuantConnect.Tests.Indicators
             Assert.AreEqual(1, indicator.Samples);
         }
 
+        [Test]
+        public void AcceptsRenkoBarsAsInput()
+        {
+            var indicator = CreateIndicator();
+            var startDate = new DateTime(2019, 1, 1);
+            if (indicator is IndicatorBase<TradeBar>)
+            {
+                var renkoBar = new RenkoBar(Ticker, startDate, startDate.AddMinutes(1), 0.9m, 1, 1, 1, 1);
+                Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+            }
+        }
+
         protected static IBaseData GetInput(DateTime startDate, int value) => GetInput(Symbols.SPY, startDate, value);
 
         protected static IBaseData GetInput(Symbol symbol, DateTime startDate, int value)
@@ -131,38 +143,27 @@ namespace QuantConnect.Tests.Indicators
         protected virtual void RunTestIndicator(IndicatorBase<T> indicator)
         {
             if (indicator is IndicatorBase<IndicatorDataPoint>)
-            {
                 TestHelper.TestIndicator(
                     indicator as IndicatorBase<IndicatorDataPoint>,
                     TestFileName,
                     TestColumnName,
                     Assertion as Action<IndicatorBase<IndicatorDataPoint>, double>
                 );
-            }
             else if (indicator is IndicatorBase<IBaseDataBar>)
-            {
                 TestHelper.TestIndicator(
                     indicator as IndicatorBase<IBaseDataBar>,
                     TestFileName,
                     TestColumnName,
                     Assertion as Action<IndicatorBase<IBaseDataBar>, double>
                 );
-            }
             else if (indicator is IndicatorBase<TradeBar>)
-            {
                 TestHelper.TestIndicator(
                     indicator as IndicatorBase<TradeBar>,
                     TestFileName,
                     TestColumnName,
                     Assertion as Action<IndicatorBase<TradeBar>, double>);
-                TestHelper.RenkoTestIndicator(
-                    indicator as IndicatorBase<TradeBar>,
-                    TestFileName);
-            }
             else
-            {
                 throw new NotSupportedException("RunTestIndicator: Unsupported indicator data type: " + typeof(T));
-            }
         }
 
         /// <summary>
@@ -187,5 +188,10 @@ namespace QuantConnect.Tests.Indicators
         /// Returns the name of the column of the CSV file corresponding to the pre-calculated data for the indicator
         /// </summary>
         protected abstract string TestColumnName { get; }
+
+        /// <summary>
+        /// Returns the name of the symbol used in the indicator
+        /// </summary>
+        protected string Ticker = "";
     }
 }

--- a/Tests/Indicators/DeMarkerIndicatorTests.cs
+++ b/Tests/Indicators/DeMarkerIndicatorTests.cs
@@ -24,6 +24,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 0.001m;
+            VolumeRenkoBarSize = 1000m;
             return new DeMarkerIndicator("DEM", 14);
         }
         

--- a/Tests/Indicators/DonchianChannelTest.cs
+++ b/Tests/Indicators/DonchianChannelTest.cs
@@ -24,6 +24,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 0.5m;
             return new DonchianChannel(50);
         }
 

--- a/Tests/Indicators/EaseOfMovementValueTests.cs
+++ b/Tests/Indicators/EaseOfMovementValueTests.cs
@@ -25,6 +25,7 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<TradeBar> CreateIndicator()
         {
+            RenkoBarSize = 0.5m;
             return new EaseOfMovementValue();
         }
 

--- a/Tests/Indicators/EaseOfMovementValueTests.cs
+++ b/Tests/Indicators/EaseOfMovementValueTests.cs
@@ -78,5 +78,24 @@ namespace QuantConnect.Tests.Indicators
             Assert.AreEqual(0.00639, (double)emv.Current.Value, 0.00001);
             Assert.IsTrue(emv.IsReady);
         }
+
+        /// <summary>
+        /// The final value of this indicator is zero because it uses the Volume of the bars it receives.
+        /// Since RenkoBar's don't always have Volume, the final current value is zero. Therefore we
+        /// skip this test
+        /// </summary>
+        /// <param name="indicator"></param>
+        protected override void IndicatorValueIsNotZeroAfterReceiveRenkoBars(IndicatorBase indicator)
+        {
+        }
+
+        /// <summary>
+        /// The final value of this indicator is zero because the bars it's receiving are the same.
+        /// Therefore we skip this test
+        /// </summary>
+        /// <param name="indicator"></param>
+        protected override void IndicatorValueIsNotZeroAfterReceiveVolumeRenkoBars(IndicatorBase indicator)
+        {
+        }
     }
 }

--- a/Tests/Indicators/FisherTransformTests.cs
+++ b/Tests/Indicators/FisherTransformTests.cs
@@ -24,6 +24,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 0.5m;
             return new FisherTransform(10);
         }
 

--- a/Tests/Indicators/FractalAdaptiveMovingAverageTests.cs
+++ b/Tests/Indicators/FractalAdaptiveMovingAverageTests.cs
@@ -25,6 +25,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 0.5m;
             return new FractalAdaptiveMovingAverage(16);
         }
 

--- a/Tests/Indicators/IchimokuKinkoHyoTests.cs
+++ b/Tests/Indicators/IchimokuKinkoHyoTests.cs
@@ -25,6 +25,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 0.1m;
+            VolumeRenkoBarSize = 0.5m;
             return new IchimokuKinkoHyo();
         }
 

--- a/Tests/Indicators/KeltnerChannelsTests.cs
+++ b/Tests/Indicators/KeltnerChannelsTests.cs
@@ -24,6 +24,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 0.5m;
             return new KeltnerChannels(20, 1.5m);
         }
 

--- a/Tests/Indicators/MassIndexTests.cs
+++ b/Tests/Indicators/MassIndexTests.cs
@@ -24,6 +24,7 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<TradeBar> CreateIndicator()
         {
+            VolumeRenkoBarSize = 0.5m;
             return new MassIndex();
         }
 

--- a/Tests/Indicators/MassIndexTests.cs
+++ b/Tests/Indicators/MassIndexTests.cs
@@ -24,6 +24,7 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<TradeBar> CreateIndicator()
         {
+            RenkoBarSize = 0.1m;
             VolumeRenkoBarSize = 0.5m;
             return new MassIndex();
         }

--- a/Tests/Indicators/McClellanIndicatorsTestHelper.cs
+++ b/Tests/Indicators/McClellanIndicatorsTestHelper.cs
@@ -17,6 +17,7 @@ using System;
 using NUnit.Framework;
 using QuantConnect.Data.Consolidators;
 using QuantConnect.Indicators;
+using QuantConnect.Data.Market;
 
 namespace QuantConnect.Tests.Indicators
 {
@@ -58,20 +59,20 @@ namespace QuantConnect.Tests.Indicators
         }
 
         /// <summary>
-        /// Run test for McClellan Indicator asserting it can receive BaseRenkoBar's as input
+        /// Updates the given consolidator with the entries from the given external CSV file
         /// </summary>
-        /// <param name="indicator">McClellan Indicator instance</param>
         /// <param name="renkoConsolidator">RenkoConsoliadtor instance</param>
         /// <param name="fileName">External source file name</param>
-        public static void RunRenkoTestIndicator<T>(T indicator, IDataConsolidator renkoConsolidator, string fileName)
-            where T : TradeBarIndicator, ITestMcClellanOscillator
+        public static void UpdateRenkoConsolidator(IDataConsolidator renkoConsolidator, string fileName)
         {
+            var closeValue = 1m;
             foreach (var parts in TestHelper.GetCsvFileStream(fileName))
             {
                 parts.TryGetValue("a/d difference", out var adDifference);
                 parts.TryGetValue("date", out var date);
 
-                var data = new IndicatorDataPoint(Parse.DateTimeExact(date, "yyyyMMdd"), adDifference.ToDecimal());
+                var data = new TradeBar() { Symbol = Symbols.SPY, Close = closeValue, Open = closeValue - 1, Volume = 1, Time = Parse.DateTimeExact(date, "yyyyMMdd") };
+                closeValue++;
                 renkoConsolidator.Update(data);
             }
         }

--- a/Tests/Indicators/McClellanIndicatorsTestHelper.cs
+++ b/Tests/Indicators/McClellanIndicatorsTestHelper.cs
@@ -15,6 +15,7 @@
 
 using System;
 using NUnit.Framework;
+using QuantConnect.Data.Consolidators;
 using QuantConnect.Indicators;
 
 namespace QuantConnect.Tests.Indicators
@@ -53,6 +54,25 @@ namespace QuantConnect.Tests.Indicators
 
                 // Source data has only 2 decimal places
                 Assert.AreEqual(Parse.Double(expected), (double)indicator.Current.Value, 0.02d);
+            }
+        }
+
+        /// <summary>
+        /// Run test for McClellan Indicator asserting it can receive BaseRenkoBar's as input
+        /// </summary>
+        /// <param name="indicator">McClellan Indicator instance</param>
+        /// <param name="renkoConsolidator">RenkoConsoliadtor instance</param>
+        /// <param name="fileName">External source file name</param>
+        public static void RunRenkoTestIndicator<T>(T indicator, IDataConsolidator renkoConsolidator, string fileName)
+            where T : TradeBarIndicator, ITestMcClellanOscillator
+        {
+            foreach (var parts in TestHelper.GetCsvFileStream(fileName))
+            {
+                parts.TryGetValue("a/d difference", out var adDifference);
+                parts.TryGetValue("date", out var date);
+
+                var data = new IndicatorDataPoint(Parse.DateTimeExact(date, "yyyyMMdd"), adDifference.ToDecimal());
+                renkoConsolidator.Update(data);
             }
         }
 

--- a/Tests/Indicators/McClellanOscillatorTests.cs
+++ b/Tests/Indicators/McClellanOscillatorTests.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
 
@@ -86,6 +87,34 @@ namespace QuantConnect.Tests.Indicators
             McClellanIndicatorTestHelper.RunTestIndicator(indicator, TestFileName, TestColumnName);
             indicator.Reset();
             McClellanIndicatorTestHelper.RunTestIndicator(indicator, TestFileName, TestColumnName);
+        }
+
+        [Test]
+        public override void AcceptsRenkoBarsAsInput()
+        {
+            var indicator = new TestMcClellanOscillator();
+            var renkoConsolidator = new RenkoConsolidator(RenkoBarSize);
+            renkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+            {
+                Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+            };
+
+            McClellanIndicatorTestHelper.RunRenkoTestIndicator(indicator, renkoConsolidator, TestFileName);
+            renkoConsolidator.Dispose();
+        }
+
+        [Test]
+        public override void AcceptsVolumeRenkoBarsAsInput()
+        {
+            var indicator = new TestMcClellanOscillator();
+            var volumeRenkoConsolidator = new VolumeRenkoConsolidator(RenkoBarSize);
+            volumeRenkoConsolidator.DataConsolidated += (sender, volumeRenkoBar) =>
+            {
+                Assert.DoesNotThrow(() => indicator.Update(volumeRenkoBar));
+            };
+
+            McClellanIndicatorTestHelper.RunRenkoTestIndicator(indicator, volumeRenkoConsolidator, TestFileName);
+            volumeRenkoConsolidator.Dispose();
         }
 
         protected override string TestFileName => "mcclellan_data.csv";

--- a/Tests/Indicators/McClellanOscillatorTests.cs
+++ b/Tests/Indicators/McClellanOscillatorTests.cs
@@ -93,13 +93,14 @@ namespace QuantConnect.Tests.Indicators
         public override void AcceptsRenkoBarsAsInput()
         {
             var indicator = new TestMcClellanOscillator();
-            var renkoConsolidator = new RenkoConsolidator(RenkoBarSize);
+            var renkoConsolidator = new RenkoConsolidator(0.5m);
             renkoConsolidator.DataConsolidated += (sender, renkoBar) =>
             {
                 Assert.DoesNotThrow(() => indicator.Update(renkoBar));
             };
 
-            McClellanIndicatorTestHelper.RunRenkoTestIndicator(indicator, renkoConsolidator, TestFileName);
+            McClellanIndicatorTestHelper.UpdateRenkoConsolidator(renkoConsolidator, TestFileName);
+            Assert.AreNotEqual(0, indicator.Samples);
             renkoConsolidator.Dispose();
         }
 
@@ -107,13 +108,14 @@ namespace QuantConnect.Tests.Indicators
         public override void AcceptsVolumeRenkoBarsAsInput()
         {
             var indicator = new TestMcClellanOscillator();
-            var volumeRenkoConsolidator = new VolumeRenkoConsolidator(RenkoBarSize);
+            var volumeRenkoConsolidator = new VolumeRenkoConsolidator(0.5m);
             volumeRenkoConsolidator.DataConsolidated += (sender, volumeRenkoBar) =>
             {
                 Assert.DoesNotThrow(() => indicator.Update(volumeRenkoBar));
             };
 
-            McClellanIndicatorTestHelper.RunRenkoTestIndicator(indicator, volumeRenkoConsolidator, TestFileName);
+            McClellanIndicatorTestHelper.UpdateRenkoConsolidator(volumeRenkoConsolidator, TestFileName);
+            Assert.AreNotEqual(0, indicator.Samples);
             volumeRenkoConsolidator.Dispose();
         }
 

--- a/Tests/Indicators/McClellanSummationIndexTests.cs
+++ b/Tests/Indicators/McClellanSummationIndexTests.cs
@@ -93,13 +93,14 @@ namespace QuantConnect.Tests.Indicators
         public override void AcceptsRenkoBarsAsInput()
         {
             var indicator = new TestMcClellanSummationIndex();
-            var renkoConsolidator = new RenkoConsolidator(RenkoBarSize);
+            var renkoConsolidator = new RenkoConsolidator(0.5m);
             renkoConsolidator.DataConsolidated += (sender, renkoBar) =>
             {
                 Assert.DoesNotThrow(() => indicator.Update(renkoBar));
             };
 
-            McClellanIndicatorTestHelper.RunRenkoTestIndicator(indicator, renkoConsolidator, TestFileName);
+            McClellanIndicatorTestHelper.UpdateRenkoConsolidator(renkoConsolidator, TestFileName);
+            Assert.AreNotEqual(0, indicator.Samples);
             renkoConsolidator.Dispose();
         }
 
@@ -107,13 +108,14 @@ namespace QuantConnect.Tests.Indicators
         public override void AcceptsVolumeRenkoBarsAsInput()
         {
             var indicator = new TestMcClellanSummationIndex();
-            var volumeRenkoConsolidator = new VolumeRenkoConsolidator(RenkoBarSize);
+            var volumeRenkoConsolidator = new VolumeRenkoConsolidator(0.5m);
             volumeRenkoConsolidator.DataConsolidated += (sender, volumeRenkoBar) =>
             {
                 Assert.DoesNotThrow(() => indicator.Update(volumeRenkoBar));
             };
 
-            McClellanIndicatorTestHelper.RunRenkoTestIndicator(indicator, volumeRenkoConsolidator, TestFileName);
+            McClellanIndicatorTestHelper.UpdateRenkoConsolidator(volumeRenkoConsolidator, TestFileName);
+            Assert.AreNotEqual(0, indicator.Samples);
             volumeRenkoConsolidator.Dispose();
         }
 

--- a/Tests/Indicators/McClellanSummationIndexTests.cs
+++ b/Tests/Indicators/McClellanSummationIndexTests.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
 
@@ -86,6 +87,34 @@ namespace QuantConnect.Tests.Indicators
             McClellanIndicatorTestHelper.RunTestIndicator(indicator, TestFileName, TestColumnName);
             indicator.Reset();
             McClellanIndicatorTestHelper.RunTestIndicator(indicator, TestFileName, TestColumnName);
+        }
+
+        [Test]
+        public override void AcceptsRenkoBarsAsInput()
+        {
+            var indicator = new TestMcClellanSummationIndex();
+            var renkoConsolidator = new RenkoConsolidator(RenkoBarSize);
+            renkoConsolidator.DataConsolidated += (sender, renkoBar) =>
+            {
+                Assert.DoesNotThrow(() => indicator.Update(renkoBar));
+            };
+
+            McClellanIndicatorTestHelper.RunRenkoTestIndicator(indicator, renkoConsolidator, TestFileName);
+            renkoConsolidator.Dispose();
+        }
+
+        [Test]
+        public override void AcceptsVolumeRenkoBarsAsInput()
+        {
+            var indicator = new TestMcClellanSummationIndex();
+            var volumeRenkoConsolidator = new VolumeRenkoConsolidator(RenkoBarSize);
+            volumeRenkoConsolidator.DataConsolidated += (sender, volumeRenkoBar) =>
+            {
+                Assert.DoesNotThrow(() => indicator.Update(volumeRenkoBar));
+            };
+
+            McClellanIndicatorTestHelper.RunRenkoTestIndicator(indicator, volumeRenkoConsolidator, TestFileName);
+            volumeRenkoConsolidator.Dispose();
         }
 
         protected override string TestFileName => "mcclellan_data.csv";

--- a/Tests/Indicators/MoneyFlowIndexTests.cs
+++ b/Tests/Indicators/MoneyFlowIndexTests.cs
@@ -24,6 +24,7 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<TradeBar> CreateIndicator()
         {
+            RenkoBarSize = 0.1m;
             return new MoneyFlowIndex(20);
         }
 

--- a/Tests/Indicators/OnBalanceVolumeTest.cs
+++ b/Tests/Indicators/OnBalanceVolumeTest.cs
@@ -38,5 +38,15 @@ namespace QuantConnect.Tests.Indicators
                     expected.ToStringInvariant("0.##E-00"),
                     indicator.Current.Value.ToStringInvariant("0.##E-00")
                 );
+
+        /// <summary>
+        /// The final value of this indicator is zero because it uses the Volume of the bars it receives.
+        /// Since RenkoBar's don't always have Volume, the final current value is zero. Therefore we
+        /// skip this test
+        /// </summary>
+        /// <param name="indicator"></param>
+        protected override void IndicatorValueIsNotZeroAfterReceiveRenkoBars(IndicatorBase indicator)
+        {
+        }
     }
 }

--- a/Tests/Indicators/ParabolicStopAndReverseTests.cs
+++ b/Tests/Indicators/ParabolicStopAndReverseTests.cs
@@ -24,6 +24,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 0.5m;
             return new ParabolicStopAndReverse();
         }
 

--- a/Tests/Indicators/PivotPointsHighLowTests.cs
+++ b/Tests/Indicators/PivotPointsHighLowTests.cs
@@ -114,5 +114,20 @@ namespace QuantConnect.Tests.Indicators
                 Assert.IsTrue(lowPivotPoint.Any(point => point.Value == 0));
             }
         }
+
+        /// <summary>
+        /// The expected value for this indicator is always zero
+        /// </summary>
+        /// <param name="indicator"></param>
+        protected override void IndicatorValueIsNotZeroAfterReceiveRenkoBars(IndicatorBase indicator)
+        {
+        }
+
+        /// <summary>
+        /// The expected value for this indicator is always zero
+        /// </summary>
+        protected override void IndicatorValueIsNotZeroAfterReceiveVolumeRenkoBars(IndicatorBase indicator)
+        {
+        }
     }
 }

--- a/Tests/Indicators/PythonIndicatorTests.cs
+++ b/Tests/Indicators/PythonIndicatorTests.cs
@@ -474,5 +474,23 @@ class CustomSimpleMovingAverage(PythonIndicator):
                 parameter.Language,
                 parameter.ExpectedFinalStatus);
         }
+
+        /// <summary>
+        /// The external test file of this indicator does not define market data. Therefore
+        /// we skip the test
+        /// </summary>
+        [Test]
+        public override void AcceptsRenkoBarsAsInput()
+        {
+        }
+
+        /// <summary>
+        /// The external test file of this indicator does not define market data. Therefore
+        /// we skip the test
+        /// </summary>
+        [Test]
+        public override void AcceptsVolumeRenkoBarsAsInput()
+        {
+        }
     }
 }

--- a/Tests/Indicators/RelativeDailyVolumeTests.cs
+++ b/Tests/Indicators/RelativeDailyVolumeTests.cs
@@ -112,5 +112,15 @@ namespace QuantConnect.Tests.Indicators
             Assert.IsFalse(rdv7.IsReady);
             Assert.IsFalse(rdv8.IsReady);
         }
+
+        /// <summary>
+        /// The final value of this indicator is zero because it uses the Volume of the bars it receives.
+        /// Since RenkoBar's don't always have Volume, the final current value is zero. Therefore we
+        /// skip this test
+        /// </summary>
+        /// <param name="indicator"></param>
+        protected override void IndicatorValueIsNotZeroAfterReceiveRenkoBars(IndicatorBase indicator)
+        {
+        }
     }
 }

--- a/Tests/Indicators/RelativeDailyVolumeTests.cs
+++ b/Tests/Indicators/RelativeDailyVolumeTests.cs
@@ -25,6 +25,7 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<TradeBar> CreateIndicator()
         {
+            RenkoBarSize = 0.1m;
             return new RelativeDailyVolume(2);
         }
 

--- a/Tests/Indicators/RelativeVigorIndexTests.cs
+++ b/Tests/Indicators/RelativeVigorIndexTests.cs
@@ -24,6 +24,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 10000000m;
             return new RelativeVigorIndex("RVI", 10);
         }
 

--- a/Tests/Indicators/StochasticTests.cs
+++ b/Tests/Indicators/StochasticTests.cs
@@ -25,6 +25,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 0.5m;
             return new Stochastic(12, 3, 5);
         }
 

--- a/Tests/Indicators/SuperTrendTests.cs
+++ b/Tests/Indicators/SuperTrendTests.cs
@@ -25,6 +25,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 0.5m;
             return new SuperTrend(10,3);
         }
 

--- a/Tests/Indicators/TestHelper.cs
+++ b/Tests/Indicators/TestHelper.cs
@@ -202,6 +202,22 @@ namespace QuantConnect.Tests.Indicators
         }
 
         /// <summary>
+        /// Assert the indicator accepts RenkoBar's as input. The RenkoBar's are obtained from an external
+        /// CSV file.
+        /// </summary>
+        /// <param name="indicator">The indicator under test</param>
+        /// <param name="externalDataFilename">The external CSV file name</param>
+        public static void RenkoTestIndicator(IndicatorBase<TradeBar> indicator, string externalDataFilename)
+        {
+            foreach (var parts in GetCsvFileStream(externalDataFilename))
+            {
+                var tradebar = parts.GetRenkoBar(1);
+
+                Assert.DoesNotThrow(() => indicator.Update(tradebar));
+            }
+        }
+
+        /// <summary>
         /// Tests a reset of the specified indicator after processing external data using the specified comma delimited text file.
         /// The 'Close' column will be fed to the indicator as input
         /// </summary>
@@ -392,6 +408,28 @@ namespace QuantConnect.Tests.Indicators
                 Close = dictionary.GetCsvValue("close").ToDecimal(),
                 Volume = forceVolumeColumn || dictionary.ContainsKey("volume") ? Parse.Long(dictionary.GetCsvValue("volume"), NumberStyles.AllowExponent | NumberStyles.AllowDecimalPoint) : 0
             };
+        }
+
+        /// <summary>
+        /// Grabs the RenkoBar values from the set of keys
+        /// </summary>
+        private static RenkoBar GetRenkoBar(this IReadOnlyDictionary<string, string> dictionary, decimal barSize)
+        {
+            var sid = (dictionary.ContainsKey("symbol") || dictionary.ContainsKey("ticker"))
+                ? SecurityIdentifier.GenerateEquity(dictionary.GetCsvValue("symbol", "ticker"), Market.USA)
+                : SecurityIdentifier.Empty;
+
+            return new RenkoBar(symbol : sid != SecurityIdentifier.Empty
+                    ? new Symbol(sid, dictionary.GetCsvValue("symbol", "ticker"))
+                    : Symbol.Empty,
+                start : Time.ParseDate(dictionary.GetCsvValue("date", "time")),
+                endTime : Time.ParseDate(dictionary.GetCsvValue("date", "time")),
+                brickSize : barSize,
+                open : dictionary.GetCsvValue("open").ToDecimal(),
+                high : dictionary.GetCsvValue("high").ToDecimal(),
+                low : dictionary.GetCsvValue("low").ToDecimal(),
+                close : dictionary.GetCsvValue("close").ToDecimal()
+            );
         }
     }
 }

--- a/Tests/Indicators/TestHelper.cs
+++ b/Tests/Indicators/TestHelper.cs
@@ -393,7 +393,7 @@ namespace QuantConnect.Tests.Indicators
         /// <summary>
         /// Grabs the TradeBar values from the set of keys
         /// </summary>
-        private static TradeBar GetTradeBar(this IReadOnlyDictionary<string, string> dictionary, bool forceVolumeColumn = false)
+        public static TradeBar GetTradeBar(this IReadOnlyDictionary<string, string> dictionary, bool forceVolumeColumn = false)
         {
             var sid = (dictionary.ContainsKey("symbol") || dictionary.ContainsKey("ticker"))
                 ? SecurityIdentifier.GenerateEquity(dictionary.GetCsvValue("symbol", "ticker"), Market.USA)

--- a/Tests/Indicators/TestHelper.cs
+++ b/Tests/Indicators/TestHelper.cs
@@ -202,22 +202,6 @@ namespace QuantConnect.Tests.Indicators
         }
 
         /// <summary>
-        /// Assert the indicator accepts RenkoBar's as input. The RenkoBar's are obtained from an external
-        /// CSV file.
-        /// </summary>
-        /// <param name="indicator">The indicator under test</param>
-        /// <param name="externalDataFilename">The external CSV file name</param>
-        public static void RenkoTestIndicator(IndicatorBase<TradeBar> indicator, string externalDataFilename)
-        {
-            foreach (var parts in GetCsvFileStream(externalDataFilename))
-            {
-                var tradebar = parts.GetRenkoBar(1);
-
-                Assert.DoesNotThrow(() => indicator.Update(tradebar));
-            }
-        }
-
-        /// <summary>
         /// Tests a reset of the specified indicator after processing external data using the specified comma delimited text file.
         /// The 'Close' column will be fed to the indicator as input
         /// </summary>

--- a/Tests/Indicators/TestHelper.cs
+++ b/Tests/Indicators/TestHelper.cs
@@ -203,16 +203,19 @@ namespace QuantConnect.Tests.Indicators
         }
 
         /// <summary>
-        /// Asserts the given indicator can receive RenkoBar's as input
+        /// Updates the given consolidator with the entries from the given external CSV file
         /// </summary>
-        /// <param name="indicator">The indicator under test</param>
-        /// <param name="renkoConsolidator">The consolidator to generate the RenkoBar's</param>
+        /// <param name="renkoConsolidator">RenkoConsolidator instance to update</param>
         /// <param name="externalDataFilename">The external CSV file name</param>
-        public static void RunRenkoTestIndicator(IndicatorBase<TradeBar> indicator, IDataConsolidator renkoConsolidator, string externalDataFilename)
+        public static void UpdateRenkoConsolidator(IDataConsolidator renkoConsolidator, string externalDataFilename)
         {
             foreach (var parts in GetCsvFileStream(externalDataFilename))
             {
                 var tradebar = parts.GetTradeBar();
+                if (tradebar.Volume == 0)
+                {
+                    tradebar.Volume = 1;
+                }
                 renkoConsolidator.Update(tradebar);
             }
         }

--- a/Tests/Indicators/TimeProfileTests.cs
+++ b/Tests/Indicators/TimeProfileTests.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Tests.Indicators
 
         protected override IndicatorBase<TradeBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
             return new TimeProfile(3);
         }
         protected override Action<IndicatorBase<TradeBar>, double> Assertion

--- a/Tests/Indicators/UltimateOscillatorTests.cs
+++ b/Tests/Indicators/UltimateOscillatorTests.cs
@@ -24,6 +24,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 0.1m;
+            VolumeRenkoBarSize = 10000000m;
             return new UltimateOscillator(7, 14, 28);
         }
 

--- a/Tests/Indicators/VolumeProfileTests.cs
+++ b/Tests/Indicators/VolumeProfileTests.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Tests.Indicators
 
         protected override IndicatorBase<TradeBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
             return new VolumeProfile(3);
         }
         protected override Action<IndicatorBase<TradeBar>, double> Assertion

--- a/Tests/Indicators/VolumeWeightedAveragePriceIndicatorTests.cs
+++ b/Tests/Indicators/VolumeWeightedAveragePriceIndicatorTests.cs
@@ -27,6 +27,7 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<TradeBar> CreateIndicator()
         {
+            RenkoBarSize = 0.1m;
             return new VolumeWeightedAveragePriceIndicator(50);
         }
 

--- a/Tests/Indicators/VolumeWeightedAveragePriceIndicatorTests.cs
+++ b/Tests/Indicators/VolumeWeightedAveragePriceIndicatorTests.cs
@@ -83,5 +83,15 @@ namespace QuantConnect.Tests.Indicators
             ind.Update(new TradeBar(DateTime.UtcNow, Symbols.SPY, 2m, 2m, 2m, 2m, 1));
             Assert.AreEqual(ind.Current.Value, 2m);
         }
+
+        /// <summary>
+        /// The final value of this indicator is zero because it uses the Volume of the bars it receives.
+        /// Since RenkoBar's don't always have Volume, the final current value is zero. Therefore we
+        /// skip this test
+        /// </summary>
+        /// <param name="indicator"></param>
+        protected override void IndicatorValueIsNotZeroAfterReceiveRenkoBars(IndicatorBase indicator)
+        {
+        }
     }
 }

--- a/Tests/Indicators/WilderSwingIndexTests.cs
+++ b/Tests/Indicators/WilderSwingIndexTests.cs
@@ -36,5 +36,15 @@ namespace QuantConnect.Tests.Indicators
         {
             get { return "SI"; }
         }
+
+        /// <summary>
+        /// The final value of this indicator after being warmed up with VolumeRenkoBar's, is zero
+        /// since sometimes it receives two consecutive bars with the same open and close values.
+        /// Therefore we skip this test.
+        /// </summary>
+        /// <param name="indicator"></param>
+        protected override void IndicatorValueIsNotZeroAfterReceiveVolumeRenkoBars(IndicatorBase indicator)
+        {
+        }
     }
 }

--- a/Tests/Indicators/WilliamsPercentRTests.cs
+++ b/Tests/Indicators/WilliamsPercentRTests.cs
@@ -24,6 +24,8 @@ namespace QuantConnect.Tests.Indicators
     {
         protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
+            RenkoBarSize = 1m;
+            VolumeRenkoBarSize = 0.5m;
             return new WilliamsPercentR(14);
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Make `BaseRenkoBar` inherit from `TradeBar`
- Remove repeated fields in `BaseRenkoBar` such as: `Open, High, Low` and `Close`
- Add regression test explaining how to update an indicator with a RenkoBar
- Add unit tests asserting any indicator which inherits from `IndicatorBase<TradeBar>, IndicatorBase<IBaseDate>, BarIndicator` or `IndicatorBase<IBaseDataBar>` can receive `RenkoBar`'s and `VolumeRenkoBar`'s
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #331 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change users will be able to use indicators with `RenkoBar`'s and `VolumeRenkoBar`'s
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change may need updates to documentation advising indicators can be updated with `RenkoBar`'s or `VolumeRenkoBar`'s
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- There was created one regression algorithm which updates three indicators with `RenkoBar's`. On the end of the algorithm it asserts all the indicators are ready and their current value is different from zero.
- Using the data from the test file defined by each indicator, it was asserted the indicator could receive as input `RenkoBar`'s and `VolumeRenkoBar`'s
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
