### PR TITLE
Normalize Date timezone

### DIFF
--- a/Algorithm.Python/BaseFrameworkRegressionAlgorithm.py
+++ b/Algorithm.Python/BaseFrameworkRegressionAlgorithm.py
@@ -35,7 +35,7 @@ class BaseFrameworkRegressionAlgorithm(QCAlgorithm):
         # With this procedure, the Alpha Model will experience multiple universe changes
         self.add_universe_selection(ScheduledUniverseSelectionModel(
             self.date_rules.every_day(), self.time_rules.midnight,
-            lambda dt: symbols if dt.replace(tzinfo=None) < self.end_date - timedelta(1) else []))
+            lambda dt: symbols if dt < self.end_date - timedelta(1) else []))
 
         self.set_alpha(ConstantAlphaModel(InsightType.PRICE, InsightDirection.UP, timedelta(31), 0.025, None))
         self.set_portfolio_construction(EqualWeightingPortfolioConstructionModel())

--- a/Common/Data/UniverseSelection/ScheduledUniverse.cs
+++ b/Common/Data/UniverseSelection/ScheduledUniverse.cs
@@ -100,7 +100,7 @@ namespace QuantConnect.Data.UniverseSelection
         /// <returns>The data that passes the filter</returns>
         public override IEnumerable<Symbol> SelectSymbols(DateTime utcTime, BaseDataCollection data)
         {
-            return _selector(utcTime);
+            return _selector(DateTime.SpecifyKind(utcTime, DateTimeKind.Unspecified));
         }
 
         /// <summary>

--- a/Common/Scheduling/ScheduleManager.cs
+++ b/Common/Scheduling/ScheduleManager.cs
@@ -191,7 +191,7 @@ namespace QuantConnect.Scheduling
         {
             // back the date up to ensure we get all events, the event scheduler will skip past events that whose time has passed
             var dates = GetDatesDeferred(dateRule, _securities);
-            var eventTimes = timeRule.CreateUtcEventTimes(dates.Select(x => DateTime.SpecifyKind(x, DateTimeKind.Unspecified)));
+            var eventTimes = timeRule.CreateUtcEventTimes(dates);
             var scheduledEvent = new ScheduledEvent(name, eventTimes, callback);
             Add(scheduledEvent);
 

--- a/Common/Scheduling/ScheduleManager.cs
+++ b/Common/Scheduling/ScheduleManager.cs
@@ -20,6 +20,7 @@ using NodaTime;
 using QuantConnect.Securities;
 using QuantConnect.Logging;
 using Python.Runtime;
+using System.Linq;
 
 namespace QuantConnect.Scheduling
 {
@@ -190,7 +191,7 @@ namespace QuantConnect.Scheduling
         {
             // back the date up to ensure we get all events, the event scheduler will skip past events that whose time has passed
             var dates = GetDatesDeferred(dateRule, _securities);
-            var eventTimes = timeRule.CreateUtcEventTimes(dates);
+            var eventTimes = timeRule.CreateUtcEventTimes(dates.Select(x => DateTime.SpecifyKind(x, DateTimeKind.Unspecified)));
             var scheduledEvent = new ScheduledEvent(name, eventTimes, callback);
             Add(scheduledEvent);
 
@@ -281,7 +282,7 @@ namespace QuantConnect.Scheduling
         /// </summary>
         internal static IEnumerable<DateTime> GetDatesDeferred(IDateRule dateRule, SecurityManager securities)
         {
-            foreach (var item in dateRule.GetDates(securities.UtcTime.Date.AddDays(-1), Time.EndOfTime))
+            foreach (var item in dateRule.GetDates(DateTime.SpecifyKind(securities.UtcTime.Date.AddDays(-1), DateTimeKind.Unspecified), Time.EndOfTime))
             {
                 yield return item;
             }

--- a/Common/Scheduling/ScheduleManager.cs
+++ b/Common/Scheduling/ScheduleManager.cs
@@ -20,7 +20,6 @@ using NodaTime;
 using QuantConnect.Securities;
 using QuantConnect.Logging;
 using Python.Runtime;
-using System.Linq;
 
 namespace QuantConnect.Scheduling
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Some C# methods call python methods with date parameters that do not have the same timezone. Thus, when the C# dates are converted into python `datetime` objects, some of them have a timezone and others don't so an exception is thrown when compared (can't compare offset-naive and offset-aware datetimes). For that reason, since python `datetime` objects do not have a timezone by default, I modified some of the C# methods I mentioned so that they didn't have a timezone too (DateTime.Kind = Unspecified). However, there are other C# methods that have this same bug (such as `OrderEvent.UtcTime`) but making a change in that class would be a breaking change, so I skipped them.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #8402 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, users will be able to compare dates directly in python (for some methods such as `FuncDateRule()`)
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I modified a python regression algorithm that was handling the timezone bug manually and I also made a unit test asserting the dates returned by `ScheduleManager.GetDatesDeferred()` were normalized.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
