### PR TITLE
Update returns symbol data ROC for Risk Parity PCM

### DIFF
--- a/Algorithm.Framework/Portfolio/ReturnsSymbolData.cs
+++ b/Algorithm.Framework/Portfolio/ReturnsSymbolData.cs
@@ -30,6 +30,11 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         private readonly RollingWindow<IndicatorDataPoint> _window;
 
         /// <summary>
+        /// The symbol's asset rate of change indicator
+        /// </summary>
+        public RateOfChange ROC { get {  return _roc; } }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ReturnsSymbolData"/> class
         /// </summary>
         /// <param name="symbol">The symbol of the data that updates the indicators</param>

--- a/Algorithm.Framework/Portfolio/RiskParityPortfolioConstructionModel.cs
+++ b/Algorithm.Framework/Portfolio/RiskParityPortfolioConstructionModel.cs
@@ -230,7 +230,8 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             // clean up data for removed securities
             foreach (var removed in changes.RemovedSecurities)
             {
-                _symbolDataDict.Remove(removed.Symbol);
+                _symbolDataDict.Remove(removed.Symbol, out var removedSymbolData);
+                algorithm.UnregisterIndicator(removedSymbolData.ROC);
             }
 
             if (changes.AddedSecurities.Count == 0)
@@ -245,6 +246,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                 {
                     var symbolData = new ReturnsSymbolData(added.Symbol, _lookback, _period);
                     _symbolDataDict[added.Symbol] = symbolData;
+                    algorithm.RegisterIndicator(added.Symbol, symbolData.ROC, _resolution);
                 }
             }
 

--- a/Algorithm.Framework/Portfolio/RiskParityPortfolioConstructionModel.py
+++ b/Algorithm.Framework/Portfolio/RiskParityPortfolioConstructionModel.py
@@ -42,7 +42,7 @@ class RiskParityPortfolioConstructionModel(PortfolioConstructionModel):
         super().__init__()
         if portfolioBias == PortfolioBias.Short:
             raise ArgumentException("Long position must be allowed in RiskParityPortfolioConstructionModel.")
-        
+
         self.lookback = lookback
         self.period = period
         self.resolution = resolution
@@ -102,6 +102,7 @@ class RiskParityPortfolioConstructionModel(PortfolioConstructionModel):
         for removed in changes.RemovedSecurities:
             symbolData = self.symbolDataBySymbol.pop(removed.Symbol, None)
             symbolData.Reset()
+            algorithm.UnregisterIndicator(symbolData.roc)
 
         # initialize data for added securities
         symbols = [ x.Symbol for x in changes.AddedSecurities ]
@@ -116,6 +117,7 @@ class RiskParityPortfolioConstructionModel(PortfolioConstructionModel):
                 symbolData = self.RiskParitySymbolData(symbol, self.lookback, self.period)
                 symbolData.WarmUpIndicators(history.loc[ticker])
                 self.symbolDataBySymbol[symbol] = symbolData
+                algorithm.RegisterIndicator(symbol, symbolData.roc, self.resolution)
 
     class RiskParitySymbolData:
         '''Contains data specific to a symbol required by this model'''


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This makes sure the `RiskParityPortfolioConstructionModel` updates the assets' ROC for proper weights calculation.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #7476 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Regression algorithm

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
