### PR TITLE
Use MHDB in VIX Futures Expiry Function

### DIFF
--- a/Common/Securities/Future/FuturesExpiryFunctions.cs
+++ b/Common/Securities/Future/FuturesExpiryFunctions.cs
@@ -405,15 +405,16 @@ namespace QuantConnect.Securities.Future
                     return priorBusinessDay.Add(TimeSpan.FromHours(21));
                 })
             },
-            // CBOE Volatility Index Futures (VIX): https://cfe.cboe.com/cfe-products/vx-cboe-volatility-index-vix-futures/contract-specifications
+            // CBOE Volatility Index Futures (VIX): https://www.cboe.com/tradable_products/vix/vix_futures/specifications/
             {Symbol.Create(Futures.Indices.VIX, SecurityType.Future, Market.CFE), (time =>
                 {
                     // Trading can occur up to 9:00 a.m. Eastern Time (ET) on the "Wednesday that is 30 days prior to
                     // the third Friday of the calendar month immediately following the month in which the contract expires".
                     var nextThirdFriday = FuturesExpiryUtilityFunctions.ThirdFriday(time.AddMonths(1));
                     var expiryDate = nextThirdFriday.AddDays(-30);
+                    var holidays = MarketHoursDatabase.FromDataFolder().GetEntry(Market.CFE, Futures.Indices.VIX, SecurityType.Future).ExchangeHours.Holidays;
                     // If the next third Friday or the Wednesday are holidays, then it is moved to the previous day.
-                    if (USHoliday.Dates.Contains(expiryDate) || USHoliday.Dates.Contains(nextThirdFriday))
+                    if (holidays.Contains(expiryDate) || holidays.Contains(nextThirdFriday))
                     {
                         expiryDate = expiryDate.AddDays(-1);
                     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Use MHDB instead of USHolidays to get the Holidays for VIX Futures expiry function
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Partially #7506 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, VIX Futures will have the correct contracts
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests for VIX Futures expiry function were ran
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
