### PR TITLE
Made changes in the ParseOptionTickerOSI function. Now it can handle …

### DIFF
--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -328,13 +328,13 @@ namespace QuantConnect
         /// <returns>The OSI ticker representation</returns>
         public static string GenerateOptionTickerOSICompact(this Symbol symbol)
         {
-        // First, validate that the symbol is of the correct security type
-        if (!symbol.SecurityType.IsOption())
-        {
-            throw new ArgumentException(
-                Messages.SymbolRepresentation.UnexpectedSecurityTypeForMethod(nameof(GenerateOptionTickerOSICompact), symbol.SecurityType));
-        }
-        return GenerateOptionTickerOSICompact(symbol.Underlying.Value, symbol.ID.OptionRight, symbol.ID.StrikePrice, symbol.ID.Date);
+            // First, validate that the symbol is of the correct security type
+            if (!symbol.SecurityType.IsOption())
+            {
+                throw new ArgumentException(
+                    Messages.SymbolRepresentation.UnexpectedSecurityTypeForMethod(nameof(GenerateOptionTickerOSICompact), symbol.SecurityType));
+            }
+            return GenerateOptionTickerOSICompact(symbol.Underlying.Value, symbol.ID.OptionRight, symbol.ID.StrikePrice, symbol.ID.Date);
         }
 
         /// <summary>
@@ -348,7 +348,7 @@ namespace QuantConnect
         /// <returns>The OSI ticker representation</returns>
         public static string GenerateOptionTickerOSICompact(string underlying, OptionRight right, decimal strikePrice, DateTime expiration)
         {
-        return Invariant($"{underlying}{expiration.ToStringInvariant(DateFormat.SixCharacter)}{right.ToStringPerformance()[0]}{(strikePrice * 1000m):00000000}");
+            return Invariant($"{underlying}{expiration.ToStringInvariant(DateFormat.SixCharacter)}{right.ToStringPerformance()[0]}{(strikePrice * 1000m):00000000}");
         }
 
         /// <summary>

--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -23,6 +23,7 @@ using QuantConnect.Securities.Option;
 using QuantConnect.Securities.Future;
 using QuantConnect.Securities.FutureOption;
 using static QuantConnect.StringExtensions;
+using System.Text.RegularExpressions;
 
 namespace QuantConnect
 {
@@ -338,30 +339,26 @@ namespace QuantConnect
         /// <returns>Symbol object for the specified OSI option ticker string</returns>
         public static Symbol ParseOptionTickerOSI(string ticker, SecurityType securityType, OptionStyle optionStyle, string market)
         {
-            var optionTicker = ticker.Substring(0, 6).Trim();
-            var expiration = DateTime.ParseExact(ticker.Substring(6, 6), DateFormat.SixCharacter, null);
-            OptionRight right;
-            if (ticker[12] == 'C' || ticker[12] == 'c')
+            
+            var match = Regex.Match(ticker, @"^([A-Z]+)\s*(\d{6})([CP])(\d{8})$", RegexOptions.IgnoreCase);
+            if (!match.Success)
             {
-                right = OptionRight.Call;
+                throw new FormatException("Invalid ticker format.");
             }
-            else if (ticker[12] == 'P' || ticker[12] == 'p')
-            {
-                right = OptionRight.Put;
-            }
-            else
-            {
-                throw new FormatException(Messages.SymbolRepresentation.UnexpectedOptionRightFormatForParseOptionTickerOSI(ticker));
-            }
-            var strike = Parse.Decimal(ticker.Substring(13, 8)) / 1000m;
+
+            var optionTicker = match.Groups[1].Value;
+            var expiration = DateTime.ParseExact(match.Groups[2].Value, "yyMMdd", null);
+            OptionRight right = match.Groups[3].Value.ToUpper() == "C" ? OptionRight.Call : OptionRight.Put;
+            var strike = decimal.Parse(match.Groups[4].Value) / 1000m;
+
             SecurityIdentifier underlyingSid;
             if (securityType == SecurityType.Option)
             {
                 underlyingSid = SecurityIdentifier.GenerateEquity(optionTicker, market);
-                // let it fallback to it's default handling, which include mapping
+                // Reset optionTicker for default handling
                 optionTicker = null;
             }
-            else if(securityType == SecurityType.IndexOption)
+            else if (securityType == SecurityType.IndexOption)
             {
                 underlyingSid = SecurityIdentifier.GenerateIndex(OptionSymbol.MapToUnderlying(optionTicker, securityType), market);
             }
@@ -369,9 +366,12 @@ namespace QuantConnect
             {
                 throw new NotImplementedException($"ParseOptionTickerOSI(): {Messages.SymbolRepresentation.SecurityTypeNotImplemented(securityType)}");
             }
+
             var sid = SecurityIdentifier.GenerateOption(expiration, underlyingSid, optionTicker, market, strike, right, optionStyle);
             return new Symbol(sid, ticker, new Symbol(underlyingSid, underlyingSid.Symbol));
         }
+    
+
 
         /// <summary>
         /// Function returns option ticker from IQFeed option ticker

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -36,7 +36,18 @@ namespace QuantConnect.Tests.Common
         [TestCase("SPY   230111C02400000", SecurityType.Option, OptionStyle.American, "SPY", "SPY")]
         [TestCase("AAPL240614C00100000", SecurityType.Option, OptionStyle.American, "AAPL", "AAPL")]
         [TestCase("MSFT240614C00150000", SecurityType.Option, OptionStyle.American, "MSFT", "MSFT")]
-
+        [TestCase("AMZN  220630C01000000", SecurityType.Option, OptionStyle.American, "AMZN", "AMZN")]
+        [TestCase("NFLX  230122P00250000", SecurityType.Option, OptionStyle.American, "NFLX", "NFLX")]
+        [TestCase("TSLA  240815C00775000", SecurityType.Option, OptionStyle.American, "TSLA", "TSLA")]
+        [TestCase("V     231211P00220000", SecurityType.Option, OptionStyle.American, "V", "V")]
+        [TestCase("JPM   240501C00130750", SecurityType.Option, OptionStyle.American, "JPM", "JPM")]
+        [TestCase("IBM   250212P00145000", SecurityType.Option, OptionStyle.American, "IBM", "IBM")]
+        [TestCase("BABA  240508C00088880", SecurityType.Option, OptionStyle.American, "BABA", "BABA")]
+        [TestCase("DIS   230630C00075000", SecurityType.Option, OptionStyle.American, "DIS", "DIS")]
+        [TestCase("ORCL  231030C00065000", SecurityType.Option, OptionStyle.American, "ORCL", "ORCL")]
+        [TestCase("CSCO  230501P00045000", SecurityType.Option, OptionStyle.American, "CSCO", "CSCO")]
+        [TestCase("DAX   250715C01000000", SecurityType.IndexOption, OptionStyle.European, "DAX", "DAX")]
+        [TestCase("FTSE  230122C00750000", SecurityType.IndexOption, OptionStyle.European, "FTSE", "FTSE")]
         public void ParseOptionTickerOSI(string optionStr, SecurityType securityType, OptionStyle optionStyle,
             string expectedTargetOptionTicker, string expectedUnderlyingTicker)
         {
@@ -54,6 +65,25 @@ namespace QuantConnect.Tests.Common
             const string expected = @"ABCDEF 060318C00047500";
             var symbol = SymbolRepresentation.GenerateOptionTickerOSI("ABCDEF", OptionRight.Call, 47.50m, new DateTime(2006, 03, 18));
             Assert.AreEqual(expected, symbol);
+        }
+
+        [TestCase("SPXW", OptionRight.Call, 2400.00, "230111", "SPXW230111C02400000")]
+        [TestCase("SPY", OptionRight.Put, 250.00, "230615", "SPY230615P00250000")]
+        [TestCase("AAPL", OptionRight.Call, 100.00, "240614", "AAPL240614C00100000")]
+        [TestCase("MSFT", OptionRight.Put, 150.00, "240614", "MSFT240614P00150000")]
+        [TestCase("GOOG", OptionRight.Call, 2000.00, "211231", "GOOG211231C02000000")]
+        [TestCase("AMZN", OptionRight.Put, 3500.50, "250101", "AMZN250101P03500500")]
+        [TestCase("NFLX", OptionRight.Call, 500.25, "221201", "NFLX221201C00500250")]
+        [TestCase("TSLA", OptionRight.Put, 725.00, "241231", "TSLA241231P00725000")]
+        [TestCase("V", OptionRight.Call, 220.00, "230420", "V230420C00220000")]
+        [TestCase("JPM", OptionRight.Put, 130.75, "230710", "JPM230710P00130750")]
+        [TestCase("IBM", OptionRight.Call, 145.00, "250212", "IBM250212C00145000")]
+        [TestCase("BABA", OptionRight.Put, 88.88, "240508", "BABA240508P00088880")]
+        public void GenerateOptionTickerOSICompact_ValidInputs(string underlying, OptionRight right, decimal strikePrice, string date, string expected)
+        {
+            DateTime expiration = DateTime.ParseExact(date, "yyMMdd", System.Globalization.CultureInfo.InvariantCulture);
+            string result = SymbolRepresentation.GenerateOptionTickerOSICompact(underlying, right, strikePrice, expiration);
+            Assert.AreEqual(expected, result);
         }
 
         [Test]

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -34,6 +34,9 @@ namespace QuantConnect.Tests.Common
 
         [TestCase("SPXW  230111C02400000", SecurityType.IndexOption, OptionStyle.European, "SPXW", "SPX")]
         [TestCase("SPY   230111C02400000", SecurityType.Option, OptionStyle.American, "SPY", "SPY")]
+        [TestCase("AAPL240614C00100000", SecurityType.Option, OptionStyle.American, "AAPL", "AAPL")]
+        [TestCase("MSFT240614C00150000", SecurityType.Option, OptionStyle.American, "MSFT", "MSFT")]
+
         public void ParseOptionTickerOSI(string optionStr, SecurityType securityType, OptionStyle optionStyle,
             string expectedTargetOptionTicker, string expectedUnderlyingTicker)
         {

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -32,24 +32,22 @@ namespace QuantConnect.Tests.Common
             Assert.AreEqual(expected, result);
         }
 
-        [TestCase("SPXW  230111C02400000", SecurityType.IndexOption, OptionStyle.European, "SPXW", "SPX")]
-        [TestCase("SPY   230111C02400000", SecurityType.Option, OptionStyle.American, "SPY", "SPY")]
-        [TestCase("AAPL240614C00100000", SecurityType.Option, OptionStyle.American, "AAPL", "AAPL")]
-        [TestCase("MSFT240614C00150000", SecurityType.Option, OptionStyle.American, "MSFT", "MSFT")]
-        [TestCase("AMZN  220630C01000000", SecurityType.Option, OptionStyle.American, "AMZN", "AMZN")]
-        [TestCase("NFLX  230122P00250000", SecurityType.Option, OptionStyle.American, "NFLX", "NFLX")]
-        [TestCase("TSLA  240815C00775000", SecurityType.Option, OptionStyle.American, "TSLA", "TSLA")]
-        [TestCase("V     231211P00220000", SecurityType.Option, OptionStyle.American, "V", "V")]
-        [TestCase("JPM   240501C00130750", SecurityType.Option, OptionStyle.American, "JPM", "JPM")]
-        [TestCase("IBM   250212P00145000", SecurityType.Option, OptionStyle.American, "IBM", "IBM")]
-        [TestCase("BABA  240508C00088880", SecurityType.Option, OptionStyle.American, "BABA", "BABA")]
-        [TestCase("DIS   230630C00075000", SecurityType.Option, OptionStyle.American, "DIS", "DIS")]
-        [TestCase("ORCL  231030C00065000", SecurityType.Option, OptionStyle.American, "ORCL", "ORCL")]
-        [TestCase("CSCO  230501P00045000", SecurityType.Option, OptionStyle.American, "CSCO", "CSCO")]
-        [TestCase("DAX   250715C01000000", SecurityType.IndexOption, OptionStyle.European, "DAX", "DAX")]
-        [TestCase("FTSE  230122C00750000", SecurityType.IndexOption, OptionStyle.European, "FTSE", "FTSE")]
-        public void ParseOptionTickerOSI(string optionStr, SecurityType securityType, OptionStyle optionStyle,
-            string expectedTargetOptionTicker, string expectedUnderlyingTicker)
+        [TestCase("SPXW  230111C02400000", SecurityType.IndexOption, OptionStyle.European, "SPXW", "SPX", 2400.00, "2023-01-11")]
+        [TestCase("SPY   230111C02400000", SecurityType.Option, OptionStyle.American, "SPY", "SPY", 2400.00, "2023-01-11")]
+        [TestCase("AAPL240614C00100000", SecurityType.Option, OptionStyle.American, "AAPL", "AAPL", 100.00, "2024-06-14")]
+        [TestCase("MSFT240614C00150000", SecurityType.Option, OptionStyle.American, "MSFT", "MSFT", 150.00, "2024-06-14")]
+        [TestCase("AMZN  220630C01000000", SecurityType.Option, OptionStyle.American, "AMZN", "AMZN", 1000.00, "2022-06-30")]
+        [TestCase("NFLX  230122P00250000", SecurityType.Option, OptionStyle.American, "NFLX", "NFLX", 250.00, "2023-01-22")]
+        [TestCase("TSLA  240815C00775000", SecurityType.Option, OptionStyle.American, "TSLA", "TSLA", 775.00, "2024-08-15")]
+        [TestCase("V     231211P00220000", SecurityType.Option, OptionStyle.American, "V", "V", 220.00, "2023-12-11")]
+        [TestCase("JPM   240501C00130750", SecurityType.Option, OptionStyle.American, "JPM", "JPM", 130.75, "2024-05-01")]
+        [TestCase("IBM   250212P00145000", SecurityType.Option, OptionStyle.American, "IBM", "IBM", 145.00, "2025-02-12")]
+        [TestCase("DIS   230630C00075000", SecurityType.Option, OptionStyle.American, "DIS", "DIS", 75.00, "2023-06-30")]
+        [TestCase("ORCL  231030C00065000", SecurityType.Option, OptionStyle.American, "ORCL", "ORCL", 65.00, "2023-10-30")]
+        [TestCase("CSCO  230501P00045000", SecurityType.Option, OptionStyle.American, "CSCO", "CSCO", 45.00, "2023-05-01")]
+        [TestCase("DAX   250715C01000000", SecurityType.IndexOption, OptionStyle.European, "DAX", "DAX", 1000.00, "2025-07-15")]
+        [TestCase("FTSE  230122C00750000", SecurityType.IndexOption, OptionStyle.European, "FTSE", "FTSE", 750.00, "2023-01-22")]
+        public void ParseOptionTickerOSI(string optionStr, SecurityType securityType, OptionStyle optionStyle,string expectedTargetOptionTicker, string expectedUnderlyingTicker, decimal expectedStrikePrice, string expectedDate)
         {
             var result = SymbolRepresentation.ParseOptionTickerOSI(optionStr, securityType, optionStyle, Market.USA);
 
@@ -57,6 +55,8 @@ namespace QuantConnect.Tests.Common
             Assert.AreEqual(expectedUnderlyingTicker, result.Underlying.ID.Symbol);
             Assert.AreEqual(securityType, result.ID.SecurityType);
             Assert.AreEqual(optionStyle, result.ID.OptionStyle);
+            Assert.AreEqual(expectedStrikePrice, result.ID.StrikePrice);
+            Assert.AreEqual(DateTime.Parse(expectedDate), result.ID.Date);
         }
 
         [Test]


### PR DESCRIPTION
…both with and without space


<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Closes #8205 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
