### PR TITLE
Remove: log ETA calculation 

### DIFF
--- a/DownloaderDataProvider/Program.cs
+++ b/DownloaderDataProvider/Program.cs
@@ -127,10 +127,8 @@ public static class Program
                     if (utcNow - lastLogStatusTime >= _logDisplayInterval)
                     {
                         lastLogStatusTime = utcNow;
-                        var progressSoFar = (data.EndTime - dataDownloadConfig.StartDate).TotalSeconds + totalDataPerSymbolInSeconds * completeSymbolCount;
-                        var eta = CalculateETA(utcNow, startDownloadUtcTime, totalDataInSeconds, progressSoFar);
                         var progress = CalculateProgress(data.EndTime, dataDownloadConfig.StartDate, dataDownloadConfig.EndDate);
-                        Log.Trace($"DownloaderDataProvider.RunDownload(): Downloading {downloadParameters.Symbol} data: {progress:F2}%. ETA: {eta}");
+                        Log.Trace($"DownloaderDataProvider.RunDownload(): Downloading {downloadParameters.Symbol} data: {progress:F2}%.");
                     }
 
                     return data;
@@ -158,37 +156,6 @@ public static class Program
     {
         var entry = _marketHoursDatabase.GetEntry(symbol.ID.Market, symbol, symbol.SecurityType);
         return (entry.DataTimeZone, entry.ExchangeHours.TimeZone);
-    }
-
-    /// <summary>
-    /// Calculates the Estimated Time of Arrival (ETA) based on the current progress of a download.
-    /// </summary>
-    /// <param name="utcNow">The current UTC DateTime.</param>
-    /// <param name="startUtcTime">The DateTime when the download started.</param>
-    /// <param name="totalDataInSeconds"></param>
-    /// <param name="currentProgressSecond"></param>
-    /// <returns>A TimeSpan representing the Estimated Time of Arrival (ETA).</returns>
-    /// <remarks>
-    /// The method calculates the time elapsed since the start of downloading and estimates
-    /// the remaining time based on the current progress. It uses the difference between
-    /// the end time and the end date to calculate missing data time, and the difference
-    /// between the end time and the start date to calculate the progress so far.
-    /// The ETA is then calculated based on these values.
-    /// </remarks>
-    public static TimeSpan CalculateETA(DateTime utcNow, DateTime startUtcTime, double totalDataInSeconds, double currentProgressSecond)
-    {
-        // Calculate how much time has passed since the start of downloading
-        TimeSpan howMuchItTookSoFar = utcNow - startUtcTime;
-
-        var missingDataSecond = totalDataInSeconds - currentProgressSecond;
-
-        // Calculate ETA in seconds
-        var etaSeconds = (missingDataSecond / currentProgressSecond) * howMuchItTookSoFar.TotalSeconds;
-
-        // Convert ETA from seconds to TimeSpan
-        TimeSpan etaTimeSpan = TimeSpan.FromSeconds(etaSeconds);
-
-        return etaTimeSpan;
     }
 
     /// <summary>

--- a/Tests/DownloaderDataProvider/DownloadHelperTests.cs
+++ b/Tests/DownloaderDataProvider/DownloadHelperTests.cs
@@ -52,64 +52,6 @@ namespace QuantConnect.Tests.DownloaderDataProvider
         /// </summary>
         private readonly string _dataDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
-        [TestCase("2020/01/01", "2024/01/01", 3, 0)]
-        public void CalculateETAShouldDownloadAllSymbols(DateTime downloadStartDate, DateTime downloadEndDate, int amountDownloadSymbol, int alreadyDownloadedSymbol)
-        {
-            var totalDataPerSymbolInSeconds = (downloadEndDate - downloadStartDate).TotalSeconds;
-            var totalDataInSeconds = totalDataPerSymbolInSeconds * amountDownloadSymbol;
-
-            var mockRunningDateTime = new DateTime(2024, 04, 26, 1, 10, 10);
-            var endDateTime = downloadStartDate;
-            while (alreadyDownloadedSymbol != amountDownloadSymbol)
-            {
-                do
-                {
-                    endDateTime = endDateTime.AddDays(1);
-
-                    // Simulate real-time by advancing the mockRunningDateTime by 2 milliseconds
-                    var utcNow = mockRunningDateTime.AddMilliseconds(2);
-                    var progressSoFar = (endDateTime - downloadStartDate).TotalSeconds + totalDataPerSymbolInSeconds * alreadyDownloadedSymbol;
-                    var eta = Program.CalculateETA(utcNow, mockRunningDateTime, totalDataInSeconds, progressSoFar);
-
-                    if (endDateTime < downloadEndDate)
-                    {
-                        Assert.Greater(eta.TotalSeconds, 0);
-                    }
-                } while (endDateTime != downloadEndDate);
-
-                endDateTime = downloadStartDate;
-                alreadyDownloadedSymbol++;
-            }
-
-            Assert.That(amountDownloadSymbol, Is.EqualTo(alreadyDownloadedSymbol));
-        }
-
-        [TestCase("2020/01/01", "2024/01/01", "2020/1/10", 1, 0, 1, 161)]
-        [TestCase("2019/01/01", "2023/01/01", "2021/2/10", 2, 1, 10, 3)]
-        [TestCase("2021/01/01", "2022/01/01", "2021/5/10", 3, 2, 5, 1)]
-        public void CalculateETAShouldReturnCorrectETA(
-            DateTime downloadStartDate,
-            DateTime downloadEndDate,
-            DateTime currentDownloadedDataFromDataDownloader,
-            int amountOfDownloadSymbol,
-            int alreadyDownloadedSymbol,
-            int minusUtcNowSecond,
-            int expectedTotalSeconds)
-        {
-            var mockUtcTimeNow = new DateTime(2024, 04, 26, 1, 1, 10);
-
-            DateTime runUtcTime = mockUtcTimeNow.AddSeconds(-minusUtcNowSecond);
-
-            var totalDataPerSymbolInSeconds = (downloadEndDate - downloadStartDate).TotalSeconds;
-            var totalDataInSeconds = totalDataPerSymbolInSeconds * amountOfDownloadSymbol;
-
-            var progressSoFar = (currentDownloadedDataFromDataDownloader - downloadStartDate).TotalSeconds + totalDataPerSymbolInSeconds * alreadyDownloadedSymbol;
-
-            var eta = Program.CalculateETA(mockUtcTimeNow, runUtcTime, totalDataInSeconds, progressSoFar);
-
-            Assert.That(expectedTotalSeconds, Is.EqualTo((int)eta.TotalSeconds));
-        }
-
         [TestCase(TickType.Trade, Resolution.Daily)]
         public void RunDownload(TickType tickType, Resolution resolution)
         {

--- a/Tests/DownloaderDataProvider/DownloadHelperTests.cs
+++ b/Tests/DownloaderDataProvider/DownloadHelperTests.cs
@@ -30,6 +30,11 @@ namespace QuantConnect.Tests.DownloaderDataProvider
     [TestFixture]
     public class DownloadHelperTests
     {
+        /// <summary>
+        /// Temporary data download directory
+        /// </summary>
+        private readonly string _dataDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
         private IDataCacheProvider _cacheProvider;
 
         [OneTimeSetUp]
@@ -45,69 +50,6 @@ namespace QuantConnect.Tests.DownloaderDataProvider
             {
                 _cacheProvider.Dispose();
             }
-        }
-
-        /// <summary>
-        /// Temporary data download directory
-        /// </summary>
-        private readonly string _dataDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-
-        [TestCase("2020/01/01", "2024/01/01", 3, 0)]
-        public void CalculateETAShouldDownloadAllSymbols(DateTime downloadStartDate, DateTime downloadEndDate, int amountDownloadSymbol, int alreadyDownloadedSymbol)
-        {
-            var totalDataPerSymbolInSeconds = (downloadEndDate - downloadStartDate).TotalSeconds;
-            var totalDataInSeconds = totalDataPerSymbolInSeconds * amountDownloadSymbol;
-
-            var mockRunningDateTime = new DateTime(2024, 04, 26, 1, 10, 10);
-            var endDateTime = downloadStartDate;
-            while (alreadyDownloadedSymbol != amountDownloadSymbol)
-            {
-                do
-                {
-                    endDateTime = endDateTime.AddDays(1);
-
-                    // Simulate real-time by advancing the mockRunningDateTime by 2 milliseconds
-                    var utcNow = mockRunningDateTime.AddMilliseconds(2);
-                    var progressSoFar = (endDateTime - downloadStartDate).TotalSeconds + totalDataPerSymbolInSeconds * alreadyDownloadedSymbol;
-                    var eta = Program.CalculateETA(utcNow, mockRunningDateTime, totalDataInSeconds, progressSoFar);
-
-                    if (endDateTime < downloadEndDate)
-                    {
-                        Assert.Greater(eta.TotalSeconds, 0);
-                    }
-                } while (endDateTime != downloadEndDate);
-
-                endDateTime = downloadStartDate;
-                alreadyDownloadedSymbol++;
-            }
-
-            Assert.That(amountDownloadSymbol, Is.EqualTo(alreadyDownloadedSymbol));
-        }
-
-        [TestCase("2020/01/01", "2024/01/01", "2020/1/10", 1, 0, 1, 161)]
-        [TestCase("2019/01/01", "2023/01/01", "2021/2/10", 2, 1, 10, 3)]
-        [TestCase("2021/01/01", "2022/01/01", "2021/5/10", 3, 2, 5, 1)]
-        public void CalculateETAShouldReturnCorrectETA(
-            DateTime downloadStartDate,
-            DateTime downloadEndDate,
-            DateTime currentDownloadedDataFromDataDownloader,
-            int amountOfDownloadSymbol,
-            int alreadyDownloadedSymbol,
-            int minusUtcNowSecond,
-            int expectedTotalSeconds)
-        {
-            var mockUtcTimeNow = new DateTime(2024, 04, 26, 1, 1, 10);
-
-            DateTime runUtcTime = mockUtcTimeNow.AddSeconds(-minusUtcNowSecond);
-
-            var totalDataPerSymbolInSeconds = (downloadEndDate - downloadStartDate).TotalSeconds;
-            var totalDataInSeconds = totalDataPerSymbolInSeconds * amountOfDownloadSymbol;
-
-            var progressSoFar = (currentDownloadedDataFromDataDownloader - downloadStartDate).TotalSeconds + totalDataPerSymbolInSeconds * alreadyDownloadedSymbol;
-
-            var eta = Program.CalculateETA(mockUtcTimeNow, runUtcTime, totalDataInSeconds, progressSoFar);
-
-            Assert.That(expectedTotalSeconds, Is.EqualTo((int)eta.TotalSeconds));
         }
 
         [TestCase(TickType.Trade, Resolution.Daily)]

--- a/Tests/DownloaderDataProvider/DownloadHelperTests.cs
+++ b/Tests/DownloaderDataProvider/DownloadHelperTests.cs
@@ -30,11 +30,6 @@ namespace QuantConnect.Tests.DownloaderDataProvider
     [TestFixture]
     public class DownloadHelperTests
     {
-        /// <summary>
-        /// Temporary data download directory
-        /// </summary>
-        private readonly string _dataDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-
         private IDataCacheProvider _cacheProvider;
 
         [OneTimeSetUp]
@@ -50,6 +45,69 @@ namespace QuantConnect.Tests.DownloaderDataProvider
             {
                 _cacheProvider.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Temporary data download directory
+        /// </summary>
+        private readonly string _dataDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+        [TestCase("2020/01/01", "2024/01/01", 3, 0)]
+        public void CalculateETAShouldDownloadAllSymbols(DateTime downloadStartDate, DateTime downloadEndDate, int amountDownloadSymbol, int alreadyDownloadedSymbol)
+        {
+            var totalDataPerSymbolInSeconds = (downloadEndDate - downloadStartDate).TotalSeconds;
+            var totalDataInSeconds = totalDataPerSymbolInSeconds * amountDownloadSymbol;
+
+            var mockRunningDateTime = new DateTime(2024, 04, 26, 1, 10, 10);
+            var endDateTime = downloadStartDate;
+            while (alreadyDownloadedSymbol != amountDownloadSymbol)
+            {
+                do
+                {
+                    endDateTime = endDateTime.AddDays(1);
+
+                    // Simulate real-time by advancing the mockRunningDateTime by 2 milliseconds
+                    var utcNow = mockRunningDateTime.AddMilliseconds(2);
+                    var progressSoFar = (endDateTime - downloadStartDate).TotalSeconds + totalDataPerSymbolInSeconds * alreadyDownloadedSymbol;
+                    var eta = Program.CalculateETA(utcNow, mockRunningDateTime, totalDataInSeconds, progressSoFar);
+
+                    if (endDateTime < downloadEndDate)
+                    {
+                        Assert.Greater(eta.TotalSeconds, 0);
+                    }
+                } while (endDateTime != downloadEndDate);
+
+                endDateTime = downloadStartDate;
+                alreadyDownloadedSymbol++;
+            }
+
+            Assert.That(amountDownloadSymbol, Is.EqualTo(alreadyDownloadedSymbol));
+        }
+
+        [TestCase("2020/01/01", "2024/01/01", "2020/1/10", 1, 0, 1, 161)]
+        [TestCase("2019/01/01", "2023/01/01", "2021/2/10", 2, 1, 10, 3)]
+        [TestCase("2021/01/01", "2022/01/01", "2021/5/10", 3, 2, 5, 1)]
+        public void CalculateETAShouldReturnCorrectETA(
+            DateTime downloadStartDate,
+            DateTime downloadEndDate,
+            DateTime currentDownloadedDataFromDataDownloader,
+            int amountOfDownloadSymbol,
+            int alreadyDownloadedSymbol,
+            int minusUtcNowSecond,
+            int expectedTotalSeconds)
+        {
+            var mockUtcTimeNow = new DateTime(2024, 04, 26, 1, 1, 10);
+
+            DateTime runUtcTime = mockUtcTimeNow.AddSeconds(-minusUtcNowSecond);
+
+            var totalDataPerSymbolInSeconds = (downloadEndDate - downloadStartDate).TotalSeconds;
+            var totalDataInSeconds = totalDataPerSymbolInSeconds * amountOfDownloadSymbol;
+
+            var progressSoFar = (currentDownloadedDataFromDataDownloader - downloadStartDate).TotalSeconds + totalDataPerSymbolInSeconds * alreadyDownloadedSymbol;
+
+            var eta = Program.CalculateETA(mockUtcTimeNow, runUtcTime, totalDataInSeconds, progressSoFar);
+
+            Assert.That(expectedTotalSeconds, Is.EqualTo((int)eta.TotalSeconds));
         }
 
         [TestCase(TickType.Trade, Resolution.Daily)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This pull request removes the calculation of ETA (Estimated Time of Arrival) logs, as it was found to be inaccurate when dealing with certain security types. Instead, the PR retains information about the downloading progress of each symbol.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Related PR
- https://github.com/QuantConnect/Lean/pull/7984

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The ETA log calculation was causing inaccuracies, particularly when handling specific security types. Removing this calculation simplifies the process and ensures that users receive accurate information about the download progress. By retaining information about downloading each symbol, users can still monitor the progress effectively without relying on potentially misleading ETA estimation

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change has been tested by **running existing tests** to ensure that the functionality remains intact after removing the ETA log calculation. Additionally, **manual testing** has been performed through the execution of the downloader launcher application to verify that the download progress information is displayed correctly for each symbol.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
