### PR TITLE
Remove duplicated keys in OpenInterestFutureUniverseSelectionModel

### DIFF
--- a/Algorithm.Framework/Selection/OpenInterestFutureUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/OpenInterestFutureUniverseSelectionModel.cs
@@ -75,13 +75,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
         protected override FutureFilterUniverse Filter(FutureFilterUniverse filter)
         {
             // Remove duplicated keys
-            var newFilter = filter;
-            var distinct = filter.Data.DistinctBy(x => x.Value);
-            if (filter.Data.Count() != distinct.Count())
-            {
-                newFilter = new FutureFilterUniverse(distinct, filter.LocalTime);
-            }
-            return newFilter.Contracts(FilterByOpenInterest(newFilter.ToDictionary(x => x, x => _marketHoursDatabase.GetEntry(x.ID.Market, x, x.ID.SecurityType))));
+            return filter.Contracts(FilterByOpenInterest(filter.DistinctBy(x => x).ToDictionary(x => x, x => _marketHoursDatabase.GetEntry(x.ID.Market, x, x.ID.SecurityType))));
         }
 
         /// <summary>

--- a/Algorithm.Framework/Selection/OpenInterestFutureUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/OpenInterestFutureUniverseSelectionModel.cs
@@ -70,11 +70,18 @@ namespace QuantConnect.Algorithm.Framework.Selection
         }
 
         /// <summary>
-        ///     Defines the future chain universe filter
+        /// Defines the future chain universe filter
         /// </summary>
         protected override FutureFilterUniverse Filter(FutureFilterUniverse filter)
         {
-            return filter.Contracts(FilterByOpenInterest(filter.ToDictionary(x => x, x => _marketHoursDatabase.GetEntry(x.ID.Market, x, x.ID.SecurityType))));
+            // Remove duplicated keys
+            var newFilter = filter;
+            var distinct = filter.Data.DistinctBy(x => x.Value);
+            if (filter.Data.Count() != distinct.Count())
+            {
+                newFilter = new FutureFilterUniverse(distinct, filter.LocalTime);
+            }
+            return newFilter.Contracts(FilterByOpenInterest(newFilter.ToDictionary(x => x, x => _marketHoursDatabase.GetEntry(x.ID.Market, x, x.ID.SecurityType))));
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
There are two open interest files from 6E Future at daily (and minute resolution) that maps to the same symbol in OpenInterestFutureUniverseSelectionModel, thus the method `OpenInterestFutureUniverseSelectionModel.Filter()` throws an exception when found this duplicated symbol. I added a LINQ method to remove those duplicated entries before creating a dictionary for the `OpenInterestFutureUniverseSelectionModel.FilterByOpenInterest()` method.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #8354 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, user's algorithms won't throw an exception when using 6E Future with OpenInterestFutureUniverseSelectionModel
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I reproduced the bug locally using the algo provided in the GH issue and asserted it didn't fail after the changes.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
