### PR TITLE
Fix bug in FrontMonth() option filter

### DIFF
--- a/Algorithm.CSharp/OptionChainSubscriptionRemovalRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionChainSubscriptionRemovalRegressionAlgorithm.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.Algorithm.CSharp
 
         public override void OnEndOfAlgorithm()
         {
-            if (_optionCount != 30)
+            if (_optionCount != 45)
             {
                 throw new Exception($"Unexpected option count {_optionCount}, expected 30");
             }
@@ -113,7 +113,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 112057601;
+        public long DataPoints => 112808126;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/OptionChainSubscriptionRemovalRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionChainSubscriptionRemovalRegressionAlgorithm.cs
@@ -52,7 +52,7 @@ namespace QuantConnect.Algorithm.CSharp
         {
             if (_optionCount != 45)
             {
-                throw new Exception($"Unexpected option count {_optionCount}, expected 30");
+                throw new Exception($"Unexpected option count {_optionCount}, expected 45");
             }
         }
 

--- a/Common/Securities/ContractSecurityFilterUniverse.cs
+++ b/Common/Securities/ContractSecurityFilterUniverse.cs
@@ -130,6 +130,7 @@ namespace QuantConnect.Securities
                 }
             }).ToList();
 
+            _alreadyAppliedTypeFilters = true;
             return (T) this;
         }
 
@@ -155,8 +156,8 @@ namespace QuantConnect.Securities
         {
             if (_alreadyAppliedTypeFilters)
             {
-                throw new InvalidOperationException("The type filters have already been applied, so no changes to the type are allowed now. " +
-                    "Please, apply this filter before applying other filters such as FrontMonth() or BackMonths()");
+                throw new InvalidOperationException("Type filters have already been applied, " +
+                    "please call StandardsOnly() before applying other filters such as FrontMonth() or BackMonths()");
             }
 
             Type = ContractExpirationType.Standard;
@@ -171,8 +172,8 @@ namespace QuantConnect.Securities
         {
             if (_alreadyAppliedTypeFilters)
             {
-                throw new InvalidOperationException("The type filters have already been applied, so no changes to the type are allowed now. " +
-                    "Please, apply this filter before applying other filters such as FrontMonth() or BackMonths()");
+                throw new InvalidOperationException("Type filters have already been applied, " +
+                    "please call IncludeWeeklys() before applying other filters such as FrontMonth() or BackMonths()");
             }
 
             Type |= ContractExpirationType.Weekly;
@@ -196,7 +197,6 @@ namespace QuantConnect.Securities
         public virtual T FrontMonth()
         {
             ApplyTypesFilter();
-            _alreadyAppliedTypeFilters = true;
             var ordered = this.OrderBy(x => x.ID.Date).ToList();
             if (ordered.Count == 0) return (T) this;
             var frontMonth = ordered.TakeWhile(x => ordered[0].ID.Date == x.ID.Date);
@@ -212,7 +212,6 @@ namespace QuantConnect.Securities
         public virtual T BackMonths()
         {
             ApplyTypesFilter();
-            _alreadyAppliedTypeFilters = true;
             var ordered = this.OrderBy(x => x.ID.Date).ToList();
             if (ordered.Count == 0) return (T) this;
             var backMonths = ordered.SkipWhile(x => ordered[0].ID.Date == x.ID.Date);

--- a/Common/Securities/ContractSecurityFilterUniverse.cs
+++ b/Common/Securities/ContractSecurityFilterUniverse.cs
@@ -155,7 +155,8 @@ namespace QuantConnect.Securities
         {
             if (_alreadyAppliedTypeFilters)
             {
-                throw new Exception("The type filters have already been applied, so no changes to the type are allowed now.");
+                throw new InvalidOperationException("The type filters have already been applied, so no changes to the type are allowed now. " +
+                    "Please, apply this filter before applying other filters such as FrontMonth() or BackMonths()");
             }
 
             Type = ContractExpirationType.Standard;
@@ -170,7 +171,8 @@ namespace QuantConnect.Securities
         {
             if (_alreadyAppliedTypeFilters)
             {
-                throw new Exception("The type filters have already been applied, so no changes to the type are allowed now.");
+                throw new InvalidOperationException("The type filters have already been applied, so no changes to the type are allowed now. " +
+                    "Please, apply this filter before applying other filters such as FrontMonth() or BackMonths()");
             }
 
             Type |= ContractExpirationType.Weekly;

--- a/Tests/Common/Securities/OptionFilterTests.cs
+++ b/Tests/Common/Securities/OptionFilterTests.cs
@@ -447,7 +447,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var underlying = new Tick { Value = 10m, Time = new DateTime(2016, 02, 26) };
 
-            Func<OptionFilterUniverse, OptionFilterUniverse> universeFunc = universe => universe.FrontMonth();
+            Func<OptionFilterUniverse, OptionFilterUniverse> universeFunc = universe => universe.IncludeWeeklys().FrontMonth();
 
             Func<IDerivativeSecurityFilterUniverse, IDerivativeSecurityFilterUniverse> func =
                 universe => universeFunc(universe as OptionFilterUniverse);
@@ -481,7 +481,7 @@ namespace QuantConnect.Tests.Common.Securities
 
             var underlying = new Tick { Value = 10m, Time = new DateTime(2016, 02, 26) };
 
-            Func<OptionFilterUniverse, OptionFilterUniverse> universeFunc = universe => universe.BackMonth();
+            Func<OptionFilterUniverse, OptionFilterUniverse> universeFunc = universe => universe.IncludeWeeklys().BackMonth();
 
             Func<IDerivativeSecurityFilterUniverse, IDerivativeSecurityFilterUniverse> func =
                 universe => universeFunc(universe as OptionFilterUniverse);

--- a/Tests/Research/QuantBookHistoryTests.cs
+++ b/Tests/Research/QuantBookHistoryTests.cs
@@ -496,5 +496,57 @@ def getHistoryCount(history):
                 }
             });
         }
+
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void GetOptionContractsWithFrontMonthFilter(Language language)
+        {
+            var qb = new QuantBook();
+            var start = new DateTime(2015, 12, 24);
+            var end = new DateTime(2015, 12, 24);
+
+            var goog = qb.AddEquity("GOOG");
+            var option = qb.AddOption(goog.Symbol);
+            option.SetFilter(universe => universe.Strikes(-5, 5).FrontMonth());
+            using (Py.GIL())
+            {
+                var history = qb.GetOptionHistory(goog.Symbol, start, end, Resolution.Minute, fillForward: false, extendedMarketHours: false);
+
+                Assert.DoesNotThrow(() =>
+                {
+                    if (language == Language.CSharp)
+                    {
+                        Assert.NotZero(history.Count());
+                        using (Py.GIL())
+                        {
+                            dynamic data = history.GetAllData();
+                            var labels = data.axes[0].names;
+                            Assert.AreEqual("expiry", (labels[0] as PyObject).As<string>());
+                        }
+                    }
+                    else
+                    {
+                        using (Py.GIL())
+                        {
+                            var testModule = PyModule.FromString("testModule",
+                            @"
+from AlgorithmImports import *
+def getAllData():
+    qb = QuantBook()
+    underlying_symbol = qb.AddEquity(""GOOG"").Symbol
+    option = qb.AddOption(underlying_symbol)
+    option.SetFilter(lambda option_filter_universe: option_filter_universe.Strikes(-5, 5).FrontMonth())
+    option_history = qb.OptionHistory(underlying_symbol, datetime(2015, 12, 24), datetime(2015, 12, 24), Resolution.Minute, fillForward=False, extendedMarketHours=False)
+    data = option_history.GetAllData()
+    return data.axes[0].names[0]");
+
+                            dynamic getAllData = testModule.GetAttr("getAllData");
+                            var data = getAllData();
+                            Assert.AreEqual("expiry", data.AsManagedObject(typeof(string)));
+                        }
+                    }
+                });
+            }
+        }
     }
 }

--- a/Tests/Research/QuantBookHistoryTests.cs
+++ b/Tests/Research/QuantBookHistoryTests.cs
@@ -501,34 +501,28 @@ def getHistoryCount(history):
         [TestCase(Language.Python)]
         public void GetOptionContractsWithFrontMonthFilter(Language language)
         {
-            var qb = new QuantBook();
-            var start = new DateTime(2015, 12, 24);
-            var end = new DateTime(2015, 12, 24);
-
-            var goog = qb.AddEquity("GOOG");
-            var option = qb.AddOption(goog.Symbol);
-            option.SetFilter(universe => universe.Strikes(-5, 5).FrontMonth());
             using (Py.GIL())
             {
-                var history = qb.GetOptionHistory(goog.Symbol, start, end, Resolution.Minute, fillForward: false, extendedMarketHours: false);
-
                 Assert.DoesNotThrow(() =>
                 {
                     if (language == Language.CSharp)
                     {
-                        Assert.NotZero(history.Count());
-                        using (Py.GIL())
-                        {
-                            dynamic data = history.GetAllData();
-                            var labels = data.axes[0].names;
-                            Assert.AreEqual("expiry", (labels[0] as PyObject).As<string>());
-                        }
+                        var qb = new QuantBook();
+                        var start = new DateTime(2015, 12, 24);
+                        var end = new DateTime(2015, 12, 24);
+
+                        var goog = qb.AddEquity("GOOG");
+                        var option = qb.AddOption(goog.Symbol);
+                        option.SetFilter(universe => universe.Strikes(-5, 5).FrontMonth());
+
+                        var history = qb.GetOptionHistory(goog.Symbol, start, end, Resolution.Minute, fillForward: false, extendedMarketHours: false);
+                        dynamic data = history.GetAllData();
+                        var labels = data.axes[0].names;
+                        Assert.AreEqual("expiry", (labels[0] as PyObject).As<string>());
                     }
                     else
                     {
-                        using (Py.GIL())
-                        {
-                            var testModule = PyModule.FromString("testModule",
+                        var testModule = PyModule.FromString("testModule",
                             @"
 from AlgorithmImports import *
 def getAllData():
@@ -540,10 +534,9 @@ def getAllData():
     data = option_history.GetAllData()
     return data.axes[0].names[0]");
 
-                            dynamic getAllData = testModule.GetAttr("getAllData");
-                            var data = getAllData();
-                            Assert.AreEqual("expiry", data.AsManagedObject(typeof(string)));
-                        }
+                        dynamic getAllData = testModule.GetAttr("getAllData");
+                        var data = getAllData();
+                        Assert.AreEqual("expiry", data.AsManagedObject(typeof(string)));
                     }
                 });
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
When the `FrontMonth()` filter was used, it selected the option contracts with the closest expiration dates. However, it didn't take into account if the option type was standard or weekly. Therefore, sometimes the option contracts selected by `FrontMonth()` were all weekly but the Type defined in the universe was standard, so they were removed when the method `ContractSecurityFilterUniverse.AppyTypesFilter()` was executed. This PR solves the mentioned bug in the `FrontMonth()`and `BackMonths()` option filters.

On the other hand, it's worth mentioned that the statistics of the regression algorithm `OptionChainSubscriptionRemovalRegressionAlgorithm` changed since it was also using the option filter`FrontMonth()`.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7786 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change will fix the method `FrontMonth()` as well as `BackMonths`
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Since the original bug was reported in QC Cloud research notebooks, I made a unit test in this environment in C# and Python. The test creates a quantbook and adds an option and its underlying, to then set up the universe filter `FrontMonth()`. Then it requests the option history and using that response requests all the data with the method `GetAllData()`. Finally, it asserts that the data returned contains option contracts.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
