### PR TITLE
Implement Download Project in Lean

### DIFF
--- a/Common/DataDownloaderGetParameters.cs
+++ b/Common/DataDownloaderGetParameters.cs
@@ -63,5 +63,11 @@ namespace QuantConnect
             EndUtc = endUtc;
             TickType = tickType ?? TickType.Trade;
         }
+
+        /// <summary>
+        /// Returns a string representation of the <see cref="DataDownloaderGetParameters"/> object.
+        /// </summary>
+        /// <returns>A string representing the object's properties.</returns>
+        public override string ToString() => $"Symbol: {Symbol}, Resolution: {Resolution}, StartUtc: {StartUtc}, EndUtc: {EndUtc}, TickType: {TickType}";
     }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY ./Lean/Data/ /Lean/Data/
 COPY ./Lean/Launcher/bin/Debug/ /Lean/Launcher/bin/Debug/
 COPY ./Lean/Optimizer.Launcher/bin/Debug/ /Lean/Optimizer.Launcher/bin/Debug/
 COPY ./Lean/Report/bin/Debug/ /Lean/Report/bin/Debug/
-COPY ./Lean/DownloaderDataProvider/ /Lean/DownloaderDataProvider/
+COPY ./Lean/DownloaderDataProvider/bin/Debug/ /Lean/DownloaderDataProvider/bin/Debug/
 
 # Can override with '-w'
 WORKDIR /Lean/Launcher/bin/Debug

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY ./Lean/Data/ /Lean/Data/
 COPY ./Lean/Launcher/bin/Debug/ /Lean/Launcher/bin/Debug/
 COPY ./Lean/Optimizer.Launcher/bin/Debug/ /Lean/Optimizer.Launcher/bin/Debug/
 COPY ./Lean/Report/bin/Debug/ /Lean/Report/bin/Debug/
+COPY ./Lean/DownloaderDataProvider/ /Lean/DownloaderDataProvider/
 
 # Can override with '-w'
 WORKDIR /Lean/Launcher/bin/Debug

--- a/DownloaderDataProvider/DataDownloadConfig.cs
+++ b/DownloaderDataProvider/DataDownloadConfig.cs
@@ -51,11 +51,6 @@ namespace QuantConnect.Lean.DownloaderDataProvider
         private string _endDate;
 
         /// <summary>
-        /// Full name of the data provider for downloading data.
-        /// </summary>
-        public string DataProviderFullName { get; }
-
-        /// <summary>
         /// Type of tick data to download.
         /// </summary>
         public TickType TickType { get => ParseEnum<TickType>(_tickType); }
@@ -96,8 +91,6 @@ namespace QuantConnect.Lean.DownloaderDataProvider
         /// <param name="parameters">Dictionary containing the parameters for data download.</param>
         public DataDownloadConfig()
         {
-            DataProviderFullName = Config.Get(DownloaderCommandArguments.CommandDownloaderDataDownloader).ToString() ?? string.Empty;
-
             _tickType = Config.Get(DownloaderCommandArguments.CommandDataType).ToString() ?? string.Empty;
             _securityType = Config.Get(DownloaderCommandArguments.CommandSecurityType).ToString() ?? string.Empty;
             _resolution = Config.Get(DownloaderCommandArguments.CommandResolution).ToString() ?? string.Empty;
@@ -124,8 +117,7 @@ namespace QuantConnect.Lean.DownloaderDataProvider
         /// <returns>A string representation of the <see cref="DataDownloadConfig"/> struct.</returns>
         public override string ToString()
         {
-            return $"DataProviderFullName: {DataProviderFullName}, " +
-                   $"TickType: {TickType}, " +
+            return $"TickType: {TickType}, " +
                    $"SecurityType: {SecurityType}, " +
                    $"Resolution: {Resolution}, " +
                    $"StartDate: {StartDate:yyyyMMdd}, " +

--- a/DownloaderDataProvider/DataDownloadConfig.cs
+++ b/DownloaderDataProvider/DataDownloadConfig.cs
@@ -16,9 +16,9 @@
 
 using System.Globalization;
 using QuantConnect.Configuration;
-using QuantConnect.Lean.DownloaderDataProvider.Models.Constants;
+using QuantConnect.DownloaderDataProvider.Launcher.Models.Constants;
 
-namespace QuantConnect.Lean.DownloaderDataProvider
+namespace QuantConnect.DownloaderDataProvider.Launcher
 {
     /// <summary>
     /// Represents the configuration for data download.

--- a/DownloaderDataProvider/DataDownloadConfig.cs
+++ b/DownloaderDataProvider/DataDownloadConfig.cs
@@ -1,0 +1,153 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Globalization;
+using QuantConnect.Configuration;
+using QuantConnect.Lean.DownloaderDataProvider.Models.Constants;
+
+namespace QuantConnect.Lean.DownloaderDataProvider
+{
+    /// <summary>
+    /// Represents the configuration for data download.
+    /// </summary>
+    public struct DataDownloadConfig
+    {
+        /// <summary>
+        /// The tick type as a string.
+        /// </summary>
+        private string _tickType;
+
+        /// <summary>
+        /// The security type as a string.
+        /// </summary>
+        private string _securityType;
+
+        /// <summary>
+        /// The resolution as a string.
+        /// </summary>
+        private string _resolution;
+
+        /// <summary>
+        /// The start date as a string.
+        /// </summary>
+        private string _startDate;
+
+        /// <summary>
+        /// The end date as a string.
+        /// </summary>
+        private string _endDate;
+
+        /// <summary>
+        /// Full name of the data provider for downloading data.
+        /// </summary>
+        public string DataProviderFullName { get; }
+
+        /// <summary>
+        /// Type of tick data to download.
+        /// </summary>
+        public TickType TickType { get => ParseEnum<TickType>(_tickType); }
+
+        /// <summary>
+        /// Type of security for which data is to be downloaded.
+        /// </summary>
+        public SecurityType SecurityType { get => ParseEnum<SecurityType>(_securityType); }
+
+        /// <summary>
+        /// Resolution of the downloaded data.
+        /// </summary>
+        public Resolution Resolution { get => ParseEnum<Resolution>(_resolution); }
+
+        /// <summary>
+        /// Start date for the data download.
+        /// </summary>
+        public DateTime StartDate { get => DateTime.ParseExact(_startDate, DateFormat.EightCharacter, CultureInfo.InvariantCulture); }
+
+        /// <summary>
+        /// End date for the data download.
+        /// </summary>
+        public DateTime EndDate { get => DateTime.ParseExact(_endDate, DateFormat.EightCharacter, CultureInfo.InvariantCulture); }
+
+        /// <summary>
+        /// Market name for which the data is to be downloaded.
+        /// </summary>
+        public string MarketName { get; }
+
+        /// <summary>
+        /// List of symbols for which data is to be downloaded.
+        /// </summary>
+        public List<Symbol> Symbols { get; } = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataDownloadConfig"/> struct.
+        /// </summary>
+        /// <param name="parameters">Dictionary containing the parameters for data download.</param>
+        public DataDownloadConfig()
+        {
+            DataProviderFullName = Config.Get(DownloaderCommandArguments.CommandDownloaderDataDownloader).ToString() ?? string.Empty;
+
+            _tickType = Config.Get(DownloaderCommandArguments.CommandDataType).ToString() ?? string.Empty;
+            _securityType = Config.Get(DownloaderCommandArguments.CommandSecurityType).ToString() ?? string.Empty;
+            _resolution = Config.Get(DownloaderCommandArguments.CommandResolution).ToString() ?? string.Empty;
+
+            _startDate = Config.Get(DownloaderCommandArguments.CommandStartDate).ToString() ?? string.Empty;
+            _endDate = Config.Get(DownloaderCommandArguments.CommandEndDate).ToString() ?? string.Empty;
+
+            MarketName = Config.Get(DownloaderCommandArguments.CommandMarketName).ToString()?.ToLower() ?? Market.USA;
+
+            if (!Market.SupportedMarkets().Contains(MarketName))
+            {
+                throw new ArgumentException($"The specified market '{MarketName}' is not supported. Supported markets are: {string.Join(", ", Market.SupportedMarkets())}.");
+            }
+
+            foreach (var ticker in (Config.GetValue<Dictionary<string, string>>(DownloaderCommandArguments.CommandTickers))!.Keys)
+            {
+                Symbols.Add(Symbol.Create(ticker, SecurityType, MarketName));
+            }
+        }
+
+        /// <summary>
+        /// Returns a string representation of the <see cref="DataDownloadConfig"/> struct.
+        /// </summary>
+        /// <returns>A string representation of the <see cref="DataDownloadConfig"/> struct.</returns>
+        public override string ToString()
+        {
+            return $"DataProviderFullName: {DataProviderFullName}, " +
+                   $"TickType: {TickType}, " +
+                   $"SecurityType: {SecurityType}, " +
+                   $"Resolution: {Resolution}, " +
+                   $"StartDate: {StartDate:yyyyMMdd}, " +
+                   $"EndDate: {EndDate:yyyyMMdd}, " +
+                   $"MarketName: {MarketName}, " +
+                   $"Symbols: {string.Join(", ", Symbols.Select(s => s.ToString()))}";
+        }
+
+        /// <summary>
+        /// Parses a string value to an enum of type <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <typeparam name="TEnum">The enum type to parse to.</typeparam>
+        /// <param name="value">The string value to parse.</param>
+        /// <returns>The parsed enum value.</returns>
+        private TEnum ParseEnum<TEnum>(string value) where TEnum : struct, Enum
+        {
+            if (!Enum.TryParse(value, true, out TEnum result) || !Enum.IsDefined(typeof(TEnum), result))
+            {
+                throw new ArgumentException($"Invalid {typeof(TEnum).Name} specified. Please provide a valid {typeof(TEnum).Name}.");
+            }
+
+            return result;
+        }
+    }
+}

--- a/DownloaderDataProvider/DownloaderDataProviderArgumentParser.cs
+++ b/DownloaderDataProvider/DownloaderDataProviderArgumentParser.cs
@@ -28,7 +28,7 @@ public static class DownloaderDataProviderArgumentParser
 
     private static readonly List<CommandLineOption> Options = new List<CommandLineOption>
     {
-        new CommandLineOption(DownloaderCommandArguments.CommandDownloaderDataProvider, CommandOptionType.SingleValue),
+        new CommandLineOption(DownloaderCommandArguments.CommandDownloaderDataDownloader, CommandOptionType.SingleValue),
         new CommandLineOption(DownloaderCommandArguments.CommandDestinationDirectory, CommandOptionType.SingleValue),
         new CommandLineOption(DownloaderCommandArguments.CommandDataType, CommandOptionType.SingleValue),
         new CommandLineOption(DownloaderCommandArguments.CommandTickers, CommandOptionType.MultipleValue),
@@ -40,19 +40,17 @@ public static class DownloaderDataProviderArgumentParser
     };
 
     /// <summary>
-    /// Parses the given array of strings representing arguments into a dictionary of key-value pairs.
+    /// Parses the command-line arguments and returns a dictionary containing parsed values.
     /// </summary>
-    /// <param name="args">An array of strings representing the command line arguments.</param>
-    /// <returns>A dictionary containing parsed arguments with keys as argument names and values as argument values.</returns>
+    /// <param name="args">An array of command-line arguments.</param>
+    /// <returns>A dictionary containing parsed values from the command-line arguments.</returns>
     /// <remarks>
-    /// The arguments are expected to be in the format "--key value". For example, "--data-provider Polygon --tickers AAPL,NVDA".
+    /// The <paramref name="args"/> parameter should contain the command-line arguments to be parsed.
+    /// The method uses the ApplicationParser class to parse the arguments based on the ApplicationName, 
+    /// ApplicationDescription, ApplicationHelpText, and Options properties.
     /// </remarks>
     public static Dictionary<string, object> ParseArguments(string[] args)
     {
-        var parsedArguments = ApplicationParser.Parse(ApplicationName, ApplicationDescription, ApplicationHelpText, args, Options);
-
-        //parsedArguments[DownloaderCommandArguments.CommandTickers]
-
-        return parsedArguments;
+        return ApplicationParser.Parse(ApplicationName, ApplicationDescription, ApplicationHelpText, args, Options);
     }
 }

--- a/DownloaderDataProvider/DownloaderDataProviderArgumentParser.cs
+++ b/DownloaderDataProvider/DownloaderDataProviderArgumentParser.cs
@@ -16,9 +16,9 @@
 
 using QuantConnect.Configuration;
 using McMaster.Extensions.CommandLineUtils;
-using QuantConnect.Lean.DownloaderDataProvider.Models.Constants;
+using QuantConnect.DownloaderDataProvider.Launcher.Models.Constants;
 
-namespace QuantConnect.Lean.DownloaderDataProvider;
+namespace QuantConnect.DownloaderDataProvider.Launcher;
 
 public static class DownloaderDataProviderArgumentParser
 {

--- a/DownloaderDataProvider/DownloaderDataProviderArgumentParser.cs
+++ b/DownloaderDataProvider/DownloaderDataProviderArgumentParser.cs
@@ -1,0 +1,52 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using McMaster.Extensions.CommandLineUtils;
+using QuantConnect.Configuration;
+
+namespace QuantConnect.Lean.DownloaderDataProvider;
+
+public static class DownloaderDataProviderArgumentParser
+{
+    private const string ApplicationName = "QuantConnect.DownloaderDataProvider.exe";
+    private const string ApplicationDescription = "Welcome to Lean Downloader Data Provider! 🚀 Easily download historical data from various sources with our user-friendly application. Start exploring financial data effortlessly!";
+    private const string ApplicationHelpText = "Hm...";
+
+    private static readonly List<CommandLineOption> Options = new List<CommandLineOption>
+    {
+        new CommandLineOption("data-provider", CommandOptionType.SingleValue),
+        new CommandLineOption("destination-dir", CommandOptionType.SingleValue),
+        new CommandLineOption("data-type", CommandOptionType.SingleValue),
+        new CommandLineOption("tickers", CommandOptionType.MultipleValue),
+        new CommandLineOption("security-type", CommandOptionType.SingleValue),
+        new CommandLineOption("resolution", CommandOptionType.SingleValue),
+        new CommandLineOption("start-date", CommandOptionType.SingleValue),
+        new CommandLineOption("end-date", CommandOptionType.SingleValue)
+    };
+
+    /// <summary>
+    /// Parses the given array of strings representing arguments into a dictionary of key-value pairs.
+    /// </summary>
+    /// <param name="args">An array of strings representing the command line arguments.</param>
+    /// <returns>A dictionary containing parsed arguments with keys as argument names and values as argument values.</returns>
+    /// <remarks>
+    /// The arguments are expected to be in the format "--key value". For example, "--data-provider Polygon --tickers AAPL,NVDA".
+    /// </remarks>
+    public static Dictionary<string, object> ParseArguments(string[] args)
+    {
+        return ApplicationParser.Parse(ApplicationName, ApplicationDescription, ApplicationHelpText, args, Options);
+    }
+}

--- a/DownloaderDataProvider/DownloaderDataProviderArgumentParser.cs
+++ b/DownloaderDataProvider/DownloaderDataProviderArgumentParser.cs
@@ -29,7 +29,6 @@ public static class DownloaderDataProviderArgumentParser
     private static readonly List<CommandLineOption> Options = new List<CommandLineOption>
     {
         new CommandLineOption(DownloaderCommandArguments.CommandDownloaderDataDownloader, CommandOptionType.SingleValue),
-        new CommandLineOption(DownloaderCommandArguments.CommandDestinationDirectory, CommandOptionType.SingleValue),
         new CommandLineOption(DownloaderCommandArguments.CommandDataType, CommandOptionType.SingleValue),
         new CommandLineOption(DownloaderCommandArguments.CommandTickers, CommandOptionType.MultipleValue),
         new CommandLineOption(DownloaderCommandArguments.CommandSecurityType, CommandOptionType.SingleValue),

--- a/DownloaderDataProvider/DownloaderDataProviderArgumentParser.cs
+++ b/DownloaderDataProvider/DownloaderDataProviderArgumentParser.cs
@@ -14,8 +14,9 @@
  * limitations under the License.
 */
 
-using McMaster.Extensions.CommandLineUtils;
 using QuantConnect.Configuration;
+using McMaster.Extensions.CommandLineUtils;
+using QuantConnect.Lean.DownloaderDataProvider.Models.Constants;
 
 namespace QuantConnect.Lean.DownloaderDataProvider;
 
@@ -27,14 +28,15 @@ public static class DownloaderDataProviderArgumentParser
 
     private static readonly List<CommandLineOption> Options = new List<CommandLineOption>
     {
-        new CommandLineOption("data-provider", CommandOptionType.SingleValue),
-        new CommandLineOption("destination-dir", CommandOptionType.SingleValue),
-        new CommandLineOption("data-type", CommandOptionType.SingleValue),
-        new CommandLineOption("tickers", CommandOptionType.MultipleValue),
-        new CommandLineOption("security-type", CommandOptionType.SingleValue),
-        new CommandLineOption("resolution", CommandOptionType.SingleValue),
-        new CommandLineOption("start-date", CommandOptionType.SingleValue),
-        new CommandLineOption("end-date", CommandOptionType.SingleValue)
+        new CommandLineOption(DownloaderCommandArguments.CommandDownloaderDataProvider, CommandOptionType.SingleValue),
+        new CommandLineOption(DownloaderCommandArguments.CommandDestinationDirectory, CommandOptionType.SingleValue),
+        new CommandLineOption(DownloaderCommandArguments.CommandDataType, CommandOptionType.SingleValue),
+        new CommandLineOption(DownloaderCommandArguments.CommandTickers, CommandOptionType.MultipleValue),
+        new CommandLineOption(DownloaderCommandArguments.CommandSecurityType, CommandOptionType.SingleValue),
+        new CommandLineOption(DownloaderCommandArguments.CommandMarketName, CommandOptionType.SingleValue),
+        new CommandLineOption(DownloaderCommandArguments.CommandResolution, CommandOptionType.SingleValue),
+        new CommandLineOption(DownloaderCommandArguments.CommandStartDate, CommandOptionType.SingleValue),
+        new CommandLineOption(DownloaderCommandArguments.CommandEndDate, CommandOptionType.SingleValue)
     };
 
     /// <summary>
@@ -47,6 +49,10 @@ public static class DownloaderDataProviderArgumentParser
     /// </remarks>
     public static Dictionary<string, object> ParseArguments(string[] args)
     {
-        return ApplicationParser.Parse(ApplicationName, ApplicationDescription, ApplicationHelpText, args, Options);
+        var parsedArguments = ApplicationParser.Parse(ApplicationName, ApplicationDescription, ApplicationHelpText, args, Options);
+
+        //parsedArguments[DownloaderCommandArguments.CommandTickers]
+
+        return parsedArguments;
     }
 }

--- a/DownloaderDataProvider/Models/Constants/DownloaderCommandArguments.cs
+++ b/DownloaderDataProvider/Models/Constants/DownloaderCommandArguments.cs
@@ -1,0 +1,41 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using McMaster.Extensions.CommandLineUtils;
+
+namespace QuantConnect.Lean.DownloaderDataProvider.Models.Constants
+{
+    public sealed class DownloaderCommandArguments
+    {
+        public const string CommandDownloaderDataProvider = "data-provider";
+
+        public const string CommandDestinationDirectory = "destination-dir";
+
+        public const string CommandDataType = "data-type";
+
+        public const string CommandTickers = "tickers";
+
+        public const string CommandSecurityType = "security-type";
+
+        public const string CommandMarketName = "market";
+
+        public const string CommandResolution = "resolution";
+
+        public const string CommandStartDate = "start-date";
+
+        public const string CommandEndDate = "end-date";
+    }
+}

--- a/DownloaderDataProvider/Models/Constants/DownloaderCommandArguments.cs
+++ b/DownloaderDataProvider/Models/Constants/DownloaderCommandArguments.cs
@@ -14,15 +14,11 @@
  * limitations under the License.
 */
 
-using McMaster.Extensions.CommandLineUtils;
-
 namespace QuantConnect.Lean.DownloaderDataProvider.Models.Constants
 {
     public sealed class DownloaderCommandArguments
     {
         public const string CommandDownloaderDataDownloader = "data-downloader";
-
-        public const string CommandDestinationDirectory = "destination-dir";
 
         public const string CommandDataType = "data-type";
 

--- a/DownloaderDataProvider/Models/Constants/DownloaderCommandArguments.cs
+++ b/DownloaderDataProvider/Models/Constants/DownloaderCommandArguments.cs
@@ -20,7 +20,7 @@ namespace QuantConnect.Lean.DownloaderDataProvider.Models.Constants
 {
     public sealed class DownloaderCommandArguments
     {
-        public const string CommandDownloaderDataProvider = "data-provider";
+        public const string CommandDownloaderDataDownloader = "data-downloader";
 
         public const string CommandDestinationDirectory = "destination-dir";
 

--- a/DownloaderDataProvider/Models/Constants/DownloaderCommandArguments.cs
+++ b/DownloaderDataProvider/Models/Constants/DownloaderCommandArguments.cs
@@ -14,7 +14,7 @@
  * limitations under the License.
 */
 
-namespace QuantConnect.Lean.DownloaderDataProvider.Models.Constants
+namespace QuantConnect.DownloaderDataProvider.Launcher.Models.Constants
 {
     public sealed class DownloaderCommandArguments
     {

--- a/DownloaderDataProvider/Program.cs
+++ b/DownloaderDataProvider/Program.cs
@@ -1,0 +1,54 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using QuantConnect.Util;
+using QuantConnect.Logging;
+using QuantConnect.Interfaces;
+using QuantConnect.Configuration;
+
+namespace QuantConnect.Lean.DownloaderDataProvider;
+class Program
+{
+    static void Main(string[] args)
+    {
+        if (args.Length > 0)
+        {
+            ProcessCommand(args);
+        }
+        else
+        {
+            throw new ArgumentException($"{nameof(DownloaderDataProvider)}: The arguments array is empty. Please provide valid command line arguments.");
+        }
+    }
+    static void ProcessCommand(string[] args)
+    {
+        var optionsObject = DownloaderDataProviderArgumentParser.ParseArguments(args);
+
+        Log.Trace($"{nameof(ProcessCommand)}:Prompt Command: {string.Join(',', optionsObject)}");
+
+        Log.DebuggingEnabled = Config.GetBool("debug-mode");
+        Log.LogHandler = Composer.Instance.GetExportedValueByTypeName<ILogHandler>(Config.Get("log-handler", "CompositeLogHandler"));
+
+        if (!optionsObject.TryGetValue("data-provider", out var parsedDataProvider))
+        {
+            parsedDataProvider = "DefaultDataProvider";
+        }
+
+        var dataProvider = Composer.Instance.GetExportedValueByTypeName<IDataProvider>(parsedDataProvider.ToString());
+
+        Log.Trace($"{nameof(ProcessCommand)}: dataProvider: {dataProvider}, {dataProvider.GetType()}");
+    }
+}

--- a/DownloaderDataProvider/Program.cs
+++ b/DownloaderDataProvider/Program.cs
@@ -19,10 +19,10 @@ using QuantConnect.Data;
 using QuantConnect.Logging;
 using QuantConnect.Interfaces;
 using QuantConnect.Configuration;
-using QuantConnect.Lean.DownloaderDataProvider.Models.Constants;
+using QuantConnect.DownloaderDataProvider.Launcher.Models.Constants;
 
-namespace QuantConnect.Lean.DownloaderDataProvider;
-class Program
+namespace QuantConnect.DownloaderDataProvider.Launcher;
+public static class Program
 {
     /// <summary>
     /// Synchronizer in charge of guaranteeing a single operation per file path

--- a/DownloaderDataProvider/QuantConnect.DownloaderDataProvider.Launcher.csproj
+++ b/DownloaderDataProvider/QuantConnect.DownloaderDataProvider.Launcher.csproj
@@ -4,8 +4,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Exe</OutputType>
-    <RootNamespace>QuantConnect.Lean.DownloaderDataProvider</RootNamespace>
-    <AssemblyName>QuantConnect.Lean.DownloaderDataProvider</AssemblyName>
+    <RootNamespace>QuantConnect.DownloaderDataProvider.Launcher</RootNamespace>
+    <AssemblyName>QuantConnect.DownloaderDataProvider.Launcher</AssemblyName>
     <TargetFramework>net6.0</TargetFramework>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/DownloaderDataProvider/QuantConnect.DownloaderDataProvider.csproj
+++ b/DownloaderDataProvider/QuantConnect.DownloaderDataProvider.csproj
@@ -30,9 +30,6 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.6.0" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
 

--- a/DownloaderDataProvider/QuantConnect.DownloaderDataProvider.csproj
+++ b/DownloaderDataProvider/QuantConnect.DownloaderDataProvider.csproj
@@ -7,9 +7,12 @@
     <RootNamespace>QuantConnect.Lean.DownloaderDataProvider</RootNamespace>
     <AssemblyName>QuantConnect.Lean.DownloaderDataProvider</AssemblyName>
     <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>QuantConnect LEAN Downloader Data Provider: Project - Main startup executable for download data from various sources with our Lean-friendly application.</Description>
   </PropertyGroup>
@@ -28,6 +31,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.6.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DownloaderDataProvider/QuantConnect.DownloaderDataProvider.csproj
+++ b/DownloaderDataProvider/QuantConnect.DownloaderDataProvider.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>QuantConnect.Lean.DownloaderDataProvider</RootNamespace>
+    <AssemblyName>QuantConnect.Lean.DownloaderDataProvider</AssemblyName>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <Nullable>enable</Nullable>
+    <Description>QuantConnect LEAN Downloader Data Provider: Project - Main startup executable for download data from various sources with our Lean-friendly application.</Description>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>$(SelectedOptimization)</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Common\QuantConnect.csproj" />
+    <ProjectReference Include="..\Configuration\QuantConnect.Configuration.csproj" />
+    <ProjectReference Include="..\Engine\QuantConnect.Lean.Engine.csproj" />
+    <ProjectReference Include="..\Logging\QuantConnect.Logging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DownloaderDataProvider/QuantConnect.DownloaderDataProvider.csproj
+++ b/DownloaderDataProvider/QuantConnect.DownloaderDataProvider.csproj
@@ -37,4 +37,9 @@
     <ProjectReference Include="..\Logging\QuantConnect.Logging.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="config.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/DownloaderDataProvider/config.json
+++ b/DownloaderDataProvider/config.json
@@ -1,0 +1,17 @@
+{
+  "map-file-provider": "LocalDiskMapFileProvider",
+  "data-provider": "DefaultDataProvider",
+  "log-handler": "CompositeLogHandler",
+  "factor-file-provider": "LocalDiskFactorFileProvider",
+
+  // The root directory of the data folder for this application
+  "data-folder": "../../../Data/",
+
+  // To get your api access token go to quantconnect.com/account
+  "job-user-id": "",
+  "api-access-token": "",
+  "job-organization-id": "",
+
+  // Data downloader provider
+  "data-downloader": ""
+}

--- a/QuantConnect.Lean.sln
+++ b/QuantConnect.Lean.sln
@@ -54,7 +54,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QuantConnect.Optimizer", "O
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QuantConnect.Optimizer.Launcher", "Optimizer.Launcher\QuantConnect.Optimizer.Launcher.csproj", "{D46D2A8D-340C-4B40-8EE6-6BAA7B1198AB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantConnect.DownloaderDataProvider", "DownloaderDataProvider\QuantConnect.DownloaderDataProvider.csproj", "{D139191E-50D5-4284-AC9C-247ED60950F4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QuantConnect.DownloaderDataProvider.Launcher", "DownloaderDataProvider\QuantConnect.DownloaderDataProvider.Launcher.csproj", "{D139191E-50D5-4284-AC9C-247ED60950F4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/QuantConnect.Lean.sln
+++ b/QuantConnect.Lean.sln
@@ -54,6 +54,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QuantConnect.Optimizer", "O
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QuantConnect.Optimizer.Launcher", "Optimizer.Launcher\QuantConnect.Optimizer.Launcher.csproj", "{D46D2A8D-340C-4B40-8EE6-6BAA7B1198AB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantConnect.DownloaderDataProvider", "DownloaderDataProvider\QuantConnect.DownloaderDataProvider.csproj", "{D139191E-50D5-4284-AC9C-247ED60950F4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -146,6 +148,10 @@ Global
 		{D46D2A8D-340C-4B40-8EE6-6BAA7B1198AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D46D2A8D-340C-4B40-8EE6-6BAA7B1198AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D46D2A8D-340C-4B40-8EE6-6BAA7B1198AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D139191E-50D5-4284-AC9C-247ED60950F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D139191E-50D5-4284-AC9C-247ED60950F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D139191E-50D5-4284-AC9C-247ED60950F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D139191E-50D5-4284-AC9C-247ED60950F4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tests/DownloaderDataProvider/DownloadHelperTests.cs
+++ b/Tests/DownloaderDataProvider/DownloadHelperTests.cs
@@ -1,0 +1,83 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.DownloaderDataProvider.Launcher;
+
+namespace QuantConnect.Tests.DownloaderDataProvider
+{
+    [TestFixture]
+    public class DownloadHelperTests
+    {
+        [TestCase("2020/01/01", "2024/01/01", 3, 0)]
+        public void CalculateETAShouldDownloadAllSymbols(DateTime downloadStartDate, DateTime downloadEndDate, int amountDownloadSymbol, int alreadyDownloadedSymbol)
+        {
+            var totalDataPerSymbolInSeconds = (downloadEndDate - downloadStartDate).TotalSeconds;
+            var totalDataInSeconds = totalDataPerSymbolInSeconds * amountDownloadSymbol;
+            
+            var startUtcTime = DateTime.UtcNow;
+            var endDateTime = downloadStartDate;
+            while (alreadyDownloadedSymbol != amountDownloadSymbol)
+            {
+                do
+                {
+                    endDateTime = endDateTime.AddDays(1);
+
+                    var utcNow = DateTime.UtcNow;
+                    var progressSoFar = (endDateTime - downloadStartDate).TotalSeconds + totalDataPerSymbolInSeconds * alreadyDownloadedSymbol;
+                    var eta = Program.CalculateETA(utcNow, startUtcTime, totalDataInSeconds, progressSoFar);
+
+                    if (endDateTime < downloadEndDate)
+                    {
+                        Assert.Greater(eta.TotalSeconds, 0);
+                    }
+                } while (endDateTime != downloadEndDate);
+
+                endDateTime = downloadStartDate;
+                alreadyDownloadedSymbol++;
+            }
+
+            Assert.That(amountDownloadSymbol, Is.EqualTo(alreadyDownloadedSymbol));
+        }
+
+        [TestCase("2020/01/01", "2024/01/01", "2020/1/10", 1, 0, 1, 161)]
+        [TestCase("2019/01/01", "2023/01/01", "2021/2/10", 2, 1, 10, 3)]
+        [TestCase("2021/01/01", "2022/01/01", "2021/5/10", 3, 2, 5, 1)]
+        public void CalculateETAShouldReturnCorrectETA(
+            DateTime downloadStartDate,
+            DateTime downloadEndDate,
+            DateTime currentDownloadedDataFromDataDownloader,
+            int amountOfDownloadSymbol,
+            int alreadyDownloadedSymbol,
+            int minusUtcNowSecond,
+            int expectedTotalSeconds)
+        {
+            var mockUtcTimeNow = new DateTime(2024, 04, 26, 1, 1, 10);
+
+            DateTime runUtcTime = mockUtcTimeNow.AddSeconds(-minusUtcNowSecond);
+
+            var totalDataPerSymbolInSeconds = (downloadEndDate - downloadStartDate).TotalSeconds;
+            var totalDataInSeconds = totalDataPerSymbolInSeconds * amountOfDownloadSymbol;
+
+            var progressSoFar = (currentDownloadedDataFromDataDownloader - downloadStartDate).TotalSeconds + totalDataPerSymbolInSeconds * alreadyDownloadedSymbol;
+
+            var eta = Program.CalculateETA(mockUtcTimeNow, runUtcTime, totalDataInSeconds, progressSoFar);
+
+            Assert.That(expectedTotalSeconds, Is.EqualTo((int)eta.TotalSeconds));
+        }
+    }
+}

--- a/Tests/DownloaderDataProvider/DownloadHelperTests.cs
+++ b/Tests/DownloaderDataProvider/DownloadHelperTests.cs
@@ -28,8 +28,8 @@ namespace QuantConnect.Tests.DownloaderDataProvider
         {
             var totalDataPerSymbolInSeconds = (downloadEndDate - downloadStartDate).TotalSeconds;
             var totalDataInSeconds = totalDataPerSymbolInSeconds * amountDownloadSymbol;
-            
-            var startUtcTime = DateTime.UtcNow;
+
+            var mockRunningDateTime = new DateTime(2024, 04, 26, 1, 10, 10);
             var endDateTime = downloadStartDate;
             while (alreadyDownloadedSymbol != amountDownloadSymbol)
             {
@@ -37,9 +37,10 @@ namespace QuantConnect.Tests.DownloaderDataProvider
                 {
                     endDateTime = endDateTime.AddDays(1);
 
-                    var utcNow = DateTime.UtcNow;
+                    // Simulate real-time by advancing the mockRunningDateTime by 2 milliseconds
+                    var utcNow = mockRunningDateTime.AddMilliseconds(2);
                     var progressSoFar = (endDateTime - downloadStartDate).TotalSeconds + totalDataPerSymbolInSeconds * alreadyDownloadedSymbol;
-                    var eta = Program.CalculateETA(utcNow, startUtcTime, totalDataInSeconds, progressSoFar);
+                    var eta = Program.CalculateETA(utcNow, mockRunningDateTime, totalDataInSeconds, progressSoFar);
 
                     if (endDateTime < downloadEndDate)
                     {

--- a/Tests/Engine/DataFeeds/DownloaderDataProviderTests.cs
+++ b/Tests/Engine/DataFeeds/DownloaderDataProviderTests.cs
@@ -25,7 +25,7 @@ using System.Threading.Tasks;
 using QuantConnect.Securities;
 using QuantConnect.Data.Market;
 using System.Collections.Generic;
-using QuantConnect.Lean.Engine.DataFeeds;
+using DataFeed = QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Data.Custom.IconicTypes;
 
 namespace QuantConnect.Tests.Engine.DataFeeds
@@ -38,7 +38,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         {
             Log.DebuggingEnabled = true;
             var downloader = new DataDownloaderTest();
-            using var dataProvider = new DownloaderDataProvider(downloader);
+            using var dataProvider = new DataFeed.DownloaderDataProvider(downloader);
 
             var date = new DateTime(2000, 3, 17);
             var dataSymbol = Symbol.Create("TEST", SecurityType.Equity, Market.USA);
@@ -108,7 +108,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void CustomDataRequest()
         {
             var downloader = new DataDownloaderTest();
-            using var dataProvider = new DownloaderDataProvider(downloader);
+            using var dataProvider = new DataFeed.DownloaderDataProvider(downloader);
 
             var customData = Symbol.CreateBase(typeof(LinkedData), Symbols.SPY, Market.USA);
             var date = new DateTime(2023, 3, 17);
@@ -151,7 +151,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void CorrectArguments(Resolution resolution, SecurityType securityType)
         {
             var downloader = new DataDownloaderTest();
-            using var dataProvider = new DownloaderDataProvider(downloader);
+            using var dataProvider = new DataFeed.DownloaderDataProvider(downloader);
 
             Symbol symbol = null;
             Symbol expectedSymbol = null;

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -373,6 +373,7 @@
     <ProjectReference Include="..\Common\QuantConnect.csproj" />
     <ProjectReference Include="..\Compression\QuantConnect.Compression.csproj" />
     <ProjectReference Include="..\Configuration\QuantConnect.Configuration.csproj" />
+    <ProjectReference Include="..\DownloaderDataProvider\QuantConnect.DownloaderDataProvider.Launcher.csproj" />
     <ProjectReference Include="..\Engine\QuantConnect.Lean.Engine.csproj" />
     <ProjectReference Include="..\Indicators\QuantConnect.Indicators.csproj" />
     <ProjectReference Include="..\Optimizer\QuantConnect.Optimizer.csproj" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This Pull Request introduces a new feature to Lean, allowing users to download various data types from multiple data sources. The feature enables users to fetch **Trade**, **Quote**, and **Open Interest** data based on the capabilities of the selected data source. Additionally, users can download data for different security types such as **Equity**, **Option**, **Crypto**, etc. The data can be filtered by **start** and **end** **dates** and is **stored locally on the disk**. The aim is to improve the download speed from data sources by creating an independent download project and implementing a local algorithm for trading.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Related Pull Request
- Lean-CLI: https://github.com/QuantConnect/lean-cli/pull/447

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Downloading historical and real-time data is a crucial part of algorithmic trading strategies. With this feature, users can seamlessly download data from popular data sources like _Interactive Brokers, Oanda, Bitfinex, Coinbase Advanced Trade, Binance, Kraken, IQFeed, Polygon, FactSet, IEX, AlphaVantage, CoinApi, ThetaData, QuantConnect, Local, Terminal Link, Bybit_, and more. By providing flexibility in downloading **Trade**, **Quote**, and **Open Interest** data, users can tailor their data acquisition to suit their trading strategies.

The feature is designed to be highly customizable, **allowing users to specify the data source, data type, tickers, security type, market, resolution, and date range.** This flexibility ensures that users can retrieve the exact data they need for their **trading algorithms.**

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- End-to-end tests using sample data from various data sources to validate the complete flow of data download.
- Manual testing with different combinations of arguments to ensure all features work as expected.
- Testing through docker and lean-cli

#### Example of running DownloaderDataProvider
```
F5 --data-downloader Oanda --data-type Trade --tickers AAPL,TSLA --security-type Equity --market USA --resolution Minute --start-date 20240101 --end-date 20240404
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
