### PR TITLE
Add partial support for live algorithm redeployment with custom data

### DIFF
--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -418,7 +418,7 @@ namespace QuantConnect.Lean.Engine.Setup
 
                     // verify existing holding security type
                     Security security;
-                    if (!algorithm.Securities.TryGetValue(holding.Symbol, out security) && !AddUnrequestedSecurity(algorithm, holding.Symbol, holding.Type, out security))
+                    if (!GetOrAddUnrequestedSecurity(algorithm, holding.Symbol, holding.Type, out security))
                     {
                         continue;
                     }
@@ -459,7 +459,7 @@ namespace QuantConnect.Lean.Engine.Setup
             return true;
         }
 
-        private bool AddUnrequestedSecurity(IAlgorithm algorithm, Symbol symbol, SecurityType securityType, out Security security)
+        private bool GetOrAddUnrequestedSecurity(IAlgorithm algorithm, Symbol symbol, SecurityType securityType, out Security security)
         {
             if (!algorithm.Securities.TryGetValue(symbol, out security))
             {
@@ -523,7 +523,7 @@ namespace QuantConnect.Lean.Engine.Setup
             {
                 // verify existing holding security type
                 Security security;
-                if (!algorithm.Securities.TryGetValue(order.Symbol, out security) && !AddUnrequestedSecurity(algorithm, order.Symbol, order.SecurityType, out security))
+                if (!GetOrAddUnrequestedSecurity(algorithm, order.Symbol, order.SecurityType, out security))
                 {
                     continue;
                 }

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -630,9 +630,9 @@ namespace QuantConnect.Tests.Engine.Setup
                 get
                 {
                     yield return new TestCaseData(
-                            new Func<List<Holding>>(() => new List<Holding>()),
-                            new Func<List<Order>>(() => new List<Order>()), true);
-
+                        new Func<List<Holding>>(() => new List<Holding>()),
+                        new Func<List<Order>>(() => new List<Order>()), true);
+                    
                     yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
@@ -642,7 +642,7 @@ namespace QuantConnect.Tests.Engine.Setup
                         {
                             new LimitOrder(Symbols.SPY, 1, 1, DateTime.UtcNow)
                         }), true);
-
+                    
                     yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
@@ -652,7 +652,7 @@ namespace QuantConnect.Tests.Engine.Setup
                         {
                             new LimitOrder(Symbols.SPY_C_192_Feb19_2016, 1, 1, DateTime.UtcNow)
                         }), true);
-
+                    
                     yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
@@ -664,7 +664,7 @@ namespace QuantConnect.Tests.Engine.Setup
                             new LimitOrder(Symbols.SPY, 1, 1, DateTime.UtcNow),
                             new LimitOrder(Symbols.SPY_C_192_Feb19_2016, 1, 1, DateTime.UtcNow)
                         }), true);
-
+                    
                     yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
@@ -676,7 +676,7 @@ namespace QuantConnect.Tests.Engine.Setup
                             new LimitOrder(Symbols.SPY_C_192_Feb19_2016, 1, 1, DateTime.UtcNow),
                             new LimitOrder(Symbols.SPY, 1, 1, DateTime.UtcNow)
                         }), true);
-
+                    
                     yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
@@ -686,7 +686,7 @@ namespace QuantConnect.Tests.Engine.Setup
                         {
                             new LimitOrder(Symbols.SPY, 1, 1, DateTime.UtcNow),
                         }), true);
-
+                    
                     yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
@@ -696,7 +696,7 @@ namespace QuantConnect.Tests.Engine.Setup
                         {
                             new LimitOrder(Symbols.EURUSD, 1, 1, DateTime.UtcNow)
                         }), true);
-
+                    
                     yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
@@ -706,7 +706,7 @@ namespace QuantConnect.Tests.Engine.Setup
                         {
                             new LimitOrder(Symbols.BTCUSD, 1, 1, DateTime.UtcNow)
                         }), true);
-
+                    
                     yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
@@ -716,7 +716,7 @@ namespace QuantConnect.Tests.Engine.Setup
                         {
                             new LimitOrder(Symbols.Fut_SPY_Feb19_2016, 1, 1, DateTime.UtcNow)
                         }), true);
-
+                    
                     yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
@@ -726,11 +726,11 @@ namespace QuantConnect.Tests.Engine.Setup
                         {
                             new LimitOrder("XYZ", 1, 1, DateTime.UtcNow)
                         }), false);
-
+                    
                     yield return new TestCaseData(
                         new Func<List<Holding>>(() => { throw new Exception(); }),
                         new Func<List<Order>>(() => new List<Order>()), false);
-
+                    
                     yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>()),
                         new Func<List<Order>>(() => { throw new Exception(); }), false);

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -37,6 +37,7 @@ using QuantConnect.Tests.Common.Securities;
 using QuantConnect.Tests.Engine.DataFeeds;
 using QuantConnect.Util;
 using QuantConnect.Algorithm.CSharp;
+using System.Collections;
 
 namespace QuantConnect.Tests.Engine.Setup
 {
@@ -117,19 +118,19 @@ namespace QuantConnect.Tests.Engine.Setup
             Assert.Contains(Symbols.SPY, _algorithm.Securities.Select(x => x.Key).ToList());
         }
 
-        [Test, TestCaseSource(nameof(GetExistingHoldingsAndOrdersTestCaseData))]
+        [TestCaseSource(typeof(ExistingHoldingAndOrdersDataClass), nameof(ExistingHoldingAndOrdersDataClass.GetExistingHoldingsAndOrdersTestCaseData))]
         public void SecondExistingHoldingsAndOrdersResolution(Func<List<Holding>> getHoldings, Func<List<Order>> getOrders, bool expected)
         {
             ExistingHoldingsAndOrdersResolution(getHoldings, getOrders, expected, Resolution.Second);
         }
 
-        [Test, TestCaseSource(nameof(GetExistingHoldingsAndOrdersTestCaseData))]
+        [TestCaseSource(typeof(ExistingHoldingAndOrdersDataClass), nameof(ExistingHoldingAndOrdersDataClass.GetExistingHoldingsAndOrdersTestCaseData))]
         public void MinuteExistingHoldingsAndOrdersResolution(Func<List<Holding>> getHoldings, Func<List<Order>> getOrders, bool expected)
         {
             ExistingHoldingsAndOrdersResolution(getHoldings, getOrders, expected, Resolution.Minute);
         }
 
-        [Test, TestCaseSource(nameof(GetExistingHoldingsAndOrdersTestCaseData))]
+        [TestCaseSource(typeof(ExistingHoldingAndOrdersDataClass), nameof(ExistingHoldingAndOrdersDataClass.GetExistingHoldingsAndOrdersTestCaseData))]
         public void TickExistingHoldingsAndOrdersResolution(Func<List<Holding>> getHoldings, Func<List<Order>> getOrders, bool expected)
         {
             ExistingHoldingsAndOrdersResolution(getHoldings, getOrders, expected, Resolution.Tick);
@@ -169,7 +170,7 @@ namespace QuantConnect.Tests.Engine.Setup
             }
         }
 
-        [Test, TestCaseSource(nameof(GetExistingHoldingsAndOrdersTestCaseData))]
+        [TestCaseSource(typeof(ExistingHoldingAndOrdersDataClass), nameof(ExistingHoldingAndOrdersDataClass.GetExistingHoldingsAndOrdersTestCaseData))]
         public void ExistingHoldingsAndOrdersUniverseSettings(Func<List<Holding>> getHoldings, Func<List<Order>> getOrders, bool expected)
         {
             // Set our universe settings
@@ -232,34 +233,12 @@ namespace QuantConnect.Tests.Engine.Setup
             }
         }
 
-        [Test, TestCaseSource(nameof(GetExistingHoldingsAndOrdersTestCaseData))]
+        [TestCaseSource(typeof(ExistingHoldingAndOrdersDataClass),nameof(ExistingHoldingAndOrdersDataClass.GetExistingHoldingsAndOrdersTestCaseData))]
         public void LoadsExistingHoldingsAndOrders(Func<List<Holding>> getHoldings, Func<List<Order>> getOrders, bool expected)
         {
             var algorithm = new TestAlgorithm();
             algorithm.SetHistoryProvider(new BrokerageTransactionHandlerTests.BrokerageTransactionHandlerTests.EmptyHistoryProvider());
-            var job = GetJob();
-
-            var resultHandler = new Mock<IResultHandler>();
-            var transactionHandler = new Mock<ITransactionHandler>();
-            var realTimeHandler = new Mock<IRealTimeHandler>();
-            var objectStore = new Mock<IObjectStore>();
-            var brokerage = new Mock<IBrokerage>();
-
-            brokerage.Setup(x => x.IsConnected).Returns(true);
-            brokerage.Setup(x => x.AccountBaseCurrency).Returns(Currencies.USD);
-            brokerage.Setup(x => x.GetCashBalance()).Returns(new List<CashAmount>());
-            brokerage.Setup(x => x.GetAccountHoldings()).Returns(getHoldings);
-            brokerage.Setup(x => x.GetOpenOrders()).Returns(getOrders);
-
-            var setupHandler = new BrokerageSetupHandler();
-
-            IBrokerageFactory factory;
-            setupHandler.CreateBrokerage(job, algorithm, out factory);
-
-            var result = setupHandler.Setup(new SetupHandlerParameters(_dataManager.UniverseSelection, algorithm, brokerage.Object, job, resultHandler.Object,
-                transactionHandler.Object, realTimeHandler.Object, TestGlobals.DataCacheProvider, TestGlobals.MapFileProvider));
-
-            Assert.AreEqual(expected, result);
+            TestLoadExistingHoldingsAndOrders(algorithm, getHoldings, getOrders, expected);
 
             foreach (var security in algorithm.Securities.Values)
             {
@@ -279,30 +258,7 @@ namespace QuantConnect.Tests.Engine.Setup
             var algorithm = new TestAlgorithm();
             algorithm.AddData<CustomDataBitcoinAlgorithm.Bitcoin>("BTC");
             algorithm.SetHistoryProvider(new BrokerageTransactionHandlerTests.BrokerageTransactionHandlerTests.EmptyHistoryProvider());
-            var job = GetJob();
-
-            var resultHandler = new Mock<IResultHandler>();
-            var transactionHandler = new Mock<ITransactionHandler>();
-            var realTimeHandler = new Mock<IRealTimeHandler>();
-            var objectStore = new Mock<IObjectStore>();
-            var brokerage = new Mock<IBrokerage>();
-
-            brokerage.Setup(x => x.IsConnected).Returns(true);
-            brokerage.Setup(x => x.AccountBaseCurrency).Returns(Currencies.USD);
-            brokerage.Setup(x => x.GetCashBalance()).Returns(new List<CashAmount>());
-            brokerage.Setup(x => x.GetAccountHoldings()).Returns(getHoldings);
-            brokerage.Setup(x => x.GetOpenOrders()).Returns(getOrders);
-
-            var setupHandler = new TestBrokerageSetupHandler();
-
-            IBrokerageFactory factory;
-            setupHandler.CreateBrokerage(job, algorithm, out factory);
-
-            var parameters = new SetupHandlerParameters(_dataManager.UniverseSelection, algorithm, brokerage.Object, job, resultHandler.Object,
-                transactionHandler.Object, realTimeHandler.Object, TestGlobals.DataCacheProvider, TestGlobals.MapFileProvider);
-            var result = setupHandler.TestLoadExistingHoldingsAndOrders(brokerage.Object, algorithm, parameters);
-
-            Assert.AreEqual(expected, result);
+            TestLoadExistingHoldingsAndOrders(algorithm, getHoldings, getOrders, expected);
         }
 
         [TestCase(true)]
@@ -626,6 +582,34 @@ namespace QuantConnect.Tests.Engine.Setup
             }
         }
 
+        private void TestLoadExistingHoldingsAndOrders(IAlgorithm algorithm, Func<List<Holding>> getHoldings, Func<List<Order>> getOrders, bool expected)
+        {
+            var job = GetJob();
+
+            var resultHandler = new Mock<IResultHandler>();
+            var transactionHandler = new Mock<ITransactionHandler>();
+            var realTimeHandler = new Mock<IRealTimeHandler>();
+            var objectStore = new Mock<IObjectStore>();
+            var brokerage = new Mock<IBrokerage>();
+
+            brokerage.Setup(x => x.IsConnected).Returns(true);
+            brokerage.Setup(x => x.AccountBaseCurrency).Returns(Currencies.USD);
+            brokerage.Setup(x => x.GetCashBalance()).Returns(new List<CashAmount>());
+            brokerage.Setup(x => x.GetAccountHoldings()).Returns(getHoldings);
+            brokerage.Setup(x => x.GetOpenOrders()).Returns(getOrders);
+
+            var setupHandler = new TestBrokerageSetupHandler();
+
+            IBrokerageFactory factory;
+            setupHandler.CreateBrokerage(job, algorithm, out factory);
+
+            var parameters = new SetupHandlerParameters(_dataManager.UniverseSelection, algorithm, brokerage.Object, job, resultHandler.Object,
+                transactionHandler.Object, realTimeHandler.Object, TestGlobals.DataCacheProvider, TestGlobals.MapFileProvider);
+            var result = setupHandler.Setup(new SetupHandlerParameters(_dataManager.UniverseSelection, algorithm, brokerage.Object, job, resultHandler.Object,
+                transactionHandler.Object, realTimeHandler.Object, TestGlobals.DataCacheProvider, TestGlobals.MapFileProvider));
+            Assert.AreEqual(expected, result);
+        }
+
         private static object[] GetExistingHoldingsAndOrdersWithCustomDataTestCase =
         {
             new object[] {
@@ -639,17 +623,17 @@ namespace QuantConnect.Tests.Engine.Setup
                 true }
         };
 
-        private static TestCaseData[] GetExistingHoldingsAndOrdersTestCaseData()
+        private class ExistingHoldingAndOrdersDataClass
         {
-            return new[]
+            public static IEnumerable GetExistingHoldingsAndOrdersTestCaseData
             {
-                new TestCaseData(
-                        new Func<List<Holding>>(() => new List<Holding>()),
-                        new Func<List<Order>>(() => new List<Order>()),
-                        true)
-                    .SetName("None"),
+                get
+                {
+                    yield return new TestCaseData(
+                            new Func<List<Holding>>(() => new List<Holding>()),
+                            new Func<List<Order>>(() => new List<Order>()), true);
 
-                new TestCaseData(
+                    yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
                             new Holding { Symbol = Symbols.SPY, Quantity = 1 }
@@ -657,11 +641,9 @@ namespace QuantConnect.Tests.Engine.Setup
                         new Func<List<Order>>(() => new List<Order>
                         {
                             new LimitOrder(Symbols.SPY, 1, 1, DateTime.UtcNow)
-                        }),
-                        true)
-                    .SetName("Equity"),
+                        }), true);
 
-                new TestCaseData(
+                    yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
                             new Holding { Symbol = Symbols.SPY_C_192_Feb19_2016, Quantity = 1 }
@@ -669,11 +651,9 @@ namespace QuantConnect.Tests.Engine.Setup
                         new Func<List<Order>>(() => new List<Order>
                         {
                             new LimitOrder(Symbols.SPY_C_192_Feb19_2016, 1, 1, DateTime.UtcNow)
-                        }),
-                        true)
-                    .SetName("Option"),
+                        }), true);
 
-                new TestCaseData(
+                    yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
                             new Holding { Symbol = Symbols.SPY, Quantity = 1 },
@@ -683,11 +663,9 @@ namespace QuantConnect.Tests.Engine.Setup
                         {
                             new LimitOrder(Symbols.SPY, 1, 1, DateTime.UtcNow),
                             new LimitOrder(Symbols.SPY_C_192_Feb19_2016, 1, 1, DateTime.UtcNow)
-                        }),
-                        true)
-                    .SetName("Equity + Option"),
+                        }), true);
 
-                new TestCaseData(
+                    yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
                             new Holding { Symbol = Symbols.SPY_C_192_Feb19_2016, Quantity = 1 },
@@ -697,11 +675,9 @@ namespace QuantConnect.Tests.Engine.Setup
                         {
                             new LimitOrder(Symbols.SPY_C_192_Feb19_2016, 1, 1, DateTime.UtcNow),
                             new LimitOrder(Symbols.SPY, 1, 1, DateTime.UtcNow)
-                        }),
-                        true)
-                    .SetName("Option + Equity"),
+                        }), true);
 
-                new TestCaseData(
+                    yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
                             new Holding { Symbol = Symbols.SPY_C_192_Feb19_2016, Quantity = 1 }
@@ -709,11 +685,9 @@ namespace QuantConnect.Tests.Engine.Setup
                         new Func<List<Order>>(() => new List<Order>
                         {
                             new LimitOrder(Symbols.SPY, 1, 1, DateTime.UtcNow),
-                        }),
-                        true)
-                    .SetName("Equity open order + Option holding"),
+                        }), true);
 
-                new TestCaseData(
+                    yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
                             new Holding { Symbol = Symbols.EURUSD, Quantity = 1 }
@@ -721,11 +695,9 @@ namespace QuantConnect.Tests.Engine.Setup
                         new Func<List<Order>>(() => new List<Order>
                         {
                             new LimitOrder(Symbols.EURUSD, 1, 1, DateTime.UtcNow)
-                        }),
-                        true)
-                    .SetName("Forex"),
+                        }), true);
 
-                new TestCaseData(
+                    yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
                             new Holding { Symbol = Symbols.BTCUSD, Quantity = 1 }
@@ -733,11 +705,9 @@ namespace QuantConnect.Tests.Engine.Setup
                         new Func<List<Order>>(() => new List<Order>
                         {
                             new LimitOrder(Symbols.BTCUSD, 1, 1, DateTime.UtcNow)
-                        }),
-                        true)
-                    .SetName("Crypto"),
+                        }), true);
 
-                new TestCaseData(
+                    yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
                             new Holding { Symbol = Symbols.Fut_SPY_Feb19_2016, Quantity = 1 }
@@ -745,11 +715,9 @@ namespace QuantConnect.Tests.Engine.Setup
                         new Func<List<Order>>(() => new List<Order>
                         {
                             new LimitOrder(Symbols.Fut_SPY_Feb19_2016, 1, 1, DateTime.UtcNow)
-                        }),
-                        true)
-                    .SetName("Future"),
+                        }), true);
 
-                new TestCaseData(
+                    yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>
                         {
                             new Holding { Symbol = Symbol.Create("XYZ", SecurityType.Base, Market.USA), Quantity = 1 }
@@ -757,22 +725,17 @@ namespace QuantConnect.Tests.Engine.Setup
                         new Func<List<Order>>(() => new List<Order>
                         {
                             new LimitOrder("XYZ", 1, 1, DateTime.UtcNow)
-                        }),
-                        false)
-                    .SetName("Base"),
+                        }), false);
 
-                new TestCaseData(
+                    yield return new TestCaseData(
                         new Func<List<Holding>>(() => { throw new Exception(); }),
-                        new Func<List<Order>>(() => new List<Order>()),
-                        false)
-                    .SetName("Invalid Holdings"),
+                        new Func<List<Order>>(() => new List<Order>()), false);
 
-                new TestCaseData(
+                    yield return new TestCaseData(
                         new Func<List<Holding>>(() => new List<Holding>()),
-                        new Func<List<Order>>(() => { throw new Exception(); }),
-                        false)
-                    .SetName("Invalid Orders"),
-            };
+                        new Func<List<Order>>(() => { throw new Exception(); }), false);
+                }
+            }
         }
 
         internal class TestAlgorithm : QCAlgorithm
@@ -825,14 +788,14 @@ namespace QuantConnect.Tests.Engine.Setup
 
         private class TestableBrokerageSetupHandler : BrokerageSetupHandler
         {
-            private readonly HashSet<SecurityType> _supportedSecurityTypes = new HashSet<SecurityType>
+            protected override HashSet<SecurityType> SupportedSecurityTypes => new HashSet<SecurityType>
             {
                 SecurityType.Equity, SecurityType.Forex, SecurityType.Cfd, SecurityType.Option, SecurityType.Future, SecurityType.Crypto
             };
 
             public void PublicGetOpenOrders(IAlgorithm algorithm, IResultHandler resultHandler, ITransactionHandler transactionHandler, IBrokerage brokerage)
             {
-                GetOpenOrders(algorithm, resultHandler, transactionHandler, brokerage, _supportedSecurityTypes);
+                GetOpenOrders(algorithm, resultHandler, transactionHandler, brokerage);
             }
         }
     }

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -36,7 +36,7 @@ using QuantConnect.Securities.Option;
 using QuantConnect.Tests.Common.Securities;
 using QuantConnect.Tests.Engine.DataFeeds;
 using QuantConnect.Util;
-using QuantConnect.Algorithm.CSharp;
+using Bitcoin = QuantConnect.Algorithm.CSharp.LiveTradingFeaturesAlgorithm.Bitcoin;
 using System.Collections;
 
 namespace QuantConnect.Tests.Engine.Setup
@@ -256,7 +256,7 @@ namespace QuantConnect.Tests.Engine.Setup
         public void LoadsExistingHoldingsAndOrdersWithCustomData(Func<List<Holding>> getHoldings, Func<List<Order>> getOrders, bool expected)
         {
             var algorithm = new TestAlgorithm();
-            algorithm.AddData<CustomDataBitcoinAlgorithm.Bitcoin>("BTC");
+            algorithm.AddData<Bitcoin>("BTC");
             algorithm.SetHistoryProvider(new BrokerageTransactionHandlerTests.BrokerageTransactionHandlerTests.EmptyHistoryProvider());
             TestLoadExistingHoldingsAndOrders(algorithm, getHoldings, getOrders, expected);
         }
@@ -614,7 +614,7 @@ namespace QuantConnect.Tests.Engine.Setup
         {
             new object[] {
                     new Func<List<Holding>>(() => new List<Holding> { new Holding { Symbol = new Symbol(
-                        SecurityIdentifier.GenerateBase(typeof(CustomDataBitcoinAlgorithm.Bitcoin), "BTC", Market.USA, false), "BTC"), Quantity = 1 }}),
+                        SecurityIdentifier.GenerateBase(typeof(Bitcoin), "BTC", Market.USA, false), "BTC"), Quantity = 1 }}),
                     new Func<List<Order>>(() => new List<Order>()),
                     true },
             new object[] {

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -598,7 +598,7 @@ namespace QuantConnect.Tests.Engine.Setup
             brokerage.Setup(x => x.GetAccountHoldings()).Returns(getHoldings);
             brokerage.Setup(x => x.GetOpenOrders()).Returns(getOrders);
 
-            var setupHandler = new TestBrokerageSetupHandler();
+            var setupHandler = new TestableBrokerageSetupHandler();
 
             IBrokerageFactory factory;
             setupHandler.CreateBrokerage(job, algorithm, out factory);
@@ -797,6 +797,11 @@ namespace QuantConnect.Tests.Engine.Setup
             {
                 GetOpenOrders(algorithm, resultHandler, transactionHandler, brokerage);
             }
+
+            public bool TestLoadExistingHoldingsAndOrders(IBrokerage brokerage, IAlgorithm algorithm, SetupHandlerParameters parameters)
+            {
+                return LoadExistingHoldingsAndOrders(brokerage, algorithm, parameters);
+            }
         }
     }
 
@@ -892,13 +897,5 @@ namespace QuantConnect.Tests.Engine.Setup
         }
 
         #endregion
-    }
-
-    public class TestBrokerageSetupHandler: BrokerageSetupHandler
-    {
-        public bool TestLoadExistingHoldingsAndOrders(IBrokerage brokerage, IAlgorithm algorithm, SetupHandlerParameters parameters)
-        {
-            return LoadExistingHoldingsAndOrders(brokerage, algorithm, parameters);
-        }
     }
 }

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -631,9 +631,12 @@ namespace QuantConnect.Tests.Engine.Setup
             new object[] {
                     new Func<List<Holding>>(() => new List<Holding> { new Holding { Symbol = new Symbol(
                         SecurityIdentifier.GenerateBase(typeof(CustomDataBitcoinAlgorithm.Bitcoin), "BTC", Market.USA, false), "BTC"), Quantity = 1 }}),
-                    new Func<List<Order>>(() => new List<Order> { new LimitOrder(new Symbol(
-                        SecurityIdentifier.GenerateBase(typeof(CustomDataBitcoinAlgorithm.Bitcoin), "BTC", Market.USA, false), "BTC"), 1, 1, DateTime.UtcNow)}),
-                    true }
+                    new Func<List<Order>>(() => new List<Order>()),
+                    true },
+            new object[] {
+                new Func<List<Holding>>(() => new List<Holding> { new Holding { Symbol = Symbols.SPY, Quantity = 1 }}),
+                new Func<List<Order>>(() => new List<Order>()),
+                true }
         };
 
         private static TestCaseData[] GetExistingHoldingsAndOrdersTestCaseData()

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -253,12 +253,12 @@ namespace QuantConnect.Tests.Engine.Setup
         }
 
         [TestCaseSource(nameof(GetExistingHoldingsAndOrdersWithCustomDataTestCase))]
-        public void LoadsExistingHoldingsAndOrdersWithCustomData(Func<List<Holding>> getHoldings, Func<List<Order>> getOrders, bool expected)
+        public void LoadsExistingHoldingsAndOrdersWithCustomData(Func<List<Holding>> getHoldings, Func<List<Order>> getOrders)
         {
             var algorithm = new TestAlgorithm();
             algorithm.AddData<Bitcoin>("BTC");
             algorithm.SetHistoryProvider(new BrokerageTransactionHandlerTests.BrokerageTransactionHandlerTests.EmptyHistoryProvider());
-            TestLoadExistingHoldingsAndOrders(algorithm, getHoldings, getOrders, expected);
+            TestLoadExistingHoldingsAndOrders(algorithm, getHoldings, getOrders, true);
         }
 
         [TestCase(true)]
@@ -613,14 +613,34 @@ namespace QuantConnect.Tests.Engine.Setup
         private static object[] GetExistingHoldingsAndOrdersWithCustomDataTestCase =
         {
             new object[] {
-                    new Func<List<Holding>>(() => new List<Holding> { new Holding { Symbol = new Symbol(
-                        SecurityIdentifier.GenerateBase(typeof(Bitcoin), "BTC", Market.USA, false), "BTC"), Quantity = 1 }}),
-                    new Func<List<Order>>(() => new List<Order>()),
-                    true },
+                new Func<List<Holding>>(() => new List<Holding> { new Holding { Symbol = new Symbol(
+                    SecurityIdentifier.GenerateBase(typeof(Bitcoin), "BTC", Market.USA, false), "BTC"), Quantity = 1 }}),
+                new Func<List<Order>>(() => new List<Order>())},
             new object[] {
                 new Func<List<Holding>>(() => new List<Holding> { new Holding { Symbol = Symbols.SPY, Quantity = 1 }}),
-                new Func<List<Order>>(() => new List<Order>()),
-                true }
+                new Func<List<Order>>(() => new List<Order>())},
+            new object[] {
+                new Func<List<Holding>>(() => new List<Holding>()),
+                new Func<List<Order>>(() => new List<Order>() { new LimitOrder(new Symbol(
+                    SecurityIdentifier.GenerateBase(typeof(Bitcoin), "BTC", Market.USA, false), "BTC"), 1, 1, DateTime.UtcNow)})},
+            new object[] {
+                new Func<List<Holding>>(() => new List<Holding> { new Holding { Symbol = new Symbol(
+                    SecurityIdentifier.GenerateBase(typeof(Bitcoin), "BTC", Market.USA, false), "BTC"), Quantity = 1 }}),
+                new Func<List<Order>>(() => new List<Order>() { new LimitOrder(new Symbol(
+                    SecurityIdentifier.GenerateBase(typeof(Bitcoin), "BTC", Market.USA, false), "BTC"), 1, 1, DateTime.UtcNow)})},
+            new object[] {
+                new Func<List<Holding>>(() => new List<Holding> { new Holding { Symbol = new Symbol(
+                    SecurityIdentifier.GenerateBase(typeof(Bitcoin), "BTC", Market.USA, false), "BTC"), Quantity = 1 },
+                    new Holding { Symbol = Symbols.SPY, Quantity = 1 }}),
+                new Func<List<Order>>(() => new List<Order>() { new LimitOrder(new Symbol(
+                    SecurityIdentifier.GenerateBase(typeof(Bitcoin), "BTC", Market.USA, false), "BTC"), 1, 1, DateTime.UtcNow)})},
+            new object[] {
+                new Func<List<Holding>>(() => new List<Holding> { new Holding { Symbol = new Symbol(
+                    SecurityIdentifier.GenerateBase(typeof(Bitcoin), "BTC", Market.USA, false), "BTC"), Quantity = 1 },
+                    new Holding { Symbol = Symbols.SPY, Quantity = 1 }}),
+                new Func<List<Order>>(() => new List<Order>() { new LimitOrder(new Symbol(
+                    SecurityIdentifier.GenerateBase(typeof(Bitcoin), "BTC", Market.USA, false), "BTC"), 1, 1, DateTime.UtcNow),
+                    new LimitOrder(Symbols.SPY, 1, 1, DateTime.UtcNow)})}
         };
 
         private class ExistingHoldingAndOrdersDataClass
@@ -726,7 +746,17 @@ namespace QuantConnect.Tests.Engine.Setup
                         {
                             new LimitOrder("XYZ", 1, 1, DateTime.UtcNow)
                         }), false);
-                    
+
+                    yield return new TestCaseData(
+                        new Func<List<Holding>>(() => new List<Holding>
+                        {
+                            new Holding { Symbol = new Symbol(SecurityIdentifier.GenerateBase(typeof(Bitcoin), "BTC", Market.USA, false), "BTC"), Quantity = 1 }
+                        }),
+                        new Func<List<Order>>(() => new List<Order>
+                        {
+                            new LimitOrder(new Symbol(SecurityIdentifier.GenerateBase(typeof(Bitcoin), "BTC", Market.USA, false), "BTC"), 1, 1, DateTime.UtcNow)
+                        }), false);
+
                     yield return new TestCaseData(
                         new Func<List<Holding>>(() => { throw new Exception(); }),
                         new Func<List<Order>>(() => new List<Order>()), false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
So far, when a live algorithm was re-deployed with custom data, the algorithm finished with an error message saying the security type of the custom data wasn't supported.  Now, partial support has been added to handle the case where the custom data was already part of the `Securities` in the algorithm redeployed. Additionally, there were found some unit test related with the issue that were never run, therefore they were fixed as well.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/QuantConnect/Lean/issues/7518
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change users will be able to re-deploy live algos that hold custom data without getting any errors, as long as the custom data is included in the algorithm Securities.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There were created unit tests asserting the custom data being held could be added again to the algorithm without any errors.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
