### PR TITLE
Fix Overflow bug in RandomDataGenerator

### DIFF
--- a/Tests/ToolBox/RandomDataGenerator/DividendSplitMapGeneratorTests.cs
+++ b/Tests/ToolBox/RandomDataGenerator/DividendSplitMapGeneratorTests.cs
@@ -1,0 +1,74 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using QuantConnect.ToolBox.RandomDataGenerator;
+using System;
+
+namespace QuantConnect.Tests.ToolBox.RandomDataGenerator
+{
+    [TestFixture]
+    public class DividendSplitMapGeneratorTests
+    {
+        [TestCase(240, 0.9857119009006162)]
+        [TestCase(120, 0.9716279515771061)]
+        [TestCase(60, 0.9440608762859234)]
+        [TestCase(12, 0.7498942093324559)]
+        [TestCase(6, 0.5623413251903491)]
+        [TestCase(3, 0.31622776601683794)]
+        [TestCase(1, 0.03162277660168379)]
+        public void GetsExpectedLowerBound(int months, double expectedLowerBound)
+        {
+            var lowerBound = (double)DividendSplitMapGenerator.GetLowerBoundForPreviousSplitFactor(months);
+            Assert.AreEqual(expectedLowerBound, lowerBound, delta: 0.0000000000001);
+            Assert.IsTrue(Math.Pow(lowerBound, lowerBound * 2) >= 0.0009);
+        }
+
+        [TestCase(240)]
+        [TestCase(120)]
+        [TestCase(60)]
+        [TestCase(12)]
+        [TestCase(6)]
+        [TestCase(3)]
+        [TestCase(1)]
+        public void GetsValidNextPreviousSplitFactor(int months)
+        {
+            var lowerBound = DividendSplitMapGenerator.GetLowerBoundForPreviousSplitFactor(months);
+            var upperBound = 1;
+            var nextPreviousSplitFactor = DividendSplitMapGenerator.GetNextPreviousSplitFactor(new Random(), lowerBound, upperBound);
+            Assert.IsTrue(lowerBound <= nextPreviousSplitFactor && nextPreviousSplitFactor <= upperBound);
+            Assert.IsTrue(0.001 <= Math.Pow((double)nextPreviousSplitFactor, 2 * (double)months) && Math.Pow((double)nextPreviousSplitFactor, 2 * (double)months) <= 1);
+        }
+
+        [TestCase(240)]
+        [TestCase(120)]
+        [TestCase(60)]
+        [TestCase(12)]
+        [TestCase(6)]
+        [TestCase(3)]
+        [TestCase(1)]
+        public void PriceScaledBySplitFactorIsBounded(int months)
+        {
+            var maxPossiblePrice = 1000m;
+            var minPossiblePrice = 0.0001m;
+            var lowerBound = DividendSplitMapGenerator.GetLowerBoundForPreviousSplitFactor(months);
+            var upperBound = 1;
+            var nextPreviousSplitFactor = DividendSplitMapGenerator.GetNextPreviousSplitFactor(new Random(), lowerBound, upperBound);
+            var finalSplitFactor = (decimal)Math.Pow((double)nextPreviousSplitFactor, 2 * (double)months);
+            Assert.IsTrue(0.0001m <= (maxPossiblePrice / finalSplitFactor) && (maxPossiblePrice / finalSplitFactor) <= 1000000m, (maxPossiblePrice / finalSplitFactor).ToString());
+            Assert.IsTrue(0.0001m <= (minPossiblePrice / finalSplitFactor) && (minPossiblePrice / finalSplitFactor) <= 1000000m, (minPossiblePrice / finalSplitFactor).ToString());
+        }
+    }
+}

--- a/Tests/ToolBox/RandomDataGenerator/DividendSplitMapGeneratorTests.cs
+++ b/Tests/ToolBox/RandomDataGenerator/DividendSplitMapGeneratorTests.cs
@@ -61,14 +61,14 @@ namespace QuantConnect.Tests.ToolBox.RandomDataGenerator
         [TestCase(1)]
         public void PriceScaledBySplitFactorIsBounded(int months)
         {
-            var maxPossiblePrice = 1000m;
+            var maxPossiblePrice = 1000000m;
             var minPossiblePrice = 0.0001m;
             var lowerBound = DividendSplitMapGenerator.GetLowerBoundForPreviousSplitFactor(months);
             var upperBound = 1;
             var nextPreviousSplitFactor = DividendSplitMapGenerator.GetNextPreviousSplitFactor(new Random(), lowerBound, upperBound);
             var finalSplitFactor = (decimal)Math.Pow((double)nextPreviousSplitFactor, 2 * (double)months);
-            Assert.IsTrue(0.0001m <= (maxPossiblePrice / finalSplitFactor) && (maxPossiblePrice / finalSplitFactor) <= 1000000m, (maxPossiblePrice / finalSplitFactor).ToString());
-            Assert.IsTrue(0.0001m <= (minPossiblePrice / finalSplitFactor) && (minPossiblePrice / finalSplitFactor) <= 1000000m, (minPossiblePrice / finalSplitFactor).ToString());
+            Assert.IsTrue(0.0001m <= (maxPossiblePrice / finalSplitFactor) && (maxPossiblePrice / finalSplitFactor) <= 1000000000m, (maxPossiblePrice / finalSplitFactor).ToString());
+            Assert.IsTrue(0.0001m <= (minPossiblePrice / finalSplitFactor) && (minPossiblePrice / finalSplitFactor) <= 1000000000m, (minPossiblePrice / finalSplitFactor).ToString());
         }
     }
 }

--- a/Tests/ToolBox/RandomDataGenerator/RandomDataGeneratorTests.cs
+++ b/Tests/ToolBox/RandomDataGenerator/RandomDataGeneratorTests.cs
@@ -56,12 +56,7 @@ namespace QuantConnect.Tests.ToolBox.RandomDataGenerator
             Assert.GreaterOrEqual(delistDate, midPoint);
         }
 
-        [Repeat(10)]
-        [TestCase("20230101", "20230108")]
-        [TestCase("20230101", "20230201")]
-        [TestCase("20230501", "20230801")]
-        [TestCase("20230101", "20230801")]
-        [TestCase("20180101", "20230101")]
+        [TestCase("20220101", "20230101")]
         public void RandomGeneratorProducesValuesBoundedForEquitiesWhenSplit(string start, string end)
         {
             var settings = RandomDataGeneratorSettings.FromCommandLineArguments(
@@ -83,7 +78,8 @@ namespace QuantConnect.Tests.ToolBox.RandomDataGenerator
                 "BaroneAdesiWhaleyApproximationEngine",
                 "Daily",
                 "1",
-                new List<string>()
+                new List<string>(),
+                100
             );
 
             var securityManager = new SecurityManager(new TimeKeeper(settings.Start, new[] { TimeZones.Utc }));
@@ -117,7 +113,7 @@ namespace QuantConnect.Tests.ToolBox.RandomDataGenerator
             foreach (var tick in tickHistory)
             {
                 tick.Value = tick.Value / dividendsSplitsMaps.FinalSplitFactor;
-                Assert.IsTrue( 0.00099m <= tick.Value && tick.Value <= 10000000 );
+                Assert.IsTrue( 0.001m <= tick.Value && tick.Value <= 10000000, $"The tick value was {tick.Value} but should have been bounded by 0.001 and 10 000 000");
             }
         }
 

--- a/Tests/ToolBox/RandomDataGenerator/RandomDataGeneratorTests.cs
+++ b/Tests/ToolBox/RandomDataGenerator/RandomDataGeneratorTests.cs
@@ -113,7 +113,7 @@ namespace QuantConnect.Tests.ToolBox.RandomDataGenerator
             foreach (var tick in tickHistory)
             {
                 tick.Value = tick.Value / dividendsSplitsMaps.FinalSplitFactor;
-                Assert.IsTrue( 0.001m <= tick.Value && tick.Value <= 10000000, $"The tick value was {tick.Value} but should have been bounded by 0.001 and 10 000 000");
+                Assert.IsTrue( 0.001m <= tick.Value && tick.Value <= 1000000000, $"The tick value was {tick.Value} but should have been bounded by 0.001 and 1 000 000 000");
             }
         }
 

--- a/ToolBox/RandomDataGenerator/DividendSplitMapGenerator.cs
+++ b/ToolBox/RandomDataGenerator/DividendSplitMapGenerator.cs
@@ -170,6 +170,16 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
                         // Have a 5% chance of a split every month
                         if (hasSplits && _randomValueGenerator.NextBool(5.0))
                         {
+                            // Produce another split factor that is also bounded by the min and max split factors allowed
+                            if (_randomValueGenerator.NextBool(5.0)) // Add the possibility of a reverse split
+                            {
+                                previousSplitFactor = ((decimal)_random.NextDouble()) * (previousSplitFactor - minPreviousSplitFactor) + minPreviousSplitFactor;
+                            }
+                            else
+                            {
+                                previousSplitFactor = ((decimal)_random.NextDouble()) * (maxPreviousSplitFactor - previousSplitFactor) + previousSplitFactor;
+                            }
+
                             splitDates.Add(_randomValueGenerator.NextDate(tick.Time, tick.Time.AddMonths(1), (DayOfWeek)_random.Next(1, 5)));
                         }
                         // 10% chance of being renamed every month

--- a/ToolBox/RandomDataGenerator/DividendSplitMapGenerator.cs
+++ b/ToolBox/RandomDataGenerator/DividendSplitMapGenerator.cs
@@ -93,8 +93,8 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
 
             var previousX = _random.NextDouble();
 
-            // Since the largest equity value we can obtain is 1000, if we want this price divided by the FinalSplitFactor
-            // to be upper bounded by 1 000 000 we need to make sure the FinalSplitFactor is lower bounded by 0.001. Therefore,
+            // Since the largest equity value we can obtain is 1 000 000, if we want this price divided by the FinalSplitFactor
+            // to be upper bounded by 1 000 000 000 we need to make sure the FinalSplitFactor is lower bounded by 0.001. Therefore,
             // since in the worst of the cases FinalSplitFactor = (previousSplitFactor)^(2m), where m is the number of months
             // in the time span, we need to lower bound previousSplitFactor by (0.001)^(1/(2m))
             //

--- a/ToolBox/RandomDataGenerator/DividendSplitMapGenerator.cs
+++ b/ToolBox/RandomDataGenerator/DividendSplitMapGenerator.cs
@@ -77,7 +77,10 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
             var dividendEveryQuarter = _randomValueGenerator.NextBool(_settings.DividendEveryQuarterPercentage);
 
             var previousX = _random.NextDouble();
-            var previousSplitFactor = hasSplits ? (decimal)_random.NextDouble() : 1;
+            var months = tickHistory.Select(x => x.Time.Month.ToString()+ "-" + x.Time.Year.ToString()).GroupBy(x => x).Count();
+            var minPreviousSplitFactor = (decimal)(Math.Pow((double)0.1, 1 / (double)(2 * months)));
+            var maxPreviousSplitFactor = 1;
+            var previousSplitFactor = hasSplits ? ((decimal)_random.NextDouble())*(maxPreviousSplitFactor - minPreviousSplitFactor) + minPreviousSplitFactor : 1;
             var previousPriceFactor = hasDividends ? (decimal)Math.Tanh(previousX) : 1;
 
             var splitDates = new List<DateTime>();
@@ -167,18 +170,6 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
                         // Have a 5% chance of a split every month
                         if (hasSplits && _randomValueGenerator.NextBool(5.0))
                         {
-                            do
-                            {
-                                if (previousSplitFactor < 1)
-                                {
-                                    previousSplitFactor += (decimal)(_random.NextDouble() - _random.NextDouble());
-                                }
-                                else
-                                {
-                                    previousSplitFactor *= (decimal)_random.NextDouble() * _random.Next(1, 5);
-                                }
-                            } while (previousSplitFactor < 0);
-
                             splitDates.Add(_randomValueGenerator.NextDate(tick.Time, tick.Time.AddMonths(1), (DayOfWeek)_random.Next(1, 5)));
                         }
                         // 10% chance of being renamed every month

--- a/ToolBox/RandomDataGenerator/DividendSplitMapGenerator.cs
+++ b/ToolBox/RandomDataGenerator/DividendSplitMapGenerator.cs
@@ -26,6 +26,8 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
     /// </summary>
     public class DividendSplitMapGenerator
     {
+        private const double _minimumFinalSplitFactorAllowed = 0.001;
+
         /// <summary>
         /// The final factor to adjust all prices with in order to maintain price continuity.
         /// </summary>
@@ -91,20 +93,19 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
 
             var previousX = _random.NextDouble();
 
-            // Since the largest equity value we can obtain is 10 000 000, if we want this price divided by the FinalSplitFactor
-            // to be upper bounded by 100 000 000 we need to make sure the FinalSplitFactor is lower bounded by 0.1. Therefore,
+            // Since the largest equity value we can obtain is 1000, if we want this price divided by the FinalSplitFactor
+            // to be upper bounded by 1 000 000 we need to make sure the FinalSplitFactor is lower bounded by 0.001. Therefore,
             // since in the worst of the cases FinalSplitFactor = (previousSplitFactor)^(2m), where m is the number of months
-            // in the time span, we need to lower bound previousSplitFactor by (0.1)^(1/(2m))
+            // in the time span, we need to lower bound previousSplitFactor by (0.001)^(1/(2m))
             //
-            // In the sameway, since the smallest equity value is 0.01, if we want this price divided by the FinalSplitFactor
-            // to be lower bounded by 0.01 we need to make sure the FinalSplitFactor is upper bounded by 1. Therefore, since
-            // in the worst of the cases FinalSplitFactor = (previousSplitFactor)^(2m), where m is the number of months in
-            // the time span, we need to upper bound previousSplitFactor by 1
+            // On the other hand, if the upper bound for the previousSplitFactor is 1, then the FinalSplitFactor will be, in the
+            // worst of the cases as small as the minimum equity value we can obtain
 
             var months = (int)Math.Round(_settings.End.Subtract(_settings.Start).Days / (365.25 / 12));
-            var minPreviousSplitFactor = (decimal)(Math.Pow((double)0.1, 1 / (double)(2 * months)));
+            months = months != 0 ? months : 1;
+            var minPreviousSplitFactor = GetLowerBoundForPreviousSplitFactor(months);
             var maxPreviousSplitFactor = 1;
-            var previousSplitFactor = hasSplits ? ((decimal)_random.NextDouble())*(maxPreviousSplitFactor - minPreviousSplitFactor) + minPreviousSplitFactor : 1;
+            var previousSplitFactor = hasSplits ? GetNextPreviousSplitFactor(_random, minPreviousSplitFactor, maxPreviousSplitFactor) : 1;
             var previousPriceFactor = hasDividends ? (decimal)Math.Tanh(previousX) : 1;
 
             var splitDates = new List<DateTime>();
@@ -197,11 +198,15 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
                             // Produce another split factor that is also bounded by the min and max split factors allowed
                             if (_randomValueGenerator.NextBool(5.0)) // Add the possibility of a reverse split
                             {
-                                previousSplitFactor = ((decimal)_random.NextDouble()) * (previousSplitFactor - minPreviousSplitFactor) + minPreviousSplitFactor;
+                                // A reverse split is a split that is smaller than the current previousSplitFactor
+                                // Update previousSplitFactor with a smaller value that is still bounded below by minPreviousSplitFactor
+                                previousSplitFactor = GetNextPreviousSplitFactor(_random, minPreviousSplitFactor, previousSplitFactor);
                             }
                             else
                             {
-                                previousSplitFactor = ((decimal)_random.NextDouble()) * (maxPreviousSplitFactor - previousSplitFactor) + previousSplitFactor;
+                                // Update previousSplitFactor with a higher value that is still bounded by maxPreviousSplitFactor
+                                // Usually, the split factor tends to grow across the time span(See /Data/Equity/usa/factor_files/aapl for instance)
+                                previousSplitFactor = GetNextPreviousSplitFactor(_random, previousSplitFactor, maxPreviousSplitFactor);
                             }
 
                             splitDates.Add(_randomValueGenerator.NextDate(tick.Time, tick.Time.AddMonths(1), (DayOfWeek)_random.Next(1, 5)));
@@ -228,6 +233,33 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
                     firstTick = false;
                 }
             }
+        }
+
+        /// <summary>
+        /// Gets a lower bound that guarantees the FinalSplitFactor, in all the possible
+        /// cases, will never be smaller than the _minimumFinalSplitFactorAllowed (0.001)
+        /// </summary>
+        /// <param name="months">The lower bound for the previous split factor is based on
+        /// the number of months between the start and end date from ticksHistory <see cref="GenerateSplitsDividends(IEnumerable{Tick})"></param>
+        /// <returns>A valid lower bound that guarantees the FinalSplitFactor is always higher
+        /// than the _minimumFinalSplitFactorAllowed</returns>
+        public static decimal GetLowerBoundForPreviousSplitFactor(int months)
+        {
+            return (decimal)(Math.Pow(_minimumFinalSplitFactorAllowed, 1 / (double)(2 * months)));
+        }
+
+        /// <summary>
+        /// Gets a new valid previousSplitFactor that is still bounded by the given upper and lower
+        /// bounds
+        /// </summary>
+        /// <param name="random">Random number generator</param>
+        /// <param name="lowerBound">Minimum allowed value to obtain</param>
+        /// <param name="upperBound">Maximum allowed value to obtain</param>
+        /// <returns>A new valid previousSplitFactor that is still bounded by the given upper and lower
+        /// bounds</returns>
+        public static decimal GetNextPreviousSplitFactor(Random random, decimal lowerBound, decimal upperBound)
+        {
+            return ((decimal)random.NextDouble()) * (upperBound - lowerBound) + lowerBound;
         }
     }
 }

--- a/ToolBox/RandomDataGenerator/RandomDataGeneratorSettings.cs
+++ b/ToolBox/RandomDataGenerator/RandomDataGeneratorSettings.cs
@@ -43,6 +43,7 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
         public double HasIpoPercentage { get; init; }
         public double HasRenamePercentage { get; init; }
         public double HasSplitsPercentage { get; init; }
+        public double MonthSplitPercentage { get; init; }
         public double HasDividendsPercentage { get; init; }
         public double DividendEveryQuarterPercentage { get; init; }
         public string OptionPriceEngineName { get; init; }
@@ -68,7 +69,8 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
             string optionPriceEngineName,
             string volatilityModelResolutionString,
             string chainSymbolCountString,
-            List<string> tickers
+            List<string> tickers,
+            double monthSplitPercentage = 5.0
             )
         {
             var randomSeedSet = true;
@@ -319,6 +321,7 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
                 HasIpoPercentage = hasIpoPercentage,
                 HasRenamePercentage = hasRenamePercentage,
                 HasSplitsPercentage = hasSplitsPercentage,
+                MonthSplitPercentage = monthSplitPercentage,
                 HasDividendsPercentage = hasDividendsPercentage,
                 DividendEveryQuarterPercentage = dividendEveryQuarterPercentage,
                 OptionPriceEngineName = optionPriceEngineName,

--- a/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
+++ b/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
@@ -222,7 +222,7 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
                 }
                 default:
                 {
-                    return price > 0 && price < 1000000;
+                    return price > 0 && price < 10000000;
                 }
             }
         }

--- a/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
+++ b/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
@@ -29,7 +29,7 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
         private readonly Random _random;
         private readonly MarketHoursDatabase _marketHoursDatabase;
         private readonly SymbolPropertiesDatabase _symbolPropertiesDatabase;
-        private const decimal _maximumPriceAllowed = 10000000m;
+        private const decimal _maximumPriceAllowed = 1000m;
 
 
         public RandomValueGenerator()

--- a/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
+++ b/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
@@ -180,9 +180,15 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
                 if (price > 1000000)
                 {
                     // The price should not be too higher
-                    // Invalidate the price to try again and decrease the probability of it to going up
-                    price = -1m;
+                    // Decrease the probability of it to going up
                     increaseProbabilityFactor = increaseProbabilityFactor + 0.05;
+                }
+
+                if (price > 10000000)
+                {
+                    // The price should not be too higher
+                    // Invalidate the price to try again
+                    price = -1;
                 }
             } while (!IsPriceValid(securityType, price) && ++attempts < 10);
 

--- a/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
+++ b/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
@@ -16,7 +16,6 @@
 using QuantConnect.Securities;
 using QuantConnect.Util;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace QuantConnect.ToolBox.RandomDataGenerator
@@ -173,9 +172,17 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
                 if (price < 20 * minimumPriceVariation)
                 {
                     // The price should not be to close to the minimum price variation.
-                    // Invalidate the price to try again and increase the probability of the it going up
+                    // Invalidate the price to try again and increase the probability of it to going up
                     price = -1m;
                     increaseProbabilityFactor = Math.Max(increaseProbabilityFactor - 0.05, 0);
+                }
+
+                if (price > 1000000)
+                {
+                    // The price should not be too higher
+                    // Invalidate the price to try again and decrease the probability of it to going up
+                    price = -1m;
+                    increaseProbabilityFactor = increaseProbabilityFactor + 0.05;
                 }
             } while (!IsPriceValid(securityType, price) && ++attempts < 10);
 
@@ -209,7 +216,7 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
                 }
                 default:
                 {
-                    return price > 0;
+                    return price > 0 && price < 1000000;
                 }
             }
         }

--- a/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
+++ b/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
         private readonly Random _random;
         private readonly MarketHoursDatabase _marketHoursDatabase;
         private readonly SymbolPropertiesDatabase _symbolPropertiesDatabase;
+        private const decimal _maximumPriceAllowed = 10000000m;
 
 
         public RandomValueGenerator()
@@ -177,14 +178,14 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
                     increaseProbabilityFactor = Math.Max(increaseProbabilityFactor - 0.05, 0);
                 }
 
-                if (price > 1000000)
+                if (price > (_maximumPriceAllowed / 10m))
                 {
                     // The price should not be too higher
                     // Decrease the probability of it to going up
                     increaseProbabilityFactor = increaseProbabilityFactor + 0.05;
                 }
 
-                if (price > 10000000)
+                if (price > _maximumPriceAllowed)
                 {
                     // The price should not be too higher
                     // Invalidate the price to try again
@@ -222,7 +223,7 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
                 }
                 default:
                 {
-                    return price > 0 && price < 10000000;
+                    return price > 0 && price < _maximumPriceAllowed;
                 }
             }
         }

--- a/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
+++ b/ToolBox/RandomDataGenerator/RandomValueGenerator.cs
@@ -29,7 +29,7 @@ namespace QuantConnect.ToolBox.RandomDataGenerator
         private readonly Random _random;
         private readonly MarketHoursDatabase _marketHoursDatabase;
         private readonly SymbolPropertiesDatabase _symbolPropertiesDatabase;
-        private const decimal _maximumPriceAllowed = 1000m;
+        private const decimal _maximumPriceAllowed = 1000000m;
 
 
         public RandomValueGenerator()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The bug was raised because of two main reasons:
1. The prices generated by `RandomValueGenerator.cs` were not upper bounded
2. The `DividendSplitMapGenerator.FinalSplitFactor` wasn't lower bounded
Therefore, if the price generated was large and the `FinalSplitFactor` was really small, the price generated divided by that small `FinalSplitFactor` turned out to be really large, even larger than the maximum `long` value

To fix this issue, the prices generated were upper bounded by 1000000 the same as the `FinalSplitFactor`, which was bounded between 0.001 and 1, so that all the values generated would be between the minimum `MinumumPriceMovement` for all the equities and 100000000. In order to bound the `FinalSplitFactor` we found that `FinalSplitFactor` was calculated with this formula
$$\text{Final Split Factor} := \Pi_{i=1}^{n} (psf_{i}),$$
where $psf_{i}$ is the value of `previousSplitFactor` in the $i$-th split month. It was found that, in the worst case, $n=2m$, where $m$ is the number of months from the start date to the end date (The range for which the data should be generated), since a split could occur each month, and sometimes, there was $2$ splits per month. Therefore, the formula for the `FinalSplitFactor` in the worst of the cases was
$$\text{Final Split Factor} := \Pi_{i=1}^{2n} (psf_{i}).$$
Now, if we wanted to guarantee that `FinalSplitFactor` was never going to be smaller than 0.001 we needed to ensure that $$0.001^{\frac{1}{2m}} < psf_{i}\quad i=1,\dots,2m,$$
since, once we have this inequality, if we multiply all of them we have that
$$0.001 < \Pi_{i=1}^{2m} psf_{i}.$$
On the other hand, we also needed to ensure that `FinalSplitFactor` was bounded by $1$, so that if the given price was really small, after being divided by the `FinalSplitFactor`, the price wasn't even smaller. With a similar reasoning, we concluded that if
each $psf_{i}$ was smaller than 1, the `FinalSplitFactor` would be also smaller than 1.

After bounding both the prices and the `FinalSplitFactor`, we generated data for 1 year, 6 months and 3 months for 1000 equity symbols. Here are some of the factor files of those symbols containing the split factor and the split dates:
![imagen](https://github.com/QuantConnect/Lean/assets/47573394/95c03d3b-08b1-476a-8e3a-beb6fb7bac06)
![imagen](https://github.com/QuantConnect/Lean/assets/47573394/3d962cec-e286-4514-bd4e-06ac72b5b984)
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7400 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change the users will be able to generate random data without errors
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There was created different unit test asserting everything worked as expected
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
