### PR TITLE
Solve missing bug with TimeZones when creating Custom Data Securities

### DIFF
--- a/Algorithm.CSharp/CustomDataWorksWithDifferentExchangesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataWorksWithDifferentExchangesRegressionAlgorithm.cs
@@ -32,10 +32,18 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2014, 05, 03);
 
             var market1 = AddForex("EURUSD", Resolution.Hour, Market.FXCM);
-            AddData<ExampleCustomData>(market1.Symbol, Resolution.Hour, TimeZones.Utc, false);
+            var firstCustomSecurity = AddData<ExampleCustomData>(market1.Symbol, Resolution.Hour, TimeZones.Utc, false);
+            if (firstCustomSecurity.Exchange.TimeZone != TimeZones.Utc)
+            {
+                throw new Exception($"The time zone of security {firstCustomSecurity} should be {TimeZones.Utc}, but it was {firstCustomSecurity.Exchange.TimeZone}");
+            }
 
             var market2 = AddForex("EURUSD", Resolution.Hour, Market.Oanda);
-            AddData<ExampleCustomData>(market2.Symbol, Resolution.Hour, TimeZones.Utc, false);
+            var secondCustomSecurity = AddData<ExampleCustomData>(market2.Symbol, Resolution.Hour, TimeZones.Utc, false);
+            if (secondCustomSecurity.Exchange.TimeZone != TimeZones.Utc)
+            {
+                throw new Exception($"The time zone of security {secondCustomSecurity} should be {TimeZones.Utc}, but it was {secondCustomSecurity.Exchange.TimeZone}");
+            }
             _noDataPointsReceived = true;
         }
 
@@ -137,7 +145,7 @@ namespace QuantConnect.Algorithm.CSharp
                 Close = csv[4].ToDecimal()
             };
 
-            _hours = (_hours + 1) % 18;
+            _hours = (_hours + 1) % 22;
             return data;
         }
     }

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -263,7 +263,7 @@ namespace QuantConnect.Algorithm
             if (timeZone != null)
             {
                 // user set time zone
-                MarketHoursDatabase.SetEntryAlwaysOpen(Market.USA, alias, SecurityType.Base, timeZone);
+                MarketHoursDatabase.SetEntryAlwaysOpen(symbol.ID.Market, alias, SecurityType.Base, timeZone);
             }
 
             //Add this new generic data as a tradeable security:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
So far, since for the custom data securities, the key name of the MHDB entry was made using USA as market, the entry did not match the symbol name, so it had to be created a new entry in MHDB with NewYork TimeZone:
![imagen](https://github.com/QuantConnect/Lean/assets/47573394/c8095864-a46b-464b-97e9-ffff00499e3e)
Now, since we are using the same market of the underlying symbol when creating the MHDB entry, the Time Zones of the custom data securities are the given ones in the `AddData()` constructor.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7495
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change users will have custom data securities with the given time zones in the `AddData()` constructor.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Once the custom data securities were created, it was asserted the Time Zones of them were the given ones in the `AddData()` constructor.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
