### PR TITLE
Fix for options indicators backwards compatibility

### DIFF
--- a/Indicators/ImpliedVolatility.cs
+++ b/Indicators/ImpliedVolatility.cs
@@ -221,10 +221,11 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
-        /// Computes the next value
+        /// Computes the next value of this indicator from the given state.
         /// </summary>
-        /// <returns>The input is returned unmodified.</returns>
-        protected override decimal ComputeIndicator()
+        /// <param name="input">The input given to the indicator</param>
+        /// <returns>A new value for this indicator</returns>
+        protected override decimal Calculate(IndicatorDataPoint input)
         {
             var time = Price.Current.Time;
 

--- a/Indicators/OptionGreekIndicatorBase.cs
+++ b/Indicators/OptionGreekIndicatorBase.cs
@@ -135,10 +135,11 @@ namespace QuantConnect.Indicators
         public override bool IsReady => ImpliedVolatility.IsReady;
 
         /// <summary>
-        /// Computes the next value of the option greek indicator
+        /// Computes the next value of this indicator from the given state.
         /// </summary>
-        /// <returns>The input is returned unmodified.</returns>
-        sealed protected override decimal ComputeIndicator()
+        /// <param name="input">The input given to the indicator</param>
+        /// <returns>A new value for this indicator</returns>
+        protected override decimal Calculate(IndicatorDataPoint input)
         {
             var time = Price.Current.EndTime;
 

--- a/Indicators/OptionIndicatorBase.cs
+++ b/Indicators/OptionIndicatorBase.cs
@@ -25,6 +25,8 @@ namespace QuantConnect.Indicators
     {
         private DateTime _expiry;
 
+        private IBaseData _lastInput;
+
         /// <summary>
         /// Option's symbol object
         /// </summary>
@@ -164,14 +166,33 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IBaseData input)
         {
+            _lastInput = input;
             return Math.Round(base.ComputeNextValue(input), 7);
         }
+
+        /// <summary>
+        /// Computes the next value of this indicator from the given state.
+        /// This will be called only when the indicator is ready, that is,
+        /// when data for all symbols at a given time is available.
+        /// </summary>
+        sealed protected override decimal ComputeIndicator()
+        {
+            return Calculate(new IndicatorDataPoint(_lastInput.EndTime, _lastInput.Value));
+        }
+
+        /// <summary>
+        /// Computes the next value of this indicator from the given state.
+        /// </summary>
+        /// <param name="input">The input given to the indicator</param>
+        /// <returns>A new value for this indicator</returns>
+        protected abstract decimal Calculate(IndicatorDataPoint input);
 
         /// <summary>
         /// Resets this indicator and all sub-indicators
         /// </summary>
         public override void Reset()
         {
+            _lastInput = null;
             RiskFreeRate.Reset();
             DividendYield.Reset();
             Price.Reset();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Fix for options indicators backwards compatibility.
Classes might be sub-classing the IV and Greek indicators.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Follow up for #8564 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Backwards compatibility

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing test suite

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
