### PR TITLE
Reduce unrequired live logs for derivatives chains

### DIFF
--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -398,19 +398,17 @@ namespace QuantConnect.Data
         /// <filterpriority>2</filterpriority>
         public override string ToString()
         {
-            return Invariant($"{Symbol.Value},#{ContractDepthOffset},{MappedSymbol},{Resolution},{Type.Name},{TickType},{DataNormalizationMode},{DataMappingMode}{(IsInternalFeed ? ",Internal" : string.Empty)}");
+            return ToString(Symbol.Value);
         }
 
-        public string ToStringWithCanonicalSymbol()
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <param name="symbol">Symbol to use in the string representation of the object</param>
+        /// <returns>/// A string that represents the current object.</returns>
+        public string ToString(string symbol)
         {
-            if (Symbol.HasCanonical())
-            {
-                return Invariant($"{Symbol.Canonical},#{ContractDepthOffset},{MappedSymbol},{Resolution},{Type.Name},{TickType},{DataNormalizationMode},{DataMappingMode}{(IsInternalFeed ? ",Internal" : string.Empty)}");
-            }
-            else
-            {
-                return ToString();
-            }
+            return Invariant($"{symbol},#{ContractDepthOffset},{MappedSymbol},{Resolution},{Type.Name},{TickType},{DataNormalizationMode},{DataMappingMode}{(IsInternalFeed ? ",Internal" : string.Empty)}");
         }
 
         /// <summary>

--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -401,6 +401,18 @@ namespace QuantConnect.Data
             return Invariant($"{Symbol.Value},#{ContractDepthOffset},{MappedSymbol},{Resolution},{Type.Name},{TickType},{DataNormalizationMode},{DataMappingMode}{(IsInternalFeed ? ",Internal" : string.Empty)}");
         }
 
+        public string ToStringWithCanonicalSymbol()
+        {
+            if (Symbol.HasCanonical())
+            {
+                return Invariant($"{Symbol.Canonical},#{ContractDepthOffset},{MappedSymbol},{Resolution},{Type.Name},{TickType},{DataNormalizationMode},{DataMappingMode}{(IsInternalFeed ? ",Internal" : string.Empty)}");
+            }
+            else
+            {
+                return ToString();
+            }
+        }
+
         /// <summary>
         /// New base class for all event classes.
         /// </summary>

--- a/Engine/DataFeeds/Enumerators/LiveMappingEventProvider.cs
+++ b/Engine/DataFeeds/Enumerators/LiveMappingEventProvider.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
             InitializeMapFile();
             var newInstance = MapFile;
 
-            Log.Trace($"LiveMappingEventProvider({Config}): new tradable date {eventArgs.Date:yyyyMMdd}. " +
+            Log.Trace($"LiveMappingEventProvider({Config.ToStringWithCanonicalSymbol()}): new tradable date {eventArgs.Date:yyyyMMdd}. " +
                 $"New MapFile: {!ReferenceEquals(currentInstance, newInstance)}. " +
                 $"MapFile.Count Old: {currentInstance?.Count()} New: {newInstance?.Count()}");
 

--- a/Engine/DataFeeds/Enumerators/LiveMappingEventProvider.cs
+++ b/Engine/DataFeeds/Enumerators/LiveMappingEventProvider.cs
@@ -38,7 +38,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
             InitializeMapFile();
             var newInstance = MapFile;
 
-            Log.Trace($"LiveMappingEventProvider({Config.ToStringWithCanonicalSymbol()}): new tradable date {eventArgs.Date:yyyyMMdd}. " +
+            // All future and option contracts sharing the same canonical symbol, share the same configuration too. Thus, in
+            // order to reduce logs, we log the configuration using the canonical symbol. See the optional parameter
+            // "overrideMessageFloodProtection" in Log.Trace() method for more information
+            var symbol = Config.Symbol.HasCanonical() ? Config.Symbol.Canonical.Value : Config.Symbol.Value;
+            Log.Trace($"LiveMappingEventProvider({Config.ToString(symbol)}): new tradable date {eventArgs.Date:yyyyMMdd}. " +
                 $"New MapFile: {!ReferenceEquals(currentInstance, newInstance)}. " +
                 $"MapFile.Count Old: {currentInstance?.Count()} New: {newInstance?.Count()}");
 

--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -145,6 +145,11 @@ namespace QuantConnect.Lean.Engine.RealTime
                 UpdateMarketHours(security);
 
                 var localMarketHours = security.Exchange.Hours.GetMarketHours(date);
+
+                // All future and option contracts sharing the same canonical symbol, share the same market
+                // hours too. Thus, in order to reduce logs, we log the market hours using the canonical
+                // symbol. See the optional parameter "overrideMessageFloodProtection" in Log.Trace()
+                // method for further information
                 var symbol = security.Symbol.HasCanonical() ? security.Symbol.Canonical : security.Symbol;
                 Log.Trace($"LiveTradingRealTimeHandler.RefreshMarketHoursToday({security.Type}): Market hours set: Symbol: {symbol} {localMarketHours} ({security.Exchange.Hours.TimeZone})");
             }
@@ -166,6 +171,11 @@ namespace QuantConnect.Lean.Engine.RealTime
             {
                 var security = kvp.Value;
                 UpdateSymbolProperties(security);
+
+                // All future and option contracts sharing the same canonical symbol, share the same symbol
+                // properties too. Thus, in order to reduce logs, we log the symbol properties using the
+                // canonical symbol. See the optional parameter "overrideMessageFloodProtection" in
+                // Log.Trace() method for further information
                 var symbol = security.Symbol.HasCanonical() ? security.Symbol.Canonical : security.Symbol;
                 Log.Trace($"LiveTradingRealTimeHandler.RefreshSymbolPropertiesToday(): Symbol properties set: " +
                     $"Symbol: {symbol} {security.SymbolProperties}");

--- a/Engine/RealTime/LiveTradingRealTimeHandler.cs
+++ b/Engine/RealTime/LiveTradingRealTimeHandler.cs
@@ -145,7 +145,8 @@ namespace QuantConnect.Lean.Engine.RealTime
                 UpdateMarketHours(security);
 
                 var localMarketHours = security.Exchange.Hours.GetMarketHours(date);
-                Log.Trace($"LiveTradingRealTimeHandler.RefreshMarketHoursToday({security.Type}): Market hours set: Symbol: {security.Symbol} {localMarketHours} ({security.Exchange.Hours.TimeZone})");
+                var symbol = security.Symbol.HasCanonical() ? security.Symbol.Canonical : security.Symbol;
+                Log.Trace($"LiveTradingRealTimeHandler.RefreshMarketHoursToday({security.Type}): Market hours set: Symbol: {symbol} {localMarketHours} ({security.Exchange.Hours.TimeZone})");
             }
         }
 
@@ -165,9 +166,9 @@ namespace QuantConnect.Lean.Engine.RealTime
             {
                 var security = kvp.Value;
                 UpdateSymbolProperties(security);
-
+                var symbol = security.Symbol.HasCanonical() ? security.Symbol.Canonical : security.Symbol;
                 Log.Trace($"LiveTradingRealTimeHandler.RefreshSymbolPropertiesToday(): Symbol properties set: " +
-                    $"Symbol: {security.Symbol} {security.SymbolProperties}");
+                    $"Symbol: {symbol} {security.SymbolProperties}");
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Reduce unrequired logs for derivatives chains (futures and options) by logging once per parent canonical symbol per update procedure. The method `Log.Trace()` has an optional parameter called `overrideMessageFloodProtection` that prevents the method to log the same message more than once. Thus, I changed the log messages in `LiveMappingEventProvider.GetEvents()`, `LiveTradingRealTimeHandler.RefreshMarketHours()` and `LiveTradingRealTimeHandler.RefreshSymbolProperties()`, to use the canonical symbol if the security symbol had it.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #8411 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, less messages will be logged helping the user to focus on the relevant logs
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested my changes running the regression algorithm `BasicTemplateOptionsAlgorithm` on paper-live mode and asserting the unrequired logs were gone.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
