### PR TITLE
Bug parameters in report bug

### DIFF
--- a/Report/ReportElements/ParametersReportElement.cs
+++ b/Report/ReportElements/ParametersReportElement.cs
@@ -15,6 +15,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace QuantConnect.Report.ReportElements
 {
@@ -59,21 +60,33 @@ namespace QuantConnect.Report.ReportElements
         public override string Render()
         {
             var items = new List<string>();
+            int parameterIndex;
+            var columns = (new Regex(@"{{\$KEY(\d+?)}}")).Matches(_template).Count;
 
-            for (int index = 0; index < _parameters.Count; index += 2)
+            for (parameterIndex = 0; parameterIndex < _parameters.Count;)
             {
                 var template = _template;
-                var firstKVP = _parameters.ElementAt(index);
-                var firstKey = string.Join(" ", (firstKVP.Key).Split("-").Select(x => x[0].ToString().ToUpper() + x.Substring(1)));
-                template = template.Replace("{{$FIRST-KPI-NAME}}", firstKey);
-                template = template.Replace("{{$FIRST-KPI-VALUE}}", firstKVP.Value);
-                if ((index + 1) < _parameters.Count)
+                int column;
+                for (column = 0; column < columns; column++)
                 {
-                    var secondKVP = _parameters.ElementAt(index + 1);
-                    var secondKey = string.Join(" ", (secondKVP.Key).Split("-").Select(x => x[0].ToString().ToUpper() + x.Substring(1)));
-                    template = template.Replace("{{$SECOND-KPI-NAME}}", secondKey);
-                    template = template.Replace("{{$SECOND-KPI-VALUE}}", secondKVP.Value);
+                    var currTemplateKey = "{{$KEY" + column.ToString() + "}}";
+                    var currTemplateValue = "{{$VALUE" + column.ToString() + "}}";
+
+                    if (parameterIndex < _parameters.Count)
+                    {
+                        var parameter = _parameters.ElementAt(parameterIndex);
+                        template = template.Replace(currTemplateKey, EmbellishKeyName(parameter.Key));
+                        template = template.Replace(currTemplateValue, parameter.Value);
+                    }
+                    else
+                    {
+                        template = template.Replace(currTemplateKey, string.Empty);
+                        template = template.Replace(currTemplateValue, string.Empty);
+                    }
+
+                    parameterIndex++;
                 }
+
                 items.Add(template);
             }
 
@@ -89,6 +102,17 @@ namespace QuantConnect.Report.ReportElements
 
             var parameters= string.Join("\n", items);
             return parameters;
+        }
+
+        /// <summary>
+        /// Replaces the "-" character in the given string for a space, and upper case
+        /// each word in the given string
+        /// </summary>
+        /// <param name="keyName">Key name to embellish</param>
+        /// <returns>The given key name embellished as the description says</returns>
+        private static string EmbellishKeyName(string keyName)
+        {
+            return string.Join(" ", (keyName).Split("-").Select(x => x[0].ToString().ToUpper() + x.Substring(1)));
         }
     }
 }

--- a/Report/ReportElements/ParametersReportElement.cs
+++ b/Report/ReportElements/ParametersReportElement.cs
@@ -105,7 +105,7 @@ namespace QuantConnect.Report.ReportElements
                 return string.Empty;
             }
 
-            var parameters= string.Join("\r\n", items);
+            var parameters= string.Join("\n", items);
             return parameters;
         }
 

--- a/Report/ReportElements/ParametersReportElement.cs
+++ b/Report/ReportElements/ParametersReportElement.cs
@@ -105,7 +105,7 @@ namespace QuantConnect.Report.ReportElements
                 return string.Empty;
             }
 
-            var parameters= string.Join("\n", items);
+            var parameters= string.Join("\r\n", items);
             return parameters;
         }
 

--- a/Report/ReportElements/ParametersReportElement.cs
+++ b/Report/ReportElements/ParametersReportElement.cs
@@ -19,7 +19,7 @@ using System.Text.RegularExpressions;
 
 namespace QuantConnect.Report.ReportElements
 {
-    internal sealed class ParametersReportElement : ReportElement
+    public class ParametersReportElement : ReportElement
     {
         private IReadOnlyDictionary<string, string> _parameters;
         private readonly string _template;
@@ -84,6 +84,11 @@ namespace QuantConnect.Report.ReportElements
                         template = template.Replace(currTemplateValue, string.Empty);
                     }
 
+                    parameterIndex++;
+                }
+
+                if (column == 0)
+                {
                     parameterIndex++;
                 }
 

--- a/Report/template.html
+++ b/Report/template.html
@@ -349,7 +349,7 @@ crisis-->
 
 <!--parameters
 <tr>
-	<td class = "title"> {{$FIRST-KPI-NAME}} </td><td> {{$FIRST-KPI-VALUE}} </td>
-	<td class = "title"> {{$SECOND-KPI-NAME}} </td><td> {{$SECOND-KPI-VALUE}} </td>
+	<td class = "title"> {{$KEY0}} </td><td> {{$VALUE0}} </td>
+	<td class = "title"> {{$KEY1}} </td><td> {{$VALUE1}} </td>
 </tr>
 parameters-->

--- a/Tests/Report/ResultDeserializationTests.cs
+++ b/Tests/Report/ResultDeserializationTests.cs
@@ -190,9 +190,11 @@ namespace QuantConnect.Tests.Report
         [TestCaseSource(nameof(CreatesReportParametersTableCorrectlyTestCases))]
         public void CreatesReportParametersTableCorrectly(string parametersTemplate, Dictionary<string, string> parameters, string expectedParametersTable)
         {
+            parametersTemplate = parametersTemplate.Replace("\r", string.Empty);
             var algorithmConfiguration = new AlgorithmConfiguration { Parameters = parameters };
             var parametersReportElment = new ParametersReportElement("parameters", "", algorithmConfiguration, null, parametersTemplate);
             var parametersTable = parametersReportElment.Render();
+            expectedParametersTable = expectedParametersTable.Replace("\r", string.Empty);
             Assert.AreEqual(expectedParametersTable, parametersTable);
         }
 

--- a/Tests/Report/ResultDeserializationTests.cs
+++ b/Tests/Report/ResultDeserializationTests.cs
@@ -188,13 +188,12 @@ namespace QuantConnect.Tests.Report
         }
 
         [TestCaseSource(nameof(CreatesReportParametersTableCorrectlyTestCases))]
-        public void CreatesReportParametersTableCorrectly(string parametersTemplate, Dictionary<string, string> parameters, bool templateFormatIsCorrect)
+        public void CreatesReportParametersTableCorrectly(string parametersTemplate, Dictionary<string, string> parameters, string expectedParametersTable)
         {
             var algorithmConfiguration = new AlgorithmConfiguration { Parameters = parameters };
             var parametersReportElment = new ParametersReportElement("parameters", "", algorithmConfiguration, null, parametersTemplate);
             var parametersTable = parametersReportElment.Render();
-            var rawTemplateKeysOrValues = (new Regex(@"{{(.*?)}}")).Matches(parametersTable).Count;
-            Assert.AreEqual(templateFormatIsCorrect, rawTemplateKeysOrValues == 0);
+            Assert.AreEqual(expectedParametersTable, parametersTable);
         }
 
         [TestCase(htmlExampleCode + @"
@@ -354,44 +353,69 @@ parameters-->", @"<!--crisis(\r|\n)*((\r|\n|.)*?)crisis-->")]
         public static object[] CreatesReportParametersTableCorrectlyTestCases = new object[]
         {
             // Happy test cases
-            new object[] { @"<!--parameters
-<tr>
+            new object[] { @"<tr>
 	<td class = ""title""> {{$KEY0}} </td><td> {{$VALUE0}} </td>
+</tr>", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" } },
+                @"<tr>
+	<td class = ""title""> Test Key One </td><td> 1 </td>
 </tr>
-parameters-->", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" } }, true},
-
-            new object[] { @"<!--parameters
 <tr>
+	<td class = ""title""> Test Key Two </td><td> 2 </td>
+</tr>
+<tr>
+	<td class = ""title""> Test Key Three </td><td> three </td>
+</tr>"},
+
+            new object[] { @"<tr>
 	<td class = ""title""> {{$KEY0}} </td><td> {{$VALUE0}} </td>
 	<td class = ""title""> {{$KEY1}} </td><td> {{$VALUE1}} </td>
+</tr>", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" } }, @"<tr>
+	<td class = ""title""> Test Key One </td><td> 1 </td>
+	<td class = ""title""> Test Key Two </td><td> 2 </td>
 </tr>
-parameters-->", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" } }, true},
-
-            new object[] { @"<!--parameters
 <tr>
+	<td class = ""title""> Test Key Three </td><td> three </td>
+	<td class = ""title"">  </td><td>  </td>
+</tr>"},
+
+            new object[] { @"<tr>
 	<td class = ""title""> {{$KEY0}} </td><td> {{$VALUE0}} </td>
 	<td class = ""title""> {{$KEY1}} </td><td> {{$VALUE1}} </td>
-</tr>
-parameters-->", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" } }, true},
+</tr>", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" } }, @"<tr>
+	<td class = ""title""> Test Key One </td><td> 1 </td>
+	<td class = ""title""> Test Key Two </td><td> 2 </td>
+</tr>"},
 
-            new object[] { @"<!--parameters
-<tr>
+            new object[] { @"<tr>
 	<td class = ""title""> {{$KEY0}} </td><td> {{$VALUE0}} </td>
 	<td class = ""title""> {{$KEY1}} </td><td> {{$VALUE1}} </td>
     <td class = ""title""> {{$KEY2}} </td><td> {{$VALUE2}} </td>
+</tr>", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" }, { "test-key-four", "4"} }, @"<tr>
+	<td class = ""title""> Test Key One </td><td> 1 </td>
+	<td class = ""title""> Test Key Two </td><td> 2 </td>
+    <td class = ""title""> Test Key Three </td><td> three </td>
 </tr>
-parameters-->", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" }, { "test-key-four", "4"} }, true},
-
-            new object[] { @"<!--parameters
 <tr>
+	<td class = ""title""> Test Key Four </td><td> 4 </td>
+	<td class = ""title"">  </td><td>  </td>
+    <td class = ""title"">  </td><td>  </td>
+</tr>"},
+            new object[] { @"<tr>
 	<td class = ""title""> {{$KEY0}} </td><td> {{$VALUE0}} </td>
 	<td class = ""title""> {{$KEY1}} </td><td> {{$VALUE1}} </td>
     <td class = ""title""> {{$KEY2}} </td><td> {{$VALUE2}} </td>
+</tr>", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" }, { "test-key-four", "4"}, { "test-key-five", "5"} }, @"<tr>
+	<td class = ""title""> Test Key One </td><td> 1 </td>
+	<td class = ""title""> Test Key Two </td><td> 2 </td>
+    <td class = ""title""> Test Key Three </td><td> three </td>
 </tr>
-parameters-->", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" }, { "test-key-four", "4"}, { "test-key-five", "5"} }, true },
-
-            new object[] { @"<!--parameters
 <tr>
+	<td class = ""title""> Test Key Four </td><td> 4 </td>
+	<td class = ""title""> Test Key Five </td><td> 5 </td>
+    <td class = ""title"">  </td><td>  </td>
+</tr>"},
+
+            new object[] { @"<tr>
 	<td class = ""title""> {{$KEY0}} </td><td> {{$VALUE0}} </td>
 	<td class = ""title""> {{$KEY1}} </td><td> {{$VALUE1}} </td>
     <td class = ""title""> {{$KEY2}} </td><td> {{$VALUE2}} </td>
@@ -404,35 +428,72 @@ parameters-->", new Dictionary<string, string>() { { "test-key-one", "1" }, { "t
     <td class = ""title""> {{$KEY9}} </td><td> {{$VALUE9}} </td>
     <td class = ""title""> {{$KEY10}} </td><td> {{$VALUE10}} </td>
     <td class = ""title""> {{$KEY11}} </td><td> {{$VALUE11}} </td>
-</tr>
-parameters-->", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" }, { "test-key-four", "4" }, { "test-key-five", "5" },
-                { "test-key-six", "6" }, { "test-key-seven", "7" }, { "test-key-eight", "8" }, { "test-key-nine", "9" }, { "test-key-10", "10"} }, true},
+</tr>", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" }, { "test-key-four", "4" }, { "test-key-five", "5" },
+                { "test-key-six", "6" }, { "test-key-seven", "7" }, { "test-key-eight", "8" }, { "test-key-nine", "9" }, { "test-key-ten", "10"}, { "test-key-eleven", "11"}}, @"<tr>
+	<td class = ""title""> Test Key One </td><td> 1 </td>
+	<td class = ""title""> Test Key Two </td><td> 2 </td>
+    <td class = ""title""> Test Key Three </td><td> three </td>
+    <td class = ""title""> Test Key Four </td><td> 4 </td>
+    <td class = ""title""> Test Key Five </td><td> 5 </td>
+    <td class = ""title""> Test Key Six </td><td> 6 </td>
+    <td class = ""title""> Test Key Seven </td><td> 7 </td>
+    <td class = ""title""> Test Key Eight </td><td> 8 </td>
+    <td class = ""title""> Test Key Nine </td><td> 9 </td>
+    <td class = ""title""> Test Key Ten </td><td> 10 </td>
+    <td class = ""title""> Test Key Eleven </td><td> 11 </td>
+    <td class = ""title"">  </td><td>  </td>
+</tr>"},
             // Sad test cases
-            new object[] { @"<!--parameters
+            new object[] { @"<tr>
+	<td class = ""title""> {{$KEY1}} </td><td> {{$VALUE1}} </td>
+</tr>", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" } }, @"<tr>
+	<td class = ""title""> {{$KEY1}} </td><td> {{$VALUE1}} </td>
+</tr>
 <tr>
 	<td class = ""title""> {{$KEY1}} </td><td> {{$VALUE1}} </td>
 </tr>
-parameters-->", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" } }, false},
-
-            new object[] { @"<!--parameters
 <tr>
-	<td class = ""title""> {{$KEY1}} </td><td> {{$VALUE}} </td>
+	<td class = ""title""> {{$KEY1}} </td><td> {{$VALUE1}} </td>
+</tr>"},
+
+            new object[] { @"<tr>
+	<td class = ""title""> {{$KEY0}} </td><td> {{$VALUE}} </td>
+</tr>", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" } }, @"<tr>
+	<td class = ""title""> Test Key One </td><td> {{$VALUE}} </td>
 </tr>
-parameters-->", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" } }, false},
-
-            new object[] { @"<!--parameters
 <tr>
-	<td class = ""title""> {{$KEY}} </td><td> {{$VALUE1}} </td>
+	<td class = ""title""> Test Key Two </td><td> {{$VALUE}} </td>
 </tr>
-parameters-->", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" } }, false},
-
-            new object[] { @"<!--parameters
 <tr>
+	<td class = ""title""> Test Key Three </td><td> {{$VALUE}} </td>
+</tr>"},
+
+            new object[] { @"<tr>
+	<td class = ""title""> {{$KEY1}} </td><td> {{$VALUE0}} </td>
+</tr>", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" } }, @"<tr>
+	<td class = ""title""> {{$KEY1}} </td><td> 1 </td>
+</tr>
+<tr>
+	<td class = ""title""> {{$KEY1}} </td><td> 2 </td>
+</tr>
+<tr>
+	<td class = ""title""> {{$KEY1}} </td><td> three </td>
+</tr>"},
+
+            new object[] { @"<tr>
 	<td class = ""title""> {{$KEY1}} </td><td> {{$VALUE1}} </td>
 	<td class = ""title""> {{$KEY2}} </td><td> {{$VALUE2}} </td>
     <td class = ""title""> {{$KEY3}} </td><td> {{$VALUE3}} </td>
+</tr>", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" }, { "test-key-four", "4"} }, @"<tr>
+	<td class = ""title""> Test Key Two </td><td> 2 </td>
+	<td class = ""title""> Test Key Three </td><td> three </td>
+    <td class = ""title""> {{$KEY3}} </td><td> {{$VALUE3}} </td>
 </tr>
-parameters-->", new Dictionary<string, string>() { { "test-key-one", "1" }, { "test-key-two", "2" }, { "test-key-three", "three" }, { "test-key-four", "4"} }, false},
+<tr>
+	<td class = ""title"">  </td><td>  </td>
+	<td class = ""title"">  </td><td>  </td>
+    <td class = ""title""> {{$KEY3}} </td><td> {{$VALUE3}} </td>
+</tr>"},
         };
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Though the main idea behind defining the parameters template as a comment in `template.html` is being able to customize them, when a row cannot be filled it displays the missing values in the row in its row format, as it's shown in the image below:
![imagen](https://github.com/QuantConnect/Lean/assets/47573394/68bfb9b6-ae8e-4617-9570-809d9847999a)

#### Description
<!--- Describe your changes in detail -->
- Solve the bug mentioned above
- Add unit tests to cover the changes
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With  this change users will be able to define the number of columns the Parameters table will have in the report generated
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
An update to documentation explaining how the user should define the keys and values in the parameters template has already been done (see https://github.com/QuantConnect/Documentation/issues/1425)
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There was created a unit test that asserted the generated parameters table were the expected one in different scenarios
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
