### PR TITLE
Add FuncTimeRule and FuncDateRule constructors for PyObject

### DIFF
--- a/Common/Scheduling/FuncDateRule.cs
+++ b/Common/Scheduling/FuncDateRule.cs
@@ -14,6 +14,7 @@
  *
 */
 
+using Python.Runtime;
 using System;
 using System.Collections.Generic;
 
@@ -35,6 +36,20 @@ namespace QuantConnect.Scheduling
         {
             Name = name;
             _getDatesFunction = getDatesFunction;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FuncDateRule"/> class using a Python function
+        /// </summary>
+        /// <param name="name">The name of this rule</param>
+        /// <param name="getDatesFunction">The time applicator function in Python</param>
+        public FuncDateRule(string name, PyObject getDatesFunction)
+        {
+            Name = name;
+            if (!getDatesFunction.TryConvertToDelegate(out _getDatesFunction))
+            {
+                throw new ArgumentException("Python DateRule provided is not a function");
+            }
         }
 
         /// <summary>

--- a/Common/Scheduling/FuncTimeRule.cs
+++ b/Common/Scheduling/FuncTimeRule.cs
@@ -14,6 +14,7 @@
  *
 */
 
+using Python.Runtime;
 using System;
 using System.Collections.Generic;
 
@@ -35,6 +36,20 @@ namespace QuantConnect.Scheduling
         {
             Name = name;
             _createUtcEventTimesFunction = createUtcEventTimesFunction;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FuncTimeRule"/> class using a Python function
+        /// </summary>
+        /// <param name="name">The name of the time rule</param>
+        /// <param name="createUtcEventTimesFunction">Function used to transform dates into event date times in Python</param>
+        public FuncTimeRule(string name, PyObject createUtcEventTimesFunction)
+        {
+            Name = name;
+            if (!createUtcEventTimesFunction.TryConvertToDelegate(out _createUtcEventTimesFunction))
+            {
+                throw new ArgumentException("Python TimeRule provided is not a function");
+            }
         }
 
         /// <summary>

--- a/Tests/Common/Scheduling/DateRulesTests.cs
+++ b/Tests/Common/Scheduling/DateRulesTests.cs
@@ -622,6 +622,26 @@ def CustomDateRule(start, end):
         }
 
         [Test]
+        public void SetFuncDateRuleInPythonWorksAsExpectedWithCSharpFunc()
+        {
+            using (Py.GIL())
+            {
+                var pythonModule = PyModule.FromString("testModule", @"
+from AlgorithmImports import *
+
+def GetFuncDateRule(csharpFunc):
+    return FuncDateRule(""CSharp"", csharpFunc)
+");
+                dynamic getFuncDateRule = pythonModule.GetAttr("GetFuncDateRule");
+                Func<DateTime, DateTime, IEnumerable<DateTime>> csharpFunc = (start, end) => { return new List<DateTime>() { new DateTime(2001, 3, 18) }; };
+                var funcDateRule = getFuncDateRule(csharpFunc);
+                Assert.AreEqual("CSharp", (funcDateRule.Name as PyObject).GetAndDispose<string>());
+                Assert.AreEqual(new DateTime(2001, 3, 18),
+                    (funcDateRule.GetDates(new DateTime(2023, 1, 1), new DateTime(2023, 2, 1)) as PyObject).GetAndDispose<List<DateTime>>().First());
+            }
+        }
+
+        [Test]
         public void SetFuncDateRuleInPythonFailsWhenDateRuleIsInvalid()
         {
             using (Py.GIL())

--- a/Tests/Common/Scheduling/TimeRulesTests.cs
+++ b/Tests/Common/Scheduling/TimeRulesTests.cs
@@ -348,6 +348,26 @@ def CustomTimeRule(dates):
         }
 
         [Test]
+        public void SetFuncTimeRuleInPythonWorksAsExpectedWithCSharpFunc()
+        {
+            using (Py.GIL())
+            {
+                var pythonModule = PyModule.FromString("testModule", @"
+from AlgorithmImports import *
+
+def GetFuncTimeRule(csharpFunc):
+    return FuncTimeRule(""CSharp"", csharpFunc)
+");
+                dynamic getFuncTimeRule = pythonModule.GetAttr("GetFuncTimeRule");
+                Func<IEnumerable<DateTime>, IEnumerable<DateTime>> csharpFunc = (dates) => { return new List<DateTime>() { new DateTime(2001, 3, 18) }; };
+                var funcTimeRule = getFuncTimeRule(csharpFunc);
+                Assert.AreEqual("CSharp", (funcTimeRule.Name as PyObject).GetAndDispose<string>());
+                Assert.AreEqual(new DateTime(2001, 3, 18),
+                    (funcTimeRule.CreateUtcEventTimes(new List<DateTime>() { new DateTime(2023, 1, 1) }) as PyObject).GetAndDispose<List<DateTime>>().First());
+            }
+        }
+
+        [Test]
         public void SetFuncTimeRuleInPythonFailsWhenInvalidTimeRule()
         {
             using (Py.GIL())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
I added a new constructor in both `FuncDateRule` and `FuncTimeRule` that accepts a Python function. I also covered my changes with unit tests.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7990 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change users will be able to create `FuncDateRule` and `FuncTimeRule` objects from Python
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created three unit tests for both `FuncTimeRule` and `FuncDateRule` that asserts different expected scenarios. The first one, asserts one can actually create an instance of one of those classes using a python function. The second one, asserts one can create an instance of those classes using a C# function from Python. And the third one, asserts each of those classes throw an exception when the python object is not a function.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
