### PR TITLE
Universe symbols selection by symbol ID string

### DIFF
--- a/Algorithm.Python/SelectUniverseSymbolsFromIDRegressionAlgorithm.py
+++ b/Algorithm.Python/SelectUniverseSymbolsFromIDRegressionAlgorithm.py
@@ -1,0 +1,56 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression algorithm asserting that universe symbols selection can be done by returning the symbol IDs in the selection function
+### </summary>
+class SelectUniverseSymbolsFromIDRegressionAlgorithm(QCAlgorithm):
+    '''
+    Regression algorithm asserting that universe symbols selection can be done by returning the symbol IDs in the selection function
+    '''
+
+    def Initialize(self):
+        self.SetStartDate(2014, 3, 24)
+        self.SetEndDate(2014, 3, 26)
+        self.SetCash(100000)
+
+        self.securities = []
+        self.UniverseSettings.Resolution = Resolution.Daily
+        self.AddUniverse(self.select_symbol)
+
+    def select_symbol(self, fundamental):
+        symbols = [x.Symbol for x in fundamental]
+
+        if not symbols:
+            return []
+
+        self.Log(f"Symbols: {', '.join([str(s) for s in symbols])}")
+        # Just for testing, but more filtering could be done here as shown below:
+        #symbols = [x.Symbol for x in fundamental if x.AssetClassification.MorningstarSectorCode == MorningstarSectorCode.Technology]
+
+        history = self.History(symbols, datetime(1998, 1, 1), self.Time, Resolution.Daily)
+
+        all_time_highs = history['high'].unstack(0).max()
+        last_closes = history['close'].unstack(0).iloc[-1]
+        security_ids = (last_closes / all_time_highs).sort_values().index[-5:]
+
+        return security_ids
+
+    def OnSecuritiesChanged(self, changes):
+        self.securities.extend(changes.AddedSecurities)
+
+    def OnEndOfAlgorithm(self):
+        if not self.securities:
+            raise Exception("No securities were selected")

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -2712,7 +2712,16 @@ namespace QuantConnect
             {
                 var result = selector(data);
                 return ReferenceEquals(result, Universe.Unchanged)
-                    ? Universe.Unchanged : ((object[])result).Select(x => (Symbol)x);
+                    ? Universe.Unchanged
+                    : ((object[])result).Select(x =>
+                    {
+                        if (x is Symbol)
+                        {
+                            return (Symbol)x;
+                        }
+
+                        return SymbolCache.TryGetSymbol((string)x, out var symbol) ? symbol : null;
+                    });
             };
         }
 

--- a/Tests/Python/PythonRegressionAlgorithmsTests.cs
+++ b/Tests/Python/PythonRegressionAlgorithmsTests.cs
@@ -1,0 +1,38 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace QuantConnect.Tests.Python
+{
+    [TestFixture]
+    public class PythonRegressionAlgorithmsTests
+    {
+        [Test]
+        public void SelectUniverseSymbolsFromIDRegressionAlgorithm()
+        {
+            var parameters = new RegressionTests.AlgorithmStatisticsTestParameters("SelectUniverseSymbolsFromIDRegressionAlgorithm",
+                new Dictionary<string, string> { {"Total Trades", "0"} },
+                Language.Python,
+                AlgorithmStatus.Completed);
+
+            AlgorithmRunner.RunLocalBacktest(parameters.Algorithm,
+                parameters.Statistics,
+                parameters.Language,
+                parameters.ExpectedFinalStatus);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

These changes make sure universe symbols can be selected by returning the symbol ID instead of the symbol itself.

This comes in handy for cases like Python algorithms that might select symbols using historical data stored in a Pandas DataFrame which is indexed with the symbol ID string (`Symbol.ID`). 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Close #7729 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit test
- Regression algorithm

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
