### PR TITLE
Improves Error Handling in OptionPriceModelResult.Evaluate

### DIFF
--- a/Common/Securities/Option/QLOptionPriceModel.cs
+++ b/Common/Securities/Option/QLOptionPriceModel.cs
@@ -124,6 +124,21 @@ namespace QuantConnect.Securities.Option
                     return OptionPriceModelResult.None;
                 }
 
+                var dayCounter = new Actual365Fixed();
+                var securityExchangeHours = security.Exchange.Hours;
+                var maturityDate = AddDays(contract.Expiry.Date, Option.DefaultSettlementDays, securityExchangeHours);
+
+                // Get time until maturity (in year)
+                var maturity = dayCounter.yearFraction(contract.Time.Date, maturityDate);
+                if (maturity < 0)
+                {
+                    if (Log.DebuggingEnabled)
+                    {
+                        Log.Debug($"QLOptionPriceModel.Evaluate(). negative time ({maturity}) given for {contract.Symbol}. Time: {contract.Time.Date}. Maturity {maturityDate}");
+                    }
+                    return OptionPriceModelResult.None;
+                }
+
                 // setting up option pricing parameters
                 var optionSecurity = (Option)security;
                 var premium = (double)optionSecurity.Price;
@@ -140,13 +155,10 @@ namespace QuantConnect.Securities.Option
                 }
 
                 var calendar = new UnitedStates();
-                var dayCounter = new Actual365Fixed();
-                var securityExchangeHours = security.Exchange.Hours;
                 var settlementDate = AddDays(contract.Time.Date, Option.DefaultSettlementDays, securityExchangeHours);
                 var evaluationDate = contract.Time.Date;
                 // TODO: static variable
                 Settings.setEvaluationDate(evaluationDate);
-                var maturityDate = AddDays(contract.Expiry.Date, Option.DefaultSettlementDays, securityExchangeHours);
                 var underlyingQuoteValue = new SimpleQuote(spot);
 
                 var dividendYieldValue = new SimpleQuote(_dividendYieldEstimator.Estimate(security, slice, contract));
@@ -155,11 +167,9 @@ namespace QuantConnect.Securities.Option
                 var riskFreeRateValue = new SimpleQuote((double)_riskFreeRateEstimator.Estimate(security, slice, contract));
                 var riskFreeRate = new Handle<YieldTermStructure>(new FlatForward(0, calendar, riskFreeRateValue, dayCounter));
 
-                // Get time until maturity (in year) and discount factor by dividend and risk free rate
-                var maturity = riskFreeRate.link.dayCounter()
-                    .yearFraction(riskFreeRate.link.referenceDate(), maturityDate);
-                var dividendDiscount = dividendYield.link.discount(maturityDate);
-                var riskFreeDiscount = riskFreeRate.link.discount(maturityDate);
+                // Get discount factor by dividend and risk free rate using the maturity
+                var dividendDiscount = dividendYield.link.discount(maturity);
+                var riskFreeDiscount = riskFreeRate.link.discount(maturity);
                 var forwardPrice = spot * dividendDiscount / riskFreeDiscount;
 
                 // Initial guess for volatility by Brenner and Subrahmanyam (1988)
@@ -189,8 +199,7 @@ namespace QuantConnect.Securities.Option
                 option.setPricingEngine(_pricingEngineFunc(contract.Symbol, stochasticProcess));
 
                 // running calculations
-                // can return negative value in neighborhood of 0
-                var npv = Math.Max(0, EvaluateOption(option));
+                var npv = EvaluateOption(option);
 
                 BlackCalculator blackCalculator = null;
 
@@ -200,13 +209,13 @@ namespace QuantConnect.Securities.Option
                 {
                     impliedVol = option.impliedVolatility(premium, stochasticProcess);
                 }
-                catch
+                catch (Exception e)
                 {
                     // A Newton-Raphson optimization estimate of the implied volatility
                     impliedVol = ImpliedVolatilityEstimation(premium, initialGuess, maturity, riskFreeDiscount, forwardPrice, payoff, out blackCalculator);
                     if (Log.DebuggingEnabled)
                     {
-                        Log.Debug($"QLOptionPriceModel.Evaluate(). Cannot calculate Implied Volatility for {contract.Symbol}. Implied volatility from Newton-Raphson optimization: {impliedVol}. Premium: {premium}. Underlying price: {spot}. Initial guess volatility: {initialGuess}. Maturity: {maturity}. Risk Free: {riskFreeDiscount}. Forward price: {forwardPrice}.");
+                        Log.Debug($"QLOptionPriceModel.Evaluate(). Cannot calculate Implied Volatility for {contract.Symbol}. Implied volatility from Newton-Raphson optimization: {impliedVol}. Premium: {premium}. Underlying price: {spot}. Initial guess volatility: {initialGuess}. Maturity: {maturity}. Risk Free: {riskFreeDiscount}. Forward price: {forwardPrice}. {e.Message} {e.StackTrace}");
                     }
                 }
 
@@ -222,12 +231,16 @@ namespace QuantConnect.Securities.Option
                 {
                     double result;
                     var isApproximation = false;
+                    Exception exception = null;
+
                     try
                     {
                         result = greek();
                     }
-                    catch (Exception)
+                    catch (Exception err)
                     {
+                        exception = err;
+
                         if (!EnableGreekApproximation)
                         {
                             return 0.0m;
@@ -250,7 +263,7 @@ namespace QuantConnect.Securities.Option
                     {
                         if (Log.DebuggingEnabled)
                         {
-                            Log.Debug($"QLOptionPriceModel.Evaluate(). NaN or Infinity greek for {contract.Symbol}. Premium: {premium}. Underlying price: {spot}. Initial guess volatility: {initialGuess}. Maturity: {maturity}. Risk Free: {riskFreeDiscount}. Forward price: {forwardPrice}. Implied Volatility: {impliedVol}. Is Approximation? {isApproximation}");
+                            Log.Debug($"QLOptionPriceModel.Evaluate(). NaN or Infinity greek for {contract.Symbol}. Premium: {premium}. Underlying price: {spot}. Initial guess volatility: {initialGuess}. Maturity: {maturity}. Risk Free: {riskFreeDiscount}. Forward price: {forwardPrice}. Implied Volatility: {impliedVol}. Is Approximation? {isApproximation}. {exception?.Message} {exception?.StackTrace}");
                         }
 
                         return 0m;
@@ -260,7 +273,7 @@ namespace QuantConnect.Securities.Option
 
                     if (value == decimal.Zero && Log.DebuggingEnabled)
                     {
-                        Log.Debug($"QLOptionPriceModel.Evaluate(). Zero-value greek for {contract.Symbol}. Premium: {premium}. Underlying price: {spot}. Initial guess volatility: {initialGuess}. Maturity: {maturity}. Risk Free: {riskFreeDiscount}. Forward price: {forwardPrice}. Implied Volatility: {impliedVol}. Is Approximation? {isApproximation}");
+                        Log.Debug($"QLOptionPriceModel.Evaluate(). Zero-value greek for {contract.Symbol}. Premium: {premium}. Underlying price: {spot}. Initial guess volatility: {initialGuess}. Maturity: {maturity}. Risk Free: {riskFreeDiscount}. Forward price: {forwardPrice}. Implied Volatility: {impliedVol}. Is Approximation? {isApproximation}. {exception?.Message} {exception?.StackTrace}");
                         return value;
                     }
 
@@ -268,7 +281,7 @@ namespace QuantConnect.Securities.Option
                 }
 
                 // producing output with lazy calculations of greeks
-                return new OptionPriceModelResult(npv.SafeDecimalCast(),  // EvaluateOption ensure it is not NaN or Infinity
+                return new OptionPriceModelResult(npv,  // EvaluateOption ensure it is not NaN or Infinity
                             () => impliedVol.IsNaNOrInfinity() ? 0m : impliedVol.SafeDecimalCast(),
                             () => new Greeks(() => tryGetGreekOrReevaluate(() => option.delta(), (black) => black.delta(spot)),
                                             () => tryGetGreekOrReevaluate(() => option.gamma(), (black) => black.gamma(spot)),
@@ -279,7 +292,7 @@ namespace QuantConnect.Securities.Option
             }
             catch (Exception err)
             {
-                Log.Debug($"QLOptionPriceModel.Evaluate() error: {err.Message}");
+                Log.Debug($"QLOptionPriceModel.Evaluate() error: {err.Message} {(Log.DebuggingEnabled ? err.StackTrace : string.Empty)}");
                 return OptionPriceModelResult.None;
             }
         }
@@ -289,7 +302,7 @@ namespace QuantConnect.Securities.Option
         /// </summary>
         /// <param name="option"></param>
         /// <returns></returns>
-        private static double EvaluateOption(VanillaOption option)
+        private static decimal EvaluateOption(VanillaOption option)
         {
             try
             {
@@ -297,14 +310,15 @@ namespace QuantConnect.Securities.Option
 
                 if (double.IsNaN(npv) ||
                     double.IsInfinity(npv))
-                    npv = 0.0;
+                    return 0;
 
-                return npv;
+                // can return negative value in neighborhood of 0
+                return Math.Max(0, npv).SafeDecimalCast();
             }
             catch (Exception err)
             {
                 Log.Debug($"QLOptionPriceModel.EvaluateOption() error: {err.Message}");
-                return 0.0;
+                return 0;
             }
         }
 


### PR DESCRIPTION
#### Description
Use the maturity calculation to calculate dividend and risk free discount to prevent the `negative time` error.
Set evaluation date before every calculation.

Adds loggings to record the reference date which is set by the `Settings.setEvaluationDate` method.
Adds Exception Message and StackTrade to `DebuggingEnabled` messages.

#### Related Issue
Ref.: #7505 #7510

#### Motivation and Context
Bug fix

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`