### PR TITLE
Handle insufficient margin for option exercise

### DIFF
--- a/Algorithm.CSharp/CustomOptionAssignmentRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomOptionAssignmentRegressionAlgorithm.cs
@@ -83,7 +83,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$4800000.00"},
             {"Lowest Capacity Asset", "GOOCV 305RBQ20WHPNQ|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "26.72%"},
-            {"OrderListHash", "db137c185e96681000e53c2c373c18e5"}
+            {"OrderListHash", "d8a544352326b3e74c0e5c9ce7517ae8"}
         };
     }
 }

--- a/Algorithm.CSharp/CustomOptionExerciseModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomOptionExerciseModelRegressionAlgorithm.cs
@@ -91,7 +91,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$87000.00"},
             {"Lowest Capacity Asset", "GOOCV 305RBQ20WHPNQ|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "10.93%"},
-            {"OrderListHash", "1b9493f01c5a9c5bc5032cf84c249782"}
+            {"OrderListHash", "f3584e74d78b3fa544f7558bb3c4c1bd"}
         };
     }
 }

--- a/Algorithm.CSharp/InsufficientBuyingPowerForAutomaticExerciseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/InsufficientBuyingPowerForAutomaticExerciseRegressionAlgorithm.cs
@@ -1,0 +1,216 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QLNet;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting that a short option position is auto exercised even when there is insufficient margin,
+    /// but triggering a margin call for the underlying stock to cover the assignment.
+    /// </summary>
+    public class InsufficientBuyingPowerForAutomaticExerciseRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _stock;
+        private Symbol _option;
+
+        private bool _stockBought;
+        private bool _optionSold;
+        private bool _optionAssigned;
+        private bool _marginCallReceived;
+
+        public override void Initialize()
+        {
+            SetStartDate(2015, 12, 23);
+            SetEndDate(2015, 12, 28);
+            SetCash(100000);
+
+            _stock = AddEquity("GOOG").Symbol;
+
+            var contracts = OptionChainProvider.GetOptionContractList(_stock, UtcTime).ToList();
+            _option = contracts
+                .Where(c => c.ID.OptionRight == OptionRight.Put)
+                .OrderBy(c => c.ID.Date)
+                .First(c => c.ID.StrikePrice == 800m);
+
+            //_option = QuantConnect.Symbol.CreateOption(_stock, Market.USA, OptionStyle.American, OptionRight.Put, 41m, new DateTime(2014, 06, 21));
+            AddOptionContract(_option);
+        }
+
+        public override void OnData(Slice data)
+        {
+            // We are done with buying
+            if (_stockBought && _optionSold)
+            {
+                return;
+            }
+
+            if (!Portfolio.Invested)
+            {
+                // We'll use all our buying power to buy the stock, so when we then open a short put position,
+                // the margin will not be enough to cover the automatic exercise
+                SetHoldings(_stock, 1);
+            }
+
+            if (_stockBought && Securities[_option].Price != 0)
+            {
+                MarketOrder(_option, -2);
+            }
+        }
+
+        public override void OnMarginCall(List<SubmitOrderRequest> requests)
+        {
+            if (!_optionAssigned)
+            {
+                throw new Exception("Expected option to have been assigned before the margin call " +
+                    "(which should have been triggered by the auto-exercise of the option with inssuficient margin).");
+            }
+
+            if (_marginCallReceived)
+            {
+                throw new Exception("Received multiple margin calls. Expected just one.");
+            }
+
+            var request = requests.Single();
+            if (request.Symbol != _stock)
+            {
+                throw new Exception("Expected margin call for the stock, but got margin call for: " + request.Symbol);
+            }
+
+            _marginCallReceived = true;
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            var order = Transactions.GetOrderById(orderEvent.OrderId);
+            Debug($"{Time} :: {order.Id} - {order.Type} - {orderEvent.Symbol}: {orderEvent.Status} - {orderEvent.Quantity} shares at {orderEvent.FillPrice}");
+
+            if (orderEvent.Status == OrderStatus.Filled)
+            {
+                if (orderEvent.Symbol == _stock)
+                {
+                    _stockBought = true;
+                }
+                else if (orderEvent.Symbol == _option)
+                {
+                    if (order.Type == OrderType.Market)
+                    {
+                        if (!_stockBought)
+                        {
+                            throw new Exception("Stock should have been bought first");
+                        }
+
+                        _optionSold = true;
+                    }
+                    else if (order.Type == OrderType.OptionExercise && orderEvent.IsAssignment)
+                    {
+                        if (!_optionSold)
+                        {
+                            throw new Exception("Option should have been sold first");
+                        }
+
+                        _optionAssigned = true;
+                    }
+                }
+                else
+                {
+                    throw new Exception("Unexpected symbol: " + orderEvent.Symbol);
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_stockBought)
+            {
+                throw new Exception("Stock was not bought");
+            }
+
+            if (!_optionSold)
+            {
+                throw new Exception("Option was not sold");
+            }
+
+            if (!_optionAssigned)
+            {
+                throw new Exception("Option was not assigned");
+            }
+
+            if (!_marginCallReceived)
+            {
+                throw new Exception("Margin call was not received");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 2821;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Trades", "4"},
+            {"Average Win", "8.96%"},
+            {"Average Loss", "-1.95%"},
+            {"Compounding Annual Return", "-67.963%"},
+            {"Drawdown", "2.900%"},
+            {"Expectancy", "-1"},
+            {"Net Profit", "-1.752%"},
+            {"Sharpe Ratio", "-6.542"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "1.125%"},
+            {"Loss Rate", "100%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "4.60"},
+            {"Alpha", "-0.007"},
+            {"Beta", "1.181"},
+            {"Annual Standard Deviation", "0.036"},
+            {"Annual Variance", "0.001"},
+            {"Information Ratio", "-1.422"},
+            {"Tracking Error", "0.03"},
+            {"Treynor Ratio", "-0.2"},
+            {"Total Fees", "$3.30"},
+            {"Estimated Strategy Capacity", "$2400000.00"},
+            {"Lowest Capacity Asset", "GOOCV 305RBQ20WHPNQ|GOOCV VP83T1ZUHROL"},
+            {"Portfolio Turnover", "54.01%"},
+            {"OrderListHash", "72e36e29e49caae435accc583f060c47"}
+        };
+    }
+}
+

--- a/Algorithm.CSharp/InsufficientBuyingPowerForAutomaticExerciseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/InsufficientBuyingPowerForAutomaticExerciseRegressionAlgorithm.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using QLNet;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;

--- a/Algorithm.CSharp/InsufficientBuyingPowerForAutomaticExerciseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/InsufficientBuyingPowerForAutomaticExerciseRegressionAlgorithm.cs
@@ -51,7 +51,6 @@ namespace QuantConnect.Algorithm.CSharp
                 .OrderBy(c => c.ID.Date)
                 .First(c => c.ID.StrikePrice == 800m);
 
-            //_option = QuantConnect.Symbol.CreateOption(_stock, Market.USA, OptionStyle.American, OptionRight.Put, 41m, new DateTime(2014, 06, 21));
             AddOptionContract(_option);
         }
 

--- a/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
@@ -128,7 +128,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$710000.00"},
             {"Lowest Capacity Asset", "GOOCV 305RBQ20WHPNQ|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "218.80%"},
-            {"OrderListHash", "02d3bd3ca1b69a6f1c64d862cd0dd4ba"}
+            {"OrderListHash", "67f42f49744d67f72f2c64b5dddb3432"}
         };
     }
 }

--- a/Brokerages/Backtesting/BacktestingBrokerage.cs
+++ b/Brokerages/Backtesting/BacktestingBrokerage.cs
@@ -466,12 +466,12 @@ namespace QuantConnect.Brokerages.Backtesting
                     var result = option.OptionAssignmentModel.GetAssignment(new OptionAssignmentParameters(option));
                     if (result != null && result.Quantity != 0)
                     {
-                        var request = new SubmitOrderRequest(OrderType.OptionExercise, option.Type, option.Symbol, Math.Abs(result.Quantity), 0m, 0m, 0m, Algorithm.UtcTime, result.Tag);
                         if (!_pendingOptionAssignments.Add(option.Symbol))
                         {
                             throw new InvalidOperationException($"Duplicate option exercise order request for symbol {option.Symbol}. Please contact support");
                         }
-                        Algorithm.Transactions.ProcessRequest(request);
+
+                        OnOptionNotification(new OptionNotificationEventArgs(option.Symbol, 0, result.Tag));
                     }
                 }
             }

--- a/Common/Brokerages/OptionNotificationEventArgs.cs
+++ b/Common/Brokerages/OptionNotificationEventArgs.cs
@@ -56,9 +56,8 @@ namespace QuantConnect.Brokerages
         /// <param name="position">The new option position</param>
         /// <param name="tag">The tag to be used for the order</param>
         public OptionNotificationEventArgs(Symbol symbol, decimal position, string tag)
+            : this(symbol, position)
         {
-            Symbol = symbol;
-            Position = position;
             Tag = tag;
         }
 

--- a/Common/Brokerages/OptionNotificationEventArgs.cs
+++ b/Common/Brokerages/OptionNotificationEventArgs.cs
@@ -34,6 +34,11 @@ namespace QuantConnect.Brokerages
         public decimal Position { get; }
 
         /// <summary>
+        /// The tag that will be used in the order
+        /// </summary>
+        public string Tag { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="OptionNotificationEventArgs"/> class
         /// </summary>
         /// <param name="symbol">The symbol</param>
@@ -45,11 +50,30 @@ namespace QuantConnect.Brokerages
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="OptionNotificationEventArgs"/> class
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="position">The new option position</param>
+        /// <param name="tag">The tag to be used for the order</param>
+        public OptionNotificationEventArgs(Symbol symbol, decimal position, string tag)
+        {
+            Symbol = symbol;
+            Position = position;
+            Tag = tag;
+        }
+
+        /// <summary>
         /// Returns the string representation of this event
         /// </summary>
         public override string ToString()
         {
-            return $"{Symbol} position: {Position}";
+            var str = $"{Symbol} position: {Position}";
+            if (!string.IsNullOrEmpty(Tag))
+            {
+                str += $", tag: {Tag}";
+            }
+
+            return str;
         }
     }
 }

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1453,7 +1453,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                             // If the quantity is already 0 for Lean and the brokerage there is nothing else todo here
                             if (quantity != 0)
                             {
-                                var exerciseOrder = GenerateOptionExerciseOrder(security, quantity);
+                                var exerciseOrder = GenerateOptionExerciseOrder(security, quantity, e.Tag);
 
                                 EmitOptionNotificationEvents(security, exerciseOrder);
                             }
@@ -1514,7 +1514,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                                 {
                                     var quantity = e.Position - security.Holdings.Quantity;
 
-                                    var exerciseOrder = GenerateOptionExerciseOrder(security, quantity);
+                                    var exerciseOrder = GenerateOptionExerciseOrder(security, quantity, e.Tag);
 
                                     EmitOptionNotificationEvents(security, exerciseOrder);
                                 }
@@ -1541,10 +1541,10 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             }
         }
 
-        private OptionExerciseOrder GenerateOptionExerciseOrder(Security security, decimal quantity)
+        private OptionExerciseOrder GenerateOptionExerciseOrder(Security security, decimal quantity, string tag)
         {
             // generate new exercise order and ticket for the option
-            var order = new OptionExerciseOrder(security.Symbol, quantity, CurrentTimeUtc);
+            var order = new OptionExerciseOrder(security.Symbol, quantity, CurrentTimeUtc, tag);
 
             // save current security prices
             order.OrderSubmissionData = new OrderSubmissionData(security.BidPrice, security.AskPrice, security.Close);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Handling insufficient margin for automatic option exercise, which was causing the "Duplicated option assignment..." exception mentioned in the related issue #7815.

With these changes, simulated option exercises are handled using the `Brokerage.OptionNofication` event to create the option exercise order instead of going through the order processor, so that the margin check is bypassed and the order is placed and filled. After this, we expect a margin call like shown in the new regression algorithm `InsufficientBuyingPowerForAutomaticExerciseRegressionAlgorithm`.

Note: about algorithm's stats change (orders hash): since simulated options exercises are now handled like expired options exercise, without going throught the order processor to place them, some order properties are not populated, like `OrderSubmissionData` and `PriceCurrency`, but this should be taclked in a separate PR to keep this clean. 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Close #7815 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Regression algorithm

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
