### PR TITLE
Fix bug when consolidating hourly bars into daily ones

### DIFF
--- a/Algorithm.CSharp/ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm.cs
@@ -1,0 +1,138 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+using QuantConnect.Interfaces;
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm that asserts Stochastic indicator, registered with a different resolution consolidator,
+    /// is warmed up properly by calling QCAlgorithm.WarmUpIndicator
+    /// </summary>
+    public class ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _spy;
+        private RelativeStrengthIndex _rsi;
+        private RelativeStrengthIndex _rsiTimeDelta;
+        private Dictionary<DateTime, decimal> _values = new();
+        private int _count;
+
+        public override void Initialize()
+        {
+            SetStartDate(2020, 5, 1);
+            SetEndDate(2020, 6, 5);
+
+            _spy = AddEquity("SPY", Resolution.Hour).Symbol;
+            _rsi = new RelativeStrengthIndex("FIRST", 15, MovingAverageType.Wilders);
+            RegisterIndicator(_spy, _rsi, Resolution.Daily);
+
+            _rsiTimeDelta = new RelativeStrengthIndex("SECOND" ,15, MovingAverageType.Wilders);
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (IsWarmingUp) return;
+
+            if (slice.ContainsKey(_spy) && slice[_spy] != null)
+            {
+                if (Time.Month == EndDate.Month)
+                {
+                    var history = History(_spy, _count, Resolution.Daily);
+                    foreach (var bar in history)
+                    {
+                        _rsiTimeDelta.Update(bar.EndTime, bar.Close);
+                        var time = bar.EndTime.Date;
+                        if (_rsiTimeDelta.Current.Value != _values[time])
+                        {
+                            throw new Exception($"Both {_rsi.Name} and {_rsiTimeDelta.Name} should have the same values, but they differ. {_rsi.Name}: {_values[time]} | {_rsiTimeDelta.Name}: {_rsiTimeDelta.Current.Value}");
+                        }
+                    }
+                    Quit();
+                }
+                else
+                {
+                    _values[Time.Date] = _rsi.Current.Value;
+                    if (Time.Hour == 16)
+                    {
+                        _count++;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 290;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 20;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-5.215"},
+            {"Tracking Error", "0.159"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm.cs
@@ -32,6 +32,7 @@ namespace QuantConnect.Algorithm.CSharp
         private RelativeStrengthIndex _rsiTimeDelta;
         private Dictionary<DateTime, decimal> _values = new();
         private int _count;
+        private bool _indicatorsCompared;
 
         public override void Initialize()
         {
@@ -68,9 +69,10 @@ namespace QuantConnect.Algorithm.CSharp
                         var time = bar.EndTime.Date;
                         if (_rsiTimeDelta.Current.Value != _values[time])
                         {
-                            throw new Exception($"Both {_rsi.Name} and {_rsiTimeDelta.Name} should have the same values, but they differ. {_rsi.Name}: {_values[time]} | {_rsiTimeDelta.Name}: {_rsiTimeDelta.Current.Value}");
+                            throw new RegressionTestException($"Both {_rsi.Name} and {_rsiTimeDelta.Name} should have the same values, but they differ. {_rsi.Name}: {_values[time]} | {_rsiTimeDelta.Name}: {_rsiTimeDelta.Current.Value}");
                         }
                     }
+                    _indicatorsCompared = true;
                     Quit();
                 }
                 else
@@ -85,6 +87,14 @@ namespace QuantConnect.Algorithm.CSharp
                         _count++;
                     }
                 }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_indicatorsCompared)
+            {
+                throw new RegressionTestException($"Indicators {_rsi.Name} and {_rsiTimeDelta.Name} should have been compared, but they were not. Please make sure the indicators are getting SPY data");
             }
         }
 

--- a/Algorithm.Python/ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm.py
+++ b/Algorithm.Python/ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm.py
@@ -19,7 +19,6 @@ from AlgorithmImports import *
 ### </summary>
 class ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm(QCAlgorithm):
     def initialize(self):
-        # change the start date between runs to check that warm up shows the correct value
         self.set_start_date(2020, 5, 1)
         self.set_end_date(2020, 6, 5)
 

--- a/Algorithm.Python/ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm.py
+++ b/Algorithm.Python/ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm.py
@@ -1,0 +1,51 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+class ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm(QCAlgorithm):
+    def initialize(self):
+        # change the start date between runs to check that warm up shows the correct value
+        self.set_start_date(2020, 5, 1)
+        self.set_end_date(2020, 6, 5)
+        self.set_cash(100000)
+
+        self.spy = self.add_equity("SPY", Resolution.HOUR).symbol
+
+        # Resolution.DAILY indicators
+        self._rsi = RelativeStrengthIndex("First", 15, MovingAverageType.WILDERS)
+        self.register_indicator(self.spy, self._rsi, Resolution.DAILY)
+
+        # Resolution.DAILY indicators
+        self._rsi_timedelta = RelativeStrengthIndex("Second", 15, MovingAverageType.WILDERS)
+        self._values = {}
+        self.count = 0;
+
+    def on_data(self, data: Slice):
+        if self.is_warming_up:
+            return
+
+        if data.contains_key(self.spy) and data[self.spy] != None:
+            if self.time.month == self.end_date.month:
+                history = self.history[TradeBar](self.spy, self.count, Resolution.DAILY)
+                for bar in history:
+                    time = bar.end_time.strftime('%Y-%m-%d')
+                    self._rsi_timedelta.update(bar.end_time, bar.close)
+                    if self._rsi_timedelta.current.value != self._values[time]:
+                        raise Exception(f"Both {self._rsi.name} and {self._rsi_timedelta.name} should have the same values, but they differ. {self._rsi.name}: {self._values[time]} | {self._rsi_timedelta.name}: {self._rsi_timedelta.current.value}")
+                self.quit()
+            else:
+                time = self.time.strftime('%Y-%m-%d')
+                self._values[time] = self._rsi.current.value
+                if self.time.hour == 16:
+                    self.count += 1

--- a/Algorithm.Python/ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm.py
+++ b/Algorithm.Python/ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm.py
@@ -38,6 +38,7 @@ class ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm(QCAlgorithm):
         self._rsi_timedelta = RelativeStrengthIndex("Second", 15, MovingAverageType.WILDERS)
         self._values = {}
         self.count = 0;
+        self._indicators_compared = False;
 
     def on_data(self, data: Slice):
         if self.is_warming_up:
@@ -51,6 +52,7 @@ class ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm(QCAlgorithm):
                     self._rsi_timedelta.update(bar.end_time, bar.close)
                     if self._rsi_timedelta.current.value != self._values[time]:
                         raise Exception(f"Both {self._rsi.name} and {self._rsi_timedelta.name} should have the same values, but they differ. {self._rsi.name}: {self._values[time]} | {self._rsi_timedelta.name}: {self._rsi_timedelta.current.value}")
+                self._indicators_compared = True
                 self.quit()
             else:
                 time = self.time.strftime('%Y-%m-%d')
@@ -61,3 +63,7 @@ class ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm(QCAlgorithm):
                 # how many we need to request from the history
                 if self.time.hour == 16:
                     self.count += 1
+
+    def on_end_of_algorithm(self):
+        if not self._indicators_compared:
+            raise Exception(f"Indicators {self._rsi.name} and {self._rsi_timedelta.name} should have been compared, but they were not. Please make sure the indicators are getting SPY data")

--- a/Algorithm.Python/ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm.py
+++ b/Algorithm.Python/ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm.py
@@ -29,7 +29,7 @@ class ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm(QCAlgorithm):
         # it depends on its previous values. Thus, if at some point the bars received by
         # the indicators differ, so will their final values
         self._rsi = RelativeStrengthIndex("First", 15, MovingAverageType.WILDERS)
-        self.register_indicator(self.spy, self._rsi, Resolution.DAILY)
+        self.register_indicator(self.spy, self._rsi, Resolution.DAILY, selector= lambda bar: (bar.close + bar.open) / 2)
 
         # We won't register this indicator as we will update it manually at the end of the
         # month, so that we can compare the values of the indicator that received consolidated
@@ -48,7 +48,8 @@ class ConsolidateHourBarsIntoDailyBarsRegressionAlgorithm(QCAlgorithm):
                 history = self.history[TradeBar](self.spy, self.count, Resolution.DAILY)
                 for bar in history:
                     time = bar.end_time.strftime('%Y-%m-%d')
-                    self._rsi_timedelta.update(bar.end_time, bar.close)
+                    average = (bar.close + bar.open) / 2
+                    self._rsi_timedelta.update(bar.end_time, average)
                     if self._rsi_timedelta.current.value != self._values[time]:
                         raise Exception(f"Both {self._rsi.name} and {self._rsi_timedelta.name} should have the same values, but they differ. {self._rsi.name}: {self._values[time]} | {self._rsi_timedelta.name}: {self._rsi_timedelta.current.value}")
                 self._indicators_compared = True

--- a/Common/Data/Consolidators/MarketHourAwareConsolidator.cs
+++ b/Common/Data/Consolidators/MarketHourAwareConsolidator.cs
@@ -132,9 +132,12 @@ namespace QuantConnect.Data.Common
         {
             Initialize(data);
 
+            // US equity hour data from the database starts at 9am but the exchange opens at 9:30am. Thus, we need to handle
+            // this case specifically to avoid skipping the first hourly bar. To avoid this, we assert the period is daily,
+            // the data resolution is hour and the exchange opens at any point in time over the data.Time to data.EndTime interval
             if (_extendedMarketHours ||
                 ExchangeHours.IsOpen(data.Time, false) ||
-                (Period == TimeSpan.FromDays(1) && ExchangeHours.IsOpen(data.Time, data.EndTime, false)))
+                (Period == Time.OneDay && (data.EndTime - data.Time == Time.OneHour) && ExchangeHours.IsOpen(data.Time, data.EndTime, false)))
             {
                 Consolidator.Update(data);
             }

--- a/Common/Data/Consolidators/MarketHourAwareConsolidator.cs
+++ b/Common/Data/Consolidators/MarketHourAwareConsolidator.cs
@@ -132,7 +132,9 @@ namespace QuantConnect.Data.Common
         {
             Initialize(data);
 
-            if (_extendedMarketHours || ExchangeHours.IsOpen(data.Time, false))
+            if (_extendedMarketHours ||
+                ExchangeHours.IsOpen(data.Time, false) ||
+                (Period == TimeSpan.FromDays(1) && ExchangeHours.IsOpen(data.Time, data.EndTime, false)))
             {
                 Consolidator.Update(data);
             }

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -330,7 +330,7 @@ namespace QuantConnect.Data.Consolidators
                 // reason we need to handle this case specifically.
                 if (inputData.EndTime - inputData.Time == TimeSpan.FromHours(1) && potentialStartTime.Date < inputData.Time.Date)
                 {
-                    potentialStartTime = inputData.Time.Date + potentialStartTime.TimeOfDay;
+                    potentialStartTime = GetRoundedBarTime(inputData.EndTime);
                 }
                 else
                 {

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -322,10 +322,17 @@ namespace QuantConnect.Data.Consolidators
         protected DateTime GetRoundedBarTime(IBaseData inputData)
         {
             var potentialStartTime = GetRoundedBarTime(inputData.Time);
-            if(_period.HasValue && potentialStartTime + _period < inputData.EndTime)
+            if (_period.HasValue)
             {
-                // whops! the end time we were giving is beyond our potential end time, so let's use the giving bars star time instead
-                potentialStartTime = inputData.Time;
+                if (inputData.EndTime - inputData.Time == TimeSpan.FromHours(1) && potentialStartTime.Date < inputData.Time.Date)
+                {
+                    potentialStartTime = inputData.Time.Date + potentialStartTime.TimeOfDay;
+                }
+                else if (potentialStartTime + _period < inputData.EndTime)
+                {
+                    // whops! the end time we were giving is beyond our potential end time, so let's use the giving bars star time instead
+                    potentialStartTime = inputData.Time;
+                }
             }
 
             return potentialStartTime;

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -324,11 +324,11 @@ namespace QuantConnect.Data.Consolidators
             var potentialStartTime = GetRoundedBarTime(inputData.Time);
             if (_period.HasValue && potentialStartTime + _period < inputData.EndTime)
             {
-                // US equity hour bars from the database start at 9am but the exchange opens at 9:30am. Thus, the method
+                // US equity hour bars from the database starts at 9am but the exchange opens at 9:30am. Thus, the method
                 // GetRoundedBarTime(inputData.Time) returns the market open of the previous day, which is not consistent
-                // with the given end time. However, while the date returned is incorrect, the time of day isn't. For that
-                // reason we need to handle this case specifically.
-                if (inputData.EndTime - inputData.Time == TimeSpan.FromHours(1) && potentialStartTime.Date < inputData.Time.Date)
+                // with the given end time. For that reason we need to handle this case specifically, by calling
+                // GetRoundedBarTime(inputData.EndTime) as it will return our expected start time: 9:30am
+                if (inputData.EndTime - inputData.Time == Time.OneHour && potentialStartTime.Date < inputData.Time.Date)
                 {
                     potentialStartTime = GetRoundedBarTime(inputData.EndTime);
                 }

--- a/Tests/Common/Data/MarketHourAwareConsolidatorTests.cs
+++ b/Tests/Common/Data/MarketHourAwareConsolidatorTests.cs
@@ -117,6 +117,54 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(1, latestBar.Low);
         }
 
+        [Test]
+        public void FirstHourBarIsNotSkippedWhenBarResolutionIsHour()
+        {
+            var symbol =  Symbols.SPY;
+            using var consolidator = new MarketHourAwareConsolidator(true, Resolution.Daily, typeof(TradeBar), TickType.Trade, false);
+            var consolidatedBarsCount = 0;
+            TradeBar latestBar = null;
+
+            consolidator.DataConsolidated += (sender, bar) =>
+            {
+                latestBar = (TradeBar)bar;
+                consolidatedBarsCount++;
+            };
+
+            var time = new DateTime(2020, 05, 01, 09, 30, 0);
+            // this bar will be ignored because it's during market closed hours and the bar resolution is not Hour
+            consolidator.Update(new TradeBar() { Time = time.Subtract(Time.OneMinute), Period = Time.OneMinute, Symbol = symbol, Open = 1});
+
+            time = new DateTime(2020, 05, 01, 09, 0, 0);
+            var hourBars = new List<TradeBar>()
+            {
+                new TradeBar() { Time = time, Period = Time.OneHour, Symbol = symbol, Open = 2 },
+                new TradeBar() { Time = time.AddHours(1), Period = Time.OneHour, Symbol = symbol, High = 200 },
+                new TradeBar() { Time = time.AddHours(2), Period = Time.OneHour, Symbol = symbol, Low = 0.02m },
+                new TradeBar() { Time = time.AddHours(3), Period = Time.OneHour, Symbol = symbol, Close = 20 },
+                new TradeBar() { Time = time.AddHours(4), Period = Time.OneHour, Symbol = symbol, Open = 3 },
+                new TradeBar() { Time = time.AddHours(5), Period = Time.OneHour, Symbol = symbol, High = 300 },
+                new TradeBar() { Time = time.AddHours(6), Period = Time.OneHour, Symbol = symbol, Low = 0.03m, Close = 30 },
+            };
+
+            foreach (var bar in hourBars)
+            {
+                consolidator.Update(bar);
+            }
+
+            consolidator.Scan(time.AddHours(7));
+
+            // Assert that the bar emitted
+            Assert.IsNotNull(latestBar);
+            Assert.AreEqual(time.AddHours(7), latestBar.EndTime);
+            Assert.AreEqual(time.AddMinutes(30), latestBar.Time);
+            Assert.AreEqual(1, consolidatedBarsCount);
+            Assert.AreEqual(2, latestBar.Open);
+            Assert.AreEqual(300, latestBar.High);
+            Assert.AreEqual(0.02, latestBar.Low);
+            Assert.AreEqual(30, latestBar.Close);
+        }
+
         [TestCase(true)]
         [TestCase(false)]
         public void DailyExtendedMarketHours(bool strictEndTime)

--- a/Tests/Common/Data/MarketHourAwareConsolidatorTests.cs
+++ b/Tests/Common/Data/MarketHourAwareConsolidatorTests.cs
@@ -152,11 +152,7 @@ namespace QuantConnect.Tests.Common.Data
                 consolidatedBarsCount++;
             };
 
-            var time = new DateTime(2020, 05, 01, 09, 30, 0);
-            // this bar will be ignored because it's during market closed hours and the bar resolution is not Hour
-            consolidator.Update(new TradeBar() { Time = time.Subtract(Time.OneMinute), Period = Time.OneMinute, Symbol = symbol, Open = 1});
-
-            time = new DateTime(2020, 05, 01, 09, 0, 0);
+            var time = new DateTime(2020, 05, 01, 09, 0, 0);
             var hourBars = new List<TradeBar>()
             {
                 new TradeBar() { Time = time, Period = Time.OneHour, Symbol = symbol, Open = 2 },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
When hourly bars were consolidated into daily ones, the first hourly bar was skipped as well as the last two. This happened because of the format of the hourly bars in the DB. While according to the exchange hours, US equities open at 09:30 and close at 16, but for every equity, its hour data in the DB starts at 09 and finish at 16:00. Thus, not all the hourly bars were taken into account when consolidating a daily bar. This PR aims to fix that bug by covering this specific case in `MarketHourAwareConsolidator.Update()` and `PeriodCountConsolidatorBase.GetRoundedBarTime()`.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #8415, #8416
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, daily consolidated bars from hourly bars will match daily bars from DB
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created a regression test to assert the bug was solved. In the regression test, I create two RelativeStrengthIndex indicators but register just one, using the symbol in hour resolution but a daily consolidator. After one month, I request data for the symbol in daily resolution and manually update the second indicator, so that I can compare the values of both indicator and assert they are the same. It's worth saying I used a RelativeStrengthIndex indicator since that indicator depends on its previous values, thus if the first value is different, so will the next values
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
