### PR TITLE
Fix bugs in `InteractiveBrokersFeeModel.cs` for Combo Market Order fees

### DIFF
--- a/Algorithm.CSharp/BasicTemplateOptionEquityStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionEquityStrategyAlgorithm.cs
@@ -133,10 +133,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$75.00"},
+            {"Total Fees", "$7.50"},
             {"Estimated Strategy Capacity", "$70000.00"},
             {"Lowest Capacity Asset", "GOOCV W78ZERHAOVVQ|GOOCV VP83T1ZUHROL"},
-            {"Portfolio Turnover", "61.34%"},
+            {"Portfolio Turnover", "61.30%"},
             {"OrderListHash", "cee5cc2b0f80c308b496cac0b8668163"}
         };
     }

--- a/Algorithm.CSharp/BasicTemplateOptionEquityStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionEquityStrategyAlgorithm.cs
@@ -133,7 +133,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$7.50"},
+            {"Total Fees", "$10.00"},
             {"Estimated Strategy Capacity", "$70000.00"},
             {"Lowest Capacity Asset", "GOOCV W78ZERHAOVVQ|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "61.30%"},

--- a/Algorithm.CSharp/ComboLegLimitOrderAlgorithm.cs
+++ b/Algorithm.CSharp/ComboLegLimitOrderAlgorithm.cs
@@ -84,10 +84,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$75.00"},
+            {"Total Fees", "$7.50"},
             {"Estimated Strategy Capacity", "$58000.00"},
             {"Lowest Capacity Asset", "GOOCV W78ZERHAOVVQ|GOOCV VP83T1ZUHROL"},
-            {"Portfolio Turnover", "30.16%"},
+            {"Portfolio Turnover", "30.15%"},
             {"OrderListHash", "2b64aec759a089d23ccf9722d6b87ccd"}
         };
     }

--- a/Algorithm.CSharp/ComboLegLimitOrderAlgorithm.cs
+++ b/Algorithm.CSharp/ComboLegLimitOrderAlgorithm.cs
@@ -84,10 +84,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$7.50"},
+            {"Total Fees", "$10.00"},
             {"Estimated Strategy Capacity", "$58000.00"},
             {"Lowest Capacity Asset", "GOOCV W78ZERHAOVVQ|GOOCV VP83T1ZUHROL"},
-            {"Portfolio Turnover", "30.15%"},
+            {"Portfolio Turnover", "30.16%"},
             {"OrderListHash", "2b64aec759a089d23ccf9722d6b87ccd"}
         };
     }

--- a/Algorithm.CSharp/ComboLimitOrderAlgorithm.cs
+++ b/Algorithm.CSharp/ComboLimitOrderAlgorithm.cs
@@ -151,7 +151,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$17.50"},
+            {"Total Fees", "$20.00"},
             {"Estimated Strategy Capacity", "$5000.00"},
             {"Lowest Capacity Asset", "GOOCV W78ZERHAOVVQ|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "60.90%"},

--- a/Algorithm.CSharp/ComboLimitOrderAlgorithm.cs
+++ b/Algorithm.CSharp/ComboLimitOrderAlgorithm.cs
@@ -151,10 +151,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$85.00"},
+            {"Total Fees", "$17.50"},
             {"Estimated Strategy Capacity", "$5000.00"},
             {"Lowest Capacity Asset", "GOOCV W78ZERHAOVVQ|GOOCV VP83T1ZUHROL"},
-            {"Portfolio Turnover", "60.92%"},
+            {"Portfolio Turnover", "60.90%"},
             {"OrderListHash", "186986b27fac082600a064a8a59df604"}
         };
     }

--- a/Algorithm.CSharp/ComboMarketOrderAlgorithm.cs
+++ b/Algorithm.CSharp/ComboMarketOrderAlgorithm.cs
@@ -33,9 +33,9 @@ namespace QuantConnect.Algorithm.CSharp
         public override void OnOrderEvent(OrderEvent orderEvent)
         {
             base.OnOrderEvent(orderEvent);
-            if (orderEvent.Status == OrderStatus.Filled && orderEvent.OrderFee.Value.Amount != 2.5m)
+            if (orderEvent.Status == OrderStatus.Filled && orderEvent.OrderFee.Value.Amount != (orderEvent.AbsoluteFillQuantity * 0.25m))
             {
-                throw new Exception($"The fee for each order should be 2.50 USD, but for order {orderEvent.OrderId} was {orderEvent.OrderFee} USD");
+                throw new Exception($"The fee for each order should be {orderEvent.AbsoluteFillQuantity * 0.25m} USD, but for order {orderEvent.OrderId} was {orderEvent.OrderFee}");
             }
         }
 
@@ -83,7 +83,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$7.50"},
+            {"Total Fees", "$10.00"},
             {"Estimated Strategy Capacity", "$70000.00"},
             {"Lowest Capacity Asset", "GOOCV W78ZERHAOVVQ|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "30.35%"},

--- a/Algorithm.CSharp/ComboMarketOrderAlgorithm.cs
+++ b/Algorithm.CSharp/ComboMarketOrderAlgorithm.cs
@@ -14,6 +14,7 @@
 */
 
 using QuantConnect.Orders;
+using System;
 using System.Collections.Generic;
 
 namespace QuantConnect.Algorithm.CSharp
@@ -27,6 +28,15 @@ namespace QuantConnect.Algorithm.CSharp
         {
             legs.ForEach(x => { x.OrderPrice = null; });
             return ComboMarketOrder(legs, quantity);
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            base.OnOrderEvent(orderEvent);
+            if (orderEvent.Status == OrderStatus.Filled && orderEvent.OrderFee.Value.Amount != 2.5m)
+            {
+                throw new Exception($"The fee for each order should be 2.50 USD, but for order {orderEvent.OrderId} was {orderEvent.OrderFee} USD");
+            }
         }
 
         /// <summary>

--- a/Algorithm.CSharp/ComboMarketOrderAlgorithm.cs
+++ b/Algorithm.CSharp/ComboMarketOrderAlgorithm.cs
@@ -73,10 +73,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$75.00"},
+            {"Total Fees", "$7.50"},
             {"Estimated Strategy Capacity", "$70000.00"},
             {"Lowest Capacity Asset", "GOOCV W78ZERHAOVVQ|GOOCV VP83T1ZUHROL"},
-            {"Portfolio Turnover", "30.36%"},
+            {"Portfolio Turnover", "30.35%"},
             {"OrderListHash", "cf49ecb1e9787688df1d9920a75b83b7"}
         };
     }

--- a/Algorithm.CSharp/CoveredAndProtectiveCallStrategiesAlgorithm.cs
+++ b/Algorithm.CSharp/CoveredAndProtectiveCallStrategiesAlgorithm.cs
@@ -128,7 +128,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$8.00"},
+            {"Total Fees", "$4.00"},
             {"Estimated Strategy Capacity", "$120000.00"},
             {"Lowest Capacity Asset", "GOOCV WBGM92QHIYO6|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "32.18%"},

--- a/Algorithm.CSharp/CoveredAndProtectivePutStrategiesAlgorithm.cs
+++ b/Algorithm.CSharp/CoveredAndProtectivePutStrategiesAlgorithm.cs
@@ -128,7 +128,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$8.00"},
+            {"Total Fees", "$4.00"},
             {"Estimated Strategy Capacity", "$160000.00"},
             {"Lowest Capacity Asset", "GOOCV 30AKMEIPOSS1Y|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "32.12%"},

--- a/Algorithm.CSharp/CoveredCallComboLimitOrderAlgorithm.cs
+++ b/Algorithm.CSharp/CoveredCallComboLimitOrderAlgorithm.cs
@@ -137,7 +137,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$3.00"},
+            {"Total Fees", "$4.50"},
             {"Estimated Strategy Capacity", "$8000.00"},
             {"Lowest Capacity Asset", "GOOCV W78ZFMEBBB2E|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "227.27%"},

--- a/Algorithm.CSharp/CoveredCallComboLimitOrderAlgorithm.cs
+++ b/Algorithm.CSharp/CoveredCallComboLimitOrderAlgorithm.cs
@@ -137,10 +137,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$18.00"},
+            {"Total Fees", "$3.00"},
             {"Estimated Strategy Capacity", "$8000.00"},
             {"Lowest Capacity Asset", "GOOCV W78ZFMEBBB2E|GOOCV VP83T1ZUHROL"},
-            {"Portfolio Turnover", "227.29%"},
+            {"Portfolio Turnover", "227.27%"},
             {"OrderListHash", "e32c0adb7140c1715808f8f9e81f0e8d"}
         };
     }

--- a/Algorithm.CSharp/LargeQuantityOptionStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/LargeQuantityOptionStrategyAlgorithm.cs
@@ -137,10 +137,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$180.50"},
+            {"Total Fees", "$9.50"},
             {"Estimated Strategy Capacity", "$6000.00"},
             {"Lowest Capacity Asset", "GOOCV 30AKMELSHQVZA|GOOCV VP83T1ZUHROL"},
-            {"Portfolio Turnover", "208.86%"},
+            {"Portfolio Turnover", "208.48%"},
             {"OrderListHash", "7f57f577df234c8817cc67fc01744f75"}
         };
     }

--- a/Algorithm.CSharp/NakedShortOptionStrategyOverMarginAlgorithm.cs
+++ b/Algorithm.CSharp/NakedShortOptionStrategyOverMarginAlgorithm.cs
@@ -162,7 +162,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$14.50"},
+            {"Total Fees", "$4.50"},
             {"Estimated Strategy Capacity", "$1800000.00"},
             {"Lowest Capacity Asset", "GOOCV 30AKMEIPOSS1Y|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "7.50%"},

--- a/Algorithm.CSharp/NullMarginComboOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/NullMarginComboOrderRegressionAlgorithm.cs
@@ -67,10 +67,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$50.00"},
+            {"Total Fees", "$5.00"},
             {"Estimated Strategy Capacity", "$8800000.00"},
             {"Lowest Capacity Asset", "GOOCV VP83T1ZUHROL"},
-            {"Portfolio Turnover", "7608.10%"},
+            {"Portfolio Turnover", "7576.00%"},
             {"OrderListHash", "d6b151001e65ab2baa0bc31720733876"}
         };
     }

--- a/Algorithm.CSharp/NullMarginComboOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/NullMarginComboOrderRegressionAlgorithm.cs
@@ -67,10 +67,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$5.00"},
+            {"Total Fees", "$7.50"},
             {"Estimated Strategy Capacity", "$8800000.00"},
             {"Lowest Capacity Asset", "GOOCV VP83T1ZUHROL"},
-            {"Portfolio Turnover", "7576.00%"},
+            {"Portfolio Turnover", "7577.77%"},
             {"OrderListHash", "d6b151001e65ab2baa0bc31720733876"}
         };
     }

--- a/Algorithm.CSharp/RevertComboOrderPositionsAlgorithm.cs
+++ b/Algorithm.CSharp/RevertComboOrderPositionsAlgorithm.cs
@@ -204,10 +204,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$150.00"},
+            {"Total Fees", "$15.00"},
             {"Estimated Strategy Capacity", "$16000.00"},
             {"Lowest Capacity Asset", "GOOCV W78ZERHAOVVQ|GOOCV VP83T1ZUHROL"},
-            {"Portfolio Turnover", "2130.97%"},
+            {"Portfolio Turnover", "2081.24%"},
             {"OrderListHash", "29943b56bdfc412d0fb7272b5d6e8ad2"}
         };
     }

--- a/Algorithm.CSharp/RevertComboOrderPositionsAlgorithm.cs
+++ b/Algorithm.CSharp/RevertComboOrderPositionsAlgorithm.cs
@@ -204,10 +204,10 @@ namespace QuantConnect.Algorithm.CSharp
             {"Information Ratio", "0"},
             {"Tracking Error", "0"},
             {"Treynor Ratio", "0"},
-            {"Total Fees", "$15.00"},
+            {"Total Fees", "$20.00"},
             {"Estimated Strategy Capacity", "$16000.00"},
             {"Lowest Capacity Asset", "GOOCV W78ZERHAOVVQ|GOOCV VP83T1ZUHROL"},
-            {"Portfolio Turnover", "2081.24%"},
+            {"Portfolio Turnover", "2083.04%"},
             {"OrderListHash", "29943b56bdfc412d0fb7272b5d6e8ad2"}
         };
     }

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -349,8 +349,10 @@ namespace QuantConnect.Brokerages.Backtesting
                                     // TODO : This check can be removed in April, 2019 -- a 6-month window to upgrade (also, suspect small % of users, if any are impacted)
                                     if (fill.OrderFee.Value.Amount == 0m)
                                     {
+                                        // It could be the case the order is a combo order, then it contains legs with different quantities and security types.
+                                        // Therefore, we need to compute the fees based on the specific leg order and security
                                         var legKVP = securities.Where(x => x.Key.Id == fill.OrderId).Single();
-                                        fill.OrderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(legKVP.Value, legKVP.Key ?? order));
+                                        fill.OrderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(legKVP.Value, legKVP.Key));
                                     }
                                 }
                             }

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -352,7 +352,7 @@ namespace QuantConnect.Brokerages.Backtesting
                                         // It could be the case the order is a combo order, then it contains legs with different quantities and security types.
                                         // Therefore, we need to compute the fees based on the specific leg order and security
                                         var legKVP = securities.Where(x => x.Key.Id == fill.OrderId).Single();
-                                        fill.OrderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(legKVP.Value, legKVP.Key));
+                                        fill.OrderFee = legKVP.Value.FeeModel.GetOrderFee(new OrderFeeParameters(legKVP.Value, legKVP.Key));
                                     }
                                 }
                             }

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -349,7 +349,8 @@ namespace QuantConnect.Brokerages.Backtesting
                                     // TODO : This check can be removed in April, 2019 -- a 6-month window to upgrade (also, suspect small % of users, if any are impacted)
                                     if (fill.OrderFee.Value.Amount == 0m)
                                     {
-                                        fill.OrderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(security, order));
+                                        var legKVP = securities.Where(x => x.Key.Id == fill.OrderId).Single();
+                                        fill.OrderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(legKVP.Value, legKVP.Key ?? order));
                                     }
                                 }
                             }

--- a/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
+++ b/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
@@ -215,7 +215,7 @@ namespace QuantConnect.Orders.Fees
                 optionsCommissionFunc = (orderSize, premium) =>
                 {
                     var commissionRate = premium >= 0.1m ?
-                                            0.7m :
+                                            0.65m :
                                             (0.05m <= premium && premium < 0.1m ? 0.5m : 0.25m);
                     return new CashAmount(Math.Max(orderSize * commissionRate, 1.0m), Currencies.USD);
                 };

--- a/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
+++ b/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
@@ -83,11 +83,6 @@ namespace QuantConnect.Orders.Fees
             }
 
             var quantity = order.AbsoluteQuantity;
-            if (order.GroupOrderManager != null)
-            {
-                quantity *= order.GroupOrderManager.AbsoluteQuantity;
-            }
-
             decimal feeResult;
             string feeCurrency;
             var market = security.Symbol.ID.Market;

--- a/Tests/Common/Brokerages/InteractiveBrokersBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/InteractiveBrokersBrokerageModelTests.cs
@@ -27,7 +27,6 @@ using QuantConnect.Securities;
 using QuantConnect.Data;
 using QuantConnect.Securities.Option;
 using QuantConnect.Securities.Forex;
-using QuantConnect.Orders.Fees;
 
 namespace QuantConnect.Tests.Common.Brokerages
 {
@@ -49,32 +48,6 @@ namespace QuantConnect.Tests.Common.Brokerages
             Assert.AreEqual(BrokerageMessageType.Warning, message.Type);
             Assert.AreEqual("NotSupported", message.Code);
             StringAssert.Contains("exercises for index and cash-settled options", message.Message);
-        }
-
-        [Test]
-        public void test()
-        {
-            var symbol = Symbol.CreateOption(Symbols.SPY,
-                                    Market.USA,
-                                    Symbols.SPY.SecurityType.DefaultOptionStyle(),
-                                    OptionRight.Put,
-                                    104m,
-                                    new DateTime(2010, 02, 20));
-
-            var tz = TimeZones.NewYork;
-            var security = new Option(symbol,
-                SecurityExchangeHours.AlwaysOpen(tz),
-                new Cash("USD", 0, 0),
-                new OptionSymbolProperties(SymbolProperties.GetDefault("USD")),
-                ErrorCurrencyConverter.Instance,
-                RegisteredSecurityDataTypesProvider.Null,
-                new SecurityCache(),
-                null
-            );
-            security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 0.38m, 0.2m));
-
-            var _feeModel = new InteractiveBrokersFeeModel();
-            var fee = _feeModel.GetOrderFee(new OrderFeeParameters(security, new MarketOrder(security.Symbol, 26, DateTime.UtcNow)));
         }
 
         [TestCaseSource(nameof(GetForexOrderTestCases))]

--- a/Tests/Common/Brokerages/InteractiveBrokersBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/InteractiveBrokersBrokerageModelTests.cs
@@ -27,6 +27,7 @@ using QuantConnect.Securities;
 using QuantConnect.Data;
 using QuantConnect.Securities.Option;
 using QuantConnect.Securities.Forex;
+using QuantConnect.Orders.Fees;
 
 namespace QuantConnect.Tests.Common.Brokerages
 {
@@ -48,6 +49,32 @@ namespace QuantConnect.Tests.Common.Brokerages
             Assert.AreEqual(BrokerageMessageType.Warning, message.Type);
             Assert.AreEqual("NotSupported", message.Code);
             StringAssert.Contains("exercises for index and cash-settled options", message.Message);
+        }
+
+        [Test]
+        public void test()
+        {
+            var symbol = Symbol.CreateOption(Symbols.SPY,
+                                    Market.USA,
+                                    Symbols.SPY.SecurityType.DefaultOptionStyle(),
+                                    OptionRight.Put,
+                                    104m,
+                                    new DateTime(2010, 02, 20));
+
+            var tz = TimeZones.NewYork;
+            var security = new Option(symbol,
+                SecurityExchangeHours.AlwaysOpen(tz),
+                new Cash("USD", 0, 0),
+                new OptionSymbolProperties(SymbolProperties.GetDefault("USD")),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache(),
+                null
+            );
+            security.SetMarketPrice(new Tick(DateTime.UtcNow, security.Symbol, 0.38m, 0.2m));
+
+            var _feeModel = new InteractiveBrokersFeeModel();
+            var fee = _feeModel.GetOrderFee(new OrderFeeParameters(security, new MarketOrder(security.Symbol, 26, DateTime.UtcNow)));
         }
 
         [TestCaseSource(nameof(GetForexOrderTestCases))]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The bug reported in the GH issue to be closed was raised because the leg order quantity was being multiplied with the combo market order quantity one unnecessary time more in `InteractiveBrokersFeeModel.GetOrderFee()`(see https://github.com/QuantConnect/Lean/pull/6813/files#diff-add351fc2b1d6c73ddf314762fca52d764588cbce6c2f78f4c532a15ad85eecfR89). When a leg order from the combo order is being created, the leg order quantity is scaled by the combo order quantity, therefore there was no need to scale it again in `InteractiveBrokersFeeModel.GetOrderFee()`. 
![imagen](https://github.com/QuantConnect/Lean/assets/47573394/0ccdee0d-fb6a-4e96-a600-ed6ecc2cfe05)
![imagen](https://github.com/QuantConnect/Lean/assets/47573394/392e7f46-b9ca-4f54-9c7c-ffb9666beda9)
Therefore, if for one leg order the quantity was -2 and the combo market order quantity was 26, the resulting quantity used to calculate the corresponding fees was 52, as it's shown in the image below:
![imagen](https://github.com/QuantConnect/Lean/assets/47573394/260b4783-070b-44ec-a56d-cb87cd1c773c)
![imagen](https://github.com/QuantConnect/Lean/assets/47573394/ed27944b-8b63-4875-b998-314d5441d11d)

Besides the original bug reported in the GH issue to be closed, there were found these other bugs:
- The fees were wrong for combo orders were the quantity of each leg differed each one another,
![imagen](https://github.com/QuantConnect/Lean/assets/47573394/70166036-01d9-408b-84fc-3e622d39b550).
This was because the order used to compute the fees was the combo group order instead of the specific leg order(see https://github.com/QuantConnect/Lean/pull/6813/files#diff-8fa3fa39d03b09a4d3a71fcc5cc2faa8d51f1191f7154bbe3ac207197c678256R356):
![imagen](https://github.com/QuantConnect/Lean/assets/47573394/f93b09ad-d40c-4b71-8e5b-bc11f5b635d0).

- The fees were wrong for combo orders were the security type of each leg differed each one another.
![imagen](https://github.com/QuantConnect/Lean/assets/47573394/f2dfb28d-d0d3-41c0-87ba-7bffdfcc1c3f).
This was because the security used to compute the fees was the combo group order security instead of the leg order security(see https://github.com/QuantConnect/Lean/pull/6813/files#diff-8fa3fa39d03b09a4d3a71fcc5cc2faa8d51f1191f7154bbe3ac207197c678256R356):
![imagen](https://github.com/QuantConnect/Lean/assets/47573394/9e21ab87-17fc-42d3-9aae-4b7899312f62)

All of them were fixed when `InteractiveBrokersFeeModel.cs` and `BacktestingBrokerage.cs` were modified to handle this cases. Finally, some regression tests were updated in their stats since the fees had been computed wrong for combo market orders using IB brokerage.

Here is an example of the amount of fees IB charges for three legs with quantities, 1, -2 and 1, and a combo market order quantity of 10:
![imagen](https://github.com/QuantConnect/Lean/assets/47573394/774722ef-ab09-4191-8b0f-57ddf2ea1599)
But these are the fees computed by lean for the same order:
![imagen](https://github.com/QuantConnect/Lean/assets/47573394/04e18c50-d9a5-4fc4-a89b-c1823e019127)


#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7362 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change users will get the correct amount of fees when using combo market orders with Interactive Brokers brokerage
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There was already a regression test that used combo market orders with IB brokerage, so it was modified to assert the fees for each order were the expected ones
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
