### PR TITLE
Fix sign of order quantity in example algorithm OnMarginCall().

### DIFF
--- a/Algorithm.CSharp/MarginCallEventsAlgorithm.cs
+++ b/Algorithm.CSharp/MarginCallEventsAlgorithm.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Algorithm.CSharp
             foreach (var order in requests.ToList())
             {
                 // liquidate an extra 10% each time we get a margin call to give us more padding
-                var newQuantity = (int)(Math.Sign(order.Quantity) * order.Quantity * 1.1m);
+                var newQuantity = (int)(order.Quantity * 1.1m);
                 requests.Remove(order);
                 requests.Add(new SubmitOrderRequest(order.OrderType, order.SecurityType, order.Symbol, newQuantity, order.StopPrice, order.LimitPrice, Time, "OnMarginCall"));
             }

--- a/Algorithm.Python/MarginCallEventsAlgorithm.py
+++ b/Algorithm.Python/MarginCallEventsAlgorithm.py
@@ -48,7 +48,7 @@ class MarginCallEventsAlgorithm(QCAlgorithm):
         for order in requests:
 
             # liquidate an extra 10% each time we get a margin call to give us more padding
-            new_quantity = int(np.sign(order.quantity) * order.quantity * 1.1)
+            new_quantity = int(order.quantity * 1.1)
             requests.remove(order)
             requests.append(SubmitOrderRequest(order.order_type, order.security_type, order.symbol, new_quantity, order.stop_price, order.limit_price, self.time, "on_margin_call"))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Stop reversing the sign of the quantity.

#### Related Issue
Closes #8250

#### Motivation and Context

See #8250.
https://github.com/QuantConnect/Lean/blob/master/Algorithm.CSharp/MarginCallEventsAlgorithm.cs
OnMarginCall() turns a proposed sale of 100 shares into a *buy* of 110 shares,
contrary to comments.

#### Requires Documentation Change
No.

#### How Has This Been Tested?

- Before: https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_580fe43d1d083d907ff8611bd2aaa667.html
- After: https://www.quantconnect.com/terminal/processCache?request=embedded_backtest_6b848bb31ac3dfcd9722dc9a4a695c93.html

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.  This algorithm has no tests, hence this regression escaping.  Addressing that backlog would be a larger project.
- [X] All new and existing tests passed.  Not actually.  The test run ended the same way the last master commit test run ended, at `ERROR:: MarketOnClose orders must be placed within 00:15:30 before market close. Override this TimeSpan buffer by setting Orders.MarketOnCloseOrder.SubmissionTimeBuffer in QCAlgorithm.Initialize().`
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->