### PR TITLE
Add extended market hours option in `DateRules.WeekStart()`

### DIFF
--- a/Common/Scheduling/DateRules.cs
+++ b/Common/Scheduling/DateRules.cs
@@ -279,6 +279,7 @@ namespace QuantConnect.Scheduling
         /// <param name="symbol">The symbol whose exchange is used to determine the first
         /// tradeable date of the week</param>
         /// <param name="daysOffset">The amount of tradable days to offset the first tradable day by</param>
+        /// <param name="extendedMarketHours">True to include extended market hours, false otherwise</param>
         /// <returns>A date rule that fires on the first + offset tradable date for the specified
         /// security each week</returns>
         public IDateRule WeekStart(Symbol symbol, int daysOffset = 0, bool extendedMarketHours = true)
@@ -366,7 +367,7 @@ namespace QuantConnect.Scheduling
         /// <param name="offset">Amount to offset the schedule by tradable days</param>
         /// <param name="searchForward">Search into the future for the closest day if true; into the past if false</param>
         /// <param name="boundary">The boundary DateTime on the resulting day</param>
-        /// <returns></returns>
+        /// <param name="extendedMarketHours">True to include extended market hours, false otherwise</param>
         private static DateTime GetScheduledDay(SecurityExchangeHours securityExchangeHours, DateTime baseDay, int offset, bool searchForward, DateTime? boundary = null, bool extendedMarketHours = true)
         {
             // By default the scheduled date is the given day

--- a/Tests/Common/Scheduling/DateRulesTests.cs
+++ b/Tests/Common/Scheduling/DateRulesTests.cs
@@ -618,6 +618,25 @@ namespace QuantConnect.Tests.Common.Scheduling
             }
         }
 
+        [Test]
+        public void StartOfWeekWithSymbolWithoutExtendedMarketHours()
+        {
+            var rules = GetDateRules();
+            var rule = rules.WeekStart(Symbols.Lookup(Symbols.SymbolsKey.Fut_SPY_Feb19_2016), extendedMarketHours: false);
+            var dates = rule.GetDates(new DateTime(2000, 01, 01), new DateTime(2000, 1, 31)).ToList();
+
+            var expectedDays = new int[] { 3, 10, 18, 24, 31 };
+            // Assert we have as many dates as expected
+            Assert.AreEqual(expectedDays.Length, dates.Count);
+
+            // Verify the days match up
+            var datesAndExpectedDays = dates.Zip(expectedDays, (date, expectedDay) => new { date, expectedDay });
+            foreach (var pair in datesAndExpectedDays)
+            {
+                Assert.AreEqual(pair.expectedDay, pair.date.Day);
+            }
+        }
+
         [TestCase(Symbols.SymbolsKey.SPY, new[] { 5, 12, 20, 26 })] // Set contains holiday on 1/17
         [TestCase(Symbols.SymbolsKey.BTCUSD, new[] { 4, 11, 18, 25 })]
         [TestCase(Symbols.SymbolsKey.EURUSD, new[] { 4, 11, 18, 25 })]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The method `DateRules.WeekStart()` always assumed extended market hours were being taken into account so when used with other methods that didn't, such as `TimeRules.AfterMarketOpen()`, it didn't work. Thus, I added an optional argument to decide whether to include them or not.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #8367 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, users will be able to use this method along with others that do not always use extended market hours
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created a unit test, that asserted the start of week dates retrieved by `DateRules.WeekStart()` didn't use extended market hours.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
