### PR TITLE
Remove securities from algorithm collection

### DIFF
--- a/Algorithm.CSharp/AddRemoveOptionUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddRemoveOptionUniverseRegressionAlgorithm.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.Algorithm.CSharp
                 // things like manually added, auto added, internal, and any other boolean state we need to track against a single security)
                 throw new Exception("The underlying equity data should NEVER be removed in this algorithm because it was manually added");
             }
-            if (_expectedSecurities.AreDifferent(Securities.Keys.ToHashSet()))
+            if (_expectedSecurities.AreDifferent(Securities.Total.Select(x => x.Symbol).ToHashSet()))
             {
                 var expected = string.Join(Environment.NewLine, _expectedSecurities.OrderBy(s => s.ToString()));
                 var actual = string.Join(Environment.NewLine, Securities.Keys.OrderBy(s => s.ToString()));

--- a/Algorithm.CSharp/ContinuousFutureRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ContinuousFutureRegressionAlgorithm.cs
@@ -149,10 +149,10 @@ namespace QuantConnect.Algorithm.CSharp
                 throw new Exception($"Unexpected symbol changed events: {_mappings.Count}, was expecting {expectedMappingCounts}");
             }
 
-            var securities = Securities.Values.Where(sec => !sec.IsTradable && !sec.Symbol.IsCanonical() && sec.Symbol.SecurityType == SecurityType.Future).ToList();
+            var securities = Securities.Total.Where(sec => !sec.IsTradable && !sec.Symbol.IsCanonical() && sec.Symbol.SecurityType == SecurityType.Future).ToList();
             if (securities.Count != 1)
             {
-                throw new Exception("We should have a non tradable future contract security!");
+                throw new Exception($"We should have a single non tradable future contract security! found: {securities.Count}");
             }
         }
 

--- a/Algorithm.CSharp/DelistingEventsAlgorithm.cs
+++ b/Algorithm.CSharp/DelistingEventsAlgorithm.cs
@@ -20,6 +20,7 @@ using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 using QuantConnect.Interfaces;
+using QuantConnect.Data.UniverseSelection;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -34,6 +35,7 @@ namespace QuantConnect.Algorithm.CSharp
     {
         private bool _receivedDelistedWarningEvent;
         private bool _receivedDelistedEvent;
+        private int _receivedSecurityChangesEvent;
         private int _dataCount;
 
         /// <summary>
@@ -109,6 +111,17 @@ namespace QuantConnect.Algorithm.CSharp
             Debug($"OnOrderEvent(OrderEvent): {Time}: {orderEvent}");
         }
 
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            foreach (var removedSecurity in changes.RemovedSecurities)
+            {
+                if (removedSecurity.Symbol.Value == "AAA.1")
+                {
+                    _receivedSecurityChangesEvent++;
+                }
+            }
+        }
+
         public override void OnEndOfAlgorithm()
         {
             if (!_receivedDelistedEvent)
@@ -122,6 +135,10 @@ namespace QuantConnect.Algorithm.CSharp
             if (_dataCount != 13)
             {
                 throw new Exception($"Unexpected data count {_dataCount}. Expected 13");
+            }
+            if (_receivedSecurityChangesEvent != 1)
+            {
+                throw new Exception($"Did not receive expected security changes removal! Got {_receivedSecurityChangesEvent}");
             }
         }
 

--- a/Algorithm.CSharp/RegressionTests/Universes/ETFConstituentUniverseCompositeDelistingRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionTests/Universes/ETFConstituentUniverseCompositeDelistingRegressionAlgorithm.cs
@@ -103,8 +103,10 @@ namespace QuantConnect.Algorithm.CSharp
             }
 
             _universeAdded |= changes.AddedSecurities.Count >= _universeSymbolCount;
-            // Subtract 1 from universe Symbol count for AAPL, since it was manually added to the algorithm
-            _universeRemoved |= changes.RemovedSecurities.Count == _universeSymbolCount - 1 && UtcTime.Date >= _delistingDate && UtcTime.Date < EndDate;
+            // TODO: shouldn't be sending AAPL as a removed security since it was added by another unvierse
+            // if we added the etf subscription it will get delisted and send us a removal event
+            var adjusment = AddETFSubscription ? 0 : -1;
+            _universeRemoved |= changes.RemovedSecurities.Count == _universeSymbolCount + adjusment && UtcTime.Date >= _delistingDate && UtcTime.Date < EndDate;
         }
 
         public override void OnEndOfAlgorithm()

--- a/Algorithm.Python/ETFConstituentUniverseCompositeDelistingRegressionAlgorithm.py
+++ b/Algorithm.Python/ETFConstituentUniverseCompositeDelistingRegressionAlgorithm.py
@@ -57,7 +57,7 @@ class ETFConstituentUniverseCompositeDelistingRegressionAlgorithm(QCAlgorithm):
 
         self.universeAdded = self.universeAdded or len(changes.AddedSecurities) >= self.universeSymbolCount
         # Subtract 1 from universe Symbol count for AAPL, since it was manually added to the algorithm
-        self.universeRemoved = self.universeRemoved or (len(changes.RemovedSecurities) == self.universeSymbolCount - 1 and self.UtcTime.date() >= self.delistingDate and self.UtcTime.date() < self.EndDate.date())
+        self.universeRemoved = self.universeRemoved or (len(changes.RemovedSecurities) == self.universeSymbolCount and self.UtcTime.date() >= self.delistingDate and self.UtcTime.date() < self.EndDate.date())
 
     def OnEndOfAlgorithm(self):
         if not self.universeAdded:

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -26,7 +26,6 @@ using QuantConnect.Orders.Fills;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Option;
-using QuantConnect.Securities.Positions;
 using QuantConnect.Util;
 
 namespace QuantConnect.Brokerages.Backtesting
@@ -546,10 +545,6 @@ namespace QuantConnect.Brokerages.Backtesting
                     // Any other type of delisting
                     OnDelistingNotification(new DelistingNotificationEventArgs(delisting.Symbol));
                 }
-
-                // don't allow users to open a new position once we sent the liquidation order
-                security.IsTradable = false;
-                security.IsDelisted = true;
 
                 // the subscription are getting removed from the data feed because they end
                 // remove security from all universes

--- a/Common/Brokerages/TradierBrokerageModel.cs
+++ b/Common/Brokerages/TradierBrokerageModel.cs
@@ -37,9 +37,6 @@ namespace QuantConnect.Brokerages
             OrderType.StopLimit
         };
 
-        private static readonly EquityExchange EquityExchange =
-            new EquityExchange(MarketHoursDatabase.FromDataFolder().GetExchangeHours(Market.USA, null, SecurityType.Equity));
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrokerageModel"/> class
         /// </summary>
@@ -159,8 +156,6 @@ namespace QuantConnect.Brokerages
         /// <returns>True if the brokerage would be able to perform the execution, false otherwise</returns>
         public override bool CanExecuteOrder(Security security, Order order)
         {
-            EquityExchange.SetLocalDateTimeFrontier(security.Exchange.LocalTime);
-
             var cache = security.GetLastData();
             if (cache == null)
             {
@@ -168,7 +163,7 @@ namespace QuantConnect.Brokerages
             }
 
             // tradier doesn't support after hours trading
-            if (!EquityExchange.IsOpenDuringBar(cache.Time, cache.EndTime, false))
+            if (!security.Exchange.IsOpenDuringBar(cache.Time, cache.EndTime, false))
             {
                 return false;
             }

--- a/Common/Data/UniverseSelection/SecurityChanges.cs
+++ b/Common/Data/UniverseSelection/SecurityChanges.cs
@@ -184,13 +184,14 @@ namespace QuantConnect.Data.UniverseSelection
         /// <summary>
         /// Helper method to filter added and removed securities based on current settings
         /// </summary>
-        private IReadOnlyList<Security> GetFilteredList(IEnumerable<Security> source, IEnumerable<Security> secondSource = null)
+        private IReadOnlyList<Security> GetFilteredList(IReadOnlySet<Security> source, IReadOnlySet<Security> secondSource = null)
         {
-            if (secondSource != null)
+            IEnumerable<Security> enumerable = source;
+            if (secondSource != null && secondSource.Count > 0)
             {
-                source = source.Union(secondSource);
+                enumerable = enumerable.Union(secondSource);
             }
-            return source.Where(kvp => !FilterCustomSecurities || kvp.Type != SecurityType.Base)
+            return enumerable.Where(kvp => !FilterCustomSecurities || kvp.Type != SecurityType.Base)
                 .Select(kvp => kvp)
                 .OrderBy(security => security.Symbol.Value)
                 .ToList();

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -591,13 +591,7 @@ namespace QuantConnect.Securities
         public virtual void SetLocalTimeKeeper(LocalTimeKeeper localTimeKeeper)
         {
             _localTimeKeeper = localTimeKeeper;
-            Exchange.SetLocalDateTimeFrontier(localTimeKeeper.LocalTime);
-
-            _localTimeKeeper.TimeUpdated += (sender, args) =>
-            {
-                //Update the Exchange/Timer:
-                Exchange.SetLocalDateTimeFrontier(args.Time);
-            };
+            Exchange.SetLocalDateTimeFrontierProvider(localTimeKeeper);
         }
 
         /// <summary>

--- a/Common/Securities/SecurityExchange.cs
+++ b/Common/Securities/SecurityExchange.cs
@@ -14,10 +14,10 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using NodaTime;
+using System.Linq;
 using QuantConnect.Util;
+using System.Collections.Generic;
 
 namespace QuantConnect.Securities
 {
@@ -26,6 +26,8 @@ namespace QuantConnect.Securities
     /// </summary>
     public class SecurityExchange
     {
+        private LocalTimeKeeper _timeProvider;
+
         /// <summary>
         /// Gets the <see cref="SecurityExchangeHours"/> for this exchange
         /// </summary>
@@ -45,7 +47,7 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Time from the most recent data
         /// </summary>
-        public DateTime LocalTime { get; private set; }
+        public DateTime LocalTime => _timeProvider.LocalTime;
 
         /// <summary>
         /// Boolean property for quickly testing if the exchange is open.
@@ -70,10 +72,10 @@ namespace QuantConnect.Securities
         /// <summary>
         /// Set the current datetime in terms of the exchange's local time zone
         /// </summary>
-        /// <param name="newLocalTime">Most recent data tick</param>
-        public void SetLocalDateTimeFrontier(DateTime newLocalTime)
+        /// <param name="timeProvider">Most recent data tick</param>
+        public void SetLocalDateTimeFrontierProvider(LocalTimeKeeper timeProvider)
         {
-            LocalTime = newLocalTime;
+            _timeProvider = timeProvider;
         }
 
         /// <summary>

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -511,7 +511,7 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return Securities.Values.Sum(security => security.Holdings.TotalFees);
+                return Securities.Total.Sum(security => security.Holdings.TotalFees);
             }
         }
 
@@ -522,7 +522,7 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return Securities.Values.Sum(security => security.Holdings.Profit);
+                return Securities.Total.Sum(security => security.Holdings.Profit);
             }
         }
 
@@ -533,7 +533,7 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return Securities.Values.Sum(security => security.Holdings.NetProfit);
+                return Securities.Total.Sum(security => security.Holdings.NetProfit);
             }
         }
 
@@ -544,7 +544,7 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return Securities.Values.Sum(security => security.Holdings.TotalSaleVolume);
+                return Securities.Total.Sum(security => security.Holdings.TotalSaleVolume);
             }
         }
 

--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -142,9 +142,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             // universes (e.g. for ETF constituent universes, since the ETF itself is used to create
                             // the universe Symbol (and set as its underlying), once the ETF is delisted, the
                             // universe should cease to exist, since there are no more constituents of that ETF).
-                            if (subscription.IsUniverseSelectionSubscription && subscription.Current.Data is Delisting)
+                            if (subscription.Current.Data.DataType == MarketDataType.Auxiliary && subscription.Current.Data is Delisting delisting)
                             {
-                                subscription.Universes.Single().Dispose();
+                                if(subscription.IsUniverseSelectionSubscription)
+                                {
+                                    subscription.Universes.Single().Dispose();
+                                }
+                                else if(delisting.Type == DelistingType.Delisted)
+                                {
+                                    changes += _universeSelection.HandleDelisting(subscription.Current.Data, subscription.Configuration.IsInternalFeed);
+                                }
                             }
 
                             packet.Add(subscription.Current.Data);

--- a/Tests/Algorithm/AlgorithmLiveTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmLiveTradingTests.cs
@@ -42,6 +42,7 @@ namespace QuantConnect.Tests.Algorithm
             algorithm.SetLiveMode(false);
             var security = algorithm.AddEquity("SPY");
             security.Exchange = new SecurityExchange(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork));
+            security.Exchange.SetLocalDateTimeFrontierProvider(algorithm.TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new Tick { Value = 270m });
             algorithm.SetFinishedWarmingUp();
 

--- a/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
@@ -414,7 +414,8 @@ namespace QuantConnect.Tests.Common.Securities
             var model = GetModel(futureSecurity, out _futureMarginModel, algorithm.Portfolio);
 
             // set closed market for simpler math
-            futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 1));
+            var localTimeKeeper = new LocalTimeKeeper(new DateTime(2020, 2, 1), TimeZones.Utc);
+            futureSecurity.Exchange.SetLocalDateTimeFrontierProvider(localTimeKeeper);
 
             var quantity = algorithm.CalculateOrderQuantity(futureSecurity.Symbol, target);
 
@@ -446,7 +447,8 @@ namespace QuantConnect.Tests.Common.Securities
             var ticker = QuantConnect.Securities.Futures.Financials.EuroDollar;
             var futureSecurity = algorithm.AddFuture(ticker);
             // set closed market for simpler math
-            futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 1));
+            var localTimeKeeper = new LocalTimeKeeper(new DateTime(2020, 2, 1), TimeZones.Utc);
+            futureSecurity.Exchange.SetLocalDateTimeFrontierProvider(localTimeKeeper);
             Update(futureSecurity, 100, algorithm);
             var model = GetModel(futureSecurity, out _futureMarginModel, algorithm.Portfolio);
 
@@ -478,7 +480,8 @@ namespace QuantConnect.Tests.Common.Securities
             var futureSecurity = algorithm.AddFuture(ticker);
             futureSecurity.BuyingPowerModel = GetModel(futureSecurity, out _futureMarginModel, algorithm.Portfolio);
             // set closed market for simpler math
-            futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 1));
+            var localTimeKeeper = new LocalTimeKeeper(new DateTime(2020, 2, 1), TimeZones.Utc);
+            futureSecurity.Exchange.SetLocalDateTimeFrontierProvider(localTimeKeeper);
             Update(futureSecurity, 100, algorithm);
             var expectedFinalQuantity = algorithm.CalculateOrderQuantity(futureSecurity.Symbol, target);
 
@@ -516,7 +519,8 @@ namespace QuantConnect.Tests.Common.Securities
             var ticker = QuantConnect.Securities.Futures.Financials.EuroDollar;
             var futureSecurity = algorithm.AddFuture(ticker);
             // set closed market for simpler math
-            futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 1));
+            var localTimeKeeper = new LocalTimeKeeper(new DateTime(2020, 2, 1), TimeZones.Utc);
+            futureSecurity.Exchange.SetLocalDateTimeFrontierProvider(localTimeKeeper);
             futureSecurity.Holdings.SetHoldings(100, 10 * Math.Sign(target));
             Update(futureSecurity, 100, algorithm);
 
@@ -556,7 +560,8 @@ namespace QuantConnect.Tests.Common.Securities
             var ticker = QuantConnect.Securities.Futures.Financials.EuroDollar;
             var futureSecurity = algorithm.AddFuture(ticker);
             // set closed market for simpler math
-            futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 1));
+            var localTimeKeeper = new LocalTimeKeeper(new DateTime(2020, 2, 1), TimeZones.Utc);
+            futureSecurity.Exchange.SetLocalDateTimeFrontierProvider(localTimeKeeper);
             futureSecurity.Holdings.SetHoldings(100, 10 * -1 * Math.Sign(target));
             Update(futureSecurity, 100, algorithm);
 
@@ -600,7 +605,8 @@ namespace QuantConnect.Tests.Common.Securities
             Update(futureSecurity, 100, algorithm);
             var model = GetModel(futureSecurity, out _futureMarginModel, algorithm.Portfolio);
             // Close market
-            futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 1));
+            var localTimeKeeper = new LocalTimeKeeper(new DateTime(2020, 2, 1), TimeZones.Utc);
+            futureSecurity.Exchange.SetLocalDateTimeFrontierProvider(localTimeKeeper);
 
             var quantityClosedMarket = algorithm.CalculateOrderQuantity(futureSecurity.Symbol, target);
             Assert.AreEqual(quantityClosedMarket.DiscretelyRoundBy(lotSize), quantityClosedMarket,
@@ -619,7 +625,7 @@ namespace QuantConnect.Tests.Common.Securities
             var maintenanceOvernight = _futureMarginModel.MaintenanceOvernightMarginRequirement;
 
             // Open market
-            futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 3));
+            localTimeKeeper.UpdateTime(new DateTime(2020, 2, 3));
 
             var fourtyPercentQuantity = (quantityClosedMarket * 0.4m).DiscretelyRoundBy(lotSize);
             futureSecurity.Holdings.SetHoldings(100, fourtyPercentQuantity);
@@ -655,7 +661,9 @@ namespace QuantConnect.Tests.Common.Securities
             _futureMarginModel.EnableIntradayMargins = true;
 
             // Open market at 10am
-            futureSecurity.Exchange.SetLocalDateTimeFrontier(localTime.AddHours(10));
+            var localTimeKeeper = timeKeeper.GetLocalTimeKeeper(TimeZones.Utc);
+            futureSecurity.Exchange.SetLocalDateTimeFrontierProvider(localTimeKeeper);
+            localTimeKeeper.UpdateTime(localTime.AddHours(10));
 
             var quantity = algorithm.CalculateOrderQuantity(futureSecurity.Symbol, target);
             var request = GetOrderRequest(futureSecurity.Symbol, quantity);
@@ -668,7 +676,7 @@ namespace QuantConnect.Tests.Common.Securities
                     new MarketOrder(futureSecurity.Symbol, quantity, DateTime.UtcNow))).IsSufficient);
 
             // Closing soon market
-            futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 3, 15,50, 0));
+            localTimeKeeper.UpdateTime(new DateTime(2020, 2, 3, 15,50, 0));
 
             Assert.IsFalse(model.HasSufficientBuyingPowerForOrder(
                 new HasSufficientBuyingPowerForOrderParameters(algorithm.Portfolio,
@@ -678,7 +686,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.IsTrue(futureSecurity.Exchange.ClosingSoon);
 
             // Close market
-            futureSecurity.Exchange.SetLocalDateTimeFrontier(new DateTime(2020, 2, 1));
+            localTimeKeeper.UpdateTime(new DateTime(2020, 2, 1));
             Assert.IsFalse(futureSecurity.Exchange.ExchangeOpen);
 
             Assert.IsFalse(model.HasSufficientBuyingPowerForOrder(

--- a/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/PatternDayTradingMarginBuyingPowerModelTests.cs
@@ -197,12 +197,13 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(openLeverage, model.GetLeverage(security));
             Assert.IsFalse(security.Exchange.ClosingSoon);
 
-            security.Exchange.SetLocalDateTimeFrontier(new DateTime(2016, 2, 16, 15, 50, 0));
+            var localTimeKeeper = TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork);
+            localTimeKeeper.UpdateTime(new DateTime(2016, 2, 16, 15, 50, 0).ConvertToUtc(TimeZones.NewYork));
             Assert.AreEqual(closedLeverage, model.GetLeverage(security));
             Assert.IsTrue(security.Exchange.ClosingSoon);
             Assert.IsTrue(security.Exchange.ExchangeOpen);
 
-            security.Exchange.SetLocalDateTimeFrontier(new DateTime(2016, 2, 16, 16, 0, 0));
+            localTimeKeeper.UpdateTime(new DateTime(2016, 2, 16, 16, 0, 0).ConvertToUtc(TimeZones.NewYork));
             Assert.IsFalse(security.Exchange.ExchangeOpen);
         }
 
@@ -360,7 +361,6 @@ namespace QuantConnect.Tests.Common.Securities
             );
             TimeKeeper.SetUtcDateTime(newLocalTime.ConvertToUtc(security.Exchange.TimeZone));
             security.BuyingPowerModel = buyingPowerModel;
-            security.Exchange.SetLocalDateTimeFrontier(newLocalTime);
             security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, newLocalTime, 100m));
             security.FeeModel = new ConstantFeeModel(0);

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -248,16 +248,16 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 // let's wait till it's remapped
                 if (securityChanges == 3)
                 {
-                    Assert.IsNotNull(_algorithm.Securities.Values.SingleOrDefault(sec => sec.IsTradable));
-                    Assert.AreEqual(3, _algorithm.Securities.Values.Count);
+                    Assert.IsNotNull(_algorithm.Securities.Total.SingleOrDefault(sec => sec.IsTradable));
+                    Assert.AreEqual(3, _algorithm.Securities.Total.Count);
 
-                    var result = LiveTradingResultHandler.GetHoldings(_algorithm.Securities.Values, _algorithm.SubscriptionManager.SubscriptionDataConfigService);
+                    var result = LiveTradingResultHandler.GetHoldings(_algorithm.Securities.Total, _algorithm.SubscriptionManager.SubscriptionDataConfigService);
                     // old future mapped contract is removed
                     Assert.AreEqual(2, result.Count);
                     Assert.IsTrue(result.TryGetValue(es.Symbol.ID.ToString(), out var holding));
                     Assert.IsTrue(result.TryGetValue(es.Mapped.ID.ToString(), out holding));
 
-                    Assert.AreEqual(0, LiveTradingResultHandler.GetHoldings(_algorithm.Securities.Values, _algorithm.SubscriptionManager.SubscriptionDataConfigService, onlyInvested: true).Count);
+                    Assert.AreEqual(0, LiveTradingResultHandler.GetHoldings(_algorithm.Securities.Total, _algorithm.SubscriptionManager.SubscriptionDataConfigService, onlyInvested: true).Count);
 
                     _algorithm.RemoveSecurity(es.Symbol);
                     // allow time for the exchange to pick up the selection point
@@ -265,10 +265,10 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 }
                 else if (securityChanges == 4)
                 {
-                    Assert.IsTrue(_algorithm.Securities.Values.All(sec => !sec.IsTradable));
-                    Assert.AreEqual(3, _algorithm.Securities.Values.Count);
+                    Assert.IsTrue(_algorithm.Securities.Total.All(sec => !sec.IsTradable));
+                    Assert.AreEqual(3, _algorithm.Securities.Total.Count);
 
-                    var result = LiveTradingResultHandler.GetHoldings(_algorithm.Securities.Values, _algorithm.SubscriptionManager.SubscriptionDataConfigService);
+                    var result = LiveTradingResultHandler.GetHoldings(_algorithm.Securities.Total, _algorithm.SubscriptionManager.SubscriptionDataConfigService);
                     Assert.AreEqual(0, result.Count);
 
                     // we got what we wanted shortcut unit test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Once a security has been delisted or no longer selected by any universe it will be remove from the main algorithm securities collection but kept in the new Total collection, this improves performance in long running backtests where security collection can get enumerated in different cases
- Minor refactor for security exchange local time to avoid having to set it explicitly

```
MASTER
	34.60 seconds at 1554k data points per second. Processing total of 53,786,087 data points.
	35.08 seconds at 1533k data points per second. Processing total of 53,786,087 data points.
	34.31 seconds at 1568k data points per second. Processing total of 53,786,087 data points.
BRANCH
	28.95 seconds at 1858k data points per second. Processing total of 53,786,087 data points.
	27.88 seconds at 1929k data points per second. Processing total of 53,786,087 data points.
	28.47 seconds at 1889k data points per second. Processing total of 53,786,087 data points.
```

Based on https://www.quantconnect.com/forum/discussion/10071/increasing-slowness-with-large-universe-option-backtests/p1
```csharp
        public override void Initialize()
        {
            SetStartDate(2013, 1, 1);
            SetEndDate(2023, 11, 1);
            UniverseSettings.Asynchronous = true;

            var underlying = AddEquity(UnderlyingTicker, Resolution.Hour).Symbol;
            var option = AddOption(underlying, Resolution.Hour);
            option.SetFilter(u => u.Expiration(0, 90).Strikes(30, 30));
        }

        public override void OnData(Slice slice)
        {
            IEnumerable<SecurityHolding> investedSecurities = Portfolio.Values.Where(sh => sh.Invested).OrderBy(x => x.Symbol.ID.ToString());
            int count = investedSecurities.Count();
            if (count > MaxInvested)
            {
                int countToLiquidate = count - MaxInvested;
                foreach (SecurityHolding securityHolding in investedSecurities)
                {
                    if (IsMarketOpen(securityHolding.Symbol))
                    {
                        --countToLiquidate;
                    }
                }
            }
            if (CurrentSlice.OptionChains.TryGetValue(OptionSymbol, out var chain))
            {
                chainSymbols.UnionWith(chain.Select(oc => oc.Symbol));
                foreach (OptionContract optionContract in chain.SkipWhile(contract => tradedSymbols.Contains(contract.Symbol)).OrderBy(x => x.Symbol.ID.ToString()))
                {
                    seenSymbols.Add(optionContract.Symbol);
                }
            }
        }
        public override void OnEndOfDay()
        {
            Log($"{(DateTime.UtcNow - dailyTracking).TotalSeconds}, {Portfolio.Count}, {Portfolio.Count(kvp => kvp.Value.Invested)}, {seenSymbols.Count()}, {tradedSymbols.Count()}, {chainSymbols.Count()}");
            dailyTracking = DateTime.UtcNow;
        }
```
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related https://github.com/QuantConnect/Lean/issues/7553
Related https://github.com/QuantConnect/Lean/issues/6790
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve speed and delisting handling
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing and performance tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
