### PR TITLE
Fixes Parse Future Symbol

### DIFF
--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -211,12 +211,28 @@ namespace QuantConnect.Tests.Common
             Assert.AreEqual(expectedValue, result);
         }
 
-        [TestCase("VXZ2")]
-        public void GenerateFutureSymbolFromTickerMissingDecadeInfo(string ticker)
+        [TestCase("VXZ2", 2012, 19)]
+        [TestCase("VXZ2", null, 18)]
+        public void GenerateFutureSymbolFromTickerMissingDecadeInfo(string ticker, int? futureYear, int day)
         {
-            var result = SymbolRepresentation.ParseFutureSymbol(ticker, 2012);
+            var result = SymbolRepresentation.ParseFutureSymbol(ticker, futureYear);
+            // When the future year is not provided, we have an ambiguous case (2002, 2012, 1902, etc) and default 2000
+            Assert.AreEqual(new DateTime(futureYear ?? 2002, 12, day), result.ID.Date.Date);
+        }
 
-            Assert.AreEqual(new DateTime(2012, 12, 19), result.ID.Date.Date);
+        [TestCase("NQZ23")]
+        public void GenerateFutureSymbolFromTickerUnknownYear(string ticker)
+        {
+            var result = SymbolRepresentation.ParseFutureSymbol(ticker);
+            // When the future year is not provided, we have an ambiguous case (1923 or 2023) and default 2000
+            Assert.AreEqual(new DateTime(2023, 12, 15), result.ID.Date.Date);
+        }
+
+        [TestCase("NQZ99")]
+        public void GenerateFutureSymbolFromTickerExpiringBefore2000(string ticker)
+        {
+            var result = SymbolRepresentation.ParseFutureSymbol(ticker, 1999);
+            Assert.AreEqual(new DateTime(1999, 12, 17), result.ID.Date.Date);
         }
     }
 }

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -212,12 +212,12 @@ namespace QuantConnect.Tests.Common
         }
 
         [TestCase("VXZ2", 2012, 19)]
-        [TestCase("VXZ2", null, 18)]
+        [TestCase("VXZ2", null, 21)]
         public void GenerateFutureSymbolFromTickerMissingDecadeInfo(string ticker, int? futureYear, int day)
         {
             var result = SymbolRepresentation.ParseFutureSymbol(ticker, futureYear);
-            // When the future year is not provided, we have an ambiguous case (2002, 2012, 1902, etc) and default 2000
-            Assert.AreEqual(new DateTime(futureYear ?? 2002, 12, day), result.ID.Date.Date);
+            // When the future year is not provided, we have an ambiguous case (2002, 2012, 1902, etc) and default current decade 2020
+            Assert.AreEqual(new DateTime(futureYear ?? 2022, 12, day), result.ID.Date.Date);
         }
 
         [TestCase("NQZ23")]


### PR DESCRIPTION
#### Description
The `SymbolRepresentation.ParseFutureSymbol` method handles futures' symbols correctly. Contracts that expired before 2000 (e.g.: NQZ99) were assigned the year 2099.

Adds Unit Tests for ParseFutureSymbol:
- Ambiguous year with missing decade
- Non-ambiguous known year
- Expiring before 2000

#### Motivation and Context
Increase the scope of Symbol parsing.

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`