### PR TITLE
Add `QCAlgorithm.OptionChain()` method to fetch option chains

### DIFF
--- a/Algorithm.CSharp/AddAndRemoveOptionContractRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddAndRemoveOptionContractRegressionAlgorithm.cs
@@ -41,9 +41,9 @@ namespace QuantConnect.Algorithm.CSharp
             var aapl = QuantConnect.Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
 
             _contract = OptionChain(aapl)
-                .OrderBy(x => x.Symbol.ID.Symbol)
-                .FirstOrDefault(optionContract => optionContract.Symbol.ID.OptionRight == OptionRight.Call
-                    && optionContract.Symbol.ID.OptionStyle == OptionStyle.American)?.Symbol;
+                .OrderBy(x => x.ID.Symbol)
+                .FirstOrDefault(optionContract => optionContract.ID.OptionRight == OptionRight.Call
+                    && optionContract.ID.OptionStyle == OptionStyle.American);
             AddOptionContract(_contract);
         }
 

--- a/Algorithm.CSharp/AddAndRemoveOptionContractRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddAndRemoveOptionContractRegressionAlgorithm.cs
@@ -40,10 +40,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             var aapl = QuantConnect.Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
 
-            _contract = OptionChainProvider.GetOptionContractList(aapl, Time)
-                .OrderBy(symbol => symbol.ID.Symbol)
-                .FirstOrDefault(optionContract => optionContract.ID.OptionRight == OptionRight.Call
-                    && optionContract.ID.OptionStyle == OptionStyle.American);
+            _contract = OptionChain(aapl)
+                .OrderBy(x => x.Symbol.ID.Symbol)
+                .FirstOrDefault(optionContract => optionContract.Symbol.ID.OptionRight == OptionRight.Call
+                    && optionContract.Symbol.ID.OptionStyle == OptionStyle.American)?.Symbol;
             AddOptionContract(_contract);
         }
 

--- a/Algorithm.CSharp/AddAndRemoveSecuritySameLoopRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddAndRemoveSecuritySameLoopRegressionAlgorithm.cs
@@ -40,9 +40,9 @@ namespace QuantConnect.Algorithm.CSharp
             var aapl = AddEquity("AAPL").Symbol;
 
             _contract = OptionChain(aapl)
-                .OrderBy(x => x.Symbol.ID.Symbol)
-                .FirstOrDefault(optionContract => optionContract.Symbol.ID.OptionRight == OptionRight.Call
-                    && optionContract.Symbol.ID.OptionStyle == OptionStyle.American);
+                .OrderBy(x => x.ID.Symbol)
+                .FirstOrDefault(optionContract => optionContract.ID.OptionRight == OptionRight.Call
+                    && optionContract.ID.OptionStyle == OptionStyle.American);
         }
 
         public override void OnData(Slice slice)

--- a/Algorithm.CSharp/AddAndRemoveSecuritySameLoopRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddAndRemoveSecuritySameLoopRegressionAlgorithm.cs
@@ -39,10 +39,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             var aapl = AddEquity("AAPL").Symbol;
 
-            _contract = OptionChainProvider.GetOptionContractList(aapl, Time)
-                .OrderBy(symbol => symbol.ID.Symbol)
-                .FirstOrDefault(optionContract => optionContract.ID.OptionRight == OptionRight.Call
-                    && optionContract.ID.OptionStyle == OptionStyle.American);
+            _contract = OptionChain(aapl)
+                .OrderBy(x => x.Symbol.ID.Symbol)
+                .FirstOrDefault(optionContract => optionContract.Symbol.ID.OptionRight == OptionRight.Call
+                    && optionContract.Symbol.ID.OptionStyle == OptionStyle.American);
         }
 
         public override void OnData(Slice slice)

--- a/Algorithm.CSharp/AddFutureOptionContractFromFutureChainRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddFutureOptionContractFromFutureChainRegressionAlgorithm.cs
@@ -49,7 +49,7 @@ namespace QuantConnect.Algorithm.CSharp
                 {
                     foreach (var contract in futuresContracts)
                     {
-                        var option_contract_symbols = OptionChainProvider.GetOptionContractList(contract.Symbol, Time).ToList();
+                        var option_contract_symbols = OptionChain(contract.Symbol).Select(x => x.Symbol).ToList();
                         if(option_contract_symbols.Count == 0)
                         {
                             continue;

--- a/Algorithm.CSharp/AddFutureOptionContractFromFutureChainRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddFutureOptionContractFromFutureChainRegressionAlgorithm.cs
@@ -49,7 +49,7 @@ namespace QuantConnect.Algorithm.CSharp
                 {
                     foreach (var contract in futuresContracts)
                     {
-                        var option_contract_symbols = OptionChain(contract.Symbol).Select(x => x.Symbol).ToList();
+                        var option_contract_symbols = OptionChain(contract.Symbol).ToList();
                         if(option_contract_symbols.Count == 0)
                         {
                             continue;

--- a/Algorithm.CSharp/AddOptionContractExpiresRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddOptionContractExpiresRegressionAlgorithm.cs
@@ -47,10 +47,10 @@ namespace QuantConnect.Algorithm.CSharp
             if (_option == null)
             {
                 var option = OptionChain(_twx)
-                    .OrderBy(x => x.Symbol.ID.Symbol)
-                    .FirstOrDefault(optionContract => optionContract.Symbol.ID.Date == _expiration
-                                                      && optionContract.Symbol.ID.OptionRight == OptionRight.Call
-                                                      && optionContract.Symbol.ID.OptionStyle == OptionStyle.American)?.Symbol;
+                    .OrderBy(x => x.ID.Symbol)
+                    .FirstOrDefault(optionContract => optionContract.ID.Date == _expiration
+                                                      && optionContract.ID.OptionRight == OptionRight.Call
+                                                      && optionContract.ID.OptionStyle == OptionStyle.American);
                 if (option != null)
                 {
                     _option = AddOptionContract(option).Symbol;

--- a/Algorithm.CSharp/AddOptionContractExpiresRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddOptionContractExpiresRegressionAlgorithm.cs
@@ -46,11 +46,11 @@ namespace QuantConnect.Algorithm.CSharp
         {
             if (_option == null)
             {
-                var option = OptionChainProvider.GetOptionContractList(_twx, Time)
-                    .OrderBy(symbol => symbol.ID.Symbol)
-                    .FirstOrDefault(optionContract => optionContract.ID.Date == _expiration
-                                                      && optionContract.ID.OptionRight == OptionRight.Call
-                                                      && optionContract.ID.OptionStyle == OptionStyle.American);
+                var option = OptionChain(_twx)
+                    .OrderBy(x => x.Symbol.ID.Symbol)
+                    .FirstOrDefault(optionContract => optionContract.Symbol.ID.Date == _expiration
+                                                      && optionContract.Symbol.ID.OptionRight == OptionRight.Call
+                                                      && optionContract.Symbol.ID.OptionStyle == OptionStyle.American)?.Symbol;
                 if (option != null)
                 {
                     _option = AddOptionContract(option).Symbol;

--- a/Algorithm.CSharp/AddOptionContractFromUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddOptionContractFromUniverseRegressionAlgorithm.cs
@@ -13,12 +13,12 @@
  * limitations under the License.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -110,14 +110,14 @@ namespace QuantConnect.Algorithm.CSharp
 
             foreach (var addedSecurity in changes.AddedSecurities)
             {
-                var option = OptionChainProvider.GetOptionContractList(addedSecurity.Symbol, Time)
-                    .OrderBy(symbol => symbol.ID.Symbol)
-                    .First(optionContract => optionContract.ID.Date == _expiration
-                                                      && optionContract.ID.OptionRight == OptionRight.Call
-                                                      && optionContract.ID.OptionStyle == OptionStyle.American);
+                var option = OptionChain(addedSecurity.Symbol)
+                    .OrderBy(contractData => contractData.Symbol.ID.Symbol)
+                    .First(optionContract => optionContract.Symbol.ID.Date == _expiration
+                                                      && optionContract.Symbol.ID.OptionRight == OptionRight.Call
+                                                      && optionContract.Symbol.ID.OptionStyle == OptionStyle.American);
                 AddOptionContract(option);
 
-                foreach (var symbol in new[] { option, option.Underlying })
+                foreach (var symbol in new[] { option.Symbol, option.Underlying.Symbol })
                 {
                     var config = SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(symbol).ToList();
 

--- a/Algorithm.CSharp/AddOptionContractFromUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddOptionContractFromUniverseRegressionAlgorithm.cs
@@ -111,10 +111,10 @@ namespace QuantConnect.Algorithm.CSharp
             foreach (var addedSecurity in changes.AddedSecurities)
             {
                 var option = OptionChain(addedSecurity.Symbol)
-                    .OrderBy(contractData => contractData.Symbol.ID.Symbol)
-                    .First(optionContract => optionContract.Symbol.ID.Date == _expiration
-                                                      && optionContract.Symbol.ID.OptionRight == OptionRight.Call
-                                                      && optionContract.Symbol.ID.OptionStyle == OptionStyle.American);
+                    .OrderBy(contractData => contractData.ID.Symbol)
+                    .First(optionContract => optionContract.ID.Date == _expiration
+                                                      && optionContract.ID.OptionRight == OptionRight.Call
+                                                      && optionContract.ID.OptionStyle == OptionStyle.American);
                 AddOptionContract(option);
 
                 foreach (var symbol in new[] { option.Symbol, option.Underlying.Symbol })

--- a/Algorithm.CSharp/AddOptionContractTwiceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddOptionContractTwiceRegressionAlgorithm.cs
@@ -43,10 +43,11 @@ namespace QuantConnect.Algorithm.CSharp
 
             var aapl = QuantConnect.Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
 
-            _contract = OptionChainProvider.GetOptionContractList(aapl, Time)
-                .OrderBy(symbol => symbol.ID.StrikePrice)
-                .FirstOrDefault(optionContract => optionContract.ID.OptionRight == OptionRight.Call
-                    && optionContract.ID.OptionStyle == OptionStyle.American);
+            _contract = OptionChain(aapl)
+                .OrderBy(x => x.Symbol.ID.StrikePrice)
+                .FirstOrDefault(optionContract => optionContract.Symbol.ID.OptionRight == OptionRight.Call
+                    && optionContract.Symbol.ID.OptionStyle == OptionStyle.American)
+                .Symbol;
             AddOptionContract(_contract);
         }
 

--- a/Algorithm.CSharp/AddOptionContractTwiceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddOptionContractTwiceRegressionAlgorithm.cs
@@ -44,10 +44,9 @@ namespace QuantConnect.Algorithm.CSharp
             var aapl = QuantConnect.Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
 
             _contract = OptionChain(aapl)
-                .OrderBy(x => x.Symbol.ID.StrikePrice)
-                .FirstOrDefault(optionContract => optionContract.Symbol.ID.OptionRight == OptionRight.Call
-                    && optionContract.Symbol.ID.OptionStyle == OptionStyle.American)
-                .Symbol;
+                .OrderBy(x => x.ID.StrikePrice)
+                .FirstOrDefault(optionContract => optionContract.ID.OptionRight == OptionRight.Call
+                    && optionContract.ID.OptionStyle == OptionStyle.American);
             AddOptionContract(_contract);
         }
 

--- a/Algorithm.CSharp/AddTwoAndRemoveOneOptionContractRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddTwoAndRemoveOneOptionContractRegressionAlgorithm.cs
@@ -42,11 +42,10 @@ namespace QuantConnect.Algorithm.CSharp
             var aapl = QuantConnect.Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
 
             var contracts = OptionChain(aapl)
-                .OrderBy(x => x.Symbol.ID.StrikePrice)
-                .Where(optionContract => optionContract.Symbol.ID.OptionRight == OptionRight.Call
-                    && optionContract.Symbol.ID.OptionStyle == OptionStyle.American)
+                .OrderBy(x => x.ID.StrikePrice)
+                .Where(optionContract => optionContract.ID.OptionRight == OptionRight.Call
+                    && optionContract.ID.OptionStyle == OptionStyle.American)
                 .Take(2)
-                .Select(x => x.Symbol)
                 .ToList();
 
             _contract1 = contracts[0];

--- a/Algorithm.CSharp/AddTwoAndRemoveOneOptionContractRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddTwoAndRemoveOneOptionContractRegressionAlgorithm.cs
@@ -41,11 +41,12 @@ namespace QuantConnect.Algorithm.CSharp
 
             var aapl = QuantConnect.Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
 
-            var contracts = OptionChainProvider.GetOptionContractList(aapl, Time)
-                .OrderBy(symbol => symbol.ID.StrikePrice)
-                .Where(optionContract => optionContract.ID.OptionRight == OptionRight.Call
-                    && optionContract.ID.OptionStyle == OptionStyle.American)
+            var contracts = OptionChain(aapl)
+                .OrderBy(x => x.Symbol.ID.StrikePrice)
+                .Where(optionContract => optionContract.Symbol.ID.OptionRight == OptionRight.Call
+                    && optionContract.Symbol.ID.OptionStyle == OptionStyle.American)
                 .Take(2)
+                .Select(x => x.Symbol)
                 .ToList();
 
             _contract1 = contracts[0];

--- a/Algorithm.CSharp/BasicTemplateOptionsAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsAlgorithm.cs
@@ -48,7 +48,10 @@ namespace QuantConnect.Algorithm.CSharp
             _optionSymbol = option.Symbol;
 
             // set our strike/expiry filter for this option chain
-            option.SetFilter(u => u);
+            option.SetFilter(u => u.Strikes(-2, +2)
+                                   // Expiration method accepts TimeSpan objects or integer for days.
+                                   // The following statements yield the same filtering criteria
+                                   .Expiration(0, 180));
                                    // .Expiration(TimeSpan.Zero, TimeSpan.FromDays(180)));
 
             // use the underlying equity as the benchmark

--- a/Algorithm.CSharp/BasicTemplateOptionsAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsAlgorithm.cs
@@ -48,10 +48,7 @@ namespace QuantConnect.Algorithm.CSharp
             _optionSymbol = option.Symbol;
 
             // set our strike/expiry filter for this option chain
-            option.SetFilter(u => u.Strikes(-2, +2)
-                                   // Expiration method accepts TimeSpan objects or integer for days.
-                                   // The following statements yield the same filtering criteria
-                                   .Expiration(0, 180));
+            option.SetFilter(u => u);
                                    // .Expiration(TimeSpan.Zero, TimeSpan.FromDays(180)));
 
             // use the underlying equity as the benchmark

--- a/Algorithm.CSharp/DelayedSettlementAfterManualSecurityRemovalAlgorithm.cs
+++ b/Algorithm.CSharp/DelayedSettlementAfterManualSecurityRemovalAlgorithm.cs
@@ -37,10 +37,11 @@ namespace QuantConnect.Algorithm.CSharp
 
             var equity = AddEquity("GOOG");
 
-            _optionSymbol = OptionChainProvider.GetOptionContractList(equity.Symbol, Time)
-                .OrderBy(symbol => symbol.ID.StrikePrice)
-                .ThenByDescending(symbol => symbol.ID.Date)
-                .First(optionContract => optionContract.ID.OptionRight == OptionRight.Call);
+            _optionSymbol = OptionChain(equity.Symbol)
+                .OrderBy(x => x.Symbol.ID.StrikePrice)
+                .ThenByDescending(x => x.Symbol.ID.Date)
+                .First(optionContract => optionContract.Symbol.ID.OptionRight == OptionRight.Call)
+                .Symbol;
             var option = AddOptionContract(_optionSymbol);
 
             option.SetSettlementModel(new DelayedSettlementModel(Option.DefaultSettlementDays, Option.DefaultSettlementTime));

--- a/Algorithm.CSharp/DelayedSettlementAfterManualSecurityRemovalAlgorithm.cs
+++ b/Algorithm.CSharp/DelayedSettlementAfterManualSecurityRemovalAlgorithm.cs
@@ -38,10 +38,9 @@ namespace QuantConnect.Algorithm.CSharp
             var equity = AddEquity("GOOG");
 
             _optionSymbol = OptionChain(equity.Symbol)
-                .OrderBy(x => x.Symbol.ID.StrikePrice)
-                .ThenByDescending(x => x.Symbol.ID.Date)
-                .First(optionContract => optionContract.Symbol.ID.OptionRight == OptionRight.Call)
-                .Symbol;
+                .OrderBy(x => x.ID.StrikePrice)
+                .ThenByDescending(x => x.ID.Date)
+                .First(optionContract => optionContract.ID.OptionRight == OptionRight.Call);
             var option = AddOptionContract(_optionSymbol);
 
             option.SetSettlementModel(new DelayedSettlementModel(Option.DefaultSettlementDays, Option.DefaultSettlementTime));

--- a/Algorithm.CSharp/DelistedIndexOptionDivestedRegression.cs
+++ b/Algorithm.CSharp/DelistedIndexOptionDivestedRegression.cs
@@ -51,8 +51,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             if (_addOption)
             {
-                var contracts = OptionChain(_spx)
-                    .Where(x => x.Symbol.ID.OptionRight == OptionRight.Put && x.Symbol.ID.Date.Date == new DateTime(2021, 1, 15));
+                var contracts = OptionChain(_spx).Where(x => x.ID.OptionRight == OptionRight.Put && x.ID.Date.Date == new DateTime(2021, 1, 15));
 
                 var option = AddIndexOptionContract(contracts.First(), Resolution.Minute);
                 _optionExpiry = option.Expiry;

--- a/Algorithm.CSharp/DelistedIndexOptionDivestedRegression.cs
+++ b/Algorithm.CSharp/DelistedIndexOptionDivestedRegression.cs
@@ -51,10 +51,8 @@ namespace QuantConnect.Algorithm.CSharp
 
             if (_addOption)
             {
-                var contracts = OptionChainProvider.GetOptionContractList(_spx, Time);
-                contracts = contracts.Where(x =>
-                    x.ID.OptionRight == OptionRight.Put &&
-                    x.ID.Date.Date == new DateTime(2021, 1, 15));
+                var contracts = OptionChain(_spx)
+                    .Where(x => x.Symbol.ID.OptionRight == OptionRight.Put && x.Symbol.ID.Date.Date == new DateTime(2021, 1, 15));
 
                 var option = AddIndexOptionContract(contracts.First(), Resolution.Minute);
                 _optionExpiry = option.Expiry;

--- a/Algorithm.CSharp/FutureOptionBuySellCallIntradayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionBuySellCallIntradayRegressionAlgorithm.cs
@@ -60,8 +60,8 @@ namespace QuantConnect.Algorithm.CSharp
             // Select a future option expiring ITM, and adds it to the algorithm.
             var esOptions = OptionChain(es20m20)
                 .Concat(OptionChain(es20h20))
-                .Where(contractData => contractData.Symbol.ID.StrikePrice == 3200m && contractData.Symbol.ID.OptionRight == OptionRight.Call)
-                .Select(contractData => AddFutureOptionContract(contractData.Symbol, Resolution.Minute).Symbol)
+                .Where(contractData => contractData.ID.StrikePrice == 3200m && contractData.ID.OptionRight == OptionRight.Call)
+                .Select(contractData => AddFutureOptionContract(contractData, Resolution.Minute).Symbol)
                 .ToList();
 
             var expectedContracts = new[]

--- a/Algorithm.CSharp/FutureOptionBuySellCallIntradayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionBuySellCallIntradayRegressionAlgorithm.cs
@@ -58,10 +58,10 @@ namespace QuantConnect.Algorithm.CSharp
                 Resolution.Minute).Symbol;
 
             // Select a future option expiring ITM, and adds it to the algorithm.
-            var esOptions = OptionChainProvider.GetOptionContractList(es20m20, Time)
-                .Concat(OptionChainProvider.GetOptionContractList(es20h20, Time))
-                .Where(x => x.ID.StrikePrice == 3200m && x.ID.OptionRight == OptionRight.Call)
-                .Select(x => AddFutureOptionContract(x, Resolution.Minute).Symbol)
+            var esOptions = OptionChain(es20m20)
+                .Concat(OptionChain(es20h20))
+                .Where(contractData => contractData.Symbol.ID.StrikePrice == 3200m && contractData.Symbol.ID.OptionRight == OptionRight.Call)
+                .Select(contractData => AddFutureOptionContract(contractData.Symbol, Resolution.Minute).Symbol)
                 .ToList();
 
             var expectedContracts = new[]

--- a/Algorithm.CSharp/FutureOptionCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallITMExpiryRegressionAlgorithm.cs
@@ -54,11 +54,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a future option expiring ITM, and adds it to the algorithm.
             _esOption = AddFutureOptionContract(OptionChain(_es19m20)
-                .Where(x => x.Symbol.ID.StrikePrice <= 3200m && x.Symbol.ID.OptionRight == OptionRight.Call)
-                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Call)
+                .OrderByDescending(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedOptionContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Call, 3200m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedOptionContract)

--- a/Algorithm.CSharp/FutureOptionCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallITMExpiryRegressionAlgorithm.cs
@@ -53,11 +53,12 @@ namespace QuantConnect.Algorithm.CSharp
                 Resolution.Minute).Symbol;
 
             // Select a future option expiring ITM, and adds it to the algorithm.
-            _esOption = AddFutureOptionContract(OptionChainProvider.GetOptionContractList(_es19m20, Time)
-                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Call)
-                .OrderByDescending(x => x.ID.StrikePrice)
+            _esOption = AddFutureOptionContract(OptionChain(_es19m20)
+                .Where(x => x.Symbol.ID.StrikePrice <= 3200m && x.Symbol.ID.OptionRight == OptionRight.Call)
+                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedOptionContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Call, 3200m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedOptionContract)

--- a/Algorithm.CSharp/FutureOptionCallITMGreeksExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallITMGreeksExpiryRegressionAlgorithm.cs
@@ -55,11 +55,12 @@ namespace QuantConnect.Algorithm.CSharp
                 TimeSpan.FromMinutes(1));
 
             // Select a future option expiring ITM, and adds it to the algorithm.
-            _esOption = AddFutureOptionContract(OptionChainProvider.GetOptionContractList(_es19m20.Symbol, new DateTime(2020, 1, 5))
-                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Call)
-                .OrderByDescending(x => x.ID.StrikePrice)
+            _esOption = AddFutureOptionContract(OptionChain(_es19m20.Symbol)
+                .Where(x => x.Symbol.ID.StrikePrice <= 3200m && x.Symbol.ID.OptionRight == OptionRight.Call)
+                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute);
+                .Single()
+                .Symbol, Resolution.Minute);
 
             _esOption.PriceModel = OptionPriceModels.BjerksundStensland();
 

--- a/Algorithm.CSharp/FutureOptionCallITMGreeksExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallITMGreeksExpiryRegressionAlgorithm.cs
@@ -56,11 +56,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a future option expiring ITM, and adds it to the algorithm.
             _esOption = AddFutureOptionContract(OptionChain(_es19m20.Symbol)
-                .Where(x => x.Symbol.ID.StrikePrice <= 3200m && x.Symbol.ID.OptionRight == OptionRight.Call)
-                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Call)
+                .OrderByDescending(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute);
+                .Single(), Resolution.Minute);
 
             _esOption.PriceModel = OptionPriceModels.BjerksundStensland();
 

--- a/Algorithm.CSharp/FutureOptionCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallOTMExpiryRegressionAlgorithm.cs
@@ -59,11 +59,12 @@ namespace QuantConnect.Algorithm.CSharp
                 Resolution.Minute).Symbol;
 
             // Select a future option call expiring OTM, and adds it to the algorithm.
-            _esOption = AddFutureOptionContract(OptionChainProvider.GetOptionContractList(_es19m20, Time)
-                .Where(x => x.ID.StrikePrice >= 3300m && x.ID.OptionRight == OptionRight.Call)
-                .OrderBy(x => x.ID.StrikePrice)
+            _esOption = AddFutureOptionContract(OptionChain(_es19m20)
+                .Where(contractData => contractData.Symbol.ID.StrikePrice >= 3300m && contractData.Symbol.ID.OptionRight == OptionRight.Call)
+                .OrderBy(contractData => contractData.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Call, 3300m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/FutureOptionCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallOTMExpiryRegressionAlgorithm.cs
@@ -60,11 +60,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a future option call expiring OTM, and adds it to the algorithm.
             _esOption = AddFutureOptionContract(OptionChain(_es19m20)
-                .Where(contractData => contractData.Symbol.ID.StrikePrice >= 3300m && contractData.Symbol.ID.OptionRight == OptionRight.Call)
-                .OrderBy(contractData => contractData.Symbol.ID.StrikePrice)
+                .Where(contractData => contractData.ID.StrikePrice >= 3300m && contractData.ID.OptionRight == OptionRight.Call)
+                .OrderBy(contractData => contractData.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Call, 3300m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/FutureOptionDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionDailyRegressionAlgorithm.cs
@@ -47,9 +47,9 @@ namespace QuantConnect.Algorithm.CSharp
                 Resolution).Symbol;
 
             // Attempt to fetch a specific future option contract
-            DcOption = OptionChainProvider.GetOptionContractList(dc, Time)
-                .Where(x => x.ID.StrikePrice == 17m && x.ID.OptionRight == OptionRight.Call)
-                .Select(x => AddFutureOptionContract(x, Resolution).Symbol)
+            DcOption = OptionChain(dc)
+                .Where(x => x.Symbol.ID.StrikePrice == 17m && x.Symbol.ID.OptionRight == OptionRight.Call)
+                .Select(x => AddFutureOptionContract(x.Symbol, Resolution).Symbol)
                 .FirstOrDefault();
 
             // Validate it is the expected contract

--- a/Algorithm.CSharp/FutureOptionDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionDailyRegressionAlgorithm.cs
@@ -48,8 +48,8 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Attempt to fetch a specific future option contract
             DcOption = OptionChain(dc)
-                .Where(x => x.Symbol.ID.StrikePrice == 17m && x.Symbol.ID.OptionRight == OptionRight.Call)
-                .Select(x => AddFutureOptionContract(x.Symbol, Resolution).Symbol)
+                .Where(x => x.ID.StrikePrice == 17m && x.ID.OptionRight == OptionRight.Call)
+                .Select(x => AddFutureOptionContract(x, Resolution).Symbol)
                 .FirstOrDefault();
 
             // Validate it is the expected contract

--- a/Algorithm.CSharp/FutureOptionIndicatorsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionIndicatorsRegressionAlgorithm.cs
@@ -33,11 +33,10 @@ namespace QuantConnect.Algorithm.CSharp
                 Resolution.Minute).Symbol;
 
             var option = AddFutureOptionContract(OptionChain(underlying)
-                .Where(x => x.Symbol.ID.StrikePrice <= 3200m && x.Symbol.ID.OptionRight == OptionRight.Call)
-                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Call)
+                .OrderByDescending(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             InitializeIndicators(option);
         }

--- a/Algorithm.CSharp/FutureOptionIndicatorsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionIndicatorsRegressionAlgorithm.cs
@@ -32,11 +32,12 @@ namespace QuantConnect.Algorithm.CSharp
             var underlying = AddFutureContract(QuantConnect.Symbol.CreateFuture(Futures.Indices.SP500EMini, Market.CME, new DateTime(2020, 3, 20)),
                 Resolution.Minute).Symbol;
 
-            var option = AddFutureOptionContract(OptionChainProvider.GetOptionContractList(underlying, Time)
-                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Call)
-                .OrderByDescending(x => x.ID.StrikePrice)
+            var option = AddFutureOptionContract(OptionChain(underlying)
+                .Where(x => x.Symbol.ID.StrikePrice <= 3200m && x.Symbol.ID.OptionRight == OptionRight.Call)
+                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             InitializeIndicators(option);
         }

--- a/Algorithm.CSharp/FutureOptionPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionPutITMExpiryRegressionAlgorithm.cs
@@ -55,11 +55,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a future option expiring ITM, and adds it to the algorithm.
             _esOption = AddFutureOptionContract(OptionChain(_es19m20)
-                .Where(x => x.Symbol.ID.StrikePrice >= 3300m && x.Symbol.ID.OptionRight == OptionRight.Put)
-                .OrderBy(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice >= 3300m && x.ID.OptionRight == OptionRight.Put)
+                .OrderBy(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Put, 3300m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/FutureOptionPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionPutITMExpiryRegressionAlgorithm.cs
@@ -54,11 +54,12 @@ namespace QuantConnect.Algorithm.CSharp
                 Resolution.Minute).Symbol;
 
             // Select a future option expiring ITM, and adds it to the algorithm.
-            _esOption = AddFutureOptionContract(OptionChainProvider.GetOptionContractList(_es19m20, Time)
-                .Where(x => x.ID.StrikePrice >= 3300m && x.ID.OptionRight == OptionRight.Put)
-                .OrderBy(x => x.ID.StrikePrice)
+            _esOption = AddFutureOptionContract(OptionChain(_es19m20)
+                .Where(x => x.Symbol.ID.StrikePrice >= 3300m && x.Symbol.ID.OptionRight == OptionRight.Put)
+                .OrderBy(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Put, 3300m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/FutureOptionPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionPutOTMExpiryRegressionAlgorithm.cs
@@ -58,11 +58,12 @@ namespace QuantConnect.Algorithm.CSharp
                 Resolution.Minute).Symbol;
 
             // Select a future option expiring ITM, and adds it to the algorithm.
-            _esOption = AddFutureOptionContract(OptionChainProvider.GetOptionContractList(_es19m20, Time)
-                .Where(x => x.ID.StrikePrice <= 3150m && x.ID.OptionRight == OptionRight.Put)
-                .OrderByDescending(x => x.ID.StrikePrice)
+            _esOption = AddFutureOptionContract(OptionChain(_es19m20)
+                .Where(x => x.Symbol.ID.StrikePrice <= 3150m && x.Symbol.ID.OptionRight == OptionRight.Put)
+                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Put, 3150m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/FutureOptionPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionPutOTMExpiryRegressionAlgorithm.cs
@@ -59,11 +59,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a future option expiring ITM, and adds it to the algorithm.
             _esOption = AddFutureOptionContract(OptionChain(_es19m20)
-                .Where(x => x.Symbol.ID.StrikePrice <= 3150m && x.Symbol.ID.OptionRight == OptionRight.Put)
-                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice <= 3150m && x.ID.OptionRight == OptionRight.Put)
+                .OrderByDescending(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Put, 3150m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/FutureOptionShortCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortCallITMExpiryRegressionAlgorithm.cs
@@ -55,11 +55,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a future option expiring ITM, and adds it to the algorithm.
             _esOption = AddFutureOptionContract(OptionChain(_es19m20)
-                .Where(x => x.Symbol.ID.StrikePrice <= 3100m && x.Symbol.ID.OptionRight == OptionRight.Call)
-                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice <= 3100m && x.ID.OptionRight == OptionRight.Call)
+                .OrderByDescending(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Call, 3100m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/FutureOptionShortCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortCallITMExpiryRegressionAlgorithm.cs
@@ -54,11 +54,12 @@ namespace QuantConnect.Algorithm.CSharp
                 Resolution.Minute).Symbol;
 
             // Select a future option expiring ITM, and adds it to the algorithm.
-            _esOption = AddFutureOptionContract(OptionChainProvider.GetOptionContractList(_es19m20, Time)
-                .Where(x => x.ID.StrikePrice <= 3100m && x.ID.OptionRight == OptionRight.Call)
-                .OrderByDescending(x => x.ID.StrikePrice)
+            _esOption = AddFutureOptionContract(OptionChain(_es19m20)
+                .Where(x => x.Symbol.ID.StrikePrice <= 3100m && x.Symbol.ID.OptionRight == OptionRight.Call)
+                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Call, 3100m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/FutureOptionShortCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortCallOTMExpiryRegressionAlgorithm.cs
@@ -56,11 +56,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a future option expiring ITM, and adds it to the algorithm.
             _esOption = AddFutureOptionContract(OptionChain(_es19m20)
-                .Where(x => x.Symbol.ID.StrikePrice >= 3400m && x.Symbol.ID.OptionRight == OptionRight.Call)
-                .OrderBy(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice >= 3400m && x.ID.OptionRight == OptionRight.Call)
+                .OrderBy(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Call, 3400m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/FutureOptionShortCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortCallOTMExpiryRegressionAlgorithm.cs
@@ -55,11 +55,12 @@ namespace QuantConnect.Algorithm.CSharp
                 Resolution.Minute).Symbol;
 
             // Select a future option expiring ITM, and adds it to the algorithm.
-            _esOption = AddFutureOptionContract(OptionChainProvider.GetOptionContractList(_es19m20, Time)
-                .Where(x => x.ID.StrikePrice >= 3400m && x.ID.OptionRight == OptionRight.Call)
-                .OrderBy(x => x.ID.StrikePrice)
+            _esOption = AddFutureOptionContract(OptionChain(_es19m20)
+                .Where(x => x.Symbol.ID.StrikePrice >= 3400m && x.Symbol.ID.OptionRight == OptionRight.Call)
+                .OrderBy(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Call, 3400m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/FutureOptionShortPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortPutITMExpiryRegressionAlgorithm.cs
@@ -54,11 +54,12 @@ namespace QuantConnect.Algorithm.CSharp
                 Resolution.Minute).Symbol;
 
             // Select a future option expiring ITM, and adds it to the algorithm.
-            _esOption = AddFutureOptionContract(OptionChainProvider.GetOptionContractList(_es19m20, Time)
-                .Where(x => x.ID.StrikePrice <= 3400m && x.ID.OptionRight == OptionRight.Put)
-                .OrderByDescending(x => x.ID.StrikePrice)
+            _esOption = AddFutureOptionContract(OptionChain(_es19m20)
+                .Where(x => x.Symbol.ID.StrikePrice <= 3400m && x.Symbol.ID.OptionRight == OptionRight.Put)
+                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Put, 3400m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/FutureOptionShortPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortPutITMExpiryRegressionAlgorithm.cs
@@ -55,11 +55,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a future option expiring ITM, and adds it to the algorithm.
             _esOption = AddFutureOptionContract(OptionChain(_es19m20)
-                .Where(x => x.Symbol.ID.StrikePrice <= 3400m && x.Symbol.ID.OptionRight == OptionRight.Put)
-                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice <= 3400m && x.ID.OptionRight == OptionRight.Put)
+                .OrderByDescending(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Put, 3400m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/FutureOptionShortPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortPutOTMExpiryRegressionAlgorithm.cs
@@ -56,11 +56,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a future option expiring ITM, and adds it to the algorithm.
             _esOption = AddFutureOptionContract(OptionChain(_es19m20)
-                .Where(x => x.Symbol.ID.StrikePrice <= 3000m && x.Symbol.ID.OptionRight == OptionRight.Put)
-                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice <= 3000m && x.ID.OptionRight == OptionRight.Put)
+                .OrderByDescending(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Put, 3000m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/FutureOptionShortPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortPutOTMExpiryRegressionAlgorithm.cs
@@ -55,11 +55,12 @@ namespace QuantConnect.Algorithm.CSharp
                 Resolution.Minute).Symbol;
 
             // Select a future option expiring ITM, and adds it to the algorithm.
-            _esOption = AddFutureOptionContract(OptionChainProvider.GetOptionContractList(_es19m20, Time)
-                .Where(x => x.ID.StrikePrice <= 3000m && x.ID.OptionRight == OptionRight.Put)
-                .OrderByDescending(x => x.ID.StrikePrice)
+            _esOption = AddFutureOptionContract(OptionChain(_es19m20)
+                .Where(x => x.Symbol.ID.StrikePrice <= 3000m && x.Symbol.ID.OptionRight == OptionRight.Put)
+                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Put, 3000m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/IndexOptionBuySellCallIntradayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionBuySellCallIntradayRegressionAlgorithm.cs
@@ -47,8 +47,8 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a index option expiring ITM, and adds it to the algorithm.
             var spxOptions = OptionChain(spx)
-                .Where(x => (x.Symbol.ID.StrikePrice == 3700m || x.Symbol.ID.StrikePrice == 3800m) && x.Symbol.ID.OptionRight == OptionRight.Call && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
-                .Select(x => AddIndexOptionContract(x.Symbol, Resolution.Minute).Symbol)
+                .Where(x => (x.ID.StrikePrice == 3700m || x.ID.StrikePrice == 3800m) && x.ID.OptionRight == OptionRight.Call && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
+                .Select(x => AddIndexOptionContract(x, Resolution.Minute).Symbol)
                 .OrderBy(x => x.ID.StrikePrice)
                 .ToList();
 

--- a/Algorithm.CSharp/IndexOptionBuySellCallIntradayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionBuySellCallIntradayRegressionAlgorithm.cs
@@ -46,9 +46,9 @@ namespace QuantConnect.Algorithm.CSharp
             var spx = AddIndex("SPX", Resolution.Minute).Symbol;
 
             // Select a index option expiring ITM, and adds it to the algorithm.
-            var spxOptions = OptionChainProvider.GetOptionContractList(spx, Time)
-                .Where(x => (x.ID.StrikePrice == 3700m || x.ID.StrikePrice == 3800m) && x.ID.OptionRight == OptionRight.Call && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
-                .Select(x => AddIndexOptionContract(x, Resolution.Minute).Symbol)
+            var spxOptions = OptionChain(spx)
+                .Where(x => (x.Symbol.ID.StrikePrice == 3700m || x.Symbol.ID.StrikePrice == 3800m) && x.Symbol.ID.OptionRight == OptionRight.Call && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
+                .Select(x => AddIndexOptionContract(x.Symbol, Resolution.Minute).Symbol)
                 .OrderBy(x => x.ID.StrikePrice)
                 .ToList();
 

--- a/Algorithm.CSharp/IndexOptionCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallITMExpiryRegressionAlgorithm.cs
@@ -51,11 +51,12 @@ namespace QuantConnect.Algorithm.CSharp
             _spx = AddIndex("SPX", Resolution).Symbol;
 
             // Select an index option expiring ITM, and adds it to the algorithm.
-            _spxOption = AddIndexOptionContract(OptionChainProvider.GetOptionContractList(_spx, Time)
-                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Call && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
-                .OrderByDescending(x => x.ID.StrikePrice)
+            _spxOption = AddIndexOptionContract(OptionChain(_spx)
+                .Where(x => x.Symbol.ID.StrikePrice <= 3200m && x.Symbol.ID.OptionRight == OptionRight.Call && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
+                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution).Symbol;
+                .Single()
+                .Symbol, Resolution).Symbol;
 
             _expectedOptionContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Call, 3200m, new DateTime(2021, 1, 15));
             if (_spxOption != _expectedOptionContract)

--- a/Algorithm.CSharp/IndexOptionCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallITMExpiryRegressionAlgorithm.cs
@@ -52,11 +52,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select an index option expiring ITM, and adds it to the algorithm.
             _spxOption = AddIndexOptionContract(OptionChain(_spx)
-                .Where(x => x.Symbol.ID.StrikePrice <= 3200m && x.Symbol.ID.OptionRight == OptionRight.Call && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
-                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Call && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
+                .OrderByDescending(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution).Symbol;
+                .Single(), Resolution).Symbol;
 
             _expectedOptionContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Call, 3200m, new DateTime(2021, 1, 15));
             if (_spxOption != _expectedOptionContract)

--- a/Algorithm.CSharp/IndexOptionCallITMGreeksExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallITMGreeksExpiryRegressionAlgorithm.cs
@@ -46,11 +46,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select an index option expiring ITM, and adds it to the algorithm.
             _spxOption = AddIndexOptionContract(OptionChain(_spx)
-                .Where(x => x.Symbol.ID.StrikePrice <= 3200m && x.Symbol.ID.OptionRight == OptionRight.Call && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
-                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Call && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
+                .OrderByDescending(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute);
+                .Single(), Resolution.Minute);
 
             _spxOption.PriceModel = OptionPriceModels.BlackScholes();
 

--- a/Algorithm.CSharp/IndexOptionCallITMGreeksExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallITMGreeksExpiryRegressionAlgorithm.cs
@@ -45,11 +45,12 @@ namespace QuantConnect.Algorithm.CSharp
             _spx = spx.Symbol;
 
             // Select an index option expiring ITM, and adds it to the algorithm.
-            _spxOption = AddIndexOptionContract(OptionChainProvider.GetOptionContractList(_spx, Time)
-                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Call && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
-                .OrderByDescending(x => x.ID.StrikePrice)
+            _spxOption = AddIndexOptionContract(OptionChain(_spx)
+                .Where(x => x.Symbol.ID.StrikePrice <= 3200m && x.Symbol.ID.OptionRight == OptionRight.Call && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
+                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute);
+                .Single()
+                .Symbol, Resolution.Minute);
 
             _spxOption.PriceModel = OptionPriceModels.BlackScholes();
 

--- a/Algorithm.CSharp/IndexOptionCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallOTMExpiryRegressionAlgorithm.cs
@@ -57,11 +57,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a index option call expiring OTM, and adds it to the algorithm.
             _spxOption = AddIndexOptionContract(OptionChain(_spx)
-                .Where(x => x.Symbol.ID.StrikePrice >= 4250m && x.Symbol.ID.OptionRight == OptionRight.Call && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
-                .OrderBy(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice >= 4250m && x.ID.OptionRight == OptionRight.Call && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
+                .OrderBy(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution).Symbol;
+                .Single(), Resolution).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Call, 4250m, new DateTime(2021, 1, 15));
             if (_spxOption != _expectedContract)

--- a/Algorithm.CSharp/IndexOptionCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallOTMExpiryRegressionAlgorithm.cs
@@ -56,11 +56,12 @@ namespace QuantConnect.Algorithm.CSharp
             _spx = AddIndex("SPX", Resolution).Symbol;
 
             // Select a index option call expiring OTM, and adds it to the algorithm.
-            _spxOption = AddIndexOptionContract(OptionChainProvider.GetOptionContractList(_spx, Time)
-                .Where(x => x.ID.StrikePrice >= 4250m && x.ID.OptionRight == OptionRight.Call && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
-                .OrderBy(x => x.ID.StrikePrice)
+            _spxOption = AddIndexOptionContract(OptionChain(_spx)
+                .Where(x => x.Symbol.ID.StrikePrice >= 4250m && x.Symbol.ID.OptionRight == OptionRight.Call && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
+                .OrderBy(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution).Symbol;
+                .Single()
+                .Symbol, Resolution).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Call, 4250m, new DateTime(2021, 1, 15));
             if (_spxOption != _expectedContract)

--- a/Algorithm.CSharp/IndexOptionPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionPutITMExpiryRegressionAlgorithm.cs
@@ -49,11 +49,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a index option expiring ITM, and adds it to the algorithm.
             _spxOption = AddIndexOptionContract(OptionChain(_spx)
-                .Where(x => x.Symbol.ID.StrikePrice >= 4200m && x.Symbol.ID.OptionRight == OptionRight.Put && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
-                .OrderBy(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice >= 4200m && x.ID.OptionRight == OptionRight.Put && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
+                .OrderBy(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Put, 4200m, new DateTime(2021, 1, 15));
             if (_spxOption != _expectedContract)

--- a/Algorithm.CSharp/IndexOptionPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionPutITMExpiryRegressionAlgorithm.cs
@@ -48,11 +48,12 @@ namespace QuantConnect.Algorithm.CSharp
             _spx = AddIndex("SPX", Resolution.Minute).Symbol;
 
             // Select a index option expiring ITM, and adds it to the algorithm.
-            _spxOption = AddIndexOptionContract(OptionChainProvider.GetOptionContractList(_spx, Time)
-                .Where(x => x.ID.StrikePrice >= 4200m && x.ID.OptionRight == OptionRight.Put && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
-                .OrderBy(x => x.ID.StrikePrice)
+            _spxOption = AddIndexOptionContract(OptionChain(_spx)
+                .Where(x => x.Symbol.ID.StrikePrice >= 4200m && x.Symbol.ID.OptionRight == OptionRight.Put && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
+                .OrderBy(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Put, 4200m, new DateTime(2021, 1, 15));
             if (_spxOption != _expectedContract)

--- a/Algorithm.CSharp/IndexOptionPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionPutOTMExpiryRegressionAlgorithm.cs
@@ -54,11 +54,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a index option expiring ITM, and adds it to the algorithm.
             _spxOption = AddIndexOptionContract(OptionChain(_spx)
-                .Where(x => x.Symbol.ID.StrikePrice <= 3200m && x.Symbol.ID.OptionRight == OptionRight.Put && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
-                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Put && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
+                .OrderByDescending(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Put, 3200m, new DateTime(2021, 1, 15));
             if (_spxOption != _expectedContract)

--- a/Algorithm.CSharp/IndexOptionPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionPutOTMExpiryRegressionAlgorithm.cs
@@ -53,11 +53,12 @@ namespace QuantConnect.Algorithm.CSharp
             _spx = AddIndex("SPX", Resolution.Minute).Symbol;
 
             // Select a index option expiring ITM, and adds it to the algorithm.
-            _spxOption = AddIndexOptionContract(OptionChainProvider.GetOptionContractList(_spx, Time)
-                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Put && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
-                .OrderByDescending(x => x.ID.StrikePrice)
+            _spxOption = AddIndexOptionContract(OptionChain(_spx)
+                .Where(x => x.Symbol.ID.StrikePrice <= 3200m && x.Symbol.ID.OptionRight == OptionRight.Put && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
+                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Put, 3200m, new DateTime(2021, 1, 15));
             if (_spxOption != _expectedContract)

--- a/Algorithm.CSharp/IndexOptionShortCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionShortCallITMExpiryRegressionAlgorithm.cs
@@ -61,11 +61,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a index option expiring ITM, and adds it to the algorithm.
             _esOption = AddIndexOptionContract(OptionChain(_spx)
-                .Where(contractData => contractData.Symbol.ID.StrikePrice <= 3200m && contractData.Symbol.ID.OptionRight == OptionRight.Call && contractData.Symbol.ID.Date.Year == 2021 && contractData.Symbol.ID.Date.Month == 1)
-                .OrderByDescending(contractData => contractData.Symbol.ID.StrikePrice)
+                .Where(contractData => contractData.ID.StrikePrice <= 3200m && contractData.ID.OptionRight == OptionRight.Call && contractData.ID.Date.Year == 2021 && contractData.ID.Date.Month == 1)
+                .OrderByDescending(contractData => contractData.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Call, 3200m, new DateTime(2021, 1, 15));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/IndexOptionShortCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionShortCallITMExpiryRegressionAlgorithm.cs
@@ -60,11 +60,12 @@ namespace QuantConnect.Algorithm.CSharp
             _spx = AddIndex("SPX", Resolution.Minute).Symbol;
 
             // Select a index option expiring ITM, and adds it to the algorithm.
-            _esOption = AddIndexOptionContract(OptionChainProvider.GetOptionContractList(_spx, Time)
-                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Call && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
-                .OrderByDescending(x => x.ID.StrikePrice)
+            _esOption = AddIndexOptionContract(OptionChain(_spx)
+                .Where(contractData => contractData.Symbol.ID.StrikePrice <= 3200m && contractData.Symbol.ID.OptionRight == OptionRight.Call && contractData.Symbol.ID.Date.Year == 2021 && contractData.Symbol.ID.Date.Month == 1)
+                .OrderByDescending(contractData => contractData.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Call, 3200m, new DateTime(2021, 1, 15));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/IndexOptionShortCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionShortCallOTMExpiryRegressionAlgorithm.cs
@@ -50,11 +50,12 @@ namespace QuantConnect.Algorithm.CSharp
             _spx = AddIndex("SPX", Resolution.Minute).Symbol;
 
             // Select a index option expiring ITM, and adds it to the algorithm.
-            _spxOption = AddIndexOptionContract(OptionChainProvider.GetOptionContractList(_spx, Time)
-                .Where(x => x.ID.StrikePrice >= 4250m && x.ID.OptionRight == OptionRight.Call && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
-                .OrderBy(x => x.ID.StrikePrice)
+            _spxOption = AddIndexOptionContract(OptionChain(_spx)
+                .Where(x => x.Symbol.ID.StrikePrice >= 4250m && x.Symbol.ID.OptionRight == OptionRight.Call && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
+                .OrderBy(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Call, 4250m, new DateTime(2021, 1, 15));
             if (_spxOption != _expectedContract)

--- a/Algorithm.CSharp/IndexOptionShortCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionShortCallOTMExpiryRegressionAlgorithm.cs
@@ -51,11 +51,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a index option expiring ITM, and adds it to the algorithm.
             _spxOption = AddIndexOptionContract(OptionChain(_spx)
-                .Where(x => x.Symbol.ID.StrikePrice >= 4250m && x.Symbol.ID.OptionRight == OptionRight.Call && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
-                .OrderBy(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice >= 4250m && x.ID.OptionRight == OptionRight.Call && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
+                .OrderBy(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Call, 4250m, new DateTime(2021, 1, 15));
             if (_spxOption != _expectedContract)

--- a/Algorithm.CSharp/IndexOptionShortPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionShortPutITMExpiryRegressionAlgorithm.cs
@@ -60,11 +60,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a index option expiring ITM, and adds it to the algorithm.
             _spxOption = AddIndexOptionContract(OptionChain(_spx)
-                .Where(contractData => contractData.Symbol.ID.StrikePrice <= 4200m && contractData.Symbol.ID.OptionRight == OptionRight.Put && contractData.Symbol.ID.Date.Year == 2021 && contractData.Symbol.ID.Date.Month == 1)
-                .OrderByDescending(contractData => contractData.Symbol.ID.StrikePrice)
+                .Where(contractData => contractData.ID.StrikePrice <= 4200m && contractData.ID.OptionRight == OptionRight.Put && contractData.ID.Date.Year == 2021 && contractData.ID.Date.Month == 1)
+                .OrderByDescending(contractData => contractData.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Put, 4200m, new DateTime(2021, 1, 15));
             if (_spxOption != _expectedContract)

--- a/Algorithm.CSharp/IndexOptionShortPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionShortPutITMExpiryRegressionAlgorithm.cs
@@ -59,11 +59,12 @@ namespace QuantConnect.Algorithm.CSharp
             _spx = AddIndex("SPX", Resolution.Minute).Symbol;
 
             // Select a index option expiring ITM, and adds it to the algorithm.
-            _spxOption = AddIndexOptionContract(OptionChainProvider.GetOptionContractList(_spx, Time)
-                .Where(x => x.ID.StrikePrice <= 4200m && x.ID.OptionRight == OptionRight.Put && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
-                .OrderByDescending(x => x.ID.StrikePrice)
+            _spxOption = AddIndexOptionContract(OptionChain(_spx)
+                .Where(contractData => contractData.Symbol.ID.StrikePrice <= 4200m && contractData.Symbol.ID.OptionRight == OptionRight.Put && contractData.Symbol.ID.Date.Year == 2021 && contractData.Symbol.ID.Date.Month == 1)
+                .OrderByDescending(contractData => contractData.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Put, 4200m, new DateTime(2021, 1, 15));
             if (_spxOption != _expectedContract)

--- a/Algorithm.CSharp/IndexOptionShortPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionShortPutOTMExpiryRegressionAlgorithm.cs
@@ -50,11 +50,12 @@ namespace QuantConnect.Algorithm.CSharp
             _spx = AddIndex("SPX", Resolution.Minute).Symbol;
 
             // Select a index option expiring ITM, and adds it to the algorithm.
-            _spxOption = AddIndexOptionContract(OptionChainProvider.GetOptionContractList(_spx, Time)
-                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Put && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
-                .OrderByDescending(x => x.ID.StrikePrice)
+            _spxOption = AddIndexOptionContract(OptionChain(_spx)
+                .Where(x => x.Symbol.ID.StrikePrice <= 3200m && x.Symbol.ID.OptionRight == OptionRight.Put && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
+                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Put, 3200m, new DateTime(2021, 1, 15));
             if (_spxOption != _expectedContract)

--- a/Algorithm.CSharp/IndexOptionShortPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionShortPutOTMExpiryRegressionAlgorithm.cs
@@ -51,11 +51,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a index option expiring ITM, and adds it to the algorithm.
             _spxOption = AddIndexOptionContract(OptionChain(_spx)
-                .Where(x => x.Symbol.ID.StrikePrice <= 3200m && x.Symbol.ID.OptionRight == OptionRight.Put && x.Symbol.ID.Date.Year == 2021 && x.Symbol.ID.Date.Month == 1)
-                .OrderByDescending(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice <= 3200m && x.ID.OptionRight == OptionRight.Put && x.ID.Date.Year == 2021 && x.ID.Date.Month == 1)
+                .OrderByDescending(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_spx, Market.USA, OptionStyle.European, OptionRight.Put, 3200m, new DateTime(2021, 1, 15));
             if (_spxOption != _expectedContract)

--- a/Algorithm.CSharp/InsufficientBuyingPowerForAutomaticExerciseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/InsufficientBuyingPowerForAutomaticExerciseRegressionAlgorithm.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             _stock = AddEquity("GOOG").Symbol;
 
-            var contracts = OptionChain(_stock).Select(x => x.Symbol).ToList();
+            var contracts = OptionChain(_stock).ToList();
             _option = contracts
                 .Where(c => c.ID.OptionRight == OptionRight.Put)
                 .OrderBy(c => c.ID.Date)

--- a/Algorithm.CSharp/InsufficientBuyingPowerForAutomaticExerciseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/InsufficientBuyingPowerForAutomaticExerciseRegressionAlgorithm.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             _stock = AddEquity("GOOG").Symbol;
 
-            var contracts = OptionChainProvider.GetOptionContractList(_stock, UtcTime).ToList();
+            var contracts = OptionChain(_stock).Select(x => x.Symbol).ToList();
             _option = contracts
                 .Where(c => c.ID.OptionRight == OptionRight.Put)
                 .OrderBy(c => c.ID.Date)

--- a/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Stock = AddEquity("GOOG", Resolution.Minute);
 
-            var contracts = OptionChainProvider.GetOptionContractList(Stock.Symbol, UtcTime).ToList();
+            var contracts = OptionChain(Stock.Symbol).Select(x => x.Symbol).ToList();
 
             PutOptionSymbol = contracts
                 .Where(c => c.ID.OptionRight == OptionRight.Put)

--- a/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetCash(100000);
             Stock = AddEquity("GOOG", Resolution.Minute);
 
-            var contracts = OptionChain(Stock.Symbol).Select(x => x.Symbol).ToList();
+            var contracts = OptionChain(Stock.Symbol).ToList();
 
             PutOptionSymbol = contracts
                 .Where(c => c.ID.OptionRight == OptionRight.Put)

--- a/Algorithm.CSharp/OptionAssignmentStatisticsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionAssignmentStatisticsRegressionAlgorithm.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             _goog = AddEquity("GOOG", Resolution.Minute);
 
-            var contracts = OptionChainProvider.GetOptionContractList(_goog.Symbol, UtcTime).ToList();
+            var contracts = OptionChain(_goog.Symbol).ToList();
 
             _googCall600Symbol = contracts
                 .Where(c => c.ID.OptionRight == OptionRight.Call)

--- a/Algorithm.CSharp/OptionChainFullDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionChainFullDataRegressionAlgorithm.cs
@@ -42,7 +42,7 @@ namespace QuantConnect.Algorithm.CSharp
 
             _optionContract = OptionChain(goog)
                 // Get contracts expiring within 10 days, with an implied volatility greater than 0.5 and a delta less than 0.5
-                .Where(contractData => contractData.Symbol.ID.Date - Time <= TimeSpan.FromDays(10) &&
+                .Where(contractData => contractData.ID.Date - Time <= TimeSpan.FromDays(10) &&
                     contractData.ImpliedVolatility > 0.5m &&
                     contractData.Greeks.Delta < 0.5m)
                 // Get the contract with the latest expiration date

--- a/Algorithm.CSharp/OptionChainFullDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionChainFullDataRegressionAlgorithm.cs
@@ -1,0 +1,127 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm illustrating the usage of the <see cref="QCAlgorithm.OptionChain(Symbol)"/> method
+    /// to get an option chain, which contains additional data besides the symbols, including prices, implied volatility and greeks.
+    /// It also shows how this data can be used to filter the contracts based on certain criteria.
+    /// </summary>
+    public class OptionChainFullDataRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _optionContract;
+
+        public override void Initialize()
+        {
+            SetStartDate(2015, 12, 24);
+            SetEndDate(2015, 12, 24);
+            SetCash(100000);
+
+            var goog = AddEquity("GOOG").Symbol;
+
+            _optionContract = OptionChain(goog)
+                // Get contracts expiring within 10 days, with an implied volatility greater than 0.5 and a delta less than 0.5
+                .Where(contractData => contractData.Symbol.ID.Date - Time <= TimeSpan.FromDays(10) &&
+                    contractData.ImpliedVolatility > 0.5m &&
+                    contractData.Greeks.Delta < 0.5m)
+                // Get the contract with the latest expiration date
+                .OrderByDescending(x => x.ID.Date)
+                .First();
+
+            AddOptionContract(_optionContract);
+        }
+
+        public override void OnData(Slice slice)
+        {
+            // Do some trading with the selected contract for sample purposes
+            if (!Portfolio.Invested)
+            {
+                MarketOrder(_optionContract, 1);
+            }
+            else
+            {
+                Liquidate();
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public virtual List<Language> Languages { get; } = new() { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 1057;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 1;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "210"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "96041"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$209.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", "GOOCV W6U7PD1F2WYU|GOOCV VP83T1ZUHROL"},
+            {"Portfolio Turnover", "85.46%"},
+            {"OrderListHash", "a7ab1a9e64fe9ba76ea33a40a78a4e3b"}
+        };
+    }
+}

--- a/Algorithm.CSharp/OptionOTMExpiryOrderHasZeroPriceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionOTMExpiryOrderHasZeroPriceRegressionAlgorithm.cs
@@ -59,11 +59,10 @@ namespace QuantConnect.Algorithm.CSharp
 
             // Select a future option call expiring OTM, and adds it to the algorithm.
             _esOption = AddFutureOptionContract(OptionChain(_es19m20)
-                .Where(x => x.Symbol.ID.StrikePrice >= 3300m && x.Symbol.ID.OptionRight == OptionRight.Call)
-                .OrderBy(x => x.Symbol.ID.StrikePrice)
+                .Where(x => x.ID.StrikePrice >= 3300m && x.ID.OptionRight == OptionRight.Call)
+                .OrderBy(x => x.ID.StrikePrice)
                 .Take(1)
-                .Single()
-                .Symbol, Resolution.Minute).Symbol;
+                .Single(), Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Call, 3300m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/OptionOTMExpiryOrderHasZeroPriceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionOTMExpiryOrderHasZeroPriceRegressionAlgorithm.cs
@@ -58,11 +58,12 @@ namespace QuantConnect.Algorithm.CSharp
                 Resolution.Minute).Symbol;
 
             // Select a future option call expiring OTM, and adds it to the algorithm.
-            _esOption = AddFutureOptionContract(OptionChainProvider.GetOptionContractList(_es19m20, Time)
-                .Where(x => x.ID.StrikePrice >= 3300m && x.ID.OptionRight == OptionRight.Call)
-                .OrderBy(x => x.ID.StrikePrice)
+            _esOption = AddFutureOptionContract(OptionChain(_es19m20)
+                .Where(x => x.Symbol.ID.StrikePrice >= 3300m && x.Symbol.ID.OptionRight == OptionRight.Call)
+                .OrderBy(x => x.Symbol.ID.StrikePrice)
                 .Take(1)
-                .Single(), Resolution.Minute).Symbol;
+                .Single()
+                .Symbol, Resolution.Minute).Symbol;
 
             _expectedContract = QuantConnect.Symbol.CreateOption(_es19m20, Market.CME, OptionStyle.American, OptionRight.Call, 3300m, new DateTime(2020, 6, 19));
             if (_esOption != _expectedContract)

--- a/Algorithm.CSharp/OptionSymbolCanonicalRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionSymbolCanonicalRegressionAlgorithm.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2014, 06, 09);
 
             var equitySymbol = AddEquity("TWX").Symbol;
-            var contracts = OptionChain(equitySymbol).Select(x => x.Symbol).ToList();
+            var contracts = OptionChain(equitySymbol).ToList();
 
             var callOptionSymbol = contracts
                 .Where(c => c.ID.OptionRight == OptionRight.Call)

--- a/Algorithm.CSharp/OptionSymbolCanonicalRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionSymbolCanonicalRegressionAlgorithm.cs
@@ -36,7 +36,7 @@ namespace QuantConnect.Algorithm.CSharp
             SetEndDate(2014, 06, 09);
 
             var equitySymbol = AddEquity("TWX").Symbol;
-            var contracts = OptionChainProvider.GetOptionContractList(equitySymbol, UtcTime).ToList();
+            var contracts = OptionChain(equitySymbol).Select(x => x.Symbol).ToList();
 
             var callOptionSymbol = contracts
                 .Where(c => c.ID.OptionRight == OptionRight.Call)

--- a/Algorithm.CSharp/OptionTimeSliceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionTimeSliceRegressionAlgorithm.cs
@@ -55,10 +55,9 @@ namespace QuantConnect.Algorithm.CSharp
 
             var underlyingPrice = Securities[_symbol].Price;
             var contractSymbol = OptionChain(_symbol)
-                .Where(x => x.Symbol.ID.StrikePrice - underlyingPrice > 0)
-                .OrderBy(x => x.Symbol.ID.Date)
-                .FirstOrDefault()
-                ?.Symbol;
+                .Where(x => x.ID.StrikePrice - underlyingPrice > 0)
+                .OrderBy(x => x.ID.Date)
+                .FirstOrDefault();
 
             if (contractSymbol != null)
             {

--- a/Algorithm.CSharp/OptionTimeSliceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionTimeSliceRegressionAlgorithm.cs
@@ -54,10 +54,11 @@ namespace QuantConnect.Algorithm.CSharp
             _lastSliceTime = Time;
 
             var underlyingPrice = Securities[_symbol].Price;
-            var contractSymbol = OptionChainProvider.GetOptionContractList(_symbol, Time)
-                .Where(x => x.ID.StrikePrice - underlyingPrice > 0)
-                .OrderBy(x => x.ID.Date)
-                .FirstOrDefault();
+            var contractSymbol = OptionChain(_symbol)
+                .Where(x => x.Symbol.ID.StrikePrice - underlyingPrice > 0)
+                .OrderBy(x => x.Symbol.ID.Date)
+                .FirstOrDefault()
+                ?.Symbol;
 
             if (contractSymbol != null)
             {
@@ -91,7 +92,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 3;
+        public int AlgorithmHistoryDataPoints => 787;
 
         /// <summary>
         /// Final status of the algorithm

--- a/Algorithm.CSharp/UniverseSelectionSymbolCacheRemovalRegressionTest.cs
+++ b/Algorithm.CSharp/UniverseSelectionSymbolCacheRemovalRegressionTest.cs
@@ -43,7 +43,7 @@ namespace QuantConnect.Algorithm.CSharp
             AddEquity("AAPL", Resolution.Daily);
             _equitySymbol = AddEquity("TWX", Resolution.Minute).Symbol;
 
-            var contracts = OptionChain(_equitySymbol).Select(x => x.Symbol).ToList();
+            var contracts = OptionChain(_equitySymbol).ToList();
 
             var callOptionSymbol = contracts
                 .Where(c => c.ID.OptionRight == OptionRight.Call)

--- a/Algorithm.CSharp/UniverseSelectionSymbolCacheRemovalRegressionTest.cs
+++ b/Algorithm.CSharp/UniverseSelectionSymbolCacheRemovalRegressionTest.cs
@@ -1,4 +1,4 @@
- 
+
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
@@ -43,7 +43,7 @@ namespace QuantConnect.Algorithm.CSharp
             AddEquity("AAPL", Resolution.Daily);
             _equitySymbol = AddEquity("TWX", Resolution.Minute).Symbol;
 
-            var contracts = OptionChainProvider.GetOptionContractList(_equitySymbol, UtcTime).ToList();
+            var contracts = OptionChain(_equitySymbol).Select(x => x.Symbol).ToList();
 
             var callOptionSymbol = contracts
                 .Where(c => c.ID.OptionRight == OptionRight.Call)

--- a/Algorithm.Python/AddOptionContractExpiresRegressionAlgorithm.py
+++ b/Algorithm.Python/AddOptionContractExpiresRegressionAlgorithm.py
@@ -43,14 +43,14 @@ class AddOptionContractExpiresRegressionAlgorithm(QCAlgorithm):
             data: Slice object keyed by symbol containing the stock data
         '''
         if self._option == None:
-            options = self.option_chain_provider.get_option_contract_list(self._twx, self.time)
-            options = sorted(options, key=lambda x: x.id.symbol)
+            options = self.option_chain(self._twx)
+            options = sorted(options, key=lambda x: x.symbol.id.symbol)
 
-            option = next((option
+            option = next((option.symbol
                            for option in options
-                           if option.id.date == self._expiration and
-                           option.id.option_right == OptionRight.CALL and
-                           option.id.option_style == OptionStyle.AMERICAN), None)
+                           if option.symbol.id.date == self._expiration and
+                           option.symbol.id.option_right == OptionRight.CALL and
+                           option.symbol.id.option_style == OptionStyle.AMERICAN), None)
             if option != None:
                 self._option = self.add_option_contract(option).symbol
 

--- a/Algorithm.Python/AddOptionContractExpiresRegressionAlgorithm.py
+++ b/Algorithm.Python/AddOptionContractExpiresRegressionAlgorithm.py
@@ -44,13 +44,13 @@ class AddOptionContractExpiresRegressionAlgorithm(QCAlgorithm):
         '''
         if self._option == None:
             options = self.option_chain(self._twx)
-            options = sorted(options, key=lambda x: x.symbol.id.symbol)
+            options = sorted(options, key=lambda x: x.id.symbol)
 
-            option = next((option.symbol
+            option = next((option
                            for option in options
-                           if option.symbol.id.date == self._expiration and
-                           option.symbol.id.option_right == OptionRight.CALL and
-                           option.symbol.id.option_style == OptionStyle.AMERICAN), None)
+                           if option.id.date == self._expiration and
+                           option.id.option_right == OptionRight.CALL and
+                           option.id.option_style == OptionStyle.AMERICAN), None)
             if option != None:
                 self._option = self.add_option_contract(option).symbol
 

--- a/Algorithm.Python/AddOptionContractFromUniverseRegressionAlgorithm.py
+++ b/Algorithm.Python/AddOptionContractFromUniverseRegressionAlgorithm.py
@@ -68,7 +68,7 @@ class AddOptionContractFromUniverseRegressionAlgorithm(QCAlgorithm):
 
         for addedSecurity in changes.added_securities:
             options = self.option_chain(addedSecurity.symbol)
-            options = sorted(options, key=lambda x: x.symbol.id.symbol)
+            options = sorted(options, key=lambda x: x.id.symbol)
 
             option = next((option
                            for option in options

--- a/Algorithm.Python/AddOptionContractFromUniverseRegressionAlgorithm.py
+++ b/Algorithm.Python/AddOptionContractFromUniverseRegressionAlgorithm.py
@@ -67,8 +67,8 @@ class AddOptionContractFromUniverseRegressionAlgorithm(QCAlgorithm):
             return
 
         for addedSecurity in changes.added_securities:
-            options = self.option_chain_provider.get_option_contract_list(addedSecurity.symbol, self.time)
-            options = sorted(options, key=lambda x: x.id.symbol)
+            options = self.option_chain(addedSecurity.symbol)
+            options = sorted(options, key=lambda x: x.symbol.id.symbol)
 
             option = next((option
                            for option in options
@@ -76,7 +76,7 @@ class AddOptionContractFromUniverseRegressionAlgorithm(QCAlgorithm):
                            option.id.option_right == OptionRight.CALL and
                            option.id.option_style == OptionStyle.AMERICAN), None)
 
-            self.add_option_contract(option)
+            self.add_option_contract(option.symbol)
 
             # just keep the first we got
             if self._option == None:

--- a/Algorithm.Python/AddOptionContractFromUniverseRegressionAlgorithm.py
+++ b/Algorithm.Python/AddOptionContractFromUniverseRegressionAlgorithm.py
@@ -76,7 +76,7 @@ class AddOptionContractFromUniverseRegressionAlgorithm(QCAlgorithm):
                            option.id.option_right == OptionRight.CALL and
                            option.id.option_style == OptionStyle.AMERICAN), None)
 
-            self.add_option_contract(option.symbol)
+            self.add_option_contract(option)
 
             # just keep the first we got
             if self._option == None:

--- a/Algorithm.Python/FutureOptionBuySellCallIntradayRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionBuySellCallIntradayRegressionAlgorithm.py
@@ -51,10 +51,9 @@ class FutureOptionBuySellCallIntradayRegressionAlgorithm(QCAlgorithm):
 
         # Select a future option expiring ITM, and adds it to the algorithm.
         self.es_options = [
-            self.add_future_option_contract(i, Resolution.MINUTE).symbol
-            for i in (self.option_chain_provider.get_option_contract_list(self.es19m20, self.time) +
-                self.option_chain_provider.get_option_contract_list(self.es20h20, self.time))
-            if i.id.strike_price == 3200.0 and i.id.option_right == OptionRight.CALL
+            self.add_future_option_contract(i.symbol, Resolution.MINUTE).symbol
+            for i in (list(self.option_chain(self.es19m20)) + list(self.option_chain(self.es20h20)))
+            if i.symbol.id.strike_price == 3200.0 and i.symbol.id.option_right == OptionRight.CALL
         ]
 
         self.expected_contracts = [

--- a/Algorithm.Python/FutureOptionBuySellCallIntradayRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionBuySellCallIntradayRegressionAlgorithm.py
@@ -51,9 +51,9 @@ class FutureOptionBuySellCallIntradayRegressionAlgorithm(QCAlgorithm):
 
         # Select a future option expiring ITM, and adds it to the algorithm.
         self.es_options = [
-            self.add_future_option_contract(i.symbol, Resolution.MINUTE).symbol
+            self.add_future_option_contract(i, Resolution.MINUTE).symbol
             for i in (list(self.option_chain(self.es19m20)) + list(self.option_chain(self.es20h20)))
-            if i.symbol.id.strike_price == 3200.0 and i.symbol.id.option_right == OptionRight.CALL
+            if i.id.strike_price == 3200.0 and i.id.option_right == OptionRight.CALL
         ]
 
         self.expected_contracts = [

--- a/Algorithm.Python/FutureOptionCallITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionCallITMExpiryRegressionAlgorithm.py
@@ -41,7 +41,10 @@ class FutureOptionCallITMExpiryRegressionAlgorithm(QCAlgorithm):
         # Select a future option expiring ITM, and adds it to the algorithm.
         self.es_option = self.add_future_option_contract(
             list(
-                sorted([x for x in self.option_chain_provider.get_option_contract_list(self.es19m20, self.time) if x.id.strike_price <= 3200.0 and x.id.option_right == OptionRight.CALL], key=lambda x: x.id.strike_price, reverse=True)
+                sorted([x.symbol
+                        for x in self.option_chain(self.es19m20)
+                        if x.symbol.id.strike_price <= 3200.0 and x.symbol.id.option_right == OptionRight.CALL],
+                       key=lambda x: x.id.strike_price, reverse=True)
             )[0], Resolution.MINUTE).symbol
 
         self.expected_contract = Symbol.create_option(self.es19m20, Market.CME, OptionStyle.AMERICAN, OptionRight.CALL, 3200.0, datetime(2020, 6, 19))

--- a/Algorithm.Python/FutureOptionCallITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionCallITMExpiryRegressionAlgorithm.py
@@ -41,9 +41,7 @@ class FutureOptionCallITMExpiryRegressionAlgorithm(QCAlgorithm):
         # Select a future option expiring ITM, and adds it to the algorithm.
         self.es_option = self.add_future_option_contract(
             list(
-                sorted([x.symbol
-                        for x in self.option_chain(self.es19m20)
-                        if x.symbol.id.strike_price <= 3200.0 and x.symbol.id.option_right == OptionRight.CALL],
+                sorted([x for x in self.option_chain(self.es19m20) if x.id.strike_price <= 3200.0 and x.id.option_right == OptionRight.CALL],
                        key=lambda x: x.id.strike_price, reverse=True)
             )[0], Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/FutureOptionCallOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionCallOTMExpiryRegressionAlgorithm.py
@@ -45,8 +45,8 @@ class FutureOptionCallOTMExpiryRegressionAlgorithm(QCAlgorithm):
         self.es_option = self.add_future_option_contract(
             list(
                 sorted(
-                    [x.symbol for x in self.option_chain(self.es19m20)
-                     if x.symbol.id.strike_price >= 3300.0 and x.symbol.id.option_right == OptionRight.CALL],
+                    [x for x in self.option_chain(self.es19m20)
+                     if x.id.strike_price >= 3300.0 and x.id.option_right == OptionRight.CALL],
                     key=lambda x: x.id.strike_price
                 )
             )[0], Resolution.MINUTE).symbol

--- a/Algorithm.Python/FutureOptionCallOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionCallOTMExpiryRegressionAlgorithm.py
@@ -45,7 +45,8 @@ class FutureOptionCallOTMExpiryRegressionAlgorithm(QCAlgorithm):
         self.es_option = self.add_future_option_contract(
             list(
                 sorted(
-                    [x for x in self.option_chain_provider.get_option_contract_list(self.es19m20, self.time) if x.id.strike_price >= 3300.0 and x.id.option_right == OptionRight.CALL],
+                    [x.symbol for x in self.option_chain(self.es19m20)
+                     if x.symbol.id.strike_price >= 3300.0 and x.symbol.id.option_right == OptionRight.CALL],
                     key=lambda x: x.id.strike_price
                 )
             )[0], Resolution.MINUTE).symbol

--- a/Algorithm.Python/FutureOptionDailyRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionDailyRegressionAlgorithm.py
@@ -34,7 +34,9 @@ class FutureOptionDailyRegressionAlgorithm(QCAlgorithm):
 
         # Attempt to fetch a specific ITM future option contract
         dc_options = [
-            self.add_future_option_contract(x, resolution).symbol for x in (self.option_chain_provider.get_option_contract_list(self.dc, self.time)) if x.id.strike_price == 17 and x.id.option_right == OptionRight.CALL
+            self.add_future_option_contract(x.symbol, resolution).symbol
+            for x in self.option_chain(self.dc)
+            if x.symbol.id.strike_price == 17 and x.symbol.id.option_right == OptionRight.CALL
         ]
         self.dc_option = dc_options[0]
 

--- a/Algorithm.Python/FutureOptionDailyRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionDailyRegressionAlgorithm.py
@@ -34,9 +34,9 @@ class FutureOptionDailyRegressionAlgorithm(QCAlgorithm):
 
         # Attempt to fetch a specific ITM future option contract
         dc_options = [
-            self.add_future_option_contract(x.symbol, resolution).symbol
+            self.add_future_option_contract(x, resolution).symbol
             for x in self.option_chain(self.dc)
-            if x.symbol.id.strike_price == 17 and x.symbol.id.option_right == OptionRight.CALL
+            if x.id.strike_price == 17 and x.id.option_right == OptionRight.CALL
         ]
         self.dc_option = dc_options[0]
 

--- a/Algorithm.Python/FutureOptionPutITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionPutITMExpiryRegressionAlgorithm.py
@@ -40,9 +40,7 @@ class FutureOptionPutITMExpiryRegressionAlgorithm(QCAlgorithm):
         # Select a future option expiring ITM, and adds it to the algorithm.
         self.es_option = self.add_future_option_contract(
             list(
-                sorted([x.symbol
-                        for x in self.option_chain(self.es19m20)
-                        if x.symbol.id.strike_price >= 3300.0 and x.symbol.id.option_right == OptionRight.PUT],
+                sorted([x for x in self.option_chain(self.es19m20) if x.id.strike_price >= 3300.0 and x.id.option_right == OptionRight.PUT],
                        key=lambda x: x.id.strike_price)
             )[0], Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/FutureOptionPutITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionPutITMExpiryRegressionAlgorithm.py
@@ -40,7 +40,10 @@ class FutureOptionPutITMExpiryRegressionAlgorithm(QCAlgorithm):
         # Select a future option expiring ITM, and adds it to the algorithm.
         self.es_option = self.add_future_option_contract(
             list(
-                sorted([x for x in self.option_chain_provider.get_option_contract_list(self.es19m20, self.time) if x.id.strike_price >= 3300.0 and x.id.option_right == OptionRight.PUT], key=lambda x: x.id.strike_price)
+                sorted([x.symbol
+                        for x in self.option_chain(self.es19m20)
+                        if x.symbol.id.strike_price >= 3300.0 and x.symbol.id.option_right == OptionRight.PUT],
+                       key=lambda x: x.id.strike_price)
             )[0], Resolution.MINUTE).symbol
 
         self.expected_contract = Symbol.create_option(self.es19m20, Market.CME, OptionStyle.AMERICAN, OptionRight.PUT, 3300.0, datetime(2020, 6, 19))

--- a/Algorithm.Python/FutureOptionPutOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionPutOTMExpiryRegressionAlgorithm.py
@@ -45,7 +45,7 @@ class FutureOptionPutOTMExpiryRegressionAlgorithm(QCAlgorithm):
         self.es_option = self.add_future_option_contract(
             list(
                 sorted(
-                    [x for x in self.option_chain_provider.get_option_contract_list(self.es19m20, self.time) if x.id.strike_price <= 3150.0 and x.id.option_right == OptionRight.PUT],
+                    [x.symbol for x in self.option_chain(self.es19m20) if x.symbol.id.strike_price <= 3150.0 and x.symbol.id.option_right == OptionRight.PUT],
                     key=lambda x: x.id.strike_price,
                     reverse=True
                 )
@@ -71,7 +71,7 @@ class FutureOptionPutOTMExpiryRegressionAlgorithm(QCAlgorithm):
             if delisting.type == DelistingType.DELISTED:
                 if delisting.time != datetime(2020, 6, 20):
                     raise AssertionError(f"Delisting happened at unexpected date: {delisting.time}")
-                
+
     def on_order_event(self, order_event: OrderEvent):
         if order_event.status != OrderStatus.FILLED:
             # There's lots of noise with OnOrderEvent, but we're only interested in fills.

--- a/Algorithm.Python/FutureOptionPutOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionPutOTMExpiryRegressionAlgorithm.py
@@ -45,7 +45,7 @@ class FutureOptionPutOTMExpiryRegressionAlgorithm(QCAlgorithm):
         self.es_option = self.add_future_option_contract(
             list(
                 sorted(
-                    [x.symbol for x in self.option_chain(self.es19m20) if x.symbol.id.strike_price <= 3150.0 and x.symbol.id.option_right == OptionRight.PUT],
+                    [x for x in self.option_chain(self.es19m20) if x.id.strike_price <= 3150.0 and x.id.option_right == OptionRight.PUT],
                     key=lambda x: x.id.strike_price,
                     reverse=True
                 )

--- a/Algorithm.Python/FutureOptionShortCallITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionShortCallITMExpiryRegressionAlgorithm.py
@@ -41,7 +41,7 @@ class FutureOptionShortCallITMExpiryRegressionAlgorithm(QCAlgorithm):
         self.es_option = self.add_future_option_contract(
             list(
                 sorted(
-                    [x.symbol for x in self.option_chain(self.es19m20) if x.symbol.id.strike_price <= 3100.0 and x.symbol.id.option_right == OptionRight.CALL],
+                    [x for x in self.option_chain(self.es19m20) if x.id.strike_price <= 3100.0 and x.id.option_right == OptionRight.CALL],
                     key=lambda x: x.id.strike_price,
                     reverse=True
                 )

--- a/Algorithm.Python/FutureOptionShortCallITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionShortCallITMExpiryRegressionAlgorithm.py
@@ -41,7 +41,7 @@ class FutureOptionShortCallITMExpiryRegressionAlgorithm(QCAlgorithm):
         self.es_option = self.add_future_option_contract(
             list(
                 sorted(
-                    [x for x in self.option_chain_provider.get_option_contract_list(self.es19m20, self.time) if x.id.strike_price <= 3100.0 and x.id.option_right == OptionRight.CALL],
+                    [x.symbol for x in self.option_chain(self.es19m20) if x.symbol.id.strike_price <= 3100.0 and x.symbol.id.option_right == OptionRight.CALL],
                     key=lambda x: x.id.strike_price,
                     reverse=True
                 )

--- a/Algorithm.Python/FutureOptionShortCallOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionShortCallOTMExpiryRegressionAlgorithm.py
@@ -42,7 +42,7 @@ class FutureOptionShortCallOTMExpiryRegressionAlgorithm(QCAlgorithm):
         self.es_option = self.add_future_option_contract(
             list(
                 sorted(
-                    [x for x in self.option_chain_provider.get_option_contract_list(self.es19m20, self.time) if x.id.strike_price >= 3400.0 and x.id.option_right == OptionRight.CALL],
+                    [x.symbol for x in self.option_chain(self.es19m20) if x.symbol.id.strike_price >= 3400.0 and x.symbol.id.option_right == OptionRight.CALL],
                     key=lambda x: x.id.strike_price
                 )
             )[0], Resolution.MINUTE).symbol

--- a/Algorithm.Python/FutureOptionShortCallOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionShortCallOTMExpiryRegressionAlgorithm.py
@@ -42,7 +42,7 @@ class FutureOptionShortCallOTMExpiryRegressionAlgorithm(QCAlgorithm):
         self.es_option = self.add_future_option_contract(
             list(
                 sorted(
-                    [x.symbol for x in self.option_chain(self.es19m20) if x.symbol.id.strike_price >= 3400.0 and x.symbol.id.option_right == OptionRight.CALL],
+                    [x for x in self.option_chain(self.es19m20) if x.id.strike_price >= 3400.0 and x.id.option_right == OptionRight.CALL],
                     key=lambda x: x.id.strike_price
                 )
             )[0], Resolution.MINUTE).symbol

--- a/Algorithm.Python/FutureOptionShortPutITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionShortPutITMExpiryRegressionAlgorithm.py
@@ -41,7 +41,7 @@ class FutureOptionShortPutITMExpiryRegressionAlgorithm(QCAlgorithm):
         self.es_option = self.add_future_option_contract(
             list(
                 sorted(
-                    [x for x in self.option_chain_provider.get_option_contract_list(self.es19m20, self.time) if x.id.strike_price <= 3400.0 and x.id.option_right == OptionRight.PUT],
+                    [x.symbol for x in self.option_chain(self.es19m20) if x.symbol.id.strike_price <= 3400.0 and x.symbol.id.option_right == OptionRight.PUT],
                     key=lambda x: x.id.strike_price,
                     reverse=True
                 )

--- a/Algorithm.Python/FutureOptionShortPutITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionShortPutITMExpiryRegressionAlgorithm.py
@@ -41,7 +41,7 @@ class FutureOptionShortPutITMExpiryRegressionAlgorithm(QCAlgorithm):
         self.es_option = self.add_future_option_contract(
             list(
                 sorted(
-                    [x.symbol for x in self.option_chain(self.es19m20) if x.symbol.id.strike_price <= 3400.0 and x.symbol.id.option_right == OptionRight.PUT],
+                    [x for x in self.option_chain(self.es19m20) if x.id.strike_price <= 3400.0 and x.id.option_right == OptionRight.PUT],
                     key=lambda x: x.id.strike_price,
                     reverse=True
                 )

--- a/Algorithm.Python/FutureOptionShortPutOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionShortPutOTMExpiryRegressionAlgorithm.py
@@ -42,7 +42,7 @@ class FutureOptionShortPutOTMExpiryRegressionAlgorithm(QCAlgorithm):
         self.es_option = self.add_future_option_contract(
             list(
                 sorted(
-                    [x for x in self.option_chain_provider.get_option_contract_list(self.es19m20, self.time) if x.id.strike_price <= 3000.0 and x.id.option_right == OptionRight.PUT],
+                    [x.symbol for x in self.option_chain(self.es19m20) if x.symbol.id.strike_price <= 3000.0 and x.symbol.id.option_right == OptionRight.PUT],
                     key=lambda x: x.id.strike_price,
                     reverse=True
                 )

--- a/Algorithm.Python/FutureOptionShortPutOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/FutureOptionShortPutOTMExpiryRegressionAlgorithm.py
@@ -42,7 +42,7 @@ class FutureOptionShortPutOTMExpiryRegressionAlgorithm(QCAlgorithm):
         self.es_option = self.add_future_option_contract(
             list(
                 sorted(
-                    [x.symbol for x in self.option_chain(self.es19m20) if x.symbol.id.strike_price <= 3000.0 and x.symbol.id.option_right == OptionRight.PUT],
+                    [x for x in self.option_chain(self.es19m20) if x.id.strike_price <= 3000.0 and x.id.option_right == OptionRight.PUT],
                     key=lambda x: x.id.strike_price,
                     reverse=True
                 )

--- a/Algorithm.Python/IndexOptionBuySellCallIntradayRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionBuySellCallIntradayRegressionAlgorithm.py
@@ -37,9 +37,9 @@ class IndexOptionBuySellCallIntradayRegressionAlgorithm(QCAlgorithm):
 
         # Select a index option expiring ITM, and adds it to the algorithm.
         spx_options = list(sorted([
-            self.add_index_option_contract(i, Resolution.MINUTE).symbol \
-                for i in self.option_chain_provider.get_option_contract_list(spx, self.time)\
-                    if (i.id.strike_price == 3700 or i.id.strike_price == 3800) and i.id.option_right == OptionRight.CALL and i.id.date.year == 2021 and i.id.date.month == 1],
+            self.add_index_option_contract(i.symbol, Resolution.MINUTE).symbol \
+                for i in self.option_chain(spx)\
+                    if (i.symbol.id.strike_price == 3700 or i.symbol.id.strike_price == 3800) and i.symbol.id.option_right == OptionRight.CALL and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1],
             key=lambda x: x.id.strike_price
         ))
 
@@ -66,7 +66,7 @@ class IndexOptionBuySellCallIntradayRegressionAlgorithm(QCAlgorithm):
 
         if spx_options[0] != expectedContract3700:
             raise Exception(f"Contract {expectedContract3700} was not found in the chain, found instead: {spx_options[0]}")
-        
+
         if spx_options[1] != expectedContract3800:
             raise Exception(f"Contract {expectedContract3800} was not found in the chain, found instead: {spx_options[1]}")
 

--- a/Algorithm.Python/IndexOptionBuySellCallIntradayRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionBuySellCallIntradayRegressionAlgorithm.py
@@ -37,9 +37,9 @@ class IndexOptionBuySellCallIntradayRegressionAlgorithm(QCAlgorithm):
 
         # Select a index option expiring ITM, and adds it to the algorithm.
         spx_options = list(sorted([
-            self.add_index_option_contract(i.symbol, Resolution.MINUTE).symbol \
+            self.add_index_option_contract(i, Resolution.MINUTE).symbol \
                 for i in self.option_chain(spx)\
-                    if (i.symbol.id.strike_price == 3700 or i.symbol.id.strike_price == 3800) and i.symbol.id.option_right == OptionRight.CALL and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1],
+                    if (i.id.strike_price == 3700 or i.id.strike_price == 3800) and i.id.option_right == OptionRight.CALL and i.id.date.year == 2021 and i.id.date.month == 1],
             key=lambda x: x.id.strike_price
         ))
 

--- a/Algorithm.Python/IndexOptionCallITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionCallITMExpiryRegressionAlgorithm.py
@@ -34,9 +34,7 @@ class IndexOptionCallITMExpiryRegressionAlgorithm(QCAlgorithm):
 
         # Select an index option expiring ITM, and adds it to the algorithm.
         self.spx_option = list(self.option_chain(self.spx))
-        self.spx_option = [i.symbol
-                           for i in self.spx_option
-                           if i.symbol.id.strike_price <= 3200 and i.symbol.id.option_right == OptionRight.CALL and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
+        self.spx_option = [i for i in self.spx_option if i.id.strike_price <= 3200 and i.id.option_right == OptionRight.CALL and i.id.date.year == 2021 and i.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price, reverse=True))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/IndexOptionCallITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionCallITMExpiryRegressionAlgorithm.py
@@ -33,8 +33,10 @@ class IndexOptionCallITMExpiryRegressionAlgorithm(QCAlgorithm):
         self.spx = self.add_index("SPX", Resolution.MINUTE).symbol
 
         # Select an index option expiring ITM, and adds it to the algorithm.
-        self.spx_option = list(self.option_chain_provider.get_option_contract_list(self.spx, self.time))
-        self.spx_option = [i for i in self.spx_option if i.id.strike_price <= 3200 and i.id.option_right == OptionRight.CALL and i.id.date.year == 2021 and i.id.date.month == 1]
+        self.spx_option = list(self.option_chain(self.spx))
+        self.spx_option = [i.symbol
+                           for i in self.spx_option
+                           if i.symbol.id.strike_price <= 3200 and i.symbol.id.option_right == OptionRight.CALL and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price, reverse=True))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 
@@ -43,8 +45,8 @@ class IndexOptionCallITMExpiryRegressionAlgorithm(QCAlgorithm):
             raise Exception(f"Contract {self.expected_option_contract} was not found in the chain")
 
         self.schedule.on(
-            self.date_rules.tomorrow, 
-            self.time_rules.after_market_open(self.spx, 1), 
+            self.date_rules.tomorrow,
+            self.time_rules.after_market_open(self.spx, 1),
             lambda: self.market_order(self.spx_option, 1)
         )
 
@@ -55,7 +57,7 @@ class IndexOptionCallITMExpiryRegressionAlgorithm(QCAlgorithm):
             if delisting.type == DelistingType.WARNING:
                 if delisting.time != datetime(2021, 1, 15):
                     raise Exception(f"Delisting warning issued at unexpected date: {delisting.time}")
-            
+
             if delisting.type == DelistingType.DELISTED:
                 if delisting.time != datetime(2021, 1, 16):
                     raise Exception(f"Delisting happened at unexpected date: {delisting.time}")

--- a/Algorithm.Python/IndexOptionCallITMGreeksExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionCallITMGreeksExpiryRegressionAlgorithm.py
@@ -30,8 +30,10 @@ class IndexOptionCallITMGreeksExpiryRegressionAlgorithm(QCAlgorithm):
         self.spx = spx.symbol
 
         # Select a index option call expiring ITM, and adds it to the algorithm.
-        self.spx_option = list(self.option_chain_provider.get_option_contract_list(self.spx, self.time))
-        self.spx_option = [i for i in self.spx_option if i.id.strike_price <= 3200 and i.id.option_right == OptionRight.CALL and i.id.date.year == 2021 and i.id.date.month == 1]
+        self.spx_option = list(self.option_chain(self.spx))
+        self.spx_option = [i.symbol
+                           for i in self.spx_option
+                           if i.symbol.id.strike_price <= 3200 and i.symbol.id.option_right == OptionRight.CALL and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price, reverse=True))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE)
 
@@ -81,7 +83,7 @@ class IndexOptionCallITMGreeksExpiryRegressionAlgorithm(QCAlgorithm):
 
         if any([i for i in rho if i == 0]):
             raise Exception("Option contract Rho was equal to zero")
-        
+
         if any([i for i in theta if i == 0]):
             raise Exception("Option contract Theta was equal to zero")
 

--- a/Algorithm.Python/IndexOptionCallITMGreeksExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionCallITMGreeksExpiryRegressionAlgorithm.py
@@ -31,9 +31,7 @@ class IndexOptionCallITMGreeksExpiryRegressionAlgorithm(QCAlgorithm):
 
         # Select a index option call expiring ITM, and adds it to the algorithm.
         self.spx_option = list(self.option_chain(self.spx))
-        self.spx_option = [i.symbol
-                           for i in self.spx_option
-                           if i.symbol.id.strike_price <= 3200 and i.symbol.id.option_right == OptionRight.CALL and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
+        self.spx_option = [i for i in self.spx_option if i.id.strike_price <= 3200 and i.id.option_right == OptionRight.CALL and i.id.date.year == 2021 and i.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price, reverse=True))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE)
 

--- a/Algorithm.Python/IndexOptionCallOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionCallOTMExpiryRegressionAlgorithm.py
@@ -38,17 +38,17 @@ class IndexOptionCallOTMExpiryRegressionAlgorithm(QCAlgorithm):
         self.spx = self.add_index("SPX", Resolution.MINUTE).symbol
 
         # Select a index option call expiring OTM, and adds it to the algorithm.
-        self.spx_option = list(self.option_chain_provider.get_option_contract_list(self.spx, self.time))
-        self.spx_option = [i for i in self.spx_option if i.id.strike_price >= 4250 and i.id.option_right == OptionRight.CALL and i.id.date.year == 2021 and i.id.date.month == 1]
+        self.spx_option = list(self.option_chain(self.spx))
+        self.spx_option = [i.symbol for i in self.spx_option if i.symbol.id.strike_price >= 4250 and i.symbol.id.option_right == OptionRight.CALL and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 
         self.expected_contract = Symbol.create_option(
-            self.spx, 
-            Market.USA, 
-            OptionStyle.EUROPEAN, 
-            OptionRight.CALL, 
-            4250, 
+            self.spx,
+            Market.USA,
+            OptionStyle.EUROPEAN,
+            OptionRight.CALL,
+            4250,
             datetime(2021, 1, 15)
         )
 
@@ -56,8 +56,8 @@ class IndexOptionCallOTMExpiryRegressionAlgorithm(QCAlgorithm):
             raise Exception(f"Contract {self.expected_contract} was not found in the chain")
 
         self.schedule.on(
-            self.date_rules.tomorrow, 
-            self.time_rules.after_market_open(self.spx, 1), 
+            self.date_rules.tomorrow,
+            self.time_rules.after_market_open(self.spx, 1),
             lambda: self.market_order(self.spx_option, 1)
         )
 

--- a/Algorithm.Python/IndexOptionCallOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionCallOTMExpiryRegressionAlgorithm.py
@@ -39,7 +39,7 @@ class IndexOptionCallOTMExpiryRegressionAlgorithm(QCAlgorithm):
 
         # Select a index option call expiring OTM, and adds it to the algorithm.
         self.spx_option = list(self.option_chain(self.spx))
-        self.spx_option = [i.symbol for i in self.spx_option if i.symbol.id.strike_price >= 4250 and i.symbol.id.option_right == OptionRight.CALL and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
+        self.spx_option = [i for i in self.spx_option if i.id.strike_price >= 4250 and i.id.option_right == OptionRight.CALL and i.id.date.year == 2021 and i.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/IndexOptionPutITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionPutITMExpiryRegressionAlgorithm.py
@@ -33,9 +33,7 @@ class IndexOptionPutITMExpiryRegressionAlgorithm(QCAlgorithm):
 
         # Select a index option expiring ITM, and adds it to the algorithm.
         self.spx_option = list(self.option_chain(self.spx))
-        self.spx_option = [i.symbol
-                           for i in self.spx_option
-                           if i.symbol.id.strike_price >= 4200 and i.symbol.id.option_right == OptionRight.PUT and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
+        self.spx_option = [i for i in self.spx_option if i.id.strike_price >= 4200 and i.id.option_right == OptionRight.PUT and i.id.date.year == 2021 and i.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/IndexOptionPutITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionPutITMExpiryRegressionAlgorithm.py
@@ -32,8 +32,10 @@ class IndexOptionPutITMExpiryRegressionAlgorithm(QCAlgorithm):
         self.spx = self.add_index("SPX", Resolution.MINUTE).symbol
 
         # Select a index option expiring ITM, and adds it to the algorithm.
-        self.spx_option = list(self.option_chain_provider.get_option_contract_list(self.spx, self.time))
-        self.spx_option = [i for i in self.spx_option if i.id.strike_price >= 4200 and i.id.option_right == OptionRight.PUT and i.id.date.year == 2021 and i.id.date.month == 1]
+        self.spx_option = list(self.option_chain(self.spx))
+        self.spx_option = [i.symbol
+                           for i in self.spx_option
+                           if i.symbol.id.strike_price >= 4200 and i.symbol.id.option_right == OptionRight.PUT and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/IndexOptionPutOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionPutOTMExpiryRegressionAlgorithm.py
@@ -39,9 +39,7 @@ class IndexOptionCallOTMExpiryRegressionAlgorithm(QCAlgorithm):
 
         # Select a index option call expiring OTM, and adds it to the algorithm.
         self.spx_option = list(self.option_chain(self.spx))
-        self.spx_option = [i.symbol
-                           for i in self.spx_option
-                           if i.symbol.id.strike_price <= 3200 and i.symbol.id.option_right == OptionRight.PUT and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
+        self.spx_option = [i for i in self.spx_option if i.id.strike_price <= 3200 and i.id.option_right == OptionRight.PUT and i.id.date.year == 2021 and i.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price, reverse=True))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/IndexOptionPutOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionPutOTMExpiryRegressionAlgorithm.py
@@ -38,17 +38,19 @@ class IndexOptionCallOTMExpiryRegressionAlgorithm(QCAlgorithm):
         self.spx = self.add_index("SPX", Resolution.MINUTE).symbol
 
         # Select a index option call expiring OTM, and adds it to the algorithm.
-        self.spx_option = list(self.option_chain_provider.get_option_contract_list(self.spx, self.time))
-        self.spx_option = [i for i in self.spx_option if i.id.strike_price <= 3200 and i.id.option_right == OptionRight.PUT and i.id.date.year == 2021 and i.id.date.month == 1]
+        self.spx_option = list(self.option_chain(self.spx))
+        self.spx_option = [i.symbol
+                           for i in self.spx_option
+                           if i.symbol.id.strike_price <= 3200 and i.symbol.id.option_right == OptionRight.PUT and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price, reverse=True))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 
         self.expected_contract = Symbol.create_option(
-            self.spx, 
-            Market.USA, 
-            OptionStyle.EUROPEAN, 
-            OptionRight.PUT, 
-            3200, 
+            self.spx,
+            Market.USA,
+            OptionStyle.EUROPEAN,
+            OptionRight.PUT,
+            3200,
             datetime(2021, 1, 15)
         )
 
@@ -56,8 +58,8 @@ class IndexOptionCallOTMExpiryRegressionAlgorithm(QCAlgorithm):
             raise Exception(f"Contract {self.expected_contract} was not found in the chain")
 
         self.schedule.on(
-            self.date_rules.tomorrow, 
-            self.time_rules.after_market_open(self.spx, 1), 
+            self.date_rules.tomorrow,
+            self.time_rules.after_market_open(self.spx, 1),
             lambda: self.market_order(self.spx_option, 1)
         )
 

--- a/Algorithm.Python/IndexOptionShortCallITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionShortCallITMExpiryRegressionAlgorithm.py
@@ -38,8 +38,8 @@ class IndexOptionShortCallITMExpiryRegressionAlgorithm(QCAlgorithm):
         self.spx = self.add_index("SPX", Resolution.MINUTE).symbol
 
         # Select a index option expiring ITM, and adds it to the algorithm.
-        self.spx_option = list(self.option_chain_provider.get_option_contract_list(self.spx, self.time))
-        self.spx_option = [i for i in self.spx_option if i.id.strike_price <= 3200 and i.id.option_right == OptionRight.CALL and i.id.date.year == 2021 and i.id.date.month == 1]
+        self.spx_option = list(self.option_chain(self.spx))
+        self.spx_option = [i.symbol for i in self.spx_option if i.symbol.id.strike_price <= 3200 and i.symbol.id.option_right == OptionRight.CALL and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price, reverse=True))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/IndexOptionShortCallITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionShortCallITMExpiryRegressionAlgorithm.py
@@ -39,7 +39,7 @@ class IndexOptionShortCallITMExpiryRegressionAlgorithm(QCAlgorithm):
 
         # Select a index option expiring ITM, and adds it to the algorithm.
         self.spx_option = list(self.option_chain(self.spx))
-        self.spx_option = [i.symbol for i in self.spx_option if i.symbol.id.strike_price <= 3200 and i.symbol.id.option_right == OptionRight.CALL and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
+        self.spx_option = [i for i in self.spx_option if i.id.strike_price <= 3200 and i.id.option_right == OptionRight.CALL and i.id.date.year == 2021 and i.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price, reverse=True))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/IndexOptionShortCallOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionShortCallOTMExpiryRegressionAlgorithm.py
@@ -35,9 +35,7 @@ class IndexOptionShortCallOTMExpiryRegressionAlgorithm(QCAlgorithm):
 
         # Select a index option expiring ITM, and adds it to the algorithm.
         self.spx_option = list(self.option_chain(self.spx))
-        self.spx_option = [i.symbol
-                           for i in self.spx_option
-                           if i.symbol.id.strike_price >= 4250 and i.symbol.id.option_right == OptionRight.CALL and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
+        self.spx_option = [i for i in self.spx_option if i.id.strike_price >= 4250 and i.id.option_right == OptionRight.CALL and i.id.date.year == 2021 and i.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/IndexOptionShortCallOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionShortCallOTMExpiryRegressionAlgorithm.py
@@ -34,8 +34,10 @@ class IndexOptionShortCallOTMExpiryRegressionAlgorithm(QCAlgorithm):
         self.spx = self.add_index("SPX", Resolution.MINUTE).symbol
 
         # Select a index option expiring ITM, and adds it to the algorithm.
-        self.spx_option = list(self.option_chain_provider.get_option_contract_list(self.spx, self.time))
-        self.spx_option = [i for i in self.spx_option if i.id.strike_price >= 4250 and i.id.option_right == OptionRight.CALL and i.id.date.year == 2021 and i.id.date.month == 1]
+        self.spx_option = list(self.option_chain(self.spx))
+        self.spx_option = [i.symbol
+                           for i in self.spx_option
+                           if i.symbol.id.strike_price >= 4250 and i.symbol.id.option_right == OptionRight.CALL and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/IndexOptionShortPutITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionShortPutITMExpiryRegressionAlgorithm.py
@@ -38,8 +38,10 @@ class IndexOptionShortCallITMExpiryRegressionAlgorithm(QCAlgorithm):
         self.spx = self.add_index("SPX", Resolution.MINUTE).symbol
 
         # Select a index option expiring ITM, and adds it to the algorithm.
-        self.spx_option = list(self.option_chain_provider.get_option_contract_list(self.spx, self.time))
-        self.spx_option = [i for i in self.spx_option if i.id.strike_price <= 4200 and i.id.option_right == OptionRight.PUT and i.id.date.year == 2021 and i.id.date.month == 1]
+        self.spx_option = list(self.option_chain(self.spx))
+        self.spx_option = [i.symbol
+                           for i in self.spx_option
+                           if i.symbol.id.strike_price <= 4200 and i.symbol.id.option_right == OptionRight.PUT and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price, reverse=True))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/IndexOptionShortPutITMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionShortPutITMExpiryRegressionAlgorithm.py
@@ -39,9 +39,7 @@ class IndexOptionShortCallITMExpiryRegressionAlgorithm(QCAlgorithm):
 
         # Select a index option expiring ITM, and adds it to the algorithm.
         self.spx_option = list(self.option_chain(self.spx))
-        self.spx_option = [i.symbol
-                           for i in self.spx_option
-                           if i.symbol.id.strike_price <= 4200 and i.symbol.id.option_right == OptionRight.PUT and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
+        self.spx_option = [i for i in self.spx_option if i.id.strike_price <= 4200 and i.id.option_right == OptionRight.PUT and i.id.date.year == 2021 and i.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price, reverse=True))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/IndexOptionShortPutOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionShortPutOTMExpiryRegressionAlgorithm.py
@@ -35,9 +35,7 @@ class IndexOptionShortCallOTMExpiryRegressionAlgorithm(QCAlgorithm):
 
         # Select a index option expiring ITM, and adds it to the algorithm.
         self.spx_option = list(self.option_chain(self.spx))
-        self.spx_option = [i.symbol
-                           for i in self.spx_option
-                           if i.symbol.id.strike_price <= 3200 and i.symbol.id.option_right == OptionRight.PUT and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
+        self.spx_option = [i for i in self.spx_option if i.id.strike_price <= 3200 and i.id.option_right == OptionRight.PUT and i.id.date.year == 2021 and i.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price, reverse=True))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/IndexOptionShortPutOTMExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/IndexOptionShortPutOTMExpiryRegressionAlgorithm.py
@@ -34,8 +34,10 @@ class IndexOptionShortCallOTMExpiryRegressionAlgorithm(QCAlgorithm):
         self.spx = self.add_index("SPX", Resolution.MINUTE).symbol
 
         # Select a index option expiring ITM, and adds it to the algorithm.
-        self.spx_option = list(self.option_chain_provider.get_option_contract_list(self.spx, self.time))
-        self.spx_option = [i for i in self.spx_option if i.id.strike_price <= 3200 and i.id.option_right == OptionRight.PUT and i.id.date.year == 2021 and i.id.date.month == 1]
+        self.spx_option = list(self.option_chain(self.spx))
+        self.spx_option = [i.symbol
+                           for i in self.spx_option
+                           if i.symbol.id.strike_price <= 3200 and i.symbol.id.option_right == OptionRight.PUT and i.symbol.id.date.year == 2021 and i.symbol.id.date.month == 1]
         self.spx_option = list(sorted(self.spx_option, key=lambda x: x.id.strike_price, reverse=True))[0]
         self.spx_option = self.add_index_option_contract(self.spx_option, Resolution.MINUTE).symbol
 

--- a/Algorithm.Python/OptionChainFullDataRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionChainFullDataRegressionAlgorithm.py
@@ -1,0 +1,45 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression algorithm illustrating the usage of the <see cref="QCAlgorithm.OptionChain(Symbol)"/> method
+### to get an option chain, which contains additional data besides the symbols, including prices, implied volatility and greeks.
+### It also shows how this data can be used to filter the contracts based on certain criteria.
+### </summary>
+class OptionChainFullDataRegressionAlgorithm(QCAlgorithm):
+
+    def initialize(self):
+        self.set_start_date(2015, 12, 24)
+        self.set_end_date(2015, 12, 24)
+        self.set_cash(100000)
+
+        goog = self.add_equity("GOOG").symbol
+
+        # Get contracts expiring within 10 days, with an implied volatility greater than 0.5 and a delta less than 0.5
+        contracts = [
+            contract_data.symbol
+            for contract_data in self.option_chain(goog)
+            if contract_data.symbol.id.date - self.time <= timedelta(days=10) and contract_data.implied_volatility > 0.5 and contract_data.greeks.delta < 0.5]
+        # Get the contract with the latest expiration date
+        self._option_contract = sorted(contracts, key=lambda x: x.id.date, reverse=True)[0]
+
+        self.add_option_contract(self._option_contract)
+
+    def on_data(self, data):
+        # Do some trading with the selected contract for sample purposes
+        if not self.portfolio.invested:
+            self.market_order(self._option_contract, 1)
+        else:
+            self.liquidate()

--- a/Algorithm.Python/OptionChainFullDataRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionChainFullDataRegressionAlgorithm.py
@@ -29,9 +29,10 @@ class OptionChainFullDataRegressionAlgorithm(QCAlgorithm):
 
         # Get contracts expiring within 10 days, with an implied volatility greater than 0.5 and a delta less than 0.5
         contracts = [
-            contract_data.symbol
+            contract_data
             for contract_data in self.option_chain(goog)
-            if contract_data.symbol.id.date - self.time <= timedelta(days=10) and contract_data.implied_volatility > 0.5 and contract_data.greeks.delta < 0.5]
+            if contract_data.id.date - self.time <= timedelta(days=10) and contract_data.implied_volatility > 0.5 and contract_data.greeks.delta < 0.5
+        ]
         # Get the contract with the latest expiration date
         self._option_contract = sorted(contracts, key=lambda x: x.id.date, reverse=True)[0]
 

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -3353,6 +3353,7 @@ namespace QuantConnect.Algorithm
             var canonicalSymbol = GetCanonicalOptionSymbol(symbol);
             IEnumerable<OptionUniverse> optionChain;
 
+            // TODO: Until future options are supported by OptionUniverse, we need to fall back to the OptionChainProvider for them
             if (canonicalSymbol.SecurityType != SecurityType.FutureOption)
             {
                 var marketHoursEntry = MarketHoursDatabase.GetEntry(canonicalSymbol.ID.Market, canonicalSymbol, canonicalSymbol.SecurityType);

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -53,9 +53,7 @@ using Index = QuantConnect.Securities.Index.Index;
 using QuantConnect.Securities.CryptoFuture;
 using QuantConnect.Algorithm.Framework.Alphas.Analysis;
 using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
-using QuantConnect.Data.Auxiliary;
 using Python.Runtime;
-using QuantConnect.Python;
 
 namespace QuantConnect.Algorithm
 {
@@ -3344,7 +3342,7 @@ namespace QuantConnect.Algorithm
         /// implied volatility and greeks.
         /// </returns>
         /// <remarks>
-        /// As of 2024/09/10, future options chain will not contain any additional data (e.g. daily price data, implied volatility and greeks),
+        /// As of 2024/09/11, future options chain will not contain any additional data (e.g. daily price data, implied volatility and greeks),
         /// it will be populated with the contract symbol only. This is expected to change in the future.
         /// </remarks>
         [DocumentationAttribute(AddingData)]
@@ -3374,7 +3372,7 @@ namespace QuantConnect.Algorithm
                     });
             }
 
-            return new DataHistory<OptionUniverse>(optionChain, new Lazy<PyObject>(() => new PandasConverter().GetDataFrame(optionChain)));
+            return new DataHistory<OptionUniverse>(optionChain, new Lazy<PyObject>(() => PandasConverter.GetDataFrame(optionChain)));
         }
 
         private static Symbol GetCanonicalOptionSymbol(Symbol symbol)

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -3354,12 +3354,9 @@ namespace QuantConnect.Algorithm
             // TODO: Until future options are supported by OptionUniverse, we need to fall back to the OptionChainProvider for them
             if (canonicalSymbol.SecurityType != SecurityType.FutureOption)
             {
-                var marketHoursEntry = MarketHoursDatabase.GetEntry(canonicalSymbol.ID.Market, canonicalSymbol, canonicalSymbol.SecurityType);
-                var previousTradingDate = QuantConnect.Time.GetStartTimeForTradeBars(marketHoursEntry.ExchangeHours, Time, QuantConnect.Time.OneDay, 1,
-                    extendedMarketHours: false, marketHoursEntry.DataTimeZone);
-                previousTradingDate = previousTradingDate.ConvertTo(marketHoursEntry.DataTimeZone, TimeZone);
-
-                var history = History<OptionUniverse>(canonicalSymbol, previousTradingDate, Time, Resolution.Daily);
+                // TODO: History<OptionUniverse>(canonicalSymbol, 1) should be enough,
+                // the universe resolution should always be daily. Change this when this is fixed in #8317
+                var history = History<OptionUniverse>(canonicalSymbol, 1, Resolution.Daily);
                 optionChain = history?.SingleOrDefault()?.Data?.Cast<OptionUniverse>() ?? Enumerable.Empty<OptionUniverse>();
             }
             else

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1852,66 +1852,6 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Helper method to get the canonical symbol for a specified symbol, taking care of mapping in the case of equity options
-        /// </summary>
-        /// <param name="symbol">The symbol to get the canonical for. It can be an underlying or an option</param>
-        /// <param name="date">The date of the request, in order to resolve mappings when necessary</param>
-        /// <param name="mapFileProvider">The optional map file provider</param>
-        /// <returns>The canonical symbol</returns>
-        public static Symbol GetCanonical(this Symbol symbol, DateTime date, IMapFileProvider mapFileProvider = null)
-        {
-            Symbol canonicalSymbol;
-            if (!symbol.SecurityType.HasOptions())
-            {
-                // we got an option
-                if (symbol.SecurityType.IsOption() && symbol.Underlying != null)
-                {
-                    // Resolve any mapping before requesting option contract list for equities
-                    // Needs to be done in order for the data file key to be accurate
-                    if (symbol.Underlying.RequiresMapping())
-                    {
-                        var mappedUnderlyingSymbol = MapUnderlyingSymbol(symbol.Underlying, date, mapFileProvider);
-
-                        canonicalSymbol = Symbol.CreateCanonicalOption(mappedUnderlyingSymbol);
-                    }
-                    else
-                    {
-                        canonicalSymbol = symbol.Canonical;
-                    }
-                }
-                else
-                {
-                    throw new NotSupportedException($"QCAlgorithm.GetCanonicalSymbol(): " +
-                        $"{nameof(SecurityType.Equity)}, {nameof(SecurityType.Future)}, or {nameof(SecurityType.Index)} is expected but was {symbol.SecurityType}");
-                }
-            }
-            else
-            {
-                // we got the underlying
-                var mappedUnderlyingSymbol = MapUnderlyingSymbol(symbol, date, mapFileProvider);
-                canonicalSymbol = Symbol.CreateCanonicalOption(mappedUnderlyingSymbol);
-            }
-
-            return canonicalSymbol;
-        }
-
-        private static Symbol MapUnderlyingSymbol(Symbol underlying, DateTime date, IMapFileProvider mapFileProvider = null)
-        {
-            if (underlying.RequiresMapping())
-            {
-                mapFileProvider ??= Composer.Instance.GetPart<IMapFileProvider>();
-                var mapFileResolver = mapFileProvider.Get(AuxiliaryDataKey.Create(underlying));
-                var mapFile = mapFileResolver.ResolveMapFile(underlying);
-                var ticker = mapFile.GetMappedSymbol(date, underlying.Value);
-                return underlying.UpdateMappedSymbol(ticker);
-            }
-            else
-            {
-                return underlying;
-            }
-        }
-
-        /// <summary>
         /// Extension method to round a datetime to the nearest unit timespan.
         /// </summary>
         /// <param name="datetime">Datetime object we're rounding.</param>

--- a/Engine/DataFeeds/BacktestingOptionChainProvider.cs
+++ b/Engine/DataFeeds/BacktestingOptionChainProvider.cs
@@ -42,12 +42,64 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// Gets the list of option contracts for a given underlying symbol
         /// </summary>
         /// <param name="symbol">The option or the underlying symbol to get the option chain for.
-        /// Providing the option allows targeting an option ticker different than the default e.g. SPXW</param>
+        /// Providing the option allows targetting an option ticker different than the default e.g. SPXW</param>
         /// <param name="date">The date for which to request the option chain (only used in backtesting)</param>
         /// <returns>The list of option contracts</returns>
         public virtual IEnumerable<Symbol> GetOptionContractList(Symbol symbol, DateTime date)
         {
-            return GetSymbols(symbol.GetCanonical(date), date);
+            Symbol canonicalSymbol;
+            if (!symbol.SecurityType.HasOptions())
+            {
+                // we got an option
+                if (symbol.SecurityType.IsOption() && symbol.Underlying != null)
+                {
+                    canonicalSymbol = GetCanonical(symbol, date);
+                }
+                else
+                {
+                    throw new NotSupportedException($"BacktestingOptionChainProvider.GetOptionContractList(): " +
+                        $"{nameof(SecurityType.Equity)}, {nameof(SecurityType.Future)}, or {nameof(SecurityType.Index)} is expected but was {symbol.SecurityType}");
+                }
+            }
+            else
+            {
+                // we got the underlying
+                var mappedUnderlyingSymbol = MapUnderlyingSymbol(symbol, date);
+                canonicalSymbol = Symbol.CreateCanonicalOption(mappedUnderlyingSymbol);
+            }
+
+            return GetSymbols(canonicalSymbol, date);
+        }
+
+        private Symbol GetCanonical(Symbol optionSymbol, DateTime date)
+        {
+            // Resolve any mapping before requesting option contract list for equities
+            // Needs to be done in order for the data file key to be accurate
+            if (optionSymbol.Underlying.RequiresMapping())
+            {
+                var mappedUnderlyingSymbol = MapUnderlyingSymbol(optionSymbol.Underlying, date);
+
+                return Symbol.CreateCanonicalOption(mappedUnderlyingSymbol);
+            }
+            else
+            {
+                return optionSymbol.Canonical;
+            }
+        }
+
+        private Symbol MapUnderlyingSymbol(Symbol underlying, DateTime date)
+        {
+            if (underlying.RequiresMapping())
+            {
+                var mapFileResolver = _mapFileProvider.Get(AuxiliaryDataKey.Create(underlying));
+                var mapFile = mapFileResolver.ResolveMapFile(underlying);
+                var ticker = mapFile.GetMappedSymbol(date, underlying.Value);
+                return underlying.UpdateMappedSymbol(ticker);
+            }
+            else
+            {
+                return underlying;
+            }
         }
     }
 }

--- a/Engine/DataFeeds/BacktestingOptionChainProvider.cs
+++ b/Engine/DataFeeds/BacktestingOptionChainProvider.cs
@@ -42,64 +42,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// Gets the list of option contracts for a given underlying symbol
         /// </summary>
         /// <param name="symbol">The option or the underlying symbol to get the option chain for.
-        /// Providing the option allows targetting an option ticker different than the default e.g. SPXW</param>
+        /// Providing the option allows targeting an option ticker different than the default e.g. SPXW</param>
         /// <param name="date">The date for which to request the option chain (only used in backtesting)</param>
         /// <returns>The list of option contracts</returns>
         public virtual IEnumerable<Symbol> GetOptionContractList(Symbol symbol, DateTime date)
         {
-            Symbol canonicalSymbol;
-            if (!symbol.SecurityType.HasOptions())
-            {
-                // we got an option
-                if (symbol.SecurityType.IsOption() && symbol.Underlying != null)
-                {
-                    canonicalSymbol = GetCanonical(symbol, date);
-                }
-                else
-                {
-                    throw new NotSupportedException($"BacktestingOptionChainProvider.GetOptionContractList(): " +
-                        $"{nameof(SecurityType.Equity)}, {nameof(SecurityType.Future)}, or {nameof(SecurityType.Index)} is expected but was {symbol.SecurityType}");
-                }
-            }
-            else
-            {
-                // we got the underlying
-                var mappedUnderlyingSymbol = MapUnderlyingSymbol(symbol, date);
-                canonicalSymbol = Symbol.CreateCanonicalOption(mappedUnderlyingSymbol);
-            }
-
-            return GetSymbols(canonicalSymbol, date);
-        }
-
-        private Symbol GetCanonical(Symbol optionSymbol, DateTime date)
-        {
-            // Resolve any mapping before requesting option contract list for equities
-            // Needs to be done in order for the data file key to be accurate
-            if (optionSymbol.Underlying.RequiresMapping())
-            {
-                var mappedUnderlyingSymbol = MapUnderlyingSymbol(optionSymbol.Underlying, date);
-
-                return Symbol.CreateCanonicalOption(mappedUnderlyingSymbol);
-            }
-            else
-            {
-                return optionSymbol.Canonical;
-            }
-        }
-
-        private Symbol MapUnderlyingSymbol(Symbol underlying, DateTime date)
-        {
-            if (underlying.RequiresMapping())
-            {
-                var mapFileResolver = _mapFileProvider.Get(AuxiliaryDataKey.Create(underlying));
-                var mapFile = mapFileResolver.ResolveMapFile(underlying);
-                var ticker = mapFile.GetMappedSymbol(date, underlying.Value);
-                return underlying.UpdateMappedSymbol(ticker);
-            }
-            else
-            {
-                return underlying;
-            }
+            return GetSymbols(symbol.GetCanonical(date), date);
         }
     }
 }

--- a/Tests/Algorithm/AlgorithmChainsTests.cs
+++ b/Tests/Algorithm/AlgorithmChainsTests.cs
@@ -1,0 +1,79 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Tests.Engine.DataFeeds;
+using QuantConnect.Util;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    [TestFixture]
+    public class AlgorithmChainsTest
+    {
+        private QCAlgorithm _algorithm;
+        private BacktestingOptionChainProvider _optionChainProvider;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            var historyProvider = Composer.Instance.GetExportedValueByTypeName<IHistoryProvider>("SubscriptionDataReaderHistoryProvider", true);
+            var parameters = new HistoryProviderInitializeParameters(null, null, TestGlobals.DataProvider, TestGlobals.DataCacheProvider,
+                TestGlobals.MapFileProvider, TestGlobals.FactorFileProvider, (_) => { }, true, new DataPermissionManager(), null,
+                new AlgorithmSettings());
+            historyProvider.Initialize(parameters);
+
+            _algorithm = new QCAlgorithm();
+            _algorithm.SetHistoryProvider(historyProvider);
+            _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(_algorithm));
+
+            _optionChainProvider = new BacktestingOptionChainProvider(TestGlobals.DataCacheProvider, TestGlobals.MapFileProvider);
+        }
+
+        private static TestCaseData[] OptionChainTestCases = new TestCaseData[]
+        {
+            // By underlying
+            new(Symbols.AAPL, new DateTime(2014, 06, 06)),
+            new(Symbols.SPX, new DateTime(2021, 01, 04)),
+            // By canonical
+            new(Symbol.CreateCanonicalOption(Symbols.AAPL), new DateTime(2014, 06, 06)),
+            new(Symbol.CreateCanonicalOption(Symbols.SPX), new DateTime(2021, 01, 04))
+        };
+
+        [TestCaseSource(nameof(OptionChainTestCases))]
+        public void GetsFullDataOptionChain(Symbol symbol, DateTime date)
+        {
+            _algorithm.SetDateTime(date.ConvertToUtc(_algorithm.TimeZone));
+            var optionContractsData = _algorithm.OptionChain(symbol).ToList();
+
+            var optionContractsSymbols = _optionChainProvider.GetOptionContractList(symbol, date).ToList();
+
+            CollectionAssert.AreEquivalent(optionContractsSymbols, optionContractsData.Select(x => x.Symbol));
+        }
+
+        [Test]
+        public void CannotGetFutureOptionsChain()
+        {
+            var result = _algorithm.OptionChain(Symbols.ES_Future_Chain).ToList();
+            Assert.IsEmpty(result);
+            Assert.IsTrue(_algorithm.LogMessages.Any(x => x.Contains($"Warning: QCAlgorithm.{nameof(QCAlgorithm.OptionChain)} method cannot be used to get future options chains yet. Until support is added, please fall back to the {nameof(QCAlgorithm.OptionChainProvider)}.", StringComparison.InvariantCulture)));
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Add `QCAlgorithm.OptionChain()` method to fetch option chains but, unlike the `IOptionChainProvider`, returning `OptionUniverse` instances instead of just the symbols, so that it includes additional daily options data like price data, implied volatility and greeks.

Follow up #8212 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

SImpler way to fetch an option universe with options data at the time of the algorithm (`QCAlgorithm.Time`). Without this, it would required making history requests as illustrated in the [`OptionUniverseHistoryRegressionAlgorithm`](https://github.com/QuantConnect/Lean/blob/master/Algorithm.CSharp/OptionUniverseHistoryRegressionAlgorithm.cs) regression algorithm.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

Need to document new method and the deprecation of `QCAlgorithm.OptionChainProvider`

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit tests
- New regression algorithms
- Existing regression algorithms, replacing  `QCAlgorithm.OptionChainProvider` with the new  `QCAlgorithm.OptionChain()` method.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
