### PR TITLE
Add Group Symbol and Total Time Execution Logging for Downloading Canonical Data

### DIFF
--- a/Common/Data/LeanDataWriter.cs
+++ b/Common/Data/LeanDataWriter.cs
@@ -35,7 +35,12 @@ namespace QuantConnect.Data
     public class LeanDataWriter
     {
         private static KeyStringSynchronizer _keySynchronizer = new();
-        private static readonly Lazy<IMapFileProvider> MapFileProvider = new(
+
+        /// <summary>
+        /// The map file provider instance to use
+        /// </summary>
+        /// <remarks>Public for testing</remarks>
+        public static Lazy<IMapFileProvider> MapFileProvider { get; set; } = new(
             Composer.Instance.GetExportedValueByTypeName<IMapFileProvider>(Config.Get("map-file-provider", "LocalDiskMapFileProvider"), forceTypeNameOnExisting: false)
         );
 

--- a/DownloaderDataProvider/DataDownloadConfig.cs
+++ b/DownloaderDataProvider/DataDownloadConfig.cs
@@ -26,54 +26,29 @@ namespace QuantConnect.DownloaderDataProvider.Launcher
     public struct DataDownloadConfig
     {
         /// <summary>
-        /// The tick type as a string.
-        /// </summary>
-        private string _tickType;
-
-        /// <summary>
-        /// The security type as a string.
-        /// </summary>
-        private string _securityType;
-
-        /// <summary>
-        /// The resolution as a string.
-        /// </summary>
-        private string _resolution;
-
-        /// <summary>
-        /// The start date as a string.
-        /// </summary>
-        private string _startDate;
-
-        /// <summary>
-        /// The end date as a string.
-        /// </summary>
-        private string _endDate;
-
-        /// <summary>
         /// Type of tick data to download.
         /// </summary>
-        public TickType TickType { get => ParseEnum<TickType>(_tickType); }
+        public TickType TickType { get; }
 
         /// <summary>
         /// Type of security for which data is to be downloaded.
         /// </summary>
-        public SecurityType SecurityType { get => ParseEnum<SecurityType>(_securityType); }
+        public SecurityType SecurityType { get; }
 
         /// <summary>
         /// Resolution of the downloaded data.
         /// </summary>
-        public Resolution Resolution { get => ParseEnum<Resolution>(_resolution); }
+        public Resolution Resolution { get; }
 
         /// <summary>
         /// Start date for the data download.
         /// </summary>
-        public DateTime StartDate { get => DateTime.ParseExact(_startDate, DateFormat.EightCharacter, CultureInfo.InvariantCulture); }
+        public DateTime StartDate { get; }
 
         /// <summary>
         /// End date for the data download.
         /// </summary>
-        public DateTime EndDate { get => DateTime.ParseExact(_endDate, DateFormat.EightCharacter, CultureInfo.InvariantCulture); }
+        public DateTime EndDate { get; }
 
         /// <summary>
         /// Market name for which the data is to be downloaded.
@@ -91,12 +66,12 @@ namespace QuantConnect.DownloaderDataProvider.Launcher
         /// <param name="parameters">Dictionary containing the parameters for data download.</param>
         public DataDownloadConfig()
         {
-            _tickType = Config.Get(DownloaderCommandArguments.CommandDataType).ToString() ?? string.Empty;
-            _securityType = Config.Get(DownloaderCommandArguments.CommandSecurityType).ToString() ?? string.Empty;
-            _resolution = Config.Get(DownloaderCommandArguments.CommandResolution).ToString() ?? string.Empty;
+            TickType = ParseEnum<TickType>(Config.Get(DownloaderCommandArguments.CommandDataType).ToString());
+            SecurityType = ParseEnum<SecurityType>(Config.Get(DownloaderCommandArguments.CommandSecurityType).ToString());
+            Resolution = ParseEnum<Resolution>(Config.Get(DownloaderCommandArguments.CommandResolution).ToString());
 
-            _startDate = Config.Get(DownloaderCommandArguments.CommandStartDate).ToString() ?? string.Empty;
-            _endDate = Config.Get(DownloaderCommandArguments.CommandEndDate).ToString() ?? string.Empty;
+            StartDate = DateTime.ParseExact(Config.Get(DownloaderCommandArguments.CommandStartDate).ToString(), DateFormat.EightCharacter, CultureInfo.InvariantCulture);
+            EndDate = DateTime.ParseExact(Config.Get(DownloaderCommandArguments.CommandEndDate).ToString(), DateFormat.EightCharacter, CultureInfo.InvariantCulture);
 
 #pragma warning disable CA1308 // class Market keeps all name in lowercase
             MarketName = Config.Get(DownloaderCommandArguments.CommandMarketName).ToString()?.ToLower(CultureInfo.InvariantCulture) ?? Market.USA;
@@ -110,6 +85,27 @@ namespace QuantConnect.DownloaderDataProvider.Launcher
             {
                 Symbols.Add(Symbol.Create(ticker, SecurityType, MarketName));
             }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataDownloadConfig"/> class with the specified parameters.
+        /// </summary>
+        /// <param name="tickType">The type of tick data to be downloaded.</param>
+        /// <param name="securityType">The type of security for which data is being downloaded.</param>
+        /// <param name="resolution">The resolution of the data being downloaded.</param>
+        /// <param name="startDate">The start date for the data download range.</param>
+        /// <param name="endDate">The end date for the data download range.</param>
+        /// <param name="market">The name of the market from which the data is being downloaded.</param>
+        /// <param name="symbols">A list of symbols for which data is being downloaded.</param>
+        public DataDownloadConfig(TickType tickType, SecurityType securityType, Resolution resolution, DateTime startDate, DateTime endDate, string market, List<Symbol> symbols)
+        {
+            TickType = tickType;
+            SecurityType = securityType;
+            Resolution = resolution;
+            StartDate = startDate;
+            EndDate = endDate;
+            MarketName = market;
+            Symbols = symbols;
         }
 
         /// <summary>

--- a/DownloaderDataProvider/DataDownloadConfig.cs
+++ b/DownloaderDataProvider/DataDownloadConfig.cs
@@ -98,8 +98,9 @@ namespace QuantConnect.DownloaderDataProvider.Launcher
             _startDate = Config.Get(DownloaderCommandArguments.CommandStartDate).ToString() ?? string.Empty;
             _endDate = Config.Get(DownloaderCommandArguments.CommandEndDate).ToString() ?? string.Empty;
 
-            MarketName = Config.Get(DownloaderCommandArguments.CommandMarketName).ToString()?.ToLower() ?? Market.USA;
-
+#pragma warning disable CA1308 // class Market keeps all name in lowercase
+            MarketName = Config.Get(DownloaderCommandArguments.CommandMarketName).ToString()?.ToLower(CultureInfo.InvariantCulture) ?? Market.USA;
+#pragma warning restore CA1308
             if (!Market.SupportedMarkets().Contains(MarketName))
             {
                 throw new ArgumentException($"The specified market '{MarketName}' is not supported. Supported markets are: {string.Join(", ", Market.SupportedMarkets())}.");
@@ -132,7 +133,7 @@ namespace QuantConnect.DownloaderDataProvider.Launcher
         /// <typeparam name="TEnum">The enum type to parse to.</typeparam>
         /// <param name="value">The string value to parse.</param>
         /// <returns>The parsed enum value.</returns>
-        private TEnum ParseEnum<TEnum>(string value) where TEnum : struct, Enum
+        private static TEnum ParseEnum<TEnum>(string value) where TEnum : struct, Enum
         {
             if (!Enum.TryParse(value, true, out TEnum result) || !Enum.IsDefined(typeof(TEnum), result))
             {

--- a/DownloaderDataProvider/Program.cs
+++ b/DownloaderDataProvider/Program.cs
@@ -104,7 +104,7 @@ public static class Program
 
             var (dataTimeZone, exchangeTimeZone) = GetDataAndExchangeTimeZoneBySymbol(symbol);
 
-            var writer = new LeanDataWriter(dataDownloadConfig.Resolution, symbol, dataDirectory, dataDownloadConfig.TickType, mapSymbol: true, dataCacheProvider: _dataCacheProvider);
+            var writer = new LeanDataWriter(dataDownloadConfig.Resolution, symbol, dataDirectory, dataDownloadConfig.TickType, mapSymbol: false, dataCacheProvider: _dataCacheProvider);
 
             var groupedData = DataFeeds.DownloaderDataProvider.FilterAndGroupDownloadDataBySymbol(
                 downloadedData,

--- a/DownloaderDataProvider/Program.cs
+++ b/DownloaderDataProvider/Program.cs
@@ -14,10 +14,12 @@
  *
 */
 
+using NodaTime;
 using QuantConnect.Util;
 using QuantConnect.Data;
 using QuantConnect.Logging;
 using QuantConnect.Interfaces;
+using QuantConnect.Securities;
 using QuantConnect.Configuration;
 using QuantConnect.DownloaderDataProvider.Launcher.Models.Constants;
 
@@ -40,6 +42,11 @@ public static class Program
     private static TimeSpan _logDisplayInterval = TimeSpan.FromSeconds(5);
 
     /// <summary>
+    /// Provides access to exchange hours and raw data times zones in various markets
+    /// </summary>
+    private static readonly MarketHoursDatabase _marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
+
+    /// <summary>
     /// The main entry point for the application.
     /// </summary>
     /// <param name="args">Command-line arguments passed to the application.</param>
@@ -57,11 +64,26 @@ public static class Program
 
         var dataDownloadConfig = new DataDownloadConfig();
 
+        RunDownload(dataDownloader, dataDownloadConfig);
+    }
+
+    /// <summary>
+    /// Executes a data download operation using the specified data downloader.
+    /// </summary>
+    /// <param name="dataDownloader">An instance of an object implementing the <see cref="IDataDownloader"/> interface, responsible for downloading data.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="dataDownloader"/> is null.</exception>
+    public static void RunDownload(IDataDownloader dataDownloader, DataDownloadConfig dataDownloadConfig)
+    {
+        if (dataDownloader == null)
+        {
+            throw new ArgumentNullException(nameof(dataDownloader), "The data downloader instance cannot be null. Please ensure that a valid instance of data downloader is provided.");
+        }
+
         // Calculate the total number of seconds between the EndDate and StartDate
         var totalDataPerSymbolInSeconds = (dataDownloadConfig.EndDate - dataDownloadConfig.StartDate).TotalSeconds;
         var totalDataInSeconds = totalDataPerSymbolInSeconds * dataDownloadConfig.Symbols.Count;
         var completeSymbolCount = 0;
-        var startUtcTime = DateTime.UtcNow;
+        var startDownloadUtcTime = DateTime.UtcNow;
 
         foreach (var symbol in dataDownloadConfig.Symbols)
         {
@@ -76,28 +98,77 @@ public static class Program
                 Log.Trace($"DownloaderDataProvider.Main(): No data available for the following parameters: {downloadParameters}");
                 continue;
             }
-            var writer = new LeanDataWriter(dataDownloadConfig.Resolution, symbol, Globals.DataFolder, dataDownloadConfig.TickType, mapSymbol: true,
-                dataCacheProvider: _dataCacheProvider);
+
+            var (dataTimeZone, exchangeTimeZone) = GetDataAndExchangeTimeZoneBySymbol(symbol);
+
+            var writer = new LeanDataWriter(dataDownloadConfig.Resolution, symbol, Globals.DataFolder, dataDownloadConfig.TickType, mapSymbol: true, dataCacheProvider: _dataCacheProvider);
+
+            var startDateTimeInExchangeTimeZone = downloadParameters.StartUtc.ConvertFromUtc(exchangeTimeZone);
+            var endDateTimeInExchangeTimeZone = downloadParameters.EndUtc.ConvertFromUtc(exchangeTimeZone);
+
+            var dataType = LeanData.GetDataType(downloadParameters.Resolution, downloadParameters.TickType);
+            var groupedData = downloadedData
+                .Where(baseData =>
+                {
+                    // Sometimes, external Downloader provider returns excess data
+                    if (baseData.Time < startDateTimeInExchangeTimeZone || baseData.Time > endDateTimeInExchangeTimeZone)
+                    {
+                        return false;
+                    }
+
+                    if (symbol.SecurityType == SecurityType.Base || baseData.GetType() == dataType)
+                    {
+                        // we need to store the data in data time zone
+                        baseData.Time = baseData.Time.ConvertTo(exchangeTimeZone, dataTimeZone);
+                        baseData.EndTime = baseData.EndTime.ConvertTo(exchangeTimeZone, dataTimeZone);
+                        return true;
+                    }
+                    return false;
+                })
+                // for canonical symbols, downloader will return data for all of the chain
+                .GroupBy(baseData => baseData.Symbol);
 
             var lastLogStatusTime = DateTime.UtcNow;
-            writer.Write(downloadedData.Select(data =>
-            {
-                var utcNow = DateTime.UtcNow;
-                if (utcNow - lastLogStatusTime >= _logDisplayInterval)
-                {
-                    lastLogStatusTime = utcNow;
-                    var progressSoFar = (data.EndTime - dataDownloadConfig.StartDate).TotalSeconds + totalDataPerSymbolInSeconds * completeSymbolCount;
-                    var eta = CalculateETA(utcNow, startUtcTime, totalDataInSeconds, progressSoFar);
-                    var progress = CalculateProgress(data.EndTime, dataDownloadConfig.StartDate, dataDownloadConfig.EndDate);
-                    Log.Trace($"DownloaderDataProvider.Main(): Downloading {downloadParameters.Symbol} data: {progress:F2}%. ETA: {eta}");
-                }
 
-                return data;
-            }));
+            foreach (var data in groupedData)
+            {
+                writer.Write(data.Select(data =>
+                {
+                    var utcNow = DateTime.UtcNow;
+                    if (utcNow - lastLogStatusTime >= _logDisplayInterval)
+                    {
+                        lastLogStatusTime = utcNow;
+                        var progressSoFar = (data.EndTime - dataDownloadConfig.StartDate).TotalSeconds + totalDataPerSymbolInSeconds * completeSymbolCount;
+                        var eta = CalculateETA(utcNow, startDownloadUtcTime, totalDataInSeconds, progressSoFar);
+                        var progress = CalculateProgress(data.EndTime, dataDownloadConfig.StartDate, dataDownloadConfig.EndDate);
+                        Log.Trace($"DownloaderDataProvider.RunDownload(): Downloading {downloadParameters.Symbol} data: {progress:F2}%. ETA: {eta}");
+                    }
+
+                    return data;
+                }));
+            }
+
             completeSymbolCount++;
-            Log.Trace($"DownloaderDataProvider.Main(): Download completed for {downloadParameters.Symbol} at {downloadParameters.Resolution} resolution, " +
+
+            Log.Trace($"DownloaderDataProvider.RunDownload(): Download completed for {downloadParameters.Symbol} at {downloadParameters.Resolution} resolution, " +
                 $"covering the period from {dataDownloadConfig.StartDate} to {dataDownloadConfig.EndDate}.");
         }
+        Log.Trace($"All downloads completed in {(DateTime.UtcNow - startDownloadUtcTime).TotalSeconds:F2} seconds.");
+    }
+
+    /// <summary>
+    /// Retrieves the data time zone and exchange time zone associated with the specified symbol.
+    /// </summary>
+    /// <param name="symbol">The symbol for which to retrieve time zones.</param>
+    /// <returns>
+    /// A tuple containing the data time zone and exchange time zone.
+    /// The data time zone represents the time zone for data related to the symbol.
+    /// The exchange time zone represents the time zone for trading activities related to the symbol.
+    /// </returns>
+    private static (DateTimeZone dataTimeZone, DateTimeZone exchangeTimeZone) GetDataAndExchangeTimeZoneBySymbol(Symbol symbol)
+    {
+        var entry = _marketHoursDatabase.GetEntry(symbol.ID.Market, symbol, symbol.SecurityType);
+        return (entry.DataTimeZone, entry.ExchangeHours.TimeZone);
     }
 
     /// <summary>

--- a/DownloaderDataProvider/Program.cs
+++ b/DownloaderDataProvider/Program.cs
@@ -65,7 +65,7 @@ public static class Program
 
         var dataDownloadConfig = new DataDownloadConfig();
 
-        RunDownload(dataDownloader, dataDownloadConfig, Globals.DataFolder);
+        RunDownload(dataDownloader, dataDownloadConfig, Globals.DataFolder, _dataCacheProvider);
     }
 
     /// <summary>
@@ -74,8 +74,9 @@ public static class Program
     /// <param name="dataDownloader">An instance of an object implementing the <see cref="IDataDownloader"/> interface, responsible for downloading data.</param>
     /// <param name="dataDownloadConfig">Configuration settings for the data download operation.</param>
     /// <param name="dataDirectory">The directory where the downloaded data will be stored.</param>
+    /// <param name="dataCacheProvider">The provider used to cache history data files</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="dataDownloader"/> is null.</exception>
-    public static void RunDownload(IDataDownloader dataDownloader, DataDownloadConfig dataDownloadConfig, string dataDirectory)
+    public static void RunDownload(IDataDownloader dataDownloader, DataDownloadConfig dataDownloadConfig, string dataDirectory, IDataCacheProvider dataCacheProvider)
     {
         if (dataDownloader == null)
         {
@@ -104,7 +105,7 @@ public static class Program
 
             var (dataTimeZone, exchangeTimeZone) = GetDataAndExchangeTimeZoneBySymbol(symbol);
 
-            var writer = new LeanDataWriter(dataDownloadConfig.Resolution, symbol, dataDirectory, dataDownloadConfig.TickType, mapSymbol: false, dataCacheProvider: _dataCacheProvider);
+            var writer = new LeanDataWriter(dataDownloadConfig.Resolution, symbol, dataDirectory, dataDownloadConfig.TickType, mapSymbol: true, dataCacheProvider: dataCacheProvider);
 
             var groupedData = DataFeeds.DownloaderDataProvider.FilterAndGroupDownloadDataBySymbol(
                 downloadedData,

--- a/DownloaderDataProvider/Program.cs
+++ b/DownloaderDataProvider/Program.cs
@@ -65,15 +65,17 @@ public static class Program
 
         var dataDownloadConfig = new DataDownloadConfig();
 
-        RunDownload(dataDownloader, dataDownloadConfig);
+        RunDownload(dataDownloader, dataDownloadConfig, Globals.DataFolder);
     }
 
     /// <summary>
     /// Executes a data download operation using the specified data downloader.
     /// </summary>
     /// <param name="dataDownloader">An instance of an object implementing the <see cref="IDataDownloader"/> interface, responsible for downloading data.</param>
+    /// <param name="dataDownloadConfig">Configuration settings for the data download operation.</param>
+    /// <param name="dataDirectory">The directory where the downloaded data will be stored.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="dataDownloader"/> is null.</exception>
-    public static void RunDownload(IDataDownloader dataDownloader, DataDownloadConfig dataDownloadConfig)
+    public static void RunDownload(IDataDownloader dataDownloader, DataDownloadConfig dataDownloadConfig, string dataDirectory)
     {
         if (dataDownloader == null)
         {
@@ -102,7 +104,7 @@ public static class Program
 
             var (dataTimeZone, exchangeTimeZone) = GetDataAndExchangeTimeZoneBySymbol(symbol);
 
-            var writer = new LeanDataWriter(dataDownloadConfig.Resolution, symbol, Globals.DataFolder, dataDownloadConfig.TickType, mapSymbol: true, dataCacheProvider: _dataCacheProvider);
+            var writer = new LeanDataWriter(dataDownloadConfig.Resolution, symbol, dataDirectory, dataDownloadConfig.TickType, mapSymbol: true, dataCacheProvider: _dataCacheProvider);
 
             var groupedData = DataFeeds.DownloaderDataProvider.FilterAndGroupDownloadDataBySymbol(
                 downloadedData,

--- a/DownloaderDataProvider/Program.cs
+++ b/DownloaderDataProvider/Program.cs
@@ -75,8 +75,9 @@ public static class Program
     /// <param name="dataDownloadConfig">Configuration settings for the data download operation.</param>
     /// <param name="dataDirectory">The directory where the downloaded data will be stored.</param>
     /// <param name="dataCacheProvider">The provider used to cache history data files</param>
+    /// <param name="mapSymbol">True if the symbol should be mapped while writing the data</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="dataDownloader"/> is null.</exception>
-    public static void RunDownload(IDataDownloader dataDownloader, DataDownloadConfig dataDownloadConfig, string dataDirectory, IDataCacheProvider dataCacheProvider)
+    public static void RunDownload(IDataDownloader dataDownloader, DataDownloadConfig dataDownloadConfig, string dataDirectory, IDataCacheProvider dataCacheProvider, bool mapSymbol = true)
     {
         if (dataDownloader == null)
         {
@@ -105,7 +106,7 @@ public static class Program
 
             var (dataTimeZone, exchangeTimeZone) = GetDataAndExchangeTimeZoneBySymbol(symbol);
 
-            var writer = new LeanDataWriter(dataDownloadConfig.Resolution, symbol, dataDirectory, dataDownloadConfig.TickType, mapSymbol: true, dataCacheProvider: dataCacheProvider);
+            var writer = new LeanDataWriter(dataDownloadConfig.Resolution, symbol, dataDirectory, dataDownloadConfig.TickType, dataCacheProvider, mapSymbol: mapSymbol);
 
             var groupedData = DataFeeds.DownloaderDataProvider.FilterAndGroupDownloadDataBySymbol(
                 downloadedData,

--- a/Tests/DownloaderDataProvider/DownloadHelperTests.cs
+++ b/Tests/DownloaderDataProvider/DownloadHelperTests.cs
@@ -110,7 +110,7 @@ namespace QuantConnect.Tests.DownloaderDataProvider
 
             var downloader = new DataDownloaderTest(mockBaseDate);
 
-            Program.RunDownload(downloader, downloadDataConfig, _dataDirectory);
+            Program.RunDownload(downloader, downloadDataConfig, _dataDirectory, TestGlobals.DataCacheProvider);
 
             var filePath = LeanData.GenerateZipFilePath(_dataDirectory, optionContracts.First(), startDate, resolution, tickType);
             var unZipData = QuantConnect.Compression.Unzip(filePath).ToDictionary(x => x.Key, x => x.Value.ToList());

--- a/Tests/DownloaderDataProvider/DownloadHelperTests.cs
+++ b/Tests/DownloaderDataProvider/DownloadHelperTests.cs
@@ -15,13 +15,12 @@
 */
 
 using System;
+using System.IO;
 using System.Linq;
 using NUnit.Framework;
-using System.Text.Json;
 using QuantConnect.Data;
 using QuantConnect.Util;
 using QuantConnect.Data.Market;
-using QuantConnect.Configuration;
 using System.Collections.Generic;
 using QuantConnect.DownloaderDataProvider.Launcher;
 
@@ -30,6 +29,11 @@ namespace QuantConnect.Tests.DownloaderDataProvider
     [TestFixture]
     public class DownloadHelperTests
     {
+        /// <summary>
+        /// Temporary data download directory
+        /// </summary>
+        private readonly string _dataDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
         [TestCase("2020/01/01", "2024/01/01", 3, 0)]
         public void CalculateETAShouldDownloadAllSymbols(DateTime downloadStartDate, DateTime downloadEndDate, int amountDownloadSymbol, int alreadyDownloadedSymbol)
         {
@@ -106,9 +110,9 @@ namespace QuantConnect.Tests.DownloaderDataProvider
 
             var downloader = new DataDownloaderTest(mockBaseDate);
 
-            Program.RunDownload(downloader, downloadDataConfig);
+            Program.RunDownload(downloader, downloadDataConfig, _dataDirectory);
 
-            var filePath = LeanData.GenerateZipFilePath(Globals.DataFolder, optionContracts.First(), startDate, resolution, tickType);
+            var filePath = LeanData.GenerateZipFilePath(_dataDirectory, optionContracts.First(), startDate, resolution, tickType);
             var unZipData = QuantConnect.Compression.Unzip(filePath).ToDictionary(x => x.Key, x => x.Value.ToList());
             Assert.GreaterOrEqual(unZipData.Count, optionContracts.Count);
 

--- a/Tests/DownloaderDataProvider/DownloadHelperTests.cs
+++ b/Tests/DownloaderDataProvider/DownloadHelperTests.cs
@@ -15,7 +15,14 @@
 */
 
 using System;
+using System.Linq;
 using NUnit.Framework;
+using System.Text.Json;
+using QuantConnect.Data;
+using QuantConnect.Util;
+using QuantConnect.Data.Market;
+using QuantConnect.Configuration;
+using System.Collections.Generic;
 using QuantConnect.DownloaderDataProvider.Launcher;
 
 namespace QuantConnect.Tests.DownloaderDataProvider
@@ -79,6 +86,84 @@ namespace QuantConnect.Tests.DownloaderDataProvider
             var eta = Program.CalculateETA(mockUtcTimeNow, runUtcTime, totalDataInSeconds, progressSoFar);
 
             Assert.That(expectedTotalSeconds, Is.EqualTo((int)eta.TotalSeconds));
+        }
+
+        [TestCase(TickType.Trade, Resolution.Daily)]
+        public void RunDownload(TickType tickType, Resolution resolution)
+        {
+            var startDate = new DateTime(2024, 01, 01);
+            var tradeDate = new DateTime(2024, 01, 10);
+            var endDate = new DateTime(2024, 02, 02);
+            var symbol = Symbols.AAPL;
+
+            var downloadDataConfig = InitializeDataDownloadConfigParameters(tickType, SecurityType.Option, resolution, startDate, endDate, new string[] { symbol.Value });
+
+            var optionContracts = GenerateOptionContracts(symbol, 100, new DateTime(2024, 03, 16));
+
+            Assert.That(optionContracts.Distinct().Count(), Is.EqualTo(optionContracts.Count));
+
+            var mockBaseDate = GenerateTradeBarByEachSymbol(optionContracts, tradeDate);
+
+            var downloader = new DataDownloaderTest(mockBaseDate);
+
+            Program.RunDownload(downloader, downloadDataConfig);
+
+            var filePath = LeanData.GenerateZipFilePath(Globals.DataFolder, optionContracts.First(), startDate, resolution, tickType);
+            var data = QuantConnect.Compression.Unzip(filePath).ToDictionary(x => x.Key, x => x.Value.ToList());
+
+            Assert.Greater(data.Count, 1);
+        }
+
+        private static IEnumerable<BaseData> GenerateTradeBarByEachSymbol(IEnumerable<Symbol> symbols, DateTime tradeDateTime)
+        {
+            var multiplier = 100;
+            foreach (var option in symbols)
+            {
+                yield return new TradeBar(tradeDateTime, option, multiplier, multiplier, multiplier, multiplier, multiplier);
+                multiplier *= 2;
+            }
+        }
+
+        private static List<Symbol> GenerateOptionContracts(Symbol underlying, decimal strikePrice, DateTime expiryDate, int strikeMultiplier = 2, int expiryAddDay = 1, int count = 2)
+        {
+            var contracts = new List<Symbol>();
+            for (int i = 0; i < count; i++)
+            {
+                contracts.Add(Symbol.CreateOption(underlying, underlying.ID.Market, OptionStyle.American, OptionRight.Put, strikePrice, expiryDate));
+                expiryDate = expiryDate.AddDays(expiryAddDay);
+                strikePrice *= strikeMultiplier;
+            }
+            return contracts;
+        }
+
+        private class DataDownloaderTest : IDataDownloader
+        {
+            public IEnumerable<BaseData> Data { get; }
+
+            public DataDownloaderTest(IEnumerable<BaseData> data)
+            {
+                Data = data;
+            }
+
+            public IEnumerable<BaseData> Get(DataDownloaderGetParameters dataDownloaderGetParameters)
+            {
+                return Data.Select(x => x);
+            }
+        }
+
+        private static DataDownloadConfig InitializeDataDownloadConfigParameters(TickType tickType, SecurityType securityType, Resolution resolution,
+            DateTime startDate, DateTime endDate, string[] tickers, string market = Market.USA)
+        {
+            Config.Set("data-type", tickType.ToStringInvariant());
+            Config.Set("security-type", securityType.ToStringInvariant());
+            Config.Set("market", market);
+            Config.Set("resolution", resolution.ToStringInvariant());
+            Config.Set("start-date", startDate.ToStringInvariant("yyyyMMdd"));
+            Config.Set("end-date", endDate.ToStringInvariant("yyyyMMdd"));
+            // serializes tickers into a dictionary similar to using DownloaderDataProviderArgumentParser.
+            Config.Set("tickers", JsonSerializer.Serialize(tickers.ToDictionary(t => t, _ => "")));
+
+            return new DataDownloadConfig();
         }
     }
 }

--- a/Tests/ToolBox/LeanDataWriterTests.cs
+++ b/Tests/ToolBox/LeanDataWriterTests.cs
@@ -106,6 +106,8 @@ namespace QuantConnect.Tests.ToolBox
         [TestCase(false)]
         public void Mapping(bool mapSymbol)
         {
+            LeanDataWriter.MapFileProvider = new Lazy<IMapFileProvider>(TestGlobals.MapFileProvider);
+
             // asset got mapped on 20080929 to SPWRA
             var symbol = Symbol.Create("SPWR", SecurityType.Equity, Market.USA);
             var leanDataWriter = new LeanDataWriter(Resolution.Daily, symbol, _dataDirectory, TickType.Trade, mapSymbol: mapSymbol);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This pull request introduces two new features:

1. **Group Symbol Addition**: When downloading canonical data, a group symbol is now included to improve data organization and clarity.
2. **Total Time Execution Logging**: Total time execution of the download provider is now logged, aiding in performance monitoring and optimization.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Related PR
- https://github.com/QuantConnect/Lean/pull/7975

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
By adding a group symbol, we aim to enhance the user experience by providing clearer organization of downloaded canonical data. Additionally, logging the total time execution of the download provider will help us monitor performance and identify potential areas for improvement.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- **Unit Testing**: Writing unit tests to cover different scenarios and ensure code reliability and stability.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
