### PR TITLE
fix: change JsonFormat modifier to static while others remain const

### DIFF
--- a/Common/Global.cs
+++ b/Common/Global.cs
@@ -35,7 +35,7 @@ namespace QuantConnect
         /// Daily and hourly time format
         public const string TwelveCharacter = "yyyyMMdd HH:mm";
         /// JSON Format Date Representation
-        public static string JsonFormat = "yyyy-MM-ddTHH:mm:ss";
+        public const string JsonFormat = "yyyy-MM-ddTHH:mm:ss";
         /// MySQL Format Date Representation
         public const string DB = "yyyy-MM-dd HH:mm:ss";
         /// QuantConnect UX Date Representation


### PR DESCRIPTION
Changed the JsonFormat variable modifier from const to static for consistency since it is the only non-const member in the DateFormat class. All other variables retain the const modifier as they represent compile-time constants.
