### PR TITLE
Modernization of syntax used in argument check exceptions

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1195,7 +1195,7 @@ namespace QuantConnect.Algorithm
                 throw new InvalidOperationException("Algorithm.SetTimeZone(): Cannot change time zone after algorithm running.");
             }
 
-            if (timeZone == null) throw new ArgumentNullException("timeZone");
+            if (timeZone == null) throw new ArgumentNullException(nameof(timeZone));
             _timeKeeper.AddTimeZone(timeZone);
             _localTimeKeeper = _timeKeeper.GetLocalTimeKeeper(timeZone);
 

--- a/AlgorithmFactory/Loader.cs
+++ b/AlgorithmFactory/Loader.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -102,7 +102,7 @@ namespace QuantConnect.AlgorithmFactory
             _workerThread = workerThread;
             if (multipleTypeNameResolverFunction == null)
             {
-                throw new ArgumentNullException("multipleTypeNameResolverFunction");
+                throw new ArgumentNullException(nameof(multipleTypeNameResolverFunction));
             }
 
             _loaderTimeLimit = loaderTimeLimit;

--- a/Common/Algorithm/Framework/Alphas/Insight.cs
+++ b/Common/Algorithm/Framework/Alphas/Insight.cs
@@ -676,7 +676,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
 
                 if (insight.GeneratedTimeUtc > insight.CloseTimeUtc)
                 {
-                    throw new ArgumentOutOfRangeException("closeTimeLocal", $"Insight closeTimeLocal must not be in the past.");
+                    throw new ArgumentOutOfRangeException(nameof(closeTimeLocal), $"Insight closeTimeLocal must not be in the past.");
                 }
 
                 insight.Period = insight.CloseTimeUtc - insight.GeneratedTimeUtc;

--- a/Common/Data/Channel.cs
+++ b/Common/Data/Channel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -48,12 +48,12 @@ namespace QuantConnect.Data
         {
             if (string.IsNullOrEmpty(channelName))
             {
-                throw new ArgumentNullException("channelName", "Channel Name can't be null or empty");
+                throw new ArgumentNullException(nameof(channelName), "Channel Name can't be null or empty");
             }
 
             if (symbol == null)
             {
-                throw new ArgumentNullException("symbol", "Symbol can't be null or empty");
+                throw new ArgumentNullException(nameof(symbol), "Symbol can't be null or empty");
             }
 
             Name = channelName;

--- a/Common/Scheduling/DateRules.cs
+++ b/Common/Scheduling/DateRules.cs
@@ -242,7 +242,7 @@ namespace QuantConnect.Scheduling
             // Check that our offset is allowed
             if (daysOffset < 0 || 6 < daysOffset)
             {
-                throw new ArgumentOutOfRangeException("daysOffset", "DateRules.WeekEnd() : Offset must be between 0 and 6");
+                throw new ArgumentOutOfRangeException(nameof(daysOffset), "DateRules.WeekEnd() : Offset must be between 0 and 6");
             }
 
             return new FuncDateRule(GetName(null, "WeekEnd", -daysOffset), (start, end) => WeekIterator(null, start, end, daysOffset, false));

--- a/Common/Securities/Option/OptionStrategies.cs
+++ b/Common/Securities/Option/OptionStrategies.cs
@@ -210,7 +210,7 @@ namespace QuantConnect.Securities.Option
 
             if (leg1Strike >= leg2Strike)
             {
-                throw new ArgumentException("BearCallSpread: leg1Strike must be less than leg2Strike", "leg1Strike, leg2Strike");
+                throw new ArgumentException("BearCallSpread: leg1Strike must be less than leg2Strike", $"{nameof(leg1Strike)}, {nameof(leg2Strike)}");
             }
 
             return new OptionStrategy
@@ -253,7 +253,7 @@ namespace QuantConnect.Securities.Option
 
             if (leg1Strike <= leg2Strike)
             {
-                throw new ArgumentException("BearPutSpread: leg1Strike must be greater than leg2Strike", "leg1Strike, leg2Strike");
+                throw new ArgumentException("BearPutSpread: leg1Strike must be greater than leg2Strike", $"{nameof(leg1Strike)}, {nameof(leg2Strike)}");
             }
 
             return new OptionStrategy
@@ -297,7 +297,7 @@ namespace QuantConnect.Securities.Option
 
             if (leg1Strike >= leg2Strike)
             {
-                throw new ArgumentException("BullCallSpread: leg1Strike must be less than leg2Strike", "leg1Strike, leg2Strike");
+                throw new ArgumentException("BullCallSpread: leg1Strike must be less than leg2Strike", $"{nameof(leg1Strike)}, {nameof(leg2Strike)}");
             }
 
             return new OptionStrategy
@@ -340,7 +340,7 @@ namespace QuantConnect.Securities.Option
 
             if (leg1Strike <= leg2Strike)
             {
-                throw new ArgumentException("BullPutSpread: leg1Strike must be greater than leg2Strike", "leg1Strike, leg2Strike");
+                throw new ArgumentException("BullPutSpread: leg1Strike must be greater than leg2Strike", $"{nameof(leg1Strike)}, {nameof(leg2Strike)}");
             }
 
             return new OptionStrategy

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -1054,11 +1054,11 @@ namespace QuantConnect.Securities
             {
                 if (subscription.Symbol != Symbol)
                 {
-                    throw new ArgumentException(Messages.Security.UnmatchingSymbols, "subscription.Symbol");
+                    throw new ArgumentException(Messages.Security.UnmatchingSymbols, $"{nameof(subscription)}.{nameof(subscription.Symbol)}");
                 }
                 if (!subscription.ExchangeTimeZone.Equals(Exchange.TimeZone))
                 {
-                    throw new ArgumentException(Messages.Security.UnmatchingExchangeTimeZones, "subscription.ExchangeTimeZone");
+                    throw new ArgumentException(Messages.Security.UnmatchingExchangeTimeZones, $"{nameof(subscription)}.{nameof(subscription.ExchangeTimeZone)}");
                 }
                 _subscriptionsBag.Add(subscription);
                 UpdateSubscriptionProperties();
@@ -1077,11 +1077,11 @@ namespace QuantConnect.Securities
                 {
                     if (subscription.Symbol != Symbol)
                     {
-                        throw new ArgumentException(Messages.Security.UnmatchingSymbols, "subscription.Symbol");
+                        throw new ArgumentException(Messages.Security.UnmatchingSymbols, $"{nameof(subscription)}.{nameof(subscription.Symbol)}");
                     }
                     if (!subscription.ExchangeTimeZone.Equals(Exchange.TimeZone))
                     {
-                         throw new ArgumentException(Messages.Security.UnmatchingExchangeTimeZones, "subscription.ExchangeTimeZone");
+                         throw new ArgumentException(Messages.Security.UnmatchingExchangeTimeZones, $"{nameof(subscription)}.{nameof(subscription.ExchangeTimeZone)}");
                     }
                     _subscriptionsBag.Add(subscription);
                 }

--- a/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
+++ b/Common/Securities/Volatility/RelativeStandardDeviationVolatilityModel.cs
@@ -77,7 +77,7 @@ namespace QuantConnect.Securities
             TimeSpan periodSpan,
             int periods)
         {
-            if (periods < 2) throw new ArgumentOutOfRangeException("periods", "'periods' must be greater than or equal to 2.");
+            if (periods < 2) throw new ArgumentOutOfRangeException(nameof(periods), "'periods' must be greater than or equal to 2.");
             _periodSpan = periodSpan;
             _window = new RollingWindow<double>(periods);
             _lastUpdate = GetLastUpdateInitialValue(periodSpan, periods);

--- a/Engine/LeanEngineSystemHandlers.cs
+++ b/Engine/LeanEngineSystemHandlers.cs
@@ -78,19 +78,19 @@ namespace QuantConnect.Lean.Engine
         {
             if (jobQueue == null)
             {
-                throw new ArgumentNullException("jobQueue");
+                throw new ArgumentNullException(nameof(jobQueue));
             }
             if (api == null)
             {
-                throw new ArgumentNullException("api");
+                throw new ArgumentNullException(nameof(api));
             }
             if (notify == null)
             {
-                throw new ArgumentNullException("notify");
+                throw new ArgumentNullException(nameof(notify));
             }
             if (leanManager == null)
             {
-                throw new ArgumentNullException("leanManager");
+                throw new ArgumentNullException(nameof(leanManager));
             }
             _api = api;
             _jobQueue = jobQueue;

--- a/Engine/RealTime/ScheduledEventFactory.cs
+++ b/Engine/RealTime/ScheduledEventFactory.cs
@@ -67,7 +67,7 @@ namespace QuantConnect.Lean.Engine.RealTime
         {
             if (endOfDayDelta >= Time.OneDay)
             {
-                throw new ArgumentException("Delta must be less than a day", "endOfDayDelta");
+                throw new ArgumentException("Delta must be less than a day", nameof(endOfDayDelta));
             }
 
             // set up an event to fire every tradeable date for the algorithm as a whole
@@ -117,7 +117,7 @@ namespace QuantConnect.Lean.Engine.RealTime
         {
             if (endOfDayDelta >= Time.OneDay)
             {
-                throw new ArgumentException("Delta must be less than a day", "endOfDayDelta");
+                throw new ArgumentException("Delta must be less than a day", nameof(endOfDayDelta));
             }
 
             var isMarketAlwaysOpen = security.Exchange.Hours.IsMarketAlwaysOpen;

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -144,7 +144,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         {
             if (brokerage == null)
             {
-                throw new ArgumentNullException("brokerage");
+                throw new ArgumentNullException(nameof(brokerage));
             }
             // multi threaded queue, used for live deployments
             _orderRequestQueue = new BusyBlockingCollection<OrderRequest>();

--- a/Indicators/ArnaudLegouxMovingAverage.cs
+++ b/Indicators/ArnaudLegouxMovingAverage.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.Indicators
         public ArnaudLegouxMovingAverage(string name, int period, int sigma = 6, decimal offset = 0.85m)
             : base(name, period)
         {
-            if (offset < 0 || offset > 1) throw new ArgumentException($"Offset parameter range is [0,1]. Value: {offset}", "offset");
+            if (offset < 0 || offset > 1) throw new ArgumentException($"Offset parameter range is [0,1]. Value: {offset}", nameof(offset));
 
             var m = Math.Floor(offset * (period - 1));
             var s = period * 1m / sigma;

--- a/Indicators/HullMovingAverage.cs
+++ b/Indicators/HullMovingAverage.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Indicators
         public HullMovingAverage(string name, int period)
             : base(name)
         {
-            if (period < 2) throw new ArgumentException("The Hull Moving Average period should be greater or equal to 2", "period");
+            if (period < 2) throw new ArgumentException("The Hull Moving Average period should be greater or equal to 2", nameof(period));
             _slowWma = new LinearWeightedMovingAverage(period);
             _fastWma = new LinearWeightedMovingAverage((int) Math.Round(period * 1d / 2));
             var k = (int)Math.Round(Math.Sqrt(period));

--- a/Indicators/Momersion.cs
+++ b/Indicators/Momersion.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -50,7 +50,7 @@ namespace QuantConnect.Indicators
         {
             if (minPeriod < 4)
             {
-                throw new ArgumentException("The minimum period should be 4.", "minPeriod");
+                throw new ArgumentException("The minimum period should be 4.", nameof(minPeriod));
             }
             _minPeriod = minPeriod;
             _multipliedDiffWindow = new RollingWindow<decimal>(fullPeriod);

--- a/Indicators/MovingAverageTypeExtensions.cs
+++ b/Indicators/MovingAverageTypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  * 
@@ -67,7 +67,7 @@ namespace QuantConnect.Indicators
                     return new ArnaudLegouxMovingAverage(period);
 
                 default:
-                    throw new ArgumentOutOfRangeException("movingAverageType");
+                    throw new ArgumentOutOfRangeException(nameof(movingAverageType));
             }
         }
 
@@ -117,7 +117,7 @@ namespace QuantConnect.Indicators
                     return new ArnaudLegouxMovingAverage(name, period);
 
                 default:
-                    throw new ArgumentOutOfRangeException("movingAverageType");
+                    throw new ArgumentOutOfRangeException(nameof(movingAverageType));
             }
         }
     }

--- a/Logging/CompositeLogHandler.cs
+++ b/Logging/CompositeLogHandler.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Logging
         {
             if (handlers == null || handlers.Length == 0)
             {
-                throw new ArgumentNullException("handlers");
+                throw new ArgumentNullException(nameof(handlers));
             }
 
             _handlers = handlers;

--- a/Logging/ILogHandlerExtensions.cs
+++ b/Logging/ILogHandlerExtensions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -33,7 +33,7 @@ namespace QuantConnect.Logging
         {
             if (logHandler == null)
             {
-                throw new ArgumentNullException("logHandler", "Log Handler cannot be null");
+                throw new ArgumentNullException(nameof(logHandler), "Log Handler cannot be null");
             }
 
             logHandler.Error(string.Format(CultureInfo.InvariantCulture, text, args));
@@ -49,7 +49,7 @@ namespace QuantConnect.Logging
         {
             if (logHandler == null)
             {
-                throw new ArgumentNullException("logHandler", "Log Handler cannot be null");
+                throw new ArgumentNullException(nameof(logHandler), "Log Handler cannot be null");
             }
 
             logHandler.Debug(string.Format(CultureInfo.InvariantCulture, text, args));
@@ -65,7 +65,7 @@ namespace QuantConnect.Logging
         {
             if (logHandler == null)
             {
-                throw new ArgumentNullException("logHandler", "Log Handler cannot be null");
+                throw new ArgumentNullException(nameof(logHandler), "Log Handler cannot be null");
             }
 
             logHandler.Trace(string.Format(CultureInfo.InvariantCulture, text, args));

--- a/Optimizer/Strategies/StepBaseOptimizationStrategy.cs
+++ b/Optimizer/Strategies/StepBaseOptimizationStrategy.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -91,7 +91,7 @@ namespace QuantConnect.Optimizer.Strategies
                     var stepSettings = Settings as StepBaseOptimizationStrategySettings;
                     if (stepSettings == null)
                     {
-                        throw new ArgumentException(nameof(settings), $"OptimizationStrategySettings is not of {nameof(StepBaseOptimizationStrategySettings)} type");
+                        throw new ArgumentException($"OptimizationStrategySettings is not of {nameof(StepBaseOptimizationStrategySettings)} type", nameof(settings));
                     }
                     CalculateStep(optimizationParameter, stepSettings.DefaultSegmentAmount);
                 }
@@ -192,7 +192,7 @@ namespace QuantConnect.Optimizer.Strategies
         {
             if (defaultSegmentAmount < 1)
             {
-                throw new ArgumentException(nameof(defaultSegmentAmount), $"Number of segments should be positive number, but specified '{defaultSegmentAmount}'");
+                throw new ArgumentException($"Number of segments should be positive number, but specified '{defaultSegmentAmount}'", nameof(defaultSegmentAmount));
             }
 
             parameter.Step = Math.Abs(parameter.MaxValue - parameter.MinValue) / defaultSegmentAmount;

--- a/ToolBox/FactorFileGenerator.cs
+++ b/ToolBox/FactorFileGenerator.cs
@@ -317,12 +317,12 @@ namespace QuantConnect.ToolBox
             {
                 if (split == null)
                 {
-                    throw new ArgumentNullException("split");
+                    throw new ArgumentNullException(nameof(split));
                 }
 
                 if (dividend == null)
                 {
-                    throw new ArgumentNullException("dividend");
+                    throw new ArgumentNullException(nameof(dividend));
                 }
 
                 Split = split;

--- a/ToolBox/IQFeed/IQ/IQSocket.cs
+++ b/ToolBox/IQFeed/IQ/IQSocket.cs
@@ -92,7 +92,7 @@ namespace QuantConnect.ToolBox.IQFeed
             {
                 throw new ArgumentException("Unable to retrieve address from specified host name.", host);
             }
-            
+
             return ipAddresses[0];
         }
 

--- a/ToolBox/IQFeed/IQ/IQSocket.cs
+++ b/ToolBox/IQFeed/IQ/IQSocket.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  * 
@@ -92,7 +92,7 @@ namespace QuantConnect.ToolBox.IQFeed
             {
                 throw new ArgumentException("Unable to retrieve address from specified host name.", host);
             }
-
+            
             return ipAddresses[0];
         }
 
@@ -191,4 +191,3 @@ namespace QuantConnect.ToolBox.IQFeed
         #endregion
     }
 }
- 

--- a/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
+++ b/ToolBox/IQFeed/IQFeedDataQueueHandler.cs
@@ -836,7 +836,7 @@ namespace QuantConnect.ToolBox.IQFeed
                 case Resolution.Tick:
                 case Resolution.Daily:
                 default:
-                    throw new ArgumentOutOfRangeException("resolution", resolution, null);
+                    throw new ArgumentOutOfRangeException(nameof(resolution), resolution, null);
             }
         }
     }

--- a/ToolBox/IQFeed/IQFeedFileHistoryProvider.cs
+++ b/ToolBox/IQFeed/IQFeedFileHistoryProvider.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -305,7 +305,7 @@ namespace QuantConnect.ToolBox.IQFeed
                 case Resolution.Tick:
                 case Resolution.Daily:
                 default:
-                    throw new ArgumentOutOfRangeException("resolution", resolution, null);
+                    throw new ArgumentOutOfRangeException(nameof(resolution), resolution, null);
             }
         }
     }


### PR DESCRIPTION
#### Description
- String literals in many argument constructors were changed to the nameof() operator
- In some instances of `ArgumentException` the arguments were in the wrong place, so I switched them (see `StepBaseOptimizationStrategy.cs`)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. (It's just syntax modernization)
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>` (it's not related to any particular issue)

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
