### PR TITLE
Use the US stock exchange calendar to populate trading days instead of the generic settlement calendar

### DIFF
--- a/Common/TradingCalendar.cs
+++ b/Common/TradingCalendar.cs
@@ -121,7 +121,7 @@ namespace QuantConnect
                 }
             }
 
-            var qlCalendar = new UnitedStates();
+            var qlCalendar = new UnitedStates(Market.NYSE);
             var options = symbols.Where(x => x.ID.SecurityType.IsOption()).ToList();
             var futures = symbols.Where(x => x.ID.SecurityType == SecurityType.Future).ToList();
 


### PR DESCRIPTION
#### Description
`TradingCalendar` currently uses the QLNet library to get the calendar. However, the default calendar is the generic settlement calendar instead of the stock exchange calendar.

#### Related Issue
Fixes #8592.

#### Requires Documentation Change
Nope.

#### How Has This Been Tested?
I did not test. Someone please patch and test.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`