### PR TITLE
Handle history provider returning null

### DIFF
--- a/Engine/HistoricalData/BrokerageHistoryProvider.cs
+++ b/Engine/HistoricalData/BrokerageHistoryProvider.cs
@@ -71,6 +71,11 @@ namespace QuantConnect.Lean.Engine.HistoricalData
             foreach (var request in requests)
             {
                 var history = _brokerage.GetHistory(request);
+                if (history == null)
+                {
+                    // doesn't support this history request, that's okay
+                    continue;
+                }
                 var subscription = CreateSubscription(request, history);
 
                 _dataPermissionManager.AssertConfiguration(subscription.Configuration, request.StartTimeLocal, request.EndTimeLocal);
@@ -78,6 +83,10 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 subscriptions.Add(subscription);
             }
 
+            if (subscriptions.Count == 0)
+            {
+                return null;
+            }
             return CreateSliceEnumerableFromSubscriptions(subscriptions, sliceTimeZone);
         }
     }

--- a/Engine/HistoricalData/HistoryProviderManager.cs
+++ b/Engine/HistoricalData/HistoryProviderManager.cs
@@ -88,6 +88,11 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                         dataQueueHandler = Composer.Instance.GetExportedValueByTypeName<IDataQueueHandler>(brokerageName);
                         // initialize it
                         dataQueueHandler.SetJob((Packets.LiveNodePacket)parameters.Job);
+                        Log.Trace($"HistoryProviderManager.Initialize(): Created and wrapped '{brokerageName}' as '{typeof(BrokerageHistoryProvider).Name}'");
+                    }
+                    else
+                    {
+                        Log.Trace($"HistoryProviderManager.Initialize(): Wrapping '{brokerageName}' instance as '{typeof(BrokerageHistoryProvider).Name}'");
                     }
 
                     // wrap it
@@ -130,6 +135,11 @@ namespace QuantConnect.Lean.Engine.HistoricalData
                 try
                 {
                     var history = historyProvider.GetHistory(historyRequets, sliceTimeZone);
+                    if (history == null)
+                    {
+                        // doesn't support this history request, that's okay
+                        continue;
+                    }
                     historyEnumerators.Add(history.GetEnumerator());
                 }
                 catch (Exception e)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Handle history provider returning null
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Use multiple different history provider sources
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
