### PR TITLE
Fix bug in QuantBook.UniverseHistory() when using Monthly date rule

### DIFF
--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -730,7 +730,10 @@ namespace QuantConnect.Research
                 }
             };
 
-            return PerformSelection<IEnumerable<T2>, BaseDataCollection>(history, castDataPoint, start, endDate, dateRule);
+            Func<BaseDataCollection, DateTime> getTime = datapoint => datapoint.EndTime;
+
+
+            return PerformSelection<IEnumerable<T2>, BaseDataCollection>(history, castDataPoint, getTime, start, endDate, dateRule);
         }
 
         /// <summary>
@@ -803,7 +806,9 @@ namespace QuantConnect.Research
                     }), slice.UtcTime);
                 };
 
-                return GetDataFrame(PerformSelection<Slice, Slice>(history, processSlice, start, endDate, dateRule), convertedType);
+                Func<Slice, DateTime> getTime = slice => slice.Time;
+
+                return GetDataFrame(PerformSelection<Slice, Slice>(history, processSlice, getTime, start, endDate, dateRule), convertedType);
             }
 
             throw new ArgumentException($"Failed to convert given universe {universe}. Please provider a valid {nameof(Universe)}");
@@ -899,7 +904,9 @@ namespace QuantConnect.Research
                 return dataPoint;
             };
 
-            return PerformSelection<BaseDataCollection, BaseDataCollection>(history, processDataPoint, start, endDate, dateRule);
+            Func<BaseDataCollection, DateTime> getTime = dataPoint => dataPoint.EndTime;
+
+            return PerformSelection<BaseDataCollection, BaseDataCollection>(history, processDataPoint, getTime, start, endDate, dateRule);
         }
 
         /// <summary>
@@ -1049,109 +1056,48 @@ namespace QuantConnect.Research
             }, TaskScheduler.Current);
         }
 
-        private static IEnumerable<T1> PerformSelection<T1, T2>(IEnumerable<T2> history, Func<T2, T1> processDataPointFunction, DateTime start, DateTime endDate, IDateRule dateRule = null)
+        private static IEnumerable<T1> PerformSelection<T1, T2>(IEnumerable<T2> history, Func<T2, T1> processDataPointFunction, Func<T2, DateTime> getTime, DateTime start, DateTime endDate, IDateRule dateRule = null)
         {
             var targetDates = dateRule?.GetDates(start, endDate) ?? Enumerable.Empty<DateTime>();
-            dynamic previousDataPoint = null;
             var targetDatesQueue = new Queue<DateTime>(targetDates);
-            var lateDataPoints = new Queue<T2>();
+            T2 previousDataPoint = default;
 
-            // Sometimes, one of the target selection dates might not be present
-            // in history. Still, we find that once we have already passed the
-            // date. Thus, we need to process the last datapoint available and
-            // save the current datapoint (the one that is greater than the target
-            // date) to process it again after the queue is dequeued, and the next
-            // target date is on the top
-            var getMissingDataPoint = new Func<dynamic>(() =>
+            foreach (var dataPoint in history)
             {
-                if (!lateDataPoints.IsNullOrEmpty())
-                {
-                    return lateDataPoints.Dequeue();
-                }
-                else
-                {
-                    return null;
-                }
-            });
-
-            foreach (dynamic dataPoint in NextDataPoint<T2>(history, getMissingDataPoint))
-            {
-                // If no date rule has been provided we will process all the datapoints from
-                // history
                 if (dateRule == null)
                 {
                     yield return processDataPointFunction(dataPoint);
                     continue;
                 }
 
-                // It could be the case that the number of target dates is smaller than the
-                // number of data points. Thus, once a datapoint has been returned for each
-                // target date in the targetDatesQueue, we have already finished and no
-                // more datapoints are needed, so we break the loop
-                if (targetDatesQueue.IsNullOrEmpty())
+                var dataPointWasProcessed = false;
+                while (targetDatesQueue.Any() && getTime(dataPoint) >= targetDatesQueue.Peek())
                 {
-                    break;
-                }
-
-                // Try to get the closest datapoint to the target date on the top of the
-                // targetDatesQueue. Still, save always the previous dataPoint
-                if (dataPoint.Time < targetDatesQueue.Peek())
-                {
-                    previousDataPoint = dataPoint;
-                    continue;
-                }
-
-                if (dataPoint.Time == targetDatesQueue.Peek())
-                {
-                    previousDataPoint = null;
-                    targetDatesQueue.Dequeue();
-                    yield return processDataPointFunction(dataPoint);
-                }
-                else
-                {
-                    // It could be the case, the target date was not present in the history
-                    // datapoints, so we jumped it. In that case, we need to return the latest
-                    // available datapoint
-                    if (previousDataPoint != null)
+                    if (getTime(dataPoint) == targetDatesQueue.Peek())
                     {
-                        yield return processDataPointFunction((dynamic)previousDataPoint);
+                        targetDatesQueue.Dequeue();
+                        yield return processDataPointFunction(dataPoint);
                     }
-
-                    // Now we need to dequeue the targetDataPoints queue until we have a target date
-                    // bigger than the current datapoint's time
-                    while (!targetDatesQueue.IsNullOrEmpty() && dataPoint.Time > targetDatesQueue.Peek())
+                    else
                     {
+                        if (!Equals(previousDataPoint, default(T2)))
+                        {
+                            yield return processDataPointFunction(previousDataPoint);
+                        }
                         targetDatesQueue.Dequeue();
                     }
 
-                    // Still, since either we procesed the previous datapoint or we moved the
-                    // targetDatesQueue until the top date was bigger than the current datapoint,
-                    // we still need to process again the current dataPoint. Thus, we enqueue it
-                    // in lateDataPoints, so that it can be processed on the next iteration
-                    lock (getMissingDataPoint)
-                    {
-                        lateDataPoints.Enqueue(dataPoint);
-                    }
+                    dataPointWasProcessed = true;
                 }
-            }
-        }
 
-        private static IEnumerable<T2> NextDataPoint<T2>(IEnumerable<T2> history, Func<dynamic> getMissingDataPoint)
-        {
-            foreach(var historyPoint in history)
-            {
-                // Before processing the current history datapoint, we need to check if there is
-                // no other missing datapoint to be processed first
-                T2 missingDataPoint;
-                lock (getMissingDataPoint)
+                if (dataPointWasProcessed)
                 {
-                    missingDataPoint = getMissingDataPoint();
+                    previousDataPoint = default;
                 }
-                if (missingDataPoint != null)
+                else
                 {
-                    yield return missingDataPoint;
+                    previousDataPoint = dataPoint;
                 }
-                yield return historyPoint;
             }
         }
     }

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -1071,6 +1071,9 @@ namespace QuantConnect.Research
                 }
 
                 var dataPointWasProcessed = false;
+                // If the datapoint date is greater than the target date on the top, process the last
+                // datapoint and remove target dates from the queue until the target date on the top is
+                // greater than the current datapoint date
                 while (targetDatesQueue.Any() && getTime(dataPoint) >= targetDatesQueue.Peek())
                 {
                     if (getTime(dataPoint) == targetDatesQueue.Peek())
@@ -1087,14 +1090,13 @@ namespace QuantConnect.Research
                         targetDatesQueue.Dequeue();
                     }
 
+                    // We use each data point just once, this is, we cannot return the same datapoint
+                    // twice
+                    previousDataPoint = default;
                     dataPointWasProcessed = true;
                 }
 
-                if (dataPointWasProcessed)
-                {
-                    previousDataPoint = default;
-                }
-                else
+                if (!dataPointWasProcessed)
                 {
                     previousDataPoint = dataPoint;
                 }

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -778,7 +778,6 @@ namespace QuantConnect.Research
 
                 var requests = CreateDateRangeHistoryRequests(new[] { universeSymbol }, convertedType, start, endDate);
                 var history = History(requests);
-                var filteredDates = dateRule?.GetDates(start, endDate)?.ToList();
 
                 HashSet<Symbol> filteredSymbols = null;
                 dynamic castedFunc = func;

--- a/Tests/Research/QuantBookSelectionTests.cs
+++ b/Tests/Research/QuantBookSelectionTests.cs
@@ -464,9 +464,9 @@ class Test():
                     return new[] { Symbols.AAPL };
                 },
                 _qb.DateRules.MonthEnd(Symbols.AAPL)).ToList();
-            var lastDayOfMonth = history.Select(x => x.First()).Select(x => x.Time).First();
+            var lastDayOfMonth = history.Select(x => x.First()).Select(x => x.EndTime).First();
             Assert.IsNotNull(lastDayOfMonth);
-            Assert.AreEqual(new DateTime(2014, 3, 31), lastDayOfMonth);
+            Assert.AreEqual(new DateTime(2014, 3, 29), lastDayOfMonth);
         }
 
         [Test]
@@ -480,7 +480,7 @@ class Test():
                     return new[] { Symbols.AAPL };
                 },
                 _qb.DateRules.MonthStart(Symbols.AAPL)).ToList();
-            var firstDayOfMonth = history.Select(x => x.First()).Select(x => x.Time).First();
+            var firstDayOfMonth = history.Select(x => x.First()).Select(x => x.EndTime).First();
             Assert.IsNotNull(firstDayOfMonth);
             Assert.AreEqual(new DateTime(2014, 4, 1), firstDayOfMonth);
         }
@@ -493,9 +493,9 @@ class Test():
                 return new[] { Symbols.AAPL };
             });
             var history = _qb.UniverseHistory(universe, new DateTime(2014, 3, 15), new DateTime(2014, 4, 7), _qb.DateRules.MonthEnd(Symbols.AAPL)).ToList();
-            var lastDayOfMonth = history.Select(x => x.First()).Select(x => x.Time).First();
+            var lastDayOfMonth = history.Select(x => x.First()).Select(x => x.EndTime).First();
             Assert.IsNotNull(lastDayOfMonth);
-            Assert.AreEqual(new DateTime(2014, 3, 31), lastDayOfMonth);
+            Assert.AreEqual(new DateTime(2014, 3, 29), lastDayOfMonth);
         }
 
         [Test]
@@ -506,7 +506,7 @@ class Test():
                 return new[] { Symbols.AAPL };
             });
             var history = _qb.UniverseHistory(universe, new DateTime(2014, 3, 15), new DateTime(2014, 4, 7), _qb.DateRules.MonthStart(Symbols.AAPL)).ToList();
-            var firstDayOfMonth = history.Select(x => x.First()).Select(x => x.Time).First();
+            var firstDayOfMonth = history.Select(x => x.First()).Select(x => x.EndTime).First();
             Assert.IsNotNull(firstDayOfMonth);
             Assert.AreEqual(new DateTime(2014, 4, 1), firstDayOfMonth);
         }
@@ -522,7 +522,7 @@ class Test():
                     return new[] { Symbols.AAPL };
                 },
                 _qb.DateRules.Every(DayOfWeek.Wednesday)).ToList();
-            var dates = history.Select(x => x.First()).Select(x => x.Time).ToList();
+            var dates = history.Select(x => x.First()).Select(x => x.EndTime).ToList();
             Assert.IsNotNull(dates);
             Assert.IsTrue(dates.All(x => x.DayOfWeek == DayOfWeek.Wednesday));
         }

--- a/Tests/Research/QuantBookSelectionTests.cs
+++ b/Tests/Research/QuantBookSelectionTests.cs
@@ -668,7 +668,7 @@ class Test():
             var dateRule = _qb.DateRules.On(new DateTime(2024, 10, 14), new DateTime(2024, 10, 16), new DateTime(2024, 10, 18));
             var selectedDates = QuantBookTestClass.PerformSelection(historyDataPoints, new DateTime(2024, 10, 14), new DateTime(2024, 10, 22), dateRule).Select(x => x.EndTime).ToList();
 
-            for (int index = 0; index < selectedDates.Count; index++)
+            for (int index = 0; index < 3; index++)
             {
                 Assert.AreEqual(historyDataPoints[index].EndTime, selectedDates[index]);
             }

--- a/Tests/Research/QuantBookSelectionTests.cs
+++ b/Tests/Research/QuantBookSelectionTests.cs
@@ -453,6 +453,80 @@ class Test():
             }
         }
 
+        [Test]
+        public void MonthlyEndGenericUniverseSelectionWorksAsExpected()
+        {
+            var history = _qb.UniverseHistory<Fundamentals, Fundamental>(
+                new DateTime(2014, 3, 24),
+                new DateTime(2014, 4, 7),
+                (fundamental) =>
+                {
+                    return new[] { Symbols.AAPL };
+                },
+                _qb.DateRules.MonthEnd(Symbols.AAPL)).ToList();
+            var lastDayOfMonth = history.Select(x => x.First()).Select(x => x.EndTime).First();
+            Assert.IsNotNull(lastDayOfMonth);
+            Assert.AreEqual(new DateTime(2014, 3, 29), lastDayOfMonth);
+        }
+
+        [Test]
+        public void MonthlyStartGenericUniverseSelectionWorksAsExpected()
+        {
+            var history = _qb.UniverseHistory<Fundamentals, Fundamental>(
+                new DateTime(2014, 3, 24),
+                new DateTime(2014, 4, 7),
+                (fundamental) =>
+                {
+                    return new[] { Symbols.AAPL };
+                },
+                _qb.DateRules.MonthStart(Symbols.AAPL)).ToList();
+            var lastDayOfMonth = history.Select(x => x.First()).Select(x => x.EndTime).First();
+            Assert.IsNotNull(lastDayOfMonth);
+            Assert.AreEqual(new DateTime(2014, 4, 1), lastDayOfMonth);
+        }
+
+        [Test]
+        public void MonthlyEndSelectionWorksAsExpected()
+        {
+            var universe = _qb.AddUniverse((IEnumerable<Fundamental> fundamentals) =>
+            {
+                return new[] { Symbols.AAPL };
+            });
+            var history = _qb.UniverseHistory(universe, new DateTime(2014, 3, 15), new DateTime(2014, 4, 7), _qb.DateRules.MonthEnd(Symbols.AAPL)).ToList();
+            var lastDayOfMonth = history.Select(x => x.First()).Select(x => x.EndTime).First();
+            Assert.IsNotNull(lastDayOfMonth);
+            Assert.AreEqual(new DateTime(2014, 3, 29), lastDayOfMonth);
+        }
+
+        [Test]
+        public void MonthlyStartSelectionWorksAsExpected()
+        {
+            var universe = _qb.AddUniverse((IEnumerable<Fundamental> fundamentals) =>
+            {
+                return new[] { Symbols.AAPL };
+            });
+            var history = _qb.UniverseHistory(universe, new DateTime(2014, 3, 15), new DateTime(2014, 4, 7), _qb.DateRules.MonthStart(Symbols.AAPL)).ToList();
+            var lastDayOfMonth = history.Select(x => x.First()).Select(x => x.EndTime).First();
+            Assert.IsNotNull(lastDayOfMonth);
+            Assert.AreEqual(new DateTime(2014, 4, 1), lastDayOfMonth);
+        }
+
+        [Test]
+        public void WeekendGenericUniverseSelectionWorksAsExpected()
+        {
+            var history = _qb.UniverseHistory<Fundamentals, Fundamental>(
+                new DateTime(2014, 3, 24),
+                new DateTime(2014, 4, 7),
+                (fundamental) =>
+                {
+                    return new[] { Symbols.AAPL };
+                },
+                _qb.DateRules.Every(DayOfWeek.Wednesday)).ToList();
+            var dates = history.Select(x => x.First()).Select(x => x.EndTime).ToList();
+            Assert.IsNotNull(dates);
+            Assert.IsTrue(dates.All(x => x.DayOfWeek == DayOfWeek.Wednesday));
+        }
+
         private static string GetBaseImplementation(int expectedCount, string identation)
         {
             return @"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
When the method `QuantBook.UniverseHistory()` was called using a monthly date rule, the returning dataframe missed certain dates from the monthly date rule. This happened since the dates returned by the date rule did not always match the dates of the datapoints returned by the history. Indeed, even though the date rules did match with the `Time` attribute of the datapoints, it wasn't true that data was available by that date. Thus, instead of using datapoint's `Time` attribute, `EndTime` attribute was used, leading to shift in the dates. Therefore, the methods `QuantBook.RunUniverseSelection()` and `UniverseHistory<T1, T2>()` were modified to always retrieve the latest data available for each selection date, i.e. if the selection date is 31/3/2014, but that date is a monday, the latest data available for that date would be 29/3/2014 which is Friday.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #8353 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, when users call `QuantBook.UniverseHistory()` with a monthly date rule, they will receive the latest available datapoint for the selection date per each month
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created 2 unit tests for each overload of the `QuantBook.UniverseHistory` method, that asserted the latest available datapoint was retrieved when using a monthly data rule.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
