### PR TITLE
Option style parameter for parsing OSI option tickers

### DIFF
--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -327,7 +327,7 @@ namespace QuantConnect
         /// <returns>Symbol object for the specified OSI option ticker string</returns>
         public static Symbol ParseOptionTickerOSI(string ticker, SecurityType securityType = SecurityType.Option, string market = Market.USA)
         {
-            return ParseOptionTickerOSI(ticker, securityType, market);
+            return ParseOptionTickerOSI(ticker, securityType, OptionStyle.American, market);
         }
 
         /// <summary>
@@ -338,8 +338,7 @@ namespace QuantConnect
         /// <param name="market">The associated market</param>
         /// <param name="optionStyle">The option style</param>
         /// <returns>Symbol object for the specified OSI option ticker string</returns>
-        public static Symbol ParseOptionTickerOSI(string ticker, SecurityType securityType = SecurityType.Option, string market = Market.USA,
-            OptionStyle optionStyle = OptionStyle.American)
+        public static Symbol ParseOptionTickerOSI(string ticker, SecurityType securityType, OptionStyle optionStyle, string market)
         {
             var optionTicker = ticker.Substring(0, 6).Trim();
             var expiration = DateTime.ParseExact(ticker.Substring(6, 6), DateFormat.SixCharacter, null);

--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -324,8 +324,10 @@ namespace QuantConnect
         /// <param name="ticker">The OSI compliant option ticker string</param>
         /// <param name="securityType">The security type</param>
         /// <param name="market">The associated market</param>
+        /// <param name="optionStyle">The option style</param>
         /// <returns>Symbol object for the specified OSI option ticker string</returns>
-        public static Symbol ParseOptionTickerOSI(string ticker, SecurityType securityType = SecurityType.Option, string market = Market.USA)
+        public static Symbol ParseOptionTickerOSI(string ticker, SecurityType securityType = SecurityType.Option, string market = Market.USA,
+            OptionStyle optionStyle = OptionStyle.American)
         {
             var optionTicker = ticker.Substring(0, 6).Trim();
             var expiration = DateTime.ParseExact(ticker.Substring(6, 6), DateFormat.SixCharacter, null);
@@ -358,7 +360,7 @@ namespace QuantConnect
             {
                 throw new NotImplementedException($"ParseOptionTickerOSI(): {Messages.SymbolRepresentation.SecurityTypeNotImplemented(securityType)}");
             }
-            var sid = SecurityIdentifier.GenerateOption(expiration, underlyingSid, optionTicker, market, strike, right, OptionStyle.American);
+            var sid = SecurityIdentifier.GenerateOption(expiration, underlyingSid, optionTicker, market, strike, right, optionStyle);
             return new Symbol(sid, ticker, new Symbol(underlyingSid, underlyingSid.Symbol));
         }
 
@@ -470,7 +472,7 @@ namespace QuantConnect
 
         /// <summary>
         /// Get the expiration year from short year (two-digit integer).
-        /// Examples: NQZ23 and NQZ3 for Dec 2023  
+        /// Examples: NQZ23 and NQZ3 for Dec 2023
         /// </summary>
         /// <param name="futureYear">Clarifies the year for the current future</param>
         /// <param name="shortYear">Year in 2 digits format (23 represents 2023)</param>

--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -324,6 +324,18 @@ namespace QuantConnect
         /// <param name="ticker">The OSI compliant option ticker string</param>
         /// <param name="securityType">The security type</param>
         /// <param name="market">The associated market</param>
+        /// <returns>Symbol object for the specified OSI option ticker string</returns>
+        public static Symbol ParseOptionTickerOSI(string ticker, SecurityType securityType = SecurityType.Option, string market = Market.USA)
+        {
+            return ParseOptionTickerOSI(ticker, securityType, market);
+        }
+
+        /// <summary>
+        /// Parses the specified OSI options ticker into a Symbol object
+        /// </summary>
+        /// <param name="ticker">The OSI compliant option ticker string</param>
+        /// <param name="securityType">The security type</param>
+        /// <param name="market">The associated market</param>
         /// <param name="optionStyle">The option style</param>
         /// <returns>Symbol object for the specified OSI option ticker string</returns>
         public static Symbol ParseOptionTickerOSI(string ticker, SecurityType securityType = SecurityType.Option, string market = Market.USA,

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -31,13 +31,17 @@ namespace QuantConnect.Tests.Common
             Assert.AreEqual(expected, result);
         }
 
-        [Test]
-        public void ParseOptionTickerOSI()
+        [TestCase("SPXW  230111C02400000", SecurityType.IndexOption, OptionStyle.European, "SPXW", "SPX")]
+        [TestCase("SPY   230111C02400000", SecurityType.Option, OptionStyle.American, "SPY", "SPY")]
+        public void ParseOptionTickerOSI(string optionStr, SecurityType securityType, OptionStyle optionStyle,
+            string expectedTargetOptionTicker, string expectedUnderlyingTicker)
         {
-            var result = SymbolRepresentation.ParseOptionTickerOSI("SPXW  230111C02400000", SecurityType.IndexOption);
+            var result = SymbolRepresentation.ParseOptionTickerOSI(optionStr, securityType, optionStyle: optionStyle);
 
-            Assert.AreEqual("SPXW", result.ID.Symbol);
-            Assert.AreEqual("SPX", result.Underlying.ID.Symbol);
+            Assert.AreEqual(expectedTargetOptionTicker, result.ID.Symbol);
+            Assert.AreEqual(expectedUnderlyingTicker, result.Underlying.ID.Symbol);
+            Assert.AreEqual(securityType, result.ID.SecurityType);
+            Assert.AreEqual(optionStyle, result.ID.OptionStyle);
         }
 
         [Test]

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Tests.Common
         public void ParseOptionTickerOSI(string optionStr, SecurityType securityType, OptionStyle optionStyle,
             string expectedTargetOptionTicker, string expectedUnderlyingTicker)
         {
-            var result = SymbolRepresentation.ParseOptionTickerOSI(optionStr, securityType, optionStyle: optionStyle);
+            var result = SymbolRepresentation.ParseOptionTickerOSI(optionStr, securityType, optionStyle, Market.USA);
 
             Assert.AreEqual(expectedTargetOptionTicker, result.ID.Symbol);
             Assert.AreEqual(expectedUnderlyingTicker, result.Underlying.ID.Symbol);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Add the option style parameter to `SymbolRepresentation.ParseOptionTickerOSI` in order to get more accurate Lean symbols from OSI tickers, which do not have enough information to know whether the option should be American or European style.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
