### PR TITLE
Adds Collective2 Payload To Logs With Debugging Enabled

### DIFF
--- a/Common/Algorithm/Framework/Portfolio/SignalExports/Collective2SignalExport.cs
+++ b/Common/Algorithm/Framework/Portfolio/SignalExports/Collective2SignalExport.cs
@@ -274,14 +274,17 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
             //Parse it
             var responseObject = response.Content.ReadFromJsonAsync<C2Response>().Result;
 
+            //For debugging purposes, append the message sent to Collective2 to the algorithms log
+            var debuggingMessage = Logging.Log.DebuggingEnabled ? $" | Message={message}" : string.Empty;
+
             if (!response.IsSuccessStatusCode)
             {
-                _algorithm.Error($"Collective2 API returned the following errors: {string.Join(",", PrintErrors(responseObject.ResponseStatus.Errors))}");
+                _algorithm.Error($"Collective2 API returned the following errors: {string.Join(",", PrintErrors(responseObject.ResponseStatus.Errors))}{debuggingMessage}");
                 return false;
             }
             else if (responseObject.Results.Count > 0)
             {
-                _algorithm.Debug($"Collective2: NewSignals={string.Join(',', responseObject.Results[0].NewSignals)} | CanceledSignals={string.Join(',', responseObject.Results[0].CanceledSignals)}");
+                _algorithm.Debug($"Collective2: NewSignals={string.Join(',', responseObject.Results[0].NewSignals)} | CanceledSignals={string.Join(',', responseObject.Results[0].CanceledSignals)}{debuggingMessage}");
             }
 
             return true;


### PR DESCRIPTION
#### Description
Adds Collective2 payload to Logs with `DebuggingEnabled`

#### Motivation and Context
Debugging purposes.

#### How Has This Been Tested?
Local backtest

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`