### PR TITLE
Options/Index Options hour/daily resolution required data only download

### DIFF
--- a/Algorithm.CSharp/BasicTemplateIndexDailyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateIndexDailyAlgorithm.cs
@@ -75,7 +75,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 0;
+        public override long DataPoints => 121;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -87,7 +87,33 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+            {"Total Orders", "4"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "1000000"},
+            {"End Equity", "1000000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-0.847"},
+            {"Tracking Error", "0.107"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "9ce3176f3cd1c0788affe7fb6d2b9c21"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateIndexOptionsDailyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateIndexOptionsDailyAlgorithm.cs
@@ -67,7 +67,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 0;
+        public override long DataPoints => 168;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -79,6 +79,32 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "1000000"},
+            {"End Equity", "1000000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-0.449"},
+            {"Tracking Error", "0.138"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
             {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
         };
     }

--- a/Common/Data/DownloaderExtensions.cs
+++ b/Common/Data/DownloaderExtensions.cs
@@ -33,7 +33,7 @@ namespace QuantConnect.Data
         /// <param name="mapFileProvider">Provides instances of <see cref="MapFileResolver"/> at run time</param>
         /// <param name="exchangeTimeZone">Provides the time zone this exchange</param>
         /// <returns>
-        /// Return DataDownloaderGetParameters with different 
+        /// Return DataDownloaderGetParameters with different
         /// <see cref="DataDownloaderGetParameters.StartUtc"/> - <seealso cref="DataDownloaderGetParameters.EndUtc"/> range
         /// and <seealso cref="Symbol"/>
         /// </returns>
@@ -55,11 +55,22 @@ namespace QuantConnect.Data
                 var yieldMappedSymbol = default(bool);
                 foreach (var symbolDateRange in mapFileProvider.RetrieveAllMappedSymbolInDateRange(dataDownloaderParameter.Symbol))
                 {
+                    var startDateTimeUtc = symbolDateRange.StartDateTimeLocal.ConvertToUtc(exchangeTimeZone);
                     var endDateTimeUtc = symbolDateRange.EndDateTimeLocal.ConvertToUtc(exchangeTimeZone);
 
                     // The first start date returns from mapFile like IPO (DateTime) and can not be greater then request StartTime
-                    // The Downloader doesn't know start DateTime exactly, it always download all data
-                    var startDateTime = symbolDateRange.StartDateTimeLocal.ConvertToUtc(exchangeTimeZone);
+                    // The Downloader doesn't know start DateTime exactly, it always download all data, except for options and index options
+                    var startDateTime = startDateTimeUtc;
+                    if (dataDownloaderParameter.Symbol.SecurityType == SecurityType.Option ||
+                        dataDownloaderParameter.Symbol.SecurityType == SecurityType.IndexOption)
+                    {
+                        if (endDateTimeUtc < dataDownloaderParameter.StartUtc)
+                        {
+                            continue;
+                        }
+
+                        startDateTime = startDateTimeUtc < dataDownloaderParameter.StartUtc ? dataDownloaderParameter.StartUtc : startDateTimeUtc;
+                    }
                     var endDateTime = endDateTimeUtc > dataDownloaderParameter.EndUtc ? dataDownloaderParameter.EndUtc : endDateTimeUtc;
 
                     yield return new DataDownloaderGetParameters(

--- a/Common/Data/DownloaderExtensions.cs
+++ b/Common/Data/DownloaderExtensions.cs
@@ -60,21 +60,28 @@ namespace QuantConnect.Data
 
                     // The first start date returns from mapFile like IPO (DateTime) and can not be greater then request StartTime
                     // The Downloader doesn't know start DateTime exactly, it always download all data, except for options and index options
-                    var startDateTime = startDateTimeUtc;
                     if (dataDownloaderParameter.Symbol.SecurityType == SecurityType.Option ||
                         dataDownloaderParameter.Symbol.SecurityType == SecurityType.IndexOption)
                     {
+                        // The symbol was delisted before the request start time
                         if (endDateTimeUtc < dataDownloaderParameter.StartUtc)
                         {
                             continue;
                         }
 
-                        startDateTime = startDateTimeUtc < dataDownloaderParameter.StartUtc ? dataDownloaderParameter.StartUtc : startDateTimeUtc;
+                        if (startDateTimeUtc < dataDownloaderParameter.StartUtc)
+                        {
+                            startDateTimeUtc = dataDownloaderParameter.StartUtc;
+                        }
                     }
-                    var endDateTime = endDateTimeUtc > dataDownloaderParameter.EndUtc ? dataDownloaderParameter.EndUtc : endDateTimeUtc;
+
+                    if (endDateTimeUtc > dataDownloaderParameter.EndUtc)
+                    {
+                        endDateTimeUtc = dataDownloaderParameter.EndUtc;
+                    }
 
                     yield return new DataDownloaderGetParameters(
-                        symbolDateRange.Symbol, dataDownloaderParameter.Resolution, startDateTime, endDateTime, dataDownloaderParameter.TickType);
+                        symbolDateRange.Symbol, dataDownloaderParameter.Resolution, startDateTimeUtc, endDateTimeUtc, dataDownloaderParameter.TickType);
                     yieldMappedSymbol = true;
                 }
 

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -283,11 +283,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 throw new InvalidOperationException($"{DataNormalizationMode.ScaledRaw} normalization mode only intended for history requests.");
             }
 
-            if (request.Configuration.SecurityType == SecurityType.IndexOption && request.Configuration.Resolution == Resolution.Daily)
-            {
-                throw new InvalidOperationException($"{Resolution.Daily} resolution is currently not supported for {SecurityType.IndexOption}, please use {Resolution.Hour} instead");
-            }
-
             // before adding the configuration to the data feed let's assert it's valid
             _dataPermissionManager.AssertConfiguration(request.Configuration, request.StartTimeLocal, request.EndTimeLocal);
 

--- a/Tests/Common/Util/DataDownloaderGetParameterExtensionsTests.cs
+++ b/Tests/Common/Util/DataDownloaderGetParameterExtensionsTests.cs
@@ -51,7 +51,10 @@ namespace QuantConnect.Tests.Common.Util
         [TestCase("../../../Data/equity/usa/minute/fb/20200401_trade.zip", 1, "FB", "2020/04/01-2000/04/02")]
         [TestCase("../../../Data/equity/usa/minute/xyz/20000401_trade.zip", 1, "XYZ", null)]
         [TestCase("../../../Data/cfd/oanda/daily/xauusd.zip", 1, "XAUUSD", null)]
-        [TestCase("../../../Data/option/usa/daily/goog_2015_quote_american.zip", 2, "GOOG", "2004/08/19-2014/04/02,2014/04/03-2024/03/07")]
+        [TestCase("../../../Data/option/usa/hour/goog_2014_quote_american.zip", 2, "GOOG", "2014/01/01-2014/04/02,2014/04/03-2015/01/01")]
+        [TestCase("../../../Data/option/usa/daily/goog_2014_quote_american.zip", 2, "GOOG", "2014/01/01-2014/04/02,2014/04/03-2015/01/01")]
+        [TestCase("../../../Data/indexoption/usa/hour/spx_2014_quote_american.zip", 1, "SPX", "2014/01/01-2015/01/01")]
+        [TestCase("../../../Data/indexoption/usa/daily/spx_2014_quote_american.zip", 1, "SPX", "2014/01/01-2015/01/01")]
         [TestCase("../../../Data/crypto/binance/hour/btcusdt_trade.zip", 1, "BTCUSDT", null)]
         [TestCase("../../../Data/cryptofuture/binance/hour/btcusdt_trade.zip", 1, "BTCUSDT", null)]
         [TestCase("../../../Data/futureoption/comex/minute/og/20200428/20200105_quote_american.zip", 1, "GC28J20", "2020/01/05-2020/01/06")]
@@ -67,7 +70,16 @@ namespace QuantConnect.Tests.Common.Util
             if (parsedDate != default)
             {
                 startDateTimeUtc = parsedDate;
-                endDateTimeUtc = parsedDate.AddDays(1);
+
+                if (resolution > Resolution.Minute &&
+                    (symbol.SecurityType == SecurityType.Option || symbol.SecurityType == SecurityType.IndexOption))
+                {
+                    endDateTimeUtc = startDateTimeUtc.AddYears(1);
+                }
+                else
+                {
+                    endDateTimeUtc = parsedDate.AddDays(1);
+                }
             }
             else
             {

--- a/Tests/Common/Util/LeanDataTests.cs
+++ b/Tests/Common/Util/LeanDataTests.cs
@@ -334,6 +334,21 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual(new DateTime(2021, 01, 04), date);
         }
 
+        [TestCase("Data\\indexoption\\usa\\hour\\spx_2021_quote_european", "SPX", SecurityType.IndexOption, Resolution.Hour, 2021)]
+        [TestCase("Data\\indexoption\\usa\\daily\\spx_2014_quote_european", "SPX", SecurityType.IndexOption, Resolution.Daily, 2014)]
+        [TestCase("Data\\option\\usa\\hour\\aapl_2021_quote_american.zip", "AAPL", SecurityType.Option, Resolution.Hour, 2021)]
+        [TestCase("Data\\option\\usa\\daily\\aapl_2014_quote_american.zip", "AAPL", SecurityType.Option, Resolution.Daily, 2014)]
+        public void ParsesHourAndDailyOptionsPathCorrectly(string path, string expectedSymbol, SecurityType expectedSecurityType,
+            Resolution expectedResolution, int expectedYear)
+        {
+            Assert.IsTrue(LeanData.TryParsePath(path, out var symbol, out var date, out var resolution));
+
+            Assert.AreEqual(expectedSecurityType, symbol.SecurityType);
+            Assert.AreEqual(expectedResolution, resolution);
+            Assert.AreEqual(expectedSymbol, symbol.ID.Symbol);
+            Assert.AreEqual(new DateTime(expectedYear, 01, 01), date);
+        }
+
         [TestCase("Data\\alternative\\estimize\\consensus\\aapl.csv", "aapl", null)]
         [TestCase("Data\\alternative\\psychsignal\\aapl\\20161007.zip", "aapl", "2016-10-07")]
         [TestCase("Data\\alternative\\sec\\aapl\\20161007_8K.zip", "aapl", "2016-10-07")]
@@ -494,7 +509,7 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual("../../../Data/futureoption/comex/minute/og/20200428/20200105_quote_american.zip", optionZipFilePath);
             Assert.AreEqual($"20200105_og_minute_quote_american_{right.ToLower()}_{strike}0000_{expiry:yyyyMMdd}.csv", optionEntryFilePath);
         }
-        
+
         [Test, TestCaseSource(nameof(AggregateTradeBarsTestData))]
         public void AggregateTradeBarsTest(TimeSpan resolution, TradeBar expectedFirstTradeBar)
         {
@@ -508,7 +523,7 @@ namespace QuantConnect.Tests.Common.Util
             };
 
             var aggregated = LeanData.AggregateTradeBars(initialBars, symbol, resolution).ToList();
-            
+
             Assert.True(aggregated.All(i => i.Period == resolution));
             Assert.True(aggregated.All(i => i.Symbol == symbol));
 
@@ -560,14 +575,14 @@ namespace QuantConnect.Tests.Common.Util
                 new QuoteBar {Time = _aggregationTime.Add(TimeSpan.FromMinutes(15)), Ask = new Bar {Open = 11, High = 25, Low = 10, Close = 21}, Bid = {Open = 10, High = 22, Low = 9, Close = 20}, Period = TimeSpan.FromMinutes(1), Symbol = symbol},
                 new QuoteBar {Time = _aggregationTime.Add(TimeSpan.FromHours(6)), Ask = new Bar {Open = 17, High = 19, Low = 12, Close = 11}, Bid = {Open = 16, High = 17, Low = 10, Close = 10}, Period = TimeSpan.FromMinutes(1), Symbol = symbol},
             };
-        
+
             var aggregated = LeanData.AggregateQuoteBars(initialBars, symbol, resolution).ToList();
-            
+
             Assert.True(aggregated.All(i => i.Period == resolution));
             Assert.True(aggregated.All(i => i.Symbol == symbol));
 
             var firstBar = aggregated.First();
-            
+
             AssertBarsAreEqual(expectedFirstBar.Ask, firstBar.Ask);
             AssertBarsAreEqual(expectedFirstBar.Bid, firstBar.Bid);
             Assert.AreEqual(expectedFirstBar.LastBidSize, firstBar.LastBidSize);
@@ -575,7 +590,7 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual(expectedFirstBar.Time, firstBar.Time);
             Assert.AreEqual(expectedFirstBar.EndTime, firstBar.EndTime);
         }
-        
+
         [Test, TestCaseSource(nameof(AggregateTickTestData))]
         public void AggregateTicksTest(TimeSpan resolution, QuoteBar expectedFirstBar)
         {
@@ -868,7 +883,7 @@ namespace QuantConnect.Tests.Common.Util
                 };
             }
         }
-        
+
         private static TestCaseData[] AggregateTickTestData
         {
             get

--- a/Tests/RegressionTests.cs
+++ b/Tests/RegressionTests.cs
@@ -91,8 +91,7 @@ namespace QuantConnect.Tests
                 { "OnOrderEventExceptionRegression", AlgorithmStatus.RuntimeError },
                 { "WarmUpAfterInitializeRegression", AlgorithmStatus.RuntimeError },
                 { "CoarseFineAsyncUniverseRegressionAlgorithm", AlgorithmStatus.Running },
-                { "BasicTemplateIndexDailyAlgorithm", AlgorithmStatus.Running },
-                { "BasicTemplateIndexOptionsDailyAlgorithm", AlgorithmStatus.Running },
+                { "BasicTemplateIndexOptionsDailyAlgorithm", AlgorithmStatus.RuntimeError },    // daily index options supported but no data
                 { "ScaledRawDataNormalizationModeNotAllowedSecuritiesAlgorithm", AlgorithmStatus.Running }
             };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This fix makes sure for options and index options hour and daily data downloads only the necessary data is downloaded, that is the year's file. This is done by limiting the request date range to the start and end dates of the file's year, which is parsed from the file name.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Reducing the amount of data downloaded if not required.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests and integration with data providers.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
