### PR TITLE
Fix brokerage tests race condition

### DIFF
--- a/Tests/Brokerages/BrokerageTests.cs
+++ b/Tests/Brokerages/BrokerageTests.cs
@@ -61,7 +61,7 @@ namespace QuantConnect.Tests.Brokerages
             CancelOpenOrders();
             LiquidateHoldings();
             Thread.Sleep(1000);
-                }
+        }
 
         [TearDown]
         public void Teardown()
@@ -139,41 +139,41 @@ namespace QuantConnect.Tests.Brokerages
         }
 
         private void HandleFillEvents(object sender, List<OrderEvent> ordeEvents)
-            {
-                Log.Trace("");
+        {
+            Log.Trace("");
             Log.Trace("ORDER STATUS CHANGED: " + ordeEvents);
-                Log.Trace("");
+            Log.Trace("");
 
             var orderEvent = ordeEvents[0];
 
-                // we need to keep this maintained properly
-                if (orderEvent.Status == OrderStatus.Filled || orderEvent.Status == OrderStatus.PartiallyFilled)
+            // we need to keep this maintained properly
+            if (orderEvent.Status == OrderStatus.Filled || orderEvent.Status == OrderStatus.PartiallyFilled)
+            {
+                Log.Trace("FILL EVENT: " + orderEvent.FillQuantity + " units of " + orderEvent.Symbol.ToString());
+
+                if (orderEvent.Status == OrderStatus.Filled)
                 {
-                    Log.Trace("FILL EVENT: " + orderEvent.FillQuantity + " units of " + orderEvent.Symbol.ToString());
-
-                    if (orderEvent.Status == OrderStatus.Filled)
-                    {
-                        OrderFillEvent.Set();
-                    }
-
-                    Security security;
-                    if (_securityProvider.TryGetValue(orderEvent.Symbol, out security))
-                    {
-                        var holding = _securityProvider[orderEvent.Symbol].Holdings;
-                        holding.SetHoldings(orderEvent.FillPrice, holding.Quantity + orderEvent.FillQuantity);
-                    }
-                    else
-                    {
-                        _securityProvider[orderEvent.Symbol] = CreateSecurity(orderEvent.Symbol);
-                        _securityProvider[orderEvent.Symbol].Holdings.SetHoldings(orderEvent.FillPrice, orderEvent.FillQuantity);
-                    }
-
-                    Log.Trace("--HOLDINGS: " + _securityProvider[orderEvent.Symbol]);
-
-                    // update order mapping
-                    var order = _orderProvider.GetOrderById(orderEvent.OrderId);
-                    order.Status = orderEvent.Status;
+                    OrderFillEvent.Set();
                 }
+
+                Security security;
+                if (_securityProvider.TryGetValue(orderEvent.Symbol, out security))
+                {
+                    var holding = _securityProvider[orderEvent.Symbol].Holdings;
+                    holding.SetHoldings(orderEvent.FillPrice, holding.Quantity + orderEvent.FillQuantity);
+                }
+                else
+                {
+                    _securityProvider[orderEvent.Symbol] = CreateSecurity(orderEvent.Symbol);
+                    _securityProvider[orderEvent.Symbol].Holdings.SetHoldings(orderEvent.FillPrice, orderEvent.FillQuantity);
+                }
+
+                Log.Trace("--HOLDINGS: " + _securityProvider[orderEvent.Symbol]);
+
+                // update order mapping
+                var order = _orderProvider.GetOrderById(orderEvent.OrderId);
+                order.Status = orderEvent.Status;
+            }
         }
 
         public static Security CreateSecurity(Symbol symbol)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Fix brokerage tests race condition. When tests place orders and then use `ModifyOrderUntilFilled` to modify them until they are filled, behaviour can be unexpected if orders are filled before `ModifyOrderUntilFilled` subscribed to the status change event to detect fill events.

This adds logic to handle this, making sure the class itself sets up events to listen to the fill event right when the order is placed.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Interactive Brokers Brokerage tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
