### PR TITLE
Fix Ultimate Oscillator divide by zero exception

### DIFF
--- a/Indicators/UltimateOscillator.cs
+++ b/Indicators/UltimateOscillator.cs
@@ -106,9 +106,16 @@ namespace QuantConnect.Indicators
             if (!IsReady)
                 return 50m;
 
-            var average1 = _sumTrueRange1.Current.Value != 0 ? _sumBuyingPressure1.Current.Value / _sumTrueRange1.Current.Value : _sumBuyingPressure1.Current.Value;
-            var average2 = _sumTrueRange2.Current.Value != 0 ? _sumBuyingPressure2.Current.Value / _sumTrueRange2.Current.Value : _sumBuyingPressure2.Current.Value;
-            var average3 = _sumTrueRange3.Current.Value != 0 ? _sumBuyingPressure3.Current.Value / _sumTrueRange3.Current.Value : _sumBuyingPressure3.Current.Value;
+            if (_sumTrueRange1.Current.Value == 0
+                || _sumTrueRange2.Current.Value == 0
+                || _sumTrueRange3.Current.Value == 0)
+            {
+                return Current.Value;
+            }
+
+            var average1 = _sumBuyingPressure1.Current.Value / _sumTrueRange1.Current.Value;
+            var average2 = _sumBuyingPressure2.Current.Value / _sumTrueRange2.Current.Value;
+            var average3 = _sumBuyingPressure3.Current.Value / _sumTrueRange3.Current.Value;
 
             return 100m * (4 * average1 + 2 * average2 + average3) / 7;
         }

--- a/Indicators/UltimateOscillator.cs
+++ b/Indicators/UltimateOscillator.cs
@@ -106,9 +106,9 @@ namespace QuantConnect.Indicators
             if (!IsReady)
                 return 50m;
 
-            var average1 = _sumBuyingPressure1.Current.Value / _sumTrueRange1.Current.Value;
-            var average2 = _sumBuyingPressure2.Current.Value / _sumTrueRange2.Current.Value;
-            var average3 = _sumBuyingPressure3.Current.Value / _sumTrueRange3.Current.Value;
+            var average1 = _sumTrueRange1.Current.Value != 0 ? _sumBuyingPressure1.Current.Value / _sumTrueRange1.Current.Value : _sumBuyingPressure1.Current.Value;
+            var average2 = _sumTrueRange2.Current.Value != 0 ? _sumBuyingPressure2.Current.Value / _sumTrueRange2.Current.Value : _sumBuyingPressure2.Current.Value;
+            var average3 = _sumTrueRange3.Current.Value != 0 ? _sumBuyingPressure3.Current.Value / _sumTrueRange3.Current.Value : _sumBuyingPressure3.Current.Value;
 
             return 100m * (4 * average1 + 2 * average2 + average3) / 7;
         }

--- a/Tests/Indicators/UltimateOscillatorTests.cs
+++ b/Tests/Indicators/UltimateOscillatorTests.cs
@@ -16,6 +16,8 @@
 using NUnit.Framework;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
+using System;
+using System.Linq;
 
 namespace QuantConnect.Tests.Indicators
 {
@@ -27,6 +29,23 @@ namespace QuantConnect.Tests.Indicators
             RenkoBarSize = 0.1m;
             VolumeRenkoBarSize = 10000000m;
             return new UltimateOscillator(7, 14, 28);
+        }
+
+        [TestCase(4f, 56)]
+        public void IndicatorWorksAsExpectedWhenPricesDontVary(float price, int n)
+        {
+            var prices = Enumerable.Repeat(price, n);
+            var indicator = CreateIndicator();
+            var time = new DateTime(2000, 5, 28);
+
+            var days = 1;
+            foreach (var p in prices)
+            {
+                Assert.DoesNotThrow(() => indicator.Update(new TradeBar() { Time=time.AddDays(days), Close = (decimal)p, Low = (decimal)p, High = (decimal)p, Value = (decimal)p}));
+                days++;
+            }
+
+            Assert.AreEqual((decimal)0, indicator.Current.Value);
         }
 
         protected override string TestFileName => "spy_ultosc.txt";

--- a/Tests/Indicators/UltimateOscillatorTests.cs
+++ b/Tests/Indicators/UltimateOscillatorTests.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Tests.Indicators
             return new UltimateOscillator(7, 14, 28);
         }
 
-        [TestCase(4f, 56)]
+        [TestCase(0f, 56)]
         public void IndicatorWorksAsExpectedWhenPricesDontVary(float price, int n)
         {
             var prices = Enumerable.Repeat(price, n);
@@ -45,7 +45,7 @@ namespace QuantConnect.Tests.Indicators
                 days++;
             }
 
-            Assert.AreEqual((decimal)0, indicator.Current.Value);
+            Assert.AreEqual((decimal)50, indicator.Current.Value);
         }
 
         protected override string TestFileName => "spy_ultosc.txt";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Ultimate Oscillator computes its values using the sum of True Range's and Buying Pressure's over certain periods of times. When the sum of the True Range's values was zero, it produced a Division by Zero exception. This could happen when the prices were the same or almost the same. Now, in those cases it returns the previous indicator value to avoid the exception.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7529 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, Ultimate Oscillator indicator won't throw any Division by Zero exceptions when computing the next value
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To ensure the changes fixed the bug, a unit test was done asserting no Division by Zero exceptions were thrown when computing the next value of the indicator, for a given sequence of repeated prices.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
