### PR TITLE
Solve bug in Tick.ParsedSaleCondition

### DIFF
--- a/Common/Data/Market/Tick.cs
+++ b/Common/Data/Market/Tick.cs
@@ -104,6 +104,11 @@ namespace QuantConnect.Data.Market
         {
             get
             {
+                if (string.IsNullOrEmpty(SaleCondition))
+                {
+                    return 0;
+                }
+
                 if (!_parsedSaleCondition.HasValue)
                 {
                     _parsedSaleCondition = uint.Parse(SaleCondition, NumberStyles.HexNumber, CultureInfo.InvariantCulture);

--- a/Tests/Common/Data/SliceTests.cs
+++ b/Tests/Common/Data/SliceTests.cs
@@ -358,6 +358,15 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(1, slice2.Ticks.Count);
         }
 
+        [TestCase(null)]
+        [TestCase("")]
+        public void AccessingTicksParsedSaleConditinoDoesNotThrow(string saleCondition)
+        {
+            var tick1 = new Tick(_dataTime, Symbols.SPY, 1.1m, 2.1m) { TickType = TickType.Trade };
+            tick1.SaleCondition = saleCondition;
+            Assert.DoesNotThrow(() => tick1.ParsedSaleCondition.ToString());
+        }
+
         [Test]
         public void MergeOptionsAndFuturesChain()
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
When `Tick.SaleCondition` was null or empty, the method `uint.Parse(SaleCondition, NumberStyles.HexNumber, CultureInfo.InvariantCulture)` threw an exception. Therefore, I added a check condition in `ParsedSaleCondition.get()` to return zero if `SaleCondition` is null or empty.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7759 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, users will not get an exception when trying to access `Tick.ParsedSaleCondition`
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I made a unit test asserting no exception was thrown after calling `Tick.ParsedSaleCondition` with the field `SaleCondition` equal to null or empty
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
