### PR TITLE
Fix currency formatting

### DIFF
--- a/Algorithm.CSharp/AddBetaIndicatorRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddBetaIndicatorRegressionAlgorithm.cs
@@ -138,7 +138,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$35000000.00"},
             {"Lowest Capacity Asset", "IBM R735QTJ8XC9X"},
             {"Portfolio Turnover", "1.51%"},
-            {"OrderListHash", "e930f95771bc50dd2db1c353e054c4e7"}
+            {"OrderListHash", "381bb9310f9dceb8a79a56849789bdab"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateCryptoAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateCryptoAlgorithm.cs
@@ -237,7 +237,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "BTCEUR 2XR"},
             {"Portfolio Turnover", "118.08%"},
-            {"OrderListHash", "551b20736f4558a5af5c02b84451fb77"}
+            {"OrderListHash", "77458586d24f1cd00623d63da8279be2"}
         };
     }
 }

--- a/Algorithm.CSharp/BybitCryptoRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/BybitCryptoRegressionAlgorithm.cs
@@ -166,7 +166,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "₮560000.00"},
             {"Lowest Capacity Asset", "BTCUSDT 2UZ"},
             {"Portfolio Turnover", "44.04%"},
-            {"OrderListHash", "fb30d137fffe2bc4195d261f0f195b69"}
+            {"OrderListHash", "b3a9eb7392ba1eb7eb0cc387f7382b6c"}
         };
     }
 }

--- a/Algorithm.CSharp/CancelOpenOrdersRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CancelOpenOrdersRegressionAlgorithm.cs
@@ -161,7 +161,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$370000.00"},
             {"Lowest Capacity Asset", "ETHUSD 2XR"},
             {"Portfolio Turnover", "104.59%"},
-            {"OrderListHash", "bd538acb61fa1fd91732212664c9bbed"}
+            {"OrderListHash", "ec714d818fa30597e992d4c6e939e68c"}
         };
     }
 }

--- a/Algorithm.CSharp/ContinuousFutureLimitIfTouchedOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ContinuousFutureLimitIfTouchedOrderRegressionAlgorithm.cs
@@ -114,7 +114,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$2600000000.00"},
             {"Lowest Capacity Asset", "ES VMKLFZIH2MTD"},
             {"Portfolio Turnover", "16.49%"},
-            {"OrderListHash", "a8b0528aa2c4c2b8f013a06104ddb1d0"}
+            {"OrderListHash", "a83211606af7216647acfd9b5f6907a5"}
         };
     }
 }

--- a/Algorithm.CSharp/ExtendedMarketTradingRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ExtendedMarketTradingRegressionAlgorithm.cs
@@ -136,7 +136,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$14000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "1.44%"},
-            {"OrderListHash", "730d1d797bbe9449a6dc123990f5bd4b"}
+            {"OrderListHash", "1ebbd6a077af944e04ee437a5219eef4"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureStopMarketOrderOnExtendedHoursRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureStopMarketOrderOnExtendedHoursRegressionAlgorithm.cs
@@ -149,7 +149,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$3400000.00"},
             {"Lowest Capacity Asset", "ES VMKLFZIH2MTD"},
             {"Portfolio Turnover", "138.95%"},
-            {"OrderListHash", "c85997dd5b7d9acda46ac9d11dd1a039"}
+            {"OrderListHash", "b26a8ad66a8dc5af768a22fbf9a80cec"}
         };
     }
 }

--- a/Algorithm.CSharp/LimitFillRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitFillRegressionAlgorithm.cs
@@ -114,7 +114,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$180000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "9.86%"},
-            {"OrderListHash", "14eaea4041585a9110df4b5861793f9e"}
+            {"OrderListHash", "a5363ad9b8119f0e256a48efdc7acbb5"}
         };
     }
 }

--- a/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitIfTouchedRegressionAlgorithm.cs
@@ -35,9 +35,9 @@ namespace QuantConnect.Algorithm.CSharp
         // We assert the following occur in FIFO order in OnOrderEvent
         private readonly Queue<string> _expectedEvents = new Queue<string>(new[]
         {
-            "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 399 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 144.6434 USD LimitPrice: 144.3551 TriggerPrice: 143.61 OrderFee: 1 USD",
-            "Time: 10/10/2013 15:57:00 OrderID: 73 EventID: 156 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 145.6636 USD LimitPrice: 145.6434 TriggerPrice: 144.89 OrderFee: 1 USD",
-            "Time: 10/11/2013 15:37:00 OrderID: 74 EventID: 380 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 146.7185 USD LimitPrice: 146.6723 TriggerPrice: 145.92 OrderFee: 1 USD"        });
+            "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 399 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: $144.6434 LimitPrice: $144.3551 TriggerPrice: $143.61 OrderFee: 1 USD",
+            "Time: 10/10/2013 15:57:00 OrderID: 73 EventID: 156 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: $145.6636 LimitPrice: $145.6434 TriggerPrice: $144.89 OrderFee: 1 USD",
+            "Time: 10/11/2013 15:37:00 OrderID: 74 EventID: 380 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: $146.7185 LimitPrice: $146.6723 TriggerPrice: $145.92 OrderFee: 1 USD"        });
 
         /// <summary>
         /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
@@ -74,10 +74,10 @@ namespace QuantConnect.Algorithm.CSharp
                     $"LIT - Quantity: {_negative * 10}");
                 _request = Transactions.AddOrder(orderRequest);
                 return;
-                
+
             }
 
-            // Order updating if request exists 
+            // Order updating if request exists
             if (_request != null)
             {
                 if (_request.Quantity == 1)
@@ -105,7 +105,7 @@ namespace QuantConnect.Algorithm.CSharp
 
                 if (orderEvent.ToString() != expected)
                 {
-                    throw new Exception($"orderEvent {orderEvent.Id} differed from {expected}");
+                    throw new Exception($"orderEvent {orderEvent.Id} differed from {expected}. Actual {orderEvent}");
                 }
             }
         }

--- a/Algorithm.CSharp/LimitOrdersAreFilledAfterHoursForFuturesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitOrdersAreFilledAfterHoursForFuturesRegressionAlgorithm.cs
@@ -149,7 +149,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$39000000.00"},
             {"Lowest Capacity Asset", "ES VMKLFZIH2MTD"},
             {"Portfolio Turnover", "33.59%"},
-            {"OrderListHash", "170df706887bac7764441b9368887a1d"}
+            {"OrderListHash", "8b3baab1411a6db34780601bdd68ef9e"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionAssignmentStatisticsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionAssignmentStatisticsRegressionAlgorithm.cs
@@ -302,7 +302,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "50.31%"},
-            {"OrderListHash", "92d006d828b582a7cc78eeb4c0161356"}
+            {"OrderListHash", "eaa2b6ffada95de55b095ed2e9953e33"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionEquityStrategyMatcherRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionEquityStrategyMatcherRegressionAlgorithm.cs
@@ -148,7 +148,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "GOOCV W78ZFMEBBB2E|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "274.86%"},
-            {"OrderListHash", "0948e7066371a8aae356145cbac0741c"}
+            {"OrderListHash", "9aa5e8c352571222f77407c62a5795c4"}
         };
     }
 }

--- a/Algorithm.CSharp/ScaledFillForwardDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ScaledFillForwardDataRegressionAlgorithm.cs
@@ -132,7 +132,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$26000.00"},
             {"Lowest Capacity Asset", "AOL R735QTJ8XC9X"},
             {"Portfolio Turnover", "12.68%"},
-            {"OrderListHash", "215c8a8ac308c82fb7b0b46f3be0972e"}
+            {"OrderListHash", "0241913ee2f0fa5af72e311a09c39f4e"}
         };
     }
 }

--- a/Algorithm.CSharp/ShortableProviderOrdersRejectedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ShortableProviderOrdersRejectedRegressionAlgorithm.cs
@@ -212,7 +212,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$99000000.00"},
             {"Lowest Capacity Asset", "AIG R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.23%"},
-            {"OrderListHash", "32ac6dfd7b74518f14fb0210ce0360df"}
+            {"OrderListHash", "7d60ef344c55973a95131cdeefdbaeb3"}
         };
     }
 }

--- a/Algorithm.CSharp/SplitEquityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SplitEquityRegressionAlgorithm.cs
@@ -184,7 +184,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", ""},
             {"Portfolio Turnover", "0%"},
-            {"OrderListHash", "7eca64a29976e1c2f206dd92b0930522"}
+            {"OrderListHash", "df486042c4e80663af46c355cb08b220"}
         };
     }
 }

--- a/Algorithm.CSharp/SplitEquityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SplitEquityRegressionAlgorithm.cs
@@ -184,7 +184,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", ""},
             {"Portfolio Turnover", "0%"},
-            {"OrderListHash", "df486042c4e80663af46c355cb08b220"}
+            {"OrderListHash", "16b303d07fd2993a588b91c64091bae3"}
         };
     }
 }

--- a/Algorithm.CSharp/SplitEquityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SplitEquityRegressionAlgorithm.cs
@@ -184,7 +184,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", ""},
             {"Portfolio Turnover", "0%"},
-            {"OrderListHash", "16b303d07fd2993a588b91c64091bae3"}
+            {"OrderListHash", "b1df545a12beb8868606e0da35c151d0"}
         };
     }
 }

--- a/Algorithm.CSharp/StopLimitOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StopLimitOrderRegressionAlgorithm.cs
@@ -178,7 +178,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$2700000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.02%"},
-            {"OrderListHash", "60a73554224704136fff171dd50d8d28"}
+            {"OrderListHash", "ebb6f711f14449c0cf8dcee645b34956"}
         };
     }
 }

--- a/Algorithm.CSharp/StopLossOnOrderEventRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StopLossOnOrderEventRegressionAlgorithm.cs
@@ -44,7 +44,8 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 // Entry short $2 below
                 var stopPrice = orderEvent.FillPrice - 2;
-                Debug($"Enter short at {orderEvent.FillPrice} set STOPLOSS at {stopPrice:C}");
+                var currencySymbol = Currencies.GetCurrencySymbol(order.PriceCurrency);
+                Debug($"Enter short at {orderEvent.FillPrice} set STOPLOSS at {currencySymbol}{stopPrice}");
                 StopMarketOrder(order.Symbol, -order.Quantity, stopPrice, "StopLoss");
             }
         }

--- a/Algorithm.CSharp/TimeInForceAlgorithm.cs
+++ b/Algorithm.CSharp/TimeInForceAlgorithm.cs
@@ -184,7 +184,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$44000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.87%"},
-            {"OrderListHash", "4f94db1e287d9dd7026bda8c93a62876"}
+            {"OrderListHash", "9ce26e877ba1b5dbe19765fb5374334e"}
         };
     }
 }

--- a/Algorithm.CSharp/TrailingStopOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TrailingStopOrderRegressionAlgorithm.cs
@@ -176,7 +176,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$36000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "5.79%"},
-            {"OrderListHash", "52f67285c3f5ecdc66f89cb1c0d08421"}
+            {"OrderListHash", "57c696c7fbfcf78702a06d137fd125b0"}
         };
     }
 }

--- a/Algorithm.CSharp/TrailingStopOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TrailingStopOrderRegressionAlgorithm.cs
@@ -176,7 +176,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$36000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "5.79%"},
-            {"OrderListHash", "57c696c7fbfcf78702a06d137fd125b0"}
+            {"OrderListHash", "fcfc3ecf4a3eff97be9f07305c97ad95"}
         };
     }
 }

--- a/Algorithm.Python/LimitIfTouchedRegressionAlgorithm.py
+++ b/Algorithm.Python/LimitIfTouchedRegressionAlgorithm.py
@@ -22,9 +22,9 @@ from collections import deque
 ### <meta name="tag" content="limit if touched order"/>
 class LimitIfTouchedRegressionAlgorithm(QCAlgorithm):
     _expectedEvents = deque([
-        "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 399 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 144.6434 USD LimitPrice: 144.3551 TriggerPrice: 143.61 OrderFee: 1 USD",
-        "Time: 10/10/2013 15:57:00 OrderID: 73 EventID: 156 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 145.6636 USD LimitPrice: 145.6434 TriggerPrice: 144.89 OrderFee: 1 USD",
-        "Time: 10/11/2013 15:37:00 OrderID: 74 EventID: 380 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: 146.7185 USD LimitPrice: 146.6723 TriggerPrice: 145.92 OrderFee: 1 USD"    ])
+        "Time: 10/10/2013 13:31:00 OrderID: 72 EventID: 399 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: $144.6434 LimitPrice: $144.3551 TriggerPrice: $143.61 OrderFee: 1 USD",
+        "Time: 10/10/2013 15:57:00 OrderID: 73 EventID: 156 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: $145.6636 LimitPrice: $145.6434 TriggerPrice: $144.89 OrderFee: 1 USD",
+        "Time: 10/11/2013 15:37:00 OrderID: 74 EventID: 380 Symbol: SPY Status: Filled Quantity: -1 FillQuantity: -1 FillPrice: $146.7185 LimitPrice: $146.6723 TriggerPrice: $145.92 OrderFee: 1 USD"    ])
 
     def Initialize(self):
         self.SetStartDate(2013, 10, 7)
@@ -51,11 +51,11 @@ class LimitIfTouchedRegressionAlgorithm(QCAlgorithm):
                     return
 
                 new_quantity = int(self._request.Quantity - self._negative)
-                self._request.UpdateQuantity(new_quantity, f"LIT - Quantity: {new_quantity}")     
+                self._request.UpdateQuantity(new_quantity, f"LIT - Quantity: {new_quantity}")
                 self._request.UpdateTriggerPrice(Extensions.RoundToSignificantDigits(self._request.Get(OrderField.TriggerPrice), 5));
 
     def OnOrderEvent(self, orderEvent):
         if orderEvent.Status == OrderStatus.Filled:
             expected = self._expectedEvents.popleft()
-            if orderEvent.ToString() != expected:
-                raise Exception(f"orderEvent {orderEvent.Id} differed from {expected}")
+            if str(orderEvent) != expected:
+                raise Exception(f"orderEvent {orderEvent.Id} differed from {expected}. Actual {orderEvent}")

--- a/Common/Currencies.cs
+++ b/Common/Currencies.cs
@@ -145,13 +145,13 @@ namespace QuantConnect
             {"LSK", "Ⱡ"},
             {"NAV", "Ꞥ"}
         };
-        
+
         /// <summary>
         /// Stable pairs in GDAX. We defined them because they have different fees in GDAX market
         /// </summary>
         [Obsolete("StablePairsGDAX is deprecated. Use StablePairsCoinbase instead.")]
         public static readonly HashSet<string> StablePairsGDAX = StablePairsCoinbase;
-        
+
         /// <summary>
         /// Stable pairs in Coinbase. We defined them because they have different fees in Coinbase market
         /// </summary>
@@ -174,7 +174,7 @@ namespace QuantConnect
             "USTUSDT",
             "WBTCBTC"
         };
-        
+
         /// <summary>
         /// Define some StableCoins that don't have direct pairs for base currencies in our SPDB in Coinbase market
         /// This is because some CryptoExchanges do not define direct pairs with the stablecoins they offer.
@@ -272,8 +272,12 @@ namespace QuantConnect
         /// <returns>The currency symbol</returns>
         public static string GetCurrencySymbol(string currency)
         {
-            string currencySymbol;
-            return CurrencySymbols.TryGetValue(currency, out currencySymbol) ? currencySymbol : currency;
+            if (string.IsNullOrEmpty(currency))
+            {
+                return string.Empty;
+            }
+
+            return CurrencySymbols.TryGetValue(currency, out var currencySymbol) ? currencySymbol : currency;
         }
 
         /// <summary>

--- a/Common/Messages/Messages.Orders.cs
+++ b/Common/Messages/Messages.Orders.cs
@@ -66,14 +66,16 @@ namespace QuantConnect
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string Tag(Orders.LimitIfTouchedOrder order)
             {
-                return Invariant($"Trigger Price: {order.TriggerPrice:C} Limit Price: {order.LimitPrice:C}");
+                // No additional information to display
+                return string.Empty;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string ToString(Orders.LimitIfTouchedOrder order)
             {
-                return Invariant($@"{Messages.Order.ToString(order)} at trigger {order.TriggerPrice.SmartRounding()} limit {
-                    order.LimitPrice.SmartRounding()}");
+                var currencySymbol = QuantConnect.Currencies.GetCurrencySymbol(order.PriceCurrency);
+                return Invariant($@"{Order.ToString(order)} at trigger {currencySymbol}{order.TriggerPrice.SmartRounding()
+                    } limit {currencySymbol}{order.LimitPrice.SmartRounding()}");
             }
         }
 
@@ -85,13 +87,15 @@ namespace QuantConnect
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string Tag(Orders.LimitOrder order)
             {
-                return Invariant($"Limit Price: {order.LimitPrice:C}");
+                // No additional information to display
+                return string.Empty;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string ToString(Orders.LimitOrder order)
             {
-                return Invariant($"{Messages.Order.ToString(order)} at limit {order.LimitPrice.SmartRounding()}");
+                var currencySymbol = QuantConnect.Currencies.GetCurrencySymbol(order.PriceCurrency);
+                return Invariant($"{Order.ToString(order)} at limit {currencySymbol}{order.LimitPrice.SmartRounding()}");
             }
         }
 
@@ -119,32 +123,34 @@ namespace QuantConnect
             {
                 var message = Invariant($@"Time: {orderEvent.UtcTime} OrderID: {orderEvent.OrderId} EventID: {
                     orderEvent.Id} Symbol: {orderEvent.Symbol.Value} Status: {orderEvent.Status} Quantity: {orderEvent.Quantity}");
+                var currencySymbol = QuantConnect.Currencies.GetCurrencySymbol(orderEvent.FillPriceCurrency);
+
                 if (orderEvent.FillQuantity != 0)
                 {
-                    message += Invariant($@" FillQuantity: {orderEvent.FillQuantity} FillPrice: {
-                        orderEvent.FillPrice.SmartRounding()} {orderEvent.FillPriceCurrency}");
+                    message += Invariant($@" FillQuantity: {orderEvent.FillQuantity
+                        } FillPrice: {currencySymbol}{orderEvent.FillPrice.SmartRounding()}");
                 }
 
                 if (orderEvent.LimitPrice.HasValue)
                 {
-                    message += Invariant($" LimitPrice: {orderEvent.LimitPrice.Value.SmartRounding()}");
+                    message += Invariant($" LimitPrice: {currencySymbol}{orderEvent.LimitPrice.Value.SmartRounding()}");
                 }
 
                 if (orderEvent.StopPrice.HasValue)
                 {
-                    message += Invariant($" StopPrice: {orderEvent.StopPrice.Value.SmartRounding()}");
+                    message += Invariant($" StopPrice: {currencySymbol}{orderEvent.StopPrice.Value.SmartRounding()}");
                 }
 
                 if (orderEvent.TrailingAmount.HasValue)
                 {
                     var trailingAmountString = TrailingStopOrder.TrailingAmount(orderEvent.TrailingAmount.Value,
-                        orderEvent.TrailingAsPercentage ?? false, orderEvent.FillPriceCurrency);
+                        orderEvent.TrailingAsPercentage ?? false, currencySymbol);
                     message += $" TrailingAmount: {trailingAmountString}";
                 }
 
                 if (orderEvent.TriggerPrice.HasValue)
                 {
-                    message += Invariant($" TriggerPrice: {orderEvent.TriggerPrice.Value.SmartRounding()}");
+                    message += Invariant($" TriggerPrice: {currencySymbol}{orderEvent.TriggerPrice.Value.SmartRounding()}");
                 }
 
                 // attach the order fee so it ends up in logs properly.
@@ -171,37 +177,39 @@ namespace QuantConnect
             public static string ShortToString(Orders.OrderEvent orderEvent)
             {
                 var message = Invariant($"{orderEvent.UtcTime} OID:{orderEvent.OrderId} {orderEvent.Symbol.Value} {orderEvent.Status} Q:{orderEvent.Quantity}");
+                var currencySymbol = QuantConnect.Currencies.GetCurrencySymbol(orderEvent.FillPriceCurrency);
+
                 if (orderEvent.FillQuantity != 0)
                 {
-                    message += Invariant($" FQ:{orderEvent.FillQuantity} FP:{orderEvent.FillPrice.SmartRounding()} {orderEvent.FillPriceCurrency}");
+                    message += Invariant($" FQ:{orderEvent.FillQuantity} FP:{currencySymbol}{orderEvent.FillPrice.SmartRounding()}");
                 }
 
                 if (orderEvent.LimitPrice.HasValue)
                 {
-                    message += Invariant($" LP:{orderEvent.LimitPrice.Value.SmartRounding()}");
+                    message += Invariant($" LP:{currencySymbol}{orderEvent.LimitPrice.Value.SmartRounding()}");
                 }
 
                 if (orderEvent.StopPrice.HasValue)
                 {
-                    message += Invariant($" SP:{orderEvent.StopPrice.Value.SmartRounding()}");
+                    message += Invariant($" SP:{currencySymbol}{orderEvent.StopPrice.Value.SmartRounding()}");
                 }
 
                 if (orderEvent.TrailingAmount.HasValue)
                 {
                     var trailingAmountString = TrailingStopOrder.TrailingAmount(orderEvent.TrailingAmount.Value,
-                        orderEvent.TrailingAsPercentage ?? false, orderEvent.FillPriceCurrency);
+                        orderEvent.TrailingAsPercentage ?? false, currencySymbol);
                     message += $" TA: {trailingAmountString}";
                 }
 
                 if (orderEvent.TriggerPrice.HasValue)
                 {
-                    message += Invariant($" TP:{orderEvent.TriggerPrice.Value.SmartRounding()}");
+                    message += Invariant($" TP:{currencySymbol}{orderEvent.TriggerPrice.Value.SmartRounding()}");
                 }
 
                 // attach the order fee so it ends up in logs properly.
                 if (orderEvent.OrderFee.Value.Amount != 0m)
                 {
-                    message += Invariant($" OF:{orderEvent.OrderFee}");
+                    message += Invariant($" OF:{currencySymbol}{orderEvent.OrderFee}");
                 }
 
                 // add message from brokerage
@@ -333,14 +341,16 @@ namespace QuantConnect
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string Tag(Orders.StopLimitOrder order)
             {
-                return Invariant($"Stop Price: {order.StopPrice:C} Limit Price: {order.LimitPrice:C}");
+                // No additional information to display
+                return string.Empty;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string ToString(Orders.StopLimitOrder order)
             {
-                return Invariant($@"{Messages.Order.ToString(order)} at stop {order.StopPrice.SmartRounding()} limit {
-                    order.LimitPrice.SmartRounding()}");
+                var currencySymbol = QuantConnect.Currencies.GetCurrencySymbol(order.PriceCurrency);
+                return Invariant($@"{Order.ToString(order)} at stop {currencySymbol}{order.StopPrice.SmartRounding()
+                    } limit {currencySymbol}{order.LimitPrice.SmartRounding()}");
             }
         }
 
@@ -352,13 +362,15 @@ namespace QuantConnect
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string Tag(Orders.StopMarketOrder order)
             {
-                return Invariant($"Stop Price: {order.StopPrice:C}");
+                // No additional information to display
+                return string.Empty;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string ToString(Orders.StopMarketOrder order)
             {
-                return Invariant($"{Messages.Order.ToString(order)} at stop {order.StopPrice.SmartRounding()}");
+                var currencySymbol = QuantConnect.Currencies.GetCurrencySymbol(order.PriceCurrency);
+                return Invariant($"{Order.ToString(order)} at stop {currencySymbol}{order.StopPrice.SmartRounding()}");
             }
         }
 
@@ -370,26 +382,33 @@ namespace QuantConnect
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string Tag(Orders.TrailingStopOrder order)
             {
-                return Invariant($"Stop Price: {order.PriceCurrency}{order.StopPrice} Trailing Amount: {TrailingAmount(order)}");
+                return Invariant($"Trailing Amount: {TrailingAmount(order)}");
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string ToString(Orders.TrailingStopOrder order)
             {
-                return Invariant($@"{Messages.Order.ToString(order)} at stop {order.StopPrice.SmartRounding()}. Trailing amount: {
-                    TrailingAmount(order)}");
+                var currencySymbol = QuantConnect.Currencies.GetCurrencySymbol(order.PriceCurrency);
+                return Invariant($@"{Order.ToString(order)} at stop {currencySymbol}{order.StopPrice.SmartRounding()}. Trailing amount: {
+                    TrailingAmountImpl(order, currencySymbol)}");
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string TrailingAmount(Orders.TrailingStopOrder order)
             {
-                return TrailingAmount(order.TrailingAmount, order.TrailingAsPercentage, order.PriceCurrency);
+                return TrailingAmountImpl(order, QuantConnect.Currencies.GetCurrencySymbol(order.PriceCurrency));
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string TrailingAmount(decimal trailingAmount, bool trailingAsPercentage, string priceCurrency)
             {
                 return trailingAsPercentage ? Invariant($"{trailingAmount * 100}%") : Invariant($"{priceCurrency}{trailingAmount}");
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static string TrailingAmountImpl(Orders.TrailingStopOrder order, string currencySymbol)
+            {
+                return TrailingAmount(order.TrailingAmount, order.TrailingAsPercentage, currencySymbol);
             }
         }
 

--- a/Common/Orders/LimitIfTouchedOrder.cs
+++ b/Common/Orders/LimitIfTouchedOrder.cs
@@ -71,11 +71,6 @@ namespace QuantConnect.Orders
         {
             TriggerPrice = (decimal) triggerPrice;
             LimitPrice = limitPrice;
-            if (string.IsNullOrEmpty(tag))
-            {
-                //Default tag values to display trigger price in GUI.
-                Tag = Messages.LimitIfTouchedOrder.Tag(this);
-            }
         }
 
         /// <summary>
@@ -83,6 +78,15 @@ namespace QuantConnect.Orders
         /// </summary>
         public LimitIfTouchedOrder()
         {
+        }
+
+        /// <summary>
+        /// Gets the default tag for this order
+        /// </summary>
+        /// <returns>The default tag</returns>
+        public override string GetDefaultTag()
+        {
+            return Messages.LimitIfTouchedOrder.Tag(this);
         }
 
         /// <summary>

--- a/Common/Orders/LimitOrder.cs
+++ b/Common/Orders/LimitOrder.cs
@@ -60,7 +60,6 @@ namespace QuantConnect.Orders
 
             if (string.IsNullOrEmpty(tag))
             {
-                //Default tag values to display limit price in GUI.
                 Tag = Messages.LimitOrder.Tag(this);
             }
         }

--- a/Common/Orders/LimitOrder.cs
+++ b/Common/Orders/LimitOrder.cs
@@ -57,11 +57,15 @@ namespace QuantConnect.Orders
             : base(symbol, quantity, time, tag, properties)
         {
             LimitPrice = limitPrice;
+        }
 
-            if (string.IsNullOrEmpty(tag))
-            {
-                Tag = Messages.LimitOrder.Tag(this);
-            }
+        /// <summary>
+        /// Gets the default tag for this order
+        /// </summary>
+        /// <returns>The default tag</returns>
+        public override string GetDefaultTag()
+        {
+            return Messages.LimitOrder.Tag(this);
         }
 
         /// <summary>
@@ -104,7 +108,7 @@ namespace QuantConnect.Orders
         /// <returns>A copy of this order</returns>
         public override Order Clone()
         {
-            var order = new LimitOrder {LimitPrice = LimitPrice};
+            var order = new LimitOrder { LimitPrice = LimitPrice };
             CopyTo(order);
             return order;
         }

--- a/Common/Orders/Order.cs
+++ b/Common/Orders/Order.cs
@@ -293,6 +293,15 @@ namespace QuantConnect.Orders
         protected abstract decimal GetValueImpl(Security security);
 
         /// <summary>
+        /// Gets the default tag for this order
+        /// </summary>
+        /// <returns>The default tag</returns>
+        public virtual string GetDefaultTag()
+        {
+            return string.Empty;
+        }
+
+        /// <summary>
         /// Gets a new unique incremental id for this order
         /// </summary>
         /// <returns>Returns a new id for this order</returns>

--- a/Common/Orders/StopLimitOrder.cs
+++ b/Common/Orders/StopLimitOrder.cs
@@ -69,12 +69,15 @@ namespace QuantConnect.Orders
         {
             StopPrice = stopPrice;
             LimitPrice = limitPrice;
+        }
 
-            if (string.IsNullOrEmpty(tag))
-            {
-                //Default tag values to display stop price in GUI.
-                Tag = Messages.StopLimitOrder.Tag(this);
-            }
+        /// <summary>
+        /// Gets the default tag for this order
+        /// </summary>
+        /// <returns>The default tag</returns>
+        public override string GetDefaultTag()
+        {
+            return Messages.StopLimitOrder.Tag(this);
         }
 
         /// <summary>
@@ -86,13 +89,13 @@ namespace QuantConnect.Orders
             // selling, so higher price will be used
             if (Quantity < 0)
             {
-                return Quantity*Math.Max(LimitPrice, security.Price);
+                return Quantity * Math.Max(LimitPrice, security.Price);
             }
 
             // buying, so lower price will be used
             if (Quantity > 0)
             {
-                return Quantity*Math.Min(LimitPrice, security.Price);
+                return Quantity * Math.Min(LimitPrice, security.Price);
             }
 
             return 0m;

--- a/Common/Orders/StopMarketOrder.cs
+++ b/Common/Orders/StopMarketOrder.cs
@@ -57,12 +57,15 @@ namespace QuantConnect.Orders
             : base(symbol, quantity, time, tag, properties)
         {
             StopPrice = stopPrice;
+        }
 
-            if (string.IsNullOrEmpty(tag))
-            {
-                //Default tag values to display stop price in GUI.
-                Tag = Messages.StopMarketOrder.Tag(this);
-            }
+        /// <summary>
+        /// Gets the default tag for this order
+        /// </summary>
+        /// <returns>The default tag</returns>
+        public override string GetDefaultTag()
+        {
+            return Messages.StopMarketOrder.Tag(this);
         }
 
         /// <summary>
@@ -74,13 +77,13 @@ namespace QuantConnect.Orders
             // selling, so higher price will be used
             if (Quantity < 0)
             {
-                return Quantity*Math.Max(StopPrice, security.Price);
+                return Quantity * Math.Max(StopPrice, security.Price);
             }
 
             // buying, so lower price will be used
             if (Quantity > 0)
             {
-                return Quantity*Math.Min(StopPrice, security.Price);
+                return Quantity * Math.Min(StopPrice, security.Price);
             }
 
             return 0m;
@@ -117,7 +120,7 @@ namespace QuantConnect.Orders
         /// <returns>A copy of this order</returns>
         public override Order Clone()
         {
-            var order = new StopMarketOrder {StopPrice = StopPrice};
+            var order = new StopMarketOrder { StopPrice = StopPrice };
             CopyTo(order);
             return order;
         }

--- a/Common/Orders/TrailingStopOrder.cs
+++ b/Common/Orders/TrailingStopOrder.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Trailing amount for this trailing stop order
         /// </summary>
-        public decimal TrailingAmount{ get; internal set; }
+        public decimal TrailingAmount { get; internal set; }
 
         /// <summary>
         /// Determines whether the <see cref="TrailingAmount"/> is a percentage or an absolute currency value
@@ -65,12 +65,6 @@ namespace QuantConnect.Orders
         {
             TrailingAmount = trailingAmount;
             TrailingAsPercentage = trailingAsPercentage;
-
-            if (string.IsNullOrEmpty(tag))
-            {
-                //Default tag values to display stop price in GUI.
-                Tag = Messages.TrailingStopOrder.Tag(this);
-            }
         }
 
         /// <summary>
@@ -89,6 +83,15 @@ namespace QuantConnect.Orders
             DateTime time, string tag = "", IOrderProperties properties = null)
             : this(symbol, quantity, 0, trailingAmount, trailingAsPercentage, time, tag, properties)
         {
+        }
+
+        /// <summary>
+        /// Gets the default tag for this order
+        /// </summary>
+        /// <returns>The default tag</returns>
+        public override string GetDefaultTag()
+        {
+            return Messages.TrailingStopOrder.Tag(this);
         }
 
         /// <summary>

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -774,6 +774,10 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             // ensure the order is tagged with a currency
             var security = _algorithm.Securities[order.Symbol];
             order.PriceCurrency = security.SymbolProperties.QuoteCurrency;
+            if (string.IsNullOrEmpty(order.Tag))
+            {
+                order.Tag = order.GetDefaultTag();
+            }
 
             // rounds off the order towards 0 to the nearest multiple of lot size
             order.Quantity = RoundOffOrder(order, security);

--- a/Tests/Common/CurrenciesTests.cs
+++ b/Tests/Common/CurrenciesTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -26,6 +26,13 @@ namespace QuantConnect.Tests.Common
     [TestFixture]
     public class CurrenciesTests
     {
+        [TestCase("")]
+        [TestCase(null)]
+        public void GetCurrencySymbolHandlesNullOrEmpty(string currency)
+        {
+            Assert.AreEqual("", Currencies.GetCurrencySymbol(currency));
+        }
+
         [TestCase(SecurityType.Forex, Market.FXCM)]
         [TestCase(SecurityType.Forex, Market.Oanda)]
         public void HasCurrencySymbolForEachForexPair(SecurityType securityType, string market)

--- a/Tests/Common/Orders/OrderTests.cs
+++ b/Tests/Common/Orders/OrderTests.cs
@@ -25,7 +25,6 @@ using QuantConnect.Securities.Cfd;
 using QuantConnect.Securities.Equity;
 using QuantConnect.Securities.Forex;
 using QuantConnect.Securities.Option;
-using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.Tests.Common.Orders
 {
@@ -51,7 +50,7 @@ namespace QuantConnect.Tests.Common.Orders
         public void LimitOrder_SetsDefaultTag(string tag)
         {
             var order = new LimitOrder(Symbols.SPY, 1m, 123.4567m, DateTime.Today, tag);
-            Assert.AreEqual(Invariant($"Limit Price: {order.LimitPrice:C}"), order.Tag);
+            Assert.AreEqual(string.Empty, order.Tag);
         }
 
         [Test]
@@ -60,7 +59,7 @@ namespace QuantConnect.Tests.Common.Orders
         public void StopLimitOrder_SetsDefaultTag(string tag)
         {
             var order = new StopLimitOrder(Symbols.SPY, 1m, 123.4567m, 234.5678m, DateTime.Today, tag);
-            Assert.AreEqual(Invariant($"Stop Price: {order.StopPrice:C} Limit Price: {order.LimitPrice:C}"), order.Tag);
+            Assert.AreEqual(string.Empty, order.Tag);
         }
 
         [Test]
@@ -69,7 +68,7 @@ namespace QuantConnect.Tests.Common.Orders
         public void StopMarketOrder_SetsDefaultTag(string tag)
         {
             var order = new StopMarketOrder(Symbols.SPY, 1m, 123.4567m, DateTime.Today, tag);
-            Assert.AreEqual(Invariant($"Stop Price: {order.StopPrice:C}"), order.Tag);
+            Assert.AreEqual(string.Empty, order.Tag);
         }
 
         [Test]
@@ -87,7 +86,7 @@ namespace QuantConnect.Tests.Common.Orders
         public void LimitIfTouchedOrder_SetsDefaultTag(string tag)
         {
             var order = new LimitIfTouchedOrder(Symbols.SPY, 1m, 123.4567m,122.4567m, DateTime.Today, tag);
-            Assert.AreEqual(Invariant($"Trigger Price: {order.TriggerPrice:C} Limit Price: {order.LimitPrice:C}"), order.Tag);
+            Assert.AreEqual(string.Empty, order.Tag);
         }
 
         [TestCase(OrderDirection.Sell, 300, 0.1, true, 270)]

--- a/Tests/Common/Orders/OrderTests.cs
+++ b/Tests/Common/Orders/OrderTests.cs
@@ -44,51 +44,6 @@ namespace QuantConnect.Tests.Common.Orders
             Assert.AreEqual(parameters.ExpectedValue, value);
         }
 
-        [Test]
-        [TestCase(null)]
-        [TestCase("")]
-        public void LimitOrder_SetsDefaultTag(string tag)
-        {
-            var order = new LimitOrder(Symbols.SPY, 1m, 123.4567m, DateTime.Today, tag);
-            Assert.AreEqual(string.Empty, order.Tag);
-        }
-
-        [Test]
-        [TestCase(null)]
-        [TestCase("")]
-        public void StopLimitOrder_SetsDefaultTag(string tag)
-        {
-            var order = new StopLimitOrder(Symbols.SPY, 1m, 123.4567m, 234.5678m, DateTime.Today, tag);
-            Assert.AreEqual(string.Empty, order.Tag);
-        }
-
-        [Test]
-        [TestCase(null)]
-        [TestCase("")]
-        public void StopMarketOrder_SetsDefaultTag(string tag)
-        {
-            var order = new StopMarketOrder(Symbols.SPY, 1m, 123.4567m, DateTime.Today, tag);
-            Assert.AreEqual(string.Empty, order.Tag);
-        }
-
-        [Test]
-        [TestCase(null)]
-        [TestCase("")]
-        public void TrailingStopOrder_SetsDefaultTag(string tag)
-        {
-            var order = new TrailingStopOrder(Symbols.SPY, 1m, 0.1m, true, DateTime.Today, tag);
-            Assert.AreEqual(Messages.TrailingStopOrder.Tag(order), order.Tag);
-        }
-
-        [Test]
-        [TestCase(null)]
-        [TestCase("")]
-        public void LimitIfTouchedOrder_SetsDefaultTag(string tag)
-        {
-            var order = new LimitIfTouchedOrder(Symbols.SPY, 1m, 123.4567m,122.4567m, DateTime.Today, tag);
-            Assert.AreEqual(string.Empty, order.Tag);
-        }
-
         [TestCase(OrderDirection.Sell, 300, 0.1, true, 270)]
         [TestCase(OrderDirection.Sell, 300, 30, false, 270)]
         [TestCase(OrderDirection.Buy, 300, 0.1, true, 330)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Clean up redundant information or order's default tags, which is duplicated in the UI as shown in the related issue https://github.com/QuantConnect/Lean/issues/7701#issuecomment-1897173899. Also we replace the string currency format specifier `:C` with manual formatting using Lean's currency which depend on the security or account currency.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #7701 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The `C` specifier would take the server locale to add the currency symbol to formatted strings and will end up with the undefined currency symbol `¤` when the server locale is not specified. Either way, this is incorrect, since the currency does not depend on the system but on the securities or algorithm's account currencies.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Existing unit tests
- Manual backtests, checking the order tags both by debugging and in the results file.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
