### PR TITLE
Improve `PythonIndicator.IsReady` implementation

### DIFF
--- a/Algorithm.Python/IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm.py
+++ b/Algorithm.Python/IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm.py
@@ -18,25 +18,62 @@ class IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm(QCAlgorithm)
     def initialize(self):
         self.set_start_date(2020, 2, 20)
         self.qqq = self.add_equity("QQQ", Resolution.DAILY).symbol
-        self.range_indicator = RangeIndicator("range")
+        self.range_indicator = RangeIndicator("range1")
         self.range_sma = IndicatorExtensions.sma(self.range_indicator, 5)
+
+        self.range_indicator_2 = RangeIndicator2("range2")
+        self.range_sma_2 = IndicatorExtensions.sma(self.range_indicator_2, 5)
 
     def on_data(self, data):
         self.range_indicator.update(data.bars.get(self.qqq))
+        self.range_indicator_2.update(data.bars.get(self.qqq))
+
         self.debug(f"{self.range_indicator.name} {self.range_indicator.value}")
         self.debug(f"{self.range_sma.name} {self.range_sma.current.value}")
+
+        self.debug(f"{self.range_indicator_2.name} {self.range_indicator_2.value}")
+        self.debug(f"{self.range_sma_2.name} {self.range_sma_2.current.value}")
 
     def on_end_of_algorithm(self):
         if not self.range_sma.is_ready:
             raise Exception(f"{self.range_sma.name} should have been ready at the end of the algorithm, but it wasn't. The indicator received {self.range_sma.samples} samples.")
+
+        if not self.range_sma_2.is_ready:
+            raise Exception(f"{self.range_sma_2.name} should have been ready at the end of the algorithm, but it wasn't. The indicator received {self.range_sma_2.samples} samples.")
 
 class RangeIndicator(PythonIndicator):
     def __init__(self, name):
         self.name = name
         self.time = datetime.min
         self.value = 0
+        self.is_ready = False;
+
+    @property
+    def is_ready(self):
+        return self._is_ready
+
+    @is_ready.setter
+    def is_ready(self, value):
+        self._is_ready = value
+
+    def update(self, bar: TradeBar):
+        if bar is None:
+            return False
+
+        self.value = bar.high - bar.low
+        self.time = bar.time
+        self.is_ready = True
+        self.on_updated(IndicatorDataPoint(bar.end_time, self.value))
+        return True
+
+class RangeIndicator2(PythonIndicator):
+    def __init__(self, name):
+        self.name = name
+        self.time = datetime.min
+        self.value = 0
         self._is_ready = False;
 
+    @property
     def is_ready(self):
         return self._is_ready
 

--- a/Algorithm.Python/IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm.py
+++ b/Algorithm.Python/IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm.py
@@ -26,6 +26,10 @@ class IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm(QCAlgorithm)
         self.debug(f"{self.range_indicator.name} {self.range_indicator.value}")
         self.debug(f"{self.range_sma.name} {self.range_sma.current.value}")
 
+    def on_end_of_algorithm(self):
+        if not self.range_sma.is_ready:
+            raise Exception(f"{self.range_sma.name} should have been ready at the end of the algorithm, but it wasn't. The indicator received {self.range_sma.samples} samples.")
+
 class RangeIndicator(PythonIndicator):
     def __init__(self, name):
         self.name = name

--- a/Algorithm.Python/IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm.py
+++ b/Algorithm.Python/IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm.py
@@ -1,0 +1,36 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+class IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm(QCAlgorithm):
+
+    def initialize(self):
+        self.set_start_date(2020, 2, 20)
+        self.qqq = self.add_equity("QQQ", Resolution.DAILY).symbol
+        self.range_indicator = RangeIndicator("range")
+        self.range_sma = IndicatorExtensions.sma(self.range_indicator, 5)
+
+    def on_data(self, data):
+        self.range_indicator.update(data.bars.get(self.qqq))
+        self.debug(f"{self.range_indicator.name} {self.range_indicator.value}")
+        self.debug(f"{self.range_sma.name} {self.range_sma.current.value}")
+
+class RangeIndicator(PythonIndicator):
+    def __init__(self, name):
+        self.name = name
+        self.time = datetime.min
+        self.value = 0
+        self._is_ready = False;
+
+    def is_ready(self):
+        return self._is_ready
+
+    def update(self, bar: TradeBar):
+        if bar is None:
+            return False
+
+        self.value = bar.high - bar.low
+        self.time = bar.time
+        self._is_ready = True
+        self.on_updated(IndicatorDataPoint(bar.end_time, self.value))
+        return True

--- a/Algorithm.Python/IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm.py
+++ b/Algorithm.Python/IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm.py
@@ -1,6 +1,17 @@
-# region imports
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from AlgorithmImports import *
-# endregion
 
 class IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm(QCAlgorithm):
 

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -638,6 +638,54 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Gets a python property by name
+        /// </summary>
+        /// <param name="instance">The object instance to search the property in</param>
+        /// <param name="name">The name of the property</param>
+        /// <returns>The python property or null if not defined or CSharp implemented</returns>
+        public static dynamic GetPythonBoolProperty(this PyObject instance, string name)
+        {
+            using (Py.GIL())
+            {
+                var objectType = instance.GetPythonType();
+                if (!objectType.HasAttr(name))
+                {
+                    return null;
+                }
+
+                var property = instance.GetAttr(name);
+                var pythonType = property.GetPythonType();
+                var isPythonDefined = pythonType.Repr().Equals("<class \'bool\'>", StringComparison.Ordinal);
+
+                if (isPythonDefined)
+                {
+                    return property;
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets a python property by name
+        /// </summary>
+        /// <param name="instance">The object instance to search the property in</param>
+        /// <param name="name">The name of the method</param>
+        /// <returns>The python property or null if not defined or CSharp implemented</returns>
+        public static dynamic GetPythonBoolPropertyWithChecks(this PyObject instance, string name)
+        {
+            using (Py.GIL())
+            {
+                if (!instance.HasAttr(name))
+                {
+                    return null;
+                }
+
+                return instance.GetPythonBoolProperty(name);
+            }
+        }
+
+        /// <summary>
         /// Gets a python method by name
         /// </summary>
         /// <param name="instance">The object instance to search the method in</param>

--- a/Common/Python/BasePythonWrapper.cs
+++ b/Common/Python/BasePythonWrapper.cs
@@ -333,7 +333,7 @@ namespace QuantConnect.Python
         /// <summary>
         /// Set of helper methods to invoke Python methods with runtime checks for return values and out parameter's conversions.
         /// </summary>
-        private class PythonRuntimeChecker
+        public class PythonRuntimeChecker
         {
             /// <summary>
             /// Invokes method <paramref name="method"/> and converts the returned value to type <typeparamref name="TResult"/>

--- a/Indicators/PythonIndicator.cs
+++ b/Indicators/PythonIndicator.cs
@@ -26,7 +26,6 @@ namespace QuantConnect.Indicators
     public class PythonIndicator : IndicatorBase<IBaseData>, IIndicatorWarmUpPeriodProvider
     {
         private bool _isReady;
-        private bool _isReadyMethodIsOverriden;
         private dynamic _pythonIsReadyMethod;
         private BasePythonWrapper<IIndicator> _indicatorWrapper;
 
@@ -87,7 +86,6 @@ namespace QuantConnect.Indicators
                 {
                     using (Py.GIL())
                     {
-                        _isReadyMethodIsOverriden = indicator.GetPythonType().HasAttr(nameof(IsReady).ToSnakeCase());
                         _pythonIsReadyMethod = indicator.GetPythonMethod(nameof(IsReady).ToSnakeCase());
                     }
                 }
@@ -103,11 +101,11 @@ namespace QuantConnect.Indicators
         {
             get
             {
-                if (_isReadyMethodIsOverriden)
+                if (_pythonIsReadyMethod != null)
                 {
                     using (Py.GIL())
                     {
-                        return (_pythonIsReadyMethod() as PyObject).GetAndDispose<bool>();
+                        return BasePythonWrapper<IIndicator>.PythonRuntimeChecker.InvokeMethod<bool>(_pythonIsReadyMethod, nameof(IsReady).ToSnakeCase());
                     }
                 }
                 else

--- a/Indicators/PythonIndicator.cs
+++ b/Indicators/PythonIndicator.cs
@@ -86,7 +86,7 @@ namespace QuantConnect.Indicators
                 {
                     using (Py.GIL())
                     {
-                        _pythonIsReadyMethod = indicator.GetPythonMethod(nameof(IsReady).ToSnakeCase());
+                        _pythonIsReadyMethod = indicator.GetPythonMethodWithChecks(nameof(IsReady).ToSnakeCase()) ?? indicator.GetPythonMethodWithChecks(nameof(IsReady));
                     }
                 }
             }

--- a/Tests/Indicators/IndicatorExtensionsTests.cs
+++ b/Tests/Indicators/IndicatorExtensionsTests.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using Python.Runtime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
+using QuantConnect.Statistics;
 
 namespace QuantConnect.Tests.Indicators
 {
@@ -646,6 +647,43 @@ namespace QuantConnect.Tests.Indicators
                 left.Update(DateTime.Today, 20);
                 Assert.AreEqual(0, composite.Current.Value);
             }
+        }
+
+        [Test]
+        public void RunPythonRegressionAlgorithmWithIndicatorExtensions()
+        {
+            var parameter = new RegressionTests.AlgorithmStatisticsTestParameters("IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm",
+                new Dictionary<string, string> {
+                    {PerformanceMetrics.TotalOrders, "0"},
+                    {"Average Win", "0%"},
+                    {"Average Loss", "0%"},
+                    {"Compounding Annual Return", "0%"},
+                    {"Drawdown", "0%"},
+                    {"Expectancy", "0"},
+                    {"Net Profit", "0%"},
+                    {"Sharpe Ratio", "0"},
+                    {"Probabilistic Sharpe Ratio", "0%"},
+                    {"Loss Rate", "0%"},
+                    {"Win Rate", "0%"},
+                    {"Profit-Loss Ratio", "0"},
+                    {"Alpha", "0"},
+                    {"Beta", "0"},
+                    {"Annual Standard Deviation", "0"},
+                    {"Annual Variance", "0"},
+                    {"Information Ratio", "-0.283"},
+                    {"Tracking Error", "0.133"},
+                    {"Treynor Ratio", "0"},
+                    {"Total Fees", "$0.00"},
+                    {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+                },
+                Language.Python,
+                AlgorithmStatus.Completed);
+
+            AlgorithmRunner.RunLocalBacktest(parameter.Algorithm,
+                parameter.Statistics,
+                parameter.Language,
+                parameter.ExpectedFinalStatus,
+                initialCash: 100000);
         }
 
         private class TestIndicatorA : IndicatorBase<IBaseData>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Since the property `BaseIndicator.IsReady` does not define a setter, when a custom indicator (which inherited from PythonIndicator) was updated manually, the property `IsReady` never became true as it was handled internally by `PythonIndicator` class. This bug was noticeable when using the method `IndicatorExtensions.Of` with a second indicator because it required the first indicator to be ready in order to update the second one. To fix this bug, I improved the get implementation of the `PythonIndicator.IsReady` property so that it used the overridden python version of `IsReady` whenever it was defined. Thus, now if the user is updating manually a custom indicator, it can (and should) override the `is_ready` method to define when the indicator is ready.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #6615 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, users will be able to define when an indicator is ready
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
These changes might require to brief the community on how the `is_ready` method must be implemented in order to use that property
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created a regression test that creates a custom indicator that updates a second one on its time whenever it's updated (using `IndicatorExtensions.SMA`). The algorithm updates the custom indicator manually and asserts the indicator is ready at the end.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
