### PR TITLE
Return valid default value for indicator `Previous` property

### DIFF
--- a/Indicators/IndicatorBase.cs
+++ b/Indicators/IndicatorBase.cs
@@ -59,7 +59,7 @@ namespace QuantConnect.Indicators
         {
             get
             {
-                return Window.Size > 1 ? Window[1] : new IndicatorDataPoint(DateTime.MinValue, 0);
+                return Window.Count > 1 ? Window[1] : new IndicatorDataPoint(DateTime.MinValue, 0);
             }
         }
 

--- a/Tests/Indicators/IndicatorTests.cs
+++ b/Tests/Indicators/IndicatorTests.cs
@@ -319,6 +319,19 @@ namespace QuantConnect.Tests.Indicators
             Assert.AreEqual(dataPoints[^2], indicator[1]);
         }
 
+        [Test]
+        public void PreviousValueIsNotNullAtStart()
+        {
+            var indicator = new TestIndicator("Test indicator");
+
+            // Access current and previous without warming the indicator up
+            var defaultValue = new IndicatorDataPoint(DateTime.MinValue, 0);
+            Assert.IsNotNull(indicator.Current);
+            Assert.AreEqual(defaultValue, indicator.Current);
+            Assert.IsNotNull(indicator.Previous);
+            Assert.AreEqual(defaultValue, indicator.Previous);
+        }
+
         private static void TestComparisonOperators<TValue>()
         {
             var indicator = new TestIndicator();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Return default `IndicatorDataPoint(DateTime.MinValue, 0)` when there's no available previous value for `Previous` property.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #7398 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit test.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
