### PR TITLE
Refactor:  Cross Zero Order event

### DIFF
--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -758,7 +758,8 @@ namespace QuantConnect.Brokerages
             {
                 // if we have a contingent that needs to be submitted then we can't respect the 'Filled' state from the order
                 // because the Lean order hasn't been technically filled yet, so mark it as 'PartiallyFilled'
-                OnOrderEvent(new OrderEvent(leanOrder, DateTime.UtcNow, OrderFee.Zero) { Status = OrderStatus.PartiallyFilled, FillQuantity = orderEvent.FillQuantity });
+                orderEvent.Status = OrderStatus.PartiallyFilled;
+                OnOrderEvent(orderEvent);
 
                 Task.Run(() =>
                 {

--- a/Tests/Brokerages/OrderCrossingBrokerageTests.cs
+++ b/Tests/Brokerages/OrderCrossingBrokerageTests.cs
@@ -70,17 +70,9 @@ namespace QuantConnect.Tests.Brokerages
 
             using var brokerage = InitializeBrokerage((leanOrder?.Symbol.Value, 180m, 10));
 
-            var skipFirstFilledEvent = default(bool);
             brokerage.OrdersStatusChanged += (_, orderEvents) =>
             {
                 var orderEventStatus = orderEvents[0].Status;
-
-                // Skip processing the first occurrence of the Filled event, The First Part of CrossZeroOrder was filled.
-                if (!skipFirstFilledEvent && orderEventStatus == OrderStatus.Filled)
-                {
-                    skipFirstFilledEvent = true;
-                    return;
-                }
 
                 actualCrossZeroOrderStatusOrdering.Enqueue(orderEventStatus);
 
@@ -146,17 +138,9 @@ namespace QuantConnect.Tests.Brokerages
 
             using var brokerage = InitializeBrokerage((leanOrder?.Symbol.Value, 180m, 10));
 
-            var skipFirstFilledEvent = default(bool);
             brokerage.OrdersStatusChanged += (_, orderEvents) =>
             {
                 var orderEventStatus = orderEvents[0].Status;
-
-                // Skip processing the first occurrence of the Filled event, The First Part of CrossZeroOrder was filled.
-                if (!skipFirstFilledEvent && orderEventStatus == OrderStatus.Filled)
-                {
-                    skipFirstFilledEvent = true;
-                    return;
-                }
 
                 actualCrossZeroOrderStatusOrdering.Enqueue(orderEventStatus);
 
@@ -359,13 +343,6 @@ namespace QuantConnect.Tests.Brokerages
             private readonly CancellationTokenSource _cancellationTokenSource = new();
 
             /// <summary>
-            /// Indicates whether the first occurrence of the Filled event has been skipped.
-            /// Used to ensure the first Filled event is processed appropriately for setting the
-            /// order state to PartiallyFilled.
-            /// </summary>
-            private bool _isSkipFirstFilled;
-
-            /// <summary>
             /// Temporarily stores the IDs of brokerage orders for testing purposes.
             /// </summary>
             private List<string> _tempBrokerageOrderIds = new();
@@ -409,16 +386,10 @@ namespace QuantConnect.Tests.Brokerages
                     leanOrder = _orderProvider.GetOrderById(orderEvent.OrderId);
                 }
 
-                // Process the first occurrence of the Filled event to simulate the leanOrder as PartiallyFilled.
-                if (!_isSkipFirstFilled && orderEvent.Status == OrderStatus.Filled)
-                {
-                    _isSkipFirstFilled = true;
-                    TryHandleRemainingCrossZeroOrder(leanOrder, orderEvent);
-                }
-                else
+                if (!TryHandleRemainingCrossZeroOrder(leanOrder, orderEvent))
                 {
                     _orderProvider.UpdateOrderStatusById(orderEvent.OrderId, orderEvent.Status);
-                }
+                }           
             }
 
             public IEnumerable<Order> GetAllOrders(Func<Order, bool> filter)
@@ -592,7 +563,11 @@ namespace QuantConnect.Tests.Brokerages
                         {
                             if (order.Status == OrderStatus.Submitted || order.Status == OrderStatus.PartiallyFilled || order.Status == OrderStatus.UpdateSubmitted)
                             {
-                                OnOrderEvent(new OrderEvent(order, new DateTime(2024, 6, 10), OrderFee.Zero) { Status = OrderStatus.Filled });
+                                var orderEvent = new OrderEvent(order, new DateTime(2024, 6, 10), OrderFee.Zero) { Status = OrderStatus.Filled };
+                                if (!TryHandleRemainingCrossZeroOrder(order, orderEvent))
+                                {
+                                    OnOrderEvent(orderEvent);
+                                }
                             }
                         }
                     }

--- a/Tests/Brokerages/OrderCrossingBrokerageTests.cs
+++ b/Tests/Brokerages/OrderCrossingBrokerageTests.cs
@@ -389,7 +389,7 @@ namespace QuantConnect.Tests.Brokerages
                 if (!TryHandleRemainingCrossZeroOrder(leanOrder, orderEvent))
                 {
                     _orderProvider.UpdateOrderStatusById(orderEvent.OrderId, orderEvent.Status);
-                }           
+                }
             }
 
             public IEnumerable<Order> GetAllOrders(Func<Order, bool> filter)


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
Reuse `OrderEvent(...)` instead of creating `new OrderEvent(...)`.

#### Related Pull Request
- https://github.com/QuantConnect/Lean/pull/8051

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make code more clear and flexible.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Run test of `OrderCrossingBrokerageTests`

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
