### PR TITLE
Pep8 GoodTilDate Adjustment

### DIFF
--- a/Common/Orders/TimeInForce.cs
+++ b/Common/Orders/TimeInForce.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -40,10 +40,7 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Gets a <see cref="GoodTilDateTimeInForce"/> instance
         /// </summary>
-        public static TimeInForce GoodTilDate(DateTime expiry)
-        {
-            return new GoodTilDateTimeInForce(expiry);
-        }
+        public static Func<DateTime, TimeInForce> GoodTilDate => (DateTime expiry) => new GoodTilDateTimeInForce(expiry);
 
         /// <summary>
         /// Checks if an order is expired


### PR DESCRIPTION
- Pep8 adjustment for GoodTilDate, so it behaves like `Expiry` static readonly funcs which will be binded to both snake case and upper constant format, `good_til_date` & `GOOD_TIL_DATE`

See https://github.com/QuantConnect/Lean/pull/7909