### PR TITLE
Fix bug in UniverseSelection.Top() method

### DIFF
--- a/Algorithm.CSharp/UniverseSelectionDefinitionsAlgorithm.cs
+++ b/Algorithm.CSharp/UniverseSelectionDefinitionsAlgorithm.cs
@@ -15,8 +15,10 @@
 */
 
 using System;
+using System.Collections.Generic;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -26,7 +28,7 @@ namespace QuantConnect.Algorithm.CSharp
     /// <meta name="tag" content="using data" />
     /// <meta name="tag" content="universes" />
     /// <meta name="tag" content="coarse universes" />
-    public class UniverseSelectionDefinitionsAlgorithm : QCAlgorithm
+    public class UniverseSelectionDefinitionsAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private SecurityChanges _changes = SecurityChanges.None;
         private bool _onSecuritiesChangedWasCalled;
@@ -34,16 +36,14 @@ namespace QuantConnect.Algorithm.CSharp
         public override void Initialize()
         {
             // subscriptions added via universe selection will have this resolution
-            UniverseSettings.Resolution = Resolution.Hour;
-            // force securities to remain in the universe for a minimm of 30 minutes
-            UniverseSettings.MinimumTimeInUniverse = TimeSpan.FromMinutes(30);
+            UniverseSettings.Resolution = Resolution.Daily;
 
             SetStartDate(2014, 03, 24);
             SetEndDate(2014, 03, 28);
             SetCash(100*1000);
 
-            // add universe for the top 50 stocks by dollar volume
-            AddUniverse(Universe.Top(50));
+            // add universe for the top 3 stocks by dollar volume
+            AddUniverse(Universe.Top(3));
         }
 
         public void OnData(TradeBars data)
@@ -84,5 +84,57 @@ namespace QuantConnect.Algorithm.CSharp
             _onSecuritiesChangedWasCalled = true;
             _changes = changes;
         }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 35417;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "7"},
+            {"Average Win", "0.00%"},
+            {"Average Loss", "0.00%"},
+            {"Compounding Annual Return", "-3.587%"},
+            {"Drawdown", "0.100%"},
+            {"Expectancy", "-0.439"},
+            {"Net Profit", "-0.050%"},
+            {"Sharpe Ratio", "-17.344"},
+            {"Sortino Ratio", "-17.344"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "50%"},
+            {"Win Rate", "50%"},
+            {"Profit-Loss Ratio", "0.12"},
+            {"Alpha", "-0.039"},
+            {"Beta", "0.017"},
+            {"Annual Standard Deviation", "0.002"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-0.747"},
+            {"Tracking Error", "0.092"},
+            {"Treynor Ratio", "-2.271"},
+            {"Total Fees", "$7.00"},
+            {"Estimated Strategy Capacity", "$1200000000.00"},
+            {"Lowest Capacity Asset", "QQQ RIWIV7K5Z9LX"},
+            {"Portfolio Turnover", "1.06%"},
+            {"OrderListHash", "395c2dd8d0a89ef1472497a641287eb1"}
+        };
     }
 }

--- a/Algorithm.CSharp/UniverseSelectionDefinitionsAlgorithm.cs
+++ b/Algorithm.CSharp/UniverseSelectionDefinitionsAlgorithm.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Algorithm.CSharp
     public class UniverseSelectionDefinitionsAlgorithm : QCAlgorithm
     {
         private SecurityChanges _changes = SecurityChanges.None;
+        private bool _onSecuritiesChangedWasCalled;
 
         public override void Initialize()
         {
@@ -37,8 +38,8 @@ namespace QuantConnect.Algorithm.CSharp
             // force securities to remain in the universe for a minimm of 30 minutes
             UniverseSettings.MinimumTimeInUniverse = TimeSpan.FromMinutes(30);
 
-            SetStartDate(2013, 10, 07);
-            SetEndDate(2013, 10, 11);
+            SetStartDate(2014, 03, 24);
+            SetEndDate(2014, 03, 28);
             SetCash(100*1000);
 
             // add universe for the top 50 stocks by dollar volume
@@ -70,8 +71,17 @@ namespace QuantConnect.Algorithm.CSharp
             _changes = SecurityChanges.None;
         }
 
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_onSecuritiesChangedWasCalled)
+            {
+                throw new Exception($"OnSecuritiesChanged() method was never called!");
+            }
+        }
+
         public override void OnSecuritiesChanged(SecurityChanges changes)
         {
+            _onSecuritiesChangedWasCalled = true;
             _changes = changes;
         }
     }

--- a/Algorithm.Python/UniverseSelectionDefinitionsAlgorithm.py
+++ b/Algorithm.Python/UniverseSelectionDefinitionsAlgorithm.py
@@ -23,18 +23,17 @@ class UniverseSelectionDefinitionsAlgorithm(QCAlgorithm):
 
     def Initialize(self):
         # subscriptions added via universe selection will have this resolution
-        self.UniverseSettings.Resolution = Resolution.Hour
-        # force securities to remain in the universe for a minimm of 30 minutes
-        self.UniverseSettings.MinimumTimeInUniverse = timedelta(minutes=30)
+        self.UniverseSettings.Resolution = Resolution.Daily
 
-        self.SetStartDate(2013,10,7)    # Set Start Date
-        self.SetEndDate(2013,10,11)     # Set End Date
+        self.SetStartDate(2014,3,24)    # Set Start Date
+        self.SetEndDate(2014,3,28)     # Set End Date
         self.SetCash(100000)            # Set Strategy Cash
 
-        # add universe for the top 50 stocks by dollar volume
-        self.AddUniverse(self.Universe.Top(50))
+        # add universe for the top 3 stocks by dollar volume
+        self.AddUniverse(self.Universe.Top(3))
 
         self.changes = None
+        self.onSecuritiesChangedWasCalled = False
 
     def OnData(self, data):
         if self.changes is None: return
@@ -51,7 +50,11 @@ class UniverseSelectionDefinitionsAlgorithm(QCAlgorithm):
 
         self.changes = None
 
-
     # this event fires whenever we have changes to our universe
     def OnSecuritiesChanged(self, changes):
         self.changes = changes
+        self.onSecuritiesChangedWasCalled = True
+
+    def OnEndOfAlgorithm(self):
+        if not self.onSecuritiesChangedWasCalled:
+            raise Exception("OnSecuritiesChanged() method was never called!")

--- a/Algorithm/UniverseDefinitions.cs
+++ b/Algorithm/UniverseDefinitions.cs
@@ -345,8 +345,7 @@ namespace QuantConnect.Algorithm
             universeSettings ??= _algorithm.UniverseSettings;
 
             var symbol = Symbol.Create("us-equity-dollar-volume-top-" + count, SecurityType.Equity, Market.USA);
-            var config = new SubscriptionDataConfig(typeof(Fundamentals), symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, true);
-            return new FuncUniverse(config, universeSettings, selectionData => (
+            return new FundamentalUniverse(universeSettings, selectionData => (
                 from c in selectionData.OfType<Fundamental>()
                 orderby c.DollarVolume descending
                 select c.Symbol).Take(count)

--- a/Algorithm/UniverseDefinitions.cs
+++ b/Algorithm/UniverseDefinitions.cs
@@ -346,7 +346,7 @@ namespace QuantConnect.Algorithm
 
             var symbol = Symbol.Create("us-equity-dollar-volume-top-" + count, SecurityType.Equity, Market.USA);
             return new FundamentalUniverse(universeSettings, selectionData => (
-                from c in selectionData.OfType<Fundamental>()
+                from c in selectionData
                 orderby c.DollarVolume descending
                 select c.Symbol).Take(count)
                 );

--- a/Algorithm/UniverseDefinitions.cs
+++ b/Algorithm/UniverseDefinitions.cs
@@ -345,7 +345,7 @@ namespace QuantConnect.Algorithm
             universeSettings ??= _algorithm.UniverseSettings;
 
             var symbol = Symbol.Create("us-equity-dollar-volume-top-" + count, SecurityType.Equity, Market.USA);
-            var config = new SubscriptionDataConfig(typeof(Fundamental), symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, true);
+            var config = new SubscriptionDataConfig(typeof(Fundamentals), symbol, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, true);
             return new FuncUniverse(config, universeSettings, selectionData => (
                 from c in selectionData.OfType<Fundamental>()
                 orderby c.DollarVolume descending


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The method `UniverseSelection.Top()` wasn't working since the config of the FuncUniverse returned instance was using `Fundamental` instead of `Fundamentals`, as it is used when creating a universe with a given selector. Now, `UniverseSelection.Top()` method returns a `FundamentalUniverse` instance to avoid this problem.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7637 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, users will be able to use `UniverseSelection.Top()` as expected
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`UniverseSelectionDefinitionAlgorithm.cs/.py` was updated to guarantee `UniverseSelection.Top()` was working as expected 
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
