### PR TITLE
Index.IsTradable Can Be Set

### DIFF
--- a/Algorithm.CSharp/BasicTemplateTradableIndexAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateTradableIndexAlgorithm.cs
@@ -1,0 +1,92 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using QuantConnect.Data;
+using System.Collections.Generic;
+using QuantConnect.Orders;
+using System.Linq;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This example demonstrates how to add index asset types and change the tradable condition
+    /// </summary>
+    /// <meta name="tag" content="using data" />
+    /// <meta name="tag" content="benchmarks" />
+    /// <meta name="tag" content="indexes" />
+    public class BasicTemplateTradableIndexAlgorithm : BasicTemplateIndexAlgorithm
+    {
+        private OrderTicket _ticket;
+
+        /// <summary>
+        /// Initialize your algorithm and add desired assets.
+        /// </summary>
+        public override void Initialize()
+        {
+            base.Initialize();
+            Securities[Spx].IsTradable = true;
+        }
+
+        /// <summary>
+        /// Index EMA Cross trading underlying.
+        /// </summary>
+        public override void OnData(Slice slice)
+        {
+            base.OnData(slice);
+            _ticket ??= MarketOrder(Spx, 1);
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_ticket.Status.IsFill())
+            {
+                throw new Exception("Index is tradable.");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new()
+        {
+            {"Total Trades", "5"},
+            {"Average Win", "6.15%"},
+            {"Average Loss", "-0.01%"},
+            {"Compounding Annual Return", "434.741%"},
+            {"Drawdown", "3.400%"},
+            {"Expectancy", "589.124"},
+            {"Net Profit", "5.510%"},
+            {"Sharpe Ratio", "-6.336"},
+            {"Probabilistic Sharpe Ratio", "0.011%"},
+            {"Loss Rate", "50%"},
+            {"Win Rate", "50%"},
+            {"Profit-Loss Ratio", "1179.25"},
+            {"Alpha", "-0.226"},
+            {"Beta", "0.02"},
+            {"Annual Standard Deviation", "0.034"},
+            {"Annual Variance", "0.001"},
+            {"Information Ratio", "-7.032"},
+            {"Tracking Error", "0.107"},
+            {"Treynor Ratio", "-10.906"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$3000.00"},
+            {"Lowest Capacity Asset", "SPX XL80P3GHDZXQ|SPX 31"},
+            {"Portfolio Turnover", "24.13%"},
+            {"OrderListHash", "41644492e032f38d0d9be0915f09a03b"}
+        };
+    }
+}

--- a/Algorithm.Python/BasicTemplateTradableIndexAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateTradableIndexAlgorithm.py
@@ -1,0 +1,30 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+from AlgorithmImports import *
+from BasicTemplateIndexAlgorithm import BasicTemplateIndexAlgorithm
+
+class BasicTemplateTradableIndexAlgorithm(BasicTemplateIndexAlgorithm):
+    ticket = None
+    def Initialize(self) -> None:
+        super().Initialize()
+        self.Securities[self.spx].IsTradable = True;
+        
+    def OnData(self, data: Slice):
+        super().OnData(data)
+        if not self.ticket:
+            self.ticket = self.MarketOrder(self.spx, 1)
+
+    def OnEndOfAlgorithm(self) -> None:
+        if self.ticket.Status != OrderStatus.Filled:
+            raise Exception("Index is tradable.")

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -3485,7 +3485,8 @@ namespace QuantConnect
         {
             foreach (var security in securityChanges.AddedSecurities)
             {
-                security.IsTradable = true;
+                // Don't update the IsTradable flag for Index
+                security.IsTradable = security.Type != SecurityType.Index || security.IsTradable;
 
                 // uses TryAdd, so don't need to worry about duplicates here
                 algorithm.Securities.Add(security);

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -3485,8 +3485,7 @@ namespace QuantConnect
         {
             foreach (var security in securityChanges.AddedSecurities)
             {
-                // Don't update the IsTradable flag for Index
-                security.IsTradable = security.Type != SecurityType.Index || security.IsTradable;
+                security.IsTradable = true;
 
                 // uses TryAdd, so don't need to worry about duplicates here
                 algorithm.Securities.Add(security);

--- a/Common/Securities/Index/Index.cs
+++ b/Common/Securities/Index/Index.cs
@@ -27,12 +27,6 @@ namespace QuantConnect.Securities.Index
     public class Index : Security
     {
         /// <summary>
-        /// Gets or sets whether or not this security should be considered tradable
-        /// </summary>
-        /// <remarks>Index are non tradable always</remarks>
-        public override bool IsTradable => false;
-
-        /// <summary>
         /// Constructor for the INDEX security
         /// </summary>
         /// <param name="exchangeHours">Defines the hours this exchange is open</param>
@@ -67,6 +61,7 @@ namespace QuantConnect.Securities.Index
                 Securities.MarginInterestRateModel.Null
                 )
         {
+            IsTradable = false;   //Index are non tradable by default
             Holdings = new IndexHolding(this, currencyConverter);
         }
 
@@ -107,6 +102,7 @@ namespace QuantConnect.Securities.Index
                 Securities.MarginInterestRateModel.Null
                 )
         {
+            IsTradable = false;   //Index are non tradable by default
             Holdings = new IndexHolding(this, currencyConverter);
         }
     }

--- a/Common/Securities/SecurityService.cs
+++ b/Common/Securities/SecurityService.cs
@@ -190,9 +190,9 @@ namespace QuantConnect.Securities
 
             // if we're just creating this security and it only has an internal
             // feed, mark it as non-tradable since the user didn't request this data
-            if (!configList.IsInternalFeed)
+            if (security.IsTradable)
             {
-                security.IsTradable = true;
+                security.IsTradable = !configList.IsInternalFeed;
             }
 
             security.AddData(configList);


### PR DESCRIPTION
#### Description
Indices are not tradable. LEAN will not set it to `true`, but the users can for backtesting.

#### Motivation and Context
Give users more control in backtesting.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Current unit tests.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`