### PR TITLE
Invalidate option orders during a stock split

### DIFF
--- a/Algorithm.CSharp/OptionOrdersOnSplitRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionOrdersOnSplitRegressionAlgorithm.cs
@@ -1,0 +1,134 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Util;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting that option orders are not allowed on split dates
+    /// </summary>
+    public class OptionOrdersOnSplitRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _aapl;
+
+        private OrderTicket _ticket;
+
+        public override void Initialize()
+        {
+            SetStartDate(2014, 6, 5);
+            SetEndDate(2014, 6, 11);
+            SetCash(100000);
+
+            _aapl = AddEquity("AAPL", Resolution.Minute, extendedMarketHours: true, dataNormalizationMode: DataNormalizationMode.Raw).Symbol;
+
+            var option = AddOption(_aapl, Resolution.Minute);
+            option.SetFilter(-1, +1, 0, 365);
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (slice.Splits.TryGetValue(_aapl, out var split))
+            {
+                Debug($"Split: {Time} - {split}");
+
+                if (split.Type == SplitType.SplitOccurred)
+                {
+                    var contract = Securities.Values
+                        .Where(x => x.Type.IsOption() && !x.Symbol.IsCanonical())
+                        .OrderBy(x => x.Symbol.ID.StrikePrice)
+                        .First();
+                    _ticket = MarketOrder(contract.Symbol, 1);
+
+                    if (_ticket.Status != OrderStatus.Invalid ||
+                        _ticket.SubmitRequest.Response.IsSuccess ||
+                        _ticket.SubmitRequest.Response.ErrorCode != OrderResponseErrorCode.OptionOrderOnStockSplit ||
+                        _ticket.SubmitRequest.Response.ErrorMessage != "Options orders are not allowed when a split occurred for its underlying stock")
+                    {
+                        throw new Exception(
+                            $"Expected invalid order ticket with error code {nameof(OrderResponseErrorCode.OptionOrderOnStockSplit)}, " +
+                            $"but received {_ticket.SubmitRequest.Response.ErrorCode} - {_ticket.SubmitRequest.Response.ErrorMessage}");
+                    }
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_ticket == null)
+            {
+                throw new Exception("Expected invalid order ticket with error code OptionOrderOnStockSplit, but no order was submitted");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 7082158;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-2.491"},
+            {"Tracking Error", "0.042"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -1176,7 +1176,9 @@ namespace QuantConnect.Algorithm
             }
 
             // Check for splits
-            if (request.SecurityType.IsOption() && CurrentSlice.Splits.TryGetValue(request.Symbol.Underlying, out _))
+            if (request.SecurityType.IsOption() &&
+                CurrentSlice.Splits.Count > 0 &&
+                CurrentSlice.Splits.TryGetValue(request.Symbol.Underlying, out _))
             {
                 return OrderResponse.Error(request, OrderResponseErrorCode.OptionOrderOnStockSplit,
                     "Options orders are not allowed when a split occurred for its underlying stock");

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -1175,7 +1175,8 @@ namespace QuantConnect.Algorithm
                 throw new ArgumentException("Can not set a limit price using market combo orders");
             }
 
-            // Check for splits
+            // Check for splits. Option are selected before the security price is split-adjusted, so in this time step
+            // we don't allow option orders to make sure they are properly filtered using the right security price.
             if (request.SecurityType.IsOption() &&
                 CurrentSlice.Splits.Count > 0 &&
                 CurrentSlice.Splits.TryGetValue(request.Symbol.Underlying, out _))

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -1175,6 +1175,13 @@ namespace QuantConnect.Algorithm
                 throw new ArgumentException("Can not set a limit price using market combo orders");
             }
 
+            // Check for splits
+            if (request.SecurityType.IsOption() && CurrentSlice.Splits.TryGetValue(request.Symbol.Underlying, out _))
+            {
+                return OrderResponse.Error(request, OrderResponseErrorCode.OptionOrderOnStockSplit,
+                    "Options orders are not allowed when a split occurred for its underlying stock");
+            }
+
             // passes all initial order checks
             return OrderResponse.Success(request);
         }

--- a/Common/Orders/OrderResponseErrorCode.cs
+++ b/Common/Orders/OrderResponseErrorCode.cs
@@ -188,6 +188,11 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Exercise time before expiry for European options (-33)
         /// </summary>
-        EuropeanOptionNotExpiredOnExercise = -33
+        EuropeanOptionNotExpiredOnExercise = -33,
+
+        /// <summary>
+        /// Option order is invalid due to underlying stock split (-34)
+        /// </summary>
+        OptionOrderOnStockSplit = -34
     }
 }

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -1655,6 +1655,7 @@ namespace QuantConnect.Tests.Algorithm
             algo.Transactions.SetOrderProcessor(_fakeOrderProcessor);
             msft = algo.Securities[Symbols.MSFT];
             msft.SetLeverage(leverage);
+            algo.SetCurrentSlice(new Slice(DateTime.MinValue, Enumerable.Empty<BaseData>(), DateTime.MinValue));
             return algo;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Options orders are not allowed during a stock split.

Reproducing the original issue:

- Add an equity and option with daily resolution:
    - Make sure there is data for the options on the day of the split or use one of the contracts in the `Securities` collection
- Place an order on the same day the `SplitType.SplitOccurred` event is received in `OnData`
    - On this time step, the order of events is as follows:
        1. Universe selection happens [here](https://github.com/jhonabreul/Lean/blob/f5d4bc4f7b7e29f12a688fbb1720c4172dca21d8/Engine/AlgorithmManager.cs#L177-L178)
        2. Security price is split-adjusted [here](https://github.com/jhonabreul/Lean/blob/f5d4bc4f7b7e29f12a688fbb1720c4172dca21d8/Engine/AlgorithmManager.cs#L397) so the strike filter in the universe selection used the pre-split security price: the selected options have pre-split strikes.
        3. The order is placed for one of these contracts, and since there is an open order and eventually a position, the contract is [never removed](https://github.com/jhonabreul/Lean/blob/f5d4bc4f7b7e29f12a688fbb1720c4172dca21d8/Engine/DataFeeds/PendingRemovalsManager.cs#L54-L55) from the securities collection.

This is what is causing this old contract to still be available. This solves this types of problems by not allowing options orders on the same time step the underlying stock split is applied.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #7444 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Regression algorithm
- Unit test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
