### PR TITLE
Fix fill forward resolution adjustment on removal

### DIFF
--- a/Algorithm.CSharp/AllShortableSymbolsCoarseSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AllShortableSymbolsCoarseSelectionRegressionAlgorithm.cs
@@ -238,7 +238,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 37754;
+        public long DataPoints => 37751;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/FillForwardResolutionAdjustedOnRemovalRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FillForwardResolutionAdjustedOnRemovalRegressionAlgorithm.cs
@@ -30,6 +30,8 @@ namespace QuantConnect.Algorithm.CSharp
             new DateTime(2013, 10, 7, 9, 31, 0),
             new DateTime(2013, 10, 8, 0, 0, 0),
             new DateTime(2013, 10, 9, 0, 0, 0),
+            new DateTime(2013, 10, 9, 0, 0, 0), // TODO
+            new DateTime(2013, 10, 9, 9, 31, 0),
             new DateTime(2013, 10, 10, 0, 0, 0),
             new DateTime(2013, 10, 11, 0, 0, 0)
         });
@@ -56,7 +58,15 @@ namespace QuantConnect.Algorithm.CSharp
 
             if (ActiveSecurities.ContainsKey("/ES"))
             {
-                RemoveSecurity("/ES");
+                if (data.ContainsKey("/ES"))
+                {
+                    RemoveSecurity("/ES");
+                }
+            }
+            else if (Time == new DateTime(2013, 10, 9, 0, 0, 0))
+            {
+                // let's re add it
+                AddFuture("ES", Resolution.Minute);
             }
         }
 
@@ -81,7 +91,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 70;
+        public long DataPoints => 96;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/FillForwardResolutionAdjustedOnRemovalRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FillForwardResolutionAdjustedOnRemovalRegressionAlgorithm.cs
@@ -1,0 +1,125 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm reproduces GH issue #8023, where fill forward resolution will no get updated in some cases on security removals
+    /// </summary>
+    public class FillForwardResolutionAdjustedOnRemovalRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private readonly Queue<DateTime> _expectedDataTimes = new(new DateTime[]
+        {
+            new DateTime(2013, 10, 7, 9, 31, 0),
+            new DateTime(2013, 10, 8, 0, 0, 0),
+            new DateTime(2013, 10, 9, 0, 0, 0),
+            new DateTime(2013, 10, 10, 0, 0, 0),
+            new DateTime(2013, 10, 11, 0, 0, 0)
+        });
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 10);
+
+            AddFuture("ES", Resolution.Minute);
+            AddEquity("SPY", Resolution.Daily);
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="data">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice data)
+        {
+            if (_expectedDataTimes.Dequeue() != Time)
+            {
+                throw new Exception($"Unexpected data time {Time}!");
+            }
+
+            if (ActiveSecurities.ContainsKey("/ES"))
+            {
+                RemoveSecurity("/ES");
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_expectedDataTimes.Count != 0)
+            {
+                throw new Exception($"OnEndOfAlgorithm(): Unexpected data times!");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public Language[] Languages { get; } = { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 70;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-5.677"},
+            {"Tracking Error", "0.271"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/RegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionAlgorithm.cs
@@ -83,7 +83,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 16896626;
+        public long DataPoints => 16896627;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -95,17 +95,17 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Orders", "1592"},
+            {"Total Orders", "1593"},
             {"Average Win", "0.00%"},
             {"Average Loss", "0.00%"},
-            {"Compounding Annual Return", "-1.257%"},
+            {"Compounding Annual Return", "-1.158%"},
             {"Drawdown", "0.000%"},
             {"Expectancy", "-0.989"},
             {"Start Equity", "10000000"},
-            {"End Equity", "9998382.41"},
+            {"End Equity", "9998403.92"},
             {"Net Profit", "-0.016%"},
-            {"Sharpe Ratio", "-18.139"},
-            {"Sortino Ratio", "-18.139"},
+            {"Sharpe Ratio", "-18.339"},
+            {"Sortino Ratio", "-18.339"},
             {"Probabilistic Sharpe Ratio", "0.000%"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
@@ -114,14 +114,14 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "-0.001"},
             {"Annual Standard Deviation", "0.001"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-8.944"},
+            {"Information Ratio", "-8.943"},
             {"Tracking Error", "0.223"},
-            {"Treynor Ratio", "27.031"},
-            {"Total Fees", "$1587.00"},
-            {"Estimated Strategy Capacity", "$64000.00"},
-            {"Lowest Capacity Asset", "IBM R735QTJ8XC9X"},
-            {"Portfolio Turnover", "1.86%"},
-            {"OrderListHash", "56c4f2806983e52ef5087606512e2844"}
+            {"Treynor Ratio", "27.123"},
+            {"Total Fees", "$1589.00"},
+            {"Estimated Strategy Capacity", "$67000000.00"},
+            {"Lowest Capacity Asset", "AIG R735QTJ8XC9X"},
+            {"Portfolio Turnover", "1.87%"},
+            {"OrderListHash", "2efcb91611db79040f62f0f5c36280c9"}
         };
     }
 }

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -210,7 +210,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         // remove
                         foreach (var request in requests)
                         {
-                            RemoveSubscription(request.Configuration, request.Universe);
+                            // universe null because we want them actually removed even if still a member of the universe, because the FF res changed
+                            // which means we will drop any data points that could be in the next potential slice being created
+                            RemoveSubscription(request.Configuration, universe: null);
                         }
 
                         // re add

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -210,15 +210,20 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         // remove
                         foreach (var request in requests)
                         {
-                            // universe null because we want them actually removed even if still a member of the universe, because the FF res changed
+                            // force because we want them actually removed even if still a member of the universe, because the FF res changed
                             // which means we will drop any data points that could be in the next potential slice being created
-                            RemoveSubscription(request.Configuration, universe: null);
+                            RemoveSubscriptionInternal(request.Configuration, universe: request.Universe, forceSubscriptionRemoval: true);
                         }
 
                         // re add
                         foreach (var request in requests)
                         {
-                            AddSubscription(new SubscriptionRequest(request, startTimeUtc: algorithm.UtcTime));
+                            // TODO: If it is an add we will set time 1 tick ahead to properly sync data
+                            // with next timeslice, avoid emitting now twice.
+                            // We do the same in the 'TimeTriggeredUniverseSubscriptionEnumeratorFactory' when handling changes
+                            AddSubscription(new SubscriptionRequest(request, startTimeUtc: algorithm.UtcTime
+                                //.AddTicks(1) TODO
+                                ));
                         }
 
                         DataFeedSubscriptions.FreezeFillForwardResolution(false);
@@ -324,6 +329,19 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <returns>True if the subscription was successfully removed, false otherwise</returns>
         public bool RemoveSubscription(SubscriptionDataConfig configuration, Universe universe = null)
         {
+            return RemoveSubscriptionInternal(configuration, universe, forceSubscriptionRemoval: false);
+        }
+
+        /// <summary>
+        /// Removes the <see cref="Subscription"/>, if it exists
+        /// </summary>
+        /// <param name="configuration">The <see cref="SubscriptionDataConfig"/> of the subscription to remove</param>
+        /// <param name="universe">Universe requesting to remove <see cref="Subscription"/>.
+        /// Default value, null, will remove all universes</param>
+        /// <param name="forceSubscriptionRemoval">We force the subscription removal by marking it as removed from universe, so that all it's data is dropped</param>
+        /// <returns>True if the subscription was successfully removed, false otherwise</returns>
+        private bool RemoveSubscriptionInternal(SubscriptionDataConfig configuration, Universe universe, bool forceSubscriptionRemoval)
+        {
             // remove the subscription from our collection, if it exists
             Subscription subscription;
 
@@ -348,6 +366,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     subscription.Dispose();
 
                     RemoveSubscriptionDataConfig(subscription);
+
+                    if (forceSubscriptionRemoval)
+                    {
+                        subscription.MarkAsRemovedFromUniverse();
+                    }
 
                     if (_liveMode)
                     {

--- a/Engine/DataFeeds/Enumerators/Factories/TimeTriggeredUniverseSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/TimeTriggeredUniverseSubscriptionEnumeratorFactory.cs
@@ -72,7 +72,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 universe.CollectionChanged += (sender, args) =>
                 {
                     // If it is an add we will set time 1 tick ahead to properly sync data
-                    // with next timeslice, if it is a remove then we will set time to now
+                    // with next timeslice, avoid emitting now twice, if it is a remove then we will set time to now
+                    // we do the same in the 'DataManager' when handling FF resolution changes
                     IList items;
                     DateTime time;
                     if (args.Action == NotifyCollectionChangedAction.Add)

--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -223,7 +223,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         // time pulse to align algorithm time with current frontier
                         yield return _timeSliceFactory.CreateTimePulse(frontierUtc);
 
-                        foreach (var kvp in universeData)
+                        // trigger the smalled resolution first, so that FF res get's set once from the start correctly
+                        // while at it, let's make it determininstic and sort by universe sid later
+                        foreach (var kvp in universeData.OrderBy(x => x.Key.Configuration.Resolution).ThenBy(x => x.Key.Symbol.ID))
                         {
                             var universe = kvp.Key;
                             var baseDataCollection = kvp.Value;

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -200,7 +200,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
 
             // determine which data subscriptions need to be removed from this universe
-            foreach (var member in universe.Securities.Values.OrderBy(member => member.Security.Symbol.SecurityType))
+            foreach (var member in universe.Securities.Values.OrderBy(member => member.Security.Symbol.SecurityType).ThenBy(x => x.Security.Symbol.ID))
             {
                 var security = member.Security;
                 // if we've selected this subscription again, keep it

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -3706,7 +3706,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             }
             else if (securityType == SecurityType.Future)
             {
-                var future = algorithm.AddFuture(Futures.Indices.SP500EMini, Resolution.Minute, extendedMarketHours: true);
+                var future = algorithm.AddFuture(Futures.Indices.SP500EMini, Resolution.Minute, extendedMarketHours: true, fillForward: false);
                 // Must include weeklys because the contracts returned by the lookup, futureSymbol1 & futureSymbol2, are non-standard
                 future.SetFilter(x => x.IncludeWeeklys());
                 exchangeTimeZone = future.Exchange.TimeZone;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix fill forward resolution adjustment on subscription removal. Adding regression algorithm reproducing issue


`Algorithm.CSharp/RegressionAlgorithm.cs`: Stats changed because it would trigger a FF resolution change, which is no longer the case
> DataManager(): Fill forward resolution has changed from 00:01:00 to 1.00:00:00 at utc: 10/11/2013 7:59:59 PM. Restarting 1 subscriptions...

`Algorithm.CSharp/AllShortableSymbolsCoarseSelectionRegressionAlgorithm.cs`: Reproduced the issue where on FF resolution change the subscription wouldn't change as expected

**Performance impact running algorithm in issue**
```
MASTER
193.02 seconds at 535k data points per second. Processing total of 103,279,020 data points.
195.87 seconds at 527k data points per second. Processing total of 103,302,428 data points.
186.96 seconds at 553k data points per second. Processing total of 103,302,428 data points.
```
```
PR
87.29 seconds at 910k data points per second. Processing total of 79,452,428 data points.
103.70 seconds at 766k data points per second. Processing total of 79,452,428 data points.
89.56 seconds at 887k data points per second. Processing total of 79,452,428 data points.
```
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/8023
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
N/A
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests and new test reproducing issue
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
