### PR TITLE
Add potential fix to overflow bug in FractalAdaptiveMovingAverage.cs

### DIFF
--- a/Indicators/FractalAdaptiveMovingAverage.cs
+++ b/Indicators/FractalAdaptiveMovingAverage.cs
@@ -102,7 +102,7 @@ namespace QuantConnect.Indicators
                 dimen = Math.Log((n1 + n2) / n3) / Math.Log(2);
             }
 
-            var alpha = (decimal)Math.Exp(_w * (dimen - 1));
+            var alpha = Extensions.SafeDecimalCast(Math.Exp(_w * (dimen - 1)));
 
             if (alpha < .01m)
             {

--- a/Indicators/FractalAdaptiveMovingAverage.cs
+++ b/Indicators/FractalAdaptiveMovingAverage.cs
@@ -99,21 +99,22 @@ namespace QuantConnect.Indicators
 
             if (n1 + n2 > 0 && n3 > 0)
             {
-                dimen = Math.Log((n1 + n2) / n3) / Math.Log(2);
+                var log = Math.Log((n1 + n2) / n3);
+                dimen = (double.IsNaN(log) ? 0 : log) / Math.Log(2);
             }
 
-            var alpha = Extensions.SafeDecimalCast(Math.Exp(_w * (dimen - 1)));
+            var alpha = Math.Exp(_w * (dimen - 1));
 
-            if (alpha < .01m)
+            if (alpha < .01)
             {
-                alpha = .01m;
+                alpha = .01;
             }
             if (alpha > 1)
             {
                 alpha = 1;
             }
 
-            return alpha * price + (1 - alpha) * Current.Value;
+            return (decimal)alpha * price + (1 - (decimal)alpha) * Current.Value;
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
After making some research and tests, it was found that the exception couldn't be raised when executing https://github.com/Marinovsky/Lean/blob/master/Indicators/FractalAdaptiveMovingAverage.cs#L111 (as the error logs pinpointed). According to the error logs, the exception was thrown when trying to cast a Double into a Decimal (see https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs#L1705). Therefore, the error could potentially be raised when evaluating
```csharp
var alpha = (decimal)Math.Exp(_w * (dimen - 1));
```
since only in that part the method makes a cast from a Double to a Decimal.
In order to potentially fix it, the method `Extensions.SafeDecimalCast()` was used, since in case of an overflow error, it returns the highest or lowest possible Decimal value.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7659 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, users will potentially be able to use `FractalAdaptiveMovingAverage` indicator without getting overflow exceptions
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
 Unfortunately, due to the uncertainty of the code that initially threw that exception, it wasn't possible to make a unit test that reproduced the bug.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
