### PR TITLE
Add missing end_date in python regression algorithm

### DIFF
--- a/Algorithm.Python/IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm.py
+++ b/Algorithm.Python/IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm.py
@@ -17,6 +17,7 @@ class IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm(QCAlgorithm)
 
     def initialize(self):
         self.set_start_date(2020, 2, 20)
+        self.set_end_date(2020, 4, 20)
         self.qqq = self.add_equity("QQQ", Resolution.DAILY).symbol
         self.range_indicator = RangeIndicator("range1")
         self.range_sma = IndicatorExtensions.sma(self.range_indicator, 5)

--- a/Tests/Indicators/IndicatorExtensionsTests.cs
+++ b/Tests/Indicators/IndicatorExtensionsTests.cs
@@ -670,8 +670,8 @@ namespace QuantConnect.Tests.Indicators
                     {"Beta", "0"},
                     {"Annual Standard Deviation", "0"},
                     {"Annual Variance", "0"},
-                    {"Information Ratio", "-0.283"},
-                    {"Tracking Error", "0.133"},
+                    {"Information Ratio", "0.717"},
+                    {"Tracking Error", "0.593"},
                     {"Treynor Ratio", "0"},
                     {"Total Fees", "$0.00"},
                     {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->Add a missing `set_end_date()` in the regression algorithm `IndicatorExtensionsSMAWithCustomIndicatorsRegressionAlgorithm.py`
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
N/A
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
