### PR TITLE
Deprecates IAlgorithmSettings.DataSubscriptionLimit

### DIFF
--- a/Algorithm.CSharp/Benchmarks/EmptyEquityAndOptions400Benchmark.cs
+++ b/Algorithm.CSharp/Benchmarks/EmptyEquityAndOptions400Benchmark.cs
@@ -64,7 +64,7 @@ namespace QuantConnect.Algorithm.CSharp.Benchmarks
 "OSCR", "WOLF", "SYF", "GOGL", "HES", "PHM", "CWEB", "ALDX", "BTWN", "AFL", "PPL", "CIM"
 
             };
-            Settings.DataSubscriptionLimit = 1000000;
+            
             SetWarmUp(TimeSpan.FromDays(1));
             foreach(var ticker in equity_symbols)
             {

--- a/Algorithm.Python/Benchmarks/EmptyEquityAndOptions400Benchmark.py
+++ b/Algorithm.Python/Benchmarks/EmptyEquityAndOptions400Benchmark.py
@@ -58,7 +58,6 @@ class EmptyEquityAndOptions400Benchmark(QCAlgorithm):
 
         ]
 
-        self.Settings.DataSubscriptionLimit = 1000000
         self.SetWarmUp(TimeSpan.FromDays(1))
         for ticker in  self.equity_symbols:
             option = self.AddOption(ticker)

--- a/Common/AlgorithmSettings.cs
+++ b/Common/AlgorithmSettings.cs
@@ -64,7 +64,8 @@ namespace QuantConnect
         /// All securities added with <see cref="IAlgorithm.AddSecurity"/> are counted as one,
         /// with the exception of options and futures where every single contract in a chain counts as one.
         /// </remarks>
-        public int DataSubscriptionLimit { get; set; }
+        [Obsolete("This property is deprecated. Please observe data subscription limits set by your brokerage to avoid runtime errors.")]
+        public int DataSubscriptionLimit { get; set; } = int.MaxValue;
 
         /// <summary>
         /// Gets/sets the SetHoldings buffers value.
@@ -123,8 +124,6 @@ namespace QuantConnect
         /// </summary>
         public AlgorithmSettings()
         {
-            // default is unlimited
-            DataSubscriptionLimit = int.MaxValue;
             LiquidateEnabled = true;
             FreePortfolioValuePercentage = 0.0025m;
             // Because the free portfolio value has a trailing behavior by default, let's add a default minimum order margin portfolio percentage

--- a/Common/Interfaces/IAlgorithmSettings.cs
+++ b/Common/Interfaces/IAlgorithmSettings.cs
@@ -80,6 +80,7 @@ namespace QuantConnect.Interfaces
         /// All securities added with <see cref="IAlgorithm.AddSecurity"/> are counted as one,
         /// with the exception of options and futures where every single contract in a chain counts as one.
         /// </remarks>
+        [Obsolete("This property is deprecated. Please observe data subscription limits set by your brokerage to avoid runtime errors.")]
         int DataSubscriptionLimit { get; set; }
 
         /// <summary>

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -397,27 +397,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
             else
             {
-                // for performance, only count if we are above the limit
-                if (SubscriptionManagerCount() > _algorithmSettings.DataSubscriptionLimit)
-                {
-                    // count data subscriptions by symbol, ignoring multiple data types.
-                    // this limit was added due to the limits IB places on number of subscriptions
-                    lock (_subscriptionManagerSubscriptions)
-                    {
-                        var uniqueCount = _subscriptionManagerSubscriptions.Keys
-                            .Where(x => !x.Symbol.IsCanonical())
-                            .DistinctBy(x => x.Symbol.Value)
-                            .Count();
-
-                        if (uniqueCount > _algorithmSettings.DataSubscriptionLimit)
-                        {
-                            throw new Exception(
-                                $"The maximum number of concurrent market data subscriptions was exceeded ({_algorithmSettings.DataSubscriptionLimit})." +
-                                "Please reduce the number of symbols requested or increase the limit using Settings.DataSubscriptionLimit.");
-                        }
-                    }
-                }
-
                 // add the time zone to our time keeper
                 _timeKeeper.AddTimeZone(newConfig.ExchangeTimeZone);
             }

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -270,17 +270,7 @@ namespace QuantConnect.Lean.Engine.Setup
 
                         // set the object store
                         algorithm.SetObjectStore(parameters.ObjectStore);
-
-                        // If we're going to receive market data from IB, set the default subscription limit to 100, algorithms can override this setting in the Initialize method
-                        if (liveJob.DataQueueHandler.Contains("InteractiveBrokersBrokerage", StringComparison.InvariantCultureIgnoreCase))
-                        {
-                            algorithm.Settings.DataSubscriptionLimit = 100;
-                            var message = $"Detected 'InteractiveBrokers' data feed. Adjusting algorithm Settings.DataSubscriptionLimit to {algorithm.Settings.DataSubscriptionLimit}." +
-                            $" Can override this setting on Initialize.";
-                            algorithm.Debug(message);
-                            Log.Trace($"BrokerageSetupHandler.Setup(): {message}");
-                        }
-
+                        
                         //Initialise the algorithm, get the required data:
                         algorithm.Initialize();
 

--- a/Tests/Algorithm/AlgorithmSettingsTest.cs
+++ b/Tests/Algorithm/AlgorithmSettingsTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -49,55 +49,7 @@ namespace QuantConnect.Tests.Algorithm
             // It should NOT send a order to set us flat
             Assert.IsTrue(fakeOrderProcessor.ProcessedOrdersRequests.IsNullOrEmpty());
         }
-
-        [Test]
-        public void SettingDataSubscriptionLimitWorksCorrectly()
-        {
-            var algo = new QCAlgorithm();
-            algo.SubscriptionManager.SetDataManager(new DataManagerStub(algo));
-            algo.Settings.DataSubscriptionLimit = 1;
-
-            var tickers = new[] { "SPY", "AAPL" };
-
-            try
-            {
-                for (int i = 0; i < 2; i++)
-                {
-                    algo.AddEquity(tickers[i]);
-                }
-                Assert.Fail();
-            }
-            catch (Exception e)
-            {
-                // We are expecting it to throw an exception due to DataSubscriptionLimit
-                Assert.IsTrue(e.Message.Contains("DataSubscriptionLimit"));
-                Assert.AreEqual(algo.Securities.Count, 1);
-            }
-        }
-
-        [Test]
-        public void DefaultValueOfDataSubscriptionLimitWorksCorrectly()
-        {
-            var algo = new QCAlgorithm();
-            algo.SubscriptionManager.SetDataManager(new DataManagerStub(algo));
-
-            var tickers = new[] { "SPY", "AAPL" };
-
-            try
-            {
-                for (int i = 0; i < 2; i++)
-                {
-                    algo.AddEquity(tickers[i]);
-                }
-                Assert.AreEqual(algo.Securities.Count, 2);
-            }
-            catch (Exception)
-            {
-                Assert.Fail();
-                // We are NOT expecting it to throw an exception due to DataSubscriptionLimit
-            }
-        }
-
+        
         [Test]
         public void SettingSetHoldingsBufferWorksCorrectly()
         {


### PR DESCRIPTION
#### Description
Deprecates `IAlgorithmSettings.DataSubscriptionLimit`.
We will let the brokerage check and notify users that they have subscribed to data feeds beyond their quota.

#### Related Issue
Closes #7453

#### Motivation and Context
QuantConnect provides a hybrid data provider so that algorithms can receive data from QC and the brokerage, e.g. Interactive Brokers. If we set a limit on LEAN, we will account for subscriptions with no limits from QC. For example, 3 Forex from QC, 5 Equity from QC and 20 Options per Equity from IB sums up to 108 subscriptions and LEAN exists with an exception when it shouldn't because the limit of 100 from IB was respected.

#### Requires Documentation Change
Yes. Need to remove the reference to `IAlgorithmSettings.DataSubscriptionLimit`, explain that IB has limit and show the message IB sends when the limit is violated.

#### How Has This Been Tested?
N/A. Remove unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`