### PR TITLE
Python consolidator removal directly from Python

### DIFF
--- a/Algorithm.Python/ManuallyRemovedConsolidatorsAlgorithm.py
+++ b/Algorithm.Python/ManuallyRemovedConsolidatorsAlgorithm.py
@@ -1,0 +1,110 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Algorithm asserting that the consolidators are removed from the SubscriptionManager.
+### This makes sure that we don't lose references to python consolidators when
+### they are wrapped in a DataConsolidatorPythonWrapper.
+### </summary>
+class ManuallyRemovedConsolidatorsAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2013, 10, 7)
+        self.set_end_date(2013, 10, 11)
+
+        self.consolidators = []
+
+        self.spy = self.add_equity("SPY").symbol
+
+        # Case 1: consolidator registered through a RegisterIndicator() call,
+        # which will wrap the consolidator instance in a DataConsolidatorPythonWrapper
+        consolidator = self.resolve_consolidator(self.spy, Resolution.MINUTE)
+        self.consolidators.append(consolidator)
+
+        indicator_name = self.create_indicator_name(self.spy, "close", Resolution.MINUTE)
+        identity = Identity(indicator_name)
+        self.indicator = self.register_indicator(self.spy, identity, consolidator)
+
+        # Case 2: consolidator registered directly through the SubscriptionManager
+        consolidator = self.resolve_consolidator(self.spy, Resolution.MINUTE)
+        self.consolidators.append(consolidator)
+        self.subscription_manager.add_consolidator(self.spy, consolidator)
+
+        # Case 3: custom python consolidator not derived from IDataConsolidator
+        consolidator = CustomQuoteBarConsolidator(timedelta(hours=1))
+        self.consolidators.append(consolidator)
+        self.subscription_manager.add_consolidator(self.spy, consolidator)
+
+    def on_end_of_algorithm(self) -> None:
+        # Remove the first consolidator
+
+        for i in range(3):
+            consolidator = self.consolidators[i]
+            self.remove_consolidator(consolidator, expected_consolidator_count=2 - i)
+
+    def remove_consolidator(self, consolidator: IDataConsolidator, expected_consolidator_count: int) -> None:
+        self.subscription_manager.remove_consolidator(self.spy, consolidator)
+
+        consolidator_count = sum(s.consolidators.count for s in self.subscription_manager.subscriptions)
+        if consolidator_count != expected_consolidator_count:
+            raise Exception(f"Unexpected number of consolidators after removal. "
+                            f"Expected: {expected_consolidator_count}. Actual: {consolidator_count}")
+
+class CustomQuoteBarConsolidator(PythonConsolidator):
+    '''A custom quote bar consolidator that inherits from PythonConsolidator and implements
+    the IDataConsolidator interface, it must implement all of IDataConsolidator. Reference
+    PythonConsolidator.cs and DataConsolidatorPythonWrapper.PY for more information.
+
+    This class shows how to implement a consolidator from scratch in Python, this gives us more
+    freedom to determine the behavior of the consolidator but can't leverage any of the built in
+    functions of an inherited class.
+
+    For this example we implemented a Quotebar from scratch'''
+
+    def __init__(self, period):
+
+        #IDataConsolidator required vars for all consolidators
+        self.consolidated = None        #Most recently consolidated piece of data.
+        self.working_data = None         #Data being currently consolidated
+        self.input_type = QuoteBar       #The type consumed by this consolidator
+        self.output_type = QuoteBar      #The type produced by this consolidator
+
+        #Consolidator Variables
+        self.period = period
+
+    def update(self, data):
+        '''Updates this consolidator with the specified data'''
+
+        #If we don't have bar yet, create one
+        if self.working_data is None:
+            self.working_data = QuoteBar(data.time,data.symbol,data.bid,data.last_bid_size,
+                data.ask,data.last_ask_size,self.period)
+
+        #Update bar using QuoteBar's update()
+        self.working_data.update(data.value, data.bid.close, data.ask.close, 0,
+            data.last_bid_size, data.last_ask_size)
+
+    def scan(self, time):
+        '''Scans this consolidator to see if it should emit a bar due to time passing'''
+
+        if self.period is not None and self.working_data is not None:
+            if time - self.working_data.time >= self.period:
+
+                #Trigger the event handler with a copy of self and the data
+                self.on_data_consolidated(self, self.working_data)
+
+                #Set the most recent consolidated piece of data and then clear the working_data
+                self.consolidated = self.working_data
+                self.working_data = None

--- a/Algorithm.Python/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.py
+++ b/Algorithm.Python/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 from AlgorithmImports import *
+from Alphas.PearsonCorrelationPairsTradingAlphaModel import PearsonCorrelationPairsTradingAlphaModel
 
 ### <summary>
 ### Framework algorithm that uses the PearsonCorrelationPairsTradingAlphaModel.

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -2691,6 +2691,7 @@ namespace QuantConnect
                     // Otherwise, pyObject is a python object that subclass a C# class, only return true if 'allowPythonDerivative'
                     var name = (((dynamic) pythonType).__name__ as PyObject).GetAndDispose<string>();
                     pythonType.Dispose();
+                    // TODO: This doesn't work for generic types: python type name != C# type name (e.g. IdentityDataConsolidator[TradeBar] != IdentityDataConsolidator`1)
                     return name == result.GetType().Name;
                 }
                 catch

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -2666,12 +2666,11 @@ namespace QuantConnect
                         return true;
                     }
 
-                    var pythonType = pyObject.GetPythonType();
+                    using var pythonType = pyObject.GetPythonType();
                     var csharpType = pythonType.As<Type>();
 
                     if (!type.IsAssignableFrom(csharpType))
                     {
-                        pythonType.Dispose();
                         return false;
                     }
 
@@ -2682,16 +2681,20 @@ namespace QuantConnect
                     // so it gets wrapped in a python wrapper, not the C# object.
                     if (result is IPythonDerivedType)
                     {
-                        pythonType.Dispose();
                         return false;
+                    }
+
+                    // If the python type object is just a representation of the C# type, the conversion is direct,
+                    // The python object is an instance of the C# class.
+                    if (PyType.Get(csharpType).Equals(pythonType))
+                    {
+                        return true;
                     }
 
                     // If the PyObject type and the managed object names are the same,
                     // pyObject is a C# object wrapped in PyObject, in this case return true
                     // Otherwise, pyObject is a python object that subclass a C# class, only return true if 'allowPythonDerivative'
-                    var name = (((dynamic) pythonType).__name__ as PyObject).GetAndDispose<string>();
-                    pythonType.Dispose();
-                    // TODO: This doesn't work for generic types: python type name != C# type name (e.g. IdentityDataConsolidator[TradeBar] != IdentityDataConsolidator`1)
+                    var name = (((dynamic)pythonType).__name__ as PyObject).GetAndDispose<string>();
                     return name == result.GetType().Name;
                 }
                 catch

--- a/Common/Python/BasePythonWrapper.cs
+++ b/Common/Python/BasePythonWrapper.cs
@@ -14,6 +14,7 @@
 */
 
 using Python.Runtime;
+using System;
 using System.Collections.Generic;
 
 namespace QuantConnect.Python
@@ -21,7 +22,7 @@ namespace QuantConnect.Python
     /// <summary>
     /// Base class for Python wrapper classes
     /// </summary>
-    public class BasePythonWrapper<TInterface>
+    public class BasePythonWrapper<TInterface> : IEquatable<BasePythonWrapper<TInterface>>
     {
         private PyObject _instance;
         private object _underlyingClrObject;
@@ -221,6 +222,43 @@ namespace QuantConnect.Python
             {
                 [key] = value
             };
+        }
+
+        /// <summary>
+        /// Determines whether the specified instance wraps the same Python object reference as this instance,
+        /// which would indicate that they are equal.
+        /// </summary>
+        /// <param name="other">The other object to compare this with</param>
+        /// <returns>True if both instances are equal, that is if both wrap the same Python object reference</returns>
+        public virtual bool Equals(BasePythonWrapper<TInterface> other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other) || ReferenceEquals(_instance, other._instance)) return true;
+
+            using var _ = Py.GIL();
+            // We only care about the Python object reference, not the underlying C# object reference for comparison
+            return PythonReferenceComparer.Instance.Equals(_instance, other._instance);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is an instance of <see cref="BasePythonWrapper{TInterface}"/>
+        /// and wraps the same Python object reference as this instance, which would indicate that they are equal.
+        /// </summary>
+        /// <param name="obj">The other object to compare this with</param>
+        /// <returns>True if both instances are equal, that is if both wrap the same Python object reference</returns>
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as BasePythonWrapper<TInterface>);
+        }
+
+        /// <summary>
+        /// Gets the hash code for the current instance
+        /// </summary>
+        /// <returns>The hash code of the current instance</returns>
+        public override int GetHashCode()
+        {
+            using var _ = Py.GIL();
+            return PythonReferenceComparer.Instance.GetHashCode(_instance);
         }
     }
 }

--- a/Common/Python/BasePythonWrapper.cs
+++ b/Common/Python/BasePythonWrapper.cs
@@ -232,12 +232,7 @@ namespace QuantConnect.Python
         /// <returns>True if both instances are equal, that is if both wrap the same Python object reference</returns>
         public virtual bool Equals(BasePythonWrapper<TInterface> other)
         {
-            if (other is null) return false;
-            if (ReferenceEquals(this, other) || ReferenceEquals(_instance, other._instance)) return true;
-
-            using var _ = Py.GIL();
-            // We only care about the Python object reference, not the underlying C# object reference for comparison
-            return PythonReferenceComparer.Instance.Equals(_instance, other._instance);
+            return other is not null && (ReferenceEquals(this, other) || Equals(other._instance));
         }
 
         /// <summary>
@@ -248,7 +243,7 @@ namespace QuantConnect.Python
         /// <returns>True if both instances are equal, that is if both wrap the same Python object reference</returns>
         public override bool Equals(object obj)
         {
-            return Equals(obj as BasePythonWrapper<TInterface>);
+            return Equals(obj as PyObject) || Equals(obj as BasePythonWrapper<TInterface>);
         }
 
         /// <summary>
@@ -259,6 +254,19 @@ namespace QuantConnect.Python
         {
             using var _ = Py.GIL();
             return PythonReferenceComparer.Instance.GetHashCode(_instance);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="PyObject"/> is equal to the current instance's underlying Python object.
+        /// </summary>
+        private bool Equals(PyObject other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(_instance, other)) return true;
+
+            using var _ = Py.GIL();
+            // We only care about the Python object reference, not the underlying C# object reference for comparison
+            return PythonReferenceComparer.Instance.Equals(_instance, other);
         }
     }
 }

--- a/Common/Python/DataConsolidatorPythonWrapper.cs
+++ b/Common/Python/DataConsolidatorPythonWrapper.cs
@@ -23,7 +23,6 @@ namespace QuantConnect.Python
     /// <summary>
     /// Provides an Data Consolidator that wraps a <see cref="PyObject"/> object that represents a custom Python consolidator
     /// </summary>
-    /// TODO: Inherit from BasePythonWrapper<IDataConsolidator> instead of BasePythonWrapper. But first fix ValidateImplementationOf to exclude properties getters and setters (IsSpecialName)
     public class DataConsolidatorPythonWrapper : BasePythonWrapper<IDataConsolidator>, IDataConsolidator
     {
         internal PyObject Model => Instance;
@@ -83,16 +82,8 @@ namespace QuantConnect.Python
         /// </summary>
         /// <param name="consolidator">Represents a custom python consolidator</param>
         public DataConsolidatorPythonWrapper(PyObject consolidator)
-            : base(consolidator, false)
+            : base(consolidator, true)
         {
-            foreach (var attributeName in new[] { "InputType", "OutputType", "WorkingData", "Consolidated" })
-            {
-                if (!HasAttr(attributeName))
-                {
-                    throw new NotImplementedException(
-                        Messages.PythonCommon.AttributeNotImplemented($"IDataConsolidator.{attributeName}", consolidator.GetPythonType()));
-                }
-            }
         }
 
         /// <summary>

--- a/Common/Python/DataConsolidatorPythonWrapper.cs
+++ b/Common/Python/DataConsolidatorPythonWrapper.cs
@@ -26,6 +26,8 @@ namespace QuantConnect.Python
     /// TODO: Inherit from BasePythonWrapper<IDataConsolidator> instead of BasePythonWrapper. But first fix ValidateImplementationOf to exclude properties getters and setters (IsSpecialName)
     public class DataConsolidatorPythonWrapper : BasePythonWrapper<IDataConsolidator>, IDataConsolidator
     {
+        internal PyObject Model => Instance;
+
         /// <summary>
         /// Gets the most recently consolidated piece of data. This will be null if this consolidator
         /// has not produced any data yet.

--- a/Tests/Common/Data/SubscriptionManagerTests.cs
+++ b/Tests/Common/Data/SubscriptionManagerTests.cs
@@ -438,7 +438,7 @@ def get_consolidator():
         }
 
         [Test]
-        public void CanAddAndRemoveCSharpConsolidatorFromPythonWithWrapper([Values] bool useWrapperToRemove)
+        public void CanAddAndRemoveCSharpConsolidatorFromPythonWithWrapper()
         {
             using var _ = Py.GIL();
             var module = PyModule.FromString("testModule",
@@ -453,19 +453,11 @@ def get_consolidator():
             var symbol = algorithm.AddEquity("SPY").Symbol;
 
             var pyConsolidator = module.GetAttr("get_consolidator").Invoke();
-            using var consolidator = new DataConsolidatorPythonWrapper(pyConsolidator);
 
-            algorithm.SubscriptionManager.AddConsolidator(Symbols.SPY, consolidator);
+            algorithm.SubscriptionManager.AddConsolidator(Symbols.SPY, pyConsolidator);
             Assert.AreEqual(1, algorithm.SubscriptionManager.Subscriptions.Sum(x => x.Consolidators.Count));
 
-            if (useWrapperToRemove)
-            {
-                algorithm.SubscriptionManager.RemoveConsolidator(Symbols.SPY, consolidator);
-            }
-            else
-            {
-                algorithm.SubscriptionManager.RemoveConsolidator(Symbols.SPY, pyConsolidator);
-            }
+            algorithm.SubscriptionManager.RemoveConsolidator(Symbols.SPY, pyConsolidator);
             Assert.AreEqual(0, algorithm.SubscriptionManager.Subscriptions.Sum(x => x.Consolidators.Count));
         }
 

--- a/Tests/Common/Data/SubscriptionManagerTests.cs
+++ b/Tests/Common/Data/SubscriptionManagerTests.cs
@@ -20,11 +20,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using NodaTime;
 using NUnit.Framework;
+using Python.Runtime;
 using QuantConnect.Data;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 using QuantConnect.Logging;
+using QuantConnect.Python;
+using QuantConnect.Statistics;
 using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Common.Data
@@ -404,6 +407,141 @@ namespace QuantConnect.Tests.Common.Data
 
             var consolidator = new TestConsolidator(subscriptionDataType, consolidatorOutputType);
             Assert.AreEqual(expected, SubscriptionManager.IsSubscriptionValidForConsolidator(subscription, consolidator, desiredTickType));
+        }
+
+        [Test]
+        public void CanAddAndRemoveCSharpConsolidatorFromPython()
+        {
+            // NOTE: we use the IdentityDataConsolidator here because it's a generic class, which reproduces the bug.
+            // pyConsolidator.TryConvert(out IDataConsolidator consolidator) will return false, because the python type name
+            // and the C# type name don't match for generic types (e.g. IdentityDataConsolidator[TradeBar] != IdentityDataConsolidator`1)
+
+            using var _ = Py.GIL();
+            var module = PyModule.FromString("testModule",
+                    @"
+from AlgorithmImports import *
+
+def get_consolidator():
+    return IdentityDataConsolidator[TradeBar]()
+");
+
+            var algorithm = new AlgorithmStub();
+            var symbol = algorithm.AddEquity("SPY").Symbol;
+
+            var consolidator = module.GetAttr("get_consolidator").Invoke();
+
+            algorithm.SubscriptionManager.AddConsolidator(symbol, consolidator);
+            Assert.AreEqual(1, algorithm.SubscriptionManager.Subscriptions.Sum(x => x.Consolidators.Count));
+
+            algorithm.SubscriptionManager.RemoveConsolidator(symbol, consolidator);
+            Assert.AreEqual(0, algorithm.SubscriptionManager.Subscriptions.Sum(x => x.Consolidators.Count));
+        }
+
+        [Test]
+        public void CanAddAndRemoveCSharpConsolidatorFromPythonWithWrapper([Values] bool useWrapperToRemove)
+        {
+            using var _ = Py.GIL();
+            var module = PyModule.FromString("testModule",
+                    @"
+from AlgorithmImports import *
+
+def get_consolidator():
+    return IdentityDataConsolidator[TradeBar]()
+");
+
+            var algorithm = new AlgorithmStub();
+            var symbol = algorithm.AddEquity("SPY").Symbol;
+
+            var pyConsolidator = module.GetAttr("get_consolidator").Invoke();
+            using var consolidator = new DataConsolidatorPythonWrapper(pyConsolidator);
+
+            algorithm.SubscriptionManager.AddConsolidator(Symbols.SPY, consolidator);
+            Assert.AreEqual(1, algorithm.SubscriptionManager.Subscriptions.Sum(x => x.Consolidators.Count));
+
+            if (useWrapperToRemove)
+            {
+                algorithm.SubscriptionManager.RemoveConsolidator(Symbols.SPY, consolidator);
+            }
+            else
+            {
+                algorithm.SubscriptionManager.RemoveConsolidator(Symbols.SPY, pyConsolidator);
+            }
+            Assert.AreEqual(0, algorithm.SubscriptionManager.Subscriptions.Sum(x => x.Consolidators.Count));
+        }
+
+        [Test]
+        public void CanAddAndRemovePythonConsolidator()
+        {
+            using var _ = Py.GIL();
+            var module = PyModule.FromString("testModule",
+                    @"
+from AlgorithmImports import *
+
+class CustomQuoteBarConsolidator(PythonConsolidator):
+
+    def __init__(self):
+
+        #IDataConsolidator required vars for all consolidators
+        self.consolidated = None
+        self.working_data = None
+        self.input_type = QuoteBar
+        self.output_type = QuoteBar
+
+    def update(self, data):
+        pass
+
+    def scan(self, time):
+        pass
+
+def get_consolidator():
+    return CustomQuoteBarConsolidator()
+");
+
+            var algorithm = new AlgorithmStub();
+            var symbol = algorithm.AddEquity("SPY").Symbol;
+
+            var pyConsolidator = module.GetAttr("get_consolidator").Invoke();
+
+            algorithm.SubscriptionManager.AddConsolidator(Symbols.SPY, pyConsolidator);
+            Assert.AreEqual(1, algorithm.SubscriptionManager.Subscriptions.Sum(x => x.Consolidators.Count));
+
+            algorithm.SubscriptionManager.RemoveConsolidator(Symbols.SPY, pyConsolidator);
+            Assert.AreEqual(0, algorithm.SubscriptionManager.Subscriptions.Sum(x => x.Consolidators.Count));
+        }
+
+        [Test]
+        public void RunRemoveConsolidatorsRegressionAlgorithm()
+        {
+            var parameter = new RegressionTests.AlgorithmStatisticsTestParameters("ManuallyRemovedConsolidatorsAlgorithm",
+                new Dictionary<string, string> {
+                    {PerformanceMetrics.TotalOrders, "0"},
+                    {"Average Win", "0%"},
+                    {"Average Loss", "0%"},
+                    {"Compounding Annual Return", "0%"},
+                    {"Drawdown", "0%"},
+                    {"Expectancy", "0"},
+                    {"Net Profit", "0%"},
+                    {"Sharpe Ratio", "0"},
+                    {"Probabilistic Sharpe Ratio", "0%"},
+                    {"Loss Rate", "0%"},
+                    {"Win Rate", "0%"},
+                    {"Profit-Loss Ratio", "0"},
+                    {"Alpha", "0"},
+                    {"Beta", "0"},
+                    {"Annual Standard Deviation", "0"},
+                    {"Annual Variance", "0"},
+                    {"Information Ratio", "-8.91"},
+                    {"Tracking Error", "0.223"},
+                    {"Treynor Ratio", "0"},
+                    {"Total Fees", "$0.00"}
+                },
+                Language.Python,
+                AlgorithmStatus.Completed);
+
+            AlgorithmRunner.RunLocalBacktest(parameter.Algorithm,
+                parameter.Statistics,
+                parameter.Language,
+                parameter.ExpectedFinalStatus);
         }
 
         private class TestConsolidator : IDataConsolidator

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -36,6 +36,7 @@ using QuantConnect.Lean.Engine.HistoricalData;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Packets;
+using QuantConnect.Python;
 using QuantConnect.Scheduling;
 using QuantConnect.Securities;
 using QuantConnect.Tests.Brokerages;
@@ -1434,6 +1435,56 @@ actualDictionary.update({'IBM': 5})
             }
         }
 
+        public class TestGenericClass<T>
+        {
+            public T Value { get; set; }
+        }
+
+        public static TestGenericClass<int> GetGenericClassObject()
+        {
+            return new TestGenericClass<int>();
+        }
+
+        [Test]
+        public void PyObjectConvertFromGenericCSharpType()
+        {
+            using (Py.GIL())
+            {
+                var module = PyModule.FromString(
+                    "PyObjectConvertFromGenericCSharpType",
+                    @"
+from QuantConnect.Tests.Common.Util import ExtensionsTests
+
+def GetGenericClassObject():
+    return ExtensionsTests.GetGenericClassObject()
+");
+
+                var genericObject = module.GetAttr("GetGenericClassObject").Invoke();
+                var result = genericObject.TryConvert<TestGenericClass<int>>(out var _);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [Test]
+        public void PyObjectConvertPythonTypeDerivedFromCSharpType([Values] bool allowPythonDerivative)
+        {
+            using (Py.GIL())
+            {
+                var module = PyModule.FromString(
+                    "PyObjectConvertPythonTypeDerivedFromCSharpType",
+                    @"
+from AlgorithmImports import *
+
+class TestPythonDerivedClass(PythonData):
+    pass
+");
+
+                var obj = module.GetAttr("TestPythonDerivedClass").Invoke();
+                var result = obj.TryConvert<PythonData>(out var _, allowPythonDerivative);
+
+                Assert.AreEqual(allowPythonDerivative, result);
+            }
+        }
 
         [Test]
         public void BatchByDoesNotDropItems()
@@ -1754,7 +1805,7 @@ def select_symbol(fundamental):
 
         [TestCase("GOOGL", "2004/08/19", "2024/03/01", 2, "GOOG,GOOGL")] // IPO: August 19, 2004
         [TestCase("GOOGL", "2010/02/01", "2012/03/01", 1, "GOOG")]
-        [TestCase("GOOGL", "2014/04/02", "2024/03/01", 2, "GOOG,GOOGL")] // The restructuring: "GOOG" to "GOOGL" 
+        [TestCase("GOOGL", "2014/04/02", "2024/03/01", 2, "GOOG,GOOGL")] // The restructuring: "GOOG" to "GOOGL"
         [TestCase("GOOGL", "2014/02/01", "2024/03/01", 2, "GOOG,GOOGL")]
         [TestCase("GOOGL", "2020/02/01", "2024/03/01", 1, "GOOGL")]
         [TestCase("GOOGL", "2023/02/01", "2024/03/01", 1, "GOOGL")]

--- a/Tests/Indicators/PythonIndicatorTests.cs
+++ b/Tests/Indicators/PythonIndicatorTests.cs
@@ -243,16 +243,20 @@ class BadCustomIndicator(PythonIndicator):
                     "timeDelta = timedelta(days=2)\n" +
                     "class CustomIndicator(PythonIndicator):\n" +
                     "   def __init__(self):\n" +
-                    "       self.Value = 0\n" +
-                    "   def Update(self, input):\n" +
-                    "       self.Value = input.Value\n" +
+                    "       self.value = 0\n" +
+                    "   def update(self, input):\n" +
+                    "       self.value = input.value\n" +
                     "       return True\n" +
                     "class CustomConsolidator(PythonConsolidator):\n" +
                     "   def __init__(self):\n" +
-                    "       self.InputType = QuoteBar\n" +
-                    "       self.OutputType = QuoteBar\n" +
-                    "       self.Consolidated = None\n" +
-                    "       self.WorkingData = None\n"
+                    "       self.input_type = QuoteBar\n" +
+                    "       self.output_type = QuoteBar\n" +
+                    "       self.consolidated = None\n" +
+                    "       self.working_data = None\n" +
+                    "   def update(self, data):\n" +
+                    "       pass\n" +
+                    "   def scan(self, time):\n" +
+                    "       pass\n"
                 );
 
                 //Get our variables from Python
@@ -297,16 +301,20 @@ class BadCustomIndicator(PythonIndicator):
                     "consolidator = QuoteBarConsolidator(timedelta(days = 5)) \n" +
                     "class CustomIndicator(PythonIndicator):\n" +
                     "   def __init__(self):\n" +
-                    "       self.Value = 0\n" +
-                    "   def Update(self, input):\n" +
-                    "       self.Value = input.Value\n" +
+                    "       self.value = 0\n" +
+                    "   def update(self, input):\n" +
+                    "       self.value = input.value\n" +
                     "       return True\n" +
                     "class CustomConsolidator(PythonConsolidator):\n" +
                     "   def __init__(self):\n" +
-                    "       self.InputType = QuoteBar\n" +
-                    "       self.OutputType = QuoteBar\n" +
-                    "       self.Consolidated = None\n" +
-                    "       self.WorkingData = None\n" +
+                    "       self.input_type = QuoteBar\n" +
+                    "       self.output_type = QuoteBar\n" +
+                    "       self.consolidated = None\n" +
+                    "       self.working_data = None\n" +
+                    "   def update(self, data):\n" +
+                    "       pass\n" +
+                    "   def scan(self, time):\n" +
+                    "       pass\n" +
                     "class InvalidConsolidator:\n" +
                     "   pass\n"
                 );

--- a/Tests/Python/BasePythonWrapperTests.cs
+++ b/Tests/Python/BasePythonWrapperTests.cs
@@ -1,0 +1,59 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Python;
+
+namespace QuantConnect.Tests.Python
+{
+    [TestFixture]
+    public class BasePythonWrapperTests
+    {
+        [Test]
+        public void EqualsReturnsTrueForWrapperAndUnderlyingModel()
+        {
+            using var _ = Py.GIL();
+
+                var module = PyModule.FromString("EqualsReturnsTrueForWrapperAndUnderlyingModel", @"
+from clr import AddReference
+AddReference('QuantConnect.Tests')
+
+from QuantConnect.Tests.Python import BasePythonWrapperTests
+
+class PythonDerivedTestModel(BasePythonWrapperTests.TestModel):
+    pass
+
+class PythonTestModel:
+    pass
+");
+                var pyDerivedModel = module.GetAttr("PythonDerivedTestModel").Invoke();
+                var wrapper = new BasePythonWrapper<ITestModel>(pyDerivedModel);
+                var pyModel = module.GetAttr("PythonTestModel").Invoke();
+
+                Assert.IsTrue(wrapper.Equals(pyDerivedModel));
+                Assert.IsTrue(wrapper.Equals(new BasePythonWrapper<ITestModel>(pyDerivedModel)));
+                Assert.IsFalse(wrapper.Equals(pyModel));
+        }
+
+        public interface ITestModel
+        {
+        }
+
+        public class TestModel : ITestModel
+        {
+        }
+    }
+}

--- a/Tests/Python/DataConsolidatorPythonWrapperTests.cs
+++ b/Tests/Python/DataConsolidatorPythonWrapperTests.cs
@@ -37,15 +37,17 @@ namespace QuantConnect.Tests.Python
             {
                 var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
-                    "class CustomConsolidator():\n" +
+                    "class CustomConsolidator(PythonConsolidator):\n" +
                     "   def __init__(self):\n" +
-                    "       self.UpdateWasCalled = False\n" +
-                    "       self.InputType = QuoteBar\n" +
-                    "       self.OutputType = QuoteBar\n" +
-                    "       self.Consolidated = None\n" +
-                    "       self.WorkingData = None\n" +
-                    "   def Update(self, data):\n" +
-                    "       self.UpdateWasCalled = True\n");
+                    "       self.update_was_called = False\n" +
+                    "       self.input_type = QuoteBar\n" +
+                    "       self.output_type = QuoteBar\n" +
+                    "       self.consolidated = None\n" +
+                    "       self.working_data = None\n" +
+                    "   def update(self, data):\n" +
+                    "       self.update_was_called = True\n" +
+                    "   def scan(self, time):\n" +
+                    "       pass\n");
 
                 var customConsolidator = module.GetAttr("CustomConsolidator").Invoke();
                 var wrapper = new DataConsolidatorPythonWrapper(customConsolidator);
@@ -67,7 +69,7 @@ namespace QuantConnect.Tests.Python
                 wrapper.Update(bar1);
 
                 bool called;
-                customConsolidator.GetAttr("UpdateWasCalled").TryConvert(out called);
+                customConsolidator.GetAttr("update_was_called").TryConvert(out called);
                 Assert.True(called);
             }
         }
@@ -79,15 +81,17 @@ namespace QuantConnect.Tests.Python
             {
                 var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
-                    "class CustomConsolidator():\n" +
+                    "class CustomConsolidator(PythonConsolidator):\n" +
                     "   def __init__(self):\n" +
-                    "       self.ScanWasCalled = False\n" +
-                    "       self.InputType = QuoteBar\n" +
-                    "       self.OutputType = QuoteBar\n" +
-                    "       self.Consolidated = None\n" +
-                    "       self.WorkingData = None\n" +
-                    "   def Scan(self,time):\n" +
-                    "       self.ScanWasCalled = True\n");
+                    "       self.scan_was_called = False\n" +
+                    "       self.input_type = QuoteBar\n" +
+                    "       self.output_type = QuoteBar\n" +
+                    "       self.consolidated = None\n" +
+                    "       self.working_data = None\n" +
+                    "   def update(self, data):\n" +
+                    "       pass\n" +
+                    "   def scan(self, time):\n" +
+                    "       self.scan_was_called = True\n");
 
                 var customConsolidator = module.GetAttr("CustomConsolidator").Invoke();
                 var wrapper = new DataConsolidatorPythonWrapper(customConsolidator);
@@ -98,7 +102,7 @@ namespace QuantConnect.Tests.Python
                 wrapper.Scan(DateTime.Now);
 
                 bool called;
-                customConsolidator.GetAttr("ScanWasCalled").TryConvert(out called);
+                customConsolidator.GetAttr("scan_was_called").TryConvert(out called);
                 Assert.True(called);
             }
         }
@@ -110,12 +114,16 @@ namespace QuantConnect.Tests.Python
             {
                 var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
-                    "class CustomConsolidator():\n" +
+                    "class CustomConsolidator(PythonConsolidator):\n" +
                     "   def __init__(self):\n" +
-                    "       self.InputType = QuoteBar\n" +
-                    "       self.OutputType = QuoteBar\n" +
-                    "       self.Consolidated = None\n" +
-                    "       self.WorkingData = None\n");
+                    "       self.input_type = QuoteBar\n" +
+                    "       self.output_type = QuoteBar\n" +
+                    "       self.consolidated = None\n" +
+                    "       self.working_data = None\n" +
+                    "   def update(self, data):\n" +
+                    "       pass\n" +
+                    "   def scan(self, time):\n" +
+                    "       pass\n");
 
                 var customConsolidator = module.GetAttr("CustomConsolidator").Invoke();
                 var wrapper = new DataConsolidatorPythonWrapper(customConsolidator);
@@ -135,12 +143,16 @@ namespace QuantConnect.Tests.Python
             {
                 var module = PyModule.FromString(Guid.NewGuid().ToString(),
                     "from AlgorithmImports import *\n" +
-                    "class CustomConsolidator():\n" +
+                    "class CustomConsolidator(PythonConsolidator):\n" +
                     "   def __init__(self):\n" +
-                    "       self.InputType = QuoteBar\n" +
-                    "       self.OutputType = QuoteBar\n" +
-                    "       self.Consolidated = None\n" +
-                    "       self.WorkingData = None\n");
+                    "       self.input_type = QuoteBar\n" +
+                    "       self.output_type = QuoteBar\n" +
+                    "       self.consolidated = None\n" +
+                    "       self.working_data = None\n" +
+                    "   def update(self, data):\n" +
+                    "       pass\n" +
+                    "   def scan(self, time):\n" +
+                    "       pass\n");
 
                 var customConsolidator = module.GetAttr("CustomConsolidator").Invoke();
                 var wrapper = new DataConsolidatorPythonWrapper(customConsolidator);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Keep cache for python consolidators in the `SubscriptionManager` to avoid loosing references to the underlying `PyObject` consolidator instance.

A manual removal of the consolidator from Python, when a custom Python class consolidator or a generic C# one is used, failed because they get wrapped internally in a `DataConsolidatorPythonWrapper`.

**Additional fix**: PyObject.TryConvert extension method to succeed for python objects that wrap a C# instance of a generic class.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #7968 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit tests
- Existing `PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm` using the Python `PearsonCorrelationPairsTradingAlphaModel`

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
