### PR TITLE
Feature: new `Tick` constructor for `TickType.OpenInterest`

### DIFF
--- a/Common/Data/DataQueueHandlerSubscriptionManager.cs
+++ b/Common/Data/DataQueueHandlerSubscriptionManager.cs
@@ -110,7 +110,9 @@ namespace QuantConnect.Data
         public IEnumerable<Symbol> GetSubscribedSymbols(TickType tickType)
         {
             var channelName = ChannelNameFromTickType(tickType);
-            return SubscribersByChannel.Keys.Where(x => x.Name == channelName)
+#pragma warning disable CA1309
+            return SubscribersByChannel.Keys.Where(x => x.Name.Equals(channelName, StringComparison.InvariantCultureIgnoreCase))
+#pragma warning restore CA1309
                 .Select(c => c.Symbol)
                 .Distinct();
         }

--- a/Common/Data/DataQueueHandlerSubscriptionManager.cs
+++ b/Common/Data/DataQueueHandlerSubscriptionManager.cs
@@ -103,6 +103,19 @@ namespace QuantConnect.Data
         }
 
         /// <summary>
+        /// Retrieves the list of unique <see cref="Symbol"/> instances that are currently subscribed for a specific <see cref="TickType"/>.
+        /// </summary>
+        /// <param name="tickType">The type of tick data to filter subscriptions by.</param>
+        /// <returns>A collection of unique <see cref="Symbol"/> objects that match the specified <paramref name="tickType"/>.</returns>
+        public IEnumerable<Symbol> GetSubscribedSymbols(TickType tickType)
+        {
+            var channelName = ChannelNameFromTickType(tickType);
+            return SubscribersByChannel.Keys.Where(x => x.Name == channelName)
+                .Select(c => c.Symbol)
+                .Distinct();
+        }
+
+        /// <summary>
         /// Checks if there is existing subscriber for current channel
         /// </summary>
         /// <param name="symbol">Symbol</param>

--- a/Common/Data/Market/Tick.cs
+++ b/Common/Data/Market/Tick.cs
@@ -232,6 +232,21 @@ namespace QuantConnect.Data.Market
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Tick"/> class to <see cref="TickType.OpenInterest"/>.
+        /// </summary>
+        /// <param name="time">The time at which the open interest tick occurred.</param>
+        /// <param name="symbol">The symbol associated with the open interest tick.</param>
+        /// <param name="openInterest">The value of the open interest for the specified symbol.</param>
+        public Tick(DateTime time, Symbol symbol, decimal openInterest)
+        {
+            Time = time;
+            Symbol = symbol;
+            Value = openInterest;
+            DataType = MarketDataType.Tick;
+            TickType = TickType.OpenInterest;
+        }
+
+        /// <summary>
         /// Initializer for a last-trade equity tick with bid or ask prices.
         /// </summary>
         /// <param name="time">Full date and time</param>

--- a/Tests/Common/Data/DataQueueHandlerSubscriptionManagerTests.cs
+++ b/Tests/Common/Data/DataQueueHandlerSubscriptionManagerTests.cs
@@ -113,6 +113,33 @@ namespace QuantConnect.Tests.Common.Data
             Assert.IsFalse(subscriptionManager.IsSubscribed(Symbols.AAPL, TickType.Quote));
         }
 
+        [TestCase(TickType.Trade, MarketDataType.TradeBar, 1)]
+        [TestCase(TickType.Trade, MarketDataType.QuoteBar, 0)]
+        [TestCase(TickType.Quote, MarketDataType.QuoteBar, 1)]
+        [TestCase(TickType.OpenInterest, MarketDataType.Tick, 1)]
+        [TestCase(TickType.OpenInterest, MarketDataType.TradeBar, 0)]
+        public void GetSubscribeSymbolsBySpecificTickType(TickType tickType, MarketDataType dataType, int expectedCount)
+        {
+            using var fakeDataQueueHandler = new FakeDataQueuehandlerSubscriptionManager((tickType) => tickType!.ToString());
+
+            switch (dataType)
+            {
+                case MarketDataType.TradeBar:
+                    fakeDataQueueHandler.Subscribe(GetSubscriptionDataConfig<TradeBar>(Symbols.AAPL, Resolution.Minute));
+                    break;
+                case MarketDataType.QuoteBar:
+                    fakeDataQueueHandler.Subscribe(GetSubscriptionDataConfig<QuoteBar>(Symbols.AAPL, Resolution.Minute));
+                    break;
+                case MarketDataType.Tick:
+                    fakeDataQueueHandler.Subscribe(GetSubscriptionDataConfig<OpenInterest>(Symbols.AAPL, Resolution.Minute));
+                    break;
+            }
+
+            var subscribeSymbols = fakeDataQueueHandler.GetSubscribedSymbols(tickType).ToList();
+
+            Assert.That(subscribeSymbols.Count, Is.EqualTo(expectedCount));
+        }
+
         #region helper
 
         private SubscriptionDataConfig GetSubscriptionDataConfig(Type T, Symbol symbol, Resolution resolution, TickType? tickType = null)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Add the new constructor of `class Tick` for `TickType.OpenInterest` to enable the reuse of external modules.
- Add the new `GetSubscribedSymbols()` method, which helps retrieve subscribed symbols using a specific `TickType` of Lean.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I want to use the **KISS** programming principle everywhere.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- run the specific test that captures symbols based on TickType.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
