### PR TITLE
Fix bug in GetLastKnownPrices() method

### DIFF
--- a/Algorithm.CSharp/MeanReversionPortfolioAlgorithm.cs
+++ b/Algorithm.CSharp/MeanReversionPortfolioAlgorithm.cs
@@ -63,7 +63,7 @@ namespace QuantConnect.DataLibrary.Tests
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 47;
+        public int AlgorithmHistoryDataPoints => 57;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/RiskParityPortfolioAlgorithm.cs
+++ b/Algorithm.CSharp/RiskParityPortfolioAlgorithm.cs
@@ -60,7 +60,7 @@ namespace QuantConnect.DataLibrary.Tests
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 509;
+        public int AlgorithmHistoryDataPoints => 519;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/RiskParityPortfolioWeightsCheckAlgorithm.cs
+++ b/Algorithm.CSharp/RiskParityPortfolioWeightsCheckAlgorithm.cs
@@ -99,7 +99,7 @@ namespace QuantConnect.DataLibrary.Tests
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 509;
+        public int AlgorithmHistoryDataPoints => 519;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -536,6 +536,37 @@ def getTickHistory(algorithm, symbol, start, end):
             Assert.AreEqual(1, lastKnownPrices.Count(data => data.GetType() == typeof(QuoteBar)));
         }
 
+        [TestCase(Resolution.Daily)]
+        [TestCase(Resolution.Minute)]
+        [TestCase(Resolution.Hour)]
+        public void GetLastKnownPricesUsesCorrectResolution(Resolution resolution)
+        {
+            var algorithm = GetAlgorithm(new DateTime(2013, 10, 8));
+
+            algorithm.SetSecurityInitializer(security =>
+            {
+                var lastKnownPrices = algorithm.GetLastKnownPrices(security).ToList();
+                var data = lastKnownPrices.Where(x => x.GetType() == typeof(TradeBar)).Single().ConvertInvariant<TradeBar>();
+                var expectedPeriod = new TimeSpan();
+                switch (resolution)
+                {
+                    case Resolution.Daily:
+                        expectedPeriod = TimeSpan.FromDays(1);
+                        break;
+                    case Resolution.Minute:
+                        expectedPeriod = TimeSpan.FromMinutes(1);
+                        break;
+                    case Resolution.Hour:
+                        expectedPeriod = TimeSpan.FromHours(1);
+                        break;
+                }
+
+                Assert.AreEqual(expectedPeriod, data.Period);
+            });
+
+            algorithm.AddEquity("SPY", resolution);
+        }
+
         [TestCase(Language.CSharp)]
         [TestCase(Language.Python)]
         public void GetLastKnownPricesCustomData(Language language)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The method `GetLastKnownPrices()` had a bug since when used within another method as a func, i.e.
```C#
SetSecurityInitializer(security => security.SetMarketPrice(GetLastKnownPrice(security)));
```
It returned data in Minute resolution when first called, even if the Resolution of the algo was a different one. Indeed, as the security wasn't present yet in `QCAlgorithm.Securities`, the method `GetResolution()` returned `UniverseSettings.Resolution`: https://github.com/QuantConnect/Lean/blob/master/Algorithm/QCAlgorithm.History.cs#L1076

With this change, the method `GetResolution()` checks no more if the security is already in `QCAlgorithm.Securities`, but it directly searchs for the SubscriptionDataConfig for it.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7359 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, users will have the correct amount of `AlgorithmHistoryDataPoints` in their algos as well as receive the data in the resolution they asked for when using `GetLastKnownPrices()` method
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was created a unit test that used the method `GetLastKnownPrices()` within a Func and finally asserted if the data received was in the expected resolution.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
