### PR TITLE
Fix null exception thrown in SubscriptionManager.ScanPastConsolidators

### DIFF
--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Data
     {
         private readonly PriorityQueue<ConsolidatorWrapper, ConsolidatorScanPriority> _consolidatorsSortedByScanTime;
         private readonly Dictionary<IDataConsolidator, ConsolidatorWrapper> _consolidators;
-        private List<ConsolidatorWrapper> _consolidatorsToAdd;
+        private List<Tuple<ConsolidatorWrapper, ConsolidatorScanPriority>> _consolidatorsToAdd;
         private object _threadSafeCollectionLock;
         private readonly ITimeKeeper _timeKeeper;
         private IAlgorithmSubscriptionManager _subscriptionManager;
@@ -188,7 +188,7 @@ namespace QuantConnect.Data
                     lock (_threadSafeCollectionLock)
                     {
                         _consolidatorsToAdd ??= new();
-                        _consolidatorsToAdd.Add(wrapper);
+                        _consolidatorsToAdd.Add(new(wrapper, wrapper.Priority));
                     }
                     return;
                 }
@@ -272,7 +272,7 @@ namespace QuantConnect.Data
             {
                 lock (_threadSafeCollectionLock)
                 {
-                    _consolidatorsToAdd.DoForEach(x => _consolidatorsSortedByScanTime.Enqueue(x, x.Priority));
+                    _consolidatorsToAdd.DoForEach(x => _consolidatorsSortedByScanTime.Enqueue(x.Item1, x.Item2));
                     _consolidatorsToAdd = null;
                 }
             }

--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Data
     {
         private readonly PriorityQueue<ConsolidatorWrapper, ConsolidatorScanPriority> _consolidatorsSortedByScanTime;
         private readonly Dictionary<IDataConsolidator, ConsolidatorWrapper> _consolidators;
-        private LinkedList<ConsolidatorWrapper> _consolidatorsToAdd;
+        private List<ConsolidatorWrapper> _consolidatorsToAdd;
         private object _threadSafeCollectionLock;
         private readonly ITimeKeeper _timeKeeper;
         private IAlgorithmSubscriptionManager _subscriptionManager;
@@ -188,7 +188,7 @@ namespace QuantConnect.Data
                     lock (_threadSafeCollectionLock)
                     {
                         _consolidatorsToAdd ??= new();
-                        _consolidatorsToAdd.AddLast(wrapper);
+                        _consolidatorsToAdd.Add(wrapper);
                     }
                     return;
                 }

--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -23,7 +23,6 @@ using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Util;
 using QuantConnect.Python;
-using System.Collections.Concurrent;
 using System.Threading;
 
 namespace QuantConnect.Data

--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Data
     {
         private readonly PriorityQueue<ConsolidatorWrapper, ConsolidatorScanPriority> _consolidatorsSortedByScanTime;
         private readonly Dictionary<IDataConsolidator, ConsolidatorWrapper> _consolidators;
-        private LinkedList<Tuple<ConsolidatorWrapper, ConsolidatorScanPriority>> _consolidatorsToAdd;
+        private LinkedList<ConsolidatorWrapper> _consolidatorsToAdd;
         private object _threadSafeCollectionLock;
         private readonly ITimeKeeper _timeKeeper;
         private IAlgorithmSubscriptionManager _subscriptionManager;
@@ -188,7 +188,7 @@ namespace QuantConnect.Data
                     lock (_threadSafeCollectionLock)
                     {
                         _consolidatorsToAdd ??= new();
-                        _consolidatorsToAdd.AddLast(new Tuple<ConsolidatorWrapper, ConsolidatorScanPriority>(wrapper, wrapper.Priority));
+                        _consolidatorsToAdd.AddLast(wrapper);
                     }
                     return;
                 }
@@ -272,7 +272,7 @@ namespace QuantConnect.Data
             {
                 lock (_threadSafeCollectionLock)
                 {
-                    _consolidatorsToAdd.DoForEach(x => _consolidatorsSortedByScanTime.Enqueue(x.Item1, x.Item2));
+                    _consolidatorsToAdd.DoForEach(x => _consolidatorsSortedByScanTime.Enqueue(x, x.Priority));
                     _consolidatorsToAdd = null;
                 }
             }

--- a/Tests/Common/Data/SubscriptionManagerTests.cs
+++ b/Tests/Common/Data/SubscriptionManagerTests.cs
@@ -188,34 +188,49 @@ namespace QuantConnect.Tests.Common.Data
             subscriptionManager.SetDataManager(new DataManagerStub());
             var start = DateTime.UtcNow;
             var end = start.AddSeconds(5);
-            var tickers = QuantConnect.Algorithm.CSharp.StressSymbols.StockSymbols.ToList();
+            var tickers = QuantConnect.Algorithm.CSharp.StressSymbols.StockSymbols.Take(100).ToList();
             var symbols = tickers.Select(ticker => Symbol.Create(ticker, SecurityType.Equity, QuantConnect.Market.USA)).ToList();
+            var consolidators = new Queue<Tuple<Symbol, IDataConsolidator>>();
             foreach (var symbol in symbols)
             {
                 subscriptionManager.Add(symbol, Resolution.Minute, DateTimeZone.Utc, DateTimeZone.Utc, true, false);
             }
 
-            var scanTask = new TaskFactory().StartNew(() =>
+            var scanTask = Task.Factory.StartNew(() =>
             {
-                Log.Trace("ScanPastConsolidators started");
+                Log.Debug("ScanPastConsolidators started");
                 while (DateTime.UtcNow < end)
                 {
-                    subscriptionManager.ScanPastConsolidators(DateTime.UtcNow, algorithm);
+                    subscriptionManager.ScanPastConsolidators(end.AddDays(1), algorithm);
                 }
-                Log.Trace("ScanPastConsolidators finished");
+                Log.Debug("ScanPastConsolidators finished");
             });
 
-            var addTask = new TaskFactory().StartNew(() =>
+            var addTask = Task.Factory.StartNew(() =>
             {
-                Log.Trace("AddConsolidators started");
-                foreach (var symbol in symbols)
+                while (scanTask.Status == TaskStatus.Running)
                 {
-                    subscriptionManager.AddConsolidator(symbol, new IdentityDataConsolidator<BaseData>());
+                    Log.Debug("AddConsolidators started");
+                    foreach (var symbol in symbols)
+                    {
+                        var consolidator = new IdentityDataConsolidator<BaseData>();
+                        subscriptionManager.AddConsolidator(symbol, consolidator);
+                        consolidators.Enqueue(new Tuple<Symbol, IDataConsolidator>(symbol, consolidator));
+                    }
+                    Log.Debug("AddConsolidators finished");
+                    Assert.AreEqual(100, consolidators.Count);
+                    Log.Debug("RemoveConsolidators started");
+                    while (consolidators.TryDequeue(out var pair))
+                    {
+                        subscriptionManager.RemoveConsolidator(pair.Item1, pair.Item2);
+                    }
+                    Log.Debug("RemoveConsolidators finished");
                 }
-                Log.Trace("AddConsolidators finished");
             });
 
             Task.WaitAll(scanTask, addTask);
+            Assert.AreEqual(100, subscriptionManager.Count);
+            Assert.AreEqual(0, consolidators.Count);
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
When the user added/removed consolidators many times, a race condition in `SubscriptionManager.ScanPastConsolidators` method happened. Specifically, the exception was thrown since the priority queue used for the consolidators was not thread safe, so while the method `ScanPastConsolidators()` was trying to peek the top of the priority queue, another thread was adding/removing elements from it. In order to fix this bug, we added a lock every time a new consolidator had to be added, and instead of adding it directly, we waited for the next call to `ScanPastConsolidators` to add it. A unit test reproducing this bug was also added.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #8248 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, there won't be any race condition when consolidators are being added at a high rate
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created a unit test with two tasks, one calling `ScanPastConsolidators()` and the other one adding and removing consolidators. This test asserted not only that the null exception wasn't thrown but also that at then of it, the expected amount of consolidators had been added and removed.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
