### PR TITLE
Fix option assignment not processed because of existing open order

### DIFF
--- a/Algorithm.CSharp/DuplicateOptionAssignmentRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DuplicateOptionAssignmentRegressionAlgorithm.cs
@@ -1,0 +1,257 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting that open orders are canceled when the option is assigned and delisted,
+    /// also making sure the assignment happens and its processed regardless of the existing of an open order for said option.
+    /// </summary>
+    public class DuplicateOptionAssignmentRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _stock;
+        private Symbol _option;
+
+        private bool _optionSold;
+        private bool _optionAssigned;
+        private bool _optionDelisted;
+        private bool _optionDelistedWarningReceived;
+        private bool _orderCanceled;
+        private bool _stockAssigned;
+
+        public override void Initialize()
+        {
+            SetStartDate(2015, 12, 17);
+            SetEndDate(2015, 12, 28);
+            SetCash(100000);
+
+            _stock = AddEquity("GOOG").Symbol;
+
+            _option = QuantConnect.Symbol.CreateOption(_stock, Market.USA, OptionStyle.American, OptionRight.Put, 800m, new DateTime(2015, 12, 24));
+
+            AddOptionContract(_option);
+        }
+
+        public override void OnData(Slice data)
+        {
+            // We are done
+            if (_optionSold)
+            {
+                return;
+            }
+
+            if (!Portfolio.Invested)
+            {
+                Sell(_option, 1);
+            }
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            if (orderEvent.Status == OrderStatus.Filled)
+            {
+                // This is the fill for the option sell order
+                if (!_optionSold)
+                {
+                    // Let's close the position but with a limit order that won't ever fill (limit price too low)
+                    // just so we keep it open until the brokerage tries to assign it
+                    LimitOrder(_option, 1, Securities[_option].Price * 0.1m);
+
+                    _optionSold = true;
+                }
+                // This is the assignment
+                else if (!_optionAssigned)
+                {
+                    if (orderEvent.Ticket.OrderType != OrderType.OptionExercise || !orderEvent.IsAssignment)
+                    {
+                        throw new Exception($"Expected option assignment but got: {orderEvent}");
+                    }
+
+                    _optionAssigned = true;
+                }
+                else if (!_stockAssigned)
+                {
+                    if (orderEvent.Ticket.OrderType != OrderType.OptionExercise || orderEvent.IsAssignment || orderEvent.Symbol != _stock)
+                    {
+                        throw new Exception($"Expected stock assignment but got: {orderEvent}");
+                    }
+
+                    _stockAssigned = true;
+                }
+                else
+                {
+                    throw new Exception($"Unexpected order fill event: {orderEvent}");
+                }
+            }
+            else if (orderEvent.Status == OrderStatus.CancelPending)
+            {
+                // We receive the delisting warning before the order cancel is requested
+                if (!_optionSold || !_optionAssigned || !_stockAssigned || !_optionDelistedWarningReceived)
+                {
+                    throw new Exception($"Unexpected cancel pending event: {orderEvent}");
+                }
+            }
+            else if (orderEvent.Status == OrderStatus.Canceled)
+            {
+                // The delisted event is received before the order is canceled
+                if (!_optionSold || !_optionAssigned || !_stockAssigned || !_optionDelistedWarningReceived || !_optionDelisted)
+                {
+                    throw new Exception($"Unexpected cancel event: {orderEvent}");
+                }
+
+                _orderCanceled = true;
+            }
+        }
+
+        public override void OnDelistings(Delistings delistings)
+        {
+            if (!delistings.TryGetValue(_option, out var delisting))
+            {
+                throw new Exception($"Unexpected delisting events");
+            }
+
+            if (delisting.Type == DelistingType.Warning)
+            {
+                if (!_optionSold || !_optionAssigned || !_stockAssigned || _optionDelistedWarningReceived)
+                {
+                    throw new Exception($"Unexpected delisting warning event: {delisting}");
+                }
+
+                _optionDelistedWarningReceived = true;
+            }
+            else
+            {
+                if (!_optionSold || !_optionAssigned || !_stockAssigned || !_optionDelistedWarningReceived || _optionDelisted)
+                {
+                    throw new Exception($"Unexpected delisting event: {delisting}");
+                }
+
+                _optionDelisted = true;
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_optionSold)
+            {
+                throw new Exception("Option was not sold");
+            }
+
+            if (!_optionAssigned)
+            {
+                throw new Exception("Option was not assigned");
+            }
+
+            if (!_stockAssigned)
+            {
+                throw new Exception("Stock was not assigned");
+            }
+
+            if (!_optionDelistedWarningReceived)
+            {
+                throw new Exception("Option delisting warning was not received");
+            }
+
+            if (!_optionDelisted)
+            {
+                throw new Exception("Option was not delisted");
+            }
+
+            if (!_orderCanceled)
+            {
+                throw new Exception("Order was not canceled");
+            }
+
+            var openOrders = Transactions.GetOpenOrders();
+            if (openOrders.Count != 0)
+            {
+                throw new Exception("There should be no open orders");
+            }
+
+            if (!Portfolio.Invested)
+            {
+                throw new Exception("Portfolio should be invested");
+            }
+
+            // We should have the stock since the option was assigned
+            if (Portfolio.Positions.Groups.Single().Single().Symbol != _stock)
+            {
+                throw new Exception("Portfolio should have the stock");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 2849;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "3"},
+            {"Average Win", "4.48%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "-19.248%"},
+            {"Drawdown", "1.100%"},
+            {"Expectancy", "-1"},
+            {"Start Equity", "100000"},
+            {"End Equity", "99319"},
+            {"Net Profit", "-0.681%"},
+            {"Sharpe Ratio", "-6.361"},
+            {"Sortino Ratio", "-4.623"},
+            {"Probabilistic Sharpe Ratio", "0.018%"},
+            {"Loss Rate", "100%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "-0.139"},
+            {"Beta", "-0.082"},
+            {"Annual Standard Deviation", "0.024"},
+            {"Annual Variance", "0.001"},
+            {"Information Ratio", "-2.525"},
+            {"Tracking Error", "0.137"},
+            {"Treynor Ratio", "1.883"},
+            {"Total Fees", "$1.00"},
+            {"Estimated Strategy Capacity", "$1300000.00"},
+            {"Lowest Capacity Asset", "GOOCV 305RBQ20WHPNQ|GOOCV VP83T1ZUHROL"},
+            {"Portfolio Turnover", "7.07%"},
+            {"OrderListHash", "0af2b780f03f5896e574ef106c07e169"}
+        };
+    }
+}

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -38,6 +38,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
     {
         private IAlgorithm _algorithm;
         private IBrokerage _brokerage;
+        private bool _brokerageIsBacktesting;
         private bool _loggedFeeAdjustmentWarning;
 
         // Counter to keep track of total amount of processed orders
@@ -158,6 +159,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
             _resultHandler = resultHandler;
 
             _brokerage = brokerage;
+            _brokerageIsBacktesting = brokerage is BacktestingBrokerage;
 
             _brokerage.OrdersStatusChanged += (sender, orderEvents) =>
             {
@@ -1506,7 +1508,10 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                                 // so we get ALL orders for this symbol that were placed or got an update in the last 'orderWindowSeconds'
 
                                 const int orderWindowSeconds = 10;
-                                if (_brokerage is BacktestingBrokerage ||
+                                // NOTE: We do this checks for actual live trading only to handle the race condition stated above
+                                // for actual brokerages (excluding paper trading with PaperBrokerage).
+                                // TODO: If we confirm this race condition applies for IB only, we could move this to the brokerage itself.
+                                if (_brokerageIsBacktesting ||
                                     !GetOrders(x =>
                                         x.Symbol == e.Symbol
                                         && (x.Status.IsOpen() || x.Status.IsFill() &&

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using QuantConnect.Brokerages;
+using QuantConnect.Brokerages.Backtesting;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.Results;
 using QuantConnect.Logging;
@@ -1505,7 +1506,8 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                                 // so we get ALL orders for this symbol that were placed or got an update in the last 'orderWindowSeconds'
 
                                 const int orderWindowSeconds = 10;
-                                if (!GetOrders(x =>
+                                if (_brokerage is BacktestingBrokerage ||
+                                    !GetOrders(x =>
                                         x.Symbol == e.Symbol
                                         && (x.Status.IsOpen() || x.Status.IsFill() &&
                                             (Math.Abs((x.Time - nowUtc).TotalSeconds) < orderWindowSeconds


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This fixes the "Duplicate option assignment" error caused by the brokerage transaction handler not being able to place the automatic exercise orders when an open order is found for the same option asset. With the fix, the exercise is placed and filled and the existing orders are canceled when the option is delisted.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #7815 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Regression algorithms (user's in the issue and the one added in the PR)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
