### PR TITLE
Improve performance of ConsolidatorScanPriority comparison

### DIFF
--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -66,7 +66,7 @@ namespace QuantConnect.Data
         {
             _consolidators = new();
             _timeKeeper = timeKeeper;
-            _consolidatorsSortedByScanTime = new(1000);
+            _consolidatorsSortedByScanTime = new(1000, ConsolidatorScanPriority.Comparer);
             _threadSafeCollectionLock = new object();
         }
 

--- a/Tests/Common/Data/ConsolidatorWrapperTests.cs
+++ b/Tests/Common/Data/ConsolidatorWrapperTests.cs
@@ -163,6 +163,26 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(consolidator.WorkingData.EndTime.ConvertToUtc(tz), wrapper.UtcScanTime);
         }
 
+        [Test]
+        public void ConsolidatorScanPriorityComparerComparesByUtcScanDateThenById()
+        {
+            var id1 = Random.Shared.NextInt64();
+            var utcScanTime = DateTime.UtcNow;
+            var priority1 = new ConsolidatorScanPriority(utcScanTime, id1);
+            var priority2 = new ConsolidatorScanPriority(utcScanTime.AddSeconds(1), id1 + 1);
+            var priority3 = new ConsolidatorScanPriority(utcScanTime, id1 + 1);
+            var priority4 = new ConsolidatorScanPriority(utcScanTime, id1);
+
+            Assert.AreEqual(-1, ConsolidatorScanPriority.Comparer.Compare(priority1, priority2));
+            Assert.AreEqual(1, ConsolidatorScanPriority.Comparer.Compare(priority2, priority1));
+            Assert.AreEqual(1, ConsolidatorScanPriority.Comparer.Compare(priority3, priority1));
+            Assert.AreEqual(-1, ConsolidatorScanPriority.Comparer.Compare(priority3, priority2));
+            Assert.AreEqual(0, ConsolidatorScanPriority.Comparer.Compare(priority1, priority4));
+            Assert.AreEqual(0, ConsolidatorScanPriority.Comparer.Compare(priority1, priority1));
+            Assert.AreEqual(1, ConsolidatorScanPriority.Comparer.Compare(priority1, null));
+            Assert.AreEqual(-1, ConsolidatorScanPriority.Comparer.Compare(null, priority1));
+            Assert.AreEqual(0, ConsolidatorScanPriority.Comparer.Compare(null, null));
+        }
         private class TestConsolidator : IDataConsolidator
         {
             public IBaseData Consolidated { get; set; }

--- a/Tests/Common/Data/ConsolidatorWrapperTests.cs
+++ b/Tests/Common/Data/ConsolidatorWrapperTests.cs
@@ -164,25 +164,46 @@ namespace QuantConnect.Tests.Common.Data
         }
 
         [Test]
-        public void ConsolidatorScanPriorityComparerComparesByUtcScanDateThenById()
+        public void ConsolidatorScanPriorityComparerComparesByUtcScanDate()
         {
-            var id1 = Random.Shared.NextInt64();
-            var utcScanTime = DateTime.UtcNow;
-            var priority1 = new ConsolidatorScanPriority(utcScanTime, id1);
-            var priority2 = new ConsolidatorScanPriority(utcScanTime.AddSeconds(1), id1 + 1);
-            var priority3 = new ConsolidatorScanPriority(utcScanTime, id1 + 1);
-            var priority4 = new ConsolidatorScanPriority(utcScanTime, id1);
+            const int id = 1;
+            var utcScanTime = new DateTime(2024, 12, 10, 0, 0, 0, DateTimeKind.Utc);
+            
+            var priority1 = new ConsolidatorScanPriority(utcScanTime, id);
+            var priority2 = new ConsolidatorScanPriority(utcScanTime.AddSeconds(1), id + 1);
+            var priority3 = new ConsolidatorScanPriority(utcScanTime, id + 1);
 
             Assert.AreEqual(-1, ConsolidatorScanPriority.Comparer.Compare(priority1, priority2));
             Assert.AreEqual(1, ConsolidatorScanPriority.Comparer.Compare(priority2, priority1));
             Assert.AreEqual(1, ConsolidatorScanPriority.Comparer.Compare(priority3, priority1));
             Assert.AreEqual(-1, ConsolidatorScanPriority.Comparer.Compare(priority3, priority2));
-            Assert.AreEqual(0, ConsolidatorScanPriority.Comparer.Compare(priority1, priority4));
             Assert.AreEqual(0, ConsolidatorScanPriority.Comparer.Compare(priority1, priority1));
+        }
+
+        [Test]
+        public void ConsolidatorScanPriorityComparerComparesByIdIfUtcScanTimesAreEqual()
+        {
+            const int id = 1;
+            var utcScanTime = new DateTime(2024, 12, 10, 0, 0, 0, DateTimeKind.Utc);
+
+            var priority1 = new ConsolidatorScanPriority(utcScanTime, id);
+            var priority2 = new ConsolidatorScanPriority(utcScanTime, id + 1);
+
+            Assert.AreEqual(1, ConsolidatorScanPriority.Comparer.Compare(priority2, priority1));
+        }
+
+        [Test]
+        public void ConsolidatorScanPriorityComparerTreatsNullsRight()
+        {
+            const int id = 1;
+            var utcScanTime = new DateTime(2024, 12, 10, 0, 0, 0, DateTimeKind.Utc);
+            var priority1 = new ConsolidatorScanPriority(utcScanTime, id);
+
             Assert.AreEqual(1, ConsolidatorScanPriority.Comparer.Compare(priority1, null));
             Assert.AreEqual(-1, ConsolidatorScanPriority.Comparer.Compare(null, priority1));
             Assert.AreEqual(0, ConsolidatorScanPriority.Comparer.Compare(null, null));
         }
+
         private class TestConsolidator : IDataConsolidator
         {
             public IBaseData Consolidated { get; set; }


### PR DESCRIPTION
#### Description

This introduces a new Comparer and supplies it to the PrioorityQueue constructor. This yields 5-10 percent improvement in data points per second for all Lean benchmarks on my machine.

#### Related Issue
See issue #8451

#### Motivation and Context
The ConsolidatorScanPriority type implements IComparable and is used as the priority in the SubscriptionManager's priority queue. Due to the way comparison is handled for the case when PriorityQueue is not supplied with IComparer instance explicitly, an intermediate ObjectComparer is used for the comparison that eventually delegates comparison to ConsolidatorScanPriority.CompareTo.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Lean benchmarks

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
