### PR TITLE
Fix brokerage transaction handler null object access bug

### DIFF
--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -705,7 +705,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
             var orderTicket = order.ToOrderTicket(algorithm.Transactions);
 
-            SetPriceAdjustmentMode(order);
+            SetPriceAdjustmentMode(order, algorithm);
 
             _openOrders.AddOrUpdate(order.Id, order, (i, o) => order);
             _completeOrders.AddOrUpdate(order.Id, order, (i, o) => order);
@@ -796,7 +796,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             order.OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Close);
 
             // Set order price adjustment mode
-            SetPriceAdjustmentMode(order);
+            SetPriceAdjustmentMode(order, _algorithm);
 
             // update the ticket's internal storage with this new order reference
             ticket.SetOrder(order);
@@ -1293,9 +1293,9 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         /// <summary>
         /// Gets the price adjustment mode for the specified symbol from its subscription configurations
         /// </summary>
-        private void SetPriceAdjustmentMode(Order order)
+        private void SetPriceAdjustmentMode(Order order, IAlgorithm algorithm)
         {
-            if (_algorithm.LiveMode)
+            if (algorithm.LiveMode)
             {
                 // live trading always uses raw prices
                 order.PriceAdjustmentMode = DataNormalizationMode.Raw;
@@ -1304,7 +1304,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
             if (!_priceAdjustmentModes.TryGetValue(order.Symbol, out var mode))
             {
-                var configs = _algorithm.SubscriptionManager.SubscriptionDataConfigService
+                var configs = algorithm.SubscriptionManager.SubscriptionDataConfigService
                     .GetSubscriptionDataConfigs(order.Symbol, includeInternalConfigs: true);
                 if (configs.Count == 0)
                 {

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -2067,9 +2067,9 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
         {
             _algorithm.SetLiveMode(liveMode);
 
-            //Initializes the transaction handler
+            // The engine might fetch brokerage open orders before even initializing the transaction handler,
+            // so let's not initialize it here to simulate that scenario
             var transactionHandler = new TestBrokerageTransactionHandler();
-            transactionHandler.Initialize(_algorithm, new BacktestingBrokerage(_algorithm), new BacktestingResultHandler());
 
             // Add the security
             var security = _algorithm.AddSecurity(SecurityType.Forex, "CADUSD", dataNormalizationMode: dataNormalizationMode);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Brokerage open orders are being set before algorithm is set to the transaction handler, so `SetPriceAdjustmentMode` needs to get the algo to use just like `AddOpenOrder` does

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See https://github.com/QuantConnect/Lean/pull/7582
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Live algorithm deployment

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
