### PR TITLE
Box Spread Option Strategy

### DIFF
--- a/Algorithm.CSharp/OptionEquityBoxSpreadRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionEquityBoxSpreadRegressionAlgorithm.cs
@@ -1,0 +1,132 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using System.Collections.Generic;
+using QuantConnect.Securities.Option.StrategyMatcher;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm exercising an equity Box Spread option strategy and asserting it's being detected by Lean and works as expected
+    /// </summary>
+    public class OptionEquityBoxSpreadRegressionAlgorithm : OptionEquityBaseStrategyRegressionAlgorithm
+    {
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
+        {
+            if (!Portfolio.Invested)
+            {
+                OptionChain chain;
+                if (IsMarketOpen(_optionSymbol) && slice.OptionChains.TryGetValue(_optionSymbol, out chain))
+                {
+                    var contracts = chain.GroupBy(x => x.Expiry)
+                        .First()
+                        .OrderBy(x => x.Strike)
+                        .ToList();
+
+                    var buySidePut = contracts.First(contract => contract.Right == OptionRight.Put);
+
+                    var sellSidePut = contracts.Last(contract => contract.Right == OptionRight.Put
+                        && contract.Expiry == buySidePut.Expiry
+                        && contract.Strike > buySidePut.Strike);
+
+                    var buySideCall = contracts.First(contract => contract.Right == OptionRight.Call
+                        && contract.Expiry == buySidePut.Expiry
+                        && contract.Strike == buySidePut.Strike);
+
+                    var sellSideCall = contracts.First(contract => contract.Right == OptionRight.Call
+                        && contract.Expiry == buySidePut.Expiry
+                        && contract.Strike == sellSidePut.Strike);
+
+                    var initialMargin = Portfolio.MarginRemaining;
+                    MarketOrder(buySideCall.Symbol, +10);
+                    MarketOrder(buySidePut.Symbol, -10);
+
+                    MarketOrder(sellSideCall.Symbol, -10);
+                    MarketOrder(sellSidePut.Symbol, +10);
+
+                    AssertOptionStrategyIsPresent(OptionStrategyDefinitions.BoxSpread.Name, 10);
+
+                    var freeMarginPostTrade = Portfolio.MarginRemaining;
+                    var expectedMarginUsage = 0m;
+                    if (expectedMarginUsage != Portfolio.TotalMarginUsed)
+                    {
+                        throw new Exception("Unexpect margin used!");
+                    }
+
+                    // we payed the ask and value using the assets price
+                    var priceSpreadDifference = GetPriceSpreadDifference(buySidePut.Symbol, buySideCall.Symbol,
+                        sellSidePut.Symbol, sellSideCall.Symbol);
+                    if (initialMargin != (freeMarginPostTrade + expectedMarginUsage + _paidFees - priceSpreadDifference))
+                    {
+                        throw new Exception("Unexpect margin remaining!");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public override long DataPoints => 471135;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public override int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "4"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "200000"},
+            {"End Equity", "197624"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$26.00"},
+            {"Estimated Strategy Capacity", "$64000.00"},
+            {"Lowest Capacity Asset", "GOOCV W78ZERHAOVVQ|GOOCV VP83T1ZUHROL"},
+            {"Portfolio Turnover", "27.98%"},
+            {"OrderListHash", "27e4456cb375fae2a15697c803bc0779"}
+        };
+    }
+}

--- a/Algorithm.CSharp/OptionEquityShortBoxSpreadRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionEquityShortBoxSpreadRegressionAlgorithm.cs
@@ -1,0 +1,139 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using System.Collections.Generic;
+using QuantConnect.Securities.Option.StrategyMatcher;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm exercising an equity Short Box Spread option strategy and asserting it's being detected by Lean and works as expected
+    /// </summary>
+    public class OptionEquityShortBoxSpreadRegressionAlgorithm : OptionEquityBaseStrategyRegressionAlgorithm
+    {
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
+        {
+            if (!Portfolio.Invested)
+            {
+                OptionChain chain;
+                if (IsMarketOpen(_optionSymbol) && slice.OptionChains.TryGetValue(_optionSymbol, out chain))
+                {
+                    var contracts = chain.GroupBy(x => x.Expiry)
+                        .First()
+                        .OrderBy(x => x.Strike)
+                        .ToList();
+
+                    var buySidePut = contracts.Last(contract => contract.Right == OptionRight.Put);
+
+                    var sellSidePut = contracts.First(contract => contract.Right == OptionRight.Put
+                        && contract.Expiry == buySidePut.Expiry
+                        && contract.Strike < buySidePut.Strike);
+
+                    var buySideCall = contracts.First(contract => contract.Right == OptionRight.Call
+                        && contract.Expiry == buySidePut.Expiry
+                        && contract.Strike == buySidePut.Strike);
+
+                    var sellSideCall = contracts.First(contract => contract.Right == OptionRight.Call
+                        && contract.Expiry == buySidePut.Expiry
+                        && contract.Strike == sellSidePut.Strike);
+
+                    var initialMargin = Portfolio.MarginRemaining;
+                    MarketOrder(buySideCall.Symbol, +10);
+                    MarketOrder(buySidePut.Symbol, -10);
+
+                    MarketOrder(sellSideCall.Symbol, -10);
+                    MarketOrder(sellSidePut.Symbol, +10);
+
+                    AssertOptionStrategyIsPresent(OptionStrategyDefinitions.ShortBoxSpread.Name, 10);
+
+                    var freeMarginPostTrade = Portfolio.MarginRemaining;
+
+                    var commissionFees = 10m * 0.65m * 4m;
+                    var orderCosts = sellSideCall.AskPrice - buySideCall.BidPrice + buySidePut.AskPrice - sellSidePut.BidPrice;
+                    var closeCost = commissionFees + orderCosts * 1000m;
+
+                    var strikeDifference = buySideCall.Strike - sellSideCall.Strike;
+
+                    var expectedMarginUsage = Math.Max(1.02m * closeCost, strikeDifference * 1000m);
+                    if (expectedMarginUsage != Portfolio.TotalMarginUsed)
+                    {
+                        throw new Exception("Unexpect margin used!");
+                    }
+
+                    // we payed the ask and value using the assets price
+                    var priceSpreadDifference = GetPriceSpreadDifference(buySidePut.Symbol, buySideCall.Symbol,
+                        sellSidePut.Symbol, sellSideCall.Symbol);
+                    if (initialMargin != (freeMarginPostTrade + expectedMarginUsage + _paidFees - priceSpreadDifference))
+                    {
+                        throw new Exception("Unexpect margin remaining!");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public override long DataPoints => 471135;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public override int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "4"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "200000"},
+            {"End Equity", "197924"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$26.00"},
+            {"Estimated Strategy Capacity", "$23000.00"},
+            {"Lowest Capacity Asset", "GOOCV W78ZERHAOVVQ|GOOCV VP83T1ZUHROL"},
+            {"Portfolio Turnover", "28.04%"},
+            {"OrderListHash", "f91f438caebb667dda197418168eadd3"}
+        };
+    }
+}

--- a/Common/Securities/Option/OptionStrategyPositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Option/OptionStrategyPositionGroupBuyingPowerModel.cs
@@ -204,7 +204,7 @@ namespace QuantConnect.Securities.Option
                 var shortPutSecurity = (Option)parameters.Portfolio.Securities[shortPutPosition.Symbol];
 
                 // commission cost: MAX($1, $0.65/contract * quantity) + bid/ask price
-                var commissionFees = Math.Max(Math.Abs(longCallPosition.Quantity) * 0.65m, 1m) * 4m;
+                var commissionFees = Math.Max(Math.Abs(longCallPosition.Quantity) * 0.65m, 1m) * 4m;    // 4 contracts in total
                 var orderCosts = shortCallSecurity.AskPrice - longCallSecurity.BidPrice + shortPutSecurity.AskPrice - longPutSecurity.BidPrice;
                 var multiplier = Math.Abs(longCallPosition.Quantity) * longCallSecurity.ContractUnitOfTrade;
                 var closeCost = commissionFees + orderCosts * multiplier;

--- a/Common/Securities/Option/OptionStrategyPositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Option/OptionStrategyPositionGroupBuyingPowerModel.cs
@@ -19,6 +19,7 @@ using QuantConnect.Orders.Fees;
 using QuantConnect.Securities.Positions;
 using QuantConnect.Securities.Option.StrategyMatcher;
 using System.Collections.Generic;
+using QuantConnect.Orders;
 
 namespace QuantConnect.Securities.Option
 {
@@ -182,6 +183,39 @@ namespace QuantConnect.Securities.Option
                 var result = GetShortPutLongPutStrikeDifferenceMargin(parameters.PositionGroup, parameters.Portfolio);
                 return new MaintenanceMargin(result);
             }
+            else if (_optionStrategy.Name == OptionStrategyDefinitions.BoxSpread.Name)
+            {
+                return new MaintenanceMargin(0);
+            }
+            else if (_optionStrategy.Name == OptionStrategyDefinitions.ShortBoxSpread.Name)
+            {
+                // MAX(1.02 x cost to close, Long Call Strike – Short Call Strike)
+                var longCallPosition = parameters.PositionGroup.Positions.Single(
+                    position => position.Quantity > 0 && position.Symbol.ID.OptionRight == OptionRight.Call);
+                var shortCallPosition = parameters.PositionGroup.Positions.Single(
+                    position => position.Quantity < 0 && position.Symbol.ID.OptionRight == OptionRight.Call);
+                var longPutPosition = parameters.PositionGroup.Positions.Single(
+                    position => position.Quantity > 0 && position.Symbol.ID.OptionRight == OptionRight.Put);
+                var shortPutPosition = parameters.PositionGroup.Positions.Single(
+                    position => position.Quantity < 0 && position.Symbol.ID.OptionRight == OptionRight.Put);
+                var longCallSecurity = (Option)parameters.Portfolio.Securities[longCallPosition.Symbol];
+                var shortCallSecurity = (Option)parameters.Portfolio.Securities[shortCallPosition.Symbol];
+                var longPutSecurity = (Option)parameters.Portfolio.Securities[longPutPosition.Symbol];
+                var shortPutSecurity = (Option)parameters.Portfolio.Securities[shortPutPosition.Symbol];
+
+                // commission cost: MAX($1, $0.65/contract * quantity) + bid/ask price
+                var commissionFees = Math.Max(Math.Abs(longCallPosition.Quantity) * 0.65m, 1m) * 4m;
+                var orderCosts = shortCallSecurity.AskPrice - longCallSecurity.BidPrice + shortPutSecurity.AskPrice - longPutSecurity.BidPrice;
+                var multiplier = Math.Abs(longCallPosition.Quantity) * longCallSecurity.ContractUnitOfTrade;
+                var closeCost = commissionFees + orderCosts * multiplier;
+                
+                var strikeDifference = longCallPosition.Symbol.ID.StrikePrice - shortCallPosition.Symbol.ID.StrikePrice;
+
+                var result = Math.Max(1.02m * closeCost, strikeDifference * multiplier);
+                var inAccountCurrency = parameters.Portfolio.CashBook.ConvertToAccountCurrency(result, longCallSecurity.QuoteCurrency.Symbol);
+
+                return new MaintenanceMargin(inAccountCurrency);
+            }
 
             throw new NotImplementedException($"Option strategy {_optionStrategy.Name} margin modeling has yet to be implemented");
         }
@@ -286,6 +320,14 @@ namespace QuantConnect.Securities.Option
             else if (_optionStrategy.Name == OptionStrategyDefinitions.IronCondor.Name)
             {
                 result = GetShortPutLongPutStrikeDifferenceMargin(parameters.PositionGroup, parameters.Portfolio);
+            }
+            else if (_optionStrategy.Name == OptionStrategyDefinitions.BoxSpread.Name)
+            {
+                result = 0m;
+            }
+            else if (_optionStrategy.Name == OptionStrategyDefinitions.ShortBoxSpread.Name)
+            {
+                result = GetMaintenanceMargin(new PositionGroupMaintenanceMarginParameters(parameters.Portfolio, parameters.PositionGroup));
             }
             else
             {

--- a/Common/Securities/Option/StrategyMatcher/OptionStrategyDefinitions.cs
+++ b/Common/Securities/Option/StrategyMatcher/OptionStrategyDefinitions.cs
@@ -328,5 +328,37 @@ namespace QuantConnect.Securities.Option.StrategyMatcher
                 OptionStrategyDefinition.CallLeg(1, (legs, p) => p.Strike > legs[2].Strike,
                     (legs, p) => p.Expiration == legs[0].Expiration)
             );
+
+        /// <summary>
+        /// Long Box Spread strategy is long 1 call and short 1 put with the same strike,
+        /// while short 1 call and long 1 put with a higher, same strike. All options have the same expiry.
+        /// expiration.
+        /// </summary>
+        public static OptionStrategyDefinition BoxSpread { get; }
+            = OptionStrategyDefinition.Create("Box Spread",
+                OptionStrategyDefinition.PutLeg(+1),
+                OptionStrategyDefinition.PutLeg(-1, (legs, p) => p.Strike < legs[0].Strike,
+                                                    (legs, p) => p.Expiration == legs[0].Expiration),
+                OptionStrategyDefinition.CallLeg(+1, (legs, c) => c.Strike == legs[1].Strike,
+                                                    (legs, c) => c.Expiration == legs[0].Expiration),
+                OptionStrategyDefinition.CallLeg(-1, (legs, c) => c.Strike == legs[0].Strike,
+                                                    (legs, c) => c.Expiration == legs[0].Expiration)
+            );
+
+        /// <summary>
+        /// Short Box Spread strategy is short 1 call and long 1 put with the same strike,
+        /// while long 1 call and short 1 put with a higher, same strike. All options have the same expiry.
+        /// expiration.
+        /// </summary>
+        public static OptionStrategyDefinition ShortBoxSpread { get; }
+            = OptionStrategyDefinition.Create("Short Box Spread",
+                OptionStrategyDefinition.PutLeg(-1),
+                OptionStrategyDefinition.PutLeg(+1, (legs, p) => p.Strike < legs[0].Strike,
+                                                    (legs, p) => p.Expiration == legs[0].Expiration),
+                OptionStrategyDefinition.CallLeg(-1, (legs, c) => c.Strike == legs[1].Strike,
+                                                    (legs, c) => c.Expiration == legs[0].Expiration),
+                OptionStrategyDefinition.CallLeg(+1, (legs, c) => c.Strike == legs[0].Strike,
+                                                    (legs, c) => c.Expiration == legs[0].Expiration)
+            );
     }
 }

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -414,6 +414,36 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, 20, true), // -20 to 0
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, -(1000000 - 20 * 0) / (0 + 1001), true),    // -20 to max short
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -20, -(1000000 - 20 * 0) / (0 + 1001) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for BoxSpread with quantities 1 and -1 are 0|2003 and 2000|0 respectively
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 0, (1000000 - 0 * 0) / (0 + 2003), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 0, (1000000 - 0 * 0) / (0 + 2003) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 0, -(1000000 + 0 * 2000) / (2000 + 0), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 0, -(1000000 + 0 * 2000) / (2000 + 0) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 20, (1000000 - 20 * 0) / (0 + 2003), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 20, (1000000 - 20 * 0) / (0 + 2003) + 1, false),    // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 20, -20, true), // 20 to 0
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 20, -(1000000 + 20 * 2000) / (2000 + 0), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 20, -(1000000 + 20 * 2000) / (2000 + 0) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -20, (1000000 + 20 * 0) / (0 + 2003), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -20, (1000000 + 20 * 0) / (0 + 2003) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -20, 20, true), // -20 to 0
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -20, -(1000000 - 20 * 2000) / (2000 + 0), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -20, -(1000000 - 20 * 2000) / (2000 + 0) - 1, false),  // -20 to max short + 1
+            // Initial margin requirement|premium for ShortBoxSpread with quantities 1 and -1 are 2000|0 and 0|2003 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 0, (1000000 - 0 * 2000) / (2000 + 0), true), // 0 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 0, (1000000 - 0 * 2000) / (2000 + 0) + 1, false), // 0 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 0, -(1000000 + 0 * 0) / (0 + 2003), true), // 0 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 0, -(1000000 + 0 * 0) / (0 + 2003) - 1, false),    // 0 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 20, (1000000 - 20 * 2000) / (2000 + 0), true),    // 20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 20, (1000000 - 20 * 2000) / (2000 + 0) + 1, false),    // 20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 20, -20, true), // 20 to 0
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 20, -(1000000 + 20 * 0) / (0 + 2003), true), // 20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 20, -(1000000 + 20 * 0) / (0 + 2003) - 1, false),  // 20 to max short + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -20, (1000000 + 20 * 2000) / (2000 + 0), true),   // -20 to max long
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -20, (1000000 + 20 * 2000) / (2000 + 0) + 1, false),   // -20 to max long + 1
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -20, 20, true), // -20 to 0
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -20, -(1000000 - 20 * 0) / (0 + 2003), true),    // -20 to max short
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -20, -(1000000 - 20 * 0) / (0 + 2003) - 1, false),  // -20 to max short + 1
         };
 
         [TestCaseSource(nameof(HasSufficientBuyingPowerForOrderTestCases))]
@@ -652,6 +682,10 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -1, 0m),             // IB:  0
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 1, 1000m),                       // IB:  1001
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -1, 0m),                         // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 1, 0m),                           // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -1, 2000m),                       // IB:  short box spread
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 1, 2000m),                   // IB:  2000
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -1, 0m),                     // IB:  box spread
         };
 
         [TestCaseSource(nameof(InitialMarginRequirementsTestCases))]
@@ -746,6 +780,10 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.ShortPutCalendarSpread, -1, 0m),             // IB:  0
             new TestCaseData(OptionStrategyDefinitions.IronCondor, 1, 1000m),                       // IB:  1017.62
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -1, 0m),                         // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 1, 0m),                           // IB:  0
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -1, 2000m),                       // IB:  short box spread
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 1, 2000m),                   // IB:  2000
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -1, 0m),                     // IB:  box spread
         };
 
         [TestCaseSource(nameof(MaintenanceMarginTestCases))]
@@ -972,6 +1010,24 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -10010m / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -10010m, -10),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -10010m - 10000m, -20),
+            // Initial margin requirement (including premium) for BoxSpread with quantity 10 and -10 is 20030 and 20000 respectively
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, 20030m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, -20030m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, -20030m, -10),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, -20030m - 20000m, -20),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, 20000m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, -20000m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, -20000m, -10),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, -20000m - 20030m, -20),
+            // Initial margin requirement (including premium) for ShortBoxSpread with quantity 10 and -10 is 20000 and 20030 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, 20000m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, -20000m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, -20000m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, -20000m - 20030m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, 20030m / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, -20030m / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, -20030m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, -20030m - 20000m, -20),
         };
 
         [TestCaseSource(nameof(OrderQuantityForDeltaBuyingPowerTestCases))]
@@ -1296,6 +1352,24 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 10010m * 9 / 10, -1),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 0m, -10),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, -10000m, -20),
+            // Initial margin requirement (including premium) for BoxSpread with quantity 10 and -10 is 20030 and 20000 respectively
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, 20030m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, 20030m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, -20000m, -20),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, 20000m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, 20000m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, -20030m, -20),
+            // Initial margin requirement (including premium) for ShortBoxSpread with quantity 10 and -10 is 20000 and 20030 respectively
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, 20000m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, 20000m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, -20030m, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, 20030m * 11 / 10, +1),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, 20030m * 9 / 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, 0m, -10),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, -20000m, -20),
         };
 
         [TestCaseSource(nameof(OrderQuantityForTargetBuyingPowerTestCases))]
@@ -1569,6 +1643,22 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 1, (1000000m - 0) + 0 + 10010m),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 10, (1000000m - 0) + 0 + 10010m),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 20, (1000000m - 0) + 0 + 10010m),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, 1, 1000000m - 0m),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, -1, (1000000m - 0m) + 0m + 20030m),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, -10, (1000000m - 0m) + 0m + 20030m),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, -20, (1000000m - 0m) + 0m + 20030m),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, -1, 1000000m - 20000m),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, 1, (1000000m - 20000m) + 20000m + 20000m),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, 10, (1000000m - 20000m) + 20000m + 20000m),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, 20, (1000000m - 20000m) + 20000m + 20000m),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, 1, 1000000m - 20000m),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, -1, (1000000m - 20000m) + 20000m + 20000m),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, -10, (1000000m - 20000m) + 20000m + 20000m),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, -20, (1000000m - 20000m) + 20000m + 20000m),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, -1, 1000000m - 0),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, 1, (1000000m - 0) + 0 + 20030m),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, 10, (1000000m - 0) + 0 + 20030m),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, 20, (1000000m - 0) + 0 + 20030m),
         };
 
         [TestCaseSource(nameof(PositionGroupBuyingPowerTestCases))]
@@ -1986,6 +2076,22 @@ namespace QuantConnect.Tests.Common.Securities
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 1),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 10),
             new TestCaseData(OptionStrategyDefinitions.IronCondor, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.BoxSpread, -10, 20),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, -10),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, 10, -20),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, -1),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, 1),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, 10),
+            new TestCaseData(OptionStrategyDefinitions.ShortBoxSpread, -10, 20),
         };
 
         [TestCaseSource(nameof(ReservedBuyingPowerImpactTestCases))]
@@ -2446,6 +2552,40 @@ namespace QuantConnect.Tests.Common.Securities
                 shortPutOption.Holdings.SetHoldings(shortPutOption.Price, -initialHoldingsQuantity);
                 shortCallOption.Holdings.SetHoldings(shortCallOption.Price, -initialHoldingsQuantity);
                 longCallOption.Holdings.SetHoldings(longCallOption.Price, initialHoldingsQuantity);
+            }
+            else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.BoxSpread.Name)
+            {
+                var longPutOption = spyMay19_320Put;
+                var shortPutOption = spyMay19_300Put;
+                var shortCallOption = spyMay19_320Call;
+                var longCallOption = spyMay19_300Call;
+
+                longPutOption.Holdings.SetHoldings(longPutOption.Price, initialHoldingsQuantity);
+                shortPutOption.Holdings.SetHoldings(shortPutOption.Price, -initialHoldingsQuantity);
+                shortCallOption.Holdings.SetHoldings(shortCallOption.Price, -initialHoldingsQuantity);
+                longCallOption.Holdings.SetHoldings(longCallOption.Price, initialHoldingsQuantity);
+
+                if (initialHoldingsQuantity < 0)
+                {
+                    expectedPositionGroupBPMStrategy = OptionStrategyDefinitions.ShortBoxSpread.Name;
+                }
+            }
+            else if (optionStrategyDefinition.Name == OptionStrategyDefinitions.ShortBoxSpread.Name)
+            {
+                var longPutOption = spyMay19_300Put;
+                var shortPutOption = spyMay19_320Put;
+                var shortCallOption = spyMay19_300Call;
+                var longCallOption = spyMay19_320Call;
+
+                longPutOption.Holdings.SetHoldings(longPutOption.Price, initialHoldingsQuantity);
+                shortPutOption.Holdings.SetHoldings(shortPutOption.Price, -initialHoldingsQuantity);
+                shortCallOption.Holdings.SetHoldings(shortCallOption.Price, -initialHoldingsQuantity);
+                longCallOption.Holdings.SetHoldings(longCallOption.Price, initialHoldingsQuantity);
+
+                if (initialHoldingsQuantity < 0)
+                {
+                    expectedPositionGroupBPMStrategy = OptionStrategyDefinitions.BoxSpread.Name;
+                }
             }
 
             var positionGroup = _portfolio.Positions.Groups.Single();

--- a/Tests/Common/Securities/Options/OptionStrategiesTests.cs
+++ b/Tests/Common/Securities/Options/OptionStrategiesTests.cs
@@ -747,5 +747,92 @@ namespace QuantConnect.Tests.Common.Securities.Options
             Assert.AreEqual(expiration, longCallLeg.Expiration);
             Assert.AreEqual(1, longCallLeg.Quantity);
         }
+
+        [Test]
+        public void FailsBuildingBoxSpreadStrategy()
+        {
+            var canonicalOptionSymbol = Symbols.SPY_Option_Chain;
+            var underlying = Symbols.SPY;
+            var expiration = new DateTime(2023, 08, 18);
+
+            var strike1 = 300m;
+            var strike2 = 325m;
+
+            // Unordered and repeated strikes
+            Assert.Throws<ArgumentException>(
+                () => OptionStrategies.BoxSpread(canonicalOptionSymbol, strike1, strike2, expiration));
+            Assert.Throws<ArgumentException>(
+                () => OptionStrategies.BoxSpread(canonicalOptionSymbol, strike1, strike1, expiration));
+        }
+
+        [Test]
+        public void BuildsBoxSpreadStrategy()
+        {
+            var canonicalOptionSymbol = Symbols.SPY_Option_Chain;
+            var underlying = Symbols.SPY;
+            var higherStrike = 320m;
+            var lowerStrike = 300m;
+            var expiration = new DateTime(2023, 08, 18);
+
+            var strategy = OptionStrategies.BoxSpread(canonicalOptionSymbol, higherStrike, lowerStrike, expiration);
+
+            Assert.AreEqual(OptionStrategyDefinitions.BoxSpread.Name, strategy.Name);
+            Assert.AreEqual(underlying, strategy.Underlying);
+            Assert.AreEqual(canonicalOptionSymbol, strategy.CanonicalOption);
+
+            Assert.AreEqual(4, strategy.OptionLegs.Count);
+            Assert.AreEqual(0, strategy.UnderlyingLegs.Count);
+
+            var longPutLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Put && x.Strike == lowerStrike);
+            Assert.AreEqual(expiration, longPutLeg.Expiration);
+            Assert.AreEqual(-1, longPutLeg.Quantity);
+
+            var shortPutLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Put && x.Strike == higherStrike);
+            Assert.AreEqual(expiration, shortPutLeg.Expiration);
+            Assert.AreEqual(1, shortPutLeg.Quantity);
+
+            var shortCallLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Call && x.Strike == lowerStrike);
+            Assert.AreEqual(expiration, shortCallLeg.Expiration);
+            Assert.AreEqual(1, shortCallLeg.Quantity);
+
+            var longCallLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Call && x.Strike == higherStrike);
+            Assert.AreEqual(expiration, longCallLeg.Expiration);
+            Assert.AreEqual(-1, longCallLeg.Quantity);
+        }
+
+        [Test]
+        public void BuildsShortBoxSpreadStrategy()
+        {
+            var canonicalOptionSymbol = Symbols.SPY_Option_Chain;
+            var underlying = Symbols.SPY;
+            var higherStrike = 320m;
+            var lowerStrike = 300m;
+            var expiration = new DateTime(2023, 08, 18);
+
+            var strategy = OptionStrategies.ShortBoxSpread(canonicalOptionSymbol, higherStrike, lowerStrike, expiration);
+
+            Assert.AreEqual(OptionStrategyDefinitions.ShortBoxSpread.Name, strategy.Name);
+            Assert.AreEqual(underlying, strategy.Underlying);
+            Assert.AreEqual(canonicalOptionSymbol, strategy.CanonicalOption);
+
+            Assert.AreEqual(4, strategy.OptionLegs.Count);
+            Assert.AreEqual(0, strategy.UnderlyingLegs.Count);
+
+            var longPutLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Put && x.Strike == lowerStrike);
+            Assert.AreEqual(expiration, longPutLeg.Expiration);
+            Assert.AreEqual(1, longPutLeg.Quantity);
+
+            var shortPutLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Put && x.Strike == higherStrike);
+            Assert.AreEqual(expiration, shortPutLeg.Expiration);
+            Assert.AreEqual(-1, shortPutLeg.Quantity);
+
+            var shortCallLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Call && x.Strike == lowerStrike);
+            Assert.AreEqual(expiration, shortCallLeg.Expiration);
+            Assert.AreEqual(-1, shortCallLeg.Quantity);
+
+            var longCallLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Call && x.Strike == higherStrike);
+            Assert.AreEqual(expiration, longCallLeg.Expiration);
+            Assert.AreEqual(1, longCallLeg.Quantity);
+        }
     }
 }

--- a/Tests/Common/Securities/Options/OptionStrategiesTests.cs
+++ b/Tests/Common/Securities/Options/OptionStrategiesTests.cs
@@ -783,21 +783,21 @@ namespace QuantConnect.Tests.Common.Securities.Options
             Assert.AreEqual(4, strategy.OptionLegs.Count);
             Assert.AreEqual(0, strategy.UnderlyingLegs.Count);
 
-            var longPutLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Put && x.Strike == lowerStrike);
+            var longPutLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Put && x.Strike == higherStrike);
             Assert.AreEqual(expiration, longPutLeg.Expiration);
-            Assert.AreEqual(-1, longPutLeg.Quantity);
+            Assert.AreEqual(1, longPutLeg.Quantity);
 
-            var shortPutLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Put && x.Strike == higherStrike);
+            var shortPutLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Put && x.Strike == lowerStrike);
             Assert.AreEqual(expiration, shortPutLeg.Expiration);
-            Assert.AreEqual(1, shortPutLeg.Quantity);
+            Assert.AreEqual(-1, shortPutLeg.Quantity);
 
-            var shortCallLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Call && x.Strike == lowerStrike);
+            var shortCallLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Call && x.Strike == higherStrike);
             Assert.AreEqual(expiration, shortCallLeg.Expiration);
-            Assert.AreEqual(1, shortCallLeg.Quantity);
+            Assert.AreEqual(-1, shortCallLeg.Quantity);
 
-            var longCallLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Call && x.Strike == higherStrike);
+            var longCallLeg = strategy.OptionLegs.Single(x => x.Right == OptionRight.Call && x.Strike == lowerStrike);
             Assert.AreEqual(expiration, longCallLeg.Expiration);
-            Assert.AreEqual(-1, longCallLeg.Quantity);
+            Assert.AreEqual(1, longCallLeg.Quantity);
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Add box spread and short box spread option strategy and their buying power model
ref magin requirements from [IB](https://www.interactivebrokers.com.hk/en/trading/margin-options.php)

Box Spread: Margin Impact = 0 USD
<img width="461" alt="image" src="https://github.com/QuantConnect/Lean/assets/56447733/65f62e99-7fbe-459d-a986-19b3f20a618f">

Short Box Spread: Margin Impact = 2000 USD
<img width="455" alt="image" src="https://github.com/QuantConnect/Lean/assets/56447733/2268ab48-c59b-4d60-8446-bf52951e79ef">

#### Related Issue
closes #8033 
closes #8034

#### Motivation and Context
missing

#### Requires Documentation Change
add section to writing algorithm -> tradings and orders -> option strategies

#### How Has This Been Tested?
- added unit tests
- added regression tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
