### PR TITLE
Dividend yield calculation fix

### DIFF
--- a/Algorithm.CSharp/FutureOptionIndicatorsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionIndicatorsRegressionAlgorithm.cs
@@ -22,7 +22,7 @@ namespace QuantConnect.Algorithm.CSharp
 {
     public class FutureOptionIndicatorsRegressionAlgorithm : OptionIndicatorsRegressionAlgorithm
     {
-        protected override string ExpectedGreeks { get; set; } = "Implied Volatility: 0.14316,Delta: 0.55278,Gamma: 0.00156,Vega: 5.60955,Theta: -0.64434,Rho: -0.0084";
+        protected override string ExpectedGreeks { get; set; } = "Implied Volatility: 0.14089,Delta: 0.6308,Gamma: 0.00207,Vega: 5.61431,Theta: -0.48816,Rho: 0.02962";
 
         public override void Initialize()
         {

--- a/Algorithm.CSharp/IndexOptionIndicatorsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionIndicatorsRegressionAlgorithm.cs
@@ -20,7 +20,7 @@ namespace QuantConnect.Algorithm.CSharp
 {
     public class IndexOptionIndicatorsRegressionAlgorithm : OptionIndicatorsRegressionAlgorithm
     {
-        protected override string ExpectedGreeks { get; set; } = "Implied Volatility: 0.18072,Delta: 0.1897,Gamma: 0.00246,Vega: 1.7607,Theta: -1.43923,Rho: 0.01673";
+        protected override string ExpectedGreeks { get; set; } = "Implied Volatility: 0.17702,Delta: 0.19195,Gamma: 0.00247,Vega: 1.69043,Theta: -1.41571,Rho: 0.01686";
 
         public override void Initialize()
         {

--- a/Algorithm.CSharp/OptionIndicatorsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionIndicatorsRegressionAlgorithm.cs
@@ -32,7 +32,7 @@ namespace QuantConnect.Algorithm.CSharp
         private Theta _theta;
         private Rho _rho;
 
-        protected virtual string ExpectedGreeks { get; set; } = "Implied Volatility: 0.45666,Delta: -0.00965,Gamma: 0.00027,Vega: 0.02602,Theta: -0.02564,Rho: 0.00033";
+        protected virtual string ExpectedGreeks { get; set; } = "Implied Volatility: 0.45254,Delta: -0.0092,Gamma: 0.00036,Vega: 0.03562,Theta: -0.0387,Rho: 0.00045";
 
         public override void Initialize()
         {

--- a/Common/Data/ConstantDividendYieldModel.cs
+++ b/Common/Data/ConstantDividendYieldModel.cs
@@ -41,5 +41,16 @@ namespace QuantConnect.Data
         {
             return _dividendYield;
         }
+
+        /// <summary>
+        /// Get dividend yield at given date and security price
+        /// </summary>
+        /// <param name="date">The date</param>
+        /// <param name="securityPrice">The security price at the given date</param>
+        /// <returns>Dividend yield on the given date of the given symbol</returns>
+        public decimal GetDividendYield(DateTime date, decimal securityPrice)
+        {
+            return _dividendYield;
+        }
     }
 }

--- a/Common/Data/IDividendYieldModel.cs
+++ b/Common/Data/IDividendYieldModel.cs
@@ -28,5 +28,13 @@ namespace QuantConnect.Data
         /// <param name="date">The date</param>
         /// <returns>Dividend yield on the given date of the given symbol</returns>
         decimal GetDividendYield(DateTime date);
+
+        /// <summary>
+        /// Get dividend yield at given date and security price
+        /// </summary>
+        /// <param name="date">The date</param>
+        /// <param name="securityPrice">The security price at the given date</param>
+        /// <returns>Dividend yield on the given date of the given symbol</returns>
+        public decimal GetDividendYield(DateTime date, decimal securityPrice);
     }
 }

--- a/Common/Python/DividendYieldModelPythonWrapper.cs
+++ b/Common/Python/DividendYieldModelPythonWrapper.cs
@@ -44,6 +44,18 @@ namespace QuantConnect.Python
         }
 
         /// <summary>
+        /// Get dividend yield at given date and security price
+        /// </summary>
+        /// <param name="date">The date</param>
+        /// <param name="securityPrice">The security price at the given date</param>
+        /// <returns>Dividend yield on the given date of the given symbol</returns>
+        /// <remarks>Price data must be raw (<see cref="DataNormalizationMode.Raw"/>)</remarks>
+        public decimal GetDividendYield(DateTime date, decimal securityPrice)
+        {
+            return InvokeMethod<decimal>(nameof(GetDividendYield), date, securityPrice);
+        }
+
+        /// <summary>
         /// Converts a <see cref="PyObject"/> object into a <see cref="IDividendYieldModel"/> object, wrapping it if necessary
         /// </summary>
         /// <param name="model">The Python model</param>

--- a/Indicators/ImpliedVolatility.cs
+++ b/Indicators/ImpliedVolatility.cs
@@ -263,7 +263,7 @@ namespace QuantConnect.Indicators
                 }
 
                 RiskFreeRate.Update(time, _riskFreeInterestRateModel.GetInterestRate(time));
-                DividendYield.Update(time, _dividendYieldModel.GetDividendYield(time));
+                DividendYield.Update(time, _dividendYieldModel.GetDividendYield(time, UnderlyingPrice.Current.Value));
 
                 var timeTillExpiry = Convert.ToDecimal((Expiry - time).TotalDays) / 365m;
                 _impliedVolatility = CalculateIV(timeTillExpiry);

--- a/Indicators/OptionGreekIndicatorBase.cs
+++ b/Indicators/OptionGreekIndicatorBase.cs
@@ -182,7 +182,7 @@ namespace QuantConnect.Indicators
                 }
 
                 RiskFreeRate.Update(time, _riskFreeInterestRateModel.GetInterestRate(time));
-                DividendYield.Update(time, _dividendYieldModel.GetDividendYield(time));
+                DividendYield.Update(time, _dividendYieldModel.GetDividendYield(time, UnderlyingPrice.Current.Value));
 
                 var timeTillExpiry = Convert.ToDecimal((Expiry - time).TotalDays / 365);
                 try

--- a/Tests/Common/Data/DividendYieldProviderTests.cs
+++ b/Tests/Common/Data/DividendYieldProviderTests.cs
@@ -33,11 +33,12 @@ namespace QuantConnect.Tests.Common.Data
         [TestCase("20200206", null, 0.0117484)]
         [TestCase("20200207", null, 0.0094262)] // Dividend on this date
         [TestCase("20200208", null, 0.0094262)]
-        [TestCase("20210203", null, 0.0217314)]
-        [TestCase("20210204", null, 0.0217314)]
-        [TestCase("20210205", null, 0.0148108)] // Dividend on this date
-        [TestCase("20210206", null, 0.0148108)]
-        [TestCase("20491231", null, 0.0148108)] // Date in far future, assuming same rate
+        [TestCase("20210203", null, 0.0067610)]
+        [TestCase("20210204", null, 0.0067610)]
+        [TestCase("20210205", null, 0.0059506)] // Dividend on this date
+        [TestCase("20210208", null, 0.0059506)]
+        [TestCase("20210209", null, 0.0059506)]
+        [TestCase("20491231", null, 0.0059506)] // Date in far future, assuming same rate
         // With price:
         [TestCase("19700306", 1.0, 0.0)]     // Date in before the first date in file
         [TestCase("20191107", 257.24, 0.0117484)] // Dividend on this date
@@ -46,11 +47,11 @@ namespace QuantConnect.Tests.Common.Data
         [TestCase("20200206", 321.45, 0.0094127)]
         [TestCase("20200207", 325.21, 0.0094262)] // Dividend on this date
         [TestCase("20200210", 320.03, 0.0095780)]
-        [TestCase("20210203", 134.99, 0.0191865)]
-        [TestCase("20210204", 133.94, 0.0193355)]
-        [TestCase("20210205", 137.39, 0.0148108)] // Dividend on this date
-        [TestCase("20210208", 136.76, 0.0148785)]
-        [TestCase("20210209", 136.91, 0.0148623)] // Date in far future, assuming same rate
+        [TestCase("20210203", 134.99, 0.0059641)]
+        [TestCase("20210204", 133.94, 0.0060107)]
+        [TestCase("20210205", 137.39, 0.0059506)] // Dividend on this date
+        [TestCase("20210208", 136.76, 0.0059780)]
+        [TestCase("20210209", 136.91, 0.0059714)] // Date in far future, assuming same rate
         public void GetDividendYieldRate(string dateString, double? price, double expected)
         {
             var symbol = Symbols.AAPL;
@@ -129,10 +130,10 @@ namespace QuantConnect.Tests.Common.Data
             {
             }
 
-            protected override List<Dividend> LoadDividends(Symbol symbol)
+            protected override List<BaseData> LoadCorporateEvents(Symbol symbol)
             {
                 FetchCount++;
-                return base.LoadDividends(symbol);
+                return base.LoadCorporateEvents(symbol);
             }
 
             public void Reset()

--- a/Tests/Common/Data/DividendYieldProviderTests.cs
+++ b/Tests/Common/Data/DividendYieldProviderTests.cs
@@ -24,14 +24,16 @@ namespace QuantConnect.Tests.Common.Data
     [TestFixture]
     public class DividendYieldProviderTests
     {
-        [TestCase("19700306", 0.0)]   // Date in before the first date in file
-        [TestCase("20200205", 0.04147)]
-        [TestCase("20200206", 0.03355)]
-        [TestCase("20200207", 0.03355)]
-        [TestCase("20210203", 0.01676)]
-        [TestCase("20210204", 0.01239)]
-        [TestCase("20210205", 0.01239)]
-        [TestCase("20491231", 0.01239)]   // Date in far future, assuming same rate
+        [TestCase("19700306", 0.0)]     // Date in before the first date in file
+        [TestCase("20200205", 0.01174)]
+        [TestCase("20200206", 0.01174)]
+        [TestCase("20200207", 0.00942)] // Dividend on this date
+        [TestCase("20200208", 0.00942)]
+        [TestCase("20210203", 0.02173)]
+        [TestCase("20210204", 0.02173)]
+        [TestCase("20210205", 0.01481)] // Dividend on this date
+        [TestCase("20210206", 0.01481)]
+        [TestCase("20491231", 0.01481)] // Date in far future, assuming same rate
         public void GetDividendYieldRate(string dateString, double expected)
         {
             var symbol = Symbols.AAPL;
@@ -104,8 +106,8 @@ namespace QuantConnect.Tests.Common.Data
             protected override TimeSpan CacheRefreshPeriod => TimeSpan.FromSeconds(1);
 
             public DividendYieldProviderTest(Symbol symbol)
-                : base(symbol) 
-            { 
+                : base(symbol)
+            {
             }
 
             protected override Dictionary<DateTime, decimal> LoadDividendYieldProvider(Symbol symbol)

--- a/Tests/Common/Data/DividendYieldProviderTests.cs
+++ b/Tests/Common/Data/DividendYieldProviderTests.cs
@@ -15,7 +15,6 @@
 
 using NUnit.Framework;
 using QuantConnect.Data;
-using QuantConnect.Data.Market;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -26,32 +25,32 @@ namespace QuantConnect.Tests.Common.Data
     public class DividendYieldProviderTests
     {
         // Without a price:
-        [TestCase("19700306", null, 0.0)]     // Date in before the first date in file
-        [TestCase("20191107", null, 0.0117484)] // Dividend on this date
-        [TestCase("20191108", null, 0.0117484)] // Same dividend yield is fill-forwarded for every day until next dividend
-        [TestCase("20200205", null, 0.0117484)]
-        [TestCase("20200206", null, 0.0117484)]
-        [TestCase("20200207", null, 0.0094262)] // Dividend on this date
-        [TestCase("20200208", null, 0.0094262)]
-        [TestCase("20210203", null, 0.0067610)]
-        [TestCase("20210204", null, 0.0067610)]
-        [TestCase("20210205", null, 0.0059506)] // Dividend on this date
-        [TestCase("20210208", null, 0.0059506)]
-        [TestCase("20210209", null, 0.0059506)]
-        [TestCase("20491231", null, 0.0059506)] // Date in far future, assuming same rate
+        [TestCase("19700306", null, 0.0)]           // Date in before the first date in file
+        [TestCase("20191107", null, 0.0118177)]     // Dividend on this date
+        [TestCase("20191108", null, 0.0118177)]     // Same dividend yield is fill-forwarded for every day until next dividend
+        [TestCase("20200205", null, 0.0118177)]
+        [TestCase("20200206", null, 0.0118177)]
+        [TestCase("20200207", null, 0.0094708)]     // Dividend on this date
+        [TestCase("20200208", null, 0.0094708)]
+        [TestCase("20210203", null, 0.0067840)]
+        [TestCase("20210204", null, 0.0067840)]
+        [TestCase("20210205", null, 0.0059684)]     // Dividend on this date
+        [TestCase("20210208", null, 0.0059684)]
+        [TestCase("20210209", null, 0.0059684)]
+        [TestCase("20491231", null, 0.0059684)]     // Date in far future, assuming same rate
         // With price:
-        [TestCase("19700306", 1.0, 0.0)]     // Date in before the first date in file
-        [TestCase("20191107", 257.24, 0.0117484)] // Dividend on this date
-        [TestCase("20191108", 259.43, 0.0116498)]
-        [TestCase("20200205", 318.85, 0.0094890)]
-        [TestCase("20200206", 321.45, 0.0094127)]
-        [TestCase("20200207", 325.21, 0.0094262)] // Dividend on this date
-        [TestCase("20200210", 320.03, 0.0095780)]
-        [TestCase("20210203", 134.99, 0.0059641)]
-        [TestCase("20210204", 133.94, 0.0060107)]
-        [TestCase("20210205", 137.39, 0.0059506)] // Dividend on this date
-        [TestCase("20210208", 136.76, 0.0059780)]
-        [TestCase("20210209", 136.91, 0.0059714)] // Date in far future, assuming same rate
+        [TestCase("19700306", 1.0, 0.0)]            // Date in before the first date in file
+        [TestCase("20191107", 257.24, 0.0118177)]   // Dividend on this date
+        [TestCase("20191108", 259.43, 0.0117179)]
+        [TestCase("20200205", 318.85, 0.0095342)]
+        [TestCase("20200206", 321.45, 0.0094571)]
+        [TestCase("20200207", 325.21, 0.0094708)]   // Dividend on this date
+        [TestCase("20200210", 320.03, 0.0096240)]
+        [TestCase("20210203", 134.99, 0.0059819)]
+        [TestCase("20210204", 133.94, 0.0060288)]
+        [TestCase("20210205", 137.39, 0.0059684)]   // Dividend on this date
+        [TestCase("20210208", 136.76, 0.0059959)]
+        [TestCase("20210209", 136.91, 0.0059893)]   // Date in far future, assuming same rate
         public void GetDividendYieldRate(string dateString, double? price, double expected)
         {
             var symbol = Symbols.AAPL;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Fix dividend yield calculation implementation:
- Dividend yield is the sum of dividends in the last 12 year period (ending in the most recent dividend date, not the price quote date. Referece: [YCharts](https://ycharts.com/glossary/terms/dividend_yield)): `dividendYield(date, lastClosePrice) = SUM(dividendsOfLastPrevious12MonthPeriod) / lastClosePrice`.
- The dividend distribution per share must be adjusted to splits that happened in the given 12 month period.
- Dividend yield is relative to the last close price at the query time, so the **raw** price is an input of the dividend yield provider:
  - In master, the model returned an estimation, getting the divided yield as calculated on the most recent dividend to the query date.

We tried to match our calculated dividend yield to charts found online as much as possible, as shown in the following charts for AAPL's historical dividend yield in the last 5 years:

##### Lean's dividend yield provider:
![image](https://github.com/user-attachments/assets/b393e8f0-f0fd-4cea-9bf9-c83a59121520)

##### Source: [YCharts](https://ycharts.com/companies/AAPL/dividend_yield)
![image](https://github.com/user-attachments/assets/1f57e679-4771-4319-873d-dfee3a01bd28)

##### Source: [Seeking Alpha](https://seekingalpha.com/symbol/AAPL/dividends/yield)
![image](https://github.com/user-attachments/assets/1d28b4c7-8c56-40c0-af6a-afeb0f5f94dc)

##### Notes:

- There is a small period after December 2022 where our chart doesn't match the third party source, but this is related to [this data issue](https://www.quantconnect.com/datasets/issue/17860):
  - It seems Lean has an additional dividend on December 2022 which affects the dividend yield calculation for dates where the trailing 12 month dividends period includes that additional one.


TLT historical dividend yield for reference to compare against the chart in the related issue (#8264):
![image](https://github.com/user-attachments/assets/db7c8f15-643a-4186-b907-78b5d1334ac6)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #8261 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Accurate dividend yield values

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
