### PR TITLE
Fix for CI python stubs

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -19,21 +19,12 @@ jobs:
       - uses: addnab/docker-run-action@v3
         with:
           image: quantconnect/lean:foundation
-          options: --workdir /__w/Lean/Lean -v /home/runner/work:/__w
+          options: --workdir /__w/Lean/Lean -v /home/runner/work:/__w -e GITHUB_REF=${{ github.ref }} -e PYPI_API_TOKEN=${{ secrets.PYPI_API_TOKEN }} -e ADDITIONAL_STUBS_REPOS=${{ secrets.ADDITIONAL_STUBS_REPOS }} -e QC_GIT_TOKEN=${{ secrets.QC_GIT_TOKEN }}
           shell: bash
           run: |
             # Build
             dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln
             # Run Tests
             dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --blame-hang-timeout 300seconds --blame-crash --filter "TestCategory!=TravisExclude&TestCategory!=ResearchRegressionTests" -- TestRunParameters.Parameter\(name=\"log-handler\", value=\"ConsoleErrorLogHandler\"\)
-
-      - name: Generate & Publish python stubs
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: addnab/docker-run-action@v3
-        with:
-          image: quantconnect/lean:foundation
-          options: --workdir /__w/Lean/Lean -v /home/runner/work:/__w -e PYPI_API_TOKEN=${{ secrets.PYPI_API_TOKEN }} -e ADDITIONAL_STUBS_REPOS=${{ secrets.ADDITIONAL_STUBS_REPOS }} -e QC_GIT_TOKEN=${{ secrets.QC_GIT_TOKEN }}
-          shell: bash
-          run: |
-            chmod +x ci_build_stubs.sh
-            ./ci_build_stubs.sh -t -g -p
+            # Generate & Publish python stubs
+            echo "GITHUB_REF $GITHUB_REF" && (([[ $GITHUB_REF = refs/tags/* ]] && chmod +x ci_build_stubs.sh && ./ci_build_stubs.sh -t -g -p) || echo "Skipping stub generation")

--- a/ci_build_stubs.sh
+++ b/ci_build_stubs.sh
@@ -102,6 +102,7 @@ if [[ " ${CLI_ARGS[@]} " =~ " -h " ]]; then
 fi
 
 if [[ ! "$GITHUB_REF" =~ "refs/tags/" ]]; then
+    echo "GITHUB_REF not defined!"
     exit 0
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix for python stubs CI generation

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related https://github.com/QuantConnect/Lean/pull/7399
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Stubs were not being generated
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running job in fork

```
Status: Downloaded newer image for quantconnect/lean:foundation
GITHUB_REF refs/heads/master
Skipping stub generation
```

```
Status: Downloaded newer image for quantconnect/lean:foundation
GITHUB_REF refs/tags/112
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
alpaca-trade-api 0.48 requires urllib3<1.25, but you have urllib3 1.26.16 which is incompatible.
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
Cloning into '/__w/Lean/Lean/Launcher/bin/Release/quantconnect-stubs-generator'...
Already on 'master'
Your branch is up to date with 'origin/master'.
From https://github.com/QuantConnect/quantconnect-stubs-generator
 * branch            master     -> FETCH_HEAD
Already up to date.
Cloning into '/__w/Lean/Lean/Launcher/bin/Release/dotnet-runtime'..
....
https://github.com/Martin-Molinero/Lean/actions/runs/5696864677/job/15442677947
```
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
