### PR TITLE
Fix contract security filter universe

### DIFF
--- a/Algorithm.CSharp/BasicTemplateFuturesDailyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesDailyAlgorithm.cs
@@ -117,7 +117,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public virtual long DataPoints => 13933;
+        public virtual long DataPoints => 14058;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/BasicTemplateFuturesWithExtendedMarketDailyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesWithExtendedMarketDailyAlgorithm.cs
@@ -43,7 +43,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 16232;
+        public override long DataPoints => 16388;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/BasicTemplateOptionsDailyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsDailyAlgorithm.cs
@@ -122,7 +122,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 36838;
+        public long DataPoints => 36834;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/DelistedFutureLiquidateDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DelistedFutureLiquidateDailyRegressionAlgorithm.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 1805;
+        public override long DataPoints => 1812;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/DelistedFutureLiquidateRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DelistedFutureLiquidateRegressionAlgorithm.cs
@@ -92,7 +92,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public virtual long DataPoints => 511797;
+        public virtual long DataPoints => 518729;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/WarmupLowerResolutionOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WarmupLowerResolutionOptionRegressionAlgorithm.cs
@@ -126,7 +126,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 982462;
+        public long DataPoints => 982362;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Common/Data/UniverseSelection/OptionChainUniverse.cs
+++ b/Common/Data/UniverseSelection/OptionChainUniverse.cs
@@ -88,7 +88,7 @@ namespace QuantConnect.Data.UniverseSelection
             // if results are not dynamic, we cache them and won't call filtering till the end of the day
             if (!results.IsDynamic)
             {
-                _cacheDate = data.Time.ConvertFromUtc(Option.Exchange.TimeZone).Date;
+                _cacheDate = exchangeDate;
             }
 
             // always prepend the underlying symbol

--- a/Common/Securities/ContractSecurityFilterUniverse.cs
+++ b/Common/Securities/ContractSecurityFilterUniverse.cs
@@ -256,11 +256,11 @@ namespace QuantConnect.Securities
 
             if (maxExpiry > Time.MaxTimeSpan) maxExpiry = Time.MaxTimeSpan;
 
-            var minExpiryToDate = UnderlyingInternal.Time.Date + minExpiry;
-            var maxExpiryToDate = UnderlyingInternal.Time.Date + maxExpiry;
+            var minExpiryToDate = UnderlyingInternal.EndTime.Date + minExpiry;
+            var maxExpiryToDate = UnderlyingInternal.EndTime.Date + maxExpiry;
 
             AllSymbols = AllSymbols
-                .Where(symbol => symbol.ID.Date >= minExpiryToDate && symbol.ID.Date <= maxExpiryToDate)
+                .Where(symbol => symbol.ID.Date.Date >= minExpiryToDate && symbol.ID.Date.Date <= maxExpiryToDate)
                 .ToList();
 
             return (T) this;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix for contract security filter universe which would would use .Time to filter expirations which could be yesterdays time at midnight localtime. Adding unit tests reproducing issue

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Selecting (0,0) strike filter wouldn't work after the initial selection because we were using Time vs EndTime
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing and added unit test reproducing issue
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
