### PR TITLE
Fix bug ImmediateExecutionModel when using Crypto

### DIFF
--- a/Algorithm.CSharp/ImmediateExecutionModelWorksWithBinanceFeeModel.cs
+++ b/Algorithm.CSharp/ImmediateExecutionModelWorksWithBinanceFeeModel.cs
@@ -24,6 +24,11 @@ using System.Collections.Generic;
 
 namespace QuantConnect.Algorithm.CSharp
 {
+    /// <summary>
+    /// Regression algorithm to test ImmediateExecutionModel places orders with the
+    /// correct quantity (taking into account the fee's) so that the fill quantity
+    /// is the expected one.
+    /// </summary>
     public class ImmediateExecutionModelWorksWithBinanceFeeModel: QCAlgorithm, IRegressionAlgorithmDefinition
     {
         public override void Initialize()

--- a/Algorithm.CSharp/ImmediateExecutionModelWorksWithBinanceFeeModel.cs
+++ b/Algorithm.CSharp/ImmediateExecutionModelWorksWithBinanceFeeModel.cs
@@ -1,0 +1,114 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class ImmediateExecutionModelWorksWithBinanceFeeModel: QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2022, 12, 13);
+            SetEndDate(2022, 12, 14);
+            SetAccountCurrency("BUSD");
+            SetCash("BUSD", 100000, 1);
+
+            UniverseSettings.Resolution = Resolution.Minute;
+
+            var symbols = new List<Symbol>() { QuantConnect.Symbol.Create("BTCBUSD", SecurityType.Crypto, Market.Binance) };
+            SetUniverseSelection(new ManualUniverseSelectionModel(symbols));
+            SetAlpha(new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, TimeSpan.FromMinutes(20), 0.025, null));
+
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel(Resolution.Minute));
+            SetExecution(new ImmediateExecutionModel());
+            SetBrokerageModel(Brokerages.BrokerageName.Binance, AccountType.Margin);
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            if (orderEvent.Status == OrderStatus.Filled)
+            {
+                if (Math.Abs(orderEvent.Quantity - 5.8m) > 0.01m)
+                {
+                    throw new RegressionTestException($"The expected quantity was {5.8m} but the quantity from the order was {orderEvent.Quantity}");
+                }
+            }
+        }
+
+        public bool CanRunLocally => true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 2882;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 60;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000.00"},
+            {"End Equity", "103411.39"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "BUSD99.75"},
+            {"Estimated Strategy Capacity", "BUSD600000.00"},
+            {"Lowest Capacity Asset", "BTCBUSD 18N"},
+            {"Portfolio Turnover", "48.18%"},
+            {"OrderListHash", "2ad07f12d7c80fd4a904269d62794e9e"}
+        };
+    }
+}

--- a/Algorithm.Python/ImmediateExecutionModelWorksWithBinanceFeeModel.py
+++ b/Algorithm.Python/ImmediateExecutionModelWorksWithBinanceFeeModel.py
@@ -1,9 +1,21 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # region imports
 from AlgorithmImports import *
 from datetime import timezone
 from Execution.ImmediateExecutionModel import ImmediateExecutionModel
 from QuantConnect.Orders import OrderEvent
-
 # endregion
 
 class ImmediateExecutionModelWorksWithBinanceFeeModel(QCAlgorithm):
@@ -23,7 +35,7 @@ class ImmediateExecutionModelWorksWithBinanceFeeModel(QCAlgorithm):
         self.set_universe_selection(ManualUniverseSelectionModel(symbols))
         self.set_alpha(ConstantAlphaModel(InsightType.PRICE, InsightDirection.UP, timedelta(minutes = 20), 0.025, None))
 
-        self.set_portfolio_construction(CustomPortfolioConstructionModel())
+        self.set_portfolio_construction(EqualWeightingPortfolioConstructionModel(Resolution.MINUTE))
         self.set_execution(ImmediateExecutionModel())
         
         
@@ -33,20 +45,3 @@ class ImmediateExecutionModelWorksWithBinanceFeeModel(QCAlgorithm):
         if order_event.status == OrderStatus.FILLED:
             if abs(order_event.quantity - 5.8) > 0.01:
                 raise Exception(f"The expected quantity was {5.8} but the quantity from the order was {order_event.quantity}")
-
-class CustomPortfolioConstructionModel(EqualWeightingPortfolioConstructionModel):
-    def __init__(self):
-        super().__init__(Resolution.DAILY)
-
-    def create_targets(self, algorithm: QCAlgorithm, insights: List[Insight]) -> List[IPortfolioTarget]:
-        targets = super().create_targets(algorithm, insights)
-        return CustomPortfolioConstructionModel.add_p_portfolio_targets_tags(targets)
-
-    @staticmethod
-    def generate_portfolio_target_tag(target: IPortfolioTarget) -> str:
-        return f"Portfolio target tag: {target.symbol} - {target.quantity}"
-
-    @staticmethod
-    def add_p_portfolio_targets_tags(targets: List[IPortfolioTarget]) -> List[IPortfolioTarget]:
-        return [PortfolioTarget(target.symbol, target.quantity, CustomPortfolioConstructionModel.generate_portfolio_target_tag(target))
-                for target in targets]

--- a/Algorithm.Python/ImmediateExecutionModelWorksWithBinanceFeeModel.py
+++ b/Algorithm.Python/ImmediateExecutionModelWorksWithBinanceFeeModel.py
@@ -17,6 +17,11 @@ from Execution.ImmediateExecutionModel import ImmediateExecutionModel
 from QuantConnect.Orders import OrderEvent
 # endregion
 
+### <summary>
+### Regression algorithm to test ImmediateExecutionModel places orders with the
+### correct quantity (taking into account the fee's) so that the fill quantity
+### is the expected one.
+### </summary>
 class ImmediateExecutionModelWorksWithBinanceFeeModel(QCAlgorithm):
 
     def Initialize(self):

--- a/Algorithm.Python/ImmediateExecutionModelWorksWithBinanceFeeModel.py
+++ b/Algorithm.Python/ImmediateExecutionModelWorksWithBinanceFeeModel.py
@@ -48,4 +48,4 @@ class ImmediateExecutionModelWorksWithBinanceFeeModel(QCAlgorithm):
     def on_order_event(self, order_event: OrderEvent) -> None:
         if order_event.status == OrderStatus.FILLED:
             if abs(order_event.quantity - 5.8) > 0.01:
-                raise Exception(f"The expected quantity was {5.8} but the quantity from the order was {order_event.quantity}")
+                raise Exception(f"The expected quantity was 5.8 but the quantity from the order was {order_event.quantity}")

--- a/Algorithm.Python/ImmediateExecutionModelWorksWithBinanceFeeModel.py
+++ b/Algorithm.Python/ImmediateExecutionModelWorksWithBinanceFeeModel.py
@@ -1,0 +1,52 @@
+# region imports
+from AlgorithmImports import *
+from datetime import timezone
+from Execution.ImmediateExecutionModel import ImmediateExecutionModel
+from QuantConnect.Orders import OrderEvent
+
+# endregion
+
+class ImmediateExecutionModelWorksWithBinanceFeeModel(QCAlgorithm):
+
+    def Initialize(self):
+        # *** initial configurations and backtest ***
+        self.SetStartDate(2022, 12, 13)  # Set Start Date
+        self.SetEndDate(2022, 12, 14)  # Set End Date
+        self.SetAccountCurrency("BUSD") # Set Account Currency
+        self.SetCash("BUSD", 100000, 1)  # Set Strategy Cash
+
+        self.universe_settings.resolution = Resolution.MINUTE
+
+        symbols = [ Symbol.create("BTCBUSD", SecurityType.CRYPTO, Market.BINANCE) ]
+
+        # set algorithm framework models
+        self.set_universe_selection(ManualUniverseSelectionModel(symbols))
+        self.set_alpha(ConstantAlphaModel(InsightType.PRICE, InsightDirection.UP, timedelta(minutes = 20), 0.025, None))
+
+        self.set_portfolio_construction(CustomPortfolioConstructionModel())
+        self.set_execution(ImmediateExecutionModel())
+        
+        
+        self.SetBrokerageModel(BrokerageName.Binance, AccountType.Margin)
+    
+    def on_order_event(self, order_event: OrderEvent) -> None:
+        if order_event.status == OrderStatus.FILLED:
+            if abs(order_event.quantity - 5.8) > 0.01:
+                raise Exception(f"The expected quantity was {5.8} but the quantity from the order was {order_event.quantity}")
+
+class CustomPortfolioConstructionModel(EqualWeightingPortfolioConstructionModel):
+    def __init__(self):
+        super().__init__(Resolution.DAILY)
+
+    def create_targets(self, algorithm: QCAlgorithm, insights: List[Insight]) -> List[IPortfolioTarget]:
+        targets = super().create_targets(algorithm, insights)
+        return CustomPortfolioConstructionModel.add_p_portfolio_targets_tags(targets)
+
+    @staticmethod
+    def generate_portfolio_target_tag(target: IPortfolioTarget) -> str:
+        return f"Portfolio target tag: {target.symbol} - {target.quantity}"
+
+    @staticmethod
+    def add_p_portfolio_targets_tags(targets: List[IPortfolioTarget]) -> List[IPortfolioTarget]:
+        return [PortfolioTarget(target.symbol, target.quantity, CustomPortfolioConstructionModel.generate_portfolio_target_tag(target))
+                for target in targets]

--- a/Algorithm.Python/ImmediateExecutionModelWorksWithBinanceFeeModel.py
+++ b/Algorithm.Python/ImmediateExecutionModelWorksWithBinanceFeeModel.py
@@ -13,7 +13,6 @@
 
 # region imports
 from AlgorithmImports import *
-from datetime import timezone
 from Execution.ImmediateExecutionModel import ImmediateExecutionModel
 from QuantConnect.Orders import OrderEvent
 # endregion

--- a/Algorithm/Execution/ImmediateExecutionModel.cs
+++ b/Algorithm/Execution/ImmediateExecutionModel.cs
@@ -17,8 +17,6 @@ using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Algorithm.Framework.Portfolio;
-using QuantConnect.Orders.Fees;
-using QuantConnect.Securities.Crypto;
 
 namespace QuantConnect.Algorithm.Framework.Execution
 {

--- a/Algorithm/Execution/ImmediateExecutionModel.cs
+++ b/Algorithm/Execution/ImmediateExecutionModel.cs
@@ -18,6 +18,7 @@ using QuantConnect.Securities;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Algorithm.Framework.Portfolio;
 using QuantConnect.Orders.Fees;
+using QuantConnect.Securities.Crypto;
 
 namespace QuantConnect.Algorithm.Framework.Execution
 {
@@ -50,10 +51,12 @@ namespace QuantConnect.Algorithm.Framework.Execution
                     // Adjust the order quantity taking into account the fee's
                     if (security.Symbol.SecurityType == SecurityType.Crypto)
                     {
-                        var marketOrder = new MarketOrder(security.Symbol, quantity, security.LocalTime.ConvertToUtc(security.Exchange.TimeZone));
-                        var orderFee = security.FeeModel.GetOrderFee(new OrderFeeParameters(security, marketOrder)).Value;
-                        var feesInAccountCurrency = algorithm.Portfolio.CashBook.ConvertToAccountCurrency(orderFee).Amount;
-                        quantity += orderFee.Amount;
+                        var orderFee = Extensions.GetMarketOrderFees(security, quantity, security.LocalTime.ConvertToUtc(security.Exchange.TimeZone), out _);
+                        Crypto.DecomposeCurrencyPair(security.Symbol, security.SymbolProperties, out var baseCurrency, out _);
+                        if (baseCurrency == orderFee.Currency)
+                        {
+                            quantity += orderFee.Amount;
+                        }
                     }
 
                     if (quantity != 0)

--- a/Algorithm/Execution/ImmediateExecutionModel.cs
+++ b/Algorithm/Execution/ImmediateExecutionModel.cs
@@ -46,18 +46,7 @@ namespace QuantConnect.Algorithm.Framework.Execution
                     var security = algorithm.Securities[target.Symbol];
 
                     // calculate remaining quantity to be ordered
-                    var quantity = OrderSizing.GetUnorderedQuantity(algorithm, target, security);
-
-                    // Adjust the order quantity taking into account the fee's
-                    if (security.Symbol.SecurityType == SecurityType.Crypto)
-                    {
-                        var orderFee = Extensions.GetMarketOrderFees(security, quantity, security.LocalTime.ConvertToUtc(security.Exchange.TimeZone), out _);
-                        Crypto.DecomposeCurrencyPair(security.Symbol, security.SymbolProperties, out var baseCurrency, out _);
-                        if (baseCurrency == orderFee.Currency)
-                        {
-                            quantity += orderFee.Amount;
-                        }
-                    }
+                    var quantity = OrderSizing.GetUnorderedQuantity(algorithm, target, security, true);
 
                     if (quantity != 0)
                     {

--- a/Algorithm/Execution/ImmediateExecutionModel.py
+++ b/Algorithm/Execution/ImmediateExecutionModel.py
@@ -33,14 +33,7 @@ class ImmediateExecutionModel(ExecutionModel):
             for target in self.targets_collection.order_by_margin_impact(algorithm):
                 security = algorithm.securities[target.symbol]
                 # calculate remaining quantity to be ordered
-                quantity = OrderSizing.get_unordered_quantity(algorithm, target, security)
-
-                # adjust the order quantity taking into account the fee's
-                if security.symbol.security_type == SecurityType.CRYPTO:
-                    order_fee = Extensions.get_market_order_fees(security, quantity, security.local_time.astimezone(timezone.utc), None)[0]
-                    base_currency = Crypto.decompose_currency_pair(security.symbol, security.symbol_properties, None, None)[0]
-                    if base_currency == order_fee.currency:
-                        quantity += order_fee.amount
+                quantity = OrderSizing.get_unordered_quantity(algorithm, target, security, True)
 
                 if quantity != 0:
                     above_minimum_portfolio = BuyingPowerModelExtensions.above_minimum_order_margin_portfolio_percentage(

--- a/Algorithm/Execution/ImmediateExecutionModel.py
+++ b/Algorithm/Execution/ImmediateExecutionModel.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 from AlgorithmImports import *
-from datetime import timezone
 
 class ImmediateExecutionModel(ExecutionModel):
     '''Provides an implementation of IExecutionModel that immediately submits market orders to achieve the desired portfolio targets'''

--- a/Algorithm/Execution/ImmediateExecutionModel.py
+++ b/Algorithm/Execution/ImmediateExecutionModel.py
@@ -33,9 +33,13 @@ class ImmediateExecutionModel(ExecutionModel):
                 security = algorithm.securities[target.symbol]
                 # calculate remaining quantity to be ordered
                 quantity = OrderSizing.get_unordered_quantity(algorithm, target, security)
-                market_order = MarketOrder(security.symbol, quantity, security.local_time)
-                order_fee = security.fee_model.get_order_fee(OrderFeeParameters(security, market_order)).value
-                quantity += order_fee.amount
+
+                # adjust the order quantity taking into account the fee's
+                if security.symbol.security_type == SecurityType.CRYPTO:
+                    market_order = MarketOrder(security.symbol, quantity, security.local_time)
+                    order_fee = security.fee_model.get_order_fee(OrderFeeParameters(security, market_order)).value
+                    quantity += order_fee.amount
+
                 current_holdings = algorithm.Portfolio[target.Symbol].Quantity
                 if quantity != 0:
                     above_minimum_portfolio = BuyingPowerModelExtensions.above_minimum_order_margin_portfolio_percentage(

--- a/Algorithm/Execution/ImmediateExecutionModel.py
+++ b/Algorithm/Execution/ImmediateExecutionModel.py
@@ -40,7 +40,6 @@ class ImmediateExecutionModel(ExecutionModel):
                     order_fee = security.fee_model.get_order_fee(OrderFeeParameters(security, market_order)).value
                     quantity += order_fee.amount
 
-                current_holdings = algorithm.Portfolio[target.Symbol].Quantity
                 if quantity != 0:
                     above_minimum_portfolio = BuyingPowerModelExtensions.above_minimum_order_margin_portfolio_percentage(
                         security.buying_power_model,

--- a/Algorithm/Execution/ImmediateExecutionModel.py
+++ b/Algorithm/Execution/ImmediateExecutionModel.py
@@ -33,6 +33,10 @@ class ImmediateExecutionModel(ExecutionModel):
                 security = algorithm.securities[target.symbol]
                 # calculate remaining quantity to be ordered
                 quantity = OrderSizing.get_unordered_quantity(algorithm, target, security)
+                market_order = MarketOrder(security.symbol, quantity, security.local_time)
+                order_fee = security.fee_model.get_order_fee(OrderFeeParameters(security, market_order)).value
+                quantity += order_fee.amount
+                current_holdings = algorithm.Portfolio[target.Symbol].Quantity
                 if quantity != 0:
                     above_minimum_portfolio = BuyingPowerModelExtensions.above_minimum_order_margin_portfolio_percentage(
                         security.buying_power_model,

--- a/Algorithm/Execution/ImmediateExecutionModel.py
+++ b/Algorithm/Execution/ImmediateExecutionModel.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 from AlgorithmImports import *
+from datetime import timezone
 
 class ImmediateExecutionModel(ExecutionModel):
     '''Provides an implementation of IExecutionModel that immediately submits market orders to achieve the desired portfolio targets'''
@@ -36,9 +37,10 @@ class ImmediateExecutionModel(ExecutionModel):
 
                 # adjust the order quantity taking into account the fee's
                 if security.symbol.security_type == SecurityType.CRYPTO:
-                    market_order = MarketOrder(security.symbol, quantity, security.local_time)
-                    order_fee = security.fee_model.get_order_fee(OrderFeeParameters(security, market_order)).value
-                    quantity += order_fee.amount
+                    order_fee = Extensions.get_market_order_fees(security, quantity, security.local_time.astimezone(timezone.utc), None)[0]
+                    base_currency = Crypto.decompose_currency_pair(security.symbol, security.symbol_properties, None, None)[0]
+                    if base_currency == order_fee.currency:
+                        quantity += order_fee.amount
 
                 if quantity != 0:
                     above_minimum_portfolio = BuyingPowerModelExtensions.above_minimum_order_margin_portfolio_percentage(

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -59,6 +59,7 @@ using QuantConnect.Securities.FutureOption;
 using QuantConnect.Securities.Option;
 using QuantConnect.Statistics;
 using Newtonsoft.Json.Linq;
+using QuantConnect.Orders.Fees;
 
 namespace QuantConnect
 {
@@ -4376,6 +4377,19 @@ namespace QuantConnect
         public static bool IsCustomDataType(Symbol symbol, Type type)
         {
             return type.Namespace != typeof(Bar).Namespace || Extensions.GetCustomDataTypeFromSymbols(new Symbol[] { symbol }) != null;
+        }
+
+        /// <summary>
+        /// Returns the amount of fee's charged by executing a market order with the given arguments
+        /// </summary>
+        /// <param name="security">Security for which we would like to make a market order</param>
+        /// <param name="quantity">Quantity of the security we are seeking to trade</param>
+        /// <param name="time">Time the order was placed</param>
+        /// <param name="marketOrder">This out parameter will contain the market order constructed</param>
+        public static CashAmount GetMarketOrderFees(Security security, decimal quantity, DateTime time, out MarketOrder marketOrder)
+        {
+            marketOrder = new MarketOrder(security.Symbol, quantity, time);
+            return security.FeeModel.GetOrderFee(new OrderFeeParameters(security, marketOrder)).Value;
         }
 
         private static Symbol ConvertToSymbol(PyObject item, bool dispose)

--- a/Common/Orders/OrderSizing.cs
+++ b/Common/Orders/OrderSizing.cs
@@ -96,7 +96,7 @@ namespace QuantConnect.Orders
             var quantity = target.Quantity - holdings - openOrderQuantity;
 
             // Adjust the order quantity taking into account the fee's
-            if (accountForFees && security.Symbol.SecurityType == SecurityType.Crypto)
+            if (accountForFees && security.Symbol.SecurityType == SecurityType.Crypto && quantity > 0)
             {
                 var orderFee = Extensions.GetMarketOrderFees(security, quantity, algorithm.UtcTime, out _);
                 var baseCurrency = ((Crypto)security).BaseCurrency.Symbol;

--- a/Common/Orders/OrderSizing.cs
+++ b/Common/Orders/OrderSizing.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using QuantConnect.Algorithm.Framework.Portfolio;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
+using QuantConnect.Securities.Crypto;
 
 namespace QuantConnect.Orders
 {
@@ -84,13 +85,26 @@ namespace QuantConnect.Orders
         /// <param name="algorithm">The algorithm instance</param>
         /// <param name="target">The portfolio target</param>
         /// <param name="security">The target security</param>
+        /// <param name="accountForFees">True for taking into account the fee's in the order quantity.
+        /// False, otherwise.</param>
         /// <returns>The signed remaining quantity to be ordered</returns>
-        public static decimal GetUnorderedQuantity(IAlgorithm algorithm, IPortfolioTarget target, Security security)
+        public static decimal GetUnorderedQuantity(IAlgorithm algorithm, IPortfolioTarget target, Security security, bool accountForFees = false)
         {
             var holdings = security.Holdings.Quantity;
             var openOrderQuantity = algorithm.Transactions.GetOpenOrderTickets(target.Symbol)
                 .Aggregate(0m, (d, t) => d + t.Quantity - t.QuantityFilled);
             var quantity = target.Quantity - holdings - openOrderQuantity;
+
+            // Adjust the order quantity taking into account the fee's
+            if (accountForFees && security.Symbol.SecurityType == SecurityType.Crypto)
+            {
+                var orderFee = Extensions.GetMarketOrderFees(security, quantity, algorithm.UtcTime, out _);
+                var baseCurrency = ((Crypto)security).BaseCurrency.Symbol;
+                if (baseCurrency == orderFee.Currency)
+                {
+                    quantity += orderFee.Amount;
+                }
+            }
 
             return AdjustByLotSize(security, quantity);
         }

--- a/Common/Securities/SecurityHolding.cs
+++ b/Common/Securities/SecurityHolding.cs
@@ -485,13 +485,11 @@ namespace QuantConnect.Securities
             }
 
             // this is in the account currency
-            var marketOrder = new MarketOrder(_security.Symbol, -quantityToUse, _security.LocalTime.ConvertToUtc(_security.Exchange.TimeZone));
+            var orderFee = Extensions.GetMarketOrderFees(_security, -quantityToUse, _security.LocalTime.ConvertToUtc(_security.Exchange.TimeZone), out var marketOrder);
 
             var feesInAccountCurrency = 0m;
             if (includeFees)
             {
-                var orderFee = _security.FeeModel.GetOrderFee(
-                    new OrderFeeParameters(_security, marketOrder)).Value;
                 feesInAccountCurrency = _currencyConverter.ConvertToAccountCurrency(orderFee).Amount;
             }
 

--- a/Tests/Algorithm/Framework/Execution/ImmediateExecutionModelTests.cs
+++ b/Tests/Algorithm/Framework/Execution/ImmediateExecutionModelTests.cs
@@ -28,7 +28,6 @@ using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Securities;
-using QuantConnect.Statistics;
 using QuantConnect.Tests.Common.Data.UniverseSelection;
 using QuantConnect.Tests.Engine.DataFeeds;
 

--- a/Tests/Algorithm/Framework/Execution/ImmediateExecutionModelTests.cs
+++ b/Tests/Algorithm/Framework/Execution/ImmediateExecutionModelTests.cs
@@ -216,42 +216,6 @@ namespace QuantConnect.Tests.Algorithm.Framework.Execution
             Assert.AreEqual(security.SymbolProperties.LotSize * side, actualOrdersSubmitted.Single().Quantity);
         }
 
-        [TestCase(Language.CSharp)]
-        [TestCase(Language.Python)]
-        public void QuantityTakesIntoAccountOrderFee(Language language)
-        {
-            var parameter = new RegressionTests.AlgorithmStatisticsTestParameters("ImmediateExecutionModelWorksWithBinanceFeeModel",
-                new Dictionary<string, string> {
-                    {PerformanceMetrics.TotalOrders, "1"},
-                    {"Average Win", "0%"},
-                    {"Average Loss", "0%"},
-                    {"Compounding Annual Return", "0%"},
-                    {"Drawdown", "0%"},
-                    {"Expectancy", "0"},
-                    {"Net Profit", "0%"},
-                    {"Sharpe Ratio", "0"},
-                    {"Probabilistic Sharpe Ratio", "0%"},
-                    {"Loss Rate", "0%"},
-                    {"Win Rate", "0%"},
-                    {"Profit-Loss Ratio", "0"},
-                    {"Alpha", "0"},
-                    {"Beta", "0"},
-                    {"Annual Standard Deviation", "0"},
-                    {"Annual Variance", "0"},
-                    {"Information Ratio", "0"},
-                    {"Tracking Error", "0"},
-                    {"Treynor Ratio", "0"},
-                    {"Total Fees", "BUSD99.75"}
-                },
-                Language.Python,
-                AlgorithmStatus.Completed);
-
-            AlgorithmRunner.RunLocalBacktest(parameter.Algorithm,
-                parameter.Statistics,
-                parameter.Language,
-                parameter.ExpectedFinalStatus);
-        }
-
         private static IExecutionModel GetExecutionModel(Language language)
         {
             if (language == Language.Python)

--- a/Tests/Algorithm/Framework/Execution/ImmediateExecutionModelTests.cs
+++ b/Tests/Algorithm/Framework/Execution/ImmediateExecutionModelTests.cs
@@ -28,6 +28,7 @@ using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Securities;
+using QuantConnect.Statistics;
 using QuantConnect.Tests.Common.Data.UniverseSelection;
 using QuantConnect.Tests.Engine.DataFeeds;
 
@@ -213,6 +214,42 @@ namespace QuantConnect.Tests.Algorithm.Framework.Execution
 
             Assert.AreEqual(1, actualOrdersSubmitted.Count);
             Assert.AreEqual(security.SymbolProperties.LotSize * side, actualOrdersSubmitted.Single().Quantity);
+        }
+
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void QuantityTakesIntoAccountOrderFee(Language language)
+        {
+            var parameter = new RegressionTests.AlgorithmStatisticsTestParameters("ImmediateExecutionModelWorksWithBinanceFeeModel",
+                new Dictionary<string, string> {
+                    {PerformanceMetrics.TotalOrders, "1"},
+                    {"Average Win", "0%"},
+                    {"Average Loss", "0%"},
+                    {"Compounding Annual Return", "0%"},
+                    {"Drawdown", "0%"},
+                    {"Expectancy", "0"},
+                    {"Net Profit", "0%"},
+                    {"Sharpe Ratio", "0"},
+                    {"Probabilistic Sharpe Ratio", "0%"},
+                    {"Loss Rate", "0%"},
+                    {"Win Rate", "0%"},
+                    {"Profit-Loss Ratio", "0"},
+                    {"Alpha", "0"},
+                    {"Beta", "0"},
+                    {"Annual Standard Deviation", "0"},
+                    {"Annual Variance", "0"},
+                    {"Information Ratio", "0"},
+                    {"Tracking Error", "0"},
+                    {"Treynor Ratio", "0"},
+                    {"Total Fees", "BUSD99.75"}
+                },
+                Language.Python,
+                AlgorithmStatus.Completed);
+
+            AlgorithmRunner.RunLocalBacktest(parameter.Algorithm,
+                parameter.Statistics,
+                parameter.Language,
+                parameter.ExpectedFinalStatus);
         }
 
         private static IExecutionModel GetExecutionModel(Language language)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
If we use the binance fee model(and other crypto fee models as well), the fees are deducted from the coin/token we receive from the trade. As a result, the ImmediateExecutionModel doesn't purchase the correct quantity of each coin/token after the fees are deducted. This PR aims to solve that issue by calculating the expected order fee's and adjusting the order quantity when the security type is crypto.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #6793 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, the market orders done by the `ImmediateExecutionModel` will have the correct quantity so that once they are filled, the filled quantity matches with the target quantity
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created one regression test in both C# and Python that reproduces the bug mentioned in the GH issue and asserts the filled quantity is the expected one and just 1 order is placed, instead of two.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
