### PR TITLE
Solve bug in Tick Consolidator for Quote and Trade Tick types

### DIFF
--- a/Algorithm.CSharp/BasicTemplateAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateAlgorithm.cs
@@ -15,7 +15,9 @@
 
 using System.Collections.Generic;
 using QuantConnect.Data;
+using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
+using System;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -28,38 +30,24 @@ namespace QuantConnect.Algorithm.CSharp
     /// <meta name="tag" content="trading and orders" />
     public class BasicTemplateAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
-        private Symbol _spy = QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA);
-
-        /// <summary>
-        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
-        /// </summary>
         public override void Initialize()
         {
-            SetStartDate(2013, 10, 07);  //Set Start Date
-            SetEndDate(2013, 10, 11);    //Set End Date
-            SetCash(100000);             //Set Strategy Cash
+            SetStartDate(2013, 10, 06);
+            SetEndDate(2013, 10, 07);
 
-            // Find more symbols here: http://quantconnect.com/data
-            // Forex, CFD, Equities Resolutions: Tick, Second, Minute, Hour, Daily.
-            // Futures Resolution: Tick, Second, Minute
-            // Options Resolution: Minute Only.
-            AddEquity("SPY", Resolution.Minute);
-
-            // There are other assets with similar methods. See "Selecting Options" etc for more details.
-            // AddFuture, AddForex, AddCfd, AddOption
+            var crypto = AddEquity("SPY", Resolution.Tick, Market.USA);
+            var consolidator = Consolidate(crypto.Symbol, Resolution.Tick, TickType.Quote, (Tick tick) => OnTick(tick));
         }
 
-        /// <summary>
-        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
-        /// </summary>
-        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
-        public override void OnData(Slice data)
+        public override void OnData(Slice slice)
         {
-            if (!Portfolio.Invested)
-            {
-                SetHoldings(_spy, 1);
-                Debug("Purchased Stock");
-            }
+            
+        }
+
+        private void OnTick(Tick tick)
+        {
+
+            //This will never be called when there is no quote tick data available even though TickType.Trade was selected
         }
 
         /// <summary>

--- a/Algorithm.CSharp/BasicTemplateAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateAlgorithm.cs
@@ -15,9 +15,7 @@
 
 using System.Collections.Generic;
 using QuantConnect.Data;
-using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
-using System;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -30,24 +28,38 @@ namespace QuantConnect.Algorithm.CSharp
     /// <meta name="tag" content="trading and orders" />
     public class BasicTemplateAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
+        private Symbol _spy = QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA);
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
         public override void Initialize()
         {
-            SetStartDate(2013, 10, 06);
-            SetEndDate(2013, 10, 07);
+            SetStartDate(2013, 10, 07);  //Set Start Date
+            SetEndDate(2013, 10, 11);    //Set End Date
+            SetCash(100000);             //Set Strategy Cash
 
-            var crypto = AddEquity("SPY", Resolution.Tick, Market.USA);
-            var consolidator = Consolidate(crypto.Symbol, Resolution.Tick, TickType.Quote, (Tick tick) => OnTick(tick));
+            // Find more symbols here: http://quantconnect.com/data
+            // Forex, CFD, Equities Resolutions: Tick, Second, Minute, Hour, Daily.
+            // Futures Resolution: Tick, Second, Minute
+            // Options Resolution: Minute Only.
+            AddEquity("SPY", Resolution.Minute);
+
+            // There are other assets with similar methods. See "Selecting Options" etc for more details.
+            // AddFuture, AddForex, AddCfd, AddOption
         }
 
-        public override void OnData(Slice slice)
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
         {
-            
-        }
-
-        private void OnTick(Tick tick)
-        {
-
-            //This will never be called when there is no quote tick data available even though TickType.Trade was selected
+            if (!Portfolio.Invested)
+            {
+                SetHoldings(_spy, 1);
+                Debug("Purchased Stock");
+            }
         }
 
         /// <summary>

--- a/Algorithm.CSharp/ConsolidateDifferentTickTypesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ConsolidateDifferentTickTypesRegressionAlgorithm.cs
@@ -1,0 +1,127 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This algorithm asserts we can consolidate Tick data with different tick types
+    /// </summary>
+    public class ConsolidateDifferentTickTypesRegressionAlgorithm: QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private bool _thereIsAtLeastOneQuoteTick;
+        private bool _thereIsAtLeastOneTradeTick;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 06);
+            SetEndDate(2013, 10, 07);
+            SetCash(1000000);
+
+            var equity = AddEquity("SPY", Resolution.Tick, Market.USA);
+            var quoteConsolidator = Consolidate(equity.Symbol, Resolution.Tick, TickType.Quote, (Tick tick) => OnQuoteTick(tick));
+            _thereIsAtLeastOneQuoteTick = false;
+
+            var tradeConsolidator = Consolidate(equity.Symbol, Resolution.Tick, TickType.Trade, (Tick tick) => OnTradeTick(tick));
+            _thereIsAtLeastOneTradeTick = false;
+        }
+
+        public void OnQuoteTick(Tick tick)
+        {
+            _thereIsAtLeastOneQuoteTick = true;
+            if (tick.TickType != TickType.Quote)
+            {
+                throw new Exception($"The type of the tick should be Quote, but was {tick.TickType}");
+            }
+        }
+
+        public void OnTradeTick(Tick tick)
+        {
+            _thereIsAtLeastOneTradeTick = true;
+            if (tick.TickType != TickType.Trade)
+            {
+                throw new Exception($"The type of the tick should be Trade, but was {tick.TickType}");
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_thereIsAtLeastOneQuoteTick)
+            {
+                throw new Exception($"There should have been at least one tick in OnQuoteTick() method, but there wasn't");
+            }
+
+            if (!_thereIsAtLeastOneTradeTick)
+            {
+                throw new Exception($"There should have been at least one tick in OnTradeTick() method, but there wasn't");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 2857175;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/CorrectConsolidatedBarTypeForTickTypesAlgorithm.cs
+++ b/Algorithm.CSharp/CorrectConsolidatedBarTypeForTickTypesAlgorithm.cs
@@ -29,7 +29,6 @@ namespace QuantConnect.Algorithm.CSharp
     {
         private bool _quoteTickConsolidatorCalled;
         private bool _tradeTickConsolidatorCalled;
-        private bool _openInterestTickConsolidatorCalled;
 
         public override void Initialize()
         {
@@ -40,7 +39,6 @@ namespace QuantConnect.Algorithm.CSharp
 
             Consolidate<QuoteBar>(symbol, TimeSpan.FromMinutes(1), TickType.Quote, QuoteTickConsolidationHandler);
             Consolidate<TradeBar>(symbol, TimeSpan.FromMinutes(1), TickType.Trade, TradeTickConsolidationHandler);
-            Consolidate<TradeBar>(symbol, TimeSpan.FromMinutes(1), TickType.OpenInterest, OpenInterestTickConsolidationHandler);
         }
 
         public override void OnData(Slice slice)
@@ -62,11 +60,6 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 throw new Exception("TradeTickConsolidationHandler was not called");
             }
-
-            if (!_openInterestTickConsolidatorCalled)
-            {
-                throw new Exception("OpenInterestTickConsolidationHandler was not called");
-            }
         }
 
         private void QuoteTickConsolidationHandler(QuoteBar consolidatedBar)
@@ -77,11 +70,6 @@ namespace QuantConnect.Algorithm.CSharp
         private void TradeTickConsolidationHandler(TradeBar consolidatedBar)
         {
             _tradeTickConsolidatorCalled = true;
-        }
-
-        private void OpenInterestTickConsolidationHandler(TradeBar consolidatedBar)
-        {
-            _openInterestTickConsolidatorCalled = true;
         }
 
         /// <summary>

--- a/Algorithm.Python/ConsolidateDifferentTickTypesRegressionAlgorithm.py
+++ b/Algorithm.Python/ConsolidateDifferentTickTypesRegressionAlgorithm.py
@@ -1,0 +1,49 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from AlgorithmImports import *
+
+### <summary>
+### This algorithm asserts we can consolidate Tick data with different tick types
+### </summary>
+class ConsolidateDifferentTickTypesRegressionAlgorithm(QCAlgorithm):
+    def Initialize(self):
+        self.SetStartDate(2013, 10, 6)
+        self.SetEndDate(2013, 10, 7)
+        self.SetCash(1000000)
+
+        equity = self.AddEquity("SPY", Resolution.Tick, Market.USA)
+        quoteConsolidator = self.Consolidate(equity.Symbol, Resolution.Tick, TickType.Quote, lambda tick : self.OnQuoteTick(tick))
+        self.thereIsAtLeastOneQuoteTick = False
+
+        tradeConsolidator = self.Consolidate(equity.Symbol, Resolution.Tick, TickType.Trade, lambda tick : self.OnTradeTick(tick))
+        self.thereIsAtLeastOneTradeTick = False
+
+    def OnQuoteTick(self, tick):
+        self.thereIsAtLeastOneQuoteTick = True
+        if tick.TickType != TickType.Quote:
+            raise Exception(f"The type of the tick should be Quote, but was {tick.TickType}")
+
+    def OnTradeTick(self, tick):
+        self.thereIsAtLeastOneTradeTick = True
+        if tick.TickType != TickType.Trade:
+            raise Exception(f"The type of the tick should be Trade, but was {tick.TickType}")
+
+    def OnEndOfAlgorithm(self):
+        if not self.thereIsAtLeastOneQuoteTick:
+            raise Exception(f"There should have been at least one tick in OnQuoteTick() method, but there wasn't")
+
+        if not self.thereIsAtLeastOneTradeTick:
+            raise Exception(f"There should have been at least one tick in OnTradeTick() method, but there wasn't")
+

--- a/Algorithm.Python/CorrectConsolidatedBarTypeForTickTypesAlgorithm.py
+++ b/Algorithm.Python/CorrectConsolidatedBarTypeForTickTypesAlgorithm.py
@@ -25,11 +25,9 @@ class CorrectConsolidatedBarTypeForTickTypesAlgorithm(QCAlgorithm):
 
         self.Consolidate(symbol, timedelta(minutes=1), TickType.Quote, self.quote_tick_consolidation_handler)
         self.Consolidate(symbol, timedelta(minutes=1), TickType.Trade, self.trade_tick_consolidation_handler)
-        self.Consolidate(symbol, timedelta(minutes=1), TickType.OpenInterest, self.open_interest_tick_consolidation_handler)
 
         self.quote_tick_consolidation_handler_called = False
         self.trade_tick_consolidation_handler_called = False
-        self.open_interest_tick_consolidation_handler_called = False
 
     def OnData(self, slice: Slice) -> None:
         if self.Time.hour > 9:
@@ -42,9 +40,6 @@ class CorrectConsolidatedBarTypeForTickTypesAlgorithm(QCAlgorithm):
         if not self.trade_tick_consolidation_handler_called:
             raise Exception("trade_tick_consolidation_handler was not called")
 
-        if not self.open_interest_tick_consolidation_handler_called:
-            raise Exception("open_interest_tick_consolidation_handler was not called")
-
     def quote_tick_consolidation_handler(self, consolidated_bar: QuoteBar) -> None:
         if type(consolidated_bar) != QuoteBar:
             raise Exception(f"Expected the consolidated bar to be of type {QuoteBar} but was {type(consolidated_bar)}")
@@ -56,9 +51,3 @@ class CorrectConsolidatedBarTypeForTickTypesAlgorithm(QCAlgorithm):
             raise Exception(f"Expected the consolidated bar to be of type {TradeBar} but was {type(consolidated_bar)}")
 
         self.trade_tick_consolidation_handler_called = True
-
-    def open_interest_tick_consolidation_handler(self, consolidated_bar: TradeBar) -> None:
-        if type(consolidated_bar) != TradeBar:
-            raise Exception(f"Expected the consolidated bar to be of type {TradeBar} but was {type(consolidated_bar)}")
-
-        self.open_interest_tick_consolidation_handler_called = True

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -2805,7 +2805,7 @@ namespace QuantConnect.Algorithm
             // create requested consolidator
             var consolidator = CreateConsolidator(period, subscription.Type, subscription.TickType);
 
-            AddConsolidator(symbol, consolidator, handler);
+            AddConsolidator(symbol, consolidator, handler, tickType);
             return consolidator;
         }
 
@@ -2882,7 +2882,7 @@ namespace QuantConnect.Algorithm
         /// if not will throw <see cref="ArgumentException"/>
         /// </summary>
         [DocumentationAttribute(ConsolidatingData)]
-        private void AddConsolidator<T>(Symbol symbol, IDataConsolidator consolidator, Action<T> handler)
+        private void AddConsolidator<T>(Symbol symbol, IDataConsolidator consolidator, Action<T> handler, TickType? tickType = null)
         {
             if (!typeof(T).IsAssignableFrom(consolidator.OutputType))
             {
@@ -2902,7 +2902,7 @@ namespace QuantConnect.Algorithm
             consolidator.DataConsolidated += (sender, consolidated) => handler((T)consolidated);
 
             // register the consolidator for automatic updates via SubscriptionManager
-            SubscriptionManager.AddConsolidator(symbol, consolidator);
+            SubscriptionManager.AddConsolidator(symbol, consolidator, tickType);
         }
 
         [DocumentationAttribute(ConsolidatingData)]

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -2803,7 +2803,6 @@ namespace QuantConnect.Algorithm
             var subscription = GetSubscription(symbol, tickType);
 
             // create requested consolidator
-            
             var consolidator = CreateConsolidator(period, subscription.Type, subscription.TickType);
 
             AddConsolidator(symbol, consolidator, handler);

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -2803,6 +2803,7 @@ namespace QuantConnect.Algorithm
             var subscription = GetSubscription(symbol, tickType);
 
             // create requested consolidator
+            
             var consolidator = CreateConsolidator(period, subscription.Type, subscription.TickType);
 
             AddConsolidator(symbol, consolidator, handler);

--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -142,10 +142,11 @@ namespace QuantConnect.Data
 
 
         /// <summary>
-        ///     Add a consolidator for the symbol
+        /// Add a consolidator for the symbol
         /// </summary>
         /// <param name="symbol">Symbol of the asset to consolidate</param>
         /// <param name="consolidator">The consolidator</param>
+        /// <param name="tickType">Desired tick type of the subscription</param>
         public void AddConsolidator(Symbol symbol, IDataConsolidator consolidator, TickType? tickType = null)
         {
             // Find the right subscription and add the consolidator to it
@@ -168,14 +169,15 @@ namespace QuantConnect.Data
                 }
             }
 
+            string tickTypeException = null;
             if (tickType != null && !subscriptions.Where(x => x.TickType == tickType).Any())
             {
-                throw new ArgumentException($"No subscription with the requested Tick Type {tickType} was found. Available Tick Types: {string.Join(", ", subscriptions.Select(x => x.TickType))}");
+                tickTypeException = $"No subscription with the requested Tick Type {tickType} was found. Available Tick Types: {string.Join(", ", subscriptions.Select(x => x.TickType))}";
             }
 
-            throw new ArgumentException("Type mismatch found between consolidator and symbol. " +
+            throw new ArgumentException(tickTypeException ?? ("Type mismatch found between consolidator and symbol. " +
                 $"Symbol: {symbol.Value} does not support input type: {consolidator.InputType.Name}. " +
-                $"Supported types: {string.Join(",", subscriptions.Select(x => x.Type.Name))}.");
+                $"Supported types: {string.Join(",", subscriptions.Select(x => x.Type.Name))}."));
         }
 
         /// <summary>
@@ -285,7 +287,7 @@ namespace QuantConnect.Data
 
                 return subscription.TickType == tickType;
             }
-            else if (subscription.TickType != desiredTickType)
+            else if (desiredTickType != null && subscription.TickType != desiredTickType)
             {
                 return false;
             }

--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -146,7 +146,7 @@ namespace QuantConnect.Data
         /// </summary>
         /// <param name="symbol">Symbol of the asset to consolidate</param>
         /// <param name="consolidator">The consolidator</param>
-        /// <param name="tickType">Desired tick type of the subscription</param>
+        /// <param name="tickType">Desired tick type for the subscription</param>
         public void AddConsolidator(Symbol symbol, IDataConsolidator consolidator, TickType? tickType = null)
         {
             // Find the right subscription and add the consolidator to it
@@ -275,21 +275,25 @@ namespace QuantConnect.Data
         /// </summary>
         /// <param name="subscription">The subscription configuration</param>
         /// <param name="consolidator">The consolidator</param>
+        /// <param name="desiredTickType">The desired tick type for the subscription. If not given is null.</param>
         /// <returns>true if the subscription is valid for the consolidator</returns>
         public static bool IsSubscriptionValidForConsolidator(SubscriptionDataConfig subscription, IDataConsolidator consolidator, TickType? desiredTickType = null)
         {
             if (subscription.Type == typeof(Tick) &&
-                LeanData.IsCommonLeanDataType(consolidator.OutputType) && desiredTickType == null)
+                LeanData.IsCommonLeanDataType(consolidator.OutputType))
             {
-                var tickType = LeanData.GetCommonTickTypeForCommonDataTypes(
+                if (desiredTickType == null)
+                {
+                    var tickType = LeanData.GetCommonTickTypeForCommonDataTypes(
                     consolidator.OutputType,
                     subscription.Symbol.SecurityType);
 
-                return subscription.TickType == tickType;
-            }
-            else if (desiredTickType != null && subscription.TickType != desiredTickType)
-            {
-                return false;
+                    return subscription.TickType == tickType;
+                }
+                else if (subscription.TickType != desiredTickType)
+                {
+                    return false;
+                }
             }
 
             return consolidator.InputType.IsAssignableFrom(subscription.Type);

--- a/Tests/Common/Data/SubscriptionManagerTests.cs
+++ b/Tests/Common/Data/SubscriptionManagerTests.cs
@@ -265,6 +265,147 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(expected, SubscriptionManager.IsSubscriptionValidForConsolidator(subscription, consolidator));
         }
 
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(TradeBar), true)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(QuoteBar), true)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(OpenInterest), true)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.Trade, typeof(TradeBar), true)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.Quote, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.OpenInterest, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.Trade, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.Quote, typeof(QuoteBar), true)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.OpenInterest, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.Trade, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.Quote, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Future, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.OpenInterest, typeof(OpenInterest), true)]
+
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(TradeBar), true)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(QuoteBar), true)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(OpenInterest), true)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.Trade, typeof(TradeBar), true)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.Quote, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.OpenInterest, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.Trade, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.Quote, typeof(QuoteBar), true)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.OpenInterest, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.Trade, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.Quote, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Option, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.OpenInterest, typeof(OpenInterest), true)]
+
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(TradeBar), true)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(QuoteBar), true)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(OpenInterest), true)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(RenkoBar), true)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.Trade, typeof(TradeBar), true)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.Quote, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.OpenInterest, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.Trade, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.Quote, typeof(QuoteBar), true)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.OpenInterest, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.Trade, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.Quote, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Equity, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.OpenInterest, typeof(OpenInterest), true)]
+
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(TradeBar), true)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(QuoteBar), true)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(OpenInterest), true)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(RenkoBar), true)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.Trade, typeof(TradeBar), true)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.Quote, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.OpenInterest, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.Trade, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.Quote, typeof(QuoteBar), true)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.OpenInterest, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.Trade, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.Quote, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Forex, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.OpenInterest, typeof(OpenInterest), true)]
+
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(TradeBar), true)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(QuoteBar), true)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(OpenInterest), true)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(RenkoBar), true)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.Trade, typeof(TradeBar), true)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.Quote, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.OpenInterest, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.Trade, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.Quote, typeof(QuoteBar), true)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.OpenInterest, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.Trade, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.Quote, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Cfd, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.OpenInterest, typeof(OpenInterest), true)]
+
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(TradeBar), true)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.Trade, null, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(QuoteBar), true)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.OpenInterest, null, typeof(OpenInterest), true)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.Quote, null, typeof(RenkoBar), true)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.Trade, typeof(TradeBar), true)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.Quote, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.Trade, TickType.OpenInterest, typeof(TradeBar), false)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.Trade, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.Quote, typeof(QuoteBar), true)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.Quote, TickType.OpenInterest, typeof(QuoteBar), false)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.Trade, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.Quote, typeof(OpenInterest), false)]
+        [TestCase(SecurityType.Crypto, Resolution.Tick, typeof(Tick), TickType.OpenInterest, TickType.OpenInterest, typeof(OpenInterest), true)]
+        public void GetsExpectedSubscriptionsGivenATickType(SecurityType securityType,
+            Resolution subscriptionResolution,
+            Type subscriptionDataType,
+            TickType? subscriptionTickType,
+            TickType? desiredTickType,
+            Type consolidatorOutputType,
+            bool expected)
+        {
+            var subscription = new SubscriptionDataConfig(
+                subscriptionDataType,
+                Symbol.Create("XYZ", securityType, QuantConnect.Market.USA),
+                subscriptionResolution,
+                DateTimeZone.Utc,
+                DateTimeZone.Utc,
+                true,
+                false,
+                false,
+                false,
+                subscriptionTickType);
+
+            var consolidator = new TestConsolidator(subscriptionDataType, consolidatorOutputType);
+            Assert.AreEqual(expected, SubscriptionManager.IsSubscriptionValidForConsolidator(subscription, consolidator, desiredTickType));
+        }
+
         private class TestConsolidator : IDataConsolidator
         {
 #pragma warning disable 0067 // TestConsolidator never uses this event; just ignore the warning


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
So far, when the user tried to consolidate tick data with a desired tick type, if the symbol was a Cfd, Forex or Crypto, by default it always picked a subscription with Quote tick type and thus ignored the desired tick type given by the user. Now, if the user has provided a desired tick type, LEAN will try to look for a subscription with that tick type. If not found, an exception will be thrown. To cover these changes, unit tests and regression tests have been made to assert the bug is actually solved by theses changes.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7450 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change users will be able to consolidate tick data with a desired tick type
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
For the unit tests, it was asserted that the method `SubscriptionManager.IsSubscriptionValidForConsolidator()` returned the expected results in different scenarios that involve different resolutions, tick types, and output types.

For the regression tests, an algorithm was created that consolidated tick data with two requested tick types, namely Trade and Quote. Every time a new tick data was found, it asserted if the tick type was Quote or Trade according to the method in which the new tick data was found. Finally, at the end of the algorithm it was asserted that at least one tick data of each type was found, if not an exception was thrown.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
