### PR TITLE
Fix: Get GroupOrders ByBrokerageId

### DIFF
--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -559,7 +559,9 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         {
             var openOrders = GetOrdersByBrokerageId(brokerageId, _openOrders);
 
-            if (openOrders.Count > 0)
+            if (openOrders.Count > 0
+                // if it's part of a group, some leg could be filled already, not part of open orders
+                && (openOrders[0].GroupOrderManager == null || openOrders[0].GroupOrderManager.Count == openOrders.Count))
             {
                 return openOrders;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This Pull Request addresses a bug in the ComboOrders retrieval process. Previously, when fetching all ComboOrders, the system would only return legs that were not fully filled, omitting those that had already been filled. This caused incomplete ComboOrders to be returned, which is incorrect behavior.
For example, if a ComboMarket Order had 3 legs:
Leg 1: `OrderStatus.Filled`
Leg 2: `OrderStatus.PartiallyFilled`
Leg 3: `OrderStatus.PartiallyFilled`
With the bug, only legs 2 and 3 would be returned, excluding the already filled leg 1, which is not the expected outcome.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Related PRs
- https://github.com/QuantConnect/Lean.Brokerages.TradeStation/pull/24

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It's crucial to understand that if only a part of the ComboOrder legs is returned, it can result in an inaccurate data representation, particularly when users require the full status of all legs. This update guarantees that all legs, irrespective of their fill status, are returned. This will provide a more accurate and comprehensive view of the ComboOrders.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- For instance: Call `OrderProvider.GetOrdersByBrokerageId(...)`  in brokerage and inspect result.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
