### PR TITLE
Refactor: Handle OrderStatus with Cross Zero Order Collection

### DIFF
--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -735,18 +735,13 @@ namespace QuantConnect.Brokerages
                 {
                     switch (leanOrderStatus)
                     {
-                        // If the order is partially filled || New || Submitted, retrieve it from the collection
-                        case OrderStatus.New:
-                        case OrderStatus.None:
-                        case OrderStatus.Submitted:
-                        case OrderStatus.PartiallyFilled:
-                            return true;
-                        // Remove the order if it has already been Filled || Canceled || Invalid
                         case OrderStatus.Filled:
-                        default:
+                        case OrderStatus.Canceled:
+                        case OrderStatus.Invalid:
                             _leanOrderByBrokerageCrossingOrders.Remove(leanOrder.Id, out var _);
-                            return true;
+                            break;
                     };
+                    return true;
                 }
                 // Return false if the brokerage order ID does not correspond to a cross-zero order
                 return false;
@@ -770,13 +765,11 @@ namespace QuantConnect.Brokerages
                         orderEvent.Status = OrderStatus.PartiallyFilled;
                         _leanOrderByBrokerageCrossingOrders.Remove(leanOrder.Id, out var _);
                         break;
-                    case OrderStatus.New:
-                    case OrderStatus.None:
-                    case OrderStatus.Submitted:
-                    case OrderStatus.PartiallyFilled:
+                    case OrderStatus.Canceled:
+                    case OrderStatus.Invalid:
+                        _leanOrderByBrokerageCrossingOrders.Remove(leanOrder.Id, out var _);
                         return false;
                     default:
-                        _leanOrderByBrokerageCrossingOrders.Remove(leanOrder.Id, out var _);
                         return false;
                 };
 

--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -738,7 +738,7 @@ namespace QuantConnect.Brokerages
                         case OrderStatus.Filled:
                         case OrderStatus.Canceled:
                         case OrderStatus.Invalid:
-                            _leanOrderByBrokerageCrossingOrders.Remove(leanOrder.Id, out var _);
+                            LeanOrderByZeroCrossBrokerageOrderId.TryRemove(brokerageOrderId, out var _);
                             break;
                     };
                     return true;

--- a/Brokerages/CrossZero/CrossZeroSecondOrderRequest.cs
+++ b/Brokerages/CrossZero/CrossZeroSecondOrderRequest.cs
@@ -28,14 +28,6 @@ namespace QuantConnect.Brokerages.CrossZero
         public CrossZeroFirstOrderRequest FirstPartCrossZeroOrder { get; }
 
         /// <summary>
-        /// Gets the type of order, converted to stop-crossing order type.
-        /// </summary>
-        /// <returns>
-        /// The converted stop-crossing order type.
-        /// </returns>
-        public new OrderType OrderType => ConvertStopCrossingOrderType(base.OrderType);
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="CrossZeroFirstOrderRequest"/> struct.
         /// </summary>
         /// <param name="leanOrder">The lean order.</param>
@@ -46,7 +38,7 @@ namespace QuantConnect.Brokerages.CrossZero
         /// <param name="crossZeroFirstOrder">The first part of the cross zero order.</param>
         public CrossZeroSecondOrderRequest(Order leanOrder, OrderType orderType, decimal orderQuantity, decimal orderQuantityHolding,
             OrderPosition orderPosition, CrossZeroFirstOrderRequest crossZeroFirstOrder)
-            : base(leanOrder, orderType, orderQuantity, orderQuantityHolding, orderPosition)
+            : base(leanOrder, ConvertStopCrossingOrderType(orderType), orderQuantity, orderQuantityHolding, orderPosition)
         {
             FirstPartCrossZeroOrder = crossZeroFirstOrder;
         }

--- a/Brokerages/CrossZero/CrossZeroSecondOrderRequest.cs
+++ b/Brokerages/CrossZero/CrossZeroSecondOrderRequest.cs
@@ -28,6 +28,14 @@ namespace QuantConnect.Brokerages.CrossZero
         public CrossZeroFirstOrderRequest FirstPartCrossZeroOrder { get; }
 
         /// <summary>
+        /// Gets the type of order, converted to stop-crossing order type.
+        /// </summary>
+        /// <returns>
+        /// The converted stop-crossing order type.
+        /// </returns>
+        public new OrderType OrderType => ConvertStopCrossingOrderType(base.OrderType);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CrossZeroFirstOrderRequest"/> struct.
         /// </summary>
         /// <param name="leanOrder">The lean order.</param>
@@ -38,7 +46,7 @@ namespace QuantConnect.Brokerages.CrossZero
         /// <param name="crossZeroFirstOrder">The first part of the cross zero order.</param>
         public CrossZeroSecondOrderRequest(Order leanOrder, OrderType orderType, decimal orderQuantity, decimal orderQuantityHolding,
             OrderPosition orderPosition, CrossZeroFirstOrderRequest crossZeroFirstOrder)
-            : base(leanOrder, ConvertStopCrossingOrderType(orderType), orderQuantity, orderQuantityHolding, orderPosition)
+            : base(leanOrder, orderType, orderQuantity, orderQuantityHolding, orderPosition)
         {
             FirstPartCrossZeroOrder = crossZeroFirstOrder;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
1. Fix Converting OrderType for CrossZeroSecondPart: The `OrderType` for the second part of the **CrossZeroOrder** is now converted in real time based on the first part, ensuring accuracy and consistency.
2. Handle Specific Lean `OrderStatus` for **First Part**: Improved handling of specific Lean `OrderStatus` when processing the first part of the **CrossZeroOrder**. This includes cleaning the relevant collection to prevent data inconsistencies.
3. Handle Specific Lean `OrderStatus` for **Second Part**: Enhanced handling of specific Lean `OrderStatus` when processing the second part of the **CrossZeroOrder**, with similar cleanup operations to maintain collection integrity.

#### Related Pull Requests
- https://github.com/QuantConnect/Lean/pull/8110
- https://github.com/QuantConnect/Lean/pull/8051

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
These changes address critical issues in the **CrossZeroOrder** process, ensuring that order types are correctly converted in real time and that specific Lean OrderStatus values are handled appropriately. By cleaning the relevant collections, we maintain data consistency and prevent potential errors or inconsistencies.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All existing tests related to the CrossZeroOrder process have been executed to ensure that these changes do not introduce any new issues and that they resolve the problems they are intended to fix.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
