### PR TITLE
feat: ETFConstituentsModel overloading constructor

### DIFF
--- a/Algorithm.CSharp/ETFConstituentsFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/ETFConstituentsFrameworkAlgorithm.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
         }
 
-        private IEnumerable<Symbol> ETFConstituentsFilter(IEnumerable<ETFConstituentData> constituents)
+        private protected IEnumerable<Symbol> ETFConstituentsFilter(IEnumerable<ETFConstituentData> constituents)
         {
             // Get the 10 securities with the largest weight in the index
             return constituents.OrderByDescending(c => c.Weight).Take(8).Select(c => c.Symbol);

--- a/Algorithm.CSharp/ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm.cs
+++ b/Algorithm.CSharp/ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm.cs
@@ -13,12 +13,7 @@
  * limitations under the License.
 */
 
-using QuantConnect.Algorithm.Framework.Alphas;
-using QuantConnect.Algorithm.Framework.Portfolio;
 using QuantConnect.Algorithm.Framework.Selection;
-using QuantConnect.Data.UniverseSelection;
-using System;
-using System.Collections.Generic;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -31,7 +26,7 @@ namespace QuantConnect.Algorithm.CSharp
         {
             base.Initialize();
 
-            AddUniverseSelection(new ETFConstituentsUniverseSelectionModel("SPY", UniverseSettings, ETFConstituentsFilter));
+            SetUniverseSelection(new ETFConstituentsUniverseSelectionModel("SPY", UniverseSettings, ETFConstituentsFilter));
         }
     }
 }

--- a/Algorithm.CSharp/ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm.cs
+++ b/Algorithm.CSharp/ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm.cs
@@ -1,0 +1,48 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2023 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Data.UniverseSelection;
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Example algorithm of using ETFConstituentsUniverseSelectionModel with simple ticker
+    /// </summary>
+    public class ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm : ETFConstituentsFrameworkAlgorithm
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2020, 12, 1);
+            SetEndDate(2020, 12, 7);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+
+            AddUniverseSelection(new ETFConstituentsUniverseSelectionModel("SPY", UniverseSettings, ETFConstituentsFilter));
+
+            AddAlpha(new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, TimeSpan.FromDays(1)));
+
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+        }
+    }
+}

--- a/Algorithm.CSharp/ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm.cs
+++ b/Algorithm.CSharp/ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm.cs
@@ -27,22 +27,11 @@ namespace QuantConnect.Algorithm.CSharp
     /// </summary>
     public class ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm : ETFConstituentsFrameworkAlgorithm
     {
-        /// <summary>
-        /// 
-        /// </summary>
         public override void Initialize()
         {
-            SetStartDate(2020, 12, 1);
-            SetEndDate(2020, 12, 7);
-            SetCash(100000);
-
-            UniverseSettings.Resolution = Resolution.Daily;
+            base.Initialize();
 
             AddUniverseSelection(new ETFConstituentsUniverseSelectionModel("SPY", UniverseSettings, ETFConstituentsFilter));
-
-            AddAlpha(new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, TimeSpan.FromDays(1)));
-
-            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
         }
     }
 }

--- a/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.cs
@@ -72,6 +72,14 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
         /// </summary>
         /// <param name="etfSymbol">Symbol of the ETF to get constituents for</param>
+        public ETFConstituentsUniverseSelectionModel(Symbol etfSymbol)
+            : this(etfSymbol, null, default(Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>>))
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
+        /// </summary>
+        /// <param name="etfSymbol">Symbol of the ETF to get constituents for</param>
         /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         public ETFConstituentsUniverseSelectionModel(
@@ -79,8 +87,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
             UniverseSettings universeSettings = null,
             PyObject universeFilterFunc = null) :
             this(etfSymbol, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>())
-        {
-        }
+        { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
@@ -128,10 +135,18 @@ namespace QuantConnect.Algorithm.Framework.Selection
         /// <param name="universeSettings">Universe settings</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
         public ETFConstituentsUniverseSelectionModel(
-            string etfTicker, 
-            UniverseSettings universeSettings = null, 
+            string etfTicker,
+            UniverseSettings universeSettings = null,
             PyObject universeFilterFunc = null) :
             this(etfTicker, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>())
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
+        /// </summary>
+        /// <param name="etfTicker">The string ETF ticker symbol</param>
+        public ETFConstituentsUniverseSelectionModel(string etfTicker)
+            : this(etfTicker, null, default(Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>>))
         { }
 
         /// <summary>

--- a/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.cs
@@ -81,9 +81,9 @@ namespace QuantConnect.Algorithm.Framework.Selection
             UniverseSettings universeSettings,
             Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
         {
-            _etfSymbol = SymbolCache.TryGetSymbol(etfTicker, out var existTicker)
-                && existTicker.SecurityType == SecurityType.Equity
-                ? existTicker : Symbol.Create(etfTicker, SecurityType.Equity, Market.USA);
+            _etfSymbol = SymbolCache.TryGetSymbol(etfTicker, out var symbol)
+                && symbol.SecurityType == SecurityType.Equity
+                ? symbol : Symbol.Create(etfTicker, SecurityType.Equity, Market.USA);
 
             _universeSettings = universeSettings;
             _universeFilterFunc = universeFilterFunc;

--- a/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.cs
@@ -14,8 +14,8 @@
 */
 
 using System;
-using System.Collections.Generic;
 using Python.Runtime;
+using System.Collections.Generic;
 using QuantConnect.Data.UniverseSelection;
 
 namespace QuantConnect.Algorithm.Framework.Selection
@@ -29,9 +29,9 @@ namespace QuantConnect.Algorithm.Framework.Selection
         private readonly UniverseSettings _universeSettings;
         private readonly Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> _universeFilterFunc;
         private Universe _universe;
-        
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelection"/> class
+        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
         /// </summary>
         /// <param name="etfSymbol">Symbol of the ETF to get constituents for</param>
         /// <param name="universeSettings">Universe settings</param>
@@ -45,9 +45,9 @@ namespace QuantConnect.Algorithm.Framework.Selection
             _universeSettings = universeSettings;
             _universeFilterFunc = universeFilterFunc;
         }
-        
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelection"/> class
+        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
         /// </summary>
         /// <param name="etfSymbol">Symbol of the ETF to get constituents for</param>
         /// <param name="universeFilterFunc">Function to filter universe results</param>
@@ -57,9 +57,9 @@ namespace QuantConnect.Algorithm.Framework.Selection
             : this(etfSymbol, null, universeFilterFunc)
         {
         }
-        
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelection"/> class
+        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
         /// </summary>
         /// <param name="etfSymbol">Symbol of the ETF to get constituents for</param>
         /// <param name="universeSettings">Universe settings</param>
@@ -67,9 +67,9 @@ namespace QuantConnect.Algorithm.Framework.Selection
             : this(etfSymbol, universeSettings, default(Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>>))
         {
         }
-        
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelection"/> class
+        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
         /// </summary>
         /// <param name="etfSymbol">Symbol of the ETF to get constituents for</param>
         /// <param name="universeSettings">Universe settings</param>
@@ -81,7 +81,59 @@ namespace QuantConnect.Algorithm.Framework.Selection
             this(etfSymbol, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>())
         {
         }
-        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
+        /// </summary>
+        /// <param name="etfTicker">The string ETF ticker symbol</param>
+        /// <param name="universeSettings">Universe settings</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        public ETFConstituentsUniverseSelectionModel(
+            string etfTicker,
+            UniverseSettings universeSettings,
+            Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
+        {
+            _etfSymbol = SymbolCache.TryGetSymbol(etfTicker, out var existTicker)
+                && existTicker.SecurityType == SecurityType.Equity
+                ? existTicker : Symbol.Create(etfTicker, SecurityType.Equity, Market.USA);
+
+            _universeSettings = universeSettings;
+            _universeFilterFunc = universeFilterFunc;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
+        /// </summary>
+        /// <param name="etfTicker">The string ETF ticker symbol</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        public ETFConstituentsUniverseSelectionModel(
+            string etfTicker,
+            Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
+            : this(etfTicker, null, universeFilterFunc)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
+        /// </summary>
+        /// <param name="etfTicker">The string ETF ticker symbol</param>
+        /// <param name="universeSettings">Universe settings</param>
+        public ETFConstituentsUniverseSelectionModel(string etfTicker, UniverseSettings universeSettings = null)
+            : this(etfTicker, universeSettings, default(Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>>))
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
+        /// </summary>
+        /// <param name="etfTicker">The string ETF ticker symbol</param>
+        /// <param name="universeSettings">Universe settings</param>
+        /// <param name="universeFilterFunc">Function to filter universe results</param>
+        public ETFConstituentsUniverseSelectionModel(
+            string etfTicker, 
+            UniverseSettings universeSettings = null, 
+            PyObject universeFilterFunc = null) :
+            this(etfTicker, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>())
+        { }
+
         /// <summary>
         /// Creates a new ETF constituents universe using this class's selection function
         /// </summary>

--- a/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.cs
@@ -55,25 +55,6 @@ namespace QuantConnect.Algorithm.Framework.Selection
             Symbol etfSymbol,
             Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>> universeFilterFunc)
             : this(etfSymbol, null, universeFilterFunc)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
-        /// </summary>
-        /// <param name="etfSymbol">Symbol of the ETF to get constituents for</param>
-        /// <param name="universeSettings">Universe settings</param>
-        public ETFConstituentsUniverseSelectionModel(Symbol etfSymbol, UniverseSettings universeSettings = null)
-            : this(etfSymbol, universeSettings, default(Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>>))
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
-        /// </summary>
-        /// <param name="etfSymbol">Symbol of the ETF to get constituents for</param>
-        public ETFConstituentsUniverseSelectionModel(Symbol etfSymbol)
-            : this(etfSymbol, null, default(Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>>))
         { }
 
         /// <summary>
@@ -119,14 +100,6 @@ namespace QuantConnect.Algorithm.Framework.Selection
             : this(etfTicker, null, universeFilterFunc)
         { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
-        /// </summary>
-        /// <param name="etfTicker">The string ETF ticker symbol</param>
-        /// <param name="universeSettings">Universe settings</param>
-        public ETFConstituentsUniverseSelectionModel(string etfTicker, UniverseSettings universeSettings = null)
-            : this(etfTicker, universeSettings, default(Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>>))
-        { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
@@ -139,14 +112,6 @@ namespace QuantConnect.Algorithm.Framework.Selection
             UniverseSettings universeSettings = null,
             PyObject universeFilterFunc = null) :
             this(etfTicker, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>())
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ETFConstituentsUniverseSelectionModel"/> class
-        /// </summary>
-        /// <param name="etfTicker">The string ETF ticker symbol</param>
-        public ETFConstituentsUniverseSelectionModel(string etfTicker)
-            : this(etfTicker, null, default(Func<IEnumerable<ETFConstituentData>, IEnumerable<Symbol>>))
         { }
 
         /// <summary>

--- a/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.py
@@ -28,7 +28,7 @@ class ETFConstituentsUniverseSelectionModel(UniverseSelectionModel):
             universeFilterFunc: Function to filter universe results'''
         if type(etfSymbol) is str:
             symbol = SymbolCache.TryGetSymbol(etfSymbol, None)
-            if symbol[0]:
+            if symbol[0] and symbol[1].SecurityType == SecurityType.Equity:
                 self.etf_symbol = symbol[1]
             else:
                 self.etf_symbol = Symbol.Create(etfSymbol, SecurityType.Equity, Market.USA)

--- a/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.py
+++ b/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.py
@@ -26,7 +26,14 @@ class ETFConstituentsUniverseSelectionModel(UniverseSelectionModel):
             etfSymbol: Symbol of the ETF to get constituents for
             universeSettings: Universe settings
             universeFilterFunc: Function to filter universe results'''
-        self.etf_symbol = etfSymbol
+        if type(etfSymbol) is str:
+            symbol = SymbolCache.TryGetSymbol(etfSymbol, None)
+            if symbol[0]:
+                self.etf_symbol = symbol[1]
+            else:
+                self.etf_symbol = Symbol.Create(etfSymbol, SecurityType.Equity, Market.USA)
+        else:
+            self.etf_symbol = etfSymbol
         self.universe_settings = universeSettings
         self.universe_filter_function = universeFilterFunc
 

--- a/Algorithm.Python/ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm.py
+++ b/Algorithm.Python/ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm.py
@@ -21,14 +21,6 @@ from ETFConstituentsFrameworkAlgorithm import ETFConstituentsFrameworkAlgorithm
 class ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm(ETFConstituentsFrameworkAlgorithm):
 
     def Initialize(self):
-        self.SetStartDate(2020, 12, 1)
-        self.SetEndDate(2020, 12, 7)
-        self.SetCash(100000)
-
-        self.UniverseSettings.Resolution = Resolution.Daily
-
+        super().Initialize()
+        
         self.AddUniverseSelection(ETFConstituentsUniverseSelectionModel("SPY", self.UniverseSettings, self.ETFConstituentsFilter))
-
-        self.AddAlpha(ConstantAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(days=1)))
-
-        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())

--- a/Algorithm.Python/ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm.py
+++ b/Algorithm.Python/ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm.py
@@ -23,4 +23,4 @@ class ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm(ETFConstituen
     def Initialize(self):
         super().Initialize()
         
-        self.AddUniverseSelection(ETFConstituentsUniverseSelectionModel("SPY", self.UniverseSettings, self.ETFConstituentsFilter))
+        self.SetUniverseSelection(ETFConstituentsUniverseSelectionModel("SPY", self.UniverseSettings, self.ETFConstituentsFilter))

--- a/Algorithm.Python/ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm.py
+++ b/Algorithm.Python/ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm.py
@@ -1,0 +1,34 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2023 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+from Selection.ETFConstituentsUniverseSelectionModel import *
+from ETFConstituentsFrameworkAlgorithm import ETFConstituentsFrameworkAlgorithm
+
+### <summary>
+### Demonstration of using the ETFConstituentsUniverseSelectionModel with simple ticker
+### </summary>
+class ETFConstituentsFrameworkWithDifferentSelectionModelAlgorithm(ETFConstituentsFrameworkAlgorithm):
+
+    def Initialize(self):
+        self.SetStartDate(2020, 12, 1)
+        self.SetEndDate(2020, 12, 7)
+        self.SetCash(100000)
+
+        self.UniverseSettings.Resolution = Resolution.Daily
+
+        self.AddUniverseSelection(ETFConstituentsUniverseSelectionModel("SPY", self.UniverseSettings, self.ETFConstituentsFilter))
+
+        self.AddAlpha(ConstantAlphaModel(InsightType.Price, InsightDirection.Up, timedelta(days=1)))
+
+        self.SetPortfolioConstruction(EqualWeightingPortfolioConstructionModel())

--- a/Tests/Algorithm/Framework/Selection/ETFConstituentsUniverseSelectionModelTests.cs
+++ b/Tests/Algorithm/Framework/Selection/ETFConstituentsUniverseSelectionModelTests.cs
@@ -143,12 +143,12 @@ class ETFConstituentsFrameworkAlgorithm(QCAlgorithm):
                     1 => new ETFConstituentsUniverseSelectionModel(ticker, universeSettings),
                     2 => new ETFConstituentsUniverseSelectionModel(ticker, ETFConstituentsFilter),
                     3 => new ETFConstituentsUniverseSelectionModel(ticker, universeSettings, ETFConstituentsFilter),
-                    4 => new ETFConstituentsUniverseSelectionModel(ticker, universeSettings, (PyObject)null),
+                    4 => new ETFConstituentsUniverseSelectionModel(ticker, universeSettings, default(PyObject)),
                     5 => new ETFConstituentsUniverseSelectionModel(symbol),
                     6 => new ETFConstituentsUniverseSelectionModel(symbol, universeSettings),
                     7 => new ETFConstituentsUniverseSelectionModel(symbol, ETFConstituentsFilter),
                     8 => new ETFConstituentsUniverseSelectionModel(symbol, universeSettings, ETFConstituentsFilter),
-                    9 => new ETFConstituentsUniverseSelectionModel(symbol, universeSettings, (PyObject)null),
+                    9 => new ETFConstituentsUniverseSelectionModel(symbol, universeSettings, default(PyObject)),
                     _ => throw new ArgumentException("Not recognize number of operation")
                 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Additional constructor overloading for `ETFConstituentsUniverseSelectionModel` 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7590

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make it easier to use

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
