### PR TITLE
Fix algorithms using OnData(TradeBars) w/o using arg or other OnData().

### DIFF
--- a/Algorithm.CSharp/BasicTemplateFillForwardAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFillForwardAlgorithm.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
 
 namespace QuantConnect.Algorithm.CSharp
@@ -41,8 +42,8 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
         /// </summary>
-        /// <param name="data">TradeBars IDictionary object with your stock data</param>
-        public void OnData(TradeBars data)
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
         {
             if (!Portfolio.Invested)
             {

--- a/Algorithm.CSharp/Benchmarks/CoarseFineUniverseSelectionBenchmark.cs
+++ b/Algorithm.CSharp/Benchmarks/CoarseFineUniverseSelectionBenchmark.cs
@@ -15,6 +15,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Data;
 using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
@@ -68,8 +69,8 @@ namespace QuantConnect.Algorithm.CSharp.Benchmarks
             return topFine.Select(x => x.Symbol);
         }
 
-        //Data Event Handler: New data arrives here. "TradeBars" type is a dictionary of strings so you can access it by symbol.
-        public void OnData(TradeBars data)
+        //Data Event Handler: New data arrives here.
+        public override void OnData(Slice slice)
         {
             // if we have no changes, do nothing
             if (_changes == SecurityChanges.None) return;

--- a/Algorithm.CSharp/Benchmarks/IndicatorRibbonBenchmark.cs
+++ b/Algorithm.CSharp/Benchmarks/IndicatorRibbonBenchmark.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
 
@@ -58,7 +59,7 @@ namespace QuantConnect.Algorithm.CSharp.Benchmarks
             }).ToArray();
         }
 
-        public void OnData(TradeBars data)
+        public override void OnData(Slice slice)
         {
             // wait for our entire ribbon to be ready
             if (!_ribbon.All(x => x.IsReady)) return;

--- a/Algorithm.CSharp/BrokerageModelAlgorithm.cs
+++ b/Algorithm.CSharp/BrokerageModelAlgorithm.cs
@@ -14,6 +14,7 @@
 */
 
 using QuantConnect.Brokerages;
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
@@ -58,8 +59,8 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
         /// </summary>
-        /// <param name="data">TradeBars IDictionary object with your stock data</param>
-        public void OnData(TradeBars data)
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
         {
             if (!Portfolio.Invested)
             {

--- a/Algorithm.CSharp/BubbleAlgorithm.cs
+++ b/Algorithm.CSharp/BubbleAlgorithm.cs
@@ -116,9 +116,9 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
-        /// New TradeBar data for our assets.
+        /// New data for our assets.
         /// </summary>
-        public void OnData(TradeBars data)
+        public override void OnData(Slice slice)
         {
             try
             {

--- a/Algorithm.CSharp/ClassicRenkoConsolidatorAlgorithm.cs
+++ b/Algorithm.CSharp/ClassicRenkoConsolidatorAlgorithm.cs
@@ -15,6 +15,7 @@
 
 using QuantConnect.Interfaces;
 using System.Collections.Generic;
+using QuantConnect.Data;
 using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 
@@ -71,7 +72,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// We're doing our analysis in the OnRenkoBar method, but the framework verifies that this method exists, so we define it.
         /// </summary>
-        public void OnData(TradeBars data)
+        public override void OnData(Slice slice)
         {
         }
 

--- a/Algorithm.CSharp/CoarseFineFundamentalComboAlgorithm.cs
+++ b/Algorithm.CSharp/CoarseFineFundamentalComboAlgorithm.cs
@@ -15,6 +15,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Data;
 using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
@@ -80,8 +81,8 @@ namespace QuantConnect.Algorithm.CSharp
             return topFine.Select(x => x.Symbol);
         }
 
-        //Data Event Handler: New data arrives here. "TradeBars" type is a dictionary of strings so you can access it by symbol.
-        public void OnData(TradeBars data)
+        //Data Event Handler: New data arrives here.
+        public override void OnData(Slice slice)
         {
             // if we have no changes, do nothing
             if (_changes == SecurityChanges.None) return;

--- a/Algorithm.CSharp/CustomBrokerageMessageHandlerAlgorithm.cs
+++ b/Algorithm.CSharp/CustomBrokerageMessageHandlerAlgorithm.cs
@@ -15,6 +15,7 @@
 
 using System;
 using QuantConnect.Brokerages;
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 
@@ -39,7 +40,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetBrokerageMessageHandler(new CustomBrokerageMessageHandler(this));
         }
 
-        public void OnData(TradeBars data)
+        public override void OnData(Slice slice)
         {
             if (Portfolio.HoldStock) return;
             Order("SPY", 100);

--- a/Algorithm.CSharp/CustomSecurityInitializerAlgorithm.cs
+++ b/Algorithm.CSharp/CustomSecurityInitializerAlgorithm.cs
@@ -45,7 +45,7 @@ namespace QuantConnect.Algorithm.CSharp
             AddSecurity(SecurityType.Equity, "SPY", Resolution.Hour);
         }
 
-        public void OnData(TradeBars data)
+        public override void OnData(Slice slice)
         {
             if (!Portfolio.Invested)
             {

--- a/Algorithm.CSharp/DataConsolidationAlgorithm.cs
+++ b/Algorithm.CSharp/DataConsolidationAlgorithm.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using QuantConnect.Data;
 using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 
@@ -123,8 +124,8 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
         /// </summary>
-        /// <param name="bars">TradeBars IDictionary object with your stock data</param>
-        public void OnData(TradeBars bars)
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
         {
             // we need to declare this method
         }

--- a/Algorithm.CSharp/ETFGlobalRotationAlgorithm.cs
+++ b/Algorithm.CSharp/ETFGlobalRotationAlgorithm.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
 
@@ -82,8 +83,8 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
         /// </summary>
-        /// <param name="data">TradeBars IDictionary object with your stock data</param>
-        public void OnData(TradeBars data)
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
         {
             try
             {
@@ -130,7 +131,7 @@ namespace QuantConnect.Algorithm.CSharp
             }
             catch (RegressionTestException ex)
             {
-                Error("OnTradeBar: " + ex.Message + "\r\n\r\n" + ex.StackTrace);
+                Error("OnData: " + ex.Message + "\r\n\r\n" + ex.StackTrace);
             }
         }
     }

--- a/Algorithm.CSharp/EmaCrossUniverseSelectionAlgorithm.cs
+++ b/Algorithm.CSharp/EmaCrossUniverseSelectionAlgorithm.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Indicators;
@@ -98,8 +99,8 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
         /// </summary>
-        /// <param name="data">TradeBars dictionary object keyed by symbol containing the stock data</param>
-        public void OnData(TradeBars data)
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
         {
             if (_changes == SecurityChanges.None) return;
 

--- a/Algorithm.CSharp/MarginCallEventsAlgorithm.cs
+++ b/Algorithm.CSharp/MarginCallEventsAlgorithm.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 
@@ -48,8 +49,8 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
         /// </summary>
-        /// <param name="data">TradeBars IDictionary object with your stock data</param>
-        public void OnData(TradeBars data)
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
         {
             if (!Portfolio.Invested)
             {

--- a/Algorithm.CSharp/MarketOnOpenOnCloseAlgorithm.cs
+++ b/Algorithm.CSharp/MarketOnOpenOnCloseAlgorithm.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
@@ -49,8 +50,8 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
         /// </summary>
-        /// <param name="data">TradeBars IDictionary object with your stock data</param>
-        public void OnData(TradeBars data)
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
         {
             if (Time.Date != last.Date) // each morning submit a market on open order
             {

--- a/Algorithm.CSharp/StressSymbolsAlgorithm.cs
+++ b/Algorithm.CSharp/StressSymbolsAlgorithm.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
 
 namespace QuantConnect.Algorithm.CSharp
@@ -93,9 +94,9 @@ namespace QuantConnect.Algorithm.CSharp
         }
 
         /// <summary>
-        /// TradeBar data event handler
+        /// data event handler
         /// </summary>
-        public void OnData(TradeBars data)
+        public override void OnData(Slice slice)
         {
 
         }


### PR DESCRIPTION
#### Description

##### Drafting process
- `sed -i 's/OnData(TradeBars [a-z]*/OnData(Slice slice/' $(git grep -l 'OnData(TradeBars')`
- `sed -i 's/public void OnData(Slice/public override void OnData(Slice/' $(git diff --name-only master)`
- add import if the file doesn't already have one
- revert the six files where the OnData() uses its TradeBars argument
- revert Algorithm.CSharp/DividendAlgorithm.cs, which has OnData(Dividends) and OnData(Splits)
- update any <param ...> on  the line before the changed line
- update any obsolete reference to "TradeBar" in the modified files

#### Related Issue
Closes #8244

#### Motivation and Context
See issue.  Starting from commit d24f665ee4c38289907782409c1d210e3d259882, these and other examples ceased getting the method calls they expected.

#### Requires Documentation Change

https://www.quantconnect.com/docs/v2/writing-algorithms/securities/asset-classes/us-equity/handling-data
text "if you define an OnData method that accepts a TradeBar argument ..."
needs a corresponding update.  The page needs that update whether or not this
pull request proceeds.

#### How Has This Been Tested?

##### Algorithm.CSharp/BasicTemplateFillForwardAlgorithm.cs
- Before: https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_a764a3cee8766f1fc166ab2142fb529b.html
- After: https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_143fa389801acb939d85be8f0c316f10.html

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.  Few of the example algorithms have tests, hence this regression escaping.  Addressing that backlog would be a larger project.
- [X] All new and existing tests passed.  Not really.  The test run ended the same way the last master commit test run ended, at `ERROR:: MarketOnClose orders must be placed within 00:15:30 before market close. Override this TimeSpan buffer by setting Orders.MarketOnCloseOrder.SubmissionTimeBuffer in QCAlgorithm.Initialize().`
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->