### PR TITLE
Live trading consolidation synchronization

### DIFF
--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -204,7 +204,7 @@ namespace QuantConnect.Lean.Engine
                 realtime.ScanPastEvents(time);
 
                 // will scan registered consolidators for which we've past the expected scan call
-                algorithm.SubscriptionManager.ScanPastConsolidators(time, algorithm);
+                algorithm.SubscriptionManager.ScanPastConsolidators(time.RoundDown(Time.OneSecond), algorithm);
 
                 //Set the algorithm and real time handler's time
                 algorithm.SetDateTime(time);

--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -86,6 +86,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             CancellationToken cancellationToken)
         {
             var delayedSubscriptionFinished = new Queue<Subscription>();
+            var prevTimeSliceTime = DateTime.MinValue;
 
             while (!cancellationToken.IsCancellationRequested)
             {
@@ -97,6 +98,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                 var frontierUtc = _timeProvider.GetUtcNow();
                 _frontierTimeProvider.SetCurrentTimeUtc(frontierUtc);
+                var timeSliceTimeUtc = DateTime.MinValue;
 
                 SecurityChanges newChanges;
                 do
@@ -155,6 +157,15 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             }
 
                             packet.Add(subscription.Current.Data);
+
+                            // Keep track of the latest data time, we will use it to determine the time slice time.
+                            // For cases like live trading, the frontierUtc might be a few milliseconds ahead of the data time,
+                            // and we want the actual data to drive the time slice time.
+                            var dataTimeUtc = subscription.Current.Data.EndTime.ConvertToUtc(subscription.Configuration.ExchangeTimeZone);
+                            if (dataTimeUtc > timeSliceTimeUtc && dataTimeUtc > prevTimeSliceTime)
+                            {
+                                timeSliceTimeUtc = dataTimeUtc;
+                            }
 
                             if (!subscription.MoveNext())
                             {
@@ -240,7 +251,15 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 while (newChanges != SecurityChanges.None
                     || _universeSelection.AddPendingInternalDataFeeds(frontierUtc));
 
-                var timeSlice = _timeSliceFactory.Create(frontierUtc, data, changes, universeDataForTimeSliceCreate);
+                // First time slice or no data, use the frontier time to make sure we always emit a time after the start time
+                // (for instance, the default benchmark security is added with a start time of 1 day before the algorithm start date)
+                if (prevTimeSliceTime == DateTime.MinValue || timeSliceTimeUtc == DateTime.MinValue)
+                {
+                    timeSliceTimeUtc = frontierUtc;
+                }
+
+                var timeSlice = _timeSliceFactory.Create(timeSliceTimeUtc, data, changes, universeDataForTimeSliceCreate);
+                prevTimeSliceTime = timeSliceTimeUtc;
 
                 while (delayedSubscriptionFinished.Count > 0)
                 {

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -4027,7 +4027,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                     // Mimic the algorithm manager consolidators scan:
 
                     // First, scan for consolidators that need to be updated
-                    _algorithm.SubscriptionManager.ScanPastConsolidators(timeSlice.Time, _algorithm);
+                    _algorithm.SubscriptionManager.ScanPastConsolidators(timeSlice.Time.RoundDown(Time.OneSecond), _algorithm);
 
                     // Then, update the consolidators with the new data
                     if (timeSlice.ConsolidatorUpdateData.Count > 0)

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -4027,6 +4027,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                     // Mimic the algorithm manager consolidators scan:
 
                     // First, scan for consolidators that need to be updated
+                    // NOTE: Rounding time down to mimic the algorithm manager consolidators scan
                     _algorithm.SubscriptionManager.ScanPastConsolidators(timeSlice.Time.RoundDown(Time.OneSecond), _algorithm);
 
                     // Then, update the consolidators with the new data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Round time down to the nearest second before calling `SubscriptionManager.ScanPastConsolidators` in the `AlgorithmManager` to account for any offset between the consolidation time and the point where `DateTime.UtcNow` is called by the live time provider.

This small offset was causing `SubscriptionManager.ScanPastConsolidators` to scan consolidators (which would emit a consolidated bar) even when the time slice carried data that was supposed to be used to feed the consolidators for the current working bar.

Example:

- Minute resolution subscription
- 5 minute bar consolidator
- A time slice carrying minute data for 9:59:00am-10:00:00am could have a time that is a few milliseconds (or even a few ticks) after 10:00:00am (becasue `DateTime.UtcNow` is called after the data is already in the subscriptions ready to be loaded to the time slice), which could cause `SubscriptionManager.ScanPastConsolidators` scan the consolidator which would emit the 9:55:00am-10:00:00am consolidated bar the last minute data was fed to the consolidator.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #8363 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit tests
- Manual live deployments (debugging and checking actual consolidated data)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
