### PR TITLE
ARIMA indicator error handling

### DIFF
--- a/Indicators/AutoRegressiveIntegratedMovingAverage.cs
+++ b/Indicators/AutoRegressiveIntegratedMovingAverage.cs
@@ -342,7 +342,7 @@ namespace QuantConnect.Indicators
                 try
                 {
                     // The function (lags[time][lagged X]) |---> ΣᵢφᵢXₜ₋ᵢ
-                    arFits = Fit.MultiDim(lags, data.Skip(_maOrder).ToArray(),
+                    arFits = Fit.MultiDim(lags, data.Skip(_arOrder).ToArray(),
                         method: DirectRegressionMethod.NormalEquations);
                 }
                 catch (Exception ex)

--- a/Indicators/AutoRegressiveIntegratedMovingAverage.cs
+++ b/Indicators/AutoRegressiveIntegratedMovingAverage.cs
@@ -349,7 +349,7 @@ namespace QuantConnect.Indicators
                 {
                     if (!_loggedOnceInAutoRegressiveStep)
                     {
-                        Logging.Log.Error($"AutoRegressiveIntegratedMovingAverage.MovingAverageStep(): {ex.Message}");
+                        Logging.Log.Error($"AutoRegressiveIntegratedMovingAverage.AutoRegressiveStep(): {ex.Message}");
                         _loggedOnceInAutoRegressiveStep = true;
                     }
 

--- a/Indicators/AutoRegressiveIntegratedMovingAverage.cs
+++ b/Indicators/AutoRegressiveIntegratedMovingAverage.cs
@@ -280,6 +280,14 @@ namespace QuantConnect.Indicators
                 catch (Exception ex)
                 {
                     Logging.Log.Error($"AutoRegressiveIntegratedMovingAverage.MovingAverageStep(): {ex.Message}");
+                    // The method Fit.MultiDim takes the appendedData array of mxn(m rows, n columns), computes its
+                    // transpose of size nxm, and then multiplies the tranpose with the original matrix, so the
+                    // resultant matrix is of size nxn. Then a linear system Ax=b is solved where A is the
+                    // aforementioned matrix and b is the data. Thus, the size of the response x is n
+                    //
+                    // It's worth saying that if intercept flag is set to true, the number of columns of the initial
+                    // matrix (appendedData) is increased in one. For more information, please see the implementation
+                    // of Fit.MultiDim() method (Ctrl + right click)
                     var size = appendedData.ToArray()[0].Length + (_intercept ? 1 : 0);
                     maFits = new double[size];
                 }
@@ -335,6 +343,12 @@ namespace QuantConnect.Indicators
                 catch (Exception ex)
                 {
                     Logging.Log.Error($"AutoRegressiveIntegratedMovingAverage.MovingAverageStep(): {ex.Message}");
+                    // The method Fit.MultiDim takes the lags array of mxn(m rows, n columns), computes its
+                    // transpose of size nxm, and then multiplies the tranpose with the original matrix, so the
+                    // resultant matrix is of size nxn. Then a linear system Ax=b is solved where A is the
+                    // aforementioned matrix and b is the data. Thus, the size of the response x is n
+                    //
+                    // For more information, please see the implementation of Fit.MultiDim() method (Ctrl + right click)
                     var size = lags.ToArray()[0].Length;
                     arFits = new double[size];
                 }

--- a/Tests/Indicators/AutoregressiveIntegratedMovingAverageTests.cs
+++ b/Tests/Indicators/AutoregressiveIntegratedMovingAverageTests.cs
@@ -98,13 +98,6 @@ namespace QuantConnect.Tests.Indicators
             Assert.LessOrEqual(1.19542348709062, betweenMethods.ToDoubleArray().StandardDeviation()); // Std. Dev
         }
 
-        [Test]
-        public override void WorksWithLowValues()
-        {
-            // Since this indicator uses the least squares fitting method, if the matrix computed with the input
-            // values is not positive definite it will fail. Thus we omit this test for this indicator.
-        }
-
         protected override IndicatorBase<IndicatorDataPoint> CreateIndicator()
         {
             var ARIMA = new AutoRegressiveIntegratedMovingAverage("ARIMA", 1, 0, 1, 50);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Add a property for ARIMA indicator that defaults to true to handle exceptions thrown by the `Fit.MultiDim()` method. When this method throws an exception, the message is logged and a zero array is set as a result.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #8039 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
LEAN should not throw unhandled exceptions
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change might require an update in the documentation briefing the users on this new argument
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There was a method that tested the indicator against small values close to zero. Since before the exceptions thrown by the indicator were unhandled, this method was overridden to be empty. Specifically, the value that made the indicator fail was zero. The indicator value on the explosion was zero and with this change the indicator value after handling the exception is also zero. This happens since the values assigned to the variables `maFits` and `arFits` when the method `Fit.MultiDim()` fails is an array of zeros of the needed size, and those values are the ones used to calculate the value of the indicator in `ComputeNextValue()`.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
