### PR TITLE
Improve exception message when generating Annual Performance Statistic

### DIFF
--- a/Common/Statistics/PortfolioStatistics.cs
+++ b/Common/Statistics/PortfolioStatistics.cs
@@ -19,7 +19,6 @@ using System.Linq;
 using MathNet.Numerics.Distributions;
 using MathNet.Numerics.Statistics;
 using Newtonsoft.Json;
-using QLNet;
 using QuantConnect.Data;
 using QuantConnect.Util;
 
@@ -352,7 +351,8 @@ namespace QuantConnect.Statistics
             try
             {
                 return Statistics.AnnualPerformance(performance, tradingDaysPerYear).SafeDecimalCast();
-            }catch (Exception ex)
+            }
+            catch (ArgumentException ex)
             {
                 var partialSums = 0.0;
                 var points = 0;
@@ -368,8 +368,8 @@ namespace QuantConnect.Statistics
                     }
                 }
 
-                throw new Exception($"An exception was thrown when trying to cast the annual performance value due to the following performance point: {troublePoint}." +
-                    $"The exception thrown was the following {ex.Message}.");
+                throw new ArgumentException($"PortfolioStatistics.GetAnnualPerformance(): An exception was thrown when trying to cast the annual performance value due to the following performance point: {troublePoint}. " +
+                    $"The exception thrown was the following: {ex.Message}.");
             }
         }
 

--- a/Common/Statistics/PortfolioStatistics.cs
+++ b/Common/Statistics/PortfolioStatistics.cs
@@ -349,7 +349,28 @@ namespace QuantConnect.Statistics
         /// <returns>Double annual performance percentage</returns>
         private static decimal GetAnnualPerformance(List<double> performance, int tradingDaysPerYear)
         {
-            return Statistics.AnnualPerformance(performance, tradingDaysPerYear).SafeDecimalCast();
+            try
+            {
+                return Statistics.AnnualPerformance(performance, tradingDaysPerYear).SafeDecimalCast();
+            }catch (Exception ex)
+            {
+                var partialSums = 0.0;
+                var points = 0;
+                double troublePoint = default;
+                foreach(var point in performance)
+                {
+                    points++;
+                    partialSums += point;
+                    if (Math.Pow(partialSums / points, tradingDaysPerYear).IsNaNOrInfinity())
+                    {
+                        troublePoint = point;
+                        break;
+                    }
+                }
+
+                throw new Exception($"An exception was thrown when trying to cast the annual performance value due to the following performance point: {troublePoint}." +
+                    $"The exception thrown was the following {ex.Message}.");
+            }
         }
 
         private static decimal GetValueAtRisk(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The exception message thrown when the casting from double to decimal was done at `PortfolioStatistics.GetAnnualPerformance()`, didn't provide enough information regarding the reason behind the failure. Now, the message is more informative, pointing out explicitly which performance point is producing the error. Furthermore, the error was produced because of a bug in the quote file data.
![image](https://github.com/QuantConnect/Lean/assets/47573394/c03d965b-ac8f-42b2-98d0-4d76dbf73c70)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7888 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change if an exception is thrown while casting the annual performance to decimal, the exception message will be more informative.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To test the exception message was the expected one the code provided in the issue was run.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
