### PR TITLE
Solve race condition bug in LocalObjectStore

### DIFF
--- a/Engine/Storage/LocalObjectStore.cs
+++ b/Engine/Storage/LocalObjectStore.cs
@@ -531,12 +531,12 @@ namespace QuantConnect.Lean.Engine.Storage
                         // clear the dirty flag
                         kvp.Value.SetClean();
 
+                        // This kvp could have been deleted by the Delete() method
                         if (!_storage.Contains(kvp))
                         {
                             try
                             {
                                 FileHandler.Delete(filePath);
-                                return true;
                             }
                             catch
                             {

--- a/Engine/Storage/LocalObjectStore.cs
+++ b/Engine/Storage/LocalObjectStore.cs
@@ -373,8 +373,15 @@ namespace QuantConnect.Lean.Engine.Storage
             var filePath = PathForKey(path);
             if (FileHandler.Exists(filePath))
             {
-                FileHandler.Delete(filePath);
-                return true;
+                try
+                {
+                    FileHandler.Delete(filePath);
+                    return true;
+                }
+                catch
+                {
+                    // This try sentence is to prevent a race condition with the Delete within the PersisData() method
+                }
             }
 
             return wasInCache;
@@ -523,6 +530,19 @@ namespace QuantConnect.Lean.Engine.Storage
 
                         // clear the dirty flag
                         kvp.Value.SetClean();
+
+                        if (!_storage.Contains(kvp))
+                        {
+                            try
+                            {
+                                FileHandler.Delete(filePath);
+                                return true;
+                            }
+                            catch
+                            {
+                                // This try sentence is to prevent a race condition with the Delete() method
+                            }
+                        }
                     }
                 }
 

--- a/Tests/Common/Storage/LocalObjectStoreTests.cs
+++ b/Tests/Common/Storage/LocalObjectStoreTests.cs
@@ -374,7 +374,6 @@ namespace QuantConnect.Tests.Common.Storage
         public void SaveAndDelete()
         {
             string path;
-            var paths = new HashSet<string>();
             using (var store = new TestLocalObjectStore())
             {
                 store.Initialize(0, 0, "", new Controls() { PersistenceIntervalSeconds = 1});
@@ -860,6 +859,9 @@ namespace QuantConnect.Tests.Common.Storage
         {
             public override void WriteAllBytes(string path, byte[] data)
             {
+                // The thread sleeps for 1 second in order to align with the
+                // other thread that will try to delete this file (see SaveAndDelete()
+                // unit test)
                 Thread.Sleep(1000);
                 base.WriteAllBytes(path, data);
             }

--- a/Tests/Common/Storage/LocalObjectStoreTests.cs
+++ b/Tests/Common/Storage/LocalObjectStoreTests.cs
@@ -376,7 +376,7 @@ namespace QuantConnect.Tests.Common.Storage
             string path;
             using (var store = new TestLocalObjectStore())
             {
-                store.Initialize(0, 0, "", new Controls() { PersistenceIntervalSeconds = 1});
+                store.Initialize(0, 0, "", new Controls() { PersistenceIntervalSeconds = 1}, new TestFileHandler());
                 Assert.IsTrue(Directory.Exists("./LocalObjectStoreTests"));
                 var key = "ILove";
                 path = store.GetFilePath(key);
@@ -845,7 +845,12 @@ namespace QuantConnect.Tests.Common.Storage
 
             public override void Initialize(int userId, int projectId, string userToken, Controls controls)
             {
-                FileHandler = new TestFileHandler();
+                base.Initialize(userId, projectId, userToken, controls);
+            }
+
+            public void Initialize(int userId, int projectId, string userToken, Controls controls, FileHandler fileHandler)
+            {
+                FileHandler = fileHandler;
                 base.Initialize(userId, projectId, userToken, controls);
             }
             protected override bool PersistData()

--- a/Tests/Common/Storage/LocalObjectStoreTests.cs
+++ b/Tests/Common/Storage/LocalObjectStoreTests.cs
@@ -25,6 +25,7 @@ using QuantConnect.Research;
 using System.Collections.Generic;
 using QuantConnect.Configuration;
 using QuantConnect.Lean.Engine.Storage;
+using System.Threading;
 
 namespace QuantConnect.Tests.Common.Storage
 {
@@ -367,6 +368,26 @@ namespace QuantConnect.Tests.Common.Storage
 
                 Assert.IsFalse(File.Exists(path));
             }
+        }
+
+        [Test]
+        public void SaveAndDelete()
+        {
+            string path;
+            var paths = new HashSet<string>();
+            using (var store = new TestLocalObjectStore())
+            {
+                store.Initialize(0, 0, "", new Controls() { PersistenceIntervalSeconds = 1});
+                Assert.IsTrue(Directory.Exists("./LocalObjectStoreTests"));
+                var key = "ILove";
+                path = store.GetFilePath(key);
+                store.SaveBytes(key, new byte[] { 1 });
+                Thread.Sleep(2000);
+                store.Delete(key);
+
+                Assert.IsTrue(store.PersistDataCalled, "PersistData() was never called!");
+            }
+            Assert.IsFalse(File.Exists(path));
         }
 
         [TestCase(FileAccess.Read, false)]
@@ -822,10 +843,25 @@ namespace QuantConnect.Tests.Common.Storage
         private class TestLocalObjectStore : LocalObjectStore
         {
             public bool PersistDataCalled { get; set; }
+
+            public override void Initialize(int userId, int projectId, string userToken, Controls controls)
+            {
+                FileHandler = new TestFileHandler();
+                base.Initialize(userId, projectId, userToken, controls);
+            }
             protected override bool PersistData()
             {
                 PersistDataCalled = true;
                 return base.PersistData();
+            }
+        }
+
+        public class TestFileHandler : FileHandler
+        {
+            public override void WriteAllBytes(string path, byte[] data)
+            {
+                Thread.Sleep(1000);
+                base.WriteAllBytes(path, data);
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The bug was raised due to a race condition when writing a file and deleting it. In order to stop it, a check condition was added at the end of the PersistData() method to remove files that have just been deleted. It's worth to mention, that the try/catch sentence was added to prevent another race condition when deleting the same file at the same time in PersistData() and Delete() methods.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7632
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change users will be able to save files and then immediately delete them without any error
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was created a unit test that reproduces the mentioned race condition sleeping certain threads. Without the changes the test fails half of the times. As it is expected, after these changes, the test works correctly all of the times.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
