### PR TITLE
Fix Insight constructors to set correct values

### DIFF
--- a/Common/Algorithm/Framework/Alphas/Insight.cs
+++ b/Common/Algorithm/Framework/Alphas/Insight.cs
@@ -176,7 +176,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="direction">The predicted direction</param>
         /// <param name="tag">The insight's tag containing additional information</param>
         public Insight(Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction, string tag = "")
-            : this(symbol, period, type, direction, null, null, tag)
+            : this(symbol, period, type, direction, null, null, null, null, tag)
         {
         }
 
@@ -221,7 +221,7 @@ namespace QuantConnect.Algorithm.Framework.Alphas
         /// <param name="direction">The predicted direction</param>
         /// <param name="tag">The insight's tag containing additional information</param>
         public Insight(Symbol symbol, Func<DateTime, DateTime> expiryFunc, InsightType type, InsightDirection direction, string tag = "")
-            : this(symbol, expiryFunc, type, direction, null, null, tag)
+            : this(symbol, expiryFunc, type, direction, null, null, null, null, tag)
         {
         }
 

--- a/Tests/Algorithm/Framework/InsightTests.cs
+++ b/Tests/Algorithm/Framework/InsightTests.cs
@@ -337,7 +337,7 @@ namespace QuantConnect.Tests.Algorithm.Framework
 
             Assert.AreEqual(expected, insight.CloseTimeUtc);
         }
-        
+
 
         [Test]
         public void ComputeCloseTimeHandlesFractionalDays()
@@ -430,6 +430,53 @@ namespace QuantConnect.Tests.Algorithm.Framework
 
             Assert.IsTrue(insight.IsActive(insight.CloseTimeUtc));
             Assert.IsFalse(insight.IsActive(insight.CloseTimeUtc.AddTicks(1)));
+        }
+
+        [Test]
+        public void ConstructorsSetsCorrectValues()
+        {
+            var tag = "Insight Tag";
+
+            Assert.Multiple(() =>
+            {
+                var insight1 = new Insight(Symbols.SPY, Time.OneDay, InsightType.Price, InsightDirection.Up, tag);
+                AssertInsigthValues(insight1, Symbols.SPY, Time.OneDay, InsightType.Price, InsightDirection.Up, null, null, null, null, tag,
+                    default(DateTime), default(DateTime));
+
+                var insight2 = new Insight(Symbols.SPY, Time.OneDay, InsightType.Price, InsightDirection.Up, 1.0, 0.5, "Model", 0.25, tag);
+                AssertInsigthValues(insight2, Symbols.SPY, Time.OneDay, InsightType.Price, InsightDirection.Up, 1.0, 0.5, "Model", 0.25, tag,
+                    default(DateTime), default(DateTime));
+
+                var insight3 = new Insight(Symbols.SPY, time => time.AddDays(1), InsightType.Price, InsightDirection.Up, tag);
+                AssertInsigthValues(insight3, Symbols.SPY, new TimeSpan(0), InsightType.Price, InsightDirection.Up, null, null, null, null, tag,
+                                   default(DateTime), default(DateTime));
+
+                var insight4 = new Insight(Symbols.SPY, time => time.AddDays(1), InsightType.Price, InsightDirection.Up, 1.0, 0.5, "Model", 0.25, tag);
+                AssertInsigthValues(insight4, Symbols.SPY, new TimeSpan(0), InsightType.Price, InsightDirection.Up, 1.0, 0.5, "Model", 0.25, tag,
+                    default(DateTime), default(DateTime));
+
+                var generatedTime = new DateTime(2024, 05, 23);
+                var insight5 = new Insight(generatedTime, Symbols.SPY, Time.OneDay, InsightType.Price, InsightDirection.Up, 1.0, 0.5, "Model", 0.25, tag);
+                AssertInsigthValues(insight5, Symbols.SPY, Time.OneDay, InsightType.Price, InsightDirection.Up, 1.0, 0.5, "Model", 0.25, tag,
+                    generatedTime, generatedTime + Time.OneDay);
+
+            });
+        }
+
+        private static void AssertInsigthValues(Insight insight, Symbol symbol, TimeSpan period, InsightType type, InsightDirection direction,
+            double? magnitude, double? confidence, string sourceModel, double? weight, string tag, DateTime generatedTimeUtc, DateTime closeTimeUtc)
+        {
+            Assert.AreEqual(symbol, insight.Symbol);
+            Assert.AreEqual(period, insight.Period);
+            Assert.AreEqual(type, insight.Type);
+            Assert.AreEqual(direction, insight.Direction);
+            Assert.AreEqual(magnitude, insight.Magnitude);
+            Assert.AreEqual(confidence, insight.Confidence);
+            Assert.AreEqual(sourceModel, insight.SourceModel);
+            Assert.AreEqual(weight, insight.Weight);
+            Assert.AreEqual(tag, insight.Tag);
+            Assert.AreEqual(generatedTimeUtc, insight.GeneratedTimeUtc);
+            Assert.AreEqual(closeTimeUtc, insight.CloseTimeUtc);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Fix Insight constructors to set correct values, caused by nullable arguments in constructor overloads.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Close #7838 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
