### PR TITLE
Minor fix for Mis-Aligned Timestamps from IndicatorHistory

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -3698,14 +3698,14 @@ namespace QuantConnect.Algorithm
 
             var indicatorsDataPointsByTime = new List<IndicatorDataPoints>();
             IndicatorDataPoint lastPoint = null;
-            void consumeLastPoint()
+            void consumeLastPoint(IndicatorDataPoint newInputPoint)
             {
                 if (lastPoint == null)
                 {
                     return;
                 }
 
-                var IndicatorDataPoints = new IndicatorDataPoints { Time = lastPoint.Time, EndTime = lastPoint.EndTime };
+                var IndicatorDataPoints = new IndicatorDataPoints { Time = newInputPoint.Time, EndTime = newInputPoint.EndTime };
                 indicatorsDataPointsByTime.Add(IndicatorDataPoints);
                 for (var i = 0; i < indicatorsDataPointPerProperty.Count; i++)
                 {
@@ -3715,23 +3715,23 @@ namespace QuantConnect.Algorithm
                 lastPoint = null;
             }
 
-            IndicatorUpdatedHandler callback = (object _, IndicatorDataPoint point) =>
+            IndicatorUpdatedHandler callback = (object _, IndicatorDataPoint newInputPoint) =>
             {
                 if (!indicator.IsReady)
                 {
                     return;
                 }
 
-                if (lastPoint != null && lastPoint.Time != point.Time)
+                if (lastPoint != null && lastPoint.Time != newInputPoint.Time)
                 {
                     // when the time changes we let through the previous point, some indicators which consume data from multiple symbols might trigger the Updated event
                     // even if their value has not changed yet
-                    consumeLastPoint();
+                    consumeLastPoint(newInputPoint);
                 }
-                lastPoint = point;
+                lastPoint = newInputPoint;
             };
             // flush the last point
-            consumeLastPoint();
+            consumeLastPoint(lastPoint);
 
             // register the callback, update the indicator and unregister finally
             indicator.Updated += callback;

--- a/Tests/Algorithm/AlgorithmIndicatorsTests.cs
+++ b/Tests/Algorithm/AlgorithmIndicatorsTests.cs
@@ -325,6 +325,10 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(0.994298416889621m, indicator.Current.Value);
             Assert.AreEqual(0.351654399192164m, indicator.ImpliedVolatility.Current.Value);
             Assert.AreEqual(389, indicatorValues.Count);
+
+            var lastData = indicatorValues.Current.Last();
+            Assert.AreEqual(new DateTime(2014, 6, 6, 16, 0, 0), lastData.EndTime);
+            Assert.AreEqual(lastData.EndTime, indicatorValues.Last().EndTime);
         }
 
         [TestCase(1)]

--- a/Tests/Algorithm/AlgorithmIndicatorsTests.cs
+++ b/Tests/Algorithm/AlgorithmIndicatorsTests.cs
@@ -156,6 +156,7 @@ namespace QuantConnect.Tests.Algorithm
 
             var lastData = indicatorValues.Current.Last();
             Assert.AreEqual(new DateTime(2013, 10, 10, 16, 0, 0), lastData.EndTime);
+            Assert.AreEqual(lastData.EndTime, indicatorValues.Last().EndTime);
         }
 
         [TestCase("Span", Language.CSharp)]
@@ -221,6 +222,7 @@ namespace QuantConnect.Tests.Algorithm
 
             var lastData = indicatorValues.Current.Last();
             Assert.AreEqual(new DateTime(2013, 10, 10, 16, 0, 0), lastData.EndTime);
+            Assert.AreEqual(lastData.EndTime, indicatorValues.Last().EndTime);
         }
 
         [TestCase(Language.Python)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Minor fir for mis-Aligned Timestamps from IndicatorHistory. Adjusting unit test to reproduce issue.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/QuantConnect/Lean/issues/8158
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
N/A
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
