### PR TITLE
Fixes AwesomeOscillator Helper Order Of Parameters

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -171,7 +171,7 @@ namespace QuantConnect.Algorithm
         /// <param name="type">The type of moving average used when computing the fast and slow term. Defaults to simple moving average.</param>
         /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar</param>
         [DocumentationAttribute(Indicators)]
-        public AwesomeOscillator AO(Symbol symbol, int slowPeriod, int fastPeriod, MovingAverageType type, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
+        public AwesomeOscillator AO(Symbol symbol, int fastPeriod, int slowPeriod, MovingAverageType type, Resolution? resolution = null, Func<IBaseData, IBaseDataBar> selector = null)
         {
             var name = CreateIndicatorName(symbol, $"AO({fastPeriod},{slowPeriod},{type})", resolution);
             var awesomeOscillator = new AwesomeOscillator(name, fastPeriod, slowPeriod, type);


### PR DESCRIPTION
#### Description
The second and third parameters are `fastPeriod` and `slowPeriod,` but we had `slowPeriod` and `fastPeriod,` which is inconsistent with the class constructor and other indicators with `fastPeriod` and `slowPeriod` parameters.

#### Related Issue
N/A

#### Motivation and Context
Consistency and documentation.

Other platforms follow this conversion:
- https://technical-analysis-library-in-python.readthedocs.io/en/latest/ta.html
short and long, which is fast and slow respectively
```python
ta.momentum.AwesomeOscillatorIndicator(high: pandas.core.series.Series, low: pandas.core.series.Series, window1: int = 5, window2: int = 34, fillna: bool = False)
```

https://qtpylib.io/docs/latest/indicators.html#awesome-oscillator
```python
bars['ao'] = bars.awesome_oscillator(weighted=False, fast=5, slow=34])
```

- https://nardew.github.io/talipp/latest/reference/talipp/indicators/AO/#talipp.indicators.AO.AO
```python
AO(fast_period: int, slow_period: int, ...)
```

#### Requires Documentation Change
No: code gen.

#### How Has This Been Tested?
N/A

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`