### PR TITLE
Change access modifiers for futures month lookup collections

### DIFF
--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -41,7 +41,7 @@ namespace QuantConnect
             /// <summary>
             /// Underlying name
             /// </summary>
-            public string Underlying { get; set;  }
+            public string Underlying { get; set; }
 
             /// <summary>
             /// Short expiration year
@@ -127,12 +127,12 @@ namespace QuantConnect
                 return null;
             }
 
-            if (!_futuresMonthCodeLookup.ContainsKey(expirationMonthString))
+            if (!FuturesMonthCodeLookup.ContainsKey(expirationMonthString))
             {
                 return null;
             }
 
-            var expirationMonth = _futuresMonthCodeLookup[expirationMonthString];
+            var expirationMonth = FuturesMonthCodeLookup[expirationMonthString];
 
             return new FutureTickerProperties
             {
@@ -164,8 +164,7 @@ namespace QuantConnect
 
             if (!SymbolPropertiesDatabase.FromDataFolder().TryGetMarket(underlying, SecurityType.Future, out var market))
             {
-                Log.Debug($@"SymbolRepresentation.ParseFutureSymbol(): {
-                    Messages.SymbolRepresentation.FailedToGetMarketForTickerAndUnderlying(ticker, underlying)}");
+                Log.Debug($@"SymbolRepresentation.ParseFutureSymbol(): {Messages.SymbolRepresentation.FailedToGetMarketForTickerAndUnderlying(ticker, underlying)}");
                 return null;
             }
 
@@ -283,7 +282,7 @@ namespace QuantConnect
 
             var expirationDay = includeExpirationDate ? $"{expiration.Day:00}" : string.Empty;
 
-            return $"{underlying}{expirationDay}{_futuresMonthLookup[month]}{year}";
+            return $"{underlying}{expirationDay}{FuturesMonthLookup[month]}{year}";
         }
 
         /// <summary>
@@ -363,7 +362,7 @@ namespace QuantConnect
                 // let it fallback to it's default handling, which include mapping
                 optionTicker = null;
             }
-            else if(securityType == SecurityType.IndexOption)
+            else if (securityType == SecurityType.IndexOption)
             {
                 underlyingSid = SecurityIdentifier.GenerateIndex(OptionSymbol.MapToUnderlying(optionTicker, securityType), market);
             }
@@ -466,7 +465,7 @@ namespace QuantConnect
         /// Provides a lookup dictionary for mapping futures month codes to their corresponding numeric values.
         /// </summary>
 #pragma warning disable CA2211 // Non-constant fields should not be visible
-        public static IReadOnlyDictionary<string, int> _futuresMonthCodeLookup = new Dictionary<string, int>
+        public static IReadOnlyDictionary<string, int> FuturesMonthCodeLookup { get; } = new Dictionary<string, int>
         {
             { "F", 1 }, // January
             { "G", 2 }, // February
@@ -485,7 +484,7 @@ namespace QuantConnect
         /// <summary>
         /// Provides a lookup dictionary for mapping numeric values to their corresponding futures month codes.
         /// </summary>
-        public static IReadOnlyDictionary<int, string> _futuresMonthLookup = _futuresMonthCodeLookup.ToDictionary(kv => kv.Value, kv => kv.Key);
+        public static IReadOnlyDictionary<int, string> FuturesMonthLookup { get; } = FuturesMonthCodeLookup.ToDictionary(kv => kv.Value, kv => kv.Key);
 #pragma warning restore CA2211 // Non-constant fields should not be visible
 
         /// <summary>

--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -462,24 +462,31 @@ namespace QuantConnect
 
                         };
 
+        /// <summary>
+        /// Provides a lookup dictionary for mapping futures month codes to their corresponding numeric values.
+        /// </summary>
+#pragma warning disable CA2211 // Non-constant fields should not be visible
+        public static IReadOnlyDictionary<string, int> _futuresMonthCodeLookup = new Dictionary<string, int>
+        {
+            { "F", 1 }, // January
+            { "G", 2 }, // February
+            { "H", 3 }, // March
+            { "J", 4 }, // April
+            { "K", 5 }, // May
+            { "M", 6 }, // June
+            { "N", 7 }, // July
+            { "Q", 8 }, // August
+            { "U", 9 }, // September
+            { "V", 10 }, // October
+            { "X", 11 }, // November
+            { "Z", 12 } // December
+        };
 
-        private static IReadOnlyDictionary<string, int> _futuresMonthCodeLookup = new Dictionary<string, int>
-                        {
-                            { "F", 1 },
-                            { "G", 2 },
-                            { "H", 3 },
-                            { "J", 4 },
-                            { "K", 5 },
-                            { "M", 6 },
-                            { "N", 7 },
-                            { "Q", 8 },
-                            { "U", 9 },
-                            { "V", 10 },
-                            { "X", 11 },
-                            { "Z", 12 }
-                        };
-
-        private static IReadOnlyDictionary<int, string> _futuresMonthLookup = _futuresMonthCodeLookup.ToDictionary(kv => kv.Value, kv => kv.Key);
+        /// <summary>
+        /// Provides a lookup dictionary for mapping numeric values to their corresponding futures month codes.
+        /// </summary>
+        public static IReadOnlyDictionary<int, string> _futuresMonthLookup = _futuresMonthCodeLookup.ToDictionary(kv => kv.Value, kv => kv.Key);
+#pragma warning restore CA2211 // Non-constant fields should not be visible
 
         /// <summary>
         /// Get the expiration year from short year (two-digit integer).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This Pull Request modifies the access modifiers for the `_futuresMonthCodeLookup` and `_futuresMonthLookup` collections, making them accessible from outside their containing class.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The motivation behind this change is to allow access to these lookup collections from other classes or modules within the project. Currently, they are declared with the default access modifier, limiting their visibility to only within the containing class. By changing the access modifiers to public, other parts of the codebase can utilize these collections without needing to expose the entire containing class.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change has been tested locally by ensuring that other classes within the project can successfully access and utilize the _futuresMonthCodeLookup and _futuresMonthLookup collections after the access modifier modification. Unit tests covering the functionality of these collections have also been executed to verify that the changes do not introduce any regressions.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
