### PR TITLE
Fix bug with custom data subscription with the same symbol from multiple exchanges

### DIFF
--- a/Algorithm.CSharp/CustomDataWorksWithDifferentExchangesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataWorksWithDifferentExchangesRegressionAlgorithm.cs
@@ -1,0 +1,145 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm to assert we can have custom data subscriptions with different exchanges
+    /// </summary>
+    public class CustomDataWorksWithDifferentExchangesRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private bool _noDataPointsReceived;
+        public override void Initialize()
+        {
+            SetStartDate(2014, 05, 02); // Set Start Date
+            SetEndDate(2014, 05, 03); // Set Start Date
+            SetAccountCurrency("USD", 10000);
+
+            var market1 = AddForex("EURUSD", Resolution.Hour, Market.FXCM);
+            AddData<ExampleCustomData>(market1.Symbol, Resolution.Hour, TimeZones.Utc, false);
+
+            var market2 = AddForex("EURUSD", Resolution.Hour, Market.Oanda);
+            AddData<ExampleCustomData>(market2.Symbol, Resolution.Hour, TimeZones.Utc, false);
+            _noDataPointsReceived = false;
+        }
+
+
+        public override void OnData(Slice slice)
+        {
+            _noDataPointsReceived = true;
+            if (slice.Count != ActiveSecurities.Count) // There are not enough custom data points for the whole algo period
+            {
+                throw new Exception($"{ActiveSecurities.Count.ToString().ToCamelCase()} data points were expected, but only {slice.Count} were received");
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_noDataPointsReceived)
+            {
+                throw new Exception($"No points were received");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 94;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 60;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+
+    public class ExampleCustomData : BaseData
+    {
+        private int _hours = 0;
+        public decimal Open;
+        public decimal High;
+        public decimal Low;
+        public decimal Close;
+
+        public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
+        {
+            var source = "https://www.dl.dropboxusercontent.com/s/d83xvd7mm9fzpk0/path_to_my_csv_data.csv?dl=0";
+            return new SubscriptionDataSource(source, SubscriptionTransportMedium.RemoteFile, FileFormat.Csv);
+        }
+
+        public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
+        {
+            var csv = line.Split(",");
+            var data = new ExampleCustomData()
+            {
+                Symbol = config.Symbol,
+                Time = date.AddHours(_hours),
+                Value = csv[4].ToDecimal(),
+                Open = csv[1].ToDecimal(),
+                High = csv[2].ToDecimal(),
+                Low = csv[3].ToDecimal(),
+                Close = csv[4].ToDecimal()
+            };
+
+            _hours = (_hours + 1) % 18;
+            return data;
+        }
+    }
+}

--- a/Algorithm.CSharp/CustomDataWorksWithDifferentExchangesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataWorksWithDifferentExchangesRegressionAlgorithm.cs
@@ -28,9 +28,8 @@ namespace QuantConnect.Algorithm.CSharp
         private bool _noDataPointsReceived;
         public override void Initialize()
         {
-            SetStartDate(2014, 05, 02); // Set Start Date
-            SetEndDate(2014, 05, 03); // Set Start Date
-            SetAccountCurrency("USD", 10000);
+            SetStartDate(2014, 05, 02);
+            SetEndDate(2014, 05, 03);
 
             var market1 = AddForex("EURUSD", Resolution.Hour, Market.FXCM);
             AddData<ExampleCustomData>(market1.Symbol, Resolution.Hour, TimeZones.Utc, false);
@@ -44,7 +43,7 @@ namespace QuantConnect.Algorithm.CSharp
         public override void OnData(Slice slice)
         {
             _noDataPointsReceived = true;
-            if (slice.Count != ActiveSecurities.Count) // There are not enough custom data points for the whole algo period
+            if (slice.Count != ActiveSecurities.Count)
             {
                 throw new Exception($"{ActiveSecurities.Count.ToString().ToCamelCase()} data points were expected, but only {slice.Count} were received");
             }

--- a/Algorithm.CSharp/CustomDataWorksWithDifferentExchangesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataWorksWithDifferentExchangesRegressionAlgorithm.cs
@@ -36,13 +36,13 @@ namespace QuantConnect.Algorithm.CSharp
 
             var market2 = AddForex("EURUSD", Resolution.Hour, Market.Oanda);
             AddData<ExampleCustomData>(market2.Symbol, Resolution.Hour, TimeZones.Utc, false);
-            _noDataPointsReceived = false;
+            _noDataPointsReceived = true;
         }
 
 
         public override void OnData(Slice slice)
         {
-            _noDataPointsReceived = true;
+            _noDataPointsReceived = false;
             if (slice.Count != ActiveSecurities.Count)
             {
                 throw new Exception($"{ActiveSecurities.Count.ToString().ToCamelCase()} data points were expected, but only {slice.Count} were received");
@@ -51,7 +51,7 @@ namespace QuantConnect.Algorithm.CSharp
 
         public override void OnEndOfAlgorithm()
         {
-            if (!_noDataPointsReceived)
+            if (_noDataPointsReceived)
             {
                 throw new Exception($"No points were received");
             }

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -193,7 +193,7 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(AddingData)]
         public Security AddData(Type dataType, Symbol underlying, Resolution? resolution = null, DateTimeZone timeZone = null, bool fillForward = false, decimal leverage = 1.0m)
         {
-            var symbol = QuantConnect.Symbol.CreateBase(dataType, underlying, Market.USA);
+            var symbol = QuantConnect.Symbol.CreateBase(dataType, underlying, underlying.ID.Market);
             return AddDataImpl(dataType, symbol, resolution, timeZone, fillForward, leverage);
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Before these changes, a user could not have custom data subscriptions with the same symbol but from different exchanges, since all the custom data subscriptions had as market `Market.USA`. With these changes, the custom data subscriptions will now have the market of the underlying security.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7495 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, users will be able to have multiple custom data subscriptions from different exchanges
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Since no regression test failed after these changes, there's no need to update the documentation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There was created a regression algorithm which created 4 subscriptions, were two of them were custom ones, but each of them had a different underlying. Every time an slice was received, it was asserted it contained values for all the subscriptions. Finally, at the end of the algorithm it was asserted at least one data point had been received.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
