### PR TITLE
Add Option Vega indicator

### DIFF
--- a/Algorithm.CSharp/OptionIndicatorsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionIndicatorsRegressionAlgorithm.cs
@@ -31,6 +31,7 @@ namespace QuantConnect.Algorithm.CSharp
         private Symbol _option;
         private ImpliedVolatility _impliedVolatility;
         private Delta _delta;
+        private Vega _vega;
 
         public override void Initialize()
         {
@@ -47,6 +48,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             _impliedVolatility = new ImpliedVolatility(_option, interestRateProvider, dividendYieldProvider, OptionPricingModelType.BlackScholes, 2);
             _delta = new Delta(_option, interestRateProvider, dividendYieldProvider, OptionPricingModelType.BinomialCoxRossRubinstein, OptionPricingModelType.BlackScholes);
+            _vega = new Vega(_option, interestRateProvider, dividendYieldProvider, OptionPricingModelType.ForwardTree, OptionPricingModelType.BlackScholes);
         }
 
         public override void OnData(Slice slice)
@@ -61,17 +63,21 @@ namespace QuantConnect.Algorithm.CSharp
 
                 _delta.Update(underlyingDataPoint);
                 _delta.Update(optionDataPoint);
+
+                _vega.Update(underlyingDataPoint);
+                _vega.Update(optionDataPoint);
             }    
         }
 
         public override void OnEndOfAlgorithm()
         {
-            if (_impliedVolatility == 0m || _delta == 0m)
+            if (_impliedVolatility == 0m || _delta == 0m || _vega == 0m)
             {
                 throw new Exception("Expected IV/greeks calculated");
             }
             Debug(@$"Implied Volatility: {_impliedVolatility.Current.Value},
-Delta: {_delta.Current.Value}");
+Delta: {_delta.Current.Value},
+Vega: {_vega.Current.Value}");
         }
 
         /// <summary>

--- a/Algorithm.Python/OptionIndicatorsRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionIndicatorsRegressionAlgorithm.py
@@ -29,6 +29,7 @@ class OptionIndicatorsRegressionAlgorithm(QCAlgorithm):
 
         self.impliedVolatility = ImpliedVolatility(self.option, interestRateProvider, dividendYieldProvider, OptionPricingModelType.BlackScholes, 2)
         self.delta = Delta(self.option, interestRateProvider, dividendYieldProvider, OptionPricingModelType.BinomialCoxRossRubinstein, OptionPricingModelType.BlackScholes)
+        self.vega = Vega(self.option, interestRateProvider, dividendYieldProvider, OptionPricingModelType.ForwardTree, OptionPricingModelType.BlackScholes)
 
     def OnData(self, slice):
         if slice.Bars.ContainsKey(self.aapl) and slice.QuoteBars.ContainsKey(self.option):
@@ -41,9 +42,13 @@ class OptionIndicatorsRegressionAlgorithm(QCAlgorithm):
             self.delta.Update(underlyingDataPoint)
             self.delta.Update(optionDataPoint)
 
+            self.vega.Update(underlyingDataPoint)
+            self.vega.Update(optionDataPoint)
+
     def OnEndOfAlgorithm(self):
         if self.impliedVolatility.Current.Value == 0 or self.delta.Current.Value == 0:
             raise Exception("Expected IV/greeks calculated")
 
         self.Debug(f"""Implied Volatility: {self.impliedVolatility.Current.Value},
-Delta: {self.delta.Current.Value}""")
+Delta: {self.delta.Current.Value},
+Vega: {self.vega.Current.Value}""")

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -2010,7 +2010,55 @@ namespace QuantConnect.Algorithm
 
             return ultimateOscillator;
         }
-        
+
+        /// <summary>
+        /// Creates a new Vega indicator for the symbol The indicator will be automatically
+        /// updated on the symbol's subscription resolution
+        /// </summary>
+        /// <param name="symbol">The option symbol whose values we want as an indicator</param>
+        /// <param name="riskFreeRate">The risk free rate</param>
+        /// <param name="dividendYield">The dividend yield</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        /// <param name="resolution">The desired resolution of the data</param>
+        /// <returns>A new Vega indicator for the specified symbol</returns>
+        [DocumentationAttribute(Indicators)]
+        public Vega V(Symbol symbol, decimal? riskFreeRate = null, decimal? dividendYield = null, OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes,
+            OptionPricingModelType? ivModel = null, Resolution? resolution = null)
+        {
+            var name = InitializeOptionIndicator<Vega>(symbol, out var riskFreeRateModel, out var dividendYieldModel, riskFreeRate, dividendYield, optionModel, resolution);
+
+            var vega = new Vega(name, symbol, riskFreeRateModel, dividendYieldModel, optionModel, ivModel);
+            RegisterIndicator(symbol, vega, ResolveConsolidator(symbol, resolution));
+            RegisterIndicator(symbol.Underlying, vega, ResolveConsolidator(symbol.Underlying, resolution));
+            return vega;
+        }
+
+        /// <summary>
+        /// Creates a new Vega indicator for the symbol The indicator will be automatically
+        /// updated on the symbol's subscription resolution
+        /// </summary>
+        /// <param name="symbol">The option symbol whose values we want as an indicator</param>
+        /// <param name="mirrorOption">The mirror option for parity calculation</param>
+        /// <param name="riskFreeRate">The risk free rate</param>
+        /// <param name="dividendYield">The dividend yield</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        /// <param name="resolution">The desired resolution of the data</param>
+        /// <returns>A new Vega indicator for the specified symbol</returns>
+        [DocumentationAttribute(Indicators)]
+        public Vega V(Symbol symbol, Symbol mirrorOption, decimal? riskFreeRate = null, decimal? dividendYield = null, OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes,
+            OptionPricingModelType? ivModel = null, Resolution? resolution = null)
+        {
+            var name = InitializeOptionIndicator<Vega>(symbol, out var riskFreeRateModel, out var dividendYieldModel, riskFreeRate, dividendYield, optionModel, resolution);
+
+            var vega = new Vega(name, symbol, mirrorOption, riskFreeRateModel, dividendYieldModel, optionModel, ivModel);
+            RegisterIndicator(symbol, vega, ResolveConsolidator(symbol, resolution));
+            RegisterIndicator(mirrorOption, vega, ResolveConsolidator(mirrorOption, resolution));
+            RegisterIndicator(symbol.Underlying, vega, ResolveConsolidator(symbol.Underlying, resolution));
+            return vega;
+        }
+
         /// <summary>
         /// Creates a new Chande's Variable Index Dynamic Average indicator.
         /// </summary>

--- a/Indicators/Vega.cs
+++ b/Indicators/Vega.cs
@@ -1,0 +1,366 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using MathNet.Numerics.Distributions;
+using Python.Runtime;
+using QuantConnect.Data;
+
+namespace QuantConnect.Indicators
+{
+    /// <summary>
+    /// Option Vega indicator that calculate the Vega of an option
+    /// </summary>
+    /// <remarks>sensitivity of option price on time decay</remarks>
+    public class Vega : OptionGreeksIndicatorBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="name">The name of this indicator</param>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYieldModel">Dividend yield model</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(string name, Symbol option, IRiskFreeInterestRateModel riskFreeRateModel, IDividendYieldModel dividendYieldModel,
+                OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : base(name, option, riskFreeRateModel, dividendYieldModel, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYieldModel">Dividend yield model</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(Symbol option, IRiskFreeInterestRateModel riskFreeRateModel, IDividendYieldModel dividendYieldModel,
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : this($"Vega({optionModel})", option, riskFreeRateModel, dividendYieldModel, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="name">The name of this indicator</param>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYieldModel">Dividend yield model</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(string name, Symbol option, PyObject riskFreeRateModel, PyObject dividendYieldModel,
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : base(name, option, riskFreeRateModel, dividendYieldModel, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYieldModel">Dividend yield model</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(Symbol option, PyObject riskFreeRateModel, PyObject dividendYieldModel,
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : this($"Vega({optionModel})", option, riskFreeRateModel, dividendYieldModel, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="name">The name of this indicator</param>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYield">Dividend yield, as a constant</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(string name, Symbol option, IRiskFreeInterestRateModel riskFreeRateModel, decimal dividendYield = 0.0m,
+                OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : base(name, option, riskFreeRateModel, dividendYield, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYield">Dividend yield, as a constant</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(Symbol option, IRiskFreeInterestRateModel riskFreeRateModel, decimal dividendYield = 0.0m,
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : this($"Vega({optionModel})", option, riskFreeRateModel, dividendYield, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="name">The name of this indicator</param>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYield">Dividend yield, as a constant</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(string name, Symbol option, PyObject riskFreeRateModel, decimal dividendYield = 0.0m,
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : base(name, option, riskFreeRateModel, dividendYield, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYield">Dividend yield, as a constant</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(Symbol option, PyObject riskFreeRateModel, decimal dividendYield = 0.0m,
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : this($"Vega({optionModel})", option, riskFreeRateModel, dividendYield, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="name">The name of this indicator</param>
+        /// <param name="option">The option to be tracked</param>am>
+        /// <param name="riskFreeRate">Risk-free rate, as a constant</param>
+        /// <param name="dividendYield">Dividend yield, as a constant</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(string name, Symbol option, decimal riskFreeRate = 0.05m, decimal dividendYield = 0.0m, 
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : base(name, option, riskFreeRate, dividendYield, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="riskFreeRate">Risk-free rate, as a constant</param>
+        /// <param name="dividendYield">Dividend yield, as a constant</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(Symbol option, decimal riskFreeRate = 0.05m, decimal dividendYield = 0.0m,
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : this($"Vega({optionModel})", option, riskFreeRate, dividendYield, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="name">The name of this indicator</param>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="mirrorOption">The mirror option for parity calculation</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYieldModel">Dividend yield model</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(string name, Symbol option, Symbol mirrorOption, IRiskFreeInterestRateModel riskFreeRateModel, IDividendYieldModel dividendYieldModel,
+                OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : base(name, option, mirrorOption, riskFreeRateModel, dividendYieldModel, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="mirrorOption">The mirror option for parity calculation</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYieldModel">Dividend yield model</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(Symbol option, Symbol mirrorOption, IRiskFreeInterestRateModel riskFreeRateModel, IDividendYieldModel dividendYieldModel,
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : this($"Vega({option},{mirrorOption},{optionModel})", option, mirrorOption, riskFreeRateModel, dividendYieldModel, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="name">The name of this indicator</param>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="mirrorOption">The mirror option for parity calculation</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYieldModel">Dividend yield model</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(string name, Symbol option, Symbol mirrorOption, PyObject riskFreeRateModel, PyObject dividendYieldModel,
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : base(name, option, mirrorOption, riskFreeRateModel, dividendYieldModel, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="mirrorOption">The mirror option for parity calculation</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYieldModel">Dividend yield model</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(Symbol option, Symbol mirrorOption, PyObject riskFreeRateModel, PyObject dividendYieldModel,
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : this($"Vega({option},{mirrorOption},{optionModel})", option, mirrorOption, riskFreeRateModel, dividendYieldModel, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="name">The name of this indicator</param>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="mirrorOption">The mirror option for parity calculation</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYield">Dividend yield, as a constant</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(string name, Symbol option, Symbol mirrorOption, IRiskFreeInterestRateModel riskFreeRateModel, decimal dividendYield = 0.0m,
+                OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : base(name, option, mirrorOption, riskFreeRateModel, dividendYield, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="mirrorOption">The mirror option for parity calculation</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYield">Dividend yield, as a constant</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(Symbol option, Symbol mirrorOption, IRiskFreeInterestRateModel riskFreeRateModel, decimal dividendYield = 0.0m,
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : this($"Vega({option},{mirrorOption},{optionModel})", option, mirrorOption, riskFreeRateModel, dividendYield, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="name">The name of this indicator</param>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="mirrorOption">The mirror option for parity calculation</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYield">Dividend yield, as a constant</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(string name, Symbol option, Symbol mirrorOption, PyObject riskFreeRateModel, decimal dividendYield = 0.0m,
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : base(name, option, mirrorOption, riskFreeRateModel, dividendYield, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="mirrorOption">The mirror option for parity calculation</param>
+        /// <param name="riskFreeRateModel">Risk-free rate model</param>
+        /// <param name="dividendYield">Dividend yield, as a constant</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(Symbol option, Symbol mirrorOption, PyObject riskFreeRateModel, decimal dividendYield = 0.0m,
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : this($"Vega({option},{mirrorOption},{optionModel})", option, mirrorOption, riskFreeRateModel, dividendYield, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="name">The name of this indicator</param>
+        /// <param name="option">The option to be tracked</param>am>
+        /// <param name="mirrorOption">The mirror option for parity calculation</param>
+        /// <param name="riskFreeRate">Risk-free rate, as a constant</param>
+        /// <param name="dividendYield">Dividend yield, as a constant</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(string name, Symbol option, Symbol mirrorOption, decimal riskFreeRate = 0.05m, decimal dividendYield = 0.0m, 
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : base(name, option, mirrorOption, riskFreeRate, dividendYield, optionModel, ivModel)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Vega class
+        /// </summary>
+        /// <param name="option">The option to be tracked</param>
+        /// <param name="mirrorOption">The mirror option for parity calculation</param>
+        /// <param name="riskFreeRate">Risk-free rate, as a constant</param>
+        /// <param name="dividendYield">Dividend yield, as a constant</param>
+        /// <param name="optionModel">The option pricing model used to estimate Vega</param>
+        /// <param name="ivModel">The option pricing model used to estimate IV</param>
+        public Vega(Symbol option, Symbol mirrorOption, decimal riskFreeRate = 0.05m, decimal dividendYield = 0.0m,
+            OptionPricingModelType optionModel = OptionPricingModelType.BlackScholes, OptionPricingModelType? ivModel = null)
+            : this($"Vega({option},{mirrorOption},{optionModel})", option, mirrorOption, riskFreeRate, dividendYield, optionModel, ivModel)
+        {
+        }
+
+        // Calculate the Vega of the option
+        protected override decimal CalculateGreek(DateTime time)
+        {
+            var timeToExpiration = Convert.ToDecimal((Expiry - time).TotalDays) / 365m;
+            var math = OptionGreekIndicatorsHelper.DecimalMath;
+
+            switch (_optionModel)
+            {
+                case OptionPricingModelType.BinomialCoxRossRubinstein:
+                case OptionPricingModelType.ForwardTree:
+                    // finite differencing method with 1% IV changes
+                    var deltaSigma = 0.01m;
+
+                    var newPrice = 0m;
+                    var price = 0m;
+                    if (_optionModel == OptionPricingModelType.BinomialCoxRossRubinstein)
+                    {
+                        newPrice = OptionGreekIndicatorsHelper.CRRTheoreticalPrice(ImpliedVolatility + deltaSigma, UnderlyingPrice, Strike, timeToExpiration, RiskFreeRate, DividendYield, Right);
+                        price = OptionGreekIndicatorsHelper.CRRTheoreticalPrice(ImpliedVolatility, UnderlyingPrice, Strike, timeToExpiration, RiskFreeRate, DividendYield, Right);
+                    }
+                    else if (_optionModel == OptionPricingModelType.ForwardTree)
+                    {
+                        newPrice = OptionGreekIndicatorsHelper.ForwardTreeTheoreticalPrice(ImpliedVolatility + deltaSigma, UnderlyingPrice, Strike, timeToExpiration, RiskFreeRate, DividendYield, Right);
+                        price = OptionGreekIndicatorsHelper.ForwardTreeTheoreticalPrice(ImpliedVolatility, UnderlyingPrice, Strike, timeToExpiration, RiskFreeRate, DividendYield, Right);
+                    }
+
+                    return (newPrice - price) / deltaSigma / 100;
+
+                case OptionPricingModelType.BlackScholes:
+                default:
+                    var norm = new Normal();
+                    var d1 = OptionGreekIndicatorsHelper.CalculateD1(UnderlyingPrice, Strike, timeToExpiration, RiskFreeRate, DividendYield, ImpliedVolatility);
+
+                    return UnderlyingPrice * math(Math.Sqrt, timeToExpiration) * math(norm.Density, d1) * math(Math.Exp, -DividendYield * timeToExpiration) / 100;
+            }
+        }
+    }
+}

--- a/Tests/Indicators/OptionBaseIndicatorTests.cs
+++ b/Tests/Indicators/OptionBaseIndicatorTests.cs
@@ -91,7 +91,7 @@ namespace QuantConnect.Tests.Indicators
             }
             
             var expected = double.Parse(items[callColumn], NumberStyles.Any, CultureInfo.InvariantCulture);
-            var acceptance = Math.Max(errorMargin * Math.Abs(expected), 1e-4);     // percentage error
+            var acceptance = Math.Max(errorMargin * Math.Abs(expected), 2e-4);     // percentage error
             Assert.AreEqual(expected, (double)callIndicator.Current.Value, acceptance);
 
             putIndicator.Update(putDataPoint);
@@ -102,7 +102,7 @@ namespace QuantConnect.Tests.Indicators
             }
 
             expected = double.Parse(items[putColumn], NumberStyles.Any, CultureInfo.InvariantCulture);
-            acceptance = Math.Max(errorMargin * Math.Abs(expected), 1e-4);     // percentage error
+            acceptance = Math.Max(errorMargin * Math.Abs(expected), 2e-4);     // percentage error
             Assert.AreEqual(expected, (double)putIndicator.Current.Value, acceptance);
         }
 

--- a/Tests/Indicators/VegaTests.cs
+++ b/Tests/Indicators/VegaTests.cs
@@ -1,0 +1,129 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+using System.IO;
+using System.Linq;
+
+namespace QuantConnect.Tests.Indicators
+{
+    [TestFixture]
+    public class VegaTests : OptionBaseIndicatorTests<Vega>
+    {
+        protected override IndicatorBase<IndicatorDataPoint> CreateIndicator()
+            => new Vega("testVegaIndicator", _symbol, 0.0403m, 0.0m);
+
+        protected override OptionIndicatorBase CreateIndicator(IRiskFreeInterestRateModel riskFreeRateModel)
+            => new Vega("testVegaIndicator", _symbol, riskFreeRateModel);
+
+        protected override OptionIndicatorBase CreateIndicator(IRiskFreeInterestRateModel riskFreeRateModel, IDividendYieldModel dividendYieldModel)
+            => new Vega("testVegaIndicator", _symbol, riskFreeRateModel, dividendYieldModel);
+
+        protected override OptionIndicatorBase CreateIndicator(QCAlgorithm algorithm)
+            => algorithm.V(_symbol);
+
+        [SetUp]
+        public void SetUp()
+        {
+            // 2 updates per iteration, 1 for greek, 1 for IV
+            RiskFreeRateUpdatesPerIteration = 2;
+            DividendYieldUpdatesPerIteration = 2;
+        }
+
+        [TestCase("american/third_party_1_greeks.csv", true, 0.2, false)]
+        [TestCase("american/third_party_1_greeks.csv", false, 0.2, false)]
+        [TestCase("american/third_party_2_greeks.csv", false, 10000, true)]
+        public void ComparesAgainstExternalData(string subPath, bool reset, double errorMargin, bool singleContract, int callColumn = 13, int putColumn = 12)
+        {
+            var path = Path.Combine("TestData", "greeksindicator", subPath);
+            // skip last entry since for deep ITM, IV will not affect much on price. Thus root finding will not be optimizing a non-convex function.
+            foreach (var line in File.ReadAllLines(path).Skip(3).SkipLast(1))
+            {
+                var items = line.Split(',');
+
+                var interestRate = Parse.Decimal(items[^2]);
+                var dividendYield = Parse.Decimal(items[^1]);
+
+                var model = ParseSymbols(items, path.Contains("american"), out var call, out var put);
+
+                Vega callIndicator;
+                Vega putIndicator;
+                if (singleContract)
+                {
+                    callIndicator = new Vega(call, interestRate, dividendYield, model);
+                    putIndicator = new Vega(put, interestRate, dividendYield, model);
+                }
+                else
+                {
+                    callIndicator = new Vega(call, put, interestRate, dividendYield, model);
+                    putIndicator = new Vega(put, call, interestRate, dividendYield, model);
+                }
+
+                RunTestIndicator(call, put, callIndicator, putIndicator, items, callColumn, putColumn, errorMargin);
+
+                if (reset == true)
+                {
+                    callIndicator.Reset();
+                    putIndicator.Reset();
+
+                    RunTestIndicator(call, put, callIndicator, putIndicator, items, callColumn, putColumn, errorMargin);
+                }
+            }
+        }
+
+        // Reference values from QuantLib
+        [TestCase(23.753, 450.0, OptionRight.Call, 60, 0.7215, OptionStyle.European)]
+        [TestCase(35.830, 450.0, OptionRight.Put, 60, 0.7195, OptionStyle.European)]
+        [TestCase(33.928, 470.0, OptionRight.Call, 60, 0.6705, OptionStyle.European)]
+        [TestCase(6.428, 470.0, OptionRight.Put, 60, 0.6181, OptionStyle.European)]
+        [TestCase(3.219, 430.0, OptionRight.Call, 60, 0.5429, OptionStyle.European)]
+        [TestCase(47.701, 430.0, OptionRight.Put, 60, 0.6922, OptionStyle.European)]
+        [TestCase(16.528, 450.0, OptionRight.Call, 180, 1.1932, OptionStyle.European)]
+        [TestCase(21.784, 450.0, OptionRight.Put, 180, 1.2263, OptionStyle.European)]
+        [TestCase(35.207, 470.0, OptionRight.Call, 180, 1.0370, OptionStyle.European)]
+        [TestCase(0.409, 470.0, OptionRight.Put, 180, 0.3528, OptionStyle.European)]
+        [TestCase(2.642, 430.0, OptionRight.Call, 180, 0.9707, OptionStyle.European)]
+        [TestCase(27.772, 430.0, OptionRight.Put, 180, 1.1816, OptionStyle.European)]
+        [TestCase(23.753, 450.0, OptionRight.Call, 60, 0.7206, OptionStyle.American)]
+        [TestCase(35.830, 450.0, OptionRight.Put, 60, 0.7189, OptionStyle.American)]
+        [TestCase(33.928, 470.0, OptionRight.Call, 60, 0.6791, OptionStyle.American)]
+        [TestCase(6.428, 470.0, OptionRight.Put, 60, 0.6290, OptionStyle.American)]
+        [TestCase(3.219, 430.0, OptionRight.Call, 60, 0.5690, OptionStyle.American)]
+        [TestCase(47.701, 430.0, OptionRight.Put, 60, 0.6921, OptionStyle.American)]
+        [TestCase(16.528, 450.0, OptionRight.Call, 180, 1.1958, OptionStyle.American)]
+        [TestCase(21.784, 450.0, OptionRight.Put, 180, 1.2248, OptionStyle.American)]
+        [TestCase(35.207, 470.0, OptionRight.Call, 180, 1.0459, OptionStyle.American)]
+        [TestCase(0.409, 470.0, OptionRight.Put, 180, 0.4350, OptionStyle.American)]
+        [TestCase(2.642, 430.0, OptionRight.Call, 180, 1.0122, OptionStyle.American)]
+        [TestCase(27.772, 430.0, OptionRight.Put, 180, 1.1852, OptionStyle.American)]
+        // No American option Vega from QuantLib
+        public void ComparesAgainstExternalData2(decimal price, decimal spotPrice, OptionRight right, int expiry, double refVega, OptionStyle style)
+        {
+            var symbol = Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, right, 450m, _reference.AddDays(expiry));
+            var model = style == OptionStyle.European ? OptionPricingModelType.BlackScholes : OptionPricingModelType.BinomialCoxRossRubinstein;
+            var indicator = new Vega(symbol, 0.053m, 0.0153m, model, OptionPricingModelType.BlackScholes);
+
+            var optionDataPoint = new IndicatorDataPoint(symbol, _reference, price);
+            var spotDataPoint = new IndicatorDataPoint(symbol.Underlying, _reference, spotPrice);
+            indicator.Update(optionDataPoint);
+            indicator.Update(spotDataPoint);
+
+            Assert.AreEqual(refVega, (double)indicator.Current.Value, 0.0005d);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Add option vega indicator, to calculate the sensitivity of IV change in option price.

#### Related Issue
closes #7669

#### Motivation and Context
Part of option greek indicator project

#### Requires Documentation Change
Handled by auto-gen

#### How Has This Been Tested?
add unit tests and 3rd party source comparison.
Note: binomial model deep ITM/OTM will not be very accurate due to IV-price is not convex.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
