### PR TITLE
Add Yearly Date Rule

### DIFF
--- a/Common/Scheduling/DateRules.cs
+++ b/Common/Scheduling/DateRules.cs
@@ -430,7 +430,7 @@ namespace QuantConnect.Scheduling
                 var baseDate = baseDateFunc(date);
                 var boundaryDate = boundaryDateFunc(date);
 
-                // Determine the scheduled day for this year
+                // Determine the scheduled day for this period
                 if (date == baseDate)
                 {
                     var scheduledDay = GetScheduledDay(securitySchedule, baseDate, offset, searchForward, boundaryDate);
@@ -466,8 +466,8 @@ namespace QuantConnect.Scheduling
             var beginningOfStartOfYear = new DateTime(start.Year, start.Month, 1);
             var endOfEndYear = new DateTime(end.Year, end.Month, DateTime.DaysInMonth(end.Year, end.Month));
 
-            // Searching forward the first of the month is baseDay, with boundary being the last
-            // Searching backward the last of the month is baseDay, with boundary being the first
+            // Searching forward the first of the year is baseDay, with boundary being the last
+            // Searching backward the last of the year is baseDay, with boundary being the first
             Func<DateTime, DateTime> baseDateFunc = date => searchForward ? new DateTime(date.Year, 1, 1) : new DateTime(date.Year, 12, 31);
             Func<DateTime, DateTime> boundaryDateFunc = date => searchForward ? new DateTime(date.Year, 12, 31) : new DateTime(date.Year, 1, 1);
 

--- a/Tests/Common/Scheduling/DateRulesTests.cs
+++ b/Tests/Common/Scheduling/DateRulesTests.cs
@@ -324,7 +324,8 @@ namespace QuantConnect.Tests.Common.Scheduling
             foreach (var date in dates)
             {
                 count++;
-                Assert.IsTrue(date.Day <= 4);
+                Assert.AreEqual(1, date.Day);
+                Assert.AreEqual(1, date.Month);
             }
 
             Assert.AreEqual(11, count);
@@ -341,6 +342,8 @@ namespace QuantConnect.Tests.Common.Scheduling
             foreach (var date in dates)
             {
                 count++;
+                Assert.AreNotEqual(2000, date.Year);
+                Assert.AreEqual(1, date.Month);
                 Assert.AreEqual(1, date.Day);
             }
 
@@ -358,18 +361,19 @@ namespace QuantConnect.Tests.Common.Scheduling
             foreach (var date in dates)
             {
                 count++;
+                Assert.AreEqual(1, date.Month);
                 Assert.AreEqual(6, date.Day);
             }
             Assert.AreEqual(11, count);
         }
 
-        [TestCase(2, false)]       // Before 11th
-        [TestCase(4, false)]
-        [TestCase(8, false)]
-        [TestCase(12, true)]      // After 11th
-        [TestCase(16, true)]
-        [TestCase(20, true)]
-        public void StartOfYearSameYearSchedule(int startingDateDay, bool expectNone)
+        [TestCase(2)]       // Before 11th
+        [TestCase(4)]
+        [TestCase(8)]
+        [TestCase(12)]      // After 11th
+        [TestCase(16)]
+        [TestCase(20)]
+        public void StartOfYearSameYearSchedule(int startingDateDay)
         {
             var startingDate = new DateTime(2000, 1, startingDateDay);
             var endingDate = new DateTime(2000, 12, 31);
@@ -378,11 +382,11 @@ namespace QuantConnect.Tests.Common.Scheduling
             var rule = rules.YearStart(10); // 11/1/2000
             var dates = rule.GetDates(startingDate, endingDate);
 
-            Assert.AreEqual(expectNone, dates.IsNullOrEmpty());
+            Assert.AreEqual(startingDateDay > 11, dates.IsNullOrEmpty());
 
-            if (!expectNone)
+            if (startingDateDay <= 11)
             {
-                Assert.AreEqual(new DateTime(2000, 1, 11), dates.First());
+                Assert.AreEqual(new DateTime(2000, 1, 11), dates.Single());
             }
         }
 
@@ -400,7 +404,7 @@ namespace QuantConnect.Tests.Common.Scheduling
                 Assert.AreNotEqual(DayOfWeek.Saturday, date.DayOfWeek);
                 Assert.AreNotEqual(DayOfWeek.Sunday, date.DayOfWeek);
                 Assert.IsTrue(date.Day <= 4);
-                Log.Trace(date.Day.ToString(CultureInfo.InvariantCulture));
+                Log.Debug(date.Day.ToString(CultureInfo.InvariantCulture));
             }
 
             Assert.AreEqual(11, count);
@@ -417,10 +421,12 @@ namespace QuantConnect.Tests.Common.Scheduling
             foreach (var date in dates)
             {
                 count++;
+                Assert.AreNotEqual(2000, date.Year);
                 Assert.AreNotEqual(DayOfWeek.Saturday, date.DayOfWeek);
                 Assert.AreNotEqual(DayOfWeek.Sunday, date.DayOfWeek);
+                Assert.AreEqual(1, date.Month);
                 Assert.IsTrue(date.Day <= 4);
-                Log.Trace(date.Day.ToString(CultureInfo.InvariantCulture));
+                Log.Debug(date.Day.ToString(CultureInfo.InvariantCulture));
             }
 
             Assert.AreEqual(10, count);
@@ -459,6 +465,7 @@ namespace QuantConnect.Tests.Common.Scheduling
             foreach (var date in dates)
             {
                 count++;
+                Assert.AreEqual(12, date.Month);
                 Assert.AreEqual(DateTime.DaysInMonth(date.Year, date.Month), date.Day);
             }
 
@@ -476,18 +483,19 @@ namespace QuantConnect.Tests.Common.Scheduling
             foreach (var date in dates)
             {
                 count++;
+                Assert.AreEqual(12, date.Month);
                 Assert.AreEqual(DateTime.DaysInMonth(date.Year, date.Month) - 5, date.Day);
             }
             Assert.AreEqual(11, count);
         }
 
-        [TestCase(5, true)]       // Before 21th
-        [TestCase(10, true)]
-        [TestCase(15, true)]
-        [TestCase(21, false)]      // After 21th
-        [TestCase(25, false)]
-        [TestCase(30, false)]
-        public void EndOfYearSameMonthSchedule(int endingDateDay, bool expectNone)
+        [TestCase(5)]       // Before 21th
+        [TestCase(10)]
+        [TestCase(15)]
+        [TestCase(21)]      // After 21th
+        [TestCase(25)]
+        [TestCase(30)]
+        public void EndOfYearSameMonthSchedule(int endingDateDay)
         {
             var startingDate = new DateTime(2000, 1, 1);
             var endingDate = new DateTime(2000, 12, endingDateDay);
@@ -496,11 +504,11 @@ namespace QuantConnect.Tests.Common.Scheduling
             var rule = rules.YearEnd(10); // 12/21/2000
             var dates = rule.GetDates(startingDate, endingDate);
 
-            Assert.AreEqual(expectNone, dates.IsNullOrEmpty());
+            Assert.AreEqual(endingDateDay < 21, dates.IsNullOrEmpty());
 
-            if (!expectNone)
+            if (endingDateDay >= 21)
             {
-                Assert.AreEqual(new DateTime(2000, 12, 21), dates.First());
+                Assert.AreEqual(new DateTime(2000, 12, 21), dates.Single());
             }
         }
 
@@ -517,8 +525,9 @@ namespace QuantConnect.Tests.Common.Scheduling
                 count++;
                 Assert.AreNotEqual(DayOfWeek.Saturday, date.DayOfWeek);
                 Assert.AreNotEqual(DayOfWeek.Sunday, date.DayOfWeek);
+                Assert.AreEqual(12, date.Month);
                 Assert.IsTrue(date.Day >= 28);
-                Log.Trace(date + " " + date.DayOfWeek);
+                Log.Debug(date + " " + date.DayOfWeek);
             }
 
             Assert.AreEqual(11, count);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Add `YearStart()` and `YearEnd()` date rules as well as the some unit tests to cover these changes
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7988 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With these changes, users will be able to schedule yearly routines when creating their algorithms in LEAN
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There were already tests for the monthly date rule so I followed that pattern to make the tests for the yearly date rule
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
