### PR TITLE
Collective2 - No index option

### DIFF
--- a/Algorithm.CSharp/RegressionTests/Collective2IndexOptionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionTests/Collective2IndexOptionAlgorithm.cs
@@ -37,8 +37,7 @@ namespace QuantConnect.Algorithm.CSharp.RegressionTests
 
         private ExponentialMovingAverage _fast;
         private ExponentialMovingAverage _slow;
-        private Symbol _spxw;
-        private Symbol _spxwOption;
+        private Symbol _symbol;
         private bool _firstCall = true;
 
         public override void Initialize()
@@ -47,21 +46,22 @@ namespace QuantConnect.Algorithm.CSharp.RegressionTests
             SetEndDate(2021, 1, 18);
             SetCash(100000);
 
-            _spxw = AddIndex("SPXW", Resolution.Minute).Symbol;
+            var underlying = AddIndex("SPX", Resolution.Minute).Symbol;
 
             // Create an SPXW option contract with a specific strike price and expiration date
-            _spxwOption = QuantConnect.Symbol.CreateOption(
-                _spxw,
+            var option = QuantConnect.Symbol.CreateOption(
+                underlying,
+                "SPXW",
                 Market.USA,
                 OptionStyle.European,
                 OptionRight.Call,
                 3800m,
                 new DateTime(2021, 1, 04));
 
-            AddIndexOptionContract(_spxwOption, Resolution.Minute);
+            _symbol = AddIndexOptionContract(option, Resolution.Minute).Symbol;
 
-            _fast = EMA(_spxw, 10, Resolution.Minute);
-            _slow = EMA(_spxw, 50, Resolution.Minute);
+            _fast = EMA(underlying, 10, Resolution.Minute);
+            _slow = EMA(underlying, 50, Resolution.Minute);
 
             // Set up the Collective2 Signal Export with the provided API key and system ID
             SignalExport.AddSignalExportProviders(new Collective2SignalExport(_collective2ApiKey, _collective2SystemId));
@@ -75,7 +75,7 @@ namespace QuantConnect.Algorithm.CSharp.RegressionTests
             // Execute only on the first data call to set initial portfolio
             if (_firstCall)
             {
-                SetHoldings(_spxw, 0.1);
+                SetHoldings(_symbol, 0.1);
                 SignalExport.SetTargetPortfolioFromPortfolio();
                 _firstCall = false;
             }
@@ -83,14 +83,14 @@ namespace QuantConnect.Algorithm.CSharp.RegressionTests
             // If the fast EMA crosses above the slow EMA, open a long position
             if (_fast > _slow && !Portfolio.Invested)
             {
-                MarketOrder(_spxw, 1);
+                MarketOrder(_symbol, 1);
                 SignalExport.SetTargetPortfolioFromPortfolio();
             }
 
             // If the fast EMA crosses below the slow EMA, open a short position
             else if (_fast < _slow && Portfolio.Invested)
             {
-                MarketOrder(_spxw, -1);
+                MarketOrder(_symbol, -1);
                 SignalExport.SetTargetPortfolioFromPortfolio();
             }
         }
@@ -113,7 +113,7 @@ namespace QuantConnect.Algorithm.CSharp.RegressionTests
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 493;
+        public long DataPoints => 4543;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -125,33 +125,33 @@ namespace QuantConnect.Algorithm.CSharp.RegressionTests
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Orders", "0"},
+            {"Total Orders", "10"},
             {"Average Win", "0%"},
-            {"Average Loss", "0%"},
-            {"Compounding Annual Return", "0%"},
-            {"Drawdown", "0%"},
-            {"Expectancy", "0"},
+            {"Average Loss", "0.00%"},
+            {"Compounding Annual Return", "-0.468%"},
+            {"Drawdown", "0.000%"},
+            {"Expectancy", "-1"},
             {"Start Equity", "100000"},
-            {"End Equity", "100000"},
-            {"Net Profit", "0%"},
-            {"Sharpe Ratio", "0"},
+            {"End Equity", "99985"},
+            {"Net Profit", "-0.015%"},
+            {"Sharpe Ratio", "-15.229"},
             {"Sortino Ratio", "0"},
-            {"Probabilistic Sharpe Ratio", "0%"},
-            {"Loss Rate", "0%"},
+            {"Probabilistic Sharpe Ratio", "0.781%"},
+            {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "0"},
-            {"Beta", "0"},
+            {"Alpha", "-0.003"},
+            {"Beta", "-0.001"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-5.208"},
+            {"Information Ratio", "-5.216"},
             {"Tracking Error", "0.103"},
-            {"Treynor Ratio", "0"},
+            {"Treynor Ratio", "5.946"},
             {"Total Fees", "$0.00"},
-            {"Estimated Strategy Capacity", "$0"},
-            {"Lowest Capacity Asset", ""},
-            {"Portfolio Turnover", "0%"},
-            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+            {"Estimated Strategy Capacity", "$8000.00"},
+            {"Lowest Capacity Asset", "SPXW XKX6S2GM9PGU|SPX 31"},
+            {"Portfolio Turnover", "0.01%"},
+            {"OrderListHash", "5b50a3d9e0afad859c3f7e2580a4f3be"}
         };
     }
 }

--- a/Algorithm.CSharp/RegressionTests/Collective2IndexOptionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionTests/Collective2IndexOptionAlgorithm.cs
@@ -1,23 +1,44 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
 using QuantConnect.Data;
 using QuantConnect.Indicators;
 using QuantConnect.Interfaces;
-using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Algorithm.CSharp.RegressionTests
 {
     public class Collective2IndexOptionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
-        private const string _collective2ApiKey = "8923ABC5-F221-4458-AF97-7CECF5BE3106";
-        private const int _collective2SystemId = 145772785;
+        /// <summary>
+        /// Collective2 APIv4 KEY: This value is provided by Collective2 in your account section (See https://collective2.com/account-info)
+        /// See API documentation at https://trade.collective2.com/c2-api
+        /// </summary>
+        private const string _collective2ApiKey = "YOUR APIV4 KEY";
+
+        /// <summary>
+        /// Collective2 System ID: This value is found beside the system's name (strategy's name) on the main system page
+        /// </summary>
+        private const int _collective2SystemId = 0;
 
         private ExponentialMovingAverage _fast;
         private Symbol _spxw;
         private Symbol _spxwOption;
+        private Symbol _symbol;
 
         public override void Initialize()
         {
@@ -32,14 +53,13 @@ namespace QuantConnect.Algorithm.CSharp.RegressionTests
                 Market.USA,
                 OptionStyle.European,
                 OptionRight.Call,
-                3200m,
-                new DateTime(2021, 1, 15));
+                3800m,
+                new DateTime(2021, 1, 04));
 
-            var foo = AddIndexOptionContract(_spxwOption, Resolution.Minute);
+            _symbol = AddIndexOptionContract(_spxwOption, Resolution.Minute).Symbol;
 
-            _fast = EMA("SPXW", 10, Resolution.Minute);
+            _fast = EMA("SPXW", 3, Resolution.Minute);
 
-            // Configurar Collective2
             var test = new Collective2SignalExport(_collective2ApiKey, _collective2SystemId);
             SignalExport.AddSignalExportProviders(test);
             SetWarmUp(100);
@@ -47,22 +67,19 @@ namespace QuantConnect.Algorithm.CSharp.RegressionTests
 
         public override void OnData(Slice slice)
         {
-            //SetHoldings("SPXW", 0.1);
-            //var chain = slice.OptionChains[_spxwOption];
-            var test = Portfolio;
             if (!Portfolio[_spxw].Invested)
             {
                 MarketOrder(_spxw, -1);
                 SignalExport.SetTargetPortfolioFromPortfolio();
             }
         }
-        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.RuntimeError;
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
 
         public bool CanRunLocally { get; } = true;
 
         public virtual List<Language> Languages { get; } = new() { Language.CSharp };
 
-        public long DataPoints => 80;
+        public long DataPoints => 493;
 
         public int AlgorithmHistoryDataPoints => 0;
 
@@ -87,8 +104,8 @@ namespace QuantConnect.Algorithm.CSharp.RegressionTests
             {"Beta", "0"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-9.604"},
-            {"Tracking Error", "0.097"},
+            {"Information Ratio", "-5.208"},
+            {"Tracking Error", "0.103"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},

--- a/Algorithm.CSharp/RegressionTests/Collective2IndexOptionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionTests/Collective2IndexOptionAlgorithm.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using QuantConnect.Algorithm.Framework.Portfolio.SignalExports;
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities.Option;
+
+namespace QuantConnect.Algorithm.CSharp.RegressionTests
+{
+    public class Collective2IndexOptionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private const string _collective2ApiKey = "8923ABC5-F221-4458-AF97-7CECF5BE3106";
+        private const int _collective2SystemId = 145772785;
+
+        private ExponentialMovingAverage _fast;
+        private Symbol _spxw;
+        private Symbol _spxwOption;
+
+        public override void Initialize()
+        {
+            SetStartDate(2021, 1, 4);
+            SetEndDate(2021, 1, 18);
+            SetCash(100000);
+
+            _spxw = AddIndex("SPXW", Resolution.Minute).Symbol;
+
+            _spxwOption = QuantConnect.Symbol.CreateOption(
+                _spxw,
+                Market.USA,
+                OptionStyle.European,
+                OptionRight.Call,
+                3200m,
+                new DateTime(2021, 1, 15));
+
+            var foo = AddIndexOptionContract(_spxwOption, Resolution.Minute);
+
+            _fast = EMA("SPXW", 10, Resolution.Minute);
+
+            // Configurar Collective2
+            var test = new Collective2SignalExport(_collective2ApiKey, _collective2SystemId);
+            SignalExport.AddSignalExportProviders(test);
+            SetWarmUp(100);
+        }
+
+        public override void OnData(Slice slice)
+        {
+            //SetHoldings("SPXW", 0.1);
+            //var chain = slice.OptionChains[_spxwOption];
+            var test = Portfolio;
+            if (!Portfolio[_spxw].Invested)
+            {
+                MarketOrder(_spxw, -1);
+                SignalExport.SetTargetPortfolioFromPortfolio();
+            }
+        }
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.RuntimeError;
+
+        public bool CanRunLocally { get; } = true;
+
+        public virtual List<Language> Languages { get; } = new() { Language.CSharp };
+
+        public long DataPoints => 80;
+
+        public int AlgorithmHistoryDataPoints => 0;
+
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-9.604"},
+            {"Tracking Error", "0.097"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Common/Algorithm/Framework/Portfolio/SignalExports/Collective2SignalExport.cs
+++ b/Common/Algorithm/Framework/Portfolio/SignalExports/Collective2SignalExport.cs
@@ -184,6 +184,9 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
                 case SecurityType.Forex:
                     typeOfSymbol = "forex";
                     break;
+                case SecurityType.IndexOption:
+                    typeOfSymbol = "option";
+                    break;
                 default:
                     typeOfSymbol = "NotImplemented";
                     break;
@@ -263,7 +266,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
             {
                 _algorithm.Debug($"Collective2: NewSignals={string.Join(',', responseObject.Results[0].NewSignals)} | CanceledSignals={string.Join(',', responseObject.Results[0].CanceledSignals)}");
             }
-            
+
             return true;
         }
 

--- a/Common/Algorithm/Framework/Portfolio/SignalExports/Collective2SignalExport.cs
+++ b/Common/Algorithm/Framework/Portfolio/SignalExports/Collective2SignalExport.cs
@@ -145,10 +145,6 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
                 else if (target.Symbol.SecurityType.IsOption())
                 {
                     symbol = SymbolRepresentation.GenerateOptionTicker(target.Symbol);
-                    if (target.Symbol.SecurityType == SecurityType.IndexOption)
-                    {
-                        symbol = target.Symbol.Canonical.Value.Replace("?", string.Empty);
-                    }
                 }
 
                 positions.Add(new Collective2Position

--- a/Common/Algorithm/Framework/Portfolio/SignalExports/Collective2SignalExport.cs
+++ b/Common/Algorithm/Framework/Portfolio/SignalExports/Collective2SignalExport.cs
@@ -145,6 +145,10 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
                 else if (target.Symbol.SecurityType.IsOption())
                 {
                     symbol = SymbolRepresentation.GenerateOptionTicker(target.Symbol);
+                    if (target.Symbol.SecurityType == SecurityType.IndexOption)
+                    {
+                        symbol = target.Symbol.Canonical.Value.Replace("?", string.Empty);
+                    }
                 }
 
                 positions.Add(new Collective2Position

--- a/Common/Algorithm/Framework/Portfolio/SignalExports/SignalExportManager.cs
+++ b/Common/Algorithm/Framework/Portfolio/SignalExports/SignalExportManager.cs
@@ -109,7 +109,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
         /// <returns>True if the portfolio targets could be sent to the different signal export providers successfully, false otherwise</returns>
         public bool SetTargetPortfolio(params PortfolioTarget[] portfolioTargets)
         {
-            if (_algorithm.LiveMode)
+            if (!_algorithm.LiveMode)
             {
                 if (!_isLiveWarningModeLog)
                 {
@@ -156,12 +156,8 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
                     continue;
                 }
 
-                //var marginParameters = MaintenanceMarginParameters.ForQuantityAtCurrentPrice(security, holding.Quantity);
                 var marginParameters = new InitialMarginParameters(security, holding.Quantity);
                 var adjustedPercent = security.BuyingPowerModel.GetInitialMarginRequirement(marginParameters) / totalPortfolioValue;
-                //test
-                //adjustedPercent = 0.3m;
-
 
                 // See PortfolioTarget.Percent:
                 // we normalize the target buying power by the leverage so we work in the land of margin

--- a/Common/Algorithm/Framework/Portfolio/SignalExports/SignalExportManager.cs
+++ b/Common/Algorithm/Framework/Portfolio/SignalExports/SignalExportManager.cs
@@ -157,7 +157,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
                 }
 
                 var marginParameters = new InitialMarginParameters(security, holding.Quantity);
-                var adjustedPercent = security.BuyingPowerModel.GetInitialMarginRequirement(marginParameters) / totalPortfolioValue;
+                var adjustedPercent = Math.Abs(security.BuyingPowerModel.GetInitialMarginRequirement(marginParameters) / totalPortfolioValue);
 
                 // See PortfolioTarget.Percent:
                 // we normalize the target buying power by the leverage so we work in the land of margin

--- a/Common/Algorithm/Framework/Portfolio/SignalExports/SignalExportManager.cs
+++ b/Common/Algorithm/Framework/Portfolio/SignalExports/SignalExportManager.cs
@@ -156,10 +156,13 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
                     continue;
                 }
 
-                var marginParameters = MaintenanceMarginParameters.ForQuantityAtCurrentPrice(security, holding.Quantity);
-                var adjustedPercent = security.BuyingPowerModel.GetMaintenanceMargin(marginParameters) / totalPortfolioValue;
+                //var marginParameters = MaintenanceMarginParameters.ForQuantityAtCurrentPrice(security, holding.Quantity);
+                var marginParameters = new InitialMarginParameters(security, holding.Quantity);
+                var adjustedPercent = security.BuyingPowerModel.GetInitialMarginRequirement(marginParameters) / totalPortfolioValue;
                 //test
-                adjustedPercent = 0.3m;
+                //adjustedPercent = 0.3m;
+
+
                 // See PortfolioTarget.Percent:
                 // we normalize the target buying power by the leverage so we work in the land of margin
                 var holdingPercent = adjustedPercent * security.BuyingPowerModel.GetLeverage(security);

--- a/Common/Algorithm/Framework/Portfolio/SignalExports/SignalExportManager.cs
+++ b/Common/Algorithm/Framework/Portfolio/SignalExports/SignalExportManager.cs
@@ -109,7 +109,7 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
         /// <returns>True if the portfolio targets could be sent to the different signal export providers successfully, false otherwise</returns>
         public bool SetTargetPortfolio(params PortfolioTarget[] portfolioTargets)
         {
-            if (!_algorithm.LiveMode)
+            if (_algorithm.LiveMode)
             {
                 if (!_isLiveWarningModeLog)
                 {
@@ -158,6 +158,8 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
 
                 var marginParameters = MaintenanceMarginParameters.ForQuantityAtCurrentPrice(security, holding.Quantity);
                 var adjustedPercent = security.BuyingPowerModel.GetMaintenanceMargin(marginParameters) / totalPortfolioValue;
+                //test
+                adjustedPercent = 0.3m;
                 // See PortfolioTarget.Percent:
                 // we normalize the target buying power by the leverage so we work in the land of margin
                 var holdingPercent = adjustedPercent * security.BuyingPowerModel.GetLeverage(security);

--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -44,7 +44,7 @@ namespace QuantConnect
             /// <summary>
             /// Underlying name
             /// </summary>
-            public string Underlying { get; set;  }
+            public string Underlying { get; set; }
 
             /// <summary>
             /// Short expiration year
@@ -167,8 +167,7 @@ namespace QuantConnect
 
             if (!SymbolPropertiesDatabase.FromDataFolder().TryGetMarket(underlying, SecurityType.Future, out var market))
             {
-                Log.Debug($@"SymbolRepresentation.ParseFutureSymbol(): {
-                    Messages.SymbolRepresentation.FailedToGetMarketForTickerAndUnderlying(ticker, underlying)}");
+                Log.Debug($@"SymbolRepresentation.ParseFutureSymbol(): {Messages.SymbolRepresentation.FailedToGetMarketForTickerAndUnderlying(ticker, underlying)}");
                 return null;
             }
 
@@ -269,7 +268,8 @@ namespace QuantConnect
                 month = expirationMonth.Month;
                 year = doubleDigitsYear ? expirationMonth.Year % 100 : expirationMonth.Year % 10;
             }
-            else {
+            else
+            {
                 // These futures expire in the month before or in the contract month
                 month += contractMonthDelta;
 
@@ -389,7 +389,7 @@ namespace QuantConnect
                 // let it fallback to it's default handling, which include mapping
                 optionTicker = null;
             }
-            else if(securityType == SecurityType.IndexOption)
+            else if (securityType == SecurityType.IndexOption)
             {
                 underlyingSid = SecurityIdentifier.GenerateIndex(OptionSymbol.MapToUnderlying(optionTicker, securityType), market);
                 underlyingSymbolValue = underlyingSid.Symbol;
@@ -478,6 +478,10 @@ namespace QuantConnect
         /// <returns>The option ticker</returns>
         public static string GenerateOptionTicker(Symbol symbol)
         {
+            if (symbol.SecurityType == SecurityType.IndexOption)
+            {
+                return symbol.Canonical.Value.Replace("?", string.Empty);
+            }
             var letter = _optionSymbology.Where(x => x.Value.Item2 == symbol.ID.OptionRight && x.Value.Item1 == symbol.ID.Date.Month).Select(x => x.Key).Single();
             var twoYearDigit = symbol.ID.Date.ToString("yy");
             return $"{SecurityIdentifier.Ticker(symbol.Underlying, symbol.ID.Date)}{twoYearDigit}{symbol.ID.Date.Day:00}{letter}{symbol.ID.StrikePrice.ToStringInvariant()}";
@@ -590,10 +594,10 @@ namespace QuantConnect
         /// <remarks>Tickers from live trading may not provide the four-digit year.</remarks>
         private static int GetExpirationYear(int? futureYear, FutureTickerProperties parsed)
         {
-            if(futureYear.HasValue)
+            if (futureYear.HasValue)
             {
                 var referenceYear = 1900 + parsed.ExpirationYearShort;
-                while(referenceYear < futureYear.Value)
+                while (referenceYear < futureYear.Value)
                 {
                     referenceYear += 10;
                 }

--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -478,7 +478,7 @@ namespace QuantConnect
         /// <returns>The option ticker</returns>
         public static string GenerateOptionTicker(Symbol symbol)
         {
-            var symbolTicker = symbol == SecurityType.IndexOption ? symbol.Canonical.Value.Replace("?", string.Empty) : SecurityIdentifier.Ticker(symbol.Underlying, symbol.ID.Date);
+            var symbolTicker = symbol.SecurityType == SecurityType.IndexOption ? symbol.Canonical.Value.Replace("?", string.Empty) : SecurityIdentifier.Ticker(symbol.Underlying, symbol.ID.Date);
             var letter = _optionSymbology.Where(x => x.Value.Item2 == symbol.ID.OptionRight && x.Value.Item1 == symbol.ID.Date.Month).Select(x => x.Key).Single();
             var twoYearDigit = symbol.ID.Date.ToString("yy");
             return $"{symbolTicker}{twoYearDigit}{symbol.ID.Date.Day:00}{letter}{symbol.ID.StrikePrice.ToStringInvariant()}";

--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -478,13 +478,10 @@ namespace QuantConnect
         /// <returns>The option ticker</returns>
         public static string GenerateOptionTicker(Symbol symbol)
         {
-            if (symbol.SecurityType == SecurityType.IndexOption)
-            {
-                return symbol.Canonical.Value.Replace("?", string.Empty);
-            }
+            var symbolTicker = symbol == SecurityType.IndexOption ? symbol.Canonical.Value.Replace("?", string.Empty) : SecurityIdentifier.Ticker(symbol.Underlying, symbol.ID.Date);
             var letter = _optionSymbology.Where(x => x.Value.Item2 == symbol.ID.OptionRight && x.Value.Item1 == symbol.ID.Date.Month).Select(x => x.Key).Single();
             var twoYearDigit = symbol.ID.Date.ToString("yy");
-            return $"{SecurityIdentifier.Ticker(symbol.Underlying, symbol.ID.Date)}{twoYearDigit}{symbol.ID.Date.Day:00}{letter}{symbol.ID.StrikePrice.ToStringInvariant()}";
+            return $"{symbolTicker}{twoYearDigit}{symbol.ID.Date.Day:00}{letter}{symbol.ID.StrikePrice.ToStringInvariant()}";
         }
 
         /// <summary>

--- a/Tests/Algorithm/Framework/Portfolio/SignalExportTargetTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/SignalExportTargetTests.cs
@@ -275,6 +275,10 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             Assert.IsTrue(result);
             var target = portfolioTargets[0];
             var targetQuantity = (int)PortfolioTarget.Percent(algorithm, target.Symbol, target.Quantity).Quantity;
+            if (quantity < 0)
+            {
+                targetQuantity = -targetQuantity;
+            }
             // The quantites can differ by one because of the number of lots for certain securities
             Assert.AreEqual(quantity, targetQuantity, 1);
         }

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -155,6 +155,15 @@ namespace QuantConnect.Tests.Common
             Assert.AreEqual(result, null);
         }
 
+        [Test]
+        public void GenerateOptionTickerWithIndexOptionReturnsCorrectTicker()
+        {
+            var expected = "AAPL";
+            var symbol = Symbol.Create("AAPL", SecurityType.IndexOption, Market.USA, null, null);
+            var result = SymbolRepresentation.GenerateOptionTicker(symbol);
+            Assert.AreEqual(expected, result);
+        }
+
         [TestCase(Futures.Energy.ArgusLLSvsWTIArgusTradeMonth, 2017, 1, 29, "AE529G7", false)] // Previous month
         [TestCase(Futures.Energy.ArgusPropaneSaudiAramco, 2017, 1, 29, "A9N29G7", false)] // Previous month
         [TestCase(Futures.Energy.BrentCrude, 2017, 1, 29, "B29H7", false)] // Second prior month
@@ -287,7 +296,7 @@ namespace QuantConnect.Tests.Common
         [TestCase("PROPANE_NON_LDH_MONT_BELVIEU", QuantConnect.Securities.Futures.Energy.PropaneNonLDHMontBelvieu)]
         [TestCase("ARGUS_PROPANE_FAR_EAST_INDEX_BALMO", QuantConnect.Securities.Futures.Energy.ArgusPropaneFarEastIndexBALMO)]
         [TestCase("GASOLINE", QuantConnect.Securities.Futures.Energy.Gasoline)]
-        [TestCase("NATURAL_GAS",QuantConnect.Securities.Futures.Energy.NaturalGas)]
+        [TestCase("NATURAL_GAS", QuantConnect.Securities.Futures.Energy.NaturalGas)]
         public void FutureEnergySymbolsWorkInPythonWithPEP8(string FutureEnergyName, string expectedFutureEnergyValue)
         {
             using (Py.GIL())

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -158,8 +158,8 @@ namespace QuantConnect.Tests.Common
         [Test]
         public void GenerateOptionTickerWithIndexOptionReturnsCorrectTicker()
         {
-            var expected = "SPXW";
-            var symbol = Symbol.Create("SPXW", SecurityType.IndexOption, Market.USA, null, null);
+            var expected = "SPXW9930L0";
+            var symbol = Symbol.Create("SPXW", SecurityType.IndexOption, Market.USA);
             var result = SymbolRepresentation.GenerateOptionTicker(symbol);
             Assert.AreEqual(expected, result);
         }

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -158,9 +158,24 @@ namespace QuantConnect.Tests.Common
         [Test]
         public void GenerateOptionTickerWithIndexOptionReturnsCorrectTicker()
         {
-            var expected = "SPXW9930L0";
-            var symbol = Symbol.Create("SPXW", SecurityType.IndexOption, Market.USA);
-            var result = SymbolRepresentation.GenerateOptionTicker(symbol);
+            // Expected ticker for the option contract
+            var expected = "SPXW2104A3800";
+
+            var underlying = Symbols.SPX;
+
+            // Create the option contract (IndexOption) with specific parameters
+            var option = Symbol.CreateOption(
+                underlying,
+                "SPXW",
+                Market.USA,
+                OptionStyle.European,
+                OptionRight.Call,
+                3800m,
+                new DateTime(2021, 1, 04));
+
+            var result = SymbolRepresentation.GenerateOptionTicker(option);
+
+            // Assert that the result matches the expected ticker
             Assert.AreEqual(expected, result);
         }
 

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -158,8 +158,8 @@ namespace QuantConnect.Tests.Common
         [Test]
         public void GenerateOptionTickerWithIndexOptionReturnsCorrectTicker()
         {
-            var expected = "AAPL";
-            var symbol = Symbol.Create("AAPL", SecurityType.IndexOption, Market.USA, null, null);
+            var expected = "SPXW";
+            var symbol = Symbol.Create("SPXW", SecurityType.IndexOption, Market.USA, null, null);
             var result = SymbolRepresentation.GenerateOptionTicker(symbol);
             Assert.AreEqual(expected, result);
         }

--- a/Tests/RegressionTestMessageHandler.cs
+++ b/Tests/RegressionTestMessageHandler.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Tests
     /// </summary>
     public class RegressionTestMessageHandler : QuantConnect.Messaging.Messaging
     {
-        private static readonly bool _updateRegressionStatistics = Config.GetBool("regression-update-statistics", true);
+        private static readonly bool _updateRegressionStatistics = Config.GetBool("regression-update-statistics", false);
         private AlgorithmNodePacket _job;
         private AlgorithmManager _algorithmManager;
 

--- a/Tests/RegressionTestMessageHandler.cs
+++ b/Tests/RegressionTestMessageHandler.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Tests
     /// </summary>
     public class RegressionTestMessageHandler : QuantConnect.Messaging.Messaging
     {
-        private static readonly bool _updateRegressionStatistics = Config.GetBool("regression-update-statistics", false);
+        private static readonly bool _updateRegressionStatistics = Config.GetBool("regression-update-statistics", true);
         private AlgorithmNodePacket _job;
         private AlgorithmManager _algorithmManager;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
This PR adds support for IndexOptions in Collective2 signal export

#### Related Issue
Closes #8487

#### Motivation and Context
This change was required to fix a bug where Collective2 did not support IndexOptions, as indicated in the ConvertTypeOfSymbol method. The fix extends compatibility to handle IndexOptions correctly.

#### Requires Documentation Change
No documentation changes are required.

#### How Has This Been Tested?
The changes were tested using regression tests and unit tests to ensure IndexOptions are correctly exported

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
