### PR TITLE
Improve the performance of RollingWindow.GetEnumerator

### DIFF
--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -244,18 +244,20 @@ namespace QuantConnect.Indicators
         /// <filterpriority>1</filterpriority>
         public IEnumerator<T> GetEnumerator()
         {
-            // we make a copy on purpose so the enumerator isn't tied
-            // to a mutable object, well it is still mutable but out of scope
-            var temp = new List<T>(_list.Count);
             try
             {
                 _listLock.EnterReadLock();
 
-                for (int i = 0; i < _list.Count; i++)
+                // we make a copy on purpose so the enumerator isn't tied
+                // to a mutable object, well it is still mutable but out of scope
+                var count = _list.Count;
+                var temp = new T[count];
+                for (int i = count - 1; i >= 0; i--)
                 {
-                    temp.Add(this[i]);
+                    temp[count - 1 - i] = _list[(_tail + i) % count];
                 }
-                return temp.GetEnumerator();
+
+                return ((IEnumerable<T>) temp).GetEnumerator();
             }
             finally
             {

--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace QuantConnect.Indicators
@@ -174,7 +175,7 @@ namespace QuantConnect.Indicators
                         return default;
                     }
 
-                    return _list[(_list.Count + _tail - i - 1) % _list.Count];
+                    return _list[GetListIndex(i, _list.Count, _tail)];
                 }
                 finally
                 {
@@ -206,7 +207,7 @@ namespace QuantConnect.Indicators
                         }
                     }
 
-                    _list[(_list.Count + _tail - i - 1) % _list.Count] = value;
+                    _list[GetListIndex(i, _list.Count, _tail)] = value;
                 }
                 finally
                 {
@@ -252,9 +253,9 @@ namespace QuantConnect.Indicators
                 // to a mutable object, well it is still mutable but out of scope
                 var count = _list.Count;
                 var temp = new T[count];
-                for (int i = count - 1; i >= 0; i--)
+                for (int i = 0; i < count; i++)
                 {
-                    temp[count - 1 - i] = _list[(_tail + i) % count];
+                    temp[i] = _list[GetListIndex(i, count, _tail)];
                 }
 
                 return ((IEnumerable<T>) temp).GetEnumerator();
@@ -325,6 +326,12 @@ namespace QuantConnect.Indicators
             {
                 _listLock.ExitWriteLock();
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetListIndex(int index, int listCount, int tail)
+        {
+            return (listCount + tail - index - 1) % listCount;
         }
 
         private void Resize(int size)

--- a/Tests/Indicators/RollingWindowTests.cs
+++ b/Tests/Indicators/RollingWindowTests.cs
@@ -114,6 +114,12 @@ namespace QuantConnect.Tests.Indicators
             Assert.AreEqual(2, inOrder[0]);
             Assert.AreEqual(1, inOrder[1]);
             Assert.AreEqual(0, inOrder[2]);
+
+            window.Add(3);
+            var inOrder2 = window.ToList();
+            Assert.AreEqual(3, inOrder2[0]);
+            Assert.AreEqual(2, inOrder2[1]);
+            Assert.AreEqual(1, inOrder2[2]);
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
This optimises the `RollingWindow.GetEnumerator` method in terms of execution time and memory allocation.

#### Related Issue
Closes https://github.com/QuantConnect/Lean/issues/8443

#### Motivation and Context
The `RollingWindow.GetEnumerator` method allocates a new list for each invocation and copies values to the list via this[int], which in turn enters/exits reader lock for each invocation. I was able to speed up this method by more than 50% in terms of execution time and achieve marginally better memory consumption by switching from `List<T>` to `T[]` and inlining the respective part of `this[int]`.

Many built-in indicators as well as some reasonable real-world use cases for RollingWindow would benefit from this change in backtesting/optimisation.

#### Requires Documentation Change
No

#### How Has This Been Tested?
<details>
  <summary>Benchmark code</summary>

    using BenchmarkDotNet.Attributes;
    using BenchmarkDotNet.Configs;
    using BenchmarkDotNet.Diagnosers;
    using BenchmarkDotNet.Jobs;
    using BenchmarkDotNet.Running;
    using QuantConnect.Indicators;
    
    var summary = BenchmarkRunner.Run<Bench>();
    
    [Config(typeof(BenchmarkConfig))]
    public class Bench
    {
        private readonly RollingWindow<decimal> _baseline = new RollingWindow<decimal>(100);
        private readonly RollingWindowToArray<decimal> _toArray = new RollingWindowToArray<decimal>(100);
        private readonly RollingWindowToArrayInlinedIndexCalculation<decimal> _toArrayInlinedIndexer = new
            RollingWindowToArrayInlinedIndexCalculation<decimal>(100);
        private readonly RollingWindowToArrayInlinedIndexerReversedFor<decimal> _toArrayInlinedIndexerReversed = new
            RollingWindowToArrayInlinedIndexerReversedFor<decimal>(100);
    
        [Benchmark]
        public decimal Baseline()
        {
            _baseline.Add(1);
            if (_baseline.IsReady)
            {
                return _baseline.Sum();
            }
            return _baseline.Max();
        }
    
        [Benchmark]
        public decimal ToArray()
        {
            _toArray.Add(1);
            if (_toArray.IsReady)
            {
                return _toArray.Sum();
            }
    
            return _toArray.Max();
        }
    
        [Benchmark]
        public decimal ToArrayInlinedIndexer()
        {
            _toArrayInlinedIndexer.Add(1);
            if (_toArrayInlinedIndexer.IsReady)
            {
                return _toArrayInlinedIndexer.Sum();
            }
    
            return _toArrayInlinedIndexer.Max();
        }
    
        [Benchmark]
        public decimal ToArrayInlinedIndexerReversed()
        {
            _toArrayInlinedIndexerReversed.Add(1);
            if (_toArrayInlinedIndexerReversed.IsReady)
            {
                return _toArrayInlinedIndexerReversed.Sum();
            }
    
            return _toArrayInlinedIndexerReversed.Max();
        }
    }
    
    public class BenchmarkConfig : ManualConfig
    {
        public BenchmarkConfig()
        {
            // Configure your benchmarks, see for more details: https://benchmarkdotnet.org/articles/configs/configs.html.
            AddJob(Job.Default);
            AddDiagnoser(MemoryDiagnoser.Default);
        }
    }
</details>

Several options were considered:
- `Baseline`: current `RollingWindow` implementation in `master`
- `ToArray`: changed `List<T>` to `T[]`
- `ToArrayInlinedIndexer`: manually inlined the appropriate part of the `this[int]` indexer
- `ToArrayInlinedIndexerReversed`: changed `for` loop to the reversed version (iterating with counter being decremented)

Benchmarking results for `RollingWindow` of size 100:
```
|                        Method |     Mean |     Error |    StdDev |   Gen0 | Allocated |
|------------------------------ |---------:|----------:|----------:|-------:|----------:|
|                      Baseline | 5.048 us | 0.0969 us | 0.1037 us | 0.1984 |   1.66 KB |
|                       ToArray | 5.099 us | 0.1017 us | 0.1808 us | 0.1907 |   1.62 KB |
|         ToArrayInlinedIndexer | 1.682 us | 0.0227 us | 0.0223 us | 0.1965 |   1.62 KB |
| ToArrayInlinedIndexerReversed | 1.680 us | 0.0281 us | 0.0312 us | 0.1965 |   1.62 KB |
```

Benchmarking results for `RollingWindow` of size 10:
```
|                        Method |     Mean |   Error |  StdDev |   Gen0 | Allocated |
|------------------------------ |---------:|--------:|--------:|-------:|----------:|
|                      Baseline | 625.4 ns | 8.17 ns | 6.82 ns | 0.0315 |     264 B |
|                       ToArray | 594.6 ns | 9.92 ns | 9.75 ns | 0.0257 |     216 B |
|         ToArrayInlinedIndexer | 275.7 ns | 5.47 ns | 8.83 ns | 0.0257 |     216 B |
| ToArrayInlinedIndexerReversed | 267.8 ns | 5.05 ns | 4.73 ns | 0.0257 |     216 B |
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have NOT added tests to cover my changes because it's performance-only related change.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
