### PR TITLE
Clone configuration on re-subscription

### DIFF
--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -230,7 +230,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             {
                                 startUtc = request.StartTimeUtc;
                             }
-                            AddSubscription(new SubscriptionRequest(request, startTimeUtc: startUtc.AddTicks(1)));
+                            AddSubscription(new SubscriptionRequest(request,
+                                startTimeUtc: startUtc.AddTicks(1),
+                                configuration: new SubscriptionDataConfig(request.Configuration)));
                         }
 
                         DataFeedSubscriptions.FreezeFillForwardResolution(false);


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Clone configuration on re-subscription. When re-subscribing a request after a fill forward resolution change, clone `SubscriptionDataConfig` to avoid memory access race conditions, like setting the `MappedSymbol` when emitting new tradable date events. 

This can happen because when removing the existing subscription, the produce enumerators are not stopped instantly since they run on separate threads, so for a little while we might have 2 `SubscriptionDataReaders` for the same configuration.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #7818 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Backtesting and existing regression algorithms

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
