### PR TITLE
Option universe resolution improvements

### DIFF
--- a/Algorithm.CSharp/LargeQuantityOptionStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/LargeQuantityOptionStrategyAlgorithm.cs
@@ -111,7 +111,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 6;
+        public int AlgorithmHistoryDataPoints => 7;
 
         /// <summary>
         /// Final status of the algorithm

--- a/Algorithm.CSharp/OptionChainedAndUniverseSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionChainedAndUniverseSelectionRegressionAlgorithm.cs
@@ -95,7 +95,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 19700;
+        public long DataPoints => 19701;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -92,7 +92,15 @@ namespace QuantConnect.Algorithm
                     {
                         Security underlyingSecurity;
                         var underlyingSymbol = security.Symbol.Underlying;
+
                         var resolution = configs.GetHighestResolution();
+                        var isFillForward = configs.IsFillForward();
+                        if (UniverseManager.TryGetValue(security.Symbol, out var universe))
+                        {
+                            // as if the universe had selected this asset, the configuration of the canonical can be different
+                            resolution = universe.UniverseSettings.Resolution;
+                            isFillForward = universe.UniverseSettings.FillForward;
+                        }
 
                         // create the underlying security object if it doesn't already exist
                         if (!Securities.TryGetValue(underlyingSymbol, out underlyingSecurity))
@@ -101,7 +109,7 @@ namespace QuantConnect.Algorithm
                                 underlyingSymbol.Value,
                                 resolution,
                                 underlyingSymbol.ID.Market,
-                                configs.IsFillForward(),
+                                isFillForward,
                                 Security.NullLeverage,
                                 configs.IsExtendedMarketHours(),
                                 dataNormalizationMode: DataNormalizationMode.Raw);

--- a/Common/Data/UniverseSelection/OptionUniverse.cs
+++ b/Common/Data/UniverseSelection/OptionUniverse.cs
@@ -277,6 +277,16 @@ namespace QuantConnect.Data.UniverseSelection
         }
 
         /// <summary>
+        /// Gets the default resolution for this data and security type
+        /// </summary>
+        /// <remarks>This is a method and not a property so that python
+        /// custom data types can override it</remarks>
+        public override Resolution DefaultResolution()
+        {
+            return Resolution.Daily;
+        }
+
+        /// <summary>
         /// Gets the CSV string representation of this universe entry
         /// </summary>
         public static string ToCsv(Symbol symbol, decimal open, decimal high, decimal low, decimal close, decimal volume, decimal? openInterest,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Improvement for resolution handling of option universes, affecting performance in live mode. Adding regression algorithm

`LargeQuantityOptionStrategyAlgorithm` 1 data point count increased because GetLastKnownPrice first requesting using default resolution, now returning more data
`OptionChainedAndUniverseSelectionRegressionAlgorithm` 1 extra data point because FF resolution changing from Daily to Minute, by custom universe selection. Option universe no longer taking into account since no FF

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related https://github.com/QuantConnect/Lean/issues/7733
Closes https://github.com/QuantConnect/Lean/issues/8317
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve live trading memory/CPU usage
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing and new tests, local live trading sanity tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
