### PR TITLE
Add BeforeMarketOpen() and AfterMarketClose() date rules

### DIFF
--- a/Common/Scheduling/TimeRules.cs
+++ b/Common/Scheduling/TimeRules.cs
@@ -159,7 +159,7 @@ namespace QuantConnect.Scheduling
         /// <param name="symbol">The symbol whose market open we want an event for</param>
         /// <param name="minutesBeforeOpen">The minutes before market open that the event should fire</param>
         /// <param name="extendedMarketOpen">True to use extended market open, false to use regular market open</param>
-        /// <returns>A time rule that fires the specified number of minutes after the symbol's market open</returns>
+        /// <returns>A time rule that fires the specified number of minutes before the symbol's market open</returns>
         public ITimeRule BeforeMarketOpen(Symbol symbol, double minutesBeforeOpen = 0, bool extendedMarketOpen = false)
         {
             return AfterMarketOpen(symbol, minutesBeforeOpen * (-1), extendedMarketOpen);
@@ -176,7 +176,7 @@ namespace QuantConnect.Scheduling
         {
             var type = extendedMarketOpen ? "ExtendedMarketOpen" : "MarketOpen";
             var afterOrBefore = minutesAfterOpen > 0 ? "after" : "before";
-            var name = Invariant($"{symbol}: {minutesAfterOpen:0.##} min {afterOrBefore} {type}");
+            var name = Invariant($"{symbol}: {Math.Abs(minutesAfterOpen):0.##} min {afterOrBefore} {type}");
             var exchangeHours = GetSecurityExchangeHours(symbol);
 
             var timeAfterOpen = TimeSpan.FromMinutes(minutesAfterOpen);
@@ -215,7 +215,7 @@ namespace QuantConnect.Scheduling
         {
             var type = extendedMarketClose ? "ExtendedMarketClose" : "MarketClose";
             var afterOrBefore = minutesBeforeClose > 0 ? "before" : "after";
-            var name = Invariant($"{symbol}: {minutesBeforeClose:0.##} min {afterOrBefore} {type}");
+            var name = Invariant($"{symbol}: {Math.Abs(minutesBeforeClose):0.##} min {afterOrBefore} {type}");
             var exchangeHours = GetSecurityExchangeHours(symbol);
 
             var timeBeforeClose = TimeSpan.FromMinutes(minutesBeforeClose);

--- a/Common/Scheduling/TimeRules.cs
+++ b/Common/Scheduling/TimeRules.cs
@@ -154,6 +154,18 @@ namespace QuantConnect.Scheduling
         }
 
         /// <summary>
+        /// Specifies an event should fire at market open +- <paramref name="minutesBeforeOpen"/>
+        /// </summary>
+        /// <param name="symbol">The symbol whose market open we want an event for</param>
+        /// <param name="minutesBeforeOpen">The minutes before market open that the event should fire</param>
+        /// <param name="extendedMarketOpen">True to use extended market open, false to use regular market open</param>
+        /// <returns>A time rule that fires the specified number of minutes after the symbol's market open</returns>
+        public ITimeRule BeforeMarketOpen(Symbol symbol, double minutesBeforeOpen = 0, bool extendedMarketOpen = false)
+        {
+            return AfterMarketOpen(symbol, minutesBeforeOpen * (-1), extendedMarketOpen);
+        }
+
+        /// <summary>
         /// Specifies an event should fire at market open +- <paramref name="minutesAfterOpen"/>
         /// </summary>
         /// <param name="symbol">The symbol whose market open we want an event for</param>
@@ -163,7 +175,8 @@ namespace QuantConnect.Scheduling
         public ITimeRule AfterMarketOpen(Symbol symbol, double minutesAfterOpen = 0, bool extendedMarketOpen = false)
         {
             var type = extendedMarketOpen ? "ExtendedMarketOpen" : "MarketOpen";
-            var name = Invariant($"{symbol}: {minutesAfterOpen:0.##} min after {type}");
+            var afterOrBefore = minutesAfterOpen > 0 ? "after" : "before";
+            var name = Invariant($"{symbol}: {minutesAfterOpen:0.##} min {afterOrBefore} {type}");
             var exchangeHours = GetSecurityExchangeHours(symbol);
 
             var timeAfterOpen = TimeSpan.FromMinutes(minutesAfterOpen);
@@ -180,6 +193,18 @@ namespace QuantConnect.Scheduling
         }
 
         /// <summary>
+        /// Specifies an event should fire at the market close +- <paramref name="minutesAfterClose"/>
+        /// </summary>
+        /// <param name="symbol">The symbol whose market close we want an event for</param>
+        /// <param name="minutesAfterClose">The time after market close that the event should fire</param>
+        /// <param name="extendedMarketClose">True to use extended market close, false to use regular market close</param>
+        /// <returns>A time rule that fires the specified number of minutes after the symbol's market close</returns>
+        public ITimeRule AfterMarketClose(Symbol symbol, double minutesAfterClose = 0, bool extendedMarketClose = false)
+        {
+            return BeforeMarketClose(symbol, minutesAfterClose * (-1), extendedMarketClose);
+        }
+
+        /// <summary>
         /// Specifies an event should fire at the market close +- <paramref name="minutesBeforeClose"/>
         /// </summary>
         /// <param name="symbol">The symbol whose market close we want an event for</param>
@@ -189,7 +214,8 @@ namespace QuantConnect.Scheduling
         public ITimeRule BeforeMarketClose(Symbol symbol, double minutesBeforeClose = 0, bool extendedMarketClose = false)
         {
             var type = extendedMarketClose ? "ExtendedMarketClose" : "MarketClose";
-            var name = Invariant($"{symbol}: {minutesBeforeClose:0.##} min before {type}");
+            var afterOrBefore = minutesBeforeClose > 0 ? "before" : "after";
+            var name = Invariant($"{symbol}: {minutesBeforeClose:0.##} min {afterOrBefore} {type}");
             var exchangeHours = GetSecurityExchangeHours(symbol);
 
             var timeBeforeClose = TimeSpan.FromMinutes(minutesBeforeClose);

--- a/Tests/Common/Scheduling/TimeRulesTests.cs
+++ b/Tests/Common/Scheduling/TimeRulesTests.cs
@@ -178,6 +178,22 @@ namespace QuantConnect.Tests.Common.Scheduling
         }
 
         [Test]
+        public void RegularBeforeMarketOpenWithDelta()
+        {
+            var rules = GetTimeRules(TimeZones.Utc);
+            var rule = rules.BeforeMarketOpen(Symbols.SPY, 30);
+            var times = rule.CreateUtcEventTimes(new[] { new DateTime(2000, 01, 03) });
+
+            int count = 0;
+            foreach (var time in times)
+            {
+                count++;
+                Assert.AreEqual(TimeSpan.FromHours(14.5 - 0.5), time.TimeOfDay);
+            }
+            Assert.AreEqual(1, count);
+        }
+
+        [Test]
         public void ExtendedMarketCloseNoDeltaForContinuousSchedules()
         {
             var rules = GetTimeRules(TimeZones.Utc);
@@ -286,6 +302,22 @@ namespace QuantConnect.Tests.Common.Scheduling
             {
                 count++;
                 Assert.AreEqual(TimeSpan.FromHours((20 + 5 - .5) % 24), time.TimeOfDay);
+            }
+            Assert.AreEqual(1, count);
+        }
+
+        [Test]
+        public void ExtendedAfterMarketCloseWithDelta()
+        {
+            var rules = GetTimeRules(TimeZones.Utc);
+            var rule = rules.AfterMarketClose(Symbols.SPY, 30, true);
+            var times = rule.CreateUtcEventTimes(new[] { new DateTime(2000, 01, 03) });
+
+            int count = 0;
+            foreach (var time in times)
+            {
+                count++;
+                Assert.AreEqual(TimeSpan.FromHours((20 + 5 + .5) % 24), time.TimeOfDay);
             }
             Assert.AreEqual(1, count);
         }

--- a/Tests/Common/Scheduling/TimeRulesTests.cs
+++ b/Tests/Common/Scheduling/TimeRulesTests.cs
@@ -177,18 +177,19 @@ namespace QuantConnect.Tests.Common.Scheduling
             Assert.AreEqual(6, count);
         }
 
-        [Test]
-        public void RegularBeforeMarketOpenWithDelta()
+        [TestCase(true, 9 - 0.5)]
+        [TestCase(false, 14.5 - 0.5)]
+        public void BeforeMarketOpenWithDelta(bool extendedMarketHours, double expectedHour)
         {
             var rules = GetTimeRules(TimeZones.Utc);
-            var rule = rules.BeforeMarketOpen(Symbols.SPY, 30);
+            var rule = rules.BeforeMarketOpen(Symbols.SPY, 30, extendedMarketHours);
             var times = rule.CreateUtcEventTimes(new[] { new DateTime(2000, 01, 03) });
 
             int count = 0;
             foreach (var time in times)
             {
                 count++;
-                Assert.AreEqual(TimeSpan.FromHours(14.5 - 0.5), time.TimeOfDay);
+                Assert.AreEqual(TimeSpan.FromHours(expectedHour), time.TimeOfDay);
             }
             Assert.AreEqual(1, count);
         }
@@ -306,18 +307,19 @@ namespace QuantConnect.Tests.Common.Scheduling
             Assert.AreEqual(1, count);
         }
 
-        [Test]
-        public void ExtendedAfterMarketCloseWithDelta()
+        [TestCase(true, (21 + 4 + .5) % 24)]
+        [TestCase(false, (21 + .5) % 24)]
+        public void AfterMarketCloseWithDelta(bool extendedMarketHours, double expectedHour)
         {
             var rules = GetTimeRules(TimeZones.Utc);
-            var rule = rules.AfterMarketClose(Symbols.SPY, 30, true);
+            var rule = rules.AfterMarketClose(Symbols.SPY, 30, extendedMarketHours);
             var times = rule.CreateUtcEventTimes(new[] { new DateTime(2000, 01, 03) });
 
             int count = 0;
             foreach (var time in times)
             {
                 count++;
-                Assert.AreEqual(TimeSpan.FromHours((20 + 5 + .5) % 24), time.TimeOfDay);
+                Assert.AreEqual(TimeSpan.FromHours(expectedHour), time.TimeOfDay);
             }
             Assert.AreEqual(1, count);
         }

--- a/Tests/Common/Scheduling/TimeRulesTests.cs
+++ b/Tests/Common/Scheduling/TimeRulesTests.cs
@@ -184,6 +184,8 @@ namespace QuantConnect.Tests.Common.Scheduling
             var rules = GetTimeRules(TimeZones.Utc);
             var rule = rules.BeforeMarketOpen(Symbols.SPY, 30, extendedMarketHours);
             var times = rule.CreateUtcEventTimes(new[] { new DateTime(2000, 01, 03) });
+            var type = extendedMarketHours ? "ExtendedMarketOpen" : "MarketOpen";
+            Assert.AreEqual($"{Symbols.SPY}: 30 min before {type}", rule.Name);
 
             int count = 0;
             foreach (var time in times)
@@ -314,6 +316,8 @@ namespace QuantConnect.Tests.Common.Scheduling
             var rules = GetTimeRules(TimeZones.Utc);
             var rule = rules.AfterMarketClose(Symbols.SPY, 30, extendedMarketHours);
             var times = rule.CreateUtcEventTimes(new[] { new DateTime(2000, 01, 03) });
+            var type = extendedMarketHours ? "ExtendedMarketClose" : "MarketClose";
+            Assert.AreEqual($"{Symbols.SPY}: 30 min after {type}", rule.Name);
 
             int count = 0;
             foreach (var time in times)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Add `BeforeMarketOpen()` and `AfterMarketClose()` date rules using the already implemented `AfterMarketOpen()` and `BeforeMarketClose()` date rules.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #8106 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change users will be able to use a date rule that fires $x$ number of minutes before the market opens or $x$ number of minutes after the market closes.
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
This change might require a change to documentation briefing the users on this new feature.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created two unit tests, one using `BeforeMarketOpen()` and the other `AfterMarketClose()`, that assert the even times created with the time rules are the expected ones.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
