### PR TITLE
Python Support for CompositeIndicator

### DIFF
--- a/Algorithm.CSharp/CompositeIndicatorWorksAsExpectedRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CompositeIndicatorWorksAsExpectedRegressionAlgorithm.cs
@@ -1,0 +1,131 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This algorithm tests the functionality of the CompositeIndicator,  
+    /// using either a lambda expression or a method reference.
+    /// </summary>
+    public class CompositeIndicatorWorksAsExpectedRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private CompositeIndicator _compositeMinDirect;
+        private CompositeIndicator _compositeMinMethod;
+        private bool _dataReceived;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 4);
+            SetEndDate(2013, 10, 5);
+            AddEquity("SPY", Resolution.Minute);
+
+            var closePrice = Identity("SPY", Resolution.Minute, Field.Close);
+            var lowPrice = MIN("SPY", 420, Resolution.Minute, Field.Low);
+
+            _compositeMinDirect = new CompositeIndicator("CompositeMinDirect", closePrice, lowPrice, (l, r) => new IndicatorResult(Math.Min(l.Current.Value, r.Current.Value)));
+            _compositeMinMethod = new CompositeIndicator("CompositeMinMethod", closePrice, lowPrice, Composer);
+
+            _dataReceived = false;
+        }
+
+        private IndicatorResult Composer(IndicatorBase l, IndicatorBase r)
+        {
+            return new IndicatorResult(Math.Min(l.Current.Value, r.Current.Value));
+        }
+
+        public override void OnData(Slice data)
+        {
+            _dataReceived = true;
+
+            if (_compositeMinDirect.Current.Value != _compositeMinMethod.Current.Value)
+            {
+                throw new RegressionTestException($"Values of indicators differ: {_compositeMinDirect.Current.Value} | {_compositeMinMethod.Current.Value}");
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_dataReceived)
+            {
+                throw new RegressionTestException("No data was processed during the algorithm execution.");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 795;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.Python/CompositeIndicatorWorksAsExpectedRegressionAlgorithm.py
+++ b/Algorithm.Python/CompositeIndicatorWorksAsExpectedRegressionAlgorithm.py
@@ -1,0 +1,42 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### This algorithm tests the functionality of the CompositeIndicator
+### using either a lambda expression or a method reference.
+### </summary>
+class CompositeIndicatorWorksAsExpectedRegressionAlgorithm(QCAlgorithm):
+    def initialize(self):
+        self.set_start_date(2013, 10, 4)
+        self.set_end_date(2013, 10, 5)
+        self.add_equity("SPY", Resolution.MINUTE)
+        close  = self.identity("SPY", Resolution.MINUTE, Field.CLOSE)
+        low = self.min("SPY", 420, Resolution.MINUTE, Field.LOW)
+        self.composite_min_direct = CompositeIndicator("CompositeMinDirect", close, low, lambda l, r: IndicatorResult(min(l.current.value, r.current.value)))
+        self.composite_min_method = CompositeIndicator("CompositeMinMethod", close, low, self.composer)
+
+        self.data_received = False
+
+    def composer(self, l, r):
+        return IndicatorResult(min(l.current.value, r.current.value))
+
+    def on_data(self, data):
+        self.data_received = True
+        if self.composite_min_direct.current.value != self.composite_min_method.current.value:
+            raise Exception(f"Values of indicators differ: {self.composite_min_direct.current.value} | {self.composite_min_method.current.value}")
+        
+    def on_end_of_algorithm(self):
+        if not self.data_received:
+            raise Exception("No data was processed during the algorithm execution.")

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -692,7 +692,7 @@ namespace QuantConnect.Algorithm
             }
             else
             {
-                RegisterIndicator(symbol, WrapPythonIndicator(indicator), consolidator,
+                RegisterIndicator(symbol, WrapPythonIndicator(indicator, (PythonIndicator)convertedIndicator), consolidator,
                     selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
             }
         }

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -299,7 +299,7 @@ namespace QuantConnect.Algorithm
                 return AddUniverse(pyObject, null, null);
             }
             // TODO: to be removed when https://github.com/QuantConnect/pythonnet/issues/62 is solved
-            else if (pyObject.TryConvert(out universe))
+            else if(pyObject.TryConvert(out universe))
             {
                 return AddUniverse(universe);
             }
@@ -662,32 +662,38 @@ namespace QuantConnect.Algorithm
         public void RegisterIndicator(Symbol symbol, PyObject indicator, IDataConsolidator consolidator, PyObject selector = null)
         {
             // TODO: to be removed when https://github.com/QuantConnect/pythonnet/issues/62 is solved
+            IndicatorBase<IndicatorDataPoint> indicatorDataPoint;
+            IndicatorBase<IBaseDataBar> indicatorDataBar;
+            IndicatorBase<TradeBar> indicatorTradeBar;
 
-            var convertedIndicator = indicator.ConvertToIndicator();
-
-            if (convertedIndicator is PythonIndicator pythonIndicator)
+            if (indicator.TryConvert<PythonIndicator>(out var pythonIndicator))
             {
                 RegisterIndicator(symbol, WrapPythonIndicator(indicator, pythonIndicator), consolidator,
                     selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
             }
-            else if (convertedIndicator is IndicatorBase<IndicatorDataPoint> indicatorDataPoint)
+            else if (indicator.TryConvert(out indicatorDataPoint))
             {
                 RegisterIndicator(symbol, indicatorDataPoint, consolidator,
                     selector?.ConvertToDelegate<Func<IBaseData, decimal>>());
             }
-            else if (convertedIndicator is IndicatorBase<IBaseDataBar> indicatorDataBar)
+            else if (indicator.TryConvert(out indicatorDataBar))
             {
                 RegisterIndicator(symbol, indicatorDataBar, consolidator,
                     selector?.ConvertToDelegate<Func<IBaseData, IBaseDataBar>>());
             }
-            else if (convertedIndicator is IndicatorBase<TradeBar> indicatorTradeBar)
+            else if (indicator.TryConvert(out indicatorTradeBar))
             {
                 RegisterIndicator(symbol, indicatorTradeBar, consolidator,
                     selector?.ConvertToDelegate<Func<IBaseData, TradeBar>>());
             }
-            else if (convertedIndicator is IndicatorBase<IBaseData> indicatorBaseData)
+            else if (indicator.TryConvert(out IndicatorBase<IBaseData> indicatorBaseData))
             {
                 RegisterIndicator(symbol, indicatorBaseData, consolidator,
+                    selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
+            }
+            else
+            {
+                RegisterIndicator(symbol, WrapPythonIndicator(indicator), consolidator,
                     selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
             }
         }
@@ -1762,7 +1768,7 @@ namespace QuantConnect.Algorithm
         {
             using (Py.GIL())
             {
-                var array = new[] { first, second, third, fourth }
+                var array = new[] {first, second, third, fourth}
                     .Select(
                         x =>
                         {

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -299,7 +299,7 @@ namespace QuantConnect.Algorithm
                 return AddUniverse(pyObject, null, null);
             }
             // TODO: to be removed when https://github.com/QuantConnect/pythonnet/issues/62 is solved
-            else if (pyObject.TryConvert(out universe))
+            else if(pyObject.TryConvert(out universe))
             {
                 return AddUniverse(universe);
             }
@@ -567,65 +567,6 @@ namespace QuantConnect.Algorithm
                     throw new ArgumentException($"QCAlgorithm.AddChainedEquityOptionUniverseSelectionModel: {universe.Repr()} or {optionFilter.Repr()} is not a valid argument.");
                 }
             }
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="CompositeIndicator"/> using two indicators and a custom Python function as a handler.
-        /// </summary>
-        /// <param name="name">The name of the composite indicator.</param>
-        /// <param name="left">The first indicator used in the composition.</param>
-        /// <param name="right">The second indicator used in the composition.</param>
-        /// <param name="handler">A Python function that takes two indicator values and returns the computed result.</param>
-        /// <returns>A new instance of <see cref="CompositeIndicator"/>.</returns>
-        /// <exception cref="ArgumentException">
-        /// Thrown when the provided left or right indicator is not a valid QuantConnect Indicator object.
-        /// </exception>
-        [DocumentationAttribute(Universes)]
-        public CompositeIndicator CompositeIndicator(string name, PyObject left, PyObject right, PyObject handler)
-        {
-            var leftIndicator = GetIndicator(left);
-            var rightIndicator = GetIndicator(right);
-            if (leftIndicator == null)
-            {
-                throw new ArgumentException($"The left argument should be a QuantConnect Indicator object, {left} was provided.");
-            }
-            if (rightIndicator == null)
-            {
-                throw new ArgumentException($"The right argument should be a QuantConnect Indicator object, {right} was provided.");
-            }
-            CompositeIndicator.IndicatorComposer composer = (left, right) =>
-            {
-                using (Py.GIL())
-                {
-                    dynamic result = handler.Invoke(left.Current.Value, right.Current.Value);
-                    return new IndicatorResult(result);
-                }
-            };
-            return new CompositeIndicator(name, leftIndicator, rightIndicator, composer);
-        }
-
-        /// <summary>
-        /// Attempts to convert a Python object into a valid QuantConnect indicator.
-        /// </summary>
-        /// <param name="pyObject">The Python object to convert.</param>
-        /// <returns>
-        /// A valid <see cref="IndicatorBase"/> instance if conversion is successful; otherwise, <c>null</c>.
-        /// </returns>
-        public IndicatorBase GetIndicator(PyObject pyObject)
-        {
-            if (pyObject.TryConvert(out IndicatorBase<IndicatorDataPoint> indicatorDataPoint))
-            {
-                return indicatorDataPoint;
-            }
-            if (pyObject.TryConvert(out IndicatorBase<IBaseDataBar> indicatorDataBar))
-            {
-                return indicatorDataBar;
-            }
-            if (pyObject.TryConvert(out IndicatorBase<TradeBar> indicatorTradeBar))
-            {
-                return indicatorTradeBar;
-            }
-            return null;
         }
 
         /// <summary>
@@ -1827,7 +1768,7 @@ namespace QuantConnect.Algorithm
         {
             using (Py.GIL())
             {
-                var array = new[] { first, second, third, fourth }
+                var array = new[] {first, second, third, fourth}
                     .Select(
                         x =>
                         {

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -690,11 +690,6 @@ namespace QuantConnect.Algorithm
                 RegisterIndicator(symbol, indicatorBaseData, consolidator,
                     selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
             }
-            else
-            {
-                RegisterIndicator(symbol, WrapPythonIndicator(indicator, (PythonIndicator)convertedIndicator), consolidator,
-                    selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
-            }
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -299,7 +299,7 @@ namespace QuantConnect.Algorithm
                 return AddUniverse(pyObject, null, null);
             }
             // TODO: to be removed when https://github.com/QuantConnect/pythonnet/issues/62 is solved
-            else if(pyObject.TryConvert(out universe))
+            else if (pyObject.TryConvert(out universe))
             {
                 return AddUniverse(universe);
             }
@@ -662,31 +662,30 @@ namespace QuantConnect.Algorithm
         public void RegisterIndicator(Symbol symbol, PyObject indicator, IDataConsolidator consolidator, PyObject selector = null)
         {
             // TODO: to be removed when https://github.com/QuantConnect/pythonnet/issues/62 is solved
-            IndicatorBase<IndicatorDataPoint> indicatorDataPoint;
-            IndicatorBase<IBaseDataBar> indicatorDataBar;
-            IndicatorBase<TradeBar> indicatorTradeBar;
 
-            if (indicator.TryConvert<PythonIndicator>(out var pythonIndicator))
+            var convertedIndicator = indicator.ConvertToIndicator();
+
+            if (convertedIndicator is PythonIndicator pythonIndicator)
             {
                 RegisterIndicator(symbol, WrapPythonIndicator(indicator, pythonIndicator), consolidator,
                     selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
             }
-            else if (indicator.TryConvert(out indicatorDataPoint))
+            else if (convertedIndicator is IndicatorBase<IndicatorDataPoint> indicatorDataPoint)
             {
                 RegisterIndicator(symbol, indicatorDataPoint, consolidator,
                     selector?.ConvertToDelegate<Func<IBaseData, decimal>>());
             }
-            else if (indicator.TryConvert(out indicatorDataBar))
+            else if (convertedIndicator is IndicatorBase<IBaseDataBar> indicatorDataBar)
             {
                 RegisterIndicator(symbol, indicatorDataBar, consolidator,
                     selector?.ConvertToDelegate<Func<IBaseData, IBaseDataBar>>());
             }
-            else if (indicator.TryConvert(out indicatorTradeBar))
+            else if (convertedIndicator is IndicatorBase<TradeBar> indicatorTradeBar)
             {
                 RegisterIndicator(symbol, indicatorTradeBar, consolidator,
                     selector?.ConvertToDelegate<Func<IBaseData, TradeBar>>());
             }
-            else if (indicator.TryConvert(out IndicatorBase<IBaseData> indicatorBaseData))
+            else if (convertedIndicator is IndicatorBase<IBaseData> indicatorBaseData)
             {
                 RegisterIndicator(symbol, indicatorBaseData, consolidator,
                     selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
@@ -1768,7 +1767,7 @@ namespace QuantConnect.Algorithm
         {
             using (Py.GIL())
             {
-                var array = new[] {first, second, third, fourth}
+                var array = new[] { first, second, third, fourth }
                     .Select(
                         x =>
                         {

--- a/Indicators/CompositeIndicator.cs
+++ b/Indicators/CompositeIndicator.cs
@@ -100,7 +100,7 @@ namespace QuantConnect.Indicators
         /// <param name="right">The right indicator for the 'composer'</param>
         /// <param name="composer">Function used to compose the left and right indicators</param>
         public CompositeIndicator(IndicatorBase left, IndicatorBase right, IndicatorComposer composer)
-            : this($"COMPOSE({left.Name},{right.Name})", left, right, composer)
+            : this(null, left, right, composer)
         { }
 
         /// <summary>

--- a/Indicators/CompositeIndicator.cs
+++ b/Indicators/CompositeIndicator.cs
@@ -115,7 +115,12 @@ namespace QuantConnect.Indicators
         /// Thrown if the provided left or right indicator is not a valid QuantConnect Indicator object.
         /// </exception>
         public CompositeIndicator(string name, PyObject left, PyObject right, PyObject handler)
-            : this(name, left.ConvertToIndicator(), right.ConvertToIndicator(), new IndicatorComposer(handler.ConvertToDelegate<Func<IndicatorBase, IndicatorBase, IndicatorResult>>()))
+            : this(
+                name,
+                (IndicatorBase)left.GetIndicatorAsManagedObject(),
+                (IndicatorBase)right.GetIndicatorAsManagedObject(),
+                new IndicatorComposer(handler.ConvertToDelegate<Func<IndicatorBase, IndicatorBase, IndicatorResult>>())
+            )
         {
         }
 

--- a/Indicators/CompositeIndicator.cs
+++ b/Indicators/CompositeIndicator.cs
@@ -116,11 +116,11 @@ namespace QuantConnect.Indicators
         public CompositeIndicator(string name, PyObject left, PyObject right, PyObject handler)
             : base(name)
         {
-            if (!TryConvertIndicator(left, out var leftIndicator))
+            if (!left.TryConvertToIndicator(out var leftIndicator))
             {
                 throw new ArgumentException($"The left argument should be a QuantConnect Indicator object, {left} was provided.");
             }
-            if (!TryConvertIndicator(right, out var rightIndicator))
+            if (!right.TryConvertToIndicator(out var rightIndicator))
             {
                 throw new ArgumentException($"The right argument should be a QuantConnect Indicator object, {right} was provided.");
             }
@@ -159,35 +159,6 @@ namespace QuantConnect.Indicators
 
             // Return the converted delegate, since it matches the signature of IndicatorComposer
             return new IndicatorComposer(composer);
-        }
-
-        /// <summary>
-        /// Attempts to convert a <see cref="PyObject"/> into an <see cref="IndicatorBase"/>.
-        /// Supports indicators based on <see cref="IndicatorDataPoint"/>, <see cref="IBaseDataBar"/>, and <see cref="TradeBar"/>.
-        /// </summary>
-        /// <param name="pyObject">The Python object to convert.</param>
-        /// <param name="indicator">The converted indicator if successful; otherwise, null.</param>
-        /// <returns>True if the conversion is successful; otherwise, false.</returns>
-        private static bool TryConvertIndicator(PyObject pyObject, out IndicatorBase indicator)
-        {
-            indicator = null;
-            if (pyObject.TryConvert(out IndicatorBase<IBaseData> ibd))
-            {
-                indicator = ibd;
-            }
-            else if (pyObject.TryConvert(out IndicatorBase<IndicatorDataPoint> idp))
-            {
-                indicator = idp;
-            }
-            else if (pyObject.TryConvert(out IndicatorBase<IBaseDataBar> idb))
-            {
-                indicator = idb;
-            }
-            else if (pyObject.TryConvert(out IndicatorBase<TradeBar> itb))
-            {
-                indicator = itb;
-            }
-            return indicator != null;
         }
 
         /// <summary>

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -294,10 +294,24 @@ namespace QuantConnect.Indicators
         {
             indicator = null;
 
-            return pyObject.TryConvert(out IndicatorBase<IndicatorDataPoint> idp) && (indicator = idp) != null ||
-                   pyObject.TryConvert(out IndicatorBase<IBaseDataBar> idb) && (indicator = idb) != null ||
-                   pyObject.TryConvert(out IndicatorBase<TradeBar> itb) && (indicator = itb) != null ||
-                   pyObject.TryConvert(out IndicatorBase<IBaseData> ibd) && (indicator = ibd) != null;
+            if (pyObject.TryConvert(out IndicatorBase<IndicatorDataPoint> idp))
+            {
+                indicator = idp;
+            }
+            else if (pyObject.TryConvert(out IndicatorBase<IBaseDataBar> idb))
+            {
+                indicator = idb;
+            }
+            else if (pyObject.TryConvert(out IndicatorBase<TradeBar> itb))
+            {
+                indicator = itb;
+            }
+            else if (pyObject.TryConvert(out IndicatorBase<IBaseData> ibd))
+            {
+                indicator = ibd;
+            }
+
+            return indicator != null;
         }
 
         /// <summary>Creates a new ExponentialMovingAverage indicator with the specified period and smoothingFactor from the left indicator

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -285,33 +285,40 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
-        /// Attempts to convert a <see cref="PyObject"/> into an <see cref="IndicatorBase"/>.
+        /// Converts a <see cref="PyObject"/> into an <see cref="IndicatorBase"/>.
         /// </summary>
         /// <param name="pyObject">The Python object to convert.</param>
-        /// <param name="indicator">The resulting indicator if successful; otherwise, null.</param>
-        /// <returns><c>true</c> if the conversion succeeds; otherwise, <c>false</c>.</returns>
-        public static bool TryConvertToIndicator(this PyObject pyObject, out IndicatorBase indicator)
+        /// <returns>The corresponding <see cref="IndicatorBase"/> if the conversion is successful.</returns>
+        public static IndicatorBase ConvertToIndicator(this PyObject pyObject)
         {
-            indicator = null;
-
-            if (pyObject.TryConvert(out IndicatorBase<IndicatorDataPoint> idp))
+            IndicatorBase indicator;
+            if (pyObject.TryConvert<PythonIndicator>(out var pi))
+            {
+                pi.SetIndicator(pyObject);
+                indicator = pi;
+            }
+            else if (pyObject.TryConvert<IndicatorBase<IndicatorDataPoint>>(out var idp))
             {
                 indicator = idp;
             }
-            else if (pyObject.TryConvert(out IndicatorBase<IBaseDataBar> idb))
+            else if (pyObject.TryConvert<IndicatorBase<IBaseDataBar>>(out var idb))
             {
                 indicator = idb;
             }
-            else if (pyObject.TryConvert(out IndicatorBase<TradeBar> itb))
+            else if (pyObject.TryConvert<IndicatorBase<TradeBar>>(out var itb))
             {
                 indicator = itb;
             }
-            else if (pyObject.TryConvert(out IndicatorBase<IBaseData> ibd))
+            else if (pyObject.TryConvert<IndicatorBase<IBaseData>>(out var ibd))
             {
                 indicator = ibd;
             }
+            else
+            {
+                indicator = new PythonIndicator(pyObject);
+            }
 
-            return indicator != null;
+            return indicator;
         }
 
         /// <summary>Creates a new ExponentialMovingAverage indicator with the specified period and smoothingFactor from the left indicator

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -19,6 +19,7 @@ using System.Globalization;
 using QuantConnect.Data;
 using Python.Runtime;
 using QuantConnect.Util;
+using QuantConnect.Data.Market;
 
 namespace QuantConnect.Indicators
 {
@@ -98,7 +99,8 @@ namespace QuantConnect.Indicators
                 denominator.Update(consolidated);
             };
 
-            var resetCompositeIndicator = new ResetCompositeIndicator(numerator, denominator, GetOverIndicatorComposer(), () => {
+            var resetCompositeIndicator = new ResetCompositeIndicator(numerator, denominator, GetOverIndicatorComposer(), () =>
+            {
                 x.Reset();
                 y.Reset();
             });
@@ -132,7 +134,7 @@ namespace QuantConnect.Indicators
         /// <returns>The sum of the left and right indicators</returns>
         public static CompositeIndicator Plus(this IndicatorBase left, IndicatorBase right)
         {
-            return new (left, right, (l, r) => l.Current.Value + r.Current.Value);
+            return new(left, right, (l, r) => l.Current.Value + r.Current.Value);
         }
 
         /// <summary>
@@ -147,7 +149,7 @@ namespace QuantConnect.Indicators
         /// <returns>The sum of the left and right indicators</returns>
         public static CompositeIndicator Plus(this IndicatorBase left, IndicatorBase right, string name)
         {
-            return new (name, left, right, (l, r) => l.Current.Value + r.Current.Value);
+            return new(name, left, right, (l, r) => l.Current.Value + r.Current.Value);
         }
 
         /// <summary>
@@ -176,7 +178,7 @@ namespace QuantConnect.Indicators
         /// <returns>The difference of the left and right indicators</returns>
         public static CompositeIndicator Minus(this IndicatorBase left, IndicatorBase right)
         {
-            return new (left, right, (l, r) => l.Current.Value - r.Current.Value);
+            return new(left, right, (l, r) => l.Current.Value - r.Current.Value);
         }
 
         /// <summary>
@@ -191,7 +193,7 @@ namespace QuantConnect.Indicators
         /// <returns>The difference of the left and right indicators</returns>
         public static CompositeIndicator Minus(this IndicatorBase left, IndicatorBase right, string name)
         {
-            return new (name, left, right, (l, r) => l.Current.Value - r.Current.Value);
+            return new(name, left, right, (l, r) => l.Current.Value - r.Current.Value);
         }
 
         /// <summary>
@@ -220,7 +222,7 @@ namespace QuantConnect.Indicators
         /// <returns>The ratio of the left to the right indicator</returns>
         public static CompositeIndicator Over(this IndicatorBase left, IndicatorBase right)
         {
-            return new (left, right, GetOverIndicatorComposer());
+            return new(left, right, GetOverIndicatorComposer());
         }
 
         /// <summary>
@@ -235,7 +237,7 @@ namespace QuantConnect.Indicators
         /// <returns>The ratio of the left to the right indicator</returns>
         public static CompositeIndicator Over(this IndicatorBase left, IndicatorBase right, string name)
         {
-            return new (name, left, right, GetOverIndicatorComposer());
+            return new(name, left, right, GetOverIndicatorComposer());
         }
 
         /// <summary>
@@ -264,7 +266,7 @@ namespace QuantConnect.Indicators
         /// <returns>The product of the left to the right indicators</returns>
         public static CompositeIndicator Times(this IndicatorBase left, IndicatorBase right)
         {
-            return new (left, right, (l, r) => l.Current.Value * r.Current.Value);
+            return new(left, right, (l, r) => l.Current.Value * r.Current.Value);
         }
 
         /// <summary>
@@ -279,7 +281,23 @@ namespace QuantConnect.Indicators
         /// <returns>The product of the left to the right indicators</returns>
         public static CompositeIndicator Times(this IndicatorBase left, IndicatorBase right, string name)
         {
-            return new (name, left, right, (l, r) => l.Current.Value * r.Current.Value);
+            return new(name, left, right, (l, r) => l.Current.Value * r.Current.Value);
+        }
+
+        /// <summary>
+        /// Attempts to convert a <see cref="PyObject"/> into an <see cref="IndicatorBase"/>.
+        /// </summary>
+        /// <param name="pyObject">The Python object to convert.</param>
+        /// <param name="indicator">The resulting indicator if successful; otherwise, null.</param>
+        /// <returns><c>true</c> if the conversion succeeds; otherwise, <c>false</c>.</returns>
+        public static bool TryConvertToIndicator(this PyObject pyObject, out IndicatorBase indicator)
+        {
+            indicator = null;
+
+            return pyObject.TryConvert(out IndicatorBase<IndicatorDataPoint> idp) && (indicator = idp) != null ||
+                   pyObject.TryConvert(out IndicatorBase<IBaseDataBar> idb) && (indicator = idb) != null ||
+                   pyObject.TryConvert(out IndicatorBase<TradeBar> itb) && (indicator = itb) != null ||
+                   pyObject.TryConvert(out IndicatorBase<IBaseData> ibd) && (indicator = ibd) != null;
         }
 
         /// <summary>Creates a new ExponentialMovingAverage indicator with the specified period and smoothingFactor from the left indicator
@@ -418,7 +436,7 @@ namespace QuantConnect.Indicators
             return SMA(indicator, period, waitForFirstToReady);
         }
 
-                /// <summary>
+        /// <summary>
         /// Creates a new CompositeIndicator such that the result will be the ratio of the left to the constant
         /// </summary>
         /// <remarks>

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -292,26 +292,27 @@ namespace QuantConnect.Indicators
         public static IndicatorBase ConvertToIndicator(this PyObject pyObject)
         {
             IndicatorBase indicator;
-            if (pyObject.TryConvert<PythonIndicator>(out var pi))
+
+            if (pyObject.TryConvert<PythonIndicator>(out var pythonIndicator))
             {
-                pi.SetIndicator(pyObject);
-                indicator = pi;
+                pythonIndicator.SetIndicator(pyObject);
+                indicator = pythonIndicator;
             }
-            else if (pyObject.TryConvert<IndicatorBase<IndicatorDataPoint>>(out var idp))
+            else if (pyObject.TryConvert<IndicatorBase<IndicatorDataPoint>>(out var dataPointIndicator))
             {
-                indicator = idp;
+                indicator = dataPointIndicator;
             }
-            else if (pyObject.TryConvert<IndicatorBase<IBaseDataBar>>(out var idb))
+            else if (pyObject.TryConvert<IndicatorBase<IBaseDataBar>>(out var baseDataBarIndicator))
             {
-                indicator = idb;
+                indicator = baseDataBarIndicator;
             }
-            else if (pyObject.TryConvert<IndicatorBase<TradeBar>>(out var itb))
+            else if (pyObject.TryConvert<IndicatorBase<TradeBar>>(out var tradeBarIndicator))
             {
-                indicator = itb;
+                indicator = tradeBarIndicator;
             }
-            else if (pyObject.TryConvert<IndicatorBase<IBaseData>>(out var ibd))
+            else if (pyObject.TryConvert<IndicatorBase<IBaseData>>(out var baseDataIndicator))
             {
-                indicator = ibd;
+                indicator = baseDataIndicator;
             }
             else
             {

--- a/Indicators/IndicatorExtensions.cs
+++ b/Indicators/IndicatorExtensions.cs
@@ -284,44 +284,6 @@ namespace QuantConnect.Indicators
             return new(name, left, right, (l, r) => l.Current.Value * r.Current.Value);
         }
 
-        /// <summary>
-        /// Converts a <see cref="PyObject"/> into an <see cref="IndicatorBase"/>.
-        /// </summary>
-        /// <param name="pyObject">The Python object to convert.</param>
-        /// <returns>The corresponding <see cref="IndicatorBase"/> if the conversion is successful.</returns>
-        public static IndicatorBase ConvertToIndicator(this PyObject pyObject)
-        {
-            IndicatorBase indicator;
-
-            if (pyObject.TryConvert<PythonIndicator>(out var pythonIndicator))
-            {
-                pythonIndicator.SetIndicator(pyObject);
-                indicator = pythonIndicator;
-            }
-            else if (pyObject.TryConvert<IndicatorBase<IndicatorDataPoint>>(out var dataPointIndicator))
-            {
-                indicator = dataPointIndicator;
-            }
-            else if (pyObject.TryConvert<IndicatorBase<IBaseDataBar>>(out var baseDataBarIndicator))
-            {
-                indicator = baseDataBarIndicator;
-            }
-            else if (pyObject.TryConvert<IndicatorBase<TradeBar>>(out var tradeBarIndicator))
-            {
-                indicator = tradeBarIndicator;
-            }
-            else if (pyObject.TryConvert<IndicatorBase<IBaseData>>(out var baseDataIndicator))
-            {
-                indicator = baseDataIndicator;
-            }
-            else
-            {
-                indicator = new PythonIndicator(pyObject);
-            }
-
-            return indicator;
-        }
-
         /// <summary>Creates a new ExponentialMovingAverage indicator with the specified period and smoothingFactor from the left indicator
         /// </summary>
         /// <param name="left">The ExponentialMovingAverage indicator will be created using the data from left</param>
@@ -602,7 +564,7 @@ namespace QuantConnect.Indicators
             return Plus(indicatorLeft, indicatorRight, name);
         }
 
-        private static dynamic GetIndicatorAsManagedObject(PyObject indicator)
+        internal static dynamic GetIndicatorAsManagedObject(this PyObject indicator)
         {
             if (indicator.TryConvert(out PythonIndicator pythonIndicator, true))
             {

--- a/Tests/Indicators/CompositeIndicatorTests.cs
+++ b/Tests/Indicators/CompositeIndicatorTests.cs
@@ -114,15 +114,15 @@ from QuantConnect.Indicators import *
 def create_composite_indicator(left, right, operation):
     if operation == 'sum':
         def composer(l, r):
-            return IndicatorResult(l.Current.Value + r.Current.Value)
+            return IndicatorResult(l.current.value + r.current.value)
     elif operation == 'min':
         def composer(l, r):
-            return IndicatorResult(min(l.Current.Value, r.Current.Value))
+            return IndicatorResult(min(l.current.value, r.current.value))
     return CompositeIndicator(left, right, composer)
 
 def update_indicators(left, right, value_left, value_right):
-    left.Update(IndicatorDataPoint(DateTime.Now, value_left))
-    right.Update(IndicatorDataPoint(DateTime.Now, value_right))
+    left.update(IndicatorDataPoint(DateTime.Now, value_left))
+    right.update(IndicatorDataPoint(DateTime.Now, value_right))
             ");
 
                 using var createCompositeIndicator = testModule.GetAttr("create_composite_indicator");
@@ -159,19 +159,19 @@ from collections import deque
 
 class CustomSimpleMovingAverage(PythonIndicator):
     def __init__(self, period):
-        self.Name = 'SMA'
-        self.Value = 0
-        self.Period = period
-        self.WarmUpPeriod = period
+        self.name = 'SMA'
+        self.value = 0
+        self.period = period
+        self.warm_up_period = period
         self.queue = deque(maxlen=period)
-        self.Current = IndicatorDataPoint(DateTime.Now, self.Value)
+        self.current = IndicatorDataPoint(DateTime.Now, self.value)
 
-    def Update(self, input):
-        self.queue.appendleft(input.Value)
+    def update(self, input):
+        self.queue.appendleft(input.value)
         count = len(self.queue)
-        self.Value = sum(self.queue) / count
-        self.Current = IndicatorDataPoint(input.Time, self.Value)
-        self.on_updated(IndicatorDataPoint(DateTime.Now, input.Value))
+        self.value = sum(self.queue) / count
+        self.current = IndicatorDataPoint(input.time, self.value)
+        self.on_updated(IndicatorDataPoint(DateTime.Now, input.value))
 "
                 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Added Python support for CompositeIndicator, allowing it to accept Python objects as input and properly convert them into QuantConnect indicators.

#### Related Issue
Closes #8587

#### Motivation and Context
This change adds support for using CompositeIndicator in Python, allowing users to create and manipulate composite indicators within a Python environment

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
