### PR TITLE
Update Minimum Price Variation of CME Oats futures in MHDB

### DIFF
--- a/Data/symbol-properties/symbol-properties-database.csv
+++ b/Data/symbol-properties/symbol-properties-database.csv
@@ -109,7 +109,7 @@ cbot,ZF,future,5-Year T-Note Futures,USD,1000.0,0.0078125,1.0
 cbot,ZL,future,Soybean Oil Futures,USD,60000.0,0.0001,1.0,,1,100
 cbot,ZM,future,Soybean Meal Futures,USD,100.0,0.1,1.0
 cbot,ZN,future,10-Year T-Note Futures,USD,1000.0,0.015625,1.0
-cbot,ZO,future,Oats Futures,USD,5000.0,0.25,1.0,,1,100
+cbot,ZO,future,Oats Futures,USD,5000.0,0.0025,1.0,,1,100
 cbot,ZS,future,Soybean Futures,USD,5000.0,0.0025,1.0,,1,100
 cbot,ZT,future,2-Year T-Note Futures,USD,2000,0.00390625,1.0
 cbot,ZW,future,Chicago SRW Wheat Futures,USD,5000.0,0.0025,1.0,,1,100

--- a/Tests/Common/Securities/PriceVariationModelsTests.cs
+++ b/Tests/Common/Securities/PriceVariationModelsTests.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Tests.Common.Securities.Equity
         [TestCase("SPY", SecurityType.Equity, Market.USA, DataNormalizationMode.SplitAdjusted)]
         [TestCase("EURUSD", SecurityType.Forex, Market.FXCM, DataNormalizationMode.Adjusted)]
         [TestCase("EURUSD", SecurityType.Forex, Market.FXCM, DataNormalizationMode.SplitAdjusted)]
+        [TestCase("ZO", SecurityType.Future, Market.CBOT, DataNormalizationMode.Adjusted)]
         public void CheckSecurityMinimumPriceVariation(string ticker, SecurityType securityType, string market, DataNormalizationMode mode)
         {
             var symbol = Symbol.Create(ticker, securityType, market);
@@ -53,6 +54,21 @@ namespace QuantConnect.Tests.Common.Securities.Equity
             actual = security.PriceVariationModel.GetMinimumPriceVariation(
                 new GetMinimumPriceVariationParameters(security, security.Price));
             Assert.AreEqual(adjutedEquity ? 0 : expected, actual);
+        }
+
+        [TestCase("ZO", SecurityType.Future, Market.CBOT, DataNormalizationMode.Adjusted, new float[] { 3.7025f, 3.72f, 3.6875f, 3.6425f, 3.5225f, 3.5125f, 3.47f, 3.46f, 3.445f, 3.4625f, 3.435f, 3.3575f })]
+        public void CheckMinimumPriceVariationWithData(string ticker, SecurityType securityType, string market, DataNormalizationMode mode, float[] data)
+        {
+            var symbol = Symbol.Create(ticker, securityType, market);
+            var security = GetSecurity(symbol, mode);
+            var minimumPriceVariation = (float)security.SymbolProperties.MinimumPriceVariation;
+
+            var lastPrice = data[0];
+            for(var index = 1; index< data.Length; index++)
+            {
+                Assert.IsTrue(Math.Round(Math.Abs(data[index] - lastPrice) % minimumPriceVariation) == 0);
+                lastPrice = data[index];
+            }
         }
 
         [TestCase(0.9, 1.123456789, 0.01)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Change minimum price variation of CME Oats futures, ZO, from `0.25` to `0.0025`
- Add unit tests to cover the changes
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7558
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change the SPDB will keep being updated
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was created a unit test that asserted the difference between the close prices of ZO were a multiples of the minimum price variation
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
