### PR TITLE
Add extra argument in `QuantBook.UniverseHistory()` for using an IDateRule

### DIFF
--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -873,8 +873,9 @@ namespace QuantConnect.Research
         /// </summary>
         private IEnumerable<BaseDataCollection> RunUniverseSelection(Universe universe, DateTime start, DateTime? end = null, IDateRule dateRule = null)
         {
-            var history = History(universe, start, end ?? DateTime.UtcNow.Date);
-            var filteredDates = dateRule?.GetDates(start, end ?? EndDate).ToHashSet();
+            var endDate = end ?? DateTime.UtcNow.Date;
+            var history = History(universe, start, endDate);
+            var filteredDates = dateRule?.GetDates(start, endDate).ToHashSet();
 
             HashSet<Symbol> filteredSymbols = null;
             foreach (var dataPoint in history)

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -686,6 +686,7 @@ namespace QuantConnect.Research
         /// <param name="start">The start date</param>
         /// <param name="end">Optionally the end date, will default to today</param>
         /// <param name="func">Optionally the universe selection function</param>
+        /// <param name="dateRule">Date rule to apply for the history data</param>
         /// <returns>Enumerable of universe selection data for each date, filtered if the func was provided</returns>
         public IEnumerable<IEnumerable<T2>> UniverseHistory<T1, T2>(DateTime start, DateTime? end = null, Func<IEnumerable<T2>, IEnumerable<Symbol>> func = null, IDateRule dateRule = null)
             where T1 : BaseDataCollection
@@ -766,10 +767,10 @@ namespace QuantConnect.Research
                 var universeSymbol = ((BaseDataCollection)convertedType.GetBaseDataInstance()).UniverseSymbol();
                 if (func == null)
                 {
-                    return History(universe, universeSymbol, start, end.Value);
+                    return History(universe, universeSymbol, start, endDate);
                 }
 
-                var requests = CreateDateRangeHistoryRequests(new[] { universeSymbol }, convertedType, start, end.Value).Where(x => x != null).ToList();
+                var requests = CreateDateRangeHistoryRequests(new[] { universeSymbol }, convertedType, start, endDate).Where(x => x != null).ToList();
                 var history = History(requests);
                 var filteredDates = dateRule?.GetDates(start, endDate).ToHashSet();
 

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -703,7 +703,7 @@ namespace QuantConnect.Research
             HashSet<Symbol> filteredSymbols = null;
             foreach (var data in history)
             {
-                if (filteredDates != null && !filteredDates.Contains(data.EndTime))
+                if (filteredDates != null && !filteredDates.Contains(data.EndTime.Date))
                 {
                     continue;
                 }
@@ -856,7 +856,7 @@ namespace QuantConnect.Research
             HashSet<Symbol> filteredSymbols = null;
             foreach (var slice in history)
             {
-                if (filteredDates != null && !filteredDates.Contains(slice.Time))
+                if (filteredDates != null && !filteredDates.Contains(slice.Time.Date))
                 {
                     continue;
                 }
@@ -893,7 +893,7 @@ namespace QuantConnect.Research
             HashSet<Symbol> filteredSymbols = null;
             foreach (var dataPoint in history)
             {
-                if (filteredDates != null && !filteredDates.Contains(dataPoint.EndTime))
+                if (filteredDates != null && !filteredDates.Contains(dataPoint.EndTime.Date))
                 {
                     continue;
                 }

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -697,19 +697,18 @@ namespace QuantConnect.Research
             var symbols = new[] { universeSymbol };
             var endDate = end ?? DateTime.UtcNow.Date;
             var requests = CreateDateRangeHistoryRequests(new[] { universeSymbol }, typeof(T1), start, endDate);
-            var history = History(requests);
+            var history = GetDataTypedHistory<BaseDataCollection>(requests).Select(x => x.Values.Single());
             var filteredDates = dateRule?.GetDates(start, endDate).ToHashSet();
 
             HashSet<Symbol> filteredSymbols = null;
             foreach (var data in history)
             {
-                if (filteredDates != null && !filteredDates.Contains(data.Time))
+                if (filteredDates != null && !filteredDates.Contains(data.EndTime))
                 {
                     continue;
                 }
 
-                var castedType = data.Values.OfType<T2>();
-
+                var castedType = data.Data.OfType<T2>();
                 if (func != null)
                 {
                     var selection = func(castedType);

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -698,7 +698,7 @@ namespace QuantConnect.Research
             var endDate = end ?? DateTime.UtcNow.Date;
             var requests = CreateDateRangeHistoryRequests(new[] { universeSymbol }, typeof(T1), start, endDate);
             var history = GetDataTypedHistory<BaseDataCollection>(requests).Select(x => x.Values.Single());
-            var filteredDates = dateRule?.GetDates(start, endDate).ToHashSet();
+            var filteredDates = dateRule?.GetDates(start, endDate)?.ToHashSet();
 
             HashSet<Symbol> filteredSymbols = null;
             foreach (var data in history)
@@ -771,7 +771,7 @@ namespace QuantConnect.Research
 
                 var requests = CreateDateRangeHistoryRequests(new[] { universeSymbol }, convertedType, start, endDate);
                 var history = History(requests);
-                var filteredDates = dateRule?.GetDates(start, endDate).ToHashSet();
+                var filteredDates = dateRule?.GetDates(start, endDate)?.ToHashSet();
 
                 return GetDataFrame(GetFilteredSlice(history, func, filteredDates), convertedType);
             }
@@ -888,7 +888,7 @@ namespace QuantConnect.Research
         {
             var endDate = end ?? DateTime.UtcNow.Date;
             var history = History(universe, start, endDate);
-            var filteredDates = dateRule?.GetDates(start, endDate).ToHashSet();
+            var filteredDates = dateRule?.GetDates(start, endDate)?.ToHashSet();
 
             HashSet<Symbol> filteredSymbols = null;
             foreach (var dataPoint in history)

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -770,7 +770,7 @@ namespace QuantConnect.Research
                     return History(universe, universeSymbol, start, endDate);
                 }
 
-                var requests = CreateDateRangeHistoryRequests(new[] { universeSymbol }, convertedType, start, endDate).Where(x => x != null).ToList();
+                var requests = CreateDateRangeHistoryRequests(new[] { universeSymbol }, convertedType, start, endDate);
                 var history = History(requests);
                 var filteredDates = dateRule?.GetDates(start, endDate).ToHashSet();
 
@@ -894,7 +894,6 @@ namespace QuantConnect.Research
             HashSet<Symbol> filteredSymbols = null;
             foreach (var dataPoint in history)
             {
-                var data = dataPoint.Data;
                 if (filteredDates != null && !filteredDates.Contains(dataPoint.Time))
                 {
                     continue;
@@ -906,7 +905,7 @@ namespace QuantConnect.Research
                 {
                     filteredSymbols = selection.ToHashSet();
                 }
-                dataPoint.Data = data.Where(x => filteredSymbols == null || filteredSymbols.Contains(x.Symbol)).ToList();
+                dataPoint.Data = dataPoint.Data.Where(x => filteredSymbols == null || filteredSymbols.Contains(x.Symbol)).ToList();
                 yield return dataPoint;
             }
         }

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -893,7 +893,7 @@ namespace QuantConnect.Research
             HashSet<Symbol> filteredSymbols = null;
             foreach (var dataPoint in history)
             {
-                if (filteredDates != null && !filteredDates.Contains(dataPoint.Time))
+                if (filteredDates != null && !filteredDates.Contains(dataPoint.EndTime))
                 {
                     continue;
                 }

--- a/Tests/Research/QuantBookSelectionTests.cs
+++ b/Tests/Research/QuantBookSelectionTests.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Tests.Research
         public void Setup()
         {
             _qb = new QuantBook();
-            _end = new DateTime(2014, 4, 7);
+            _end = new DateTime(2014, 4, 22);
             _start = new DateTime(2014, 3, 24);
         }
 
@@ -48,8 +48,8 @@ namespace QuantConnect.Tests.Research
                 var universe = _qb.AddUniverse((IEnumerable<Fundamental> fundamentals) => fundamentals.Select(x => x.Symbol));
                 var history = _qb.UniverseHistory(universe, _start, _end).ToList();
 
-                // we asked for 2 weeks, 5 work days for each week expected
-                Assert.AreEqual(10, history.Count);
+                // we asked for 4 weeks, 5 work days for each week expected
+                Assert.AreEqual(20, history.Count);
                 Assert.IsTrue(history.All(x => x.Count() > 7000));
                 Assert.IsTrue(history.All(x => x.All(fundamental => fundamental.GetType() == typeof(Fundamental))));
             }
@@ -68,9 +68,9 @@ def getUniverseHistory(qb, start, end):
                     dynamic getUniverse = testModule.GetAttr("getUniverseHistory");
                     var pyHistory = getUniverse(_qb, _start, _end);
 
-                    Assert.AreEqual(10, pyHistory.__len__().AsManagedObject(typeof(int)));
+                    Assert.AreEqual(20, pyHistory.__len__().AsManagedObject(typeof(int)));
 
-                    for (var i = 0; i < 10; i++)
+                    for (var i = 0; i < 20; i++)
                     {
                         var index = pyHistory.index[i];
                         var type = typeof(List<Fundamental>);
@@ -103,8 +103,8 @@ def getUniverseHistory(qb, start, end):
                 });
                 var history = _qb.UniverseHistory(universe, _start, _end).ToList();
 
-                // we asked for 2 weeks, 5 work days for each week expected
-                Assert.AreEqual(10, history.Count);
+                // we asked for 4 weeks, 5 work days for each week expected
+                Assert.AreEqual(20, history.Count);
                 Assert.IsTrue(history.All(x => x.Count() == 1));
                 Assert.IsTrue(history.All(x => x.Single().Symbol == Symbols.AAPL));
                 Assert.IsTrue(history.All(x => x.All(fundamental => fundamental.GetType() == typeof(Fundamental))));
@@ -135,9 +135,9 @@ class Test():
                     var instance = testModule(useUniverseUnchanged);
                     var pyHistory = instance.getUniverseHistory(_qb, _start, _end);
 
-                    Assert.AreEqual(10, pyHistory.__len__().AsManagedObject(typeof(int)));
+                    Assert.AreEqual(20, pyHistory.__len__().AsManagedObject(typeof(int)));
 
-                    for (var i = 0; i < 10; i++)
+                    for (var i = 0; i < 20; i++)
                     {
                         var index = pyHistory.index[i];
                         var series = pyHistory.loc[index];
@@ -161,9 +161,9 @@ class Test():
                 {
                     return new[] { Symbols.AAPL };
                 });
-                var history = _qb.UniverseHistory(universe, _start, _end, _qb.DateRules.MonthStart()).ToList();
+                var history = _qb.UniverseHistory(universe, _start, _end, _qb.DateRules.WeekStart()).ToList();
 
-                Assert.AreEqual(1, history.Count);
+                Assert.AreEqual(5, history.Count);
                 Assert.IsTrue(history.All(x => x.Count() == 1));
                 Assert.IsTrue(history.All(x => x.Single().Symbol == Symbols.AAPL));
                 Assert.IsTrue(history.All(x => x.All(fundamental => fundamental.GetType() == typeof(Fundamental))));
@@ -182,7 +182,7 @@ class Test():
 
     def getUniverseHistory(self, qb, start, end):
         universe = qb.AddUniverse(self.selection)
-        universeDataPerTime = qb.universe_history(universe, start, end, date_rule = qb.date_rules.month_start())
+        universeDataPerTime = qb.universe_history(universe, start, end, date_rule = qb.date_rules.week_start())
         for universeDataCollection in universeDataPerTime:
             dataPointCount = 0
             for fundamental in universeDataCollection:
@@ -196,7 +196,7 @@ class Test():
                     var instance = testModule();
                     var pyHistory = instance.getUniverseHistory(_qb, _start, _end);
 
-                    Assert.AreEqual(1, pyHistory.__len__().AsManagedObject(typeof(int)));
+                    Assert.AreEqual(5, pyHistory.__len__().AsManagedObject(typeof(int)));
                     var index = pyHistory.index[0];
                     var series = pyHistory.loc[index];
                     var type = typeof(Fundamental[]);
@@ -296,7 +296,7 @@ class Test():
                 var history = _qb.UniverseHistory<Fundamentals, Fundamental>(_start, _end).ToList();
 
                 // we asked for 2 weeks, 5 work days for each week expected
-                Assert.AreEqual(10, history.Count);
+                Assert.AreEqual(20, history.Count);
                 Assert.IsTrue(history.All(x => x.Count() > 7000));
                 Assert.IsTrue(history.All(x => x.All(fundamental => fundamental.GetType() == typeof(Fundamental))));
             }
@@ -315,9 +315,9 @@ def getUniverseHistory(qb, start, end):
                     dynamic getUniverse = testModule.GetAttr("getUniverseHistory");
                     var pyHistory = getUniverse(_qb, _start, _end);
 
-                    Assert.AreEqual(10, pyHistory.__len__().AsManagedObject(typeof(int)));
+                    Assert.AreEqual(20, pyHistory.__len__().AsManagedObject(typeof(int)));
 
-                    for (var i = 0; i < 10; i++)
+                    for (var i = 0; i < 20; i++)
                     {
                         var index = pyHistory.index[i];
                         var type = typeof(List<Fundamental>);
@@ -349,8 +349,8 @@ def getUniverseHistory(qb, start, end):
                     return Universe.Unchanged;
                 }).ToList();
 
-                // we asked for 2 weeks, 5 work days for each week expected
-                Assert.AreEqual(10, history.Count);
+                // we asked for 4 weeks, 5 work days for each week expected
+                Assert.AreEqual(20, history.Count);
                 Assert.IsTrue(history.All(x => x.Count() == 1));
                 Assert.IsTrue(history.All(x => x.Single().Symbol == Symbols.AAPL));
                 Assert.IsTrue(history.All(x => x.All(fundamental => fundamental.GetType() == typeof(Fundamental))));
@@ -381,9 +381,9 @@ class Test():
                     var instance = testModule(useUniverseUnchanged);
                     var pyHistory = instance.getUniverseHistory(_qb, _start, _end);
 
-                    Assert.AreEqual(10, pyHistory.__len__().AsManagedObject(typeof(int)));
+                    Assert.AreEqual(20, pyHistory.__len__().AsManagedObject(typeof(int)));
 
-                    for (var i = 0; i < 10; i++)
+                    for (var i = 0; i < 20; i++)
                     {
                         var index = pyHistory.index[i];
                         var series = pyHistory.loc[index];

--- a/Tests/Research/QuantBookSelectionTests.cs
+++ b/Tests/Research/QuantBookSelectionTests.cs
@@ -21,6 +21,7 @@ using QuantConnect.Research;
 using System.Collections.Generic;
 using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Scheduling;
 
 namespace QuantConnect.Tests.Research
 {
@@ -401,12 +402,10 @@ class Test():
         [TestCase(Language.Python)]
         public void GenericUniverseSelectionIsCompatibleWithDateRule(Language language)
         {
-            var selectionState = false;
             if (language == Language.CSharp)
             {
                 var history = _qb.UniverseHistory<Fundamentals, Fundamental>(_start, _end, (fundamental) =>
                 {
-                    selectionState = true;
                     return new[] { Symbols.AAPL };
                 }, _qb.DateRules.WeekEnd()).ToList();
 

--- a/Tests/Research/QuantBookSelectionTests.cs
+++ b/Tests/Research/QuantBookSelectionTests.cs
@@ -198,13 +198,16 @@ class Test():
                     var pyHistory = instance.getUniverseHistory(_qb, _start, _end);
 
                     Assert.AreEqual(4, pyHistory.__len__().AsManagedObject(typeof(int)));
-                    var index = pyHistory.index[0];
-                    var series = pyHistory.loc[index];
-                    var type = typeof(Fundamental[]);
-                    var fundamental = (Fundamental[])series.AsManagedObject(type);
+                    for (var i = 0; i < 4; i++)
+                    {
+                        var index = pyHistory.index[i];
+                        var series = pyHistory.loc[index];
+                        var type = typeof(Fundamental[]);
+                        var fundamental = (Fundamental[])series.AsManagedObject(type);
 
-                    Assert.GreaterOrEqual(fundamental.Length, 1);
-                    Assert.AreEqual(Symbols.AAPL, fundamental[0].Symbol);
+                        Assert.GreaterOrEqual(fundamental.Length, 1);
+                        Assert.AreEqual(Symbols.AAPL, fundamental[0].Symbol);
+                    }
                 }
             }
         }

--- a/Tests/Research/QuantBookSelectionTests.cs
+++ b/Tests/Research/QuantBookSelectionTests.cs
@@ -397,6 +397,60 @@ class Test():
             }
         }
 
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void GenericUniverseSelectionIsCompatibleWithDateRule(Language language)
+        {
+            var selectionState = false;
+            if (language == Language.CSharp)
+            {
+                var history = _qb.UniverseHistory<Fundamentals, Fundamental>(_start, _end, (fundamental) =>
+                {
+                    selectionState = true;
+                    return new[] { Symbols.AAPL };
+                }, _qb.DateRules.WeekEnd()).ToList();
+
+                // we asked for 4 weeks, 5 work days for each week expected
+                Assert.AreEqual(4, history.Count);
+                Assert.IsTrue(history.All(x => x.Count() == 1));
+                Assert.IsTrue(history.All(x => x.Single().Symbol == Symbols.AAPL));
+                Assert.IsTrue(history.All(x => x.All(fundamental => fundamental.GetType() == typeof(Fundamental))));
+            }
+            else
+            {
+                using (Py.GIL())
+                {
+                    dynamic testModule = PyModule.FromString("testModule",
+                    @"
+from AlgorithmImports import *
+
+class Test():
+    def selection(self, fundamentals):
+        return [ x.Symbol for x in fundamentals if x.Symbol.Value == ""AAPL"" ]
+
+    def getUniverseHistory(self, qb, start, end):
+        return qb.universe_history(Fundamentals, start, end, self.selection, date_rule = qb.date_rules.week_end())
+").GetAttr("Test");
+
+                    var instance = testModule();
+                    var pyHistory = instance.getUniverseHistory(_qb, _start, _end);
+
+                    Assert.AreEqual(4, pyHistory.__len__().AsManagedObject(typeof(int)));
+
+                    for (var i = 0; i < 4; i++)
+                    {
+                        var index = pyHistory.index[i];
+                        var series = pyHistory.loc[index];
+                        var type = typeof(Fundamental[]);
+                        var fundamental = (Fundamental[])series.AsManagedObject(type);
+
+                        Assert.GreaterOrEqual(fundamental.Length, 1);
+                        Assert.AreEqual(Symbols.AAPL, fundamental[0].Symbol);
+                    }
+                }
+            }
+        }
+
         private static string GetBaseImplementation(int expectedCount, string identation)
         {
             return @"

--- a/Tests/Research/QuantBookSelectionTests.cs
+++ b/Tests/Research/QuantBookSelectionTests.cs
@@ -296,7 +296,7 @@ class Test():
             {
                 var history = _qb.UniverseHistory<Fundamentals, Fundamental>(_start, _end).ToList();
 
-                // we asked for 2 weeks, 5 work days for each week expected
+                // we asked for 4 weeks, 5 work days for each week expected
                 Assert.AreEqual(20, history.Count);
                 Assert.IsTrue(history.All(x => x.Count() > 7000));
                 Assert.IsTrue(history.All(x => x.All(fundamental => fundamental.GetType() == typeof(Fundamental))));

--- a/Tests/Research/QuantBookSelectionTests.cs
+++ b/Tests/Research/QuantBookSelectionTests.cs
@@ -162,9 +162,9 @@ class Test():
                 {
                     return new[] { Symbols.AAPL };
                 });
-                var history = _qb.UniverseHistory(universe, _start, _end, _qb.DateRules.WeekStart()).ToList();
+                var history = _qb.UniverseHistory(universe, _start, _end, _qb.DateRules.WeekEnd()).ToList();
 
-                Assert.AreEqual(5, history.Count);
+                Assert.AreEqual(4, history.Count);
                 Assert.IsTrue(history.All(x => x.Count() == 1));
                 Assert.IsTrue(history.All(x => x.Single().Symbol == Symbols.AAPL));
                 Assert.IsTrue(history.All(x => x.All(fundamental => fundamental.GetType() == typeof(Fundamental))));
@@ -183,21 +183,21 @@ class Test():
 
     def getUniverseHistory(self, qb, start, end):
         universe = qb.AddUniverse(self.selection)
-        universeDataPerTime = qb.universe_history(universe, start, end, date_rule = qb.date_rules.week_start())
+        universeDataPerTime = qb.universe_history(universe, start, end, date_rule = qb.date_rules.week_end())
         for universeDataCollection in universeDataPerTime:
             dataPointCount = 0
             for fundamental in universeDataCollection:
                 dataPointCount += 1
                 if type(fundamental) is not Fundamental:
                     raise ValueError(f""Unexpected Fundamentals data type {type(fundamental)}! {str(fundamental)}"")
-        if dataPointCount < 1:
-            raise ValueError(f""Unexpected historical Fundamentals data count {dataPointCount}! Expected > expectedCount"")
+            if dataPointCount < 1:
+                raise ValueError(f""Unexpected historical Fundamentals data count {dataPointCount}! Expected > expectedCount"")
         return universeDataPerTime").GetAttr("Test");
 
                     var instance = testModule();
                     var pyHistory = instance.getUniverseHistory(_qb, _start, _end);
 
-                    Assert.AreEqual(5, pyHistory.__len__().AsManagedObject(typeof(int)));
+                    Assert.AreEqual(4, pyHistory.__len__().AsManagedObject(typeof(int)));
                     var index = pyHistory.index[0];
                     var series = pyHistory.loc[index];
                     var type = typeof(Fundamental[]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Add an optional extra argument in `QuantBook.UniverseHistory()` for using an IDateRule
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #8115 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, users will be able to use a date rule when requesting a universe history in their QuantBook objects
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change might require an update to documentation briefing the users on this new optional argument
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created a unit test in Python/CSharp that requests universe history using a date rule and then asserts that date rule was used by checking the amount of datapoints received
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
