### PR TITLE
Fix warm up indicator bugs

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -3028,7 +3028,8 @@ namespace QuantConnect.Algorithm
                 indicator.Update(input);
             };
 
-            WarmUpIndicatorImpl(symbol, period, onDataConsolidated, history, identityConsolidator);
+            IndicatorHistory(indicator, history, selector);
+            //WarmUpIndicatorImpl(symbol, period, onDataConsolidated, history, identityConsolidator);
         }
 
         /// <summary>
@@ -3088,13 +3089,14 @@ namespace QuantConnect.Algorithm
                 indicator.Update(selector(bar));
             };
 
-            WarmUpIndicatorImpl(symbol, period, onDataConsolidated, history, identityConsolidator);
+            IndicatorHistory(indicator, history, selector);
+            //WarmUpIndicatorImpl(symbol, period, onDataConsolidated, history, identityConsolidator);
         }
 
         private IEnumerable<Slice> GetIndicatorWarmUpHistory(IEnumerable<Symbol> symbols, IIndicator indicator, TimeSpan timeSpan, out bool identityConsolidator)
         {
             identityConsolidator = false;
-            if (AssertIndicatorHasWarmupPeriod(indicator))
+            if (!AssertIndicatorHasWarmupPeriod(indicator))
             {
                 return Enumerable.Empty<Slice>();
             }

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -3028,7 +3028,7 @@ namespace QuantConnect.Algorithm
                 indicator.Update(input);
             };
 
-            IndicatorHistory(indicator, history, selector);
+            WarmUpIndicatorImpl(symbol, period, onDataConsolidated, history, identityConsolidator);
         }
 
         /// <summary>
@@ -3088,7 +3088,7 @@ namespace QuantConnect.Algorithm
                 indicator.Update(selector(bar));
             };
 
-            IndicatorHistory(indicator, history, selector);
+            WarmUpIndicatorImpl(symbol, period, onDataConsolidated, history, identityConsolidator);
         }
 
         private IEnumerable<Slice> GetIndicatorWarmUpHistory(IEnumerable<Symbol> symbols, IIndicator indicator, TimeSpan timeSpan, out bool identityConsolidator)

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -3029,7 +3029,6 @@ namespace QuantConnect.Algorithm
             };
 
             IndicatorHistory(indicator, history, selector);
-            //WarmUpIndicatorImpl(symbol, period, onDataConsolidated, history, identityConsolidator);
         }
 
         /// <summary>
@@ -3090,7 +3089,6 @@ namespace QuantConnect.Algorithm
             };
 
             IndicatorHistory(indicator, history, selector);
-            //WarmUpIndicatorImpl(symbol, period, onDataConsolidated, history, identityConsolidator);
         }
 
         private IEnumerable<Slice> GetIndicatorWarmUpHistory(IEnumerable<Symbol> symbols, IIndicator indicator, TimeSpan timeSpan, out bool identityConsolidator)

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -3143,16 +3143,17 @@ namespace QuantConnect.Algorithm
             where T : class, IBaseData
         {
             IDataConsolidator consolidator;
-            if (identityConsolidator)
-            {
-                period = TimeSpan.Zero;
-            }
             if (SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(symbol).Count > 0)
             {
                 consolidator = Consolidate(symbol, period, handler);
             }
             else
             {
+                if (identityConsolidator)
+                {
+                    period = TimeSpan.Zero;
+                }
+
                 var providedType = typeof(T);
                 if (providedType.IsAbstract)
                 {

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -726,8 +726,23 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(HistoricalData)]
         public void WarmUpIndicator(Symbol symbol, PyObject indicator, TimeSpan period, PyObject selector = null)
         {
-            var resolution = period.ToHigherResolutionEquivalent(false);
-            WarmUpIndicator(symbol, indicator, resolution, selector);
+            if (indicator.TryConvert(out IndicatorBase<IndicatorDataPoint> indicatorDataPoint))
+            {
+                WarmUpIndicator(symbol, indicatorDataPoint, period, selector?.ConvertToDelegate<Func<IBaseData, decimal>>());
+                return;
+            }
+            if (indicator.TryConvert(out IndicatorBase<IBaseDataBar> indicatorDataBar))
+            {
+                WarmUpIndicator(symbol, indicatorDataBar, period, selector?.ConvertToDelegate<Func<IBaseData, IBaseDataBar>>());
+                return;
+            }
+            if (indicator.TryConvert(out IndicatorBase<TradeBar> indicatorTradeBar))
+            {
+                WarmUpIndicator(symbol, indicatorTradeBar, period, selector?.ConvertToDelegate<Func<IBaseData, TradeBar>>());
+                return;
+            }
+
+            WarmUpIndicator(symbol, WrapPythonIndicator(indicator), period, selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -716,6 +716,21 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Warms up a given indicator with historical data
+        /// </summary>
+        /// <param name="symbol">The symbol whose indicator we want</param>
+        /// <param name="indicator">The indicator we want to warm up</param>
+        /// <param name="period">The necessary period to warm up the indicator</param>
+        /// <param name="selector">Selects a value from the BaseData send into the indicator, if null defaults to a cast (x => (T)x)</param>
+        [DocumentationAttribute(Indicators)]
+        [DocumentationAttribute(HistoricalData)]
+        public void WarmUpIndicator(Symbol symbol, PyObject indicator, TimeSpan period, PyObject selector = null)
+        {
+            var resolution = period.ToHigherResolutionEquivalent(false);
+            WarmUpIndicator(symbol, indicator, resolution, selector);
+        }
+
+        /// <summary>
         /// Plot a chart using string series name, with value.
         /// </summary>
         /// <param name="series">Name of the plot series</param>

--- a/Tests/Algorithm/AlgorithmIndicatorsTests.cs
+++ b/Tests/Algorithm/AlgorithmIndicatorsTests.cs
@@ -308,19 +308,33 @@ namespace QuantConnect.Tests.Algorithm
             var referenceSymbol = Symbol.Create("IBM", SecurityType.Equity, Market.USA);
             var indicator = new SimpleMovingAverage("SMA", 100);
             _algorithm.SetDateTime(new DateTime(2013, 10, 11));
+            _algorithm.AddEquity(referenceSymbol);
             using (Py.GIL())
             {
                 var pythonIndicator = indicator.ToPython();
-                _algorithm.WarmUpIndicator(referenceSymbol, pythonIndicator, TimeSpan.FromMinutes(120));
+                _algorithm.WarmUpIndicator(referenceSymbol, pythonIndicator, TimeSpan.FromMinutes(60));
                 Assert.IsTrue(pythonIndicator.GetAttr("is_ready").GetAndDispose<bool>());
                 Assert.IsTrue(pythonIndicator.GetAttr("samples").GetAndDispose<int>() >= 100);
             }
         }
 
         [Test]
+        public void IndicatorCanBeWarmedUpWithTimespan()
+        {
+            var referenceSymbol = Symbol.Create("IBM", SecurityType.Equity, Market.USA);
+            _algorithm.AddEquity(referenceSymbol);
+            var indicator = new SimpleMovingAverage("SMA", 100);
+            _algorithm.SetDateTime(new DateTime(2013, 10, 11));
+            _algorithm.WarmUpIndicator(referenceSymbol, indicator, TimeSpan.FromMinutes(60));
+            Assert.IsTrue(indicator.IsReady);
+            Assert.IsTrue(indicator.Samples >= 100);
+        }
+
+        [Test]
         public void PythonCustomIndicatorCanBeWarmedUpWithTimespan()
         {
             var referenceSymbol = Symbol.Create("IBM", SecurityType.Equity, Market.USA);
+            _algorithm.AddEquity(referenceSymbol);
             _algorithm.SetDateTime(new DateTime(2013, 10, 11));
             using (Py.GIL())
             {
@@ -345,7 +359,7 @@ class CustomSimpleMovingAverage(PythonIndicator):
         return count == self.queue.maxlen");
 
                 var customIndicator = testModule.GetAttr("CustomSimpleMovingAverage").Invoke("custom".ToPython(), 100.ToPython());
-                _algorithm.WarmUpIndicator(referenceSymbol, customIndicator, TimeSpan.FromMinutes(120));
+                _algorithm.WarmUpIndicator(referenceSymbol, customIndicator, TimeSpan.FromMinutes(60));
                 Assert.IsTrue(customIndicator.GetAttr("is_ready").GetAndDispose<bool>());
                 Assert.IsTrue(customIndicator.GetAttr("samples").GetAndDispose<int>() >= 100);
             }

--- a/Tests/Algorithm/AlgorithmIndicatorsTests.cs
+++ b/Tests/Algorithm/AlgorithmIndicatorsTests.cs
@@ -311,9 +311,9 @@ namespace QuantConnect.Tests.Algorithm
             using (Py.GIL())
             {
                 var pythonIndicator = indicator.ToPython();
-                _algorithm.WarmUpIndicator(referenceSymbol, pythonIndicator, TimeSpan.FromMinutes(100));
+                _algorithm.WarmUpIndicator(referenceSymbol, pythonIndicator, TimeSpan.FromMinutes(120));
                 Assert.IsTrue(pythonIndicator.GetAttr("is_ready").GetAndDispose<bool>());
-                Assert.AreEqual(100, pythonIndicator.GetAttr("samples").GetAndDispose<int>());
+                Assert.IsTrue(pythonIndicator.GetAttr("samples").GetAndDispose<int>() >= 100);
             }
         }
 
@@ -345,9 +345,9 @@ class CustomSimpleMovingAverage(PythonIndicator):
         return count == self.queue.maxlen");
 
                 var customIndicator = testModule.GetAttr("CustomSimpleMovingAverage").Invoke("custom".ToPython(), 100.ToPython());
-                _algorithm.WarmUpIndicator(referenceSymbol, customIndicator, TimeSpan.FromMinutes(100));
+                _algorithm.WarmUpIndicator(referenceSymbol, customIndicator, TimeSpan.FromMinutes(120));
                 Assert.IsTrue(customIndicator.GetAttr("is_ready").GetAndDispose<bool>());
-                Assert.AreEqual(100, customIndicator.GetAttr("samples").GetAndDispose<int>());
+                Assert.IsTrue(customIndicator.GetAttr("samples").GetAndDispose<int>() >= 100);
             }
         }
 

--- a/Tests/Algorithm/AlgorithmIndicatorsTests.cs
+++ b/Tests/Algorithm/AlgorithmIndicatorsTests.cs
@@ -306,13 +306,14 @@ namespace QuantConnect.Tests.Algorithm
         public void PythonIndicatorCanBeWarmedUpWithTimespan()
         {
             var referenceSymbol = Symbol.Create("IBM", SecurityType.Equity, Market.USA);
-            var indicator = new SimpleMovingAverage("SMA", 60);
+            var indicator = new SimpleMovingAverage("SMA", 100);
             _algorithm.SetDateTime(new DateTime(2013, 10, 11));
             using (Py.GIL())
             {
                 var pythonIndicator = indicator.ToPython();
-                _algorithm.WarmUpIndicator(referenceSymbol, pythonIndicator, TimeSpan.FromHours(1));
+                _algorithm.WarmUpIndicator(referenceSymbol, pythonIndicator, TimeSpan.FromMinutes(100));
                 Assert.IsTrue(pythonIndicator.GetAttr("is_ready").GetAndDispose<bool>());
+                Assert.AreEqual(100, pythonIndicator.GetAttr("samples").GetAndDispose<int>());
             }
         }
 
@@ -343,9 +344,10 @@ class CustomSimpleMovingAverage(PythonIndicator):
         self.value = np.sum(self.queue) / count
         return count == self.queue.maxlen");
 
-                var customIndicator = testModule.GetAttr("CustomSimpleMovingAverage").Invoke("custom".ToPython(), 60.ToPython());
-                _algorithm.WarmUpIndicator(referenceSymbol, customIndicator, TimeSpan.FromHours(1));
+                var customIndicator = testModule.GetAttr("CustomSimpleMovingAverage").Invoke("custom".ToPython(), 100.ToPython());
+                _algorithm.WarmUpIndicator(referenceSymbol, customIndicator, TimeSpan.FromMinutes(100));
                 Assert.IsTrue(customIndicator.GetAttr("is_ready").GetAndDispose<bool>());
+                Assert.AreEqual(100, customIndicator.GetAttr("samples").GetAndDispose<int>());
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
When trying to warm up an indicator using a timespan that matched a resolution, LEAN didn't warmed up the indicator because of a missing `!` in the method `QCAlgorithm.Indicators.GetIndicatorWarmUpHistory()`. Once that was fixed, when running the same example, LEAN threw an exception in method `QCAlgorithm.CreateConsolidator(Symbol, Func<DateTime, CalendarInfo>, TickType?, TimeSpan?, Resolution?, Type)` since the period became zero when the timespan matched some resolution. Besides, an overload for warming python indicators with timespan was missing. This PR aims to fix those bugs.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #8246 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, the user will be able to warm up C# and Python indicators using a timespan
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I made three unit tests, each of them asserting we could warm up an indicator (C# indicator, Python indicator or custom python indicator) using a timespan that matched some resolution.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
