### PR TITLE
Refresh symbol properties using right type for security

### DIFF
--- a/Common/Securities/IndexOption/IndexOption.cs
+++ b/Common/Securities/IndexOption/IndexOption.cs
@@ -83,5 +83,16 @@ namespace QuantConnect.Securities.IndexOption
             base.UpdateConsumersMarketPrice(data);
             ((IndexOptionSymbolProperties)SymbolProperties).UpdateMarketPrice(data);
         }
+
+        /// <summary>
+        /// Updates the symbol properties of this security
+        /// </summary>
+        internal override void UpdateSymbolProperties(SymbolProperties symbolProperties)
+        {
+            if (symbolProperties != null)
+            {
+                SymbolProperties = new IndexOptionSymbolProperties(symbolProperties);
+            }
+        }
     }
 }

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -668,5 +668,16 @@ namespace QuantConnect.Securities.Option
                 return result.ApplyTypesFilter();
             });
         }
+
+        /// <summary>
+        /// Updates the symbol properties of this security
+        /// </summary>
+        internal override void UpdateSymbolProperties(SymbolProperties symbolProperties)
+        {
+            if (symbolProperties != null)
+            {
+                SymbolProperties = new OptionSymbolProperties(symbolProperties);
+            }
+        }
     }
 }

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -100,7 +100,7 @@ namespace QuantConnect.Securities
         public SymbolProperties SymbolProperties
         {
             get;
-            internal set;
+            protected set;
         }
 
         /// <summary>
@@ -1145,6 +1145,17 @@ namespace QuantConnect.Securities
         {
             Cache.ApplySplit(split);
             UpdateMarketPrice(Cache.GetData());
+        }
+
+        /// <summary>
+        /// Updates the symbol properties of this security
+        /// </summary>
+        internal virtual void UpdateSymbolProperties(SymbolProperties symbolProperties)
+        {
+            if (symbolProperties != null)
+            {
+                SymbolProperties = symbolProperties;
+            }
         }
     }
 }

--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -242,7 +242,7 @@ namespace QuantConnect.Lean.Engine.RealTime
         {
             var symbolProperties = SymbolPropertiesDatabase.GetSymbolProperties(security.Symbol.ID.Market, security.Symbol,
                 security.Symbol.ID.SecurityType, security.QuoteCurrency.Symbol);
-            security.SymbolProperties = symbolProperties;
+            security.UpdateSymbolProperties(symbolProperties);
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Follow up for https://github.com/QuantConnect/Lean/pull/8083. 

On a SPDB refresh in live trading, the `SymbolProperties` class must be the right one for the security type: `OptionSymbolProperties` for options, `IndexOptionSymbolProperties` for index options, and the base `SymbolProperties` for the rest.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #8085 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit tests
- Live paper trading

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
