### PR TITLE
Stop support of MOC orders for Options in IB Brokerage Model 

### DIFF
--- a/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
+++ b/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
@@ -132,6 +132,13 @@ namespace QuantConnect.Brokerages
 
                 return false;
             }
+            else if (order.Type == OrderType.MarketOnClose && (security.Type == SecurityType.Option || security.Type == SecurityType.IndexOption))
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning,
+                    "InteractiveBrokers does not support Market-on-Close orders for Options",
+                    Messages.DefaultBrokerageModel.UnsupportedOrderType(this, order, _supportedOrderTypes.Where(x => x != OrderType.MarketOnClose)));
+                return false;
+            }
 
             // validate security type
             if (security.Type != SecurityType.Equity &&

--- a/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
+++ b/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
@@ -132,7 +132,7 @@ namespace QuantConnect.Brokerages
 
                 return false;
             }
-            else if (order.Type == OrderType.MarketOnClose && (security.Type == SecurityType.Option || security.Type == SecurityType.IndexOption))
+            else if (order.Type == OrderType.MarketOnClose && security.Type.IsOption())
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning,
                     "InteractiveBrokers does not support Market-on-Close orders for Options",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
I changed `InteractiveBrokersBrokerageModel` class to reject MOC orders for Options, since that's what they specify in their docs.
![image](https://github.com/QuantConnect/Lean/assets/47573394/7fd30ad9-9b98-4f7c-b17d-28a4a952935d)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7720 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change LEAN will deny users MOC orders for Options when using IB brokerage
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created unit tests that asserted the MOC orders for different types of Options(Options, Index Options and Future Options) were rejected by the IB brokerage
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
