### PR TITLE
Update UniverseDefinitions.ETF|Index overloads 

### DIFF
--- a/Algorithm.CSharp/UniverseOnlyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UniverseOnlyRegressionAlgorithm.cs
@@ -1,0 +1,109 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Asserts that algorithms can be universe-only, that is, universe selection is performed even if the ETF security is not explicitly added.
+    /// Reproduces https://github.com/QuantConnect/Lean/issues/7473
+    /// </summary>
+    public class UniverseOnlyRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private bool _selectionDone;
+
+        public override void Initialize()
+        {
+            SetStartDate(2020, 12, 1);
+            SetEndDate(2020, 12, 12);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+
+            // Add universe without a security added
+            AddUniverse(Universe.ETF("GDVD", UniverseSettings, FilterUniverse));
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_selectionDone)
+            {
+                throw new Exception("Universe selection was not performed");
+            }
+        }
+
+        private IEnumerable<Symbol> FilterUniverse(IEnumerable<ETFConstituentData> constituents)
+        {
+            _selectionDone = true;
+            return constituents.Select(x => x.Symbol);
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 118;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-0.311"},
+            {"Tracking Error", "0.07"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.Python/UniverseOnlyRegressionAlgorithm.py
+++ b/Algorithm.Python/UniverseOnlyRegressionAlgorithm.py
@@ -1,0 +1,40 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Asserts that algorithms can be universe-only, that is, universe selection is performed even if the ETF security is not explicitly added.
+### Reproduces https://github.com/QuantConnect/Lean/issues/7473
+### </summary>
+class UniverseOnlyRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        self.SetStartDate(2020, 12, 1)
+        self.SetEndDate(2020, 12, 12)
+        self.SetCash(100000)
+
+        self.UniverseSettings.Resolution = Resolution.Daily
+
+        # Add universe without a security added
+        self.AddUniverse(self.Universe.ETF("GDVD", self.UniverseSettings, self.FilterUniverse))
+
+        self.selection_done = False
+
+    def FilterUniverse(self, constituents: List[ETFConstituentData]) -> List[Symbol]:
+        self.selection_done = True
+        return [x.Symbol for x in constituents]
+
+    def OnEndOfAlgorithm(self):
+        if not self.selection_done:
+            raise Exception("Universe selection was not performed")

--- a/Algorithm/UniverseDefinitions.cs
+++ b/Algorithm/UniverseDefinitions.cs
@@ -135,6 +135,21 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Creates a universe for the constituents of the provided <paramref name="etfTicker"/>
+        /// </summary>
+        /// <param name="etfTicker">Ticker of the ETF to get constituents for</param>
+        /// <param name="universeSettings">Universe settings</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        /// <returns>New ETF constituents Universe</returns>
+        public Universe ETF(
+            string etfTicker,
+            UniverseSettings universeSettings,
+            PyObject universeFilterFunc)
+        {
+            return ETF(etfTicker, null, universeSettings, universeFilterFunc);
+        }
+
+        /// <summary>
         /// Creates a universe for the constituents of the provided ETF <paramref name="symbol"/>
         /// </summary>
         /// <param name="symbol">ETF Symbol to get constituents for</param>
@@ -245,6 +260,21 @@ namespace QuantConnect.Algorithm
             PyObject universeFilterFunc = null)
         {
             return Index(indexTicker, market, universeSettings, universeFilterFunc?.ConvertPythonUniverseFilterFunction<ETFConstituentData>());
+        }
+
+        /// <summary>
+        /// Creates a universe for the constituents of the provided <paramref name="indexTicker"/>
+        /// </summary>
+        /// <param name="indexTicker">Ticker of the index to get constituents for</param>
+        /// <param name="universeSettings">Universe settings</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        /// <returns>New index constituents Universe</returns>
+        public Universe Index(
+            string indexTicker,
+            UniverseSettings universeSettings,
+            PyObject universeFilterFunc)
+        {
+            return Index(indexTicker, null, universeSettings, universeFilterFunc);
         }
 
         /// <summary>

--- a/Tests/Algorithm/UniverseDefinitionsTests.cs
+++ b/Tests/Algorithm/UniverseDefinitionsTests.cs
@@ -25,7 +25,7 @@ using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Algorithm
 {
-    [TestFixture, Parallelizable(ParallelScope.All)]
+    [TestFixture]
     public class UniverseDefinitionsTests
     {
         [TestCase(Language.CSharp)]
@@ -73,6 +73,7 @@ def getETFs(algorithm: QCAlgorithm, symbol: Symbol, universeSettings: UniverseSe
         universeDefinitions.ETF('SPY', Market.USA, universeSettings),
         universeDefinitions.ETF('SPY', Market.USA, universeSettings, filterETFs),
         universeDefinitions.ETF('SPY', Market.USA, universeFilterFunc=filterETFs),
+        universeDefinitions.ETF('SPY', universeSettings, filterETFs),
         universeDefinitions.ETF('SPY', universeSettings=universeSettings),
         universeDefinitions.ETF('SPY', universeFilterFunc=filterETFs),
         universeDefinitions.ETF('SPY', universeSettings=universeSettings, universeFilterFunc=filterETFs),
@@ -140,6 +141,7 @@ def getIndexes(algorithm: QCAlgorithm, symbol: Symbol, universeSettings: Univers
         universeDefinitions.Index('SPY', Market.USA, universeSettings),
         universeDefinitions.Index('SPY', Market.USA, universeSettings, filterIndexes),
         universeDefinitions.Index('SPY', Market.USA, universeFilterFunc=filterIndexes),
+        universeDefinitions.Index('SPY', universeSettings, filterIndexes),
         universeDefinitions.Index('SPY', universeSettings=universeSettings),
         universeDefinitions.Index('SPY', universeFilterFunc=filterIndexes),
         universeDefinitions.Index('SPY', universeSettings=universeSettings, universeFilterFunc=filterIndexes),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Update `UniverseDefinitions.ETF|Index` overloads  for Python compatibility.

Calling `UniverseDefinition.ETF("TICKER",...)` in Python was resolving the `UserDefinition.ETF(Symbol...)` overload due to `Symbol`'s implicit string operator, causing the symbol to be wrongly created.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #7473 
Related #7006 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit tests
- Regression algorithm

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
