### PR TITLE
Benchmark data mixed normalization mode fix

### DIFF
--- a/Algorithm.CSharp/MeanReversionPortfolioAlgorithm.cs
+++ b/Algorithm.CSharp/MeanReversionPortfolioAlgorithm.cs
@@ -63,7 +63,7 @@ namespace QuantConnect.DataLibrary.Tests
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 57;
+        public int AlgorithmHistoryDataPoints => 52;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/RiskParityPortfolioAlgorithm.cs
+++ b/Algorithm.CSharp/RiskParityPortfolioAlgorithm.cs
@@ -60,7 +60,7 @@ namespace QuantConnect.DataLibrary.Tests
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 519;
+        public int AlgorithmHistoryDataPoints => 514;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/RiskParityPortfolioWeightsCheckAlgorithm.cs
+++ b/Algorithm.CSharp/RiskParityPortfolioWeightsCheckAlgorithm.cs
@@ -99,7 +99,7 @@ namespace QuantConnect.DataLibrary.Tests
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 519;
+        public int AlgorithmHistoryDataPoints => 514;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/SecuritySeederRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SecuritySeederRegressionAlgorithm.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 20;
+        public int AlgorithmHistoryDataPoints => 10;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Common/Benchmarks/SecurityBenchmark.cs
+++ b/Common/Benchmarks/SecurityBenchmark.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -58,13 +58,7 @@ namespace QuantConnect.Benchmarks
         /// <returns>The new SecurityBenchmark</returns>
         public static SecurityBenchmark CreateInstance(SecurityManager securities, Symbol symbol)
         {
-            // Create the security from this symbol
-            var security = securities.CreateSecurity(symbol,
-                new List<SubscriptionDataConfig>(),
-                leverage: 1,
-                addToSymbolCache: false);
-
-            return new SecurityBenchmark(security);
+            return new SecurityBenchmark(securities.CreateBenchmarkSecurity(symbol));
         }
     }
 }

--- a/Common/Interfaces/ISecurityService.cs
+++ b/Common/Interfaces/ISecurityService.cs
@@ -46,5 +46,10 @@ namespace QuantConnect.Interfaces
             decimal leverage = 0,
             bool addToSymbolCache = true,
             Security underlying = null);
+
+        /// <summary>
+        /// Creates a new benchmark security
+        /// </summary>
+        Security CreateBenchmarkSecurity(Symbol symbol);
     }
 }

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -437,6 +437,14 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Creates a new benchmark security
+        /// </summary>
+        public Security CreateBenchmarkSecurity(Symbol symbol)
+        {
+            return _securityService.CreateBenchmarkSecurity(symbol);
+        }
+
+        /// <summary>
         /// Set live mode state of the algorithm
         /// </summary>
         /// <param name="isLiveMode">True, live mode is enabled</param>

--- a/Common/Securities/SecurityService.cs
+++ b/Common/Securities/SecurityService.cs
@@ -66,11 +66,12 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <remarks>Following the obsoletion of Security.Subscriptions,
         /// both overloads will be merged removing <see cref="SubscriptionDataConfig"/> arguments</remarks>
-        public Security CreateSecurity(Symbol symbol,
+        private Security CreateSecurity(Symbol symbol,
             List<SubscriptionDataConfig> subscriptionDataConfigList,
-            decimal leverage = 0,
-            bool addToSymbolCache = true,
-            Security underlying = null)
+            decimal leverage,
+            bool addToSymbolCache,
+            Security underlying,
+            bool initializeSecurity)
         {
             var configList = new SubscriptionDataConfigList(symbol);
             configList.AddRange(subscriptionDataConfigList);
@@ -198,7 +199,10 @@ namespace QuantConnect.Securities
             security.AddData(configList);
 
             // invoke the security initializer
-            _securityInitializerProvider.SecurityInitializer.Initialize(security);
+            if (initializeSecurity)
+            {
+                _securityInitializerProvider.SecurityInitializer.Initialize(security);
+            }
 
             CheckCanonicalSecurityModels(security);
 
@@ -225,9 +229,38 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <remarks>Following the obsoletion of Security.Subscriptions,
         /// both overloads will be merged removing <see cref="SubscriptionDataConfig"/> arguments</remarks>
+        public Security CreateSecurity(Symbol symbol,
+            List<SubscriptionDataConfig> subscriptionDataConfigList,
+            decimal leverage = 0,
+            bool addToSymbolCache = true,
+            Security underlying = null)
+        {
+            return CreateSecurity(symbol, subscriptionDataConfigList, leverage, addToSymbolCache, underlying, initializeSecurity: true);
+        }
+
+        /// <summary>
+        /// Creates a new security
+        /// </summary>
+        /// <remarks>Following the obsoletion of Security.Subscriptions,
+        /// both overloads will be merged removing <see cref="SubscriptionDataConfig"/> arguments</remarks>
         public Security CreateSecurity(Symbol symbol, SubscriptionDataConfig subscriptionDataConfig, decimal leverage = 0, bool addToSymbolCache = true, Security underlying = null)
         {
             return CreateSecurity(symbol, new List<SubscriptionDataConfig> { subscriptionDataConfig }, leverage, addToSymbolCache, underlying);
+        }
+
+        /// <summary>
+        /// Creates a new security
+        /// </summary>
+        /// <remarks>Following the obsoletion of Security.Subscriptions,
+        /// both overloads will be merged removing <see cref="SubscriptionDataConfig"/> arguments</remarks>
+        public Security CreateBenchmarkSecurity(Symbol symbol)
+        {
+            return CreateSecurity(symbol,
+                new List<SubscriptionDataConfig>(),
+                leverage: 1,
+                addToSymbolCache: false,
+                underlying: null,
+                initializeSecurity: false);
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Skip the security security initializer for benchmark securities, avoiding the user defined ones (if set).

A user defined security initializer might use a security seeder or set the security market price with historical data and:
- If the benchmark security has not been added to the algorithm, there won't be a subscription data config to use for the historical data request.
- In this case, the universe settings will be used to make a subscription data config for the request, and if the user sets the data normalization mode to != Adjusted (which is used for benchmark securities) and the data will be mixed with initial Raw values (for example) and then the normal adjusted ones.

We avoid this by not initializing the benchmark security, since it does not need it 

##### Regression algorithms `AlgorithmHistoryDataPoints` decrease:

These algorithms use user defined security initializers that set the security market price with historical data. These history requests are skipped for benchmark securities, hence the decrease.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Close #7846 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit test and regression algorithms

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
