### PR TITLE
Make sure algorithmstubs initializes python

### DIFF
--- a/Tests/Engine/DataFeeds/AlgorithmStub.cs
+++ b/Tests/Engine/DataFeeds/AlgorithmStub.cs
@@ -14,13 +14,13 @@
  *
 */
 
+using QuantConnect.Python;
 using QuantConnect.Algorithm;
 using QuantConnect.Securities;
 using System.Collections.Generic;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Tests.Common.Securities;
-using QuantConnect.Interfaces;
 
 namespace QuantConnect.Tests.Engine.DataFeeds
 {
@@ -44,6 +44,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var orderProcessor = new FakeOrderProcessor();
             orderProcessor.TransactionManager = Transactions;
             Transactions.SetOrderProcessor(orderProcessor);
+            PythonInitializer.Initialize();
             SetPandasConverter();
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Make sure the test algorithm stubs class initializes python before trying to set the pandas data converter which requires python

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Avoid users of the algorithm stubs like brokerage unit tests to need to handle python init
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
