### PR TITLE
Skip subscription to selected securities when no tradable dates

### DIFF
--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -100,15 +100,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private IEnumerator<BaseData> CreateDataEnumerator(SubscriptionRequest request, Resolution? fillForwardResolution)
         {
             // ReSharper disable once PossibleMultipleEnumeration
-            if (!request.TradableDaysInDataTimeZone.Any())
-            {
-                _algorithm.Error(
-                    $"No data loaded for {request.Security.Symbol} because there were no tradeable dates for this security."
-                );
-                return null;
-            }
-
-            // ReSharper disable once PossibleMultipleEnumeration
             var enumerator = _subscriptionFactory.CreateEnumerator(request, _dataProvider);
             enumerator = ConfigureEnumerator(request, false, enumerator, fillForwardResolution);
 

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -100,14 +100,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private IEnumerator<BaseData> CreateDataEnumerator(SubscriptionRequest request, Resolution? fillForwardResolution)
         {
             // ReSharper disable once PossibleMultipleEnumeration
-            if (!request.TradableDaysInDataTimeZone.Any() &&
-                // We won't log this warning for options: options could be selected or manually added on Saturdays
-                // or non-tradable dates at midnight (selection for Monday or next tradable date happens on Saturday)
-                // and there might not be a tradable date between that and the algorithm's end date, causing the
-                // tradable dates enumerable to be empty. e.g an algorithm that starts on a Saturday and ends the
-                // following Sunday adds an option: selection happens on that Saturday at midnight, but the next
-                // tradable date is Monday.
-                !request.Configuration.Symbol.SecurityType.IsOption())
+            if (!request.TradableDaysInDataTimeZone.Any())
             {
                 _algorithm.Error(
                     $"No data loaded for {request.Security.Symbol} because there were no tradeable dates for this security."

--- a/Engine/DataFeeds/FileSystemDataFeed.cs
+++ b/Engine/DataFeeds/FileSystemDataFeed.cs
@@ -100,7 +100,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private IEnumerator<BaseData> CreateDataEnumerator(SubscriptionRequest request, Resolution? fillForwardResolution)
         {
             // ReSharper disable once PossibleMultipleEnumeration
-            if (!request.TradableDaysInDataTimeZone.Any())
+            if (!request.TradableDaysInDataTimeZone.Any() &&
+                // We won't log this warning for options: options could be selected or manually added on Saturdays
+                // or non-tradable dates at midnight (selection for Monday or next tradable date happens on Saturday)
+                // and there might not be a tradable date between that and the algorithm's end date, causing the
+                // tradable dates enumerable to be empty. e.g an algorithm that starts on a Saturday and ends the
+                // following Sunday adds an option: selection happens on that Saturday at midnight, but the next
+                // tradable date is Monday.
+                !request.Configuration.Symbol.SecurityType.IsOption())
             {
                 _algorithm.Error(
                     $"No data loaded for {request.Security.Symbol} because there were no tradeable dates for this security."

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -254,6 +254,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 {
                     if (!request.TradableDaysInDataTimeZone.Any())
                     {
+                        // Remove the config from the data manager. universe.GetSubscriptionRequests() might have added the configs
                         _dataManager.RemoveSubscription(request.Configuration, universe);
                         continue;
                     }

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -252,6 +252,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 foreach (var request in universe.GetSubscriptionRequests(security, dateTimeUtc, algorithmEndDateUtc,
                                                                          _algorithm.SubscriptionManager.SubscriptionDataConfigService))
                 {
+                    if (!request.TradableDaysInDataTimeZone.Any())
+                    {
+                        _dataManager.RemoveSubscription(request.Configuration, universe);
+                        continue;
+                    }
+
                     if (security.Symbol == request.Configuration.Symbol // Just in case check its the same symbol, else AddData will throw.
                         && !security.Subscriptions.Contains(request.Configuration))
                     {

--- a/Tests/Engine/DataFeeds/UniverseSelectionTests.cs
+++ b/Tests/Engine/DataFeeds/UniverseSelectionTests.cs
@@ -162,6 +162,59 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Assert.AreEqual(Symbols.AAPL, securityChanges.AddedSecurities.First().Symbol);
         }
 
+        [Test]
+        public void DoesNotAddSelectedSecuritiesIfNoTradableDates()
+        {
+            var algorithm = new AlgorithmStub(new MockDataFeed());
+            algorithm.SetStartDate(2023, 12, 01);
+            algorithm.SetEndDate(2023, 12, 30); // Sunday
+
+            algorithm.AddUniverse(
+                coarse => coarse.Select(c => c.Symbol),
+                fine => fine.Select(f => f.Symbol));
+            algorithm.OnEndOfTimeStep();
+
+            var universe = algorithm.UniverseManager.Values.First();
+
+            var getUniverseData = (DateTime dt) => new BaseDataCollection(
+                dt,
+                Symbols.AAPL,
+                [
+                    new CoarseFundamental
+                    {
+                        Symbol = Symbols.AAPL,
+                        Time = dt
+                    },
+                    new CoarseFundamental
+                    {
+                        Symbol = Symbols.SPY,
+                        Time = dt
+                    }
+                ]
+            );
+
+            // Friday, one tradeale day left before end date
+            var dateTime = new DateTime(2023, 12, 29).ConvertToUtc(algorithm.TimeZone);
+            var universeData = getUniverseData(dateTime);
+
+            var securityChanges = algorithm.DataManager.UniverseSelection.ApplyUniverseSelection(
+                universe,
+                dateTime,
+                universeData);
+            Assert.AreEqual(2, securityChanges.AddedSecurities.Count);
+            CollectionAssert.AreEquivalent(universeData.Select(x => x.Symbol), securityChanges.AddedSecurities.Select(x => x.Symbol));
+
+            // Saturday, no tradable days left before end date
+            dateTime += TimeSpan.FromDays(1);
+            universeData = getUniverseData(dateTime);
+
+            securityChanges = algorithm.DataManager.UniverseSelection.ApplyUniverseSelection(
+                universe,
+                dateTime,
+                universeData);
+            Assert.AreEqual(0, securityChanges.AddedSecurities.Count);
+        }
+
         private IEnumerable<Symbol> CoarseSelectionFunction(IEnumerable<CoarseFundamental> coarse)
         {
             return new List<Symbol> {Symbols.AAPL, Symbols.SPY};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Skip subscribing to securities selected from a universe when there are no tradable dates between selection time and end algorithm's end date since no data will be loaded for it.

With this, the odd log mentioned in the linked issue is skipped as well and unnecessary subscriptions are not added.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #8471 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests and algorithms

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
