### PR TITLE
Infer data type from configs in bar count history requests

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -1015,6 +1015,7 @@ namespace QuantConnect.Algorithm
         {
             return symbols.Where(HistoryRequestValid).SelectMany(symbol =>
             {
+                // Match or create configs for the symbol
                 var configs = GetMatchingSubscriptions(symbol, requestedType, resolution).ToList();
                 if (configs.Count == 0)
                 {
@@ -1023,6 +1024,7 @@ namespace QuantConnect.Algorithm
 
                 return configs.Select(config =>
                 {
+                    // If no requested type was passed, use the config type to get the resolution (if not provided) and the exchange hours
                     var type = requestedType ?? config.Type;
                     var res = GetResolution(symbol, resolution, type);
                     var exchange = GetExchangeHours(symbol, type);
@@ -1104,6 +1106,7 @@ namespace QuantConnect.Algorithm
             {
                 resolution = GetResolution(symbol, resolution, type);
 
+                // If type was specified and not a lean data type and also not abstract, we create a new subscription
                 if (type != null && !LeanData.IsCommonLeanDataType(type) && !type.IsAbstract)
                 {
                     // we already know it's not a common lean data type
@@ -1131,11 +1134,12 @@ namespace QuantConnect.Algorithm
                     .Where(tuple => SubscriptionDataConfigTypeFilter(type, tuple.Item1))
                     .Select(x =>
                     {
-                        var requestType = x.Item1;
-                        var entry = MarketHoursDatabase.GetEntry(symbol, new[] { requestType });
+                        var configType = x.Item1;
+                        // Use the config type to get an accurate mhdb entry
+                        var entry = MarketHoursDatabase.GetEntry(symbol, new[] { configType });
 
                         return new SubscriptionDataConfig(
-                            requestType,
+                            configType,
                             symbol,
                             resolution.Value,
                             entry.DataTimeZone,

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -1028,9 +1028,7 @@ namespace QuantConnect.Algorithm
                 // lets make sure to respect the order of the data types
                 .ThenByDescending(config => GetTickTypeOrder(config.SecurityType, config.TickType));
 
-            var matchingSubscriptions = type != null
-                ? subscriptions.Where(s => SubscriptionDataConfigTypeFilter(type, s.Type))
-                : subscriptions;
+            var matchingSubscriptions = subscriptions.Where(s => SubscriptionDataConfigTypeFilter(type, s.Type));
 
             var internalConfig = new List<SubscriptionDataConfig>();
             var userConfig = new List<SubscriptionDataConfig>();
@@ -1110,9 +1108,11 @@ namespace QuantConnect.Algorithm
                     .Where(tuple => SubscriptionDataConfigTypeFilter(type, tuple.Item1))
                     .Select(x =>
                     {
-                        var entry = MarketHoursDatabase.GetEntry(symbol, new[] { x.Item1 });
+                        var requestType = x.Item1;
+                        var entry = MarketHoursDatabase.GetEntry(symbol, new[] { requestType });
+
                         return new SubscriptionDataConfig(
-                            x.Item1,
+                            requestType,
                             symbol,
                             resolution.Value,
                             entry.DataTimeZone,

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -948,9 +948,19 @@ namespace QuantConnect.Algorithm
             Resolution? resolution = null, bool? fillForward = null, bool? extendedMarketHours = null, DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
-            var arrayOfSymbols = symbols.ToArray();
-            return CreateDateRangeHistoryRequests(symbols, Extensions.GetCustomDataTypeFromSymbols(arrayOfSymbols), startAlgoTz, endAlgoTz, resolution, fillForward, extendedMarketHours,
-                dataMappingMode, dataNormalizationMode, contractDepthOffset);
+            // Materialize the symbols to avoid multiple enumeration
+            var symbolsArray = symbols.ToArray();
+            return CreateDateRangeHistoryRequests(
+                symbolsArray,
+                Extensions.GetCustomDataTypeFromSymbols(symbolsArray),
+                startAlgoTz,
+                endAlgoTz,
+                resolution,
+                fillForward,
+                extendedMarketHours,
+                dataMappingMode,
+                dataNormalizationMode,
+                contractDepthOffset);
         }
 
         /// <summary>
@@ -982,8 +992,18 @@ namespace QuantConnect.Algorithm
             bool? fillForward = null, bool? extendedMarketHours = null, DataMappingMode? dataMappingMode = null,
             DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null)
         {
-            return CreateBarCountHistoryRequests(symbols, Extensions.GetCustomDataTypeFromSymbols(symbols.ToArray()), periods, resolution, fillForward, extendedMarketHours, dataMappingMode,
-                dataNormalizationMode, contractDepthOffset);
+            // Materialize the symbols to avoid multiple enumeration
+            var symbolsArray = symbols.ToArray();
+            return CreateBarCountHistoryRequests(
+                symbolsArray,
+                Extensions.GetCustomDataTypeFromSymbols(symbolsArray),
+                periods,
+                resolution,
+                fillForward,
+                extendedMarketHours,
+                dataMappingMode,
+                dataNormalizationMode,
+                contractDepthOffset);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -1021,15 +1021,18 @@ namespace QuantConnect.Algorithm
                     return Enumerable.Empty<HistoryRequest>();
                 }
 
-                var config = configs.First();
-                requestedType ??= config.Type;
-                var res = GetResolution(symbol, resolution, requestedType);
-                var exchange = GetExchangeHours(symbol, requestedType);
-                var start = _historyRequestFactory.GetStartTimeAlgoTz(symbol, periods, res, exchange, config.DataTimeZone, config.Type, extendedMarketHours);
-                var end = Time;
+                return configs.Select(config =>
+                {
+                    var type = requestedType ?? config.Type;
+                    var res = GetResolution(symbol, resolution, type);
+                    var exchange = GetExchangeHours(symbol, type);
+                    var start = _historyRequestFactory.GetStartTimeAlgoTz(symbol, periods, res, exchange, config.DataTimeZone,
+                        config.Type, extendedMarketHours);
+                    var end = Time;
 
-                return configs.Select(config => _historyRequestFactory.CreateHistoryRequest(config, start, end, exchange, res, fillForward,
-                    extendedMarketHours, dataMappingMode, dataNormalizationMode, contractDepthOffset));
+                    return _historyRequestFactory.CreateHistoryRequest(config, start, end, exchange, res, fillForward,
+                        extendedMarketHours, dataMappingMode, dataNormalizationMode, contractDepthOffset);
+                });
             });
         }
 

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -415,62 +415,135 @@ def getTickHistory(algorithm, symbol, start, end):
             Assert.AreEqual(expectedCount == 1 ? TickType.Trade : TickType.Quote, _testHistoryProvider.HistryRequests.First().TickType);
         }
 
-        [TestCase(Resolution.Second, Language.CSharp, true)]
-        [TestCase(Resolution.Minute, Language.CSharp, true)]
-        [TestCase(Resolution.Hour, Language.CSharp, true)]
-        [TestCase(Resolution.Daily, Language.CSharp, true)]
-        [TestCase(Resolution.Second, Language.Python, true)]
-        [TestCase(Resolution.Minute, Language.Python, true)]
-        [TestCase(Resolution.Hour, Language.Python, true)]
-        [TestCase(Resolution.Daily, Language.Python, true)]
-        [TestCase(Resolution.Second, Language.CSharp, false)]
-        [TestCase(Resolution.Minute, Language.CSharp, false)]
-        [TestCase(Resolution.Hour, Language.CSharp, false)]
-        [TestCase(Resolution.Daily, Language.CSharp, false)]
-        [TestCase(Resolution.Second, Language.Python, false)]
-        [TestCase(Resolution.Minute, Language.Python, false)]
-        [TestCase(Resolution.Hour, Language.Python, false)]
-        [TestCase(Resolution.Daily, Language.Python, false)]
-        public void BarCountHistoryRequestIsCorrectlyBuilt(Resolution resolution, Language language, bool symbolAlreadyAdded)
+        private static IEnumerable<TestCaseData> BarCountHistoryRequestTestCases
         {
-            _algorithm.SetStartDate(2013, 10, 07);
+            get
+            {
+                var spyDate = new DateTime(2013, 10, 07);
 
-            var symbol = Symbols.SPY;
+                yield return new TestCaseData(Resolution.Second, Language.CSharp, Symbols.SPY, true, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Minute, Language.CSharp, Symbols.SPY, true, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Hour, Language.CSharp, Symbols.SPY, true, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Daily, Language.CSharp, Symbols.SPY, true, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Second, Language.Python, Symbols.SPY, true, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Minute, Language.Python, Symbols.SPY, true, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Hour, Language.Python, Symbols.SPY, true, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Daily, Language.Python, Symbols.SPY, true, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Second, Language.CSharp, Symbols.SPY, false, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Minute, Language.CSharp, Symbols.SPY, false, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Hour, Language.CSharp, Symbols.SPY, false, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Daily, Language.CSharp, Symbols.SPY, false, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Second, Language.Python, Symbols.SPY, false, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Minute, Language.Python, Symbols.SPY, false, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Hour, Language.Python, Symbols.SPY, false, spyDate, null, false);
+                yield return new TestCaseData(Resolution.Daily, Language.Python, Symbols.SPY, false, spyDate, null, false);
+
+                yield return new TestCaseData(Resolution.Second, Language.CSharp, Symbols.SPY, true, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Minute, Language.CSharp, Symbols.SPY, true, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Hour, Language.CSharp, Symbols.SPY, true, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Daily, Language.CSharp, Symbols.SPY, true, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Second, Language.Python, Symbols.SPY, true, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Minute, Language.Python, Symbols.SPY, true, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Hour, Language.Python, Symbols.SPY, true, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Daily, Language.Python, Symbols.SPY, true, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Second, Language.CSharp, Symbols.SPY, false, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Minute, Language.CSharp, Symbols.SPY, false, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Hour, Language.CSharp, Symbols.SPY, false, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Daily, Language.CSharp, Symbols.SPY, false, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Second, Language.Python, Symbols.SPY, false, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Minute, Language.Python, Symbols.SPY, false, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Hour, Language.Python, Symbols.SPY, false, spyDate, null, true);
+                yield return new TestCaseData(Resolution.Daily, Language.Python, Symbols.SPY, false, spyDate, null, true);
+
+                var spxCanonicalOption = Symbol.CreateCanonicalOption(Symbols.SPX);
+                var spxDate = new DateTime(2021, 01, 12);
+
+                yield return new TestCaseData(Resolution.Daily, Language.CSharp, spxCanonicalOption, true, spxDate, null, true);
+                yield return new TestCaseData(Resolution.Daily, Language.Python, spxCanonicalOption, true, spxDate, null, true);
+                yield return new TestCaseData(null, Language.CSharp, spxCanonicalOption, true, spxDate, Resolution.Daily, true);
+                yield return new TestCaseData(null, Language.Python, spxCanonicalOption, true, spxDate, Resolution.Daily, true);
+                yield return new TestCaseData(Resolution.Daily, Language.CSharp, spxCanonicalOption, false, spxDate, null, true);
+                yield return new TestCaseData(Resolution.Daily, Language.Python, spxCanonicalOption, false, spxDate, null, true);
+                yield return new TestCaseData(null, Language.CSharp, spxCanonicalOption, false, spxDate, Resolution.Daily, true);
+                yield return new TestCaseData(null, Language.Python, spxCanonicalOption, false, spxDate, Resolution.Daily, true);
+            }
+        }
+
+        [TestCaseSource(nameof(BarCountHistoryRequestTestCases))]
+        public void BarCountHistoryRequestIsCorrectlyBuilt(Resolution? resolution, Language language, Symbol symbol,
+            bool symbolAlreadyAdded, DateTime dateTime, Resolution? defaultResolution, bool multiSymbol)
+        {
+            _algorithm.SetStartDate(dateTime);
+
             if (symbolAlreadyAdded)
             {
                 // it should not matter
-                _algorithm.AddEquity("SPY");
+                _algorithm.AddSecurity(symbol);
             }
 
             if (language == Language.CSharp)
             {
-                _algorithm.History(symbol, 10, resolution);
+                if (multiSymbol)
+                {
+                    _algorithm.History(new[] { symbol }, 10, resolution);
+                }
+                else
+                {
+                    _algorithm.History(symbol, 10, resolution);
+                }
             }
             else
             {
                 using (Py.GIL())
                 {
                     _algorithm.SetPandasConverter();
-                    _algorithm.History(symbol.ToPython(), 10, resolution);
+                    if (multiSymbol)
+                    {
+                        using var pySymbols = new[] { symbol }.ToPyListUnSafe();
+                        _algorithm.History(pySymbols, 10, resolution);
+
+                        pySymbols[0].Dispose();
+                    }
+                    else
+                    {
+                        using var pySymbol = symbol.ToPython();
+                        _algorithm.History(pySymbol, 10, resolution);
+                    }
                 }
             }
 
             Resolution? fillForwardResolution = null;
             if (resolution != Resolution.Tick)
             {
-                fillForwardResolution = resolution;
+                fillForwardResolution = resolution ?? defaultResolution;
             }
 
-            var expectedCount = resolution == Resolution.Hour || resolution == Resolution.Daily ? 1 : 2;
-            Assert.AreEqual(expectedCount, _testHistoryProvider.HistryRequests.Count);
-            Assert.AreEqual(Symbols.SPY, _testHistoryProvider.HistryRequests.First().Symbol);
-            Assert.AreEqual(resolution, _testHistoryProvider.HistryRequests.First().Resolution);
-            Assert.IsFalse(_testHistoryProvider.HistryRequests.First().IncludeExtendedMarketHours);
-            Assert.IsFalse(_testHistoryProvider.HistryRequests.First().IsCustomData);
-            Assert.AreEqual(fillForwardResolution, _testHistoryProvider.HistryRequests.First().FillForwardResolution);
-            Assert.AreEqual(DataNormalizationMode.Adjusted, _testHistoryProvider.HistryRequests.First().DataNormalizationMode);
+            if (symbol.SecurityType == SecurityType.Equity)
+            {
+                var expectedCount = resolution == Resolution.Hour || resolution == Resolution.Daily ? 1 : 2;
+                Assert.AreEqual(expectedCount, _testHistoryProvider.HistryRequests.Count);
+                var request = _testHistoryProvider.HistryRequests.First();
+                Assert.AreEqual(symbol, request.Symbol);
+                Assert.AreEqual(resolution, request.Resolution);
+                Assert.IsFalse(request.IncludeExtendedMarketHours);
+                Assert.IsFalse(request.IsCustomData);
+                Assert.AreEqual(fillForwardResolution, request.FillForwardResolution);
+                Assert.AreEqual(DataNormalizationMode.Adjusted, request.DataNormalizationMode);
 
-            Assert.AreEqual(expectedCount == 1 ? TickType.Trade : TickType.Quote, _testHistoryProvider.HistryRequests.First().TickType);
+                Assert.AreEqual(expectedCount == 1 ? TickType.Trade : TickType.Quote, request.TickType);
+            }
+            else if (symbol.SecurityType == SecurityType.IndexOption)
+            {
+                Assert.AreEqual(1, _testHistoryProvider.HistryRequests.Count);
+                var request = _testHistoryProvider.HistryRequests.Single();
+                Assert.AreEqual(symbol, request.Symbol);
+                Assert.AreEqual(resolution ?? defaultResolution, request.Resolution);
+                Assert.AreEqual(typeof(OptionUniverse), request.DataType);
+                Assert.IsFalse(request.IncludeExtendedMarketHours);
+                Assert.IsFalse(request.IsCustomData);
+                // For OptionUniverse, exchange and data time zones are set to the same value
+                Assert.AreEqual(request.ExchangeHours.TimeZone, request.DataTimeZone);
+            }
         }
 
         [TestCase(Language.CSharp, true)]
@@ -783,12 +856,15 @@ def getOpenInterestHistory(algorithm, symbol, start, end, resolution):
             {
                 var result = _algorithm.History(new[] { optionSymbol }, start, end, historyResolution, fillForward:false).ToList();
 
-                Assert.AreEqual(53, result.Count);
-                Assert.IsTrue(result.Any(slice => slice.ContainsKey(optionSymbol)));
+                Assert.Multiple(() =>
+                {
+                    Assert.AreEqual(53, result.Count);
+                    Assert.IsTrue(result.Any(slice => slice.ContainsKey(optionSymbol)));
 
-                var openInterests = result.Select(slice => slice.Get(typeof(OpenInterest)) as DataDictionary<OpenInterest>).Where(dataDictionary => dataDictionary.Count > 0).ToList();
+                    var openInterests = result.Select(slice => slice.Get(typeof(OpenInterest)) as DataDictionary<OpenInterest>).Where(dataDictionary => dataDictionary.Count > 0).ToList();
 
-                Assert.AreEqual(0, openInterests.Count);
+                    Assert.AreEqual(0, openInterests.Count);
+                });
             }
             else
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Infer data type from configs in bar count history requests: when requesting history for a list of symbols, the requested data type was assumed to be `BaseData` instead of infering or getting it from the matched/created subscripton data configurations.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #8343 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
