### PR TITLE
Introduce new `OrderPosition` enum

### DIFF
--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -411,6 +411,24 @@ namespace QuantConnect.Brokerages
             return Enumerable.Empty<BaseData>();
         }
 
+        /// <summary>
+        /// Gets the position that might result given the specified order direction and the current holdings quantity.
+        /// This is useful for brokerages that require more specific direction information than provided by the OrderDirection enum
+        /// (e.g. Tradier differentiates Buy/Sell and BuyToOpen/BuyToCover/SellShort/SellToClose)
+        /// </summary>
+        /// <param name="orderDirection">The order direction</param>
+        /// <param name="holdingsQuantity">The current holdings quantity</param>
+        /// <returns>The order position</returns>
+        protected static OrderPosition GetOrderPosition(OrderDirection orderDirection, decimal holdingsQuantity)
+        {
+            return orderDirection switch
+            {
+                OrderDirection.Buy => holdingsQuantity >= 0 ? OrderPosition.BuyToOpen : OrderPosition.BuyToClose,
+                OrderDirection.Sell => holdingsQuantity <= 0 ? OrderPosition.SellToOpen : OrderPosition.SellToClose,
+                _ => throw new ArgumentOutOfRangeException(nameof(orderDirection), orderDirection, "Invalid order direction")
+            };
+        }
+
         #region IBrokerageCashSynchronizer implementation
 
         /// <summary>

--- a/Common/Orders/OrderTypes.cs
+++ b/Common/Orders/OrderTypes.cs
@@ -107,6 +107,32 @@ namespace QuantConnect.Orders
     }
 
     /// <summary>
+    /// Position of the order
+    /// </summary>
+    public enum OrderPosition
+    {
+        /// <summary>
+        /// Indicates the buy order will result in a long position, starting either from zero or an existing long position (0)
+        /// </summary>
+        BuyToOpen,
+
+        /// <summary>
+        /// Indicates the buy order is starting from an existing short position, resulting in a closed or long position (1)
+        /// </summary>
+        BuyToClose,
+
+        /// <summary>
+        /// Indicates the sell order will result in a short position, starting either from zero or an existing short position (2)
+        /// </summary>
+        SellToOpen,
+
+        /// <summary>
+        /// Indicates the sell order is starting from an existing long position, resulting in a closed or short position (3)
+        /// </summary>
+        SellToClose,
+    }
+
+    /// <summary>
     /// Fill status of the order class.
     /// </summary>
     public enum OrderStatus

--- a/Tests/Brokerages/DefaultBrokerageTests.cs
+++ b/Tests/Brokerages/DefaultBrokerageTests.cs
@@ -1,0 +1,96 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using QuantConnect.Brokerages;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Tests.Brokerages
+{
+    /// <summary>
+    /// Additional tests for the base <see cref="Brokerage"/> class
+    /// </summary>
+    public class DefaultBrokerageTests
+    {
+        [TestCase(OrderDirection.Buy, 0, ExpectedResult = OrderPosition.BuyToOpen)]
+        [TestCase(OrderDirection.Buy, 100, ExpectedResult = OrderPosition.BuyToOpen)]
+        [TestCase(OrderDirection.Buy, -100, ExpectedResult = OrderPosition.BuyToClose)]
+        [TestCase(OrderDirection.Sell, 0, ExpectedResult = OrderPosition.SellToOpen)]
+        [TestCase(OrderDirection.Sell, 100, ExpectedResult = OrderPosition.SellToClose)]
+        [TestCase(OrderDirection.Sell, -100, ExpectedResult = OrderPosition.SellToOpen)]
+        public OrderPosition GetsOrderPosition(OrderDirection direction, decimal holdingsQuantity)
+        {
+            return TestableBrokerage.GetOrderPositionPublic(direction, holdingsQuantity);
+        }
+
+        private class TestableBrokerage : Brokerage
+        {
+            public TestableBrokerage(string name) : base(name)
+            {
+            }
+
+            public override bool IsConnected => throw new NotImplementedException();
+
+            public override bool CancelOrder(Order order)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Connect()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Disconnect()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override List<Holding> GetAccountHoldings()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override List<CashAmount> GetCashBalance()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override List<Order> GetOpenOrders()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool PlaceOrder(Order order)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool UpdateOrder(Order order)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static OrderPosition GetOrderPositionPublic(OrderDirection direction, decimal holdingsQuantity)
+            {
+                return GetOrderPosition(direction, holdingsQuantity);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This introduces the `OrderPosition` enum and a `Brokerage` method `GetOrderPosition` that gets the position that might result given the specified order direction and the current holdings quantity.
This is useful for brokerages that require more specific direction information than provided by the `OrderDirection` enum (e.g. Tradier differentiates Buy/Sell and BuyToOpen/BuyToCover/SellShort/SellToClose).

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
