### PR TITLE
TryParsePath ignores DateTime

### DIFF
--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -1209,7 +1209,7 @@ namespace QuantConnect.Util
                     {
                         dataType = typeof(ETFConstituentData);
                     }
-                    symbol = Symbol.Create(ticker, securityType, market, baseDataType: dataType);
+                    symbol = CreateSymbol(ticker, securityType, market, dataType, date);
                 }
 
             }
@@ -1220,6 +1220,37 @@ namespace QuantConnect.Util
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Creates a new Symbol based on parsed data path information.
+        /// </summary>
+        /// <param name="ticker">The parsed ticker symbol.</param>
+        /// <param name="securityType">The parsed type of security.</param>
+        /// <param name="market">The parsed market or exchange.</param>
+        /// <param name="dataType">Optional type used for generating the base data SID (applicable only for SecurityType.Base).</param>
+        /// <param name="mappingResolveDate">The date used in path parsing to create the correct symbol.</param>
+        /// <returns>A unique security identifier.</returns>
+        /// <example>
+        /// <code>
+        /// path: equity/usa/minute/spwr/20071223_trade.zip
+        /// ticker: spwr
+        /// securityType: equity
+        /// market: usa
+        /// mappingResolveDate: 2007/12/23
+        /// </code>
+        /// </example>
+        private static Symbol CreateSymbol(string ticker, SecurityType securityType, string market, Type dataType, DateTime mappingResolveDate = default)
+        {
+            if (securityType == SecurityType.Equity || securityType == SecurityType.Option)
+            {
+                var symbol = new Symbol(SecurityIdentifier.GenerateEquity(ticker, market, mappingResolveDate: mappingResolveDate), ticker);
+                return securityType == SecurityType.Option ? Symbol.CreateCanonicalOption(symbol) : symbol;
+            }
+            else
+            {
+                return Symbol.Create(ticker, securityType, market, baseDataType: dataType);
+            }
         }
 
         private static List<string> SplitDataPath(string fileName)

--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -1242,7 +1242,7 @@ namespace QuantConnect.Util
         /// </example>
         private static Symbol CreateSymbol(string ticker, SecurityType securityType, string market, Type dataType, DateTime mappingResolveDate = default)
         {
-            if (securityType == SecurityType.Equity || securityType == SecurityType.Option)
+            if (mappingResolveDate != default && (securityType == SecurityType.Equity || securityType == SecurityType.Option))
             {
                 var symbol = new Symbol(SecurityIdentifier.GenerateEquity(ticker, market, mappingResolveDate: mappingResolveDate), ticker);
                 return securityType == SecurityType.Option ? Symbol.CreateCanonicalOption(symbol) : symbol;

--- a/Tests/Common/Util/LeanDataTests.cs
+++ b/Tests/Common/Util/LeanDataTests.cs
@@ -384,15 +384,21 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual(date.Date, Parse.DateTime("2016-10-07").Date);
         }
 
-        [TestCase("equity/usa/minute/goog/20130102_quote.zip", "GOOG", "2004/08/19")]
-        [TestCase("equity/usa/minute/goog/20100102_quote.zip", "GOOG", "2004/08/19")]
-        public void TryParseMapsShouldReturnCorrectSymbol(string path, string expectedTicker, DateTime expectedDate)
+        [TestCase("equity/usa/minute/goog/20130102_quote.zip", "GOOG", null, "2004/08/19")]
+        [TestCase("equity/usa/minute/goog/20100102_quote.zip", "GOOG", null, "2004/08/19")]
+        [TestCase("equity/usa/minute/goog/20150102_quote.zip", "GOOG", "GOOCV", "2014/03/27")]
+        [TestCase("equity/usa/minute/spwr/20071223_trade.zip", "SPWR", null, "2005/11/17")]
+        [TestCase("equity/usa/minute/spwra/20101223_trade.zip", "SPWRA", "SPWR", "2005/11/17")]
+        [TestCase("equity/usa/minute/spwr/20141223_trade.zip", "SPWR", "SPWR", "2005/11/17")]
+        [TestCase("option/usa/minute/goog/20151223_openinterest_american.zip", "GOOG", "GOOCV", "2014/03/27")]
+        public void TryParseMapsShouldReturnCorrectSymbol(string path, string expectedTicker, string expectedUnderlyingTicker, DateTime expectedDate)
         {
             Assert.IsTrue(LeanData.TryParsePath(path, out var parsedSymbol, out _, out _));
 
-            Assert.That(parsedSymbol.Value, Is.EqualTo(expectedTicker));
-            Assert.Throws<AssertionException>(() => Assert.That(parsedSymbol.ID.Date, Is.EqualTo(expectedDate)));
-            Assert.Throws<AssertionException>(() => Assert.That(parsedSymbol.ID.Symbol, Is.EqualTo(expectedTicker)));
+            var symbol = parsedSymbol.HasUnderlying ? parsedSymbol.Underlying : parsedSymbol;
+            Assert.That(symbol.Value, Is.EqualTo(expectedTicker));
+            Assert.That(symbol.ID.Date, Is.EqualTo(expectedDate));
+            Assert.That(symbol.ID.Symbol, Is.EqualTo(expectedUnderlyingTicker ?? expectedTicker));
         }
 
         [TestCase(SecurityType.Base, "alteRNative")]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The current implementation in `TryParsePath()` overlooks the parsed Date component. Consequently, when parsing a path like `"equity/usa/minute/spwr/20071223_trade.zip"`, the Date portion (`20071223`, representing December 23, 2007) is ignored. This oversight leads to incorrect `Symbol` generation from _map files_.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7850

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
By incorporating the Date into the parsing logic, the algorithm can accurately generate symbols from map files, ensuring correctness in symbol creation.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To ensure the reliability and effectiveness of this fix, comprehensive testing has been conducted. This includes:
- Unit tests: New unit tests have been added to cover scenarios where the parsed Date is essential for symbol creation. These tests verify that the `TryParsePath()` method correctly handles Date parsing and generates accurate symbols.
- Integration tests: Existing integration tests have been expanded to incorporate cases where the Date component is significant. Through integration testing, the behavior of the code in real-world scenarios is validated.
- Manual testing: Various sample data sets have been employed to manually validate the functionality of the modified `TryParsePath()` method. This manual testing ensures that the fix performs as expected across different input scenarios and edge cases.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
