### PR TITLE
Add Protective Collar to Option Strategies

### DIFF
--- a/Algorithm.CSharp/OptionEquityConversionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionEquityConversionRegressionAlgorithm.cs
@@ -1,0 +1,122 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using System.Collections.Generic;
+using QuantConnect.Securities.Option.StrategyMatcher;
+using QuantConnect.Securities.Option;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm exercising an equity Conversion option strategy and asserting it's being detected by Lean and works as expected
+    /// </summary>
+    public class OptionEquityConversionRegressionAlgorithm : OptionEquityBaseStrategyRegressionAlgorithm
+    {
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
+        {
+            if (!Portfolio.Invested)
+            {
+                OptionChain chain;
+                if (IsMarketOpen(_optionSymbol) && slice.OptionChains.TryGetValue(_optionSymbol, out chain))
+                {
+                    var contracts = chain
+                        .OrderByDescending(x => x.Expiry)
+                        .ThenBy(x => x.Strike)
+                        .ToList();
+
+                    var call = contracts.Last(contract => contract.Right == OptionRight.Call);
+                    var put = contracts.Single(contract => contract.Right == OptionRight.Put && contract.Expiry == call.Expiry
+                        && contract.Strike == call.Strike);
+                    var underlying = call.Symbol.Underlying;
+
+                    var initialMargin = Portfolio.MarginRemaining;
+                    MarketOrder(underlying, 100);
+                    MarketOrder(call.Symbol, -1);
+                    MarketOrder(put.Symbol, 1);
+                    var freeMarginPostTrade = Portfolio.MarginRemaining;
+                    AssertOptionStrategyIsPresent(OptionStrategyDefinitions.Conversion.Name, 1);
+
+                    var callInTheMoneyAmount = ((Option)Securities[call.Symbol]).GetIntrinsicValue(Securities[underlying].Price);
+                    var expectedMarginUsage = (callInTheMoneyAmount + 0.1m * call.Strike) * 100;
+
+                    if (expectedMarginUsage != Portfolio.TotalMarginUsed)
+                    {
+                        throw new Exception("Unexpect margin used!");
+                    }
+
+                    // we payed the ask and value using the assets price
+                    var priceSpreadDifference = GetPriceSpreadDifference(call.Symbol, put.Symbol, underlying);
+                    if (initialMargin != (freeMarginPostTrade + expectedMarginUsage + _paidFees - priceSpreadDifference))
+                    {
+                        throw new Exception("Unexpect margin remaining!");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public override long DataPoints => 471135;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public override int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "3"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "200000"},
+            {"End Equity", "199859"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$3.00"},
+            {"Estimated Strategy Capacity", "$1600000.00"},
+            {"Lowest Capacity Asset", "GOOCV W78ZFMML01JA|GOOCV VP83T1ZUHROL"},
+            {"Portfolio Turnover", "38.88%"},
+            {"OrderListHash", "8d8b71fdb1faafde96e301b4b2f9ca7d"}
+        };
+    }
+}

--- a/Algorithm.CSharp/OptionEquityProtectiveCollarRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionEquityProtectiveCollarRegressionAlgorithm.cs
@@ -1,0 +1,123 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Securities;
+using QuantConnect.Data.Market;
+using System.Collections.Generic;
+using QuantConnect.Securities.Option.StrategyMatcher;
+using QuantConnect.Securities.Option;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm exercising an equity Protective Collar option strategy and asserting it's being detected by Lean and works as expected
+    /// </summary>
+    public class OptionEquityProtectiveCollarRegressionAlgorithm : OptionEquityBaseStrategyRegressionAlgorithm
+    {
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
+        {
+            if (!Portfolio.Invested)
+            {
+                OptionChain chain;
+                if (IsMarketOpen(_optionSymbol) && slice.OptionChains.TryGetValue(_optionSymbol, out chain))
+                {
+                    var contracts = chain
+                        .OrderByDescending(x => x.Expiry)
+                        .ThenBy(x => x.Strike)
+                        .ToList();
+
+                    var call = contracts.Last(contract => contract.Right == OptionRight.Call);
+                    var put = contracts.First(contract => contract.Right == OptionRight.Put && contract.Expiry == call.Expiry
+                        && contract.Strike < call.Strike);
+                    var underlying = call.Symbol.Underlying;
+
+                    var initialMargin = Portfolio.MarginRemaining;
+                    MarketOrder(underlying, 100);
+                    MarketOrder(call.Symbol, -1);
+                    MarketOrder(put.Symbol, 1);
+                    var freeMarginPostTrade = Portfolio.MarginRemaining;
+                    AssertOptionStrategyIsPresent(OptionStrategyDefinitions.ProtectiveCollar.Name, 1);
+
+                    var putOutOfTheMoneyAmount = ((Option)Securities[put.Symbol]).OutOfTheMoneyAmount(Securities[underlying].Price);
+                    var expectedMarginUsage = Math.Min(putOutOfTheMoneyAmount + 0.1m * put.Strike, 0.25m * call.Strike) * 100;
+
+                    if (expectedMarginUsage != Portfolio.TotalMarginUsed)
+                    {
+                        throw new Exception("Unexpect margin used!");
+                    }
+
+                    // we payed the ask and value using the assets price
+                    var priceSpreadDifference = GetPriceSpreadDifference(call.Symbol, put.Symbol, underlying);
+                    if (initialMargin != (freeMarginPostTrade + expectedMarginUsage + _paidFees - priceSpreadDifference))
+                    {
+                        throw new Exception("Unexpect margin remaining!");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public override long DataPoints => 471135;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public override int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "3"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "200000"},
+            {"End Equity", "199859"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$3.00"},
+            {"Estimated Strategy Capacity", "$1600000.00"},
+            {"Lowest Capacity Asset", "GOOCV W78ZFMML01JA|GOOCV VP83T1ZUHROL"},
+            {"Portfolio Turnover", "38.71%"},
+            {"OrderListHash", "74791244fa3c7fbefd47dd99c3cd6fa7"}
+        };
+    }
+}

--- a/Algorithm.CSharp/OptionEquityReverseConversionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionEquityReverseConversionRegressionAlgorithm.cs
@@ -1,0 +1,122 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using System.Collections.Generic;
+using QuantConnect.Securities.Option.StrategyMatcher;
+using QuantConnect.Securities.Option;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm exercising an equity Reverse Conversion option strategy and asserting it's being detected by Lean and works as expected
+    /// </summary>
+    public class OptionEquityReverseConversionRegressionAlgorithm : OptionEquityBaseStrategyRegressionAlgorithm
+    {
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
+        {
+            if (!Portfolio.Invested)
+            {
+                OptionChain chain;
+                if (IsMarketOpen(_optionSymbol) && slice.OptionChains.TryGetValue(_optionSymbol, out chain))
+                {
+                    var contracts = chain
+                        .OrderByDescending(x => x.Expiry)
+                        .ThenBy(x => x.Strike)
+                        .ToList();
+
+                    var call = contracts.Last(contract => contract.Right == OptionRight.Call);
+                    var put = contracts.Single(contract => contract.Right == OptionRight.Put && contract.Expiry == call.Expiry
+                        && contract.Strike == call.Strike);
+                    var underlying = call.Symbol.Underlying;
+
+                    var initialMargin = Portfolio.MarginRemaining;
+                    MarketOrder(underlying, -100);
+                    MarketOrder(call.Symbol, 1);
+                    MarketOrder(put.Symbol, -1);
+                    var freeMarginPostTrade = Portfolio.MarginRemaining;
+                    AssertOptionStrategyIsPresent(OptionStrategyDefinitions.ReverseConversion.Name, 1);
+
+                    var putInTheMoneyAmount = ((Option)Securities[put.Symbol]).GetIntrinsicValue(Securities[underlying].Price);
+                    var expectedMarginUsage = (putInTheMoneyAmount + 0.1m * call.Strike) * 100;
+
+                    if (expectedMarginUsage != Portfolio.TotalMarginUsed)
+                    {
+                        throw new Exception("Unexpect margin used!");
+                    }
+
+                    // we payed the ask and value using the assets price
+                    var priceSpreadDifference = GetPriceSpreadDifference(call.Symbol, put.Symbol, underlying);
+                    if (initialMargin != (freeMarginPostTrade + expectedMarginUsage + _paidFees - priceSpreadDifference))
+                    {
+                        throw new Exception("Unexpect margin remaining!");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public override long DataPoints => 471135;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public override int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "3"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "200000"},
+            {"End Equity", "199801"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$3.00"},
+            {"Estimated Strategy Capacity", "$7500000.00"},
+            {"Lowest Capacity Asset", "GOOCV W78ZFMML01JA|GOOCV VP83T1ZUHROL"},
+            {"Portfolio Turnover", "38.84%"},
+            {"OrderListHash", "722e8214812becc745646ff31fcbce1b"}
+        };
+    }
+}

--- a/Common/Securities/Option/OptionStrategies.cs
+++ b/Common/Securities/Option/OptionStrategies.cs
@@ -180,6 +180,19 @@ namespace QuantConnect.Securities.Option
         }
 
         /// <summary>
+        /// Creates a Reverse Conversion strategy that consists of buying 1 put contract and 1 lot of the underlying.
+        /// </summary>
+        /// <param name="canonicalOption">Option symbol</param>
+        /// <param name="strike">The strike price for the put option contract</param>
+        /// <param name="expiration">The expiration date for the put option contract</param>
+        /// <returns>Option strategy specification</returns>
+        public static OptionStrategy ReverseConversion(Symbol canonicalOption, decimal strike, DateTime expiration)
+        {
+            // Since a reverse conversion is an inverted conversion, we can just use the Conversion method and invert the legs
+            return InvertStrategy(Conversion(canonicalOption, strike, expiration), OptionStrategyDefinitions.ReverseConversion.Name);
+        }
+
+        /// <summary>
         /// Creates a Naked Call strategy that consists of selling 1 call contract.
         /// </summary>
         /// <param name="canonicalOption">Option symbol</param>

--- a/Common/Securities/Option/OptionStrategies.cs
+++ b/Common/Securities/Option/OptionStrategies.cs
@@ -165,6 +165,21 @@ namespace QuantConnect.Securities.Option
         }
 
         /// <summary>
+        /// Creates a Conversion strategy that consists of buying 1 put contract, 1 lot of the underlying and selling 1 call contract.
+        /// Put and call must have the same expiration date, underlying (multiplier), and strike price.
+        /// </summary>
+        /// <param name="canonicalOption">Option symbol</param>
+        /// <param name="strike">The strike price for the call and put option contract</param>
+        /// <param name="expiration">The expiration date for the put option contract</param>
+        /// <returns>Option strategy specification</returns>
+        public static OptionStrategy Conversion(Symbol canonicalOption, decimal strike, DateTime expiration)
+        {
+            var strategy = ProtectiveCollar(canonicalOption, strike, strike, expiration);
+            strategy.Name = OptionStrategyDefinitions.Conversion.Name;
+            return strategy;
+        }
+
+        /// <summary>
         /// Creates a Naked Call strategy that consists of selling 1 call contract.
         /// </summary>
         /// <param name="canonicalOption">Option symbol</param>

--- a/Common/Securities/Option/OptionStrategies.cs
+++ b/Common/Securities/Option/OptionStrategies.cs
@@ -145,7 +145,7 @@ namespace QuantConnect.Securities.Option
         /// <returns>Option strategy specification</returns>
         public static OptionStrategy ProtectiveCollar(Symbol canonicalOption, decimal callStrike, decimal putStrike, DateTime expiration)
         {
-            if (callStrike <= putStrike)
+            if (callStrike < putStrike)
             {
                 throw new ArgumentException("ProtectiveCollar: callStrike must be greater than putStrike", $"{nameof(callStrike)}, {nameof(putStrike)}");
             }

--- a/Common/Securities/Option/OptionStrategies.cs
+++ b/Common/Securities/Option/OptionStrategies.cs
@@ -136,12 +136,12 @@ namespace QuantConnect.Securities.Option
         }
 
         /// <summary>
-        /// Creates a Protective Put strategy that consists of buying 1 put contract and 1 lot of the underlying.
+        /// Creates a Protective Collar strategy that consists of buying 1 put contract and 1 lot of the underlying.
         /// </summary>
         /// <param name="canonicalOption">Option symbol</param>
         /// <param name="callStrike">The strike price for the call option contract</param>
         /// <param name="putStrike">The strike price for the put option contract</param>
-        /// <param name="expiration">The expiration date for the put option contract</param>
+        /// <param name="expiration">Option expiration date</param>
         /// <returns>Option strategy specification</returns>
         public static OptionStrategy ProtectiveCollar(Symbol canonicalOption, decimal callStrike, decimal putStrike, DateTime expiration)
         {
@@ -170,7 +170,7 @@ namespace QuantConnect.Securities.Option
         /// </summary>
         /// <param name="canonicalOption">Option symbol</param>
         /// <param name="strike">The strike price for the call and put option contract</param>
-        /// <param name="expiration">The expiration date for the put option contract</param>
+        /// <param name="expiration">Option expiration date</param>
         /// <returns>Option strategy specification</returns>
         public static OptionStrategy Conversion(Symbol canonicalOption, decimal strike, DateTime expiration)
         {
@@ -184,7 +184,7 @@ namespace QuantConnect.Securities.Option
         /// </summary>
         /// <param name="canonicalOption">Option symbol</param>
         /// <param name="strike">The strike price for the put option contract</param>
-        /// <param name="expiration">The expiration date for the put option contract</param>
+        /// <param name="expiration">Option expiration date</param>
         /// <returns>Option strategy specification</returns>
         public static OptionStrategy ReverseConversion(Symbol canonicalOption, decimal strike, DateTime expiration)
         {

--- a/Common/Securities/Option/StrategyMatcher/OptionStrategyDefinitions.cs
+++ b/Common/Securities/Option/StrategyMatcher/OptionStrategyDefinitions.cs
@@ -105,6 +105,18 @@ namespace QuantConnect.Securities.Option.StrategyMatcher
             );
 
         /// <summary>
+        /// Hold 1 lot of the underlying, sell 1 call contract and buy 1 put contract.
+        /// The strike price of the short call is below the strike of the long put with the same expiration.
+        /// </summary>
+        /// <remarks>Combination of <see cref="CoveredCall"/> and <see cref="ProtectivePut"/></remarks>
+        public static OptionStrategyDefinition ProtectiveCollar { get; }
+            = OptionStrategyDefinition.Create("Protective Collar", 1,
+                OptionStrategyDefinition.CallLeg(-1),
+                OptionStrategyDefinition.PutLeg(1, (legs, p) => p.Strike < legs[0].Strike,
+                                                   (legs, p) => p.Expiration == legs[0].Expiration)
+            );
+
+        /// <summary>
         /// Sell 1 call contract without holding the underlying
         /// </summary>
         public static OptionStrategyDefinition NakedCall { get; }

--- a/Common/Securities/Option/StrategyMatcher/OptionStrategyDefinitions.cs
+++ b/Common/Securities/Option/StrategyMatcher/OptionStrategyDefinitions.cs
@@ -117,6 +117,18 @@ namespace QuantConnect.Securities.Option.StrategyMatcher
             );
 
         /// <summary>
+        /// Hold 1 lot of the underlying, sell 1 call contract and buy 1 put contract.
+        /// The strike price of the call and put are the same, with the same expiration.
+        /// </summary>
+        /// <remarks>A special case of <see cref="ProtectiveCollar"/>
+        public static OptionStrategyDefinition Conversion { get; }
+            = OptionStrategyDefinition.Create("Conversion", 1,
+                OptionStrategyDefinition.CallLeg(-1),
+                OptionStrategyDefinition.PutLeg(1, (legs, p) => p.Strike == legs[0].Strike,
+                                                   (legs, p) => p.Expiration == legs[0].Expiration)
+            );
+
+        /// <summary>
         /// Sell 1 call contract without holding the underlying
         /// </summary>
         public static OptionStrategyDefinition NakedCall { get; }

--- a/Common/Securities/Option/StrategyMatcher/OptionStrategyDefinitions.cs
+++ b/Common/Securities/Option/StrategyMatcher/OptionStrategyDefinitions.cs
@@ -129,6 +129,18 @@ namespace QuantConnect.Securities.Option.StrategyMatcher
             );
 
         /// <summary>
+        /// Hold 1 lot of the underlying, sell 1 call contract and buy 1 put contract.
+        /// The strike price of the call and put are the same, with the same expiration.
+        /// </summary>
+        /// <remarks>Inverse of <see cref="Conversion"/>
+        public static OptionStrategyDefinition ReverseConversion { get; }
+            = OptionStrategyDefinition.Create("Reverse Conversion", -1,
+                OptionStrategyDefinition.CallLeg(1),
+                OptionStrategyDefinition.PutLeg(-1, (legs, p) => p.Strike == legs[0].Strike,
+                                                   (legs, p) => p.Expiration == legs[0].Expiration)
+            );
+
+        /// <summary>
         /// Sell 1 call contract without holding the underlying
         /// </summary>
         public static OptionStrategyDefinition NakedCall { get; }

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -2401,12 +2401,22 @@ namespace QuantConnect.Tests.Common.Securities
                 _equity.Holdings.SetHoldings(_equity.Price, initialHoldingsQuantity * _putOption.ContractMultiplier);
                 spyMay19_300Call.Holdings.SetHoldings(spyMay19_300Call.Price, -initialHoldingsQuantity);
                 spyMay19_300Put.Holdings.SetHoldings(spyMay19_300Put.Price, initialHoldingsQuantity);
+
+                if (initialHoldingsQuantity < 0)
+                {
+                    expectedPositionGroupBPMStrategy = OptionStrategyDefinitions.ReverseConversion.Name;
+                }
             }
             else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.ReverseConversion.Name)
             {
                 _equity.Holdings.SetHoldings(_equity.Price, -initialHoldingsQuantity * _putOption.ContractMultiplier);
                 spyMay19_300Call.Holdings.SetHoldings(spyMay19_300Call.Price, initialHoldingsQuantity);
                 spyMay19_300Put.Holdings.SetHoldings(spyMay19_300Put.Price, -initialHoldingsQuantity);
+
+                if (initialHoldingsQuantity < 0)
+                {
+                    expectedPositionGroupBPMStrategy = OptionStrategyDefinitions.Conversion.Name;
+                }
             }
             else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.BearCallSpread.Name)
             {

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -159,6 +159,21 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, -(1000000 - 20 * 10250) / (10250 + 0), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, -(1000000 - 20 * 10250) / (10250 + 0) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for ProtectiveCollar with quantities 1 and -1 are 19250|0 and 19250|9198 respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 0, (1000000 - 0 * 19250) / (19250 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 0, (1000000 - 0 * 19250) / (19250 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 0, -(1000000 + 0 * 19250) / (19250 + 9198), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 0, -(1000000 + 0 * 19250) / (19250 + 9198) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 20, (1000000 - 20 * 19250) / (19250 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 20, (1000000 - 20 * 19250) / (19250 + 0) + 1, false),    // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 20, -20, true), // 20 to 0
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 20, -(1000000 + 20 * 19250) / (19250 + 9198), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 20, -(1000000 + 20 * 19250) / (19250 + 9198) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, (1000000 + 20 * 19250) / (19250 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, (1000000 + 20 * 19250) / (19250 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, 20, true), // -20 to 0
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, -(1000000 - 20 * 19250) / (19250 + 9198), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, -(1000000 - 20 * 19250) / (19250 + 9198) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for BearCallSpread with quantities 1 and -1 are 1000|0 and 0|1200 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, (1000000 - 0 * 1000) / (1000 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, (1000000 - 0 * 1000) / (1000 + 0) + 1, false), // 0 to max long + 1
@@ -618,6 +633,8 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -1, 10000m),                     // IB:  10276.15
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 1, 10000m),                   // IB:  inverted covered put
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -1, 12000m),                  // IB:  covered put
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 1, 19250m),                // IB:  19250
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -1, 19250m),               // IB:  same as long
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 1000m),                   // IB:  1000
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                     // IB:  0
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 1, 0m),                       // IB:  0
@@ -712,6 +729,8 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -1, 10000m),                     // IB:  10276
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 1, 10000m),                   // IB:  inverted covered Put
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -1, 10250m),                  // IB:  covered Put
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 1, 8000m),                 // IB:  8000
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -1, 8000m),                // IB:  same as long
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 1000m),                   // IB:  10000
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                     // IB:  0
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 1, 0m),                       // IB:  0
@@ -819,6 +838,15 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102500m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102500m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102500m - 102520m, -20),
+            // Initial margin requirement (including premium) for ProtectiveCollar with quantity 10 and -10 is 192500 and 284480 respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 192500m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -192500m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -192500m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -192500m - 284480m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 284480m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -284480m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -284480m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -284480m - 192500m, -20),
             // Initial margin requirement (including premium) for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10000m / 10, -1),
@@ -1143,6 +1171,15 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 102500m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102520m, -20),
+            // Initial margin requirement (including premium) for ProtectiveCollar with quantity 10 and -10 is 192500m and 284880m respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 192500m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 192500m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -284880m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 284880m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 284880m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -192500m, -20),
             // Initial margin requirement (including premium) for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 9 / 10, -1),
@@ -1417,6 +1454,14 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 1, (1000000m - 102500m) + 102500m + 102500m),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 10, (1000000m - 102500m) + 102500m + 102500m),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 20, (1000000m - 102500m) + 102500m + 102500m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 1, 1000000m - 80000m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -1, (1000000m - 80000m) + 80000m + 192500m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -10, (1000000m - 80000m) + 80000m + 192500m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -20, (1000000m - 80000m) + 80000m + 192500m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -1, 1000000m - 80000m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 1, (1000000m - 80000m) + 80000m + 284480m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 10, (1000000m - 80000m) + 80000m + 284480m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 20, (1000000m - 80000m) + 80000m + 284480m),
             new TestCaseData(OptionStrategyDefinitions.NakedCall, 10, +1, 1000000m - 194000m),
             new TestCaseData(OptionStrategyDefinitions.NakedCall, 10, -1, (1000000m - 194000m) + 194000m + 194000m),
             new TestCaseData(OptionStrategyDefinitions.NakedCall, 10, -10, (1000000m - 194000m) + 194000m + 194000m),
@@ -1850,6 +1895,14 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 10),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 20),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10),
@@ -2230,6 +2283,12 @@ namespace QuantConnect.Tests.Common.Securities
                 {
                     expectedPositionGroupBPMStrategy = OptionStrategyDefinitions.CoveredPut.Name;
                 }
+            }
+            else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.ProtectiveCollar.Name)
+            {
+                _equity.Holdings.SetHoldings(_equity.Price, initialHoldingsQuantity * _putOption.ContractMultiplier);
+                spyMay19_320Call.Holdings.SetHoldings(spyMay19_320Call.Price, -initialHoldingsQuantity);
+                spyMay19_300Put.Holdings.SetHoldings(spyMay19_300Put.Price, initialHoldingsQuantity);
             }
             else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.BearCallSpread.Name)
             {

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -174,6 +174,21 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, -(1000000 - 20 * 19250) / (19250 + 9198), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, -(1000000 - 20 * 19250) / (19250 + 9198) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for Conversion with quantities 1 and -1 are 21250|0 and 21250|11198 respectively
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, (1000000 - 0 * 21250) / (21250 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, (1000000 - 0 * 21250) / (21250 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, -(1000000 + 0 * 21250) / (21250 + 11198), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, -(1000000 + 0 * 21250) / (21250 + 11198) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, (1000000 - 20 * 21250) / (21250 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, (1000000 - 20 * 21250) / (21250 + 0) + 1, false),    // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, -20, true), // 20 to 0
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, -(1000000 + 20 * 21250) / (21250 + 11198), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, -(1000000 + 20 * 21250) / (21250 + 11198) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, (1000000 + 20 * 21250) / (21250 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, (1000000 + 20 * 21250) / (21250 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, 20, true), // -20 to 0
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, -(1000000 - 20 * 21250) / (21250 + 11198), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, -(1000000 - 20 * 21250) / (21250 + 11198) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for BearCallSpread with quantities 1 and -1 are 1000|0 and 0|1200 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, (1000000 - 0 * 1000) / (1000 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, (1000000 - 0 * 1000) / (1000 + 0) + 1, false), // 0 to max long + 1
@@ -635,6 +650,8 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -1, 12000m),                  // IB:  covered put
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 1, 19250m),                // IB:  19250
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -1, 19250m),               // IB:  same as long
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 1, 21250m),                      // IB:  21250
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -1, 21250m),                     // IB:  same as long
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 1000m),                   // IB:  1000
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                     // IB:  0
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 1, 0m),                       // IB:  0
@@ -731,6 +748,8 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -1, 10250m),                  // IB:  covered Put
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 1, 8000m),                 // IB:  8000
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -1, 8000m),                // IB:  same as long
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 1, 14000m),                      // IB:  14000
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -1, 14000m),                     // IB:  same as long
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 1000m),                   // IB:  10000
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                     // IB:  0
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 1, 0m),                       // IB:  0
@@ -847,6 +866,15 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -284480m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -284480m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -284480m - 192500m, -20),
+            // Initial margin requirement (including premium) for Conversion with quantity 10 and -10 is 212500 and 324480 respectively
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 212500m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -212500m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -212500m, -10),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -212500m - 324480m, -20),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 324480m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -324480m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -324480m, -10),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -324480m - 212500m, -20),
             // Initial margin requirement (including premium) for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10000m / 10, -1),
@@ -1180,6 +1208,15 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 284480m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -192500m, -20),
+            // Initial margin requirement (including premium) for Conversion with quantity 10 and -10 is 212500m and 324480m respectively
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 212500m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 212500m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -324480m, -20),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 324480m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 324480m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -212500m, -20),
             // Initial margin requirement (including premium) for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 9 / 10, -1),
@@ -1462,6 +1499,14 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 1, (1000000m - 80000m) + 80000m + 284480m),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 10, (1000000m - 80000m) + 80000m + 284480m),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 20, (1000000m - 80000m) + 80000m + 284480m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 1, 1000000m - 140000m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -1, (1000000m - 140000m) + 140000m + 212500m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -10, (1000000m - 140000m) + 140000m + 212500m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -20, (1000000m - 140000m) + 140000m + 212500m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -1, 1000000m - 140000m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 1, (1000000m - 140000m) + 140000m + 324480m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 10, (1000000m - 140000m) + 140000m + 324480m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 20, (1000000m - 140000m) + 140000m + 324480m),
             new TestCaseData(OptionStrategyDefinitions.NakedCall, 10, +1, 1000000m - 194000m),
             new TestCaseData(OptionStrategyDefinitions.NakedCall, 10, -1, (1000000m - 194000m) + 194000m + 194000m),
             new TestCaseData(OptionStrategyDefinitions.NakedCall, 10, -10, (1000000m - 194000m) + 194000m + 194000m),
@@ -1903,6 +1948,14 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 10),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 20),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10),
@@ -2288,6 +2341,12 @@ namespace QuantConnect.Tests.Common.Securities
             {
                 _equity.Holdings.SetHoldings(_equity.Price, initialHoldingsQuantity * _putOption.ContractMultiplier);
                 spyMay19_320Call.Holdings.SetHoldings(spyMay19_320Call.Price, -initialHoldingsQuantity);
+                spyMay19_300Put.Holdings.SetHoldings(spyMay19_300Put.Price, initialHoldingsQuantity);
+            }
+            else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.Conversion.Name)
+            {
+                _equity.Holdings.SetHoldings(_equity.Price, initialHoldingsQuantity * _putOption.ContractMultiplier);
+                spyMay19_300Call.Holdings.SetHoldings(spyMay19_300Call.Price, -initialHoldingsQuantity);
                 spyMay19_300Put.Holdings.SetHoldings(spyMay19_300Put.Price, initialHoldingsQuantity);
             }
             else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.BearCallSpread.Name)

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -159,51 +159,51 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, -(1000000 - 20 * 10250) / (10250 + 0), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -20, -(1000000 - 20 * 10250) / (10250 + 0) - 1, false),  // -20 to max short + 1
-            // Initial margin requirement|premium for ProtectiveCollar with quantities 1 and -1 are 19250|0 and 19250|9198 respectively
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 0, (1000000 - 0 * 19250) / (19250 + 0), true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 0, (1000000 - 0 * 19250) / (19250 + 0) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 0, -(1000000 + 0 * 19250) / (19250 + 9198), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 0, -(1000000 + 0 * 19250) / (19250 + 9198) - 1, false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 20, (1000000 - 20 * 19250) / (19250 + 0), true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 20, (1000000 - 20 * 19250) / (19250 + 0) + 1, false),    // 20 to max long + 1
+            // Initial margin requirement|premium for ProtectiveCollar with quantities 1 and -1 are 26231|0 and 26231|1 respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 0, (1000000 - 0 * 26231) / (26231 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 0, (1000000 - 0 * 26231) / (26231 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 0, -(1000000 + 0 * 26231) / (26231 + 1), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 0, -(1000000 + 0 * 26231) / (26231 + 1) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 20, (1000000 - 20 * 26231) / (26231 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 20, (1000000 - 20 * 26231) / (26231 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 20, -(1000000 + 20 * 19250) / (19250 + 9198), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 20, -(1000000 + 20 * 19250) / (19250 + 9198) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, (1000000 + 20 * 19250) / (19250 + 0), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, (1000000 + 20 * 19250) / (19250 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 20, -(1000000 + 20 * 26231) / (26231 + 1), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 20, -(1000000 + 20 * 26231) / (26231 + 1) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, (1000000 + 20 * 26231) / (26231 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, (1000000 + 20 * 26231) / (26231 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, -(1000000 - 20 * 19250) / (19250 + 9198), true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, -(1000000 - 20 * 19250) / (19250 + 9198) - 1, false),  // -20 to max short + 1
-            // Initial margin requirement|premium for Conversion with quantities 1 and -1 are 21250|0 and 10250|11198 respectively
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, (1000000 - 0 * 21250) / (21250 + 0), true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, (1000000 - 0 * 21250) / (21250 + 0) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, -(1000000 + 0 * 10250) / (10250 + 11198), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, -(1000000 + 0 * 10250) / (10250 + 11198) - 1, false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, (1000000 - 20 * 21250) / (21250 + 0), true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, (1000000 - 20 * 21250) / (21250 + 0) + 1, false),    // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, -(1000000 - 20 * 26231) / (26231 + 1), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, -(1000000 - 20 * 26231) / (26231 + 1) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for Conversion with quantities 1 and -1 are 26295|0 and 26231|146 respectively
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, (1000000 - 0 * 26295) / (26295 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, (1000000 - 0 * 26295) / (26295 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, -(1000000 + 0 * 26231) / (26231 + 146), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, -(1000000 + 0 * 26231) / (26231 + 146) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, (1000000 - 20 * 26295) / (26295 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, (1000000 - 20 * 26295) / (26295 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.Conversion, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, -(1000000 + 20 * 10250) / (10250 + 11198), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, -(1000000 + 20 * 10250) / (10250 + 11198) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, (1000000 + 20 * 21250) / (21250 + 0), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, (1000000 + 20 * 21250) / (21250 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, -(1000000 + 20 * 26231) / (26231 + 146), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, -(1000000 + 20 * 26231) / (26231 + 146) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, (1000000 + 20 * 26295) / (26295 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, (1000000 + 20 * 26295) / (26295 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.Conversion, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, -(1000000 - 20 * 10250) / (10250 + 11198), true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, -(1000000 - 20 * 10250) / (10250 + 11198) - 1, false),  // -20 to max short + 1
-            // Initial margin requirement|premium for ReverseConversion with quantities 1 and -1 are 10250|11198 and 21250|0 respectively
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 0, (1000000 - 0 * 10250) / (10250 + 11198), true), // 0 to max long
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 0, (1000000 - 0 * 10250) / (10250 + 11198) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 0, -(1000000 + 0 * 21250) / (21250 + 0), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 0, -(1000000 + 0 * 21250) / (21250 + 0) - 1, false),    // 0 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 20, (1000000 - 20 * 10250) / (10250 + 11198), true),    // 20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 20, (1000000 - 20 * 10250) / (10250 + 11198) + 1, false),    // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, -(1000000 - 20 * 26231) / (26231 + 146), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, -(1000000 - 20 * 26231) / (26231 + 146) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for ReverseConversion with quantities 1 and -1 are 26231|146 and 26295|0 respectively
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 0, (1000000 - 0 * 26231) / (26231 + 146), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 0, (1000000 - 0 * 26231) / (26231 + 146) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 0, -(1000000 + 0 * 26295) / (26295 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 0, -(1000000 + 0 * 26295) / (26295 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 20, (1000000 - 20 * 26231) / (26231 + 146), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 20, (1000000 - 20 * 26231) / (26231 + 146) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 20, -(1000000 + 20 * 21250) / (21250 + 0), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 20, -(1000000 + 20 * 21250) / (21250 + 0) - 1, false),  // 20 to max short + 1
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -20, (1000000 + 20 * 10250) / (10250 + 11198), true),   // -20 to max long
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -20, (1000000 + 20 * 10250) / (10250 + 11198) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 20, -(1000000 + 20 * 26295) / (26295 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 20, -(1000000 + 20 * 26295) / (26295 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -20, (1000000 + 20 * 26231) / (26231 + 146), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -20, (1000000 + 20 * 26231) / (26231 + 146) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -20, -(1000000 - 20 * 21250) / (21250 + 0), true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -20, -(1000000 - 20 * 21250) / (21250 + 0) - 1, false),  // -20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -20, -(1000000 - 20 * 26295) / (26295 + 0), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -20, -(1000000 - 20 * 26295) / (26295 + 0) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for BearCallSpread with quantities 1 and -1 are 1000|0 and 0|1200 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, (1000000 - 0 * 1000) / (1000 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, (1000000 - 0 * 1000) / (1000 + 0) + 1, false), // 0 to max long + 1
@@ -663,12 +663,12 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -1, 10000m),                     // IB:  10276.15
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 1, 10000m),                   // IB:  inverted covered put
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -1, 12000m),                  // IB:  covered put
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 1, 19250m),                // IB:  19250
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -1, 19250m),               // IB:  same as long
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 1, 21250m),                      // IB:  21250
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -1, 10250m),                     // IB:  reverse conversion
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 1, 10250m),               // IB:  10250
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -1, 21250m),              // IB:  conversion
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 1, 26231m),                // IB:  26231
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -1, 26231m),               // IB:  same as long
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 1, 26295m),                      // IB:  26295
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -1, 26230m),                     // IB:  reverse conversion
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 1, 26231m),               // IB:  26231
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -1, 26295m),              // IB:  conversion
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 1000m),                   // IB:  1000
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                     // IB:  0
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 1, 0m),                       // IB:  0
@@ -763,12 +763,12 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.CoveredPut, -1, 10000m),                     // IB:  10276
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, 1, 10000m),                   // IB:  inverted covered Put
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -1, 10250m),                  // IB:  covered Put
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 1, 8000m),                 // IB:  8000
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -1, 8000m),                // IB:  same as long
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 1, 14000m),                      // IB:  14000
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -1, 3000m),                      // IB:  reverse conversion
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 1, 3000m),                // IB:  14000
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -1, 14000m),              // IB:  conversion
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 1, 6202m),                 // IB:  6202
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -1, 6202m),                // IB:  same as long
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 1, 5303m),                       // IB:  5303
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -1, 5240m),                      // IB:  reverse conversion
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 1, 5240m),                // IB:  5240
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -1, 5303m),               // IB:  conversion
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 1000m),                   // IB:  10000
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                     // IB:  0
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 1, 0m),                       // IB:  0
@@ -876,33 +876,32 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102500m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102500m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102500m - 102520m, -20),
-            // Initial margin requirement (including premium) for ProtectiveCollar with quantity 10 and -10 is 192500 and 284480 respectively
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 192500m / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -192500m / 10, -1),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -192500m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -192500m - 284480m, -20),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 284480m / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -284480m / 10, -1),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -284480m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -284480m - 192500m, -20),
-            // Initial margin requirement (including premium) for Conversion with quantity 10 and -10 is 212500 and 214480 respectively
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 212500m / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -212500m / 10, -1),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -212500m, -10),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -212500m - 214480m, -20),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 214480m / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -214480m / 10, -1),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -214480m, -10),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -214480m - 212500m, -20),
-            // Initial margin requirement (including premium) for ReverseConversion with quantity 10 and -10 is 214480 and 212500 respectively
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 214480m / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -214480m / 10, -1),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -214480m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -214480m - 212500m, -20),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 212500m / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -212500m / 10, -1),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -212500m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -212500m - 214480m, -20),
+            // Initial margin requirement (including premium) for ProtectiveCollar with quantity 10 and -10 is 262310 and 262318 respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 262310m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -262310m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -262310m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -262310m - 262318m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 262318m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -262318m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -262318m - 262310m, -20),
+            // Initial margin requirement (including premium) for Conversion with quantity 10 and -10 is 262945 and 263778 respectively
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 262945m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -262945m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -262945m, -10),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -262945m - 263778m, -20),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 263778m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -263778m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -263778m, -10),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -263778m - 262945m, -20),
+            // Initial margin requirement (including premium) for ReverseConversion with quantity 10 and -10 is 263768 and 262915 respectively
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 263768m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -263768m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -263768m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -263768m - 262915m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 262915m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -262915m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -262915m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -262915m - 263768m, -20),
             // Initial margin requirement (including premium) for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10000m / 10, -1),
@@ -1227,33 +1226,33 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 102500m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102520m, -20),
-            // Initial margin requirement (including premium) for ProtectiveCollar with quantity 10 and -10 is 192500m and 284480m respectively
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 192500m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 192500m * 9 / 10, -1),
+            // Initial margin requirement (including premium) for ProtectiveCollar with quantity 10 and -10 is 262310m and 262318m respectively
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 262310m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 262310m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -284480m, -20),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 284480m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 284480m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -262318m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 262318m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 262318m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -192500m, -20),
-            // Initial margin requirement (including premium) for Conversion with quantity 10 and -10 is 212500m and 214480m respectively
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 212500m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 212500m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -262310m, -20),
+            // Initial margin requirement (including premium) for Conversion with quantity 10 and -10 is 262945m and 263778m respectively
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 262945m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 262945m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -214480m, -20),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 214480m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 214480m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -263778m, -20),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 263778m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 263778m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -212500m, -20),
-            // Initial margin requirement (including premium) for ReverseConversion with quantity 10 and -10 is 214480m and 212500m respectively
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 214480m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 214480m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -262945m, -20),
+            // Initial margin requirement (including premium) for ReverseConversion with quantity 10 and -10 is 263768m and 262915m respectively
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 263768m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 263768m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -212500m, -20),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 212500m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 212500m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -262915m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 262915m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 262915m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -214480m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -263768m, -20),
             // Initial margin requirement (including premium) for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 9 / 10, -1),
@@ -1528,30 +1527,30 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 1, (1000000m - 102500m) + 102500m + 102500m),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 10, (1000000m - 102500m) + 102500m + 102500m),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 20, (1000000m - 102500m) + 102500m + 102500m),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 1, 1000000m - 80000m),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -1, (1000000m - 80000m) + 80000m + 192500m),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -10, (1000000m - 80000m) + 80000m + 192500m),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -20, (1000000m - 80000m) + 80000m + 192500m),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -1, 1000000m - 80000m),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 1, (1000000m - 80000m) + 80000m + 284480m),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 10, (1000000m - 80000m) + 80000m + 284480m),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 20, (1000000m - 80000m) + 80000m + 284480m),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 1, 1000000m - 140000m),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -1, (1000000m - 140000m) + 140000m + 212500m),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -10, (1000000m - 140000m) + 140000m + 212500m),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -20, (1000000m - 140000m) + 140000m + 212500m),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -1, 1000000m - 30000m),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 1, (1000000m - 30000m) + 30000m + 214480m),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 10, (1000000m - 30000m) + 30000m + 214480m),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 20, (1000000m - 30000m) + 30000m + 214480m),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 1, 1000000m - 30000m),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -1, (1000000m - 30000m) + 30000m + 214480m),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -10, (1000000m - 30000m) + 30000m + 214480m),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -20, (1000000m - 30000m) + 30000m + 214480m),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -1, 1000000m - 140000m),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 1, (1000000m - 140000m) + 140000m + 212500m),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 10, (1000000m - 140000m) + 140000m + 212500m),
-            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 20, (1000000m - 140000m) + 140000m + 212500m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 1, 1000000m - 62020m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -1, (1000000m - 62020m) + 62020m + 262318m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -10, (1000000m - 62020m) + 62020m + 262318m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -20, (1000000m - 62020m) + 62020m + 262318m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -1, 1000000m - 62020m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 1, (1000000m - 62020m) + 62020m + 262310m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 10, (1000000m - 62020m) + 62020m + 262310m),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 20, (1000000m - 62020m) + 62020m + 262310m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 1, 1000000m - 53030m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -1, (1000000m - 53030m) + 53030m + 262945m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -10, (1000000m - 53030m) + 53030m + 262945m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -20, (1000000m - 53030m) + 53030m + 262945m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -1, 1000000m - 52400m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 1, (1000000m - 52400m) + 52400m + 263778m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 10, (1000000m - 52400m) + 52400m + 263778m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 20, (1000000m - 52400m) + 52400m + 263778m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 1, 1000000m - 52400m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -1, (1000000m - 52400m) + 52400m + 263768m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -10, (1000000m - 52400m) + 52400m + 263768m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -20, (1000000m - 52400m) + 52400m + 263768m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -1, 1000000m - 53010m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 1, (1000000m - 53010m) + 53010m + 262915m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 10, (1000000m - 53010m) + 53010m + 262915m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 20, (1000000m - 53010m) + 53010m + 262915m),
             new TestCaseData(OptionStrategyDefinitions.NakedCall, 10, +1, 1000000m - 194000m),
             new TestCaseData(OptionStrategyDefinitions.NakedCall, 10, -1, (1000000m - 194000m) + 194000m + 194000m),
             new TestCaseData(OptionStrategyDefinitions.NakedCall, 10, -10, (1000000m - 194000m) + 194000m + 194000m),
@@ -2314,6 +2313,18 @@ namespace QuantConnect.Tests.Common.Securities
             var spyMay17_300Put = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Put, 300, may172023));
             spyMay17_300Put.SetMarketPrice(new Tick { Value = 0.01m });
 
+            var jun212024 = new DateTime(2024, 06, 21);
+
+            var spyJun21_534Call = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Call, 534, jun212024));
+            spyJun21_534Call.SetMarketPrice(new Tick { Value = 0.01m });
+            var spyJun21_524Call = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Call, 524, jun212024));
+            spyJun21_524Call.SetMarketPrice(new Tick { Value = 2.29m });
+
+            var spyJun21_524Put = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Put, 524, jun212024));
+            spyJun21_524Put.SetMarketPrice(new Tick { Value = 0.827m });
+            var spyJun21_514Put = _algorithm.AddOptionContract(Symbols.CreateOptionSymbol("SPY", OptionRight.Put, 514, jun212024));
+            spyJun21_514Put.SetMarketPrice(new Tick { Value = 0.018m });
+
             _equity.SetMarketPrice(new Tick { Value = 410m });
             _equity.SetLeverage(4);
 
@@ -2392,15 +2403,21 @@ namespace QuantConnect.Tests.Common.Securities
             }
             else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.ProtectiveCollar.Name)
             {
+                _equity.SetMarketPrice(new Tick { Value = 524.62m });
+                _equity.SetLeverage(2);
+
                 _equity.Holdings.SetHoldings(_equity.Price, initialHoldingsQuantity * _putOption.ContractMultiplier);
-                spyMay19_320Call.Holdings.SetHoldings(spyMay19_320Call.Price, -initialHoldingsQuantity);
-                spyMay19_300Put.Holdings.SetHoldings(spyMay19_300Put.Price, initialHoldingsQuantity);
+                spyJun21_534Call.Holdings.SetHoldings(spyJun21_534Call.Price, -initialHoldingsQuantity);
+                spyJun21_514Put.Holdings.SetHoldings(spyJun21_514Put.Price, initialHoldingsQuantity);
             }
             else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.Conversion.Name)
             {
+                _equity.SetMarketPrice(new Tick { Value = 524.63m });
+                _equity.SetLeverage(2);
+
                 _equity.Holdings.SetHoldings(_equity.Price, initialHoldingsQuantity * _putOption.ContractMultiplier);
-                spyMay19_300Call.Holdings.SetHoldings(spyMay19_300Call.Price, -initialHoldingsQuantity);
-                spyMay19_300Put.Holdings.SetHoldings(spyMay19_300Put.Price, initialHoldingsQuantity);
+                spyJun21_524Call.Holdings.SetHoldings(spyJun21_524Call.Price, -initialHoldingsQuantity);
+                spyJun21_524Put.Holdings.SetHoldings(spyJun21_524Put.Price, initialHoldingsQuantity);
 
                 if (initialHoldingsQuantity < 0)
                 {
@@ -2409,9 +2426,12 @@ namespace QuantConnect.Tests.Common.Securities
             }
             else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.ReverseConversion.Name)
             {
+                _equity.SetMarketPrice(new Tick { Value = 524.61m });
+                _equity.SetLeverage(2);
+
                 _equity.Holdings.SetHoldings(_equity.Price, -initialHoldingsQuantity * _putOption.ContractMultiplier);
-                spyMay19_300Call.Holdings.SetHoldings(spyMay19_300Call.Price, initialHoldingsQuantity);
-                spyMay19_300Put.Holdings.SetHoldings(spyMay19_300Put.Price, -initialHoldingsQuantity);
+                spyJun21_524Call.Holdings.SetHoldings(spyJun21_524Call.Price, initialHoldingsQuantity);
+                spyJun21_524Put.Holdings.SetHoldings(spyJun21_524Put.Price, -initialHoldingsQuantity);
 
                 if (initialHoldingsQuantity < 0)
                 {

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -174,21 +174,36 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, -(1000000 - 20 * 19250) / (19250 + 9198), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -20, -(1000000 - 20 * 19250) / (19250 + 9198) - 1, false),  // -20 to max short + 1
-            // Initial margin requirement|premium for Conversion with quantities 1 and -1 are 21250|0 and 21250|11198 respectively
+            // Initial margin requirement|premium for Conversion with quantities 1 and -1 are 21250|0 and 10250|11198 respectively
             new TestCaseData(OptionStrategyDefinitions.Conversion, 0, (1000000 - 0 * 21250) / (21250 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.Conversion, 0, (1000000 - 0 * 21250) / (21250 + 0) + 1, false), // 0 to max long + 1
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, -(1000000 + 0 * 21250) / (21250 + 11198), true), // 0 to max short
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, -(1000000 + 0 * 21250) / (21250 + 11198) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, -(1000000 + 0 * 10250) / (10250 + 11198), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 0, -(1000000 + 0 * 10250) / (10250 + 11198) - 1, false),    // 0 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.Conversion, 20, (1000000 - 20 * 21250) / (21250 + 0), true),    // 20 to max long
             new TestCaseData(OptionStrategyDefinitions.Conversion, 20, (1000000 - 20 * 21250) / (21250 + 0) + 1, false),    // 20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.Conversion, 20, -20, true), // 20 to 0
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, -(1000000 + 20 * 21250) / (21250 + 11198), true), // 20 to max short
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, -(1000000 + 20 * 21250) / (21250 + 11198) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, -(1000000 + 20 * 10250) / (10250 + 11198), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 20, -(1000000 + 20 * 10250) / (10250 + 11198) - 1, false),  // 20 to max short + 1
             new TestCaseData(OptionStrategyDefinitions.Conversion, -20, (1000000 + 20 * 21250) / (21250 + 0), true),   // -20 to max long
             new TestCaseData(OptionStrategyDefinitions.Conversion, -20, (1000000 + 20 * 21250) / (21250 + 0) + 1, false),   // -20 to max long + 1
             new TestCaseData(OptionStrategyDefinitions.Conversion, -20, 20, true), // -20 to 0
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, -(1000000 - 20 * 21250) / (21250 + 11198), true),    // -20 to max short
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, -(1000000 - 20 * 21250) / (21250 + 11198) - 1, false),  // -20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, -(1000000 - 20 * 10250) / (10250 + 11198), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -20, -(1000000 - 20 * 10250) / (10250 + 11198) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for ReverseConversion with quantities 1 and -1 are 10250|11198 and 21250|0 respectively
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 0, (1000000 - 0 * 10250) / (10250 + 11198), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 0, (1000000 - 0 * 10250) / (10250 + 11198) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 0, -(1000000 + 0 * 21250) / (21250 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 0, -(1000000 + 0 * 21250) / (21250 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 20, (1000000 - 20 * 10250) / (10250 + 11198), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 20, (1000000 - 20 * 10250) / (10250 + 11198) + 1, false),    // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 20, -20, true), // 20 to 0
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 20, -(1000000 + 20 * 21250) / (21250 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 20, -(1000000 + 20 * 21250) / (21250 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -20, (1000000 + 20 * 10250) / (10250 + 11198), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -20, (1000000 + 20 * 10250) / (10250 + 11198) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -20, 20, true), // -20 to 0
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -20, -(1000000 - 20 * 21250) / (21250 + 0), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -20, -(1000000 - 20 * 21250) / (21250 + 0) - 1, false),  // -20 to max short + 1
             // Initial margin requirement|premium for BearCallSpread with quantities 1 and -1 are 1000|0 and 0|1200 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, (1000000 - 0 * 1000) / (1000 + 0), true), // 0 to max long
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 0, (1000000 - 0 * 1000) / (1000 + 0) + 1, false), // 0 to max long + 1
@@ -651,7 +666,9 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 1, 19250m),                // IB:  19250
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -1, 19250m),               // IB:  same as long
             new TestCaseData(OptionStrategyDefinitions.Conversion, 1, 21250m),                      // IB:  21250
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -1, 21250m),                     // IB:  same as long
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -1, 10250m),                     // IB:  reverse conversion
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 1, 10250m),               // IB:  10250
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -1, 21250m),              // IB:  conversion
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 1000m),                   // IB:  1000
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                     // IB:  0
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 1, 0m),                       // IB:  0
@@ -749,7 +766,9 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 1, 8000m),                 // IB:  8000
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -1, 8000m),                // IB:  same as long
             new TestCaseData(OptionStrategyDefinitions.Conversion, 1, 14000m),                      // IB:  14000
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -1, 14000m),                     // IB:  same as long
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -1, 3000m),                      // IB:  reverse conversion
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 1, 3000m),                // IB:  14000
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -1, 14000m),              // IB:  conversion
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 1, 1000m),                   // IB:  10000
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, -1, 0m),                     // IB:  0
             new TestCaseData(OptionStrategyDefinitions.BearPutSpread, 1, 0m),                       // IB:  0
@@ -866,15 +885,24 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -284480m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -284480m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -284480m - 192500m, -20),
-            // Initial margin requirement (including premium) for Conversion with quantity 10 and -10 is 212500 and 324480 respectively
+            // Initial margin requirement (including premium) for Conversion with quantity 10 and -10 is 212500 and 214480 respectively
             new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 212500m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -212500m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -212500m, -10),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -212500m - 324480m, -20),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 324480m / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -324480m / 10, -1),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -324480m, -10),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -324480m - 212500m, -20),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -212500m - 214480m, -20),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 214480m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -214480m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -214480m, -10),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -214480m - 212500m, -20),
+            // Initial margin requirement (including premium) for ReverseConversion with quantity 10 and -10 is 214480 and 212500 respectively
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 214480m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -214480m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -214480m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -214480m - 212500m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 212500m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -212500m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -212500m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -212500m - 214480m, -20),
             // Initial margin requirement (including premium) for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10000m / 10, -1),
@@ -1208,15 +1236,24 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 284480m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -192500m, -20),
-            // Initial margin requirement (including premium) for Conversion with quantity 10 and -10 is 212500m and 324480m respectively
+            // Initial margin requirement (including premium) for Conversion with quantity 10 and -10 is 212500m and 214480m respectively
             new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 212500m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 212500m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.Conversion, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -324480m, -20),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 324480m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 324480m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -214480m, -20),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 214480m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 214480m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -212500m, -20),
+            // Initial margin requirement (including premium) for ReverseConversion with quantity 10 and -10 is 214480m and 212500m respectively
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 214480m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 214480m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -212500m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 212500m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 212500m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -214480m, -20),
             // Initial margin requirement (including premium) for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 10000m * 9 / 10, -1),
@@ -1503,10 +1540,18 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -1, (1000000m - 140000m) + 140000m + 212500m),
             new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -10, (1000000m - 140000m) + 140000m + 212500m),
             new TestCaseData(OptionStrategyDefinitions.Conversion, 10, -20, (1000000m - 140000m) + 140000m + 212500m),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -1, 1000000m - 140000m),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 1, (1000000m - 140000m) + 140000m + 324480m),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 10, (1000000m - 140000m) + 140000m + 324480m),
-            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 20, (1000000m - 140000m) + 140000m + 324480m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, -1, 1000000m - 30000m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 1, (1000000m - 30000m) + 30000m + 214480m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 10, (1000000m - 30000m) + 30000m + 214480m),
+            new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 20, (1000000m - 30000m) + 30000m + 214480m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 1, 1000000m - 30000m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -1, (1000000m - 30000m) + 30000m + 214480m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -10, (1000000m - 30000m) + 30000m + 214480m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -20, (1000000m - 30000m) + 30000m + 214480m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -1, 1000000m - 140000m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 1, (1000000m - 140000m) + 140000m + 212500m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 10, (1000000m - 140000m) + 140000m + 212500m),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 20, (1000000m - 140000m) + 140000m + 212500m),
             new TestCaseData(OptionStrategyDefinitions.NakedCall, 10, +1, 1000000m - 194000m),
             new TestCaseData(OptionStrategyDefinitions.NakedCall, 10, -1, (1000000m - 194000m) + 194000m + 194000m),
             new TestCaseData(OptionStrategyDefinitions.NakedCall, 10, -10, (1000000m - 194000m) + 194000m + 194000m),
@@ -1956,6 +2001,14 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 1),
             new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 10),
             new TestCaseData(OptionStrategyDefinitions.Conversion, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.ReverseConversion, -10, 20),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, 1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -1),
             new TestCaseData(OptionStrategyDefinitions.BearCallSpread, 10, -10),
@@ -2348,6 +2401,12 @@ namespace QuantConnect.Tests.Common.Securities
                 _equity.Holdings.SetHoldings(_equity.Price, initialHoldingsQuantity * _putOption.ContractMultiplier);
                 spyMay19_300Call.Holdings.SetHoldings(spyMay19_300Call.Price, -initialHoldingsQuantity);
                 spyMay19_300Put.Holdings.SetHoldings(spyMay19_300Put.Price, initialHoldingsQuantity);
+            }
+            else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.ReverseConversion.Name)
+            {
+                _equity.Holdings.SetHoldings(_equity.Price, -initialHoldingsQuantity * _putOption.ContractMultiplier);
+                spyMay19_300Call.Holdings.SetHoldings(spyMay19_300Call.Price, initialHoldingsQuantity);
+                spyMay19_300Put.Holdings.SetHoldings(spyMay19_300Put.Price, -initialHoldingsQuantity);
             }
             else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.BearCallSpread.Name)
             {

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -1171,13 +1171,13 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 102500m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectivePut, -10, -102520m, -20),
-            // Initial margin requirement (including premium) for ProtectiveCollar with quantity 10 and -10 is 192500m and 284880m respectively
+            // Initial margin requirement (including premium) for ProtectiveCollar with quantity 10 and -10 is 192500m and 284480m respectively
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 192500m * 11 / 10, +1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 192500m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, 0m, -10),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -284880m, -20),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 284880m * 11 / 10, +1),
-            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 284880m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, 10, -284480m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 284480m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 284480m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.ProtectiveCollar, -10, -192500m, -20),
             // Initial margin requirement (including premium) for BearCallSpread with quantity 10 and -10 is 10000 and 12000 respectively

--- a/Tests/Common/Securities/Options/OptionStrategiesTests.cs
+++ b/Tests/Common/Securities/Options/OptionStrategiesTests.cs
@@ -210,7 +210,7 @@ namespace QuantConnect.Tests.Common.Securities.Options
 
             var strategy = OptionStrategies.ReverseConversion(canonicalOptionSymbol, strike, expiration);
 
-            Assert.AreEqual(OptionStrategyDefinitions.Conversion.Name, strategy.Name);
+            Assert.AreEqual(OptionStrategyDefinitions.ReverseConversion.Name, strategy.Name);
             Assert.AreEqual(underlying, strategy.Underlying);
             Assert.AreEqual(canonicalOptionSymbol, strategy.CanonicalOption);
             Assert.AreEqual(2, strategy.OptionLegs.Count);

--- a/Tests/Common/Securities/Options/OptionStrategiesTests.cs
+++ b/Tests/Common/Securities/Options/OptionStrategiesTests.cs
@@ -201,6 +201,39 @@ namespace QuantConnect.Tests.Common.Securities.Options
         }
 
         [Test]
+        public void BuildsReverseConversionStrategy()
+        {
+            var canonicalOptionSymbol = Symbols.SPY_Option_Chain;
+            var underlying = Symbols.SPY;
+            var strike = 350m;
+            var expiration = new DateTime(2023, 08, 18);
+
+            var strategy = OptionStrategies.ReverseConversion(canonicalOptionSymbol, strike, expiration);
+
+            Assert.AreEqual(OptionStrategyDefinitions.Conversion.Name, strategy.Name);
+            Assert.AreEqual(underlying, strategy.Underlying);
+            Assert.AreEqual(canonicalOptionSymbol, strategy.CanonicalOption);
+            Assert.AreEqual(2, strategy.OptionLegs.Count);
+
+            var callOptionLeg = strategy.OptionLegs[0];
+            Assert.AreEqual(OptionRight.Call, callOptionLeg.Right);
+            Assert.AreEqual(strike, callOptionLeg.Strike);
+            Assert.AreEqual(expiration, callOptionLeg.Expiration);
+            Assert.AreEqual(1, callOptionLeg.Quantity);
+
+            var putOptionLeg = strategy.OptionLegs[1];
+            Assert.AreEqual(OptionRight.Put, putOptionLeg.Right);
+            Assert.AreEqual(strike, putOptionLeg.Strike);
+            Assert.AreEqual(expiration, putOptionLeg.Expiration);
+            Assert.AreEqual(-1, putOptionLeg.Quantity);
+
+            Assert.AreEqual(1, strategy.UnderlyingLegs.Count);
+            var underlyingLeg = strategy.UnderlyingLegs[0];
+            Assert.AreEqual(underlying, underlyingLeg.Symbol);
+            Assert.AreEqual(-100, underlyingLeg.Quantity);
+        }
+
+        [Test]
         public void BuildsNakedCallStrategy()
         {
             var canonicalOptionSymbol = Symbols.SPY_Option_Chain;

--- a/Tests/Common/Securities/Options/OptionStrategiesTests.cs
+++ b/Tests/Common/Securities/Options/OptionStrategiesTests.cs
@@ -168,6 +168,39 @@ namespace QuantConnect.Tests.Common.Securities.Options
         }
 
         [Test]
+        public void BuildsConversionStrategy()
+        {
+            var canonicalOptionSymbol = Symbols.SPY_Option_Chain;
+            var underlying = Symbols.SPY;
+            var strike = 350m;
+            var expiration = new DateTime(2023, 08, 18);
+
+            var strategy = OptionStrategies.Conversion(canonicalOptionSymbol, strike, expiration);
+
+            Assert.AreEqual(OptionStrategyDefinitions.Conversion.Name, strategy.Name);
+            Assert.AreEqual(underlying, strategy.Underlying);
+            Assert.AreEqual(canonicalOptionSymbol, strategy.CanonicalOption);
+            Assert.AreEqual(2, strategy.OptionLegs.Count);
+
+            var callOptionLeg = strategy.OptionLegs[0];
+            Assert.AreEqual(OptionRight.Call, callOptionLeg.Right);
+            Assert.AreEqual(strike, callOptionLeg.Strike);
+            Assert.AreEqual(expiration, callOptionLeg.Expiration);
+            Assert.AreEqual(-1, callOptionLeg.Quantity);
+
+            var putOptionLeg = strategy.OptionLegs[1];
+            Assert.AreEqual(OptionRight.Put, putOptionLeg.Right);
+            Assert.AreEqual(strike, putOptionLeg.Strike);
+            Assert.AreEqual(expiration, putOptionLeg.Expiration);
+            Assert.AreEqual(1, putOptionLeg.Quantity);
+
+            Assert.AreEqual(1, strategy.UnderlyingLegs.Count);
+            var underlyingLeg = strategy.UnderlyingLegs[0];
+            Assert.AreEqual(underlying, underlyingLeg.Symbol);
+            Assert.AreEqual(100, underlyingLeg.Quantity);
+        }
+
+        [Test]
         public void BuildsNakedCallStrategy()
         {
             var canonicalOptionSymbol = Symbols.SPY_Option_Chain;

--- a/Tests/Common/Securities/Options/OptionStrategiesTests.cs
+++ b/Tests/Common/Securities/Options/OptionStrategiesTests.cs
@@ -134,6 +134,40 @@ namespace QuantConnect.Tests.Common.Securities.Options
         }
 
         [Test]
+        public void BuildsProtectiveCollarStrategy()
+        {
+            var canonicalOptionSymbol = Symbols.SPY_Option_Chain;
+            var underlying = Symbols.SPY;
+            var callStrike = 350m;
+            var putStrike = 300m;
+            var expiration = new DateTime(2023, 08, 18);
+
+            var strategy = OptionStrategies.ProtectiveCollar(canonicalOptionSymbol, callStrike, putStrike, expiration);
+
+            Assert.AreEqual(OptionStrategyDefinitions.ProtectiveCollar.Name, strategy.Name);
+            Assert.AreEqual(underlying, strategy.Underlying);
+            Assert.AreEqual(canonicalOptionSymbol, strategy.CanonicalOption);
+            Assert.AreEqual(2, strategy.OptionLegs.Count);
+
+            var callOptionLeg = strategy.OptionLegs[0];
+            Assert.AreEqual(OptionRight.Call, callOptionLeg.Right);
+            Assert.AreEqual(callStrike, callOptionLeg.Strike);
+            Assert.AreEqual(expiration, callOptionLeg.Expiration);
+            Assert.AreEqual(-1, callOptionLeg.Quantity);
+
+            var putOptionLeg = strategy.OptionLegs[1];
+            Assert.AreEqual(OptionRight.Put, putOptionLeg.Right);
+            Assert.AreEqual(putStrike, putOptionLeg.Strike);
+            Assert.AreEqual(expiration, putOptionLeg.Expiration);
+            Assert.AreEqual(1, putOptionLeg.Quantity);
+
+            Assert.AreEqual(1, strategy.UnderlyingLegs.Count);
+            var underlyingLeg = strategy.UnderlyingLegs[0];
+            Assert.AreEqual(underlying, underlyingLeg.Symbol);
+            Assert.AreEqual(100, underlyingLeg.Quantity);
+        }
+
+        [Test]
         public void BuildsNakedCallStrategy()
         {
             var canonicalOptionSymbol = Symbols.SPY_Option_Chain;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Add support Protective Collar, Conversion and Reverse Conversion to abstraction option combo orders in `OptionStrategies` class.
(source of margin requirement: https://www.interactivebrokers.com.hk/en/trading/margin-options.php)

Margin (might have very slight difference due to non-perfect underlying price -> other strategy minorly involved [<$5]):
- Protective Collar:
<img width="344" alt="collar" src="https://github.com/QuantConnect/Lean/assets/56447733/a057b689-6d98-4c69-be79-39626adc2cae">

- Conversion:
<img width="344" alt="collar" src="https://github.com/QuantConnect/Lean/assets/56447733/1e5ae18c-0e6b-4bfc-b62d-d372ac562a72">

- Reversal:
<img width="343" alt="reversal" src="https://github.com/QuantConnect/Lean/assets/56447733/b473d5f5-dac8-47a2-b0c5-9d2eb572ac2a">

#### Related Issue
closes #6919
closes #8035
closes #8036

#### Motivation and Context
missing feature

#### Requires Documentation Change
Amendment to https://www.quantconnect.com/docs/v2/writing-algorithms/trading-and-orders/option-strategies/protective-collar
Add new page for `Conversion` and `Reverse Conversion`

#### How Has This Been Tested?
- added unit test
- added regression test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
