### PR TITLE
Solve bug in `ETFConstituentsUniverseSelectionModel`

### DIFF
--- a/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.cs
@@ -67,7 +67,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
             Symbol etfSymbol,
             UniverseSettings universeSettings = null,
             PyObject universeFilterFunc = null) :
-            this(etfSymbol, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>())
+            this(etfSymbol, universeSettings, universeFilterFunc?.ConvertPythonUniverseFilterFunction<ETFConstituentData>())
         { }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
             string etfTicker,
             UniverseSettings universeSettings = null,
             PyObject universeFilterFunc = null) :
-            this(etfTicker, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>())
+            this(etfTicker, universeSettings, universeFilterFunc?.ConvertPythonUniverseFilterFunction<ETFConstituentData>())
         { }
 
         /// <summary>

--- a/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/ETFConstituentsUniverseSelectionModel.cs
@@ -67,7 +67,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
             Symbol etfSymbol,
             UniverseSettings universeSettings = null,
             PyObject universeFilterFunc = null) :
-            this(etfSymbol, universeSettings, universeFilterFunc?.ConvertPythonUniverseFilterFunction<ETFConstituentData>())
+            this(etfSymbol, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>())
         { }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
             string etfTicker,
             UniverseSettings universeSettings = null,
             PyObject universeFilterFunc = null) :
-            this(etfTicker, universeSettings, universeFilterFunc?.ConvertPythonUniverseFilterFunction<ETFConstituentData>())
+            this(etfTicker, universeSettings, universeFilterFunc.ConvertPythonUniverseFilterFunction<ETFConstituentData>())
         { }
 
         /// <summary>

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -2697,7 +2697,7 @@ namespace QuantConnect
             Func<IEnumerable<T>, object> convertedFunc;
             Func<IEnumerable<T>, IEnumerable<Symbol>> filterFunc = null;
 
-            if (universeFilterFunc.TryConvertToDelegate(out convertedFunc))
+            if (universeFilterFunc != null && universeFilterFunc.TryConvertToDelegate(out convertedFunc))
             {
                 filterFunc = convertedFunc.ConvertToUniverseSelectionSymbolDelegate();
             }

--- a/Tests/Algorithm/Framework/Selection/ETFConstituentsUniverseSelectionModelTests.cs
+++ b/Tests/Algorithm/Framework/Selection/ETFConstituentsUniverseSelectionModelTests.cs
@@ -22,6 +22,7 @@ using QuantConnect.Securities;
 using System.Collections.Generic;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Algorithm.Framework.Selection;
+using Moq;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Selection
 {
@@ -165,6 +166,8 @@ class ETFConstituentsFrameworkAlgorithm(QCAlgorithm):
 
                 Assert.AreEqual(symbol.SecurityType, universe.Configuration.Symbol.SecurityType);
                 Assert.IsTrue(universe.Configuration.Symbol.ID.Symbol.StartsWithInvariant("qc-universe-"));
+                var data = new Mock<BaseDataCollection>();
+                Assert.DoesNotThrow(() => universe.PerformSelection(DateTime.UtcNow, data.Object));
 
             } while (++numberOfOperation <= 9) ;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The bug was raised after calling an overload constructor using just the ticker as a parameter. Since the universeFilterFunc was null, after calling the method `Extensions.ConvertPythonUniverseFilterFunction` to convert the filter, the method `Extensions.TryConvertToDelegate` returned true and thus, the filterfunc assigned was the one returned by the method `ConvertToUniverseSelectionSymbolDelegate()` which used the null filterfunc. Therefore, by the time the filterfunc was called, it produced a null reference exception. To fix this, and additional check was placed in the method `Extensions.ConvertPythonUniverseFilterFunction()` to avoid calling `Extensions.ConvertToUniverseSelectionSymbolDelegate` when the universeFilterFunc was null. Finally, when the method `ETFConstituentsUniverseSelectionModel.CreateUniverses()` was called, since the `_univreseFilterFunc` was null, a default filter was selected in one of the `ETFConstituentsUniverse` constructors.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7590 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, users will be able to create a `ETFConstituentsUniverseSelectionModel` object, just using a ticker as parameter
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Since the exception was thrown when the universe filter func was called, the test `ETFConstituentsUniverseSelectionModelTests.ETFConstituentsUniverseSelectionModelTestAllConstructor` was modified to assert no exception was thrown when universe filter func was called.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
