### PR TITLE
Fix label bug in QCAlgorihtm.Python.History() when requesting data for BaseCollection Datasets

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -948,7 +948,8 @@ namespace QuantConnect.Algorithm
             Resolution? resolution = null, bool? fillForward = null, bool? extendedMarketHours = null, DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
-            return CreateDateRangeHistoryRequests(symbols, typeof(BaseData), startAlgoTz, endAlgoTz, resolution, fillForward, extendedMarketHours,
+            symbols = symbols.ToArray();
+            return CreateDateRangeHistoryRequests(symbols, GetCustomDataTypeFromSymbols(symbols as Symbol[]) ?? typeof(BaseData), startAlgoTz, endAlgoTz, resolution, fillForward, extendedMarketHours,
                 dataMappingMode, dataNormalizationMode, contractDepthOffset);
         }
 

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -949,7 +949,7 @@ namespace QuantConnect.Algorithm
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
             symbols = symbols.ToArray();
-            return CreateDateRangeHistoryRequests(symbols, GetCustomDataTypeFromSymbols(symbols as Symbol[]) ?? typeof(BaseData), startAlgoTz, endAlgoTz, resolution, fillForward, extendedMarketHours,
+            return CreateDateRangeHistoryRequests(symbols, GetCustomDataTypeFromSymbols((Symbol[])symbols) ?? typeof(BaseData), startAlgoTz, endAlgoTz, resolution, fillForward, extendedMarketHours,
                 dataMappingMode, dataNormalizationMode, contractDepthOffset);
         }
 

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -904,8 +904,13 @@ namespace QuantConnect.Algorithm
             }
 
             var symbols = tickers.ConvertToSymbolEnumerable();
+            Type dataType = null;
+            if (symbols.Any() && symbols.All(x => Securities.Keys.Contains(x)) && symbols.All(x => Securities[x].IsCustomData()))
+            {
+                dataType = Securities[symbols.First()]?.SubscriptionDataConfig.Type;
+            }
             return GetDataFrame(History(symbols, periods, resolution, fillForward, extendedMarketHours, dataMappingMode, dataNormalizationMode,
-                contractDepthOffset));
+                contractDepthOffset), dataType);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -903,8 +903,8 @@ namespace QuantConnect.Algorithm
                 return GetDataFrame(History(requests.Where(x => x != null)), type);
             }
 
-            var symbols = tickers.ConvertToSymbolEnumerable();
-            Type dataType = GetCustomDataTypeFromSymbols(symbols);
+            var symbols = tickers.ConvertToSymbolEnumerable().ToArray();
+            var dataType = GetCustomDataTypeFromSymbols(symbols);
 
             return GetDataFrame(History(symbols, periods, resolution, fillForward, extendedMarketHours, dataMappingMode, dataNormalizationMode,
                 contractDepthOffset), dataType);
@@ -966,8 +966,8 @@ namespace QuantConnect.Algorithm
                 return GetDataFrame(History(requests.Where(x => x != null)), type);
             }
 
-            var symbols = tickers.ConvertToSymbolEnumerable();
-            Type dataType = GetCustomDataTypeFromSymbols(symbols);
+            var symbols = tickers.ConvertToSymbolEnumerable().ToArray();
+            var dataType = GetCustomDataTypeFromSymbols(symbols);
 
             return GetDataFrame(History(symbols, start, end, resolution, fillForward, extendedMarketHours, dataMappingMode,
                 dataNormalizationMode, contractDepthOffset), dataType);
@@ -1609,12 +1609,16 @@ namespace QuantConnect.Algorithm
             return history;
         }
 
-        private Type GetCustomDataTypeFromSymbols(IEnumerable<Symbol> symbols)
+        private Type GetCustomDataTypeFromSymbols(Symbol[] symbols)
         {
-            var arraySymbols = symbols.ToArray();
-            if (arraySymbols.Any() && arraySymbols.All(x => Securities[x].IsCustomData()))
+            if (symbols.Any())
             {
-                SecurityIdentifier.TryGetCustomDataTypeInstance(arraySymbols[0].ID.Symbol, out var dataType);
+                SecurityIdentifier.TryGetCustomDataTypeInstance(symbols[0].ID.Symbol, out var dataType);
+                if (symbols.Any(x => !SecurityIdentifier.TryGetCustomDataTypeInstance(x.ID.Symbol, out var customDataType) || customDataType != dataType))
+                {
+                    return null;
+                }
+
                 return dataType;
             }
 

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -1613,12 +1613,11 @@ namespace QuantConnect.Algorithm
         {
             if (symbols.Any())
             {
-                SecurityIdentifier.TryGetCustomDataTypeInstance(symbols[0].ID.Symbol, out var dataType);
-                if (symbols.Any(x => !SecurityIdentifier.TryGetCustomDataTypeInstance(x.ID.Symbol, out var customDataType) || customDataType != dataType))
+                if (!SecurityIdentifier.TryGetCustomDataTypeInstance(symbols[0].ID.Symbol, out var dataType)
+                    || symbols.Any(x => !SecurityIdentifier.TryGetCustomDataTypeInstance(x.ID.Symbol, out var customDataType) || customDataType != dataType))
                 {
                     return null;
                 }
-
                 return dataType;
             }
 

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -904,11 +904,8 @@ namespace QuantConnect.Algorithm
             }
 
             var symbols = tickers.ConvertToSymbolEnumerable();
-            Type dataType = null;
-            if (symbols.Any() && symbols.All(x => Securities.Keys.Contains(x)) && symbols.All(x => Securities[x].IsCustomData()))
-            {
-                dataType = Securities[symbols.First()]?.SubscriptionDataConfig.Type;
-            }
+            Type dataType = GetCustomDataTypeFromSymbols(symbols);
+
             return GetDataFrame(History(symbols, periods, resolution, fillForward, extendedMarketHours, dataMappingMode, dataNormalizationMode,
                 contractDepthOffset), dataType);
         }
@@ -970,11 +967,7 @@ namespace QuantConnect.Algorithm
             }
 
             var symbols = tickers.ConvertToSymbolEnumerable();
-            Type dataType = null;
-            if (symbols.Any() && symbols.All(x => Securities.Keys.Contains(x)) && symbols.All(x => Securities[x].IsCustomData()))
-            {
-                dataType = Securities[symbols.First()]?.SubscriptionDataConfig.Type;
-            }
+            Type dataType = GetCustomDataTypeFromSymbols(symbols);
 
             return GetDataFrame(History(symbols, start, end, resolution, fillForward, extendedMarketHours, dataMappingMode,
                 dataNormalizationMode, contractDepthOffset), dataType);
@@ -1614,6 +1607,18 @@ namespace QuantConnect.Algorithm
                 }
             }
             return history;
+        }
+
+        private Type GetCustomDataTypeFromSymbols(IEnumerable<Symbol> symbols)
+        {
+            var arraySymbols = symbols.ToArray();
+            if (arraySymbols.Any() && arraySymbols.All(x => Securities[x].IsCustomData()))
+            {
+                SecurityIdentifier.TryGetCustomDataTypeInstance(arraySymbols[0].ID.Symbol, out var dataType);
+                return dataType;
+            }
+
+            return null;
         }
     }
 }

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -966,7 +966,8 @@ namespace QuantConnect.Algorithm
 
             var symbols = tickers.ConvertToSymbolEnumerable();
             return GetDataFrame(History(symbols, start, end, resolution, fillForward, extendedMarketHours, dataMappingMode,
-                dataNormalizationMode, contractDepthOffset), symbols.Any() ? Securities[symbols.First()]?.SubscriptionDataConfig.Type : null);
+                dataNormalizationMode, contractDepthOffset),
+                symbols.Any() && Securities.Values.All(x => x.IsCustomData()) ? Securities[symbols.First()].SubscriptionDataConfig.Type : null);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -965,9 +965,14 @@ namespace QuantConnect.Algorithm
             }
 
             var symbols = tickers.ConvertToSymbolEnumerable();
+            Type dataType = null;
+            if (symbols.Any() && symbols.All(x => Securities.Keys.Contains(x)) && symbols.All(x => Securities[x].IsCustomData()))
+            {
+                dataType = Securities[symbols.First()]?.SubscriptionDataConfig.Type;
+            }
+
             return GetDataFrame(History(symbols, start, end, resolution, fillForward, extendedMarketHours, dataMappingMode,
-                dataNormalizationMode, contractDepthOffset),
-                symbols.Any() && Securities.Values.All(x => x.IsCustomData()) ? Securities[symbols.First()].SubscriptionDataConfig.Type : null);
+                dataNormalizationMode, contractDepthOffset), dataType);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -966,7 +966,7 @@ namespace QuantConnect.Algorithm
 
             var symbols = tickers.ConvertToSymbolEnumerable();
             return GetDataFrame(History(symbols, start, end, resolution, fillForward, extendedMarketHours, dataMappingMode,
-                dataNormalizationMode, contractDepthOffset));
+                dataNormalizationMode, contractDepthOffset), symbols.Any() ? Securities[symbols.First()]?.SubscriptionDataConfig.Type : null);
         }
 
         /// <summary>

--- a/Tests/Common/Securities/SecurityIdentifierTests.cs
+++ b/Tests/Common/Securities/SecurityIdentifierTests.cs
@@ -26,6 +26,12 @@ using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Logging;
 using QuantConnect.Util;
 using QuantConnect.Securities;
+using QuantConnect.Data.Fundamental;
+using QuantConnect.Data.Custom.AlphaStreams;
+using QuantConnect.Data.Custom.IconicTypes;
+using QuantConnect.Data.Custom.Intrinio;
+using QuantConnect.Data.Custom;
+using QuantConnect.Data.Custom.Tiingo;
 
 namespace QuantConnect.Tests.Common.Securities
 {
@@ -610,6 +616,33 @@ namespace QuantConnect.Tests.Common.Securities
 
             CollectionAssert.AreEqual(expected, sids);
         }
+
+        [TestCaseSource(nameof(ReturnsExpectedCustomDataTypeTestCases))]
+        public void ReturnsExpectedCustomDataType(string symbol, Type expectedDataType)
+        {
+            SecurityIdentifier.GenerateBaseSymbol(expectedDataType, symbol.Split(".")[0]);
+            var result = SecurityIdentifier.TryGetCustomDataTypeInstance(symbol, out var obtainedDataType);
+
+            Assert.AreEqual(expectedDataType, obtainedDataType);
+        }
+
+        public static object[] ReturnsExpectedCustomDataTypeTestCases =
+        {
+            new object[] {"BTC.Bitcoin", typeof(CustomDataBitcoinAlgorithm.Bitcoin)},
+            new object[] {"AAPL.FundamentalUniverse", typeof(FundamentalUniverse)},
+            new object[] {"AAPL.PlaceHolder", typeof(PlaceHolder)},
+            new object[] {"AAPL.LinkedData", typeof(LinkedData)},
+            new object[] {"AAPL.UnlinkedData", typeof(UnlinkedData)},
+            new object[] {"AAPL.UnlinkedDataTradeBar", typeof(UnlinkedDataTradeBar)},
+            new object[] {"AAPL.IndexedLinkedData", typeof(IndexedLinkedData)},
+            new object[] {"AAPL.IndexedLinkedData2", typeof(IndexedLinkedData2)},
+            new object[] {"AAPL.IntrinioEconomicDataSources", typeof(IntrinioEconomicDataSources)},
+            new object[] {"AAPL.IntrinioEconomicData", typeof(IntrinioEconomicData)},
+            new object[] {"AAPL.FxcmVolume", typeof(FxcmVolume)},
+            new object[] {"AAPL.Tiingo", typeof(Tiingo)},
+            new object[] {"AAPL.TiingoDailyData", typeof(TiingoDailyData)},
+            new object[] {"AAPL.TiingoPrice", typeof(TiingoPrice)},
+        };
 
         class Container
         {

--- a/Tests/Research/QuantBookHistoryTests.cs
+++ b/Tests/Research/QuantBookHistoryTests.cs
@@ -598,7 +598,7 @@ def getHistory():
             var symbol = qb.AddEquity("AAPL", Resolution.Daily).Symbol;
             var datasetSymbol = Symbol.CreateBase(typeof(FundamentalUniverse), symbol, symbol.ID.Market);
             MarketHoursDatabase.Reset();
-            Assert.DoesNotThrow(() => qb.History(datasetSymbol, new DateTime(2014, 3, 1), new DateTime(2014, 4, 1), Resolution.Daily));
+            Assert.DoesNotThrow(() => qb.History(datasetSymbol, new DateTime(2014, 3, 1), new DateTime(2014, 4, 1), Resolution.Daily).ToList());
         }
 
         [Test]

--- a/Tests/Research/QuantBookHistoryTests.cs
+++ b/Tests/Research/QuantBookHistoryTests.cs
@@ -541,5 +541,29 @@ def getAllData():
                 });
             }
         }
+
+        [Test]
+        public void HistoryDataDoesnNotReturnDataLabelWithBaseDataCollectionTypes()
+        {
+            using (Py.GIL())
+            {
+                var testModule = PyModule.FromString("testModule",
+                    @"
+from AlgorithmImports import *
+
+def getHistory():
+    qb = QuantBook()
+    symbol = qb.AddEquity(""AAPL"", Resolution.Daily).symbol
+    dataset_symbol = qb.AddData(FundamentalUniverse, symbol).symbol
+    history = qb.History(dataset_symbol, datetime(2014, 3, 1), datetime(2014, 4, 1), Resolution.Daily)
+    return history
+");
+                dynamic getHistory = testModule.GetAttr("getHistory");
+                var pyHistory = getHistory() as PyObject;
+                dynamic isHistoryEmpty = (pyHistory as dynamic).empty;
+                Assert.IsFalse((isHistoryEmpty as PyObject).GetAndDispose<bool?>());
+                Assert.IsFalse(pyHistory.HasAttr("data"));
+            }
+        }
     }
 }

--- a/Tests/Research/QuantBookHistoryTests.cs
+++ b/Tests/Research/QuantBookHistoryTests.cs
@@ -565,5 +565,29 @@ def getHistory():
                 Assert.IsFalse(pyHistory.HasAttr("data"));
             }
         }
+
+        [Test]
+        public void HistoryDataDoesnNotReturnDataLabelWithBaseDataCollectionTypesAndPeriods()
+        {
+            using (Py.GIL())
+            {
+                var testModule = PyModule.FromString("testModule",
+                    @"
+from AlgorithmImports import *
+
+def getHistory():
+    qb = QuantBook()
+    symbol = qb.AddEquity(""AAPL"", Resolution.Daily).symbol
+    dataset_symbol = qb.AddData(FundamentalUniverse, symbol).symbol
+    history = qb.History(dataset_symbol, 4015, Resolution.Daily)
+    return history
+");
+                dynamic getHistory = testModule.GetAttr("getHistory");
+                var pyHistory = getHistory() as PyObject;
+                dynamic isHistoryEmpty = (pyHistory as dynamic).empty;
+                Assert.IsFalse((isHistoryEmpty as PyObject).GetAndDispose<bool?>());
+                Assert.IsFalse(pyHistory.HasAttr("data"));
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#### Description
<!--- Describe your changes in detail -->
If the user requested history data for a custom dataset symbol using the overloaded method which didn't require the custom datatype, the dataframe returned contained a label called "data". This happened since the method `QCAlgorithm.Python.TryCleanupCollectionDataFrame()` requires the datatype to remove the "data" label, otherwise it doesn't remove it. This PR fix this bug and adds a unit test covering this case.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #6630 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, when users call `QCAlgorithm.Python.History()` for custom symbols without specifying the custom datatype the dataframe returned won't contain a "data" label
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created a unit test which reproduces the bug mentioned in the GH issue and asserts the dataframe returned doesn't contain a "data" label
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
