### PR TITLE
Fix for live multi resolution FF enumerator

### DIFF
--- a/Tests/Engine/DataFeeds/Enumerators/LiveFillForwardEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/LiveFillForwardEnumeratorTests.cs
@@ -119,13 +119,15 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
         [Test]
         public void HandlesDaylightSavingTimeChange()
         {
+            // In 2018, Daylight Saving Time (DST) began at 2 AM on Sunday, March 11
+            // This means that clocks were moved forward one hour on March 11
             var reference = new DateTime(2018, 3, 10);
             var period = Time.OneDay;
             var underlying = new List<TradeBar>
             {
                 new TradeBar(reference, Symbols.SPY, 10, 20, 5, 15, 123456, period),
-                // Daylight Saving Time change -> add 1 hour
-                new TradeBar(reference.AddDays(1).AddHours(1), Symbols.SPY, 100, 200, 50, 150, 1234560, period)
+                // Daylight Saving Time change, the data still goes from midnight to midnight
+                new TradeBar(reference.AddDays(1), Symbols.SPY, 100, 200, 50, 150, 1234560, period)
             };
 
             var timeProvider = new ManualTimeProvider(TimeZones.NewYork);
@@ -172,21 +174,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
         {
             var timeProvider = new ManualTimeProvider(new DateTime(2020, 5, 21, 9, 40, 0, 100), TimeZones.NewYork);
 
-            var enqueueableEnumerator = new EnqueueableEnumerator<BaseData>();
-            using var fillForwardEnumerator = new LiveFillForwardEnumerator(
-                timeProvider,
-                enqueueableEnumerator,
-                new SecurityExchange(MarketHoursDatabase.FromDataFolder()
-                    .ExchangeHoursListing
-                    .First(kvp => kvp.Key.Market == Market.USA && kvp.Key.SecurityType == SecurityType.Equity)
-                    .Value
-                    .ExchangeHours),
-                Ref.CreateReadOnly(() => Resolution.Minute.ToTimeSpan()),
-                false,
-                Time.EndOfTime,
-                Resolution.Minute,
-                TimeZones.NewYork, false
-            );
+            using var fillForwardEnumerator = GetLiveFillForwardEnumerator(timeProvider, Resolution.Minute, out var enqueueableEnumerator, false);
             var openingBar = new TradeBar
             {
                 Open = 0.01m,
@@ -230,29 +218,17 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             Assert.IsFalse(fillForwardEnumerator.Current.IsFillForward);
         }
 
-        [TestCase(Resolution.Daily)]
-        [TestCase(Resolution.Hour)]
-        [TestCase(Resolution.Minute)]
-        [TestCase(Resolution.Second)]
-        public void TakesIntoAccountTimeOut(Resolution resolution)
+        [TestCase(Resolution.Hour, true)]
+        [TestCase(Resolution.Minute, true)]
+        [TestCase(Resolution.Second, true)]
+        [TestCase(Resolution.Hour, false)]
+        [TestCase(Resolution.Minute, false)]
+        [TestCase(Resolution.Second, false)]
+        public void TakesIntoAccountTimeOut(Resolution resolution, bool dataArrivedLate)
         {
-            var timeProvider = new ManualTimeProvider(new DateTime(2020, 5, 21, 9, 30, 0, 0), TimeZones.NewYork);
+            var timeProvider = new ManualTimeProvider(new DateTime(2020, 5, 21, 10, 0, 0, 0), TimeZones.NewYork);
 
-            var enqueueableEnumerator = new EnqueueableEnumerator<BaseData>();
-            using var fillForwardEnumerator = new LiveFillForwardEnumerator(
-                timeProvider,
-                enqueueableEnumerator,
-                new SecurityExchange(MarketHoursDatabase.FromDataFolder()
-                    .ExchangeHoursListing
-                    .First(kvp => kvp.Key.Market == Market.USA && kvp.Key.SecurityType == SecurityType.Equity)
-                    .Value
-                    .ExchangeHours),
-                Ref.CreateReadOnly(() => resolution.ToTimeSpan()),
-                false,
-                Time.EndOfTime,
-                resolution,
-                TimeZones.NewYork, false
-            );
+            using var fillForwardEnumerator = GetLiveFillForwardEnumerator(timeProvider, resolution, out var enqueueableEnumerator, dailyStrictEndTimeEnabled: false);
             var openingBar = new TradeBar
             {
                 Open = 0.01m,
@@ -260,7 +236,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
                 Low = 0.01m,
                 Close = 0.01m,
                 Volume = 1,
-                EndTime = new DateTime(2020, 5, 21, 9, 30, 0),
+                EndTime = new DateTime(2020, 5, 21, 10, 0, 0),
                 Symbol = Symbols.AAPL
             };
             var secondBar = new TradeBar
@@ -283,20 +259,204 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
 
             // Advance the time, we don't expect a fill-forward bar because the timeout amount has not passed yet
             timeProvider.Advance(resolution.ToTimeSpan());
-            Assert.IsTrue(fillForwardEnumerator.MoveNext());
-            Assert.IsNull(fillForwardEnumerator.Current);
+            if (dataArrivedLate)
+            {
+                Assert.IsTrue(fillForwardEnumerator.MoveNext());
+                Assert.IsNull(fillForwardEnumerator.Current);
 
-            // Advance the time, including the expected timout, we expect a fill-forward bar.
-            timeProvider.Advance(LiveFillForwardEnumerator.GetMaximumDataTimeout(resolution));
-            Assert.IsTrue(fillForwardEnumerator.MoveNext());
-            Assert.IsTrue(fillForwardEnumerator.Current.IsFillForward);
-            Assert.AreEqual(openingBar.Open, ((TradeBar)fillForwardEnumerator.Current).Open);
-            Assert.AreEqual(openingBar.EndTime.Add(resolution.ToTimeSpan()), fillForwardEnumerator.Current.EndTime);
+                // Advance the time, including the expected timout, we expect a fill-forward bar.
+                timeProvider.Advance(LiveFillForwardEnumerator.GetMaximumDataTimeout(resolution));
+                Assert.IsTrue(fillForwardEnumerator.MoveNext());
+                Assert.IsTrue(fillForwardEnumerator.Current.IsFillForward);
+                Assert.AreEqual(openingBar.Open, ((TradeBar)fillForwardEnumerator.Current).Open);
+                Assert.AreEqual(openingBar.EndTime.Add(resolution.ToTimeSpan()), fillForwardEnumerator.Current.EndTime);
+            }
 
             // Now we expect data. The secondBar should be fill-forwarded from here on out after the MoveNext
             enqueueableEnumerator.Enqueue(secondBar);
             Assert.IsTrue(fillForwardEnumerator.MoveNext());
             Assert.IsFalse(fillForwardEnumerator.Current.IsFillForward);
+        }
+
+        [TestCase(true, true)]
+        [TestCase(false, true)]
+        [TestCase(true, false)]
+        [TestCase(false, false)]
+        public void TakesIntoAccountTimeOutDaily(bool dailyStrictEndTimeEnabled, bool dataArrivedLate)
+        {
+            var resolution = Resolution.Daily;
+            var referenceOpenTime = new DateTime(2020, 5, 21, 9, 30, 0);
+            var referenceTime = new DateTime(2020, 5, 21, 16, 0, 0);
+            if (!dailyStrictEndTimeEnabled)
+            {
+                referenceOpenTime = referenceOpenTime.Date;
+                referenceTime = referenceTime.Date.AddDays(1);
+            }
+            var timeProvider = new ManualTimeProvider(referenceTime, TimeZones.NewYork);
+            using var fillForwardEnumerator = GetLiveFillForwardEnumerator(timeProvider, resolution, out var enqueueableEnumerator, dailyStrictEndTimeEnabled);
+            var openingBar = new TradeBar
+            {
+                Open = 0.01m,
+                High = 0.01m,
+                Low = 0.01m,
+                Close = 0.01m,
+                Volume = 1,
+                Time = referenceOpenTime,
+                EndTime = referenceTime,
+                Symbol = Symbols.AAPL
+            };
+            var secondBar = new TradeBar
+            {
+                Open = 1m,
+                High = 2m,
+                Low = 1m,
+                Close = 2m,
+                Volume = 100,
+                Time = referenceOpenTime.AddDays(1),
+                EndTime = referenceTime.AddDays(1),
+                Symbol = Symbols.AAPL
+            };
+
+            // Enqueue the first point, which will be emitted ASAP.
+            enqueueableEnumerator.Enqueue(openingBar);
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.NotNull(fillForwardEnumerator.Current);
+            Assert.AreEqual(openingBar.Open, ((TradeBar)fillForwardEnumerator.Current).Open);
+            Assert.AreEqual(openingBar.EndTime, fillForwardEnumerator.Current.EndTime);
+
+            // Advance the time, we don't expect a fill-forward bar because the timeout amount has not passed yet
+            timeProvider.SetCurrentTime(secondBar.EndTime);
+
+            if (dataArrivedLate)
+            {
+                Assert.IsTrue(fillForwardEnumerator.MoveNext());
+                Assert.IsNull(fillForwardEnumerator.Current);
+
+                // Advance the time, including the expected timout, we expect a fill-forward bar.
+                timeProvider.Advance(LiveFillForwardEnumerator.GetMaximumDataTimeout(resolution));
+                Assert.IsTrue(fillForwardEnumerator.MoveNext());
+                Assert.IsTrue(fillForwardEnumerator.Current.IsFillForward);
+                Assert.AreEqual(openingBar.Open, ((TradeBar)fillForwardEnumerator.Current).Open);
+                Assert.AreEqual(secondBar.EndTime, fillForwardEnumerator.Current.EndTime);
+            }
+
+            // Now we expect data. The secondBar should be fill-forwarded from here on out after the MoveNext
+            enqueueableEnumerator.Enqueue(secondBar);
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.IsFalse(fillForwardEnumerator.Current.IsFillForward);
+            Assert.AreEqual(secondBar.Open, ((TradeBar)fillForwardEnumerator.Current).Open);
+            Assert.AreEqual(secondBar.EndTime, fillForwardEnumerator.Current.EndTime);
+        }
+
+        [TestCase(Resolution.Minute)]
+        [TestCase(Resolution.Hour)]
+        public void MultiResolutionSmallerFillForwardResolution(Resolution resolution)
+        {
+            var ffResolution = Resolution.Second;
+            var referenceOpenTime = new DateTime(2020, 5, 21, 14, 0, 0);
+            if (resolution == Resolution.Minute)
+            {
+                referenceOpenTime = new DateTime(2020, 5, 21, 15, 59, 0);
+            }
+            var referenceTime = new DateTime(2020, 5, 21, 15, 0, 0);
+
+            var timeProvider = new ManualTimeProvider(referenceTime, TimeZones.NewYork);
+            using var fillForwardEnumerator = GetLiveFillForwardEnumerator(timeProvider, resolution, out var enqueueableEnumerator, true, ffResolution);
+            var openingBar = new TradeBar
+            {
+                Open = 0.01m,
+                High = 0.01m,
+                Low = 0.01m,
+                Close = 0.01m,
+                Volume = 1,
+                Time = referenceOpenTime,
+                EndTime = referenceTime,
+                Symbol = Symbols.AAPL
+            };
+
+            // Enqueue the first point, which will be emitted ASAP.
+            enqueueableEnumerator.Enqueue(openingBar);
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.NotNull(fillForwardEnumerator.Current);
+            Assert.AreEqual(openingBar.Open, ((TradeBar)fillForwardEnumerator.Current).Open);
+            Assert.AreEqual(openingBar.EndTime, fillForwardEnumerator.Current.EndTime);
+
+            // Advance the time, we expect a fill-forward bar
+
+            for (var i = 0; i < 60; i++)
+            {
+                timeProvider.Advance(Time.OneSecond);
+
+                Assert.IsTrue(fillForwardEnumerator.MoveNext());
+                Assert.NotNull(fillForwardEnumerator.Current);
+                Assert.AreEqual(openingBar.Open, ((TradeBar)fillForwardEnumerator.Current).Open);
+                Assert.AreEqual(timeProvider.GetUtcNow().ConvertFromUtc(TimeZones.NewYork), fillForwardEnumerator.Current.EndTime);
+            }
+        }
+
+        [TestCase(Resolution.Daily, Resolution.Minute)]
+        [TestCase(Resolution.Hour, Resolution.Minute)]
+        [TestCase(Resolution.Daily, Resolution.Second)]
+        [TestCase(Resolution.Hour, Resolution.Second)]
+        public void MultiResolutionMarketClose(Resolution resolution, Resolution ffResolution)
+        {
+            var referenceOpenTime = new DateTime(2020, 5, 21, 9, 30, 0);
+            if (resolution == Resolution.Hour)
+            {
+                referenceOpenTime = new DateTime(2020, 5, 21, 15, 0, 0);
+            }
+            var referenceTime = new DateTime(2020, 5, 21, 16, 0, 0);
+            var timeProvider = new ManualTimeProvider(referenceTime, TimeZones.NewYork);
+            using var fillForwardEnumerator = GetLiveFillForwardEnumerator(timeProvider, resolution, out var enqueueableEnumerator, true, ffResolution);
+            var openingBar = new TradeBar
+            {
+                Open = 0.01m,
+                High = 0.01m,
+                Low = 0.01m,
+                Close = 0.01m,
+                Volume = 1,
+                Time = referenceOpenTime,
+                EndTime = referenceTime,
+                Symbol = Symbols.AAPL
+            };
+
+            // Enqueue the first point, which will be emitted ASAP.
+            enqueueableEnumerator.Enqueue(openingBar);
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.NotNull(fillForwardEnumerator.Current);
+            Assert.AreEqual(openingBar.Open, ((TradeBar)fillForwardEnumerator.Current).Open);
+            Assert.AreEqual(openingBar.EndTime, fillForwardEnumerator.Current.EndTime);
+
+            for (var i = 0; i < 600; i++)
+            {
+                // Advance the time, we don't expect a fill-forward bar, we've emitted our daily bar already and market is closed
+                timeProvider.Advance(ffResolution.ToTimeSpan());
+                Assert.IsTrue(fillForwardEnumerator.MoveNext());
+                Assert.IsNull(fillForwardEnumerator.Current);
+            }
+        }
+
+        private static LiveFillForwardEnumerator GetLiveFillForwardEnumerator(ITimeProvider timeProvider, Resolution resolution,
+            out EnqueueableEnumerator<BaseData> enqueueableEnumerator, bool dailyStrictEndTimeEnabled, Resolution? ffResolution = null)
+        {
+            enqueueableEnumerator = new EnqueueableEnumerator<BaseData>();
+            var fillForwardEnumerator = new LiveFillForwardEnumerator(
+                timeProvider,
+                enqueueableEnumerator,
+                new SecurityExchange(MarketHoursDatabase.FromDataFolder()
+                    .ExchangeHoursListing
+                    .First(kvp => kvp.Key.Market == Market.USA && kvp.Key.SecurityType == SecurityType.Equity)
+                    .Value
+                    .ExchangeHours),
+                Ref.CreateReadOnly(() => (ffResolution ?? resolution).ToTimeSpan()),
+                false,
+                Time.EndOfTime,
+                resolution,
+                TimeZones.NewYork,
+                dailyStrictEndTimeEnabled: dailyStrictEndTimeEnabled
+            );
+
+            return fillForwardEnumerator;
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Adjust live FF enumerator to rely on the base FF enumerator logic and just filter out results based on the frontier. Adding unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See https://github.com/QuantConnect/Lean/pull/8001
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve multi resolution live FF support
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing and new tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
