### PR TITLE
Adds Overload to AddIndexOption

### DIFF
--- a/Algorithm.CSharp/BasicTemplateSPXWeeklyIndexOptionsAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateSPXWeeklyIndexOptionsAlgorithm.cs
@@ -43,14 +43,12 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2021, 1, 10);
             SetCash(1000000);
 
-            var spx = AddIndex("SPX").Symbol;
-
             // regular option SPX contracts
-            var spxOptions = AddIndexOption(spx);
+            var spxOptions = AddIndexOption("SPX");
             spxOptions.SetFilter(u => u.Strikes(0, 1).Expiration(0, 30));
 
             // weekly option SPX contracts
-            var spxw = AddIndexOption(spx, "SPXW");
+            var spxw = AddIndexOption("SPX", "SPXW");
             spxw.SetFilter(u => u.Strikes(0, 1)
                  // single week ahead since there are many SPXW contracts and we want to preserve performance
                  .Expiration(0, 7)

--- a/Algorithm.Python/BasicTemplateSPXWeeklyIndexOptionsAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateSPXWeeklyIndexOptionsAlgorithm.py
@@ -25,14 +25,12 @@ class BasicTemplateSPXWeeklyIndexOptionsAlgorithm(QCAlgorithm):
         self.set_end_date(2021, 1, 10)
         self.set_cash(1000000)
 
-        self.spx = self.add_index("SPX").symbol
-
         # regular option SPX contracts
-        self.spx_options = self.add_index_option(self.spx)
+        self.spx_options = self.add_index_option("SPX")
         self.spx_options.set_filter(lambda u: (u.strikes(0, 1).expiration(0, 30)))
 
         # weekly option SPX contracts
-        spxw = self.add_index_option(self.spx, "SPXW")
+        spxw = self.add_index_option("SPX", "SPXW")
         # set our strike/expiry filter for this option chain
         spxw.set_filter(lambda u: (u.strikes(0, 1)
                                      # single week ahead since there are many SPXW contracts and we want to preserve performance

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2298,7 +2298,7 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(AddingData)]
         public IndexOption AddIndexOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true)
         {
-            if (symbol.SecurityType != SecurityType.IndexOption && !symbol.IsCanonical())
+            if (symbol.SecurityType != SecurityType.IndexOption || symbol.IsCanonical())
             {
                 throw new ArgumentException("Symbol provided must be non-canonical and of type SecurityType.IndexOption");
             }

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -33,6 +33,7 @@ using QuantConnect.Securities;
 using QuantConnect.Securities.Cfd;
 using QuantConnect.Securities.Equity;
 using QuantConnect.Securities.Forex;
+using QuantConnect.Securities.IndexOption;
 using QuantConnect.Securities.Option;
 using QuantConnect.Statistics;
 using QuantConnect.Util;
@@ -2221,18 +2222,15 @@ namespace QuantConnect.Algorithm
         /// <summary>
         /// Creates and adds index options to the algorithm.
         /// </summary>
-        /// <param name="ticker">The ticker of the Index Option</param>
+        /// <param name="underlying">The underlying ticker of the Index Option</param>
         /// <param name="resolution">Resolution of the index option contracts, i.e. the granularity of the data</param>
-        /// <param name="market">Market of the index option. If no market is provided, we default to <see cref="Market.USA"/> </param>
+        /// <param name="market">The foreign exchange trading market, <seealso cref="Market"/>. Default value is null and looked up using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
         /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
         /// <returns>Canonical Option security</returns>
         [DocumentationAttribute(AddingData)]
-        public Option AddIndexOption(string ticker, Resolution? resolution = null, string market = Market.USA, bool fillForward = true)
+        public IndexOption AddIndexOption(string underlying, Resolution? resolution = null, string market = null, bool fillForward = true)
         {
-            return AddIndexOption(
-                QuantConnect.Symbol.Create(ticker, SecurityType.Index, market),
-                resolution,
-                fillForward);
+            return AddIndexOption(underlying, null, resolution, market, fillForward);
         }
 
         /// <summary>
@@ -2243,7 +2241,7 @@ namespace QuantConnect.Algorithm
         /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
         /// <returns>Canonical Option security</returns>
         [DocumentationAttribute(AddingData)]
-        public Option AddIndexOption(Symbol symbol, Resolution? resolution = null, bool fillForward = true)
+        public IndexOption AddIndexOption(Symbol symbol, Resolution? resolution = null, bool fillForward = true)
         {
             return AddIndexOption(symbol, null, resolution, fillForward);
         }
@@ -2257,30 +2255,35 @@ namespace QuantConnect.Algorithm
         /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
         /// <returns>Canonical Option security</returns>
         [DocumentationAttribute(AddingData)]
-        public Option AddIndexOption(Symbol symbol, string targetOption, Resolution? resolution = null, bool fillForward = true)
+        public IndexOption AddIndexOption(Symbol symbol, string targetOption, Resolution? resolution = null, bool fillForward = true)
         {
             if (symbol.SecurityType != SecurityType.Index)
             {
                 throw new ArgumentException("Symbol provided must be of type SecurityType.Index");
             }
 
-            return AddOption(symbol, targetOption, resolution, symbol.ID.Market, fillForward);
+            return (IndexOption)AddOption(symbol, targetOption, resolution, symbol.ID.Market, fillForward);
         }
 
         /// <summary>
         /// Creates and adds index options to the algorithm.
         /// </summary>
-        /// <param name="ticker">The ticker of the Index Option</param>
+        /// <param name="underlying">The underlying ticker of the Index Option</param>
         /// <param name="targetOption">The target option ticker. This is useful when the option ticker does not match the underlying, e.g. SPX index and the SPXW weekly option. If null is provided will use underlying</param>
         /// <param name="resolution">Resolution of the index option contracts, i.e. the granularity of the data</param>
-        /// <param name="market">Market of the index option. If no market is provided, we default to <see cref="Market.USA"/> </param>
+        /// <param name="market">The foreign exchange trading market, <seealso cref="Market"/>. Default value is null and looked up using BrokerageModel.DefaultMarkets in <see cref="AddSecurity{T}"/></param>
         /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
         /// <returns>Canonical Option security</returns>
         [DocumentationAttribute(AddingData)]
-        public Option AddIndexOption(string ticker, string targetOption, Resolution? resolution = null, string market = Market.USA, bool fillForward = true)
+        public IndexOption AddIndexOption(string underlying, string targetOption, Resolution? resolution = null, string market = null, bool fillForward = true)
         {
+            if (market == null && !BrokerageModel.DefaultMarkets.TryGetValue(SecurityType.Index, out market))
+            {
+                throw new KeyNotFoundException($"No default market set for underlying security type: {SecurityType.Index}");
+            }
+            
             return AddIndexOption(
-                QuantConnect.Symbol.Create(ticker, SecurityType.Index, market),
+                QuantConnect.Symbol.Create(underlying, SecurityType.Index, market),
                 targetOption, resolution, fillForward);
         }
 
@@ -2293,14 +2296,14 @@ namespace QuantConnect.Algorithm
         /// <returns>Index Option Contract</returns>
         /// <exception cref="ArgumentException">The provided Symbol is not an Index Option</exception>
         [DocumentationAttribute(AddingData)]
-        public Option AddIndexOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true)
+        public IndexOption AddIndexOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true)
         {
-            if (symbol.SecurityType != SecurityType.IndexOption)
+            if (symbol.SecurityType != SecurityType.IndexOption && !symbol.IsCanonical())
             {
-                throw new ArgumentException("Symbol provided must be of type SecurityType.IndexOption");
+                throw new ArgumentException("Symbol provided must be non-canonical and of type SecurityType.IndexOption");
             }
 
-            return AddOptionContract(symbol, resolution, fillForward);
+            return (IndexOption)AddOptionContract(symbol, resolution, fillForward);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2268,6 +2268,23 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Creates and adds index options to the algorithm.
+        /// </summary>
+        /// <param name="ticker">The ticker of the Index Option</param>
+        /// <param name="targetOption">The target option ticker. This is useful when the option ticker does not match the underlying, e.g. SPX index and the SPXW weekly option. If null is provided will use underlying</param>
+        /// <param name="resolution">Resolution of the index option contracts, i.e. the granularity of the data</param>
+        /// <param name="market">Market of the index option. If no market is provided, we default to <see cref="Market.USA"/> </param>
+        /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
+        /// <returns>Canonical Option security</returns>
+        [DocumentationAttribute(AddingData)]
+        public Option AddIndexOption(string ticker, string targetOption, Resolution? resolution = null, string market = Market.USA, bool fillForward = true)
+        {
+            return AddIndexOption(
+                QuantConnect.Symbol.Create(ticker, SecurityType.Index, market),
+                targetOption, resolution, fillForward);
+        }
+
+        /// <summary>
         /// Adds an index option contract to the algorithm.
         /// </summary>
         /// <param name="symbol">Symbol of the index option contract</param>


### PR DESCRIPTION
#### Description
The new overload provides the same functionality of the `AddIndexOption(string, Resolution, string, bool)` overload which doesn't require the `AddIndex` method call and saving its `Symbol`.

#### Related Issue
N/A

#### Motivation and Context
Consistency: `AddIndexOption(string, Resolution, string, bool)`  provides this option.

#### Requires Documentation Change
Yes. Example with SPXW won't require adding the index. 

#### How Has This Been Tested?
Updated regression test.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`