### PR TITLE
Beta Indicator Supports QuoteBar

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -316,7 +316,7 @@ namespace QuantConnect.Algorithm
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         /// <returns>The Beta indicator for the given parameters</returns>
         [DocumentationAttribute(Indicators)]
-        public Beta B(Symbol target, Symbol reference, int period, Resolution? resolution = null, Func<IBaseData, TradeBar> selector = null)
+        public Beta B(Symbol target, Symbol reference, int period, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(QuantConnect.Symbol.None, $"B({period})", resolution);
             var beta = new Beta(name, target, reference, period);

--- a/Indicators/Beta.cs
+++ b/Indicators/Beta.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Indicators
     /// It is common practice to use the SPX index as a benchmark of the overall reference market when it comes to Beta 
     /// calculations.
     /// </summary>
-    public class Beta : TradeBarIndicator, IIndicatorWarmUpPeriodProvider
+    public class Beta : BarIndicator, IIndicatorWarmUpPeriodProvider
     {
         /// <summary>
         /// RollingWindow to store the data points of the target symbol
@@ -140,7 +140,7 @@ namespace QuantConnect.Indicators
         /// <param name="input">The input value of this indicator on this time step.
         /// It can be either from the target or the reference symbol</param>
         /// <returns>The beta value of the target used in relation with the reference</returns>
-        protected override decimal ComputeNextValue(TradeBar input)
+        protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             var inputSymbol = input.Symbol;
             if (inputSymbol == _targetSymbol)

--- a/Tests/Indicators/BetaIndicatorTests.cs
+++ b/Tests/Indicators/BetaIndicatorTests.cs
@@ -142,6 +142,21 @@ namespace QuantConnect.Tests.Indicators
             secondVolumeRenkoConsolidator.Dispose();
         }
 
+
+        [Test]
+        public void AcceptsQuoteBarsAsInput()
+        {
+            var indicator = new Beta("testBetaIndicator", Symbols.IBM, Symbols.SPY, 5);
+
+            for (var i = 10; i > 0; i--)
+            {
+                indicator.Update(new QuoteBar { Symbol = Symbols.IBM, Ask = new Bar(1, 2, 1, 500), Bid = new Bar(1, 2, 1, 500), Time = _reference.AddDays(1 + i) });
+                indicator.Update(new QuoteBar { Symbol = Symbols.SPY, Ask = new Bar(1, 2, 1, 500), Time = _reference.AddDays(1 + i) });
+            }
+
+            Assert.AreEqual(2, indicator.Samples);
+        }
+
         [Test]
         public void EqualBetaValue()
         {

--- a/Tests/Indicators/BetaIndicatorTests.cs
+++ b/Tests/Indicators/BetaIndicatorTests.cs
@@ -23,7 +23,7 @@ using static QuantConnect.Tests.Indicators.TestHelper;
 namespace QuantConnect.Tests.Indicators
 {
     [TestFixture]
-    public class BetaIndicatorTests : CommonIndicatorTests<TradeBar>
+    public class BetaIndicatorTests : CommonIndicatorTests<IBaseDataBar>
     {
         protected override string TestFileName => "bi_datatest.csv";
 
@@ -31,7 +31,7 @@ namespace QuantConnect.Tests.Indicators
 
         private DateTime _reference = new DateTime(2020, 1, 1);
 
-        protected override IndicatorBase<TradeBar> CreateIndicator()
+        protected override IndicatorBase<IBaseDataBar> CreateIndicator()
         {
             var indicator = new Beta("testBetaIndicator", "AMZN 2T", "SPX 2T", 5);
             return indicator;


### PR DESCRIPTION
#### Description
`Beta` indicator supports `QuoteBar`.
`Beta` must support `QuoteBar` from Forex/CDF and `QuoteBarConsolidator`.

#### Related Issue
Ref.: #6985 #7538

#### Motivation and Context
The `TradeBar` indicator type imposes limitations that we don't need, since `Beta` doesn't require the `Volume`.

#### Requires Documentation Change
Auto-gen.

#### How Has This Been Tested?
New unit test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`