### PR TITLE
Async universe selection

### DIFF
--- a/Algorithm.CSharp/AsynchronousUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AsynchronousUniverseRegressionAlgorithm.cs
@@ -1,36 +1,33 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
 */
 
-namespace QuantConnect.Securities
+namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
-    /// Filters a set of derivative symbols using the underlying price data.
+    /// Example algorithm using the asynchronous universe selection functionality
     /// </summary>
-    public interface IDerivativeSecurityFilter
+    public class AsynchronousUniverseRegressionAlgorithm : FundamentalRegressionAlgorithm
     {
         /// <summary>
-        /// Filters the input set of symbols represented by the universe 
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
         /// </summary>
-        /// <param name="universe">derivative symbols universe used in filtering</param>
-        /// <returns>The filtered set of symbols</returns>
-        IDerivativeSecurityFilterUniverse Filter(IDerivativeSecurityFilterUniverse universe);
+        public override void Initialize()
+        {
+            base.Initialize();
 
-        /// <summary>
-        /// True if this universe filter can run async in the data stack
-        /// </summary>
-        bool Asynchronous { get; set; }
+            UniverseSettings.Asynchronous = true;
+        }
     }
 }

--- a/Algorithm.CSharp/CoarseFineAsyncUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CoarseFineAsyncUniverseRegressionAlgorithm.cs
@@ -1,0 +1,98 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using QuantConnect.Interfaces;
+using System.Collections.Generic;
+using QuantConnect.Data.Fundamental;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Algorithm.Framework.Selection;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting that using separate coarse & fine selection with async universe settings is not allowed
+    /// </summary>
+    public class CoarseFineAsyncUniverseRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 11);
+
+            UniverseSettings.Asynchronous = true;
+
+            var threwException = false;
+            try
+            {
+                AddUniverse(CoarseSelectionFunction, FineSelectionFunction);
+            }
+            catch (ArgumentException)
+            {
+                threwException = true;
+                // expected
+            }
+
+            if (!threwException)
+            {
+                throw new Exception("Expected exception to be thrown for AddUniverse");
+            }
+
+            SetUniverseSelection(new FineFundamentalUniverseSelectionModel(CoarseSelectionFunction, FineSelectionFunction));
+        }
+
+        private IEnumerable<Symbol> CoarseSelectionFunction(IEnumerable<CoarseFundamental> coarse)
+        {
+            return Enumerable.Empty<Symbol>();
+        }
+
+        private IEnumerable<Symbol> FineSelectionFunction(IEnumerable<FineFundamental> fine)
+        {
+            return Enumerable.Empty<Symbol>();
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 0;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.Framework/Selection/FineFundamentalUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/FineFundamentalUniverseSelectionModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using Python.Runtime;
 using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.UniverseSelection;
-using QuantConnect.Securities;
 
 namespace QuantConnect.Algorithm.Framework.Selection
 {

--- a/Algorithm.Framework/Selection/FundamentalUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/FundamentalUniverseSelectionModel.cs
@@ -118,6 +118,10 @@ namespace QuantConnect.Algorithm.Framework.Selection
                 var universe = CreateCoarseFundamentalUniverse(algorithm);
                 if (_filterFineData)
                 {
+                    if (universe.UniverseSettings.Asynchronous.HasValue && universe.UniverseSettings.Asynchronous.Value)
+                    {
+                        throw new ArgumentException("Asynchronous universe setting is not supported for coarse & fine selections, please use the new Fundamental single pass selection");
+                    }
 #pragma warning disable CS0618 // Type or member is obsolete
                     universe = new FineFundamentalFilteredUniverse(universe, fine => SelectFine(algorithm, fine));
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/Algorithm.Framework/Selection/FundamentalUniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/FundamentalUniverseSelectionModel.py
@@ -44,6 +44,8 @@ class FundamentalUniverseSelectionModel:
         else:
             universe = self.CreateCoarseFundamentalUniverse(algorithm)
             if self.filterFineData:
+                if universe.UniverseSettings.Asynchronous:
+                    raise ValueError("Asynchronous universe setting is not supported for coarse & fine selections, please use the new Fundamental single pass selection")
                 universe = FineFundamentalFilteredUniverse(universe, lambda fine: self.SelectFine(algorithm, fine))
             return [universe]
 

--- a/Algorithm.Python/AsynchronousUniverseRegressionAlgorithm.py
+++ b/Algorithm.Python/AsynchronousUniverseRegressionAlgorithm.py
@@ -1,0 +1,24 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+from FundamentalRegressionAlgorithm import FundamentalRegressionAlgorithm
+
+### <summary>
+### Example algorithm using the asynchronous universe selection functionality
+### </summary>
+class AsynchronousUniverseRegressionAlgorithm(FundamentalRegressionAlgorithm):
+
+    def Initialize(self):
+        super().Initialize()
+        self.UniverseSettings.Asynchronous = True

--- a/Algorithm.Python/CoarseFineAsyncUniverseRegressionAlgorithm.py
+++ b/Algorithm.Python/CoarseFineAsyncUniverseRegressionAlgorithm.py
@@ -1,0 +1,46 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression algorithm asserting that using separate coarse & fine selection with async universe settings is not allowed
+### </summary>
+class CoarseFineAsyncUniverseRegressionAlgorithm(QCAlgorithm):
+
+    def Initialize(self):
+        '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+
+        self.SetStartDate(2013, 10, 7)
+        self.SetEndDate(2013, 10, 11)
+
+        self.UniverseSettings.Asynchronous = True
+
+        threw_exception = False
+        try:
+            self.AddUniverse(self.CoarseSelectionFunction, self.FineSelectionFunction)
+        except:
+            # expected
+            threw_exception = True
+            pass
+
+        if not threw_exception:
+            raise ValueError("Expected exception to be thrown for AddUniverse")
+
+        self.SetUniverseSelection(FineFundamentalUniverseSelectionModel(self.CoarseSelectionFunction, self.FineSelectionFunction))
+
+    def CoarseSelectionFunction(self, coarse):
+        return []
+
+    def FineSelectionFunction(self, fine):
+        return []

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1851,7 +1851,10 @@ namespace QuantConnect.Algorithm
                 if (!UniverseManager.ContainsKey(symbol))
                 {
                     var canonicalConfig = configs.First();
-                    var settings = new UniverseSettings(canonicalConfig.Resolution, leverage, fillForward, extendedMarketHours, UniverseSettings.MinimumTimeInUniverse);
+                    var settings = new UniverseSettings(canonicalConfig.Resolution, leverage, fillForward, extendedMarketHours, UniverseSettings.MinimumTimeInUniverse)
+                    {
+                        Asynchronous = UniverseSettings.Asynchronous
+                    };
                     if (symbol.SecurityType.IsOption())
                     {
                         universe = new OptionChainUniverse((Option)security, settings);
@@ -1868,6 +1871,7 @@ namespace QuantConnect.Algorithm
                             DataNormalizationMode = dataNormalizationMode ?? UniverseSettings.GetUniverseNormalizationModeOrDefault(symbol.SecurityType),
                             ContractDepthOffset = (int)contractOffset,
                             SubscriptionDataTypes = dataTypes,
+                            Asynchronous = UniverseSettings.Asynchronous
                         };
                         ContinuousContractUniverse.AddConfigurations(SubscriptionManager.SubscriptionDataConfigService, continuousUniverseSettings, security.Symbol);
 

--- a/Common/Data/UniverseSelection/BaseDataCollection.cs
+++ b/Common/Data/UniverseSelection/BaseDataCollection.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Data.UniverseSelection
         /// <summary>
         /// Gets or sets the contracts selected by the universe
         /// </summary>
-        public IReadOnlyCollection<Symbol> FilteredContracts { get; set; }
+        public HashSet<Symbol> FilteredContracts { get; set; }
 
         /// <summary>
         /// Gets the data list
@@ -80,7 +80,7 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="data">The data to add to this collection</param>
         /// <param name="underlying">The associated underlying price data if any</param>
         /// <param name="filteredContracts">The contracts selected by the universe</param>
-        public BaseDataCollection(DateTime time, DateTime endTime, Symbol symbol, IEnumerable<BaseData> data = null, BaseData underlying = null, IReadOnlyCollection<Symbol> filteredContracts = null)
+        public BaseDataCollection(DateTime time, DateTime endTime, Symbol symbol, IEnumerable<BaseData> data = null, BaseData underlying = null, HashSet<Symbol> filteredContracts = null)
             : this(time, endTime, symbol, data != null ? data.ToList() : new List<BaseData>(), underlying, filteredContracts)
         {
         }
@@ -94,7 +94,7 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="data">The data to add to this collection</param>
         /// <param name="underlying">The associated underlying price data if any</param>
         /// <param name="filteredContracts">The contracts selected by the universe</param>
-        public BaseDataCollection(DateTime time, DateTime endTime, Symbol symbol, List<BaseData> data, BaseData underlying, IReadOnlyCollection<Symbol> filteredContracts)
+        public BaseDataCollection(DateTime time, DateTime endTime, Symbol symbol, List<BaseData> data, BaseData underlying, HashSet<Symbol> filteredContracts)
         {
             Symbol = symbol;
             Time = time;

--- a/Common/Data/UniverseSelection/ContinuousContractUniverse.cs
+++ b/Common/Data/UniverseSelection/ContinuousContractUniverse.cs
@@ -42,6 +42,12 @@ namespace QuantConnect.Data.UniverseSelection
         public override UniverseSettings UniverseSettings { get; }
 
         /// <summary>
+        /// True if this universe filter can run async in the data stack
+        /// TODO: see IContinuousSecurity.Mapped
+        /// </summary>
+        public override bool Asynchronous => false;
+
+        /// <summary>
         /// Creates a new instance
         /// </summary>
         public ContinuousContractUniverse(Security security, UniverseSettings universeSettings, bool liveMode, SubscriptionDataConfig universeConfig)
@@ -84,6 +90,7 @@ namespace QuantConnect.Data.UniverseSelection
 
             if (_currentSymbol != null)
             {
+                // TODO: this won't work with async universe selection
                 ((IContinuousSecurity)_security).Mapped = _currentSymbol;
                 yield return _currentSymbol;
             }

--- a/Common/Data/UniverseSelection/FineFundamentalFilteredUniverse.cs
+++ b/Common/Data/UniverseSelection/FineFundamentalFilteredUniverse.cs
@@ -38,6 +38,11 @@ namespace QuantConnect.Data.UniverseSelection
         public FineFundamentalFilteredUniverse(Universe universe, Func<IEnumerable<FineFundamental>, IEnumerable<Symbol>> fineSelector)
             : base(universe, universe.SelectSymbols)
         {
+            if (universe is CoarseFundamentalUniverse && universe.UniverseSettings.Asynchronous.HasValue && universe.UniverseSettings.Asynchronous.Value)
+            {
+                throw new ArgumentException("Asynchronous universe setting is not supported for coarse & fine selections, please use the new Fundamental single pass selection");
+            }
+
             FineFundamentalUniverse = new FineFundamentalUniverse(universe.UniverseSettings, fineSelector);
             FineFundamentalUniverse.SelectionChanged += (sender, args) => OnSelectionChanged(((SelectionEventArgs) args).CurrentSelection);
         }

--- a/Common/Data/UniverseSelection/FuturesChainUniverse.cs
+++ b/Common/Data/UniverseSelection/FuturesChainUniverse.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Future;
@@ -31,6 +30,21 @@ namespace QuantConnect.Data.UniverseSelection
     {
         private readonly UniverseSettings _universeSettings;
         private DateTime _cacheDate;
+
+        /// <summary>
+        /// True if this universe filter can run async in the data stack
+        /// </summary>
+        public override bool Asynchronous
+        {
+            get
+            {
+                if (UniverseSettings.Asynchronous.HasValue)
+                {
+                    return UniverseSettings.Asynchronous.Value;
+                }
+                return Future.ContractFilter.Asynchronous;
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FuturesChainUniverse"/> class
@@ -67,7 +81,7 @@ namespace QuantConnect.Data.UniverseSelection
         public override IEnumerable<Symbol> SelectSymbols(DateTime utcTime, BaseDataCollection data)
         {
             // date change detection needs to be done in exchange time zone
-            var localEndTime = data.EndTime.ConvertFromUtc(Future.Exchange.TimeZone);
+            var localEndTime = utcTime.ConvertFromUtc(Future.Exchange.TimeZone);
             var exchangeDate = localEndTime.Date;
             if (_cacheDate == exchangeDate)
             {

--- a/Common/Data/UniverseSelection/OptionChainUniverse.cs
+++ b/Common/Data/UniverseSelection/OptionChainUniverse.cs
@@ -35,6 +35,21 @@ namespace QuantConnect.Data.UniverseSelection
         private DateTime _cacheDate;
 
         /// <summary>
+        /// True if this universe filter can run async in the data stack
+        /// </summary>
+        public override bool Asynchronous
+        {
+            get
+            {
+                if (UniverseSettings.Asynchronous.HasValue)
+                {
+                    return UniverseSettings.Asynchronous.Value;
+                }
+                return Option.ContractFilter.Asynchronous;
+            }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="OptionChainUniverse"/> class
         /// </summary>
         /// <param name="option">The canonical option chain security</param>
@@ -71,7 +86,7 @@ namespace QuantConnect.Data.UniverseSelection
         public override IEnumerable<Symbol> SelectSymbols(DateTime utcTime, BaseDataCollection data)
         {
             // date change detection needs to be done in exchange time zone
-            var localEndTime = data.EndTime.ConvertFromUtc(Option.Exchange.TimeZone);
+            var localEndTime = utcTime.ConvertFromUtc(Option.Exchange.TimeZone);
             var exchangeDate = localEndTime.Date;
             if (_cacheDate == exchangeDate)
             {

--- a/Common/Data/UniverseSelection/UniverseSettings.cs
+++ b/Common/Data/UniverseSelection/UniverseSettings.cs
@@ -75,6 +75,11 @@ namespace QuantConnect.Data.UniverseSelection
         public List<Tuple<Type, TickType>> SubscriptionDataTypes;
 
         /// <summary>
+        /// True if universe selection can run asynchronous
+        /// </summary>
+        public bool? Asynchronous;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="UniverseSettings"/> class
         /// </summary>
         /// <param name="resolution">The resolution</param>
@@ -86,8 +91,9 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="dataMappingMode">The contract mapping mode to use for the security</param>
         /// <param name="contractDepthOffset">The continuous contract desired offset from the current front month.
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
+        /// <param name="asynchronous">True if universe selection can run asynchronous</param>
         public UniverseSettings(Resolution resolution, decimal leverage, bool fillForward, bool extendedMarketHours, TimeSpan minimumTimeInUniverse, DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted,
-            DataMappingMode dataMappingMode = DataMappingMode.OpenInterest, int contractDepthOffset = 0)
+            DataMappingMode dataMappingMode = DataMappingMode.OpenInterest, int contractDepthOffset = 0, bool? asynchronous = null)
         {
             Resolution = resolution;
             Leverage = leverage;
@@ -97,6 +103,7 @@ namespace QuantConnect.Data.UniverseSelection
             ExtendedMarketHours = extendedMarketHours;
             MinimumTimeInUniverse = minimumTimeInUniverse;
             DataNormalizationMode = dataNormalizationMode;
+            Asynchronous = asynchronous;
         }
 
         /// <summary>
@@ -113,6 +120,7 @@ namespace QuantConnect.Data.UniverseSelection
             MinimumTimeInUniverse = universeSettings.MinimumTimeInUniverse;
             DataNormalizationMode = universeSettings.DataNormalizationMode;
             SubscriptionDataTypes = universeSettings.SubscriptionDataTypes;
+            Asynchronous = universeSettings.Asynchronous;
         }
     }
 }

--- a/Common/Securities/EmptyContractFilter.cs
+++ b/Common/Securities/EmptyContractFilter.cs
@@ -27,6 +27,11 @@ namespace QuantConnect.Securities
     public class EmptyContractFilter : IDerivativeSecurityFilter
     {
         /// <summary>
+        /// True if this universe filter can run async in the data stack
+        /// </summary>
+        public bool Asynchronous { get; set; } = true;
+
+        /// <summary>
         /// Filters the input set of symbols represented by the universe
         /// </summary>
         /// <param name="universe">derivative symbols universe used in filtering</param>

--- a/Common/Securities/FuncSecurityDerivativeFilter.cs
+++ b/Common/Securities/FuncSecurityDerivativeFilter.cs
@@ -26,6 +26,11 @@ namespace QuantConnect.Securities
         private readonly Func<IDerivativeSecurityFilterUniverse, IDerivativeSecurityFilterUniverse> _filter;
 
         /// <summary>
+        /// True if this universe filter can run async in the data stack
+        /// </summary>
+        public bool Asynchronous { get; set; } = true;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="FuncSecurityDerivativeFilter"/> class
         /// </summary>
         /// <param name="filter">The functional implementation of the <see cref="Filter"/> method</param>

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -523,7 +523,7 @@ namespace QuantConnect.Securities.Option
         /// over market price</param>
         public void SetFilter(int minStrike, int maxStrike)
         {
-            SetFilter(universe => universe.Strikes(minStrike, maxStrike));
+            SetFilterImp(universe => universe.Strikes(minStrike, maxStrike));
         }
 
         /// <summary>
@@ -536,7 +536,7 @@ namespace QuantConnect.Securities.Option
         /// would exclude contracts expiring in more than 10 days</param>
         public void SetFilter(TimeSpan minExpiry, TimeSpan maxExpiry)
         {
-            SetFilter(universe => universe.Expiration(minExpiry, maxExpiry));
+            SetFilterImp(universe => universe.Expiration(minExpiry, maxExpiry));
         }
 
         /// <summary>
@@ -555,7 +555,7 @@ namespace QuantConnect.Securities.Option
         /// would exclude contracts expiring in more than 10 days</param>
         public void SetFilter(int minStrike, int maxStrike, TimeSpan minExpiry, TimeSpan maxExpiry)
         {
-            SetFilter(universe => universe
+            SetFilterImp(universe => universe
                 .Strikes(minStrike, maxStrike)
                 .Expiration(minExpiry, maxExpiry));
         }
@@ -576,7 +576,7 @@ namespace QuantConnect.Securities.Option
         /// would exclude contracts expiring in more than 10 days</param>
         public void SetFilter(int minStrike, int maxStrike, int minExpiryDays, int maxExpiryDays)
         {
-            SetFilter(universe => universe
+            SetFilterImp(universe => universe
                 .Strikes(minStrike, maxStrike)
                 .Expiration(minExpiryDays, maxExpiryDays));
         }
@@ -593,6 +593,7 @@ namespace QuantConnect.Securities.Option
                 var result = universeFunc(optionUniverse);
                 return result.ApplyTypesFilter();
             });
+            ContractFilter.Asynchronous = false;
         }
 
         /// <summary>
@@ -631,6 +632,7 @@ namespace QuantConnect.Securities.Option
                 }
                 return optionUniverse.ApplyTypesFilter();
             });
+            ContractFilter.Asynchronous = false;
         }
 
         /// <summary>
@@ -644,6 +646,16 @@ namespace QuantConnect.Securities.Option
             }
 
             base.SetDataNormalizationMode(mode);
+        }
+
+        private void SetFilterImp(Func<OptionFilterUniverse, OptionFilterUniverse> universeFunc)
+        {
+            ContractFilter = new FuncSecurityDerivativeFilter(universe =>
+            {
+                var optionUniverse = universe as OptionFilterUniverse;
+                var result = universeFunc(optionUniverse);
+                return result.ApplyTypesFilter();
+            });
         }
     }
 }

--- a/Common/Util/LinqExtensions.cs
+++ b/Common/Util/LinqExtensions.cs
@@ -309,7 +309,11 @@ namespace QuantConnect.Util
         /// <returns>True if there are any differences between the two sets, false otherwise</returns>
         public static bool AreDifferent<T>(this ISet<T> left, ISet<T> right)
         {
-            return left.Except(right).Any() || right.Except(left).Any();
+            if(ReferenceEquals(left, right))
+            {
+                return false;
+            }
+            return !left.SetEquals(right);
         }
 
         /// <summary>

--- a/Engine/DataFeeds/Enumerators/UniverseSelectionEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/UniverseSelectionEnumerator.cs
@@ -1,0 +1,92 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Linq;
+using QuantConnect.Data;
+using System.Collections;
+using System.Collections.Generic;
+using QuantConnect.Data.UniverseSelection;
+
+namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
+{
+    /// <summary>
+    /// Enumerator that performs universe selection
+    /// </summary>
+    public class UniverseSelectionEnumerator : IEnumerator<BaseData>
+    {
+        private BaseDataCollection _previous;
+        private readonly SubscriptionRequest _request;
+        private readonly IEnumerator<BaseData> _baseEnumerator;
+        private readonly TimeZoneOffsetProvider _offsetProvider;
+
+        /// <summary>
+        /// The current data point
+        /// </summary>
+        public BaseData Current { get; set; }
+        object IEnumerator.Current => Current;
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        public UniverseSelectionEnumerator(IEnumerator<BaseData> baseEnumerator, SubscriptionRequest request)
+        {
+            _request = request;
+            _baseEnumerator = baseEnumerator;
+            _offsetProvider = new TimeZoneOffsetProvider(request.Configuration.ExchangeTimeZone, request.StartTimeUtc, request.EndTimeUtc);
+        }
+
+        /// <summary>
+        /// Will move this enumerator next
+        /// </summary>
+        public bool MoveNext()
+        {
+            var result = _baseEnumerator.MoveNext();
+            Current = _baseEnumerator.Current;
+            if (result && Current is BaseDataCollection collection)
+            {
+                var timeUtc = _offsetProvider.ConvertToUtc(collection.EndTime);
+                var selection = _request.Universe.SelectSymbols(timeUtc, collection);
+                if (ReferenceEquals(selection, Universe.Unchanged))
+                {
+                    collection.FilteredContracts = _previous.FilteredContracts;
+                }
+                else
+                {
+                    collection.FilteredContracts = selection.ToHashSet();
+                }
+                _previous = collection;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Reset this enumerator
+        /// </summary>
+        public void Reset()
+        {
+            _previous = null;
+            _baseEnumerator.Reset();
+        }
+
+        /// <summary>
+        /// Dispose of this enumerator
+        /// </summary>
+        public void Dispose()
+        {
+            _baseEnumerator.Dispose();
+        }
+    }
+}

--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -180,7 +180,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                                 }
                                 else
                                 {
-                                    collection = new BaseDataCollection(frontierUtc, frontierUtc, subscription.Configuration.Symbol, packetData, packetBaseDataCollection?.Underlying, null);
+                                    collection = new BaseDataCollection(frontierUtc, frontierUtc, subscription.Configuration.Symbol, packetData, packetBaseDataCollection?.Underlying, packetBaseDataCollection?.FilteredContracts);
                                     if (universeData == null)
                                     {
                                         universeData = new Dictionary<Universe, BaseDataCollection>();

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -90,6 +90,7 @@ namespace QuantConnect.Tests
                 { "TrainingInitializeRegressionAlgorithm", AlgorithmStatus.RuntimeError },
                 { "OnOrderEventExceptionRegression", AlgorithmStatus.RuntimeError },
                 { "WarmUpAfterInitializeRegression", AlgorithmStatus.RuntimeError },
+                { "CoarseFineAsyncUniverseRegressionAlgorithm", AlgorithmStatus.Running },
                 { "BasicTemplateIndexDailyAlgorithm", AlgorithmStatus.Running },
                 { "BasicTemplateIndexOptionsDailyAlgorithm", AlgorithmStatus.Running },
                 { "ScaledRawDataNormalizationModeNotAllowedSecuritiesAlgorithm", AlgorithmStatus.Running }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Add support for async universe selection, which will happen ahead of time in the data stack for a performance improvement

```csharp
        public override void Initialize()
        {
            SetStartDate(2023, 5, 1);
            SetEndDate(2023, 10, 27);
            AddOption(AddEquity("SPY", Resolution.Minute).Symbol);
        }
        public override void OnData(Slice data)
        {
            if (!Portfolio.Invested)
            {
                SetHoldings(_spy, 1);
                Debug("Purchased Stock");
            }
            else
                Liquidate();
        }
```
```
Master
24.34 seconds at 15498k data points per second. Processing total of 377,286,337 data points.
22.84 seconds at 16521k data points per second. Processing total of 377,286,337 data points.
24.90 seconds at 15152k data points per second. Processing total of 377,286,337 data points.
Branch
15.71 seconds at 24019k data points per second. Processing total of 377,286,337 data points.
15.75 seconds at 23956k data points per second. Processing total of 377,286,337 data points.
15.66 seconds at 24086k data points per second. Processing total of 377,286,337 data points.
```


`AsynchronousUniverseRegressionAlgorithm` vs `FundamentalRegressionAlgorithm`
```
C# master
0.34 seconds at 232k data points per second. Processing total of 78,861 data points.
0.34 seconds at 230k data points per second. Processing total of 78,861 data points.
C# Async
0.24 seconds at 330k data points per second. Processing total of 78,861 data points.
0.26 seconds at 302k data points per second. Processing total of 78,861 data points.
Py master
0.50 seconds at 159k data points per second. Processing total of 78,861 data points.
0.53 seconds at 150k data points per second. Processing total of 78,861 data points.
Py Async
0.38 seconds at 206k data points per second. Processing total of 78,861 data points.
0.38 seconds at 207k data points per second. Processing total of 78,861 data points.
```
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See https://github.com/QuantConnect/Lean/issues/7553
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Peformance
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing unit & regression tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
