### PR TITLE
Fix Python `Consolidate` API to respect strict daily times for Daily resolution

### DIFF
--- a/Algorithm.Python/ConsolidateRegressionAlgorithm.py
+++ b/Algorithm.Python/ConsolidateRegressionAlgorithm.py
@@ -21,14 +21,44 @@ class ConsolidateRegressionAlgorithm(QCAlgorithm):
 
     # Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
     def initialize(self):
-        self.set_start_date(2013, 10, 8)
-        self.set_end_date(2013, 10, 20)
+        self.set_start_date(2020, 1, 5)
+        self.set_end_date(2020, 1, 20)
 
         SP500 = Symbol.create(Futures.Indices.SP_500_E_MINI, SecurityType.FUTURE, Market.CME)
-        self._symbol = _symbol = self.future_chain_provider.get_future_contract_list(SP500, self.start_date)[0]
-        self.add_future_contract(_symbol)
+        symbol = self.future_chain_provider.get_future_contract_list(SP500, self.start_date)[0]
+        self._future = self.add_future_contract(symbol)
 
-        self._consolidation_counts = [0] * 6
+        tradable_dates_count = len(list(Time.each_tradeable_day_in_time_zone(self._future.exchange.hours,
+                                                                             self.start_date,
+                                                                             self.end_date,
+                                                                             self._future.exchange.time_zone,
+                                                                             False)));
+        self._expected_consolidation_counts = [];
+
+        self.consolidate(symbol, Calendar.MONTHLY, lambda bar: self.update_monthly_consolidator(bar, -1)) # shouldn't consolidate
+
+        self.consolidate(symbol, Calendar.WEEKLY, TickType.TRADE, lambda bar: self.update_weekly_consolidator(bar))
+
+        self.consolidate(symbol, Resolution.DAILY, lambda bar: self.update_trade_bar(bar, 0))
+        self._expected_consolidation_counts.append(tradable_dates_count)
+
+        self.consolidate(symbol, Resolution.DAILY, TickType.QUOTE, lambda bar: self.update_quote_bar(bar, 1))
+        self._expected_consolidation_counts.append(tradable_dates_count)
+
+        self.consolidate(symbol, timedelta(1), lambda bar: self.update_trade_bar(bar, 2))
+        self._expected_consolidation_counts.append(tradable_dates_count - 1)
+
+        self.consolidate(symbol, timedelta(1), TickType.QUOTE, lambda bar: self.update_quote_bar(bar, 3))
+        self._expected_consolidation_counts.append(tradable_dates_count - 1)
+
+        # sending None tick type
+        self.consolidate(symbol, timedelta(1), None, lambda bar: self.update_trade_bar(bar, 4))
+        self._expected_consolidation_counts.append(tradable_dates_count - 1)
+
+        self.consolidate(symbol, Resolution.DAILY, None, lambda bar: self.update_trade_bar(bar, 5))
+        self._expected_consolidation_counts.append(tradable_dates_count)
+
+        self._consolidation_counts = [0] * len(self._expected_consolidation_counts)
         self._smas = [SimpleMovingAverage(10) for x in self._consolidation_counts]
         self._last_sma_updates = [datetime.min for x in self._consolidation_counts]
         self._monthly_consolidator_sma = SimpleMovingAverage(10)
@@ -37,26 +67,9 @@ class ConsolidateRegressionAlgorithm(QCAlgorithm):
         self._weekly_consolidation_count = 0
         self._last_weekly_sma_update = datetime.min
 
-        self.consolidate(_symbol, Calendar.MONTHLY, lambda bar: self.update_monthly_consolidator(bar, -1)) # shouldn't consolidate
-
-        self.consolidate(_symbol, Calendar.WEEKLY, TickType.TRADE, lambda bar: self.update_weekly_consolidator(bar))
-
-        self.consolidate(_symbol, Resolution.DAILY, lambda bar: self.update_trade_bar(bar, 0))
-
-        self.consolidate(_symbol, Resolution.DAILY, TickType.QUOTE, lambda bar: self.update_quote_bar(bar, 1))
-
-        self.consolidate(_symbol, timedelta(1), lambda bar: self.update_trade_bar(bar, 2))
-
-        self.consolidate(_symbol, timedelta(1), TickType.QUOTE, lambda bar: self.update_quote_bar(bar, 3))
-
-        # sending None tick type
-        self.consolidate(_symbol, timedelta(1), None, lambda bar: self.update_trade_bar(bar, 4))
-
-        self.consolidate(_symbol, Resolution.DAILY, None, lambda bar: self.update_trade_bar(bar, 5))
-
         # custom data
         self._custom_data_consolidator = 0
-        custom_symbol = self.add_data(Bitcoin, "BTC", Resolution.MINUTE).symbol
+        custom_symbol = self.add_data(Bitcoin, "BTC", Resolution.DAILY).symbol
         self.consolidate(custom_symbol, timedelta(1), lambda bar: self.increment_counter(1))
 
         self._custom_data_consolidator2 = 0
@@ -87,18 +100,25 @@ class ConsolidateRegressionAlgorithm(QCAlgorithm):
         self._last_weekly_sma_update = bar.end_time
         self._weekly_consolidation_count += 1
 
-    def  OnEndOfAlgorithm(self):
-        expected_consolidations = 9
-        expected_weekly_consolidations = 1
-        if (any(i != expected_consolidations for i in self._consolidation_counts) or
-            self._weekly_consolidation_count != expected_weekly_consolidations or
-            self._custom_data_consolidator == 0 or
-            self._custom_data_consolidator2 == 0):
-            raise ValueError("Unexpected consolidation count")
+    def on_end_of_algorithm(self):
+        for i, expected_consolidation_count in enumerate(self._expected_consolidation_counts):
+            consolidation_count = self._consolidation_counts[i]
+            if consolidation_count != expected_consolidation_count:
+                raise ValueError(f"Unexpected consolidation count for index {i}: expected {expected_consolidation_count} but was {consolidation_count}")
+
+        expected_weekly_consolidations = (self.end_date - self.start_date).days // 7
+        if self._weekly_consolidation_count != expected_weekly_consolidations:
+            raise ValueError(f"Expected {expected_weekly_consolidations} weekly consolidations but found {self._weekly_consolidation_count}")
+
+        if self._custom_data_consolidator == 0:
+            raise ValueError("Custom data consolidator did not consolidate any data")
+
+        if self._custom_data_consolidator2 == 0:
+            raise ValueError("Custom data consolidator 2 did not consolidate any data")
 
         for i, sma in enumerate(self._smas):
-            if sma.samples != expected_consolidations:
-                raise Exception(f"Expected {expected_consolidations} samples in each SMA but found {sma.samples} in SMA in index {i}")
+            if sma.samples != self._expected_consolidation_counts[i]:
+                raise Exception(f"Expected {self._expected_consolidation_counts[i]} samples in each SMA but found {sma.samples} in SMA in index {i}")
 
             last_update = self._last_sma_updates[i]
             if sma.current.time != last_update:
@@ -115,5 +135,5 @@ class ConsolidateRegressionAlgorithm(QCAlgorithm):
 
     # on_data event is the primary entry point for your algorithm. Each new data point will be pumped in here.
     def on_data(self, data):
-        if not self.portfolio.invested:
-           self.set_holdings(self._symbol, 0.5)
+        if not self.portfolio.invested and self._future.has_data:
+           self.set_holdings(self._future.symbol, 0.5)

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -1386,40 +1386,40 @@ namespace QuantConnect.Algorithm
         /// Registers the <paramref name="handler"/> to receive consolidated data for the specified symbol
         /// </summary>
         /// <param name="symbol">The symbol who's data is to be consolidated</param>
-        /// <param name="resolution">The consolidation period</param>
+        /// <param name="period">The consolidation period</param>
         /// <param name="handler">Data handler receives new consolidated data when generated</param>
         /// <returns>A new consolidator matching the requested parameters with the handler already registered</returns>
         [DocumentationAttribute(ConsolidatingData)]
-        public IDataConsolidator Consolidate(Symbol symbol, Resolution resolution, PyObject handler)
+        public IDataConsolidator Consolidate(Symbol symbol, Resolution period, PyObject handler)
         {
-            return Consolidate(symbol, resolution, null, handler);
+            return Consolidate(symbol, period, null, handler);
         }
 
         /// <summary>
         /// Registers the <paramref name="handler"/> to receive consolidated data for the specified symbol
         /// </summary>
         /// <param name="symbol">The symbol who's data is to be consolidated</param>
-        /// <param name="resolution">The consolidation period</param>
+        /// <param name="period">The consolidation period</param>
         /// <param name="tickType">The tick type of subscription used as data source for consolidator. Specify null to use first subscription found.</param>
         /// <param name="handler">Data handler receives new consolidated data when generated</param>
         /// <returns>A new consolidator matching the requested parameters with the handler already registered</returns>
         [DocumentationAttribute(ConsolidatingData)]
-        public IDataConsolidator Consolidate(Symbol symbol, Resolution resolution, TickType? tickType, PyObject handler)
+        public IDataConsolidator Consolidate(Symbol symbol, Resolution period, TickType? tickType, PyObject handler)
         {
             // resolve consolidator input subscription
             var type = GetSubscription(symbol, tickType).Type;
 
             if (type == typeof(TradeBar))
             {
-                return Consolidate(symbol, resolution, tickType, handler.ConvertToDelegate<Action<TradeBar>>());
+                return Consolidate(symbol, period, tickType, handler.ConvertToDelegate<Action<TradeBar>>());
             }
 
             if (type == typeof(QuoteBar))
             {
-                return Consolidate(symbol, resolution, tickType, handler.ConvertToDelegate<Action<QuoteBar>>());
+                return Consolidate(symbol, period, tickType, handler.ConvertToDelegate<Action<QuoteBar>>());
             }
 
-            return Consolidate(symbol, resolution, tickType, handler.ConvertToDelegate<Action<BaseData>>());
+            return Consolidate(symbol, period, tickType, handler.ConvertToDelegate<Action<BaseData>>());
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This PR fixes the `ConsolidateRegressionAlgorithm`, which was failing in the CI:

- Fix Bitcoin custom data time range: historical data goes from April 2014 and is daily (see https://data.nasdaq.com/databases/BITFINEX)
- Fix python `Consolidate` implementations to respect daily strict times for `Daily` resolution
- Fix expected consolidated bar counts:
    - TLDR: consolidating using `Resolution.Daily` (with strict daily times set) results in N bars, and using `TimeSpan.FromDays(1)` results in N-1 bars. 
    - Consolidating with `Resolution.Daily` will generate bars respecting strict daily start-end times.
    - Consolidating with `TimeSpan.FromDays(1)` or a calendar info representing 1 day will generate full daily midnight-to-midnight bars. In this case the last data feed to the algorithm is for market close time, before `EndTime` midnight, so the bar corresponding to that day is not consolidated.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`ConsolidateRegressionAlgorithm` fixed.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
