### PR TITLE
Fix IndicatorHistory API for options indicators in Python

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -3150,19 +3150,7 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(Indicators)]
         public void WarmUpIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, TimeSpan period, Func<IBaseData, decimal> selector = null)
         {
-            var history = GetIndicatorWarmUpHistory(new[] { symbol }, indicator, period, out var identityConsolidator);
-            if (history == Enumerable.Empty<Slice>()) return;
-
-            // assign default using cast
-            selector ??= (x => x.Value);
-
-            Action<IBaseData> onDataConsolidated = bar =>
-            {
-                var input = new IndicatorDataPoint(bar.Symbol, bar.EndTime, selector(bar));
-                indicator.Update(input);
-            };
-
-            WarmUpIndicatorImpl(symbol, period, onDataConsolidated, history, identityConsolidator);
+            WarmUpIndicator([symbol], indicator, period, selector);
         }
 
         /// <summary>
@@ -3176,10 +3164,19 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(Indicators)]
         public void WarmUpIndicator(IEnumerable<Symbol> symbols, IndicatorBase<IndicatorDataPoint> indicator, TimeSpan period, Func<IBaseData, decimal> selector = null)
         {
-            if (AssertIndicatorHasWarmupPeriod(indicator))
+            var history = GetIndicatorWarmUpHistory(symbols, indicator, period, out var identityConsolidator);
+            if (history == Enumerable.Empty<Slice>()) return;
+
+            // assign default using cast
+            selector ??= (x => x.Value);
+
+            Action<IBaseData> onDataConsolidated = bar =>
             {
-                IndicatorHistory(indicator, symbols, period, null, selector);
-            }
+                var input = new IndicatorDataPoint(bar.Symbol, bar.EndTime, selector(bar));
+                indicator.Update(input);
+            };
+
+            WarmUpIndicatorImpl(symbols, period, onDataConsolidated, history, identityConsolidator);
         }
 
         /// <summary>
@@ -3227,10 +3224,19 @@ namespace QuantConnect.Algorithm
         public void WarmUpIndicator<T>(IEnumerable<Symbol> symbols, IndicatorBase<T> indicator, TimeSpan period, Func<IBaseData, T> selector = null)
             where T : class, IBaseData
         {
-            if (AssertIndicatorHasWarmupPeriod(indicator))
+            var history = GetIndicatorWarmUpHistory(symbols, indicator, period, out var identityConsolidator);
+            if (history == Enumerable.Empty<Slice>()) return;
+
+            // assign default using cast
+            selector ??= (x => (T)x);
+
+            // we expect T type as input
+            Action<T> onDataConsolidated = bar =>
             {
-                IndicatorHistory(indicator, symbols, period, null, selector);
-            }
+                indicator.Update(selector(bar));
+            };
+
+            WarmUpIndicatorImpl(symbols, period, onDataConsolidated, history, identityConsolidator);
         }
 
         /// <summary>
@@ -3245,19 +3251,7 @@ namespace QuantConnect.Algorithm
         public void WarmUpIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, TimeSpan period, Func<IBaseData, T> selector = null)
             where T : class, IBaseData
         {
-            var history = GetIndicatorWarmUpHistory(new[] { symbol }, indicator, period, out var identityConsolidator);
-            if (history == Enumerable.Empty<Slice>()) return;
-
-            // assign default using cast
-            selector ??= (x => (T)x);
-
-            // we expect T type as input
-            Action<T> onDataConsolidated = bar =>
-            {
-                indicator.Update(selector(bar));
-            };
-
-            WarmUpIndicatorImpl(symbol, period, onDataConsolidated, history, identityConsolidator);
+            WarmUpIndicator([symbol], indicator, period, selector);
         }
 
         private IEnumerable<Slice> GetIndicatorWarmUpHistory(IEnumerable<Symbol> symbols, IIndicator indicator, TimeSpan timeSpan, out bool identityConsolidator)
@@ -3308,73 +3302,84 @@ namespace QuantConnect.Algorithm
             return true;
         }
 
-        private void WarmUpIndicatorImpl<T>(Symbol symbol, TimeSpan period, Action<T> handler, IEnumerable<Slice> history, bool identityConsolidator)
+        private void WarmUpIndicatorImpl<T>(IEnumerable<Symbol> symbols, TimeSpan period, Action<T> handler, IEnumerable<Slice> history, bool identityConsolidator)
             where T : class, IBaseData
         {
-            IDataConsolidator consolidator;
-            if (SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(symbol).Count > 0)
+            var consolidators = symbols.ToDictionary(symbol => symbol, symbol =>
             {
-                consolidator = Consolidate(symbol, period, handler);
-            }
-            else
-            {
-                if (identityConsolidator)
+                IDataConsolidator consolidator;
+                if (SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(symbol).Count > 0)
                 {
-                    period = TimeSpan.Zero;
-                }
-
-                var providedType = typeof(T);
-                if (providedType.IsAbstract)
-                {
-                    var dataType = SubscriptionManager.LookupSubscriptionConfigDataTypes(
-                        symbol.SecurityType,
-                        Resolution.Daily,
-                        // order by tick type so that behavior is consistent with 'GetSubscription()'
-                        symbol.IsCanonical())
-                        // make sure common lean data types are at the bottom
-                        .OrderByDescending(tuple => LeanData.IsCommonLeanDataType(tuple.Item1))
-                        .ThenBy(tuple => tuple.Item2).First();
-
-                    consolidator = CreateConsolidator(period, dataType.Item1, dataType.Item2);
+                    consolidator = Consolidate(symbol, period, handler);
                 }
                 else
                 {
-                    // if the 'providedType' is not abstract we use it instead to determine which consolidator to use
-                    var tickType = LeanData.GetCommonTickTypeForCommonDataTypes(providedType, symbol.SecurityType);
-                    consolidator = CreateConsolidator(period, providedType, tickType);
-                }
-                consolidator.DataConsolidated += (s, bar) => handler((T)bar);
-            }
+                    if (identityConsolidator)
+                    {
+                        period = TimeSpan.Zero;
+                    }
 
-            var consolidatorInputType = consolidator.InputType;
-            IBaseData lastBar = null;
+                    var providedType = typeof(T);
+                    if (providedType.IsAbstract)
+                    {
+                        var dataType = SubscriptionManager.LookupSubscriptionConfigDataTypes(
+                            symbol.SecurityType,
+                            Resolution.Daily,
+                            // order by tick type so that behavior is consistent with 'GetSubscription()'
+                            symbol.IsCanonical())
+                            // make sure common lean data types are at the bottom
+                            .OrderByDescending(tuple => LeanData.IsCommonLeanDataType(tuple.Item1))
+                            .ThenBy(tuple => tuple.Item2).First();
+
+                        consolidator = CreateConsolidator(period, dataType.Item1, dataType.Item2);
+                    }
+                    else
+                    {
+                        // if the 'providedType' is not abstract we use it instead to determine which consolidator to use
+                        var tickType = LeanData.GetCommonTickTypeForCommonDataTypes(providedType, symbol.SecurityType);
+                        consolidator = CreateConsolidator(period, providedType, tickType);
+                    }
+                    consolidator.DataConsolidated += (s, bar) => handler((T)bar);
+                }
+
+                return consolidator;
+            });
+
+            var lastBars = new Dictionary<Symbol, IBaseData>();
             foreach (var slice in history)
             {
-                if (slice.TryGet(consolidatorInputType, symbol, out var data))
+                foreach (var (symbol, consolidator) in consolidators)
                 {
-                    lastBar = data;
-                    consolidator.Update(lastBar);
+                    var consolidatorInputType = consolidator.InputType;
+                    if (slice.TryGet(consolidatorInputType, symbol, out var data))
+                    {
+                        var lastBar = lastBars[symbol] = data;
+                        consolidator.Update(lastBar);
+                    }
                 }
             }
 
             // Scan for time after we've pumped all the data through for this consolidator
-            if (lastBar != null)
+            foreach (var (symbol, consolidator) in consolidators)
             {
-                DateTime currentTime;
-                if (Securities.TryGetValue(symbol, out var security))
+                if (lastBars.TryGetValue(symbol, out var lastBar))
                 {
-                    currentTime = security.LocalTime;
-                }
-                else
-                {
-                    var exchangeHours = MarketHoursDatabase.GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
-                    currentTime = UtcTime.ConvertFromUtc(exchangeHours.TimeZone);
+                    DateTime currentTime;
+                    if (Securities.TryGetValue(symbol, out var security))
+                    {
+                        currentTime = security.LocalTime;
+                    }
+                    else
+                    {
+                        var exchangeHours = MarketHoursDatabase.GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+                        currentTime = UtcTime.ConvertFromUtc(exchangeHours.TimeZone);
+                    }
+
+                    consolidator.Scan(currentTime);
                 }
 
-                consolidator.Scan(currentTime);
+                SubscriptionManager.RemoveConsolidator(symbol, consolidator);
             }
-
-            SubscriptionManager.RemoveConsolidator(symbol, consolidator);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -23,7 +23,6 @@ using System.Linq;
 using Python.Runtime;
 using QuantConnect.Util;
 using static QuantConnect.StringExtensions;
-using QuantConnect.Interfaces;
 using QuantConnect.Data.Common;
 
 namespace QuantConnect.Algorithm
@@ -3169,6 +3168,23 @@ namespace QuantConnect.Algorithm
         /// <summary>
         /// Warms up a given indicator with historical data
         /// </summary>
+        /// <param name="symbols">The symbols whose indicator we want</param>
+        /// <param name="indicator">The indicator we want to warm up</param>
+        /// <param name="period">The necessary period to warm up the indicator</param>
+        /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
+        [DocumentationAttribute(HistoricalData)]
+        [DocumentationAttribute(Indicators)]
+        public void WarmUpIndicator(IEnumerable<Symbol> symbols, IndicatorBase<IndicatorDataPoint> indicator, TimeSpan period, Func<IBaseData, decimal> selector = null)
+        {
+            if (AssertIndicatorHasWarmupPeriod(indicator))
+            {
+                IndicatorHistory(indicator, symbols, period, null, selector);
+            }
+        }
+
+        /// <summary>
+        /// Warms up a given indicator with historical data
+        /// </summary>
         /// <param name="symbol">The symbol whose indicator we want</param>
         /// <param name="indicator">The indicator we want to warm up</param>
         /// <param name="resolution">The resolution</param>
@@ -3196,6 +3212,24 @@ namespace QuantConnect.Algorithm
             if (AssertIndicatorHasWarmupPeriod(indicator))
             {
                 IndicatorHistory(indicator, symbols, 0, resolution, selector);
+            }
+        }
+
+        /// <summary>
+        /// Warms up a given indicator with historical data
+        /// </summary>
+        /// <param name="symbols">The symbols whose indicator we want</param>
+        /// <param name="indicator">The indicator we want to warm up</param>
+        /// <param name="period">The necessary period to warm up the indicator</param>
+        /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to the Value property of BaseData (x => x.Value)</param>
+        [DocumentationAttribute(HistoricalData)]
+        [DocumentationAttribute(Indicators)]
+        public void WarmUpIndicator<T>(IEnumerable<Symbol> symbols, IndicatorBase<T> indicator, TimeSpan period, Func<IBaseData, T> selector = null)
+            where T : class, IBaseData
+        {
+            if (AssertIndicatorHasWarmupPeriod(indicator))
+            {
+                IndicatorHistory(indicator, symbols, period, null, selector);
             }
         }
 

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -663,30 +663,36 @@ namespace QuantConnect.Algorithm
         {
             // TODO: to be removed when https://github.com/QuantConnect/pythonnet/issues/62 is solved
             var convertedIndicator = ConvertPythonIndicator(indicator);
-            if (convertedIndicator is PythonIndicator pythonIndicator)
+            switch (convertedIndicator)
             {
-                RegisterIndicator(symbol, pythonIndicator, consolidator,
-                    selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
-            }
-            else if (convertedIndicator is IndicatorBase<IndicatorDataPoint> dataPointIndicator)
-            {
-                RegisterIndicator(symbol, dataPointIndicator, consolidator,
-                    selector?.ConvertToDelegate<Func<IBaseData, decimal>>());
-            }
-            else if (convertedIndicator is IndicatorBase<IBaseDataBar> dataBarIndicator)
-            {
-                RegisterIndicator(symbol, dataBarIndicator, consolidator,
-                    selector?.ConvertToDelegate<Func<IBaseData, IBaseDataBar>>());
-            }
-            else if (convertedIndicator is IndicatorBase<TradeBar> tradeBarIndicator)
-            {
-                RegisterIndicator(symbol, tradeBarIndicator, consolidator,
-                    selector?.ConvertToDelegate<Func<IBaseData, TradeBar>>());
-            }
-            else if (convertedIndicator is IndicatorBase<IBaseData> baseDataIndicator)
-            {
-                RegisterIndicator(symbol, baseDataIndicator, consolidator,
-                    selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
+                case PythonIndicator pythonIndicator:
+                    RegisterIndicator(symbol, pythonIndicator, consolidator,
+                        selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
+                    break;
+
+                case IndicatorBase<IndicatorDataPoint> dataPointIndicator:
+                    RegisterIndicator(symbol, dataPointIndicator, consolidator,
+                        selector?.ConvertToDelegate<Func<IBaseData, decimal>>());
+                    break;
+
+                case IndicatorBase<IBaseDataBar> baseDataBarIndicator:
+                    RegisterIndicator(symbol, baseDataBarIndicator, consolidator,
+                        selector?.ConvertToDelegate<Func<IBaseData, IBaseDataBar>>());
+                    break;
+
+                case IndicatorBase<TradeBar> tradeBarIndicator:
+                    RegisterIndicator(symbol, tradeBarIndicator, consolidator,
+                        selector?.ConvertToDelegate<Func<IBaseData, TradeBar>>());
+                    break;
+
+                case IndicatorBase<IBaseData> baseDataIndicator:
+                    RegisterIndicator(symbol, baseDataIndicator, consolidator,
+                        selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
+                    break;
+
+                default:
+                    // Shouldn't happen, ConvertPythonIndicator will wrap the PyObject in a PythonIndicator instance if it can't convert it
+                    throw new ArgumentException($"Indicator type {indicator.GetPythonType().Name} is not supported.");
             }
         }
 
@@ -702,24 +708,33 @@ namespace QuantConnect.Algorithm
         public void WarmUpIndicator(Symbol symbol, PyObject indicator, Resolution? resolution = null, PyObject selector = null)
         {
             // TODO: to be removed when https://github.com/QuantConnect/pythonnet/issues/62 is solved
+            var convertedIndicator = ConvertPythonIndicator(indicator);
+            switch (convertedIndicator)
+            {
+                case PythonIndicator pythonIndicator:
+                    WarmUpIndicator(symbol, pythonIndicator, resolution, selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
+                    break;
 
-            if (indicator.TryConvert(out IndicatorBase<IndicatorDataPoint> indicatorDataPoint))
-            {
-                WarmUpIndicator(symbol, indicatorDataPoint, resolution, selector?.ConvertToDelegate<Func<IBaseData, decimal>>());
-                return;
-            }
-            if (indicator.TryConvert(out IndicatorBase<IBaseDataBar> indicatorDataBar))
-            {
-                WarmUpIndicator(symbol, indicatorDataBar, resolution, selector?.ConvertToDelegate<Func<IBaseData, IBaseDataBar>>());
-                return;
-            }
-            if (indicator.TryConvert(out IndicatorBase<TradeBar> indicatorTradeBar))
-            {
-                WarmUpIndicator(symbol, indicatorTradeBar, resolution, selector?.ConvertToDelegate<Func<IBaseData, TradeBar>>());
-                return;
-            }
+                case IndicatorBase<IndicatorDataPoint> dataPointIndicator:
+                    WarmUpIndicator(symbol, dataPointIndicator, resolution, selector?.ConvertToDelegate<Func<IBaseData, decimal>>());
+                    break;
 
-            WarmUpIndicator(symbol, WrapPythonIndicator(indicator), resolution, selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
+                case IndicatorBase<IBaseDataBar> baseDataBarIndicator:
+                    WarmUpIndicator(symbol, baseDataBarIndicator, resolution, selector?.ConvertToDelegate<Func<IBaseData, IBaseDataBar>>());
+                    break;
+
+                case IndicatorBase<TradeBar> tradeBarIndicator:
+                    WarmUpIndicator(symbol, tradeBarIndicator, resolution, selector?.ConvertToDelegate<Func<IBaseData, TradeBar>>());
+                    break;
+
+                case IndicatorBase<IBaseData> baseDataIndicator:
+                    WarmUpIndicator(symbol, baseDataIndicator, resolution, selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
+                    break;
+
+                default:
+                    // Shouldn't happen, ConvertPythonIndicator will wrap the PyObject in a PythonIndicator instance if it can't convert it
+                    throw new ArgumentException($"Indicator type {indicator.GetPythonType().Name} is not supported.");
+            }
         }
 
         /// <summary>
@@ -733,23 +748,116 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(HistoricalData)]
         public void WarmUpIndicator(Symbol symbol, PyObject indicator, TimeSpan period, PyObject selector = null)
         {
-            if (indicator.TryConvert(out IndicatorBase<IndicatorDataPoint> indicatorDataPoint))
+            var convertedIndicator = ConvertPythonIndicator(indicator);
+            switch (convertedIndicator)
             {
-                WarmUpIndicator(symbol, indicatorDataPoint, period, selector?.ConvertToDelegate<Func<IBaseData, decimal>>());
-                return;
-            }
-            if (indicator.TryConvert(out IndicatorBase<IBaseDataBar> indicatorDataBar))
-            {
-                WarmUpIndicator(symbol, indicatorDataBar, period, selector?.ConvertToDelegate<Func<IBaseData, IBaseDataBar>>());
-                return;
-            }
-            if (indicator.TryConvert(out IndicatorBase<TradeBar> indicatorTradeBar))
-            {
-                WarmUpIndicator(symbol, indicatorTradeBar, period, selector?.ConvertToDelegate<Func<IBaseData, TradeBar>>());
-                return;
-            }
+                case PythonIndicator pythonIndicator:
+                    WarmUpIndicator(symbol, pythonIndicator, period, selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
+                    break;
 
-            WarmUpIndicator(symbol, WrapPythonIndicator(indicator), period, selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
+                case IndicatorBase<IndicatorDataPoint> dataPointIndicator:
+                    WarmUpIndicator(symbol, dataPointIndicator, period, selector?.ConvertToDelegate<Func<IBaseData, decimal>>());
+                    break;
+
+                case IndicatorBase<IBaseDataBar> baseDataBarIndicator:
+                    WarmUpIndicator(symbol, baseDataBarIndicator, period, selector?.ConvertToDelegate<Func<IBaseData, IBaseDataBar>>());
+                    break;
+
+                case IndicatorBase<TradeBar> tradeBarIndicator:
+                    WarmUpIndicator(symbol, tradeBarIndicator, period, selector?.ConvertToDelegate<Func<IBaseData, TradeBar>>());
+                    break;
+
+                case IndicatorBase<IBaseData> baseDataIndicator:
+                    WarmUpIndicator(symbol, baseDataIndicator, period, selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
+                    break;
+
+                default:
+                    // Shouldn't happen, ConvertPythonIndicator will wrap the PyObject in a PythonIndicator instance if it can't convert it
+                    throw new ArgumentException($"Indicator type {indicator.GetPythonType().Name} is not supported.");
+            }
+        }
+
+        /// <summary>
+        /// Warms up a given indicator with historical data
+        /// </summary>
+        /// <param name="symbol">The symbol or symbols to retrieve historical data for</param>
+        /// <param name="indicator">The indicator we want to warm up</param>
+        /// <param name="resolution">The resolution</param>
+        /// <param name="selector">Selects a value from the BaseData send into the indicator, if null defaults to a cast (x => (T)x)</param>
+        [DocumentationAttribute(Indicators)]
+        [DocumentationAttribute(HistoricalData)]
+        public void WarmUpIndicator(PyObject symbol, PyObject indicator, Resolution? resolution = null, PyObject selector = null)
+        {
+            // TODO: to be removed when https://github.com/QuantConnect/pythonnet/issues/62 is solved
+            var symbols = symbol.ConvertToSymbolEnumerable();
+            var convertedIndicator = ConvertPythonIndicator(indicator);
+            switch (convertedIndicator)
+            {
+                case PythonIndicator pythonIndicator:
+                    WarmUpIndicator(symbols, pythonIndicator, resolution, selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
+                    break;
+
+                case IndicatorBase<IndicatorDataPoint> dataPointIndicator:
+                    WarmUpIndicator(symbols, dataPointIndicator, resolution, selector?.ConvertToDelegate<Func<IBaseData, decimal>>());
+                    break;
+
+                case IndicatorBase<IBaseDataBar> baseDataBarIndicator:
+                    WarmUpIndicator(symbols, baseDataBarIndicator, resolution, selector?.ConvertToDelegate<Func<IBaseData, IBaseDataBar>>());
+                    break;
+
+                case IndicatorBase<TradeBar> tradeBarIndicator:
+                    WarmUpIndicator(symbols, tradeBarIndicator, resolution, selector?.ConvertToDelegate<Func<IBaseData, TradeBar>>());
+                    break;
+
+                case IndicatorBase<IBaseData> baseDataIndicator:
+                    WarmUpIndicator(symbols, baseDataIndicator, resolution, selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
+                    break;
+
+                default:
+                    // Shouldn't happen, ConvertPythonIndicator will wrap the PyObject in a PythonIndicator instance if it can't convert it
+                    throw new ArgumentException($"Indicator type {indicator.GetPythonType().Name} is not supported.");
+            }
+        }
+
+        /// <summary>
+        /// Warms up a given indicator with historical data
+        /// </summary>
+        /// <param name="symbol">The symbol or symbols to retrieve historical data for</param>
+        /// <param name="indicator">The indicator we want to warm up</param>
+        /// <param name="period">The necessary period to warm up the indicator</param>
+        /// <param name="selector">Selects a value from the BaseData send into the indicator, if null defaults to a cast (x => (T)x)</param>
+        [DocumentationAttribute(Indicators)]
+        [DocumentationAttribute(HistoricalData)]
+        public void WarmUpIndicator(PyObject symbol, PyObject indicator, TimeSpan period, PyObject selector = null)
+        {
+            var symbols = symbol.ConvertToSymbolEnumerable();
+            var convertedIndicator = ConvertPythonIndicator(indicator);
+            switch (convertedIndicator)
+            {
+                case PythonIndicator pythonIndicator:
+                    WarmUpIndicator(symbols, pythonIndicator, period, selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
+                    break;
+
+                case IndicatorBase<IndicatorDataPoint> dataPointIndicator:
+                    WarmUpIndicator(symbols, dataPointIndicator, period, selector?.ConvertToDelegate<Func<IBaseData, decimal>>());
+                    break;
+
+                case IndicatorBase<IBaseDataBar> baseDataBarIndicator:
+                    WarmUpIndicator(symbols, baseDataBarIndicator, period, selector?.ConvertToDelegate<Func<IBaseData, IBaseDataBar>>());
+                    break;
+
+                case IndicatorBase<TradeBar> tradeBarIndicator:
+                    WarmUpIndicator(symbols, tradeBarIndicator, period, selector?.ConvertToDelegate<Func<IBaseData, TradeBar>>());
+                    break;
+
+                case IndicatorBase<IBaseData> baseDataIndicator:
+                    WarmUpIndicator(symbols, baseDataIndicator, period, selector?.ConvertToDelegate<Func<IBaseData, IBaseData>>());
+                    break;
+
+                default:
+                    // Shouldn't happen, ConvertPythonIndicator will wrap the PyObject in a PythonIndicator instance if it can't convert it
+                    throw new ArgumentException($"Indicator type {indicator.GetPythonType().Name} is not supported.");
+            }
         }
 
         /// <summary>
@@ -1824,23 +1932,7 @@ namespace QuantConnect.Algorithm
             {
                 convertedIndicator = WrapPythonIndicator(pyIndicator, pythonIndicator);
             }
-            else if (pyIndicator.TryConvert(out IndicatorBase<IndicatorDataPoint> dataPointIndicator))
-            {
-                convertedIndicator = dataPointIndicator;
-            }
-            else if (pyIndicator.TryConvert(out IndicatorBase<IBaseDataBar> dataBarIndicator))
-            {
-                convertedIndicator = dataBarIndicator;
-            }
-            else if (pyIndicator.TryConvert(out IndicatorBase<TradeBar> tradeBarIndicator))
-            {
-                convertedIndicator = tradeBarIndicator;
-            }
-            else if (pyIndicator.TryConvert(out IndicatorBase<IBaseData> baseDataIndicator))
-            {
-                convertedIndicator = baseDataIndicator;
-            }
-            else
+            else if (!pyIndicator.TryConvert(out convertedIndicator))
             {
                 convertedIndicator = WrapPythonIndicator(pyIndicator);
             }

--- a/Common/Indicators/InternalIndicatorValues.cs
+++ b/Common/Indicators/InternalIndicatorValues.cs
@@ -163,12 +163,21 @@ namespace QuantConnect.Indicators
             public override IndicatorDataPoint UpdateValue()
             {
                 var value = _propertyInfo.GetValue(Indicator);
+                if (value == null)
+                {
+                    return null;
+                }
+
                 if (_currentInfo != null)
                 {
                     value = _currentInfo.GetValue(value);
                 }
                 var point = value as IndicatorDataPoint;
-                Values.Add(point);
+                if (Values.Count == 0 || point.EndTime != Values[^1].EndTime)
+                {
+                    Values.Add(point);
+                }
+
                 return point;
             }
         }

--- a/Tests/Algorithm/AlgorithmIndicatorsTests.cs
+++ b/Tests/Algorithm/AlgorithmIndicatorsTests.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Moq;
 using NUnit.Framework;
@@ -24,6 +25,7 @@ using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.HistoricalData;
+using QuantConnect.Python;
 using QuantConnect.Tests.Engine.DataFeeds;
 using QuantConnect.Tests.Research;
 
@@ -482,6 +484,48 @@ class GoodCustomIndicator:
             Assert.AreEqual(requestCount, result.Count);
             Assert.AreEqual(10 + requestCount - 1, indicator.Samples);
             Assert.IsTrue(indicator.IsReady);
+        }
+
+        [Test]
+        public void OptionsIndicatorHistoryIsSupportedInPython([Range(1, 4)] int overload, [Values] bool useMirrorContract)
+        {
+            _algorithm.SetDateTime(new DateTime(2014, 06, 07));
+
+            var contract = Symbol.CreateOption("AAPL", Market.USA, OptionStyle.American, OptionRight.Call, 505, new DateTime(2014, 6, 27));
+            var mirrorContract = useMirrorContract
+                ? Symbol.CreateOption("AAPL", Market.USA, OptionStyle.American, OptionRight.Put, 505, new DateTime(2014, 6, 27))
+                : null;
+            var underlying = contract.Underlying;
+
+            var indicator = new ImpliedVolatility(contract, optionModel: OptionPricingModelType.BlackScholes, mirrorOption: mirrorContract);
+
+            using var _ = Py.GIL();
+
+            using var pyIndicator = indicator.ToPython();
+            var symbols = useMirrorContract ? new[] { contract, mirrorContract, underlying } : new[] { contract, underlying };
+            using var pySymbols = symbols.ToPyListUnSafe();
+
+            var symbolsHistory = overload != 4
+                ? null
+                : _algorithm.History(symbols, TimeSpan.FromDays(2), Resolution.Minute);
+
+            var indicatorHistory = overload switch
+            {
+                1 => _algorithm.IndicatorHistory(pyIndicator, pySymbols, TimeSpan.FromDays(2), Resolution.Minute),
+                2 => _algorithm.IndicatorHistory(pyIndicator, pySymbols, 60 * 24 * 2, Resolution.Minute),
+                3 => _algorithm.IndicatorHistory(pyIndicator, pySymbols, new DateTime(2014, 6, 6), new DateTime(2014, 6, 7), Resolution.Minute),
+                4 => _algorithm.IndicatorHistory(pyIndicator, symbolsHistory),
+                _ => throw new ArgumentOutOfRangeException(nameof(overload), "Invalid overload")
+            };
+
+            Assert.AreEqual(390, indicatorHistory.Count);
+
+            using var dataFrame = indicatorHistory.DataFrame;
+            Assert.AreEqual(390, dataFrame.GetAttr("shape")[0].GetAndDispose<int>());
+            // Assert dataframe column names are current, price, oppositeprice and underlyingprice
+            var columns = dataFrame.GetAttr("columns").InvokeMethod<List<string>>("tolist");
+            var expectedColumns = new[] { "current", "price", "oppositeprice", "underlyingprice" };
+            CollectionAssert.AreEquivalent(expectedColumns, columns);
         }
 
 

--- a/Tests/Algorithm/AlgorithmIndicatorsTests.cs
+++ b/Tests/Algorithm/AlgorithmIndicatorsTests.cs
@@ -533,9 +533,9 @@ class GoodCustomIndicator:
         {
             _algorithm.SetDateTime(new DateTime(2014, 06, 07));
 
-            var contract = Symbol.CreateOption("AAPL", Market.USA, OptionStyle.American, OptionRight.Call, 505, new DateTime(2014, 6, 27));
+            var contract = Symbol.CreateOption("AAPL", Market.USA, OptionStyle.American, OptionRight.Call, 505, new DateTime(2014, 07, 19));
             var mirrorContract = useMirrorContract
-                ? Symbol.CreateOption("AAPL", Market.USA, OptionStyle.American, OptionRight.Put, 505, new DateTime(2014, 6, 27))
+                ? Symbol.CreateOption("AAPL", Market.USA, OptionStyle.American, OptionRight.Put, 505, new DateTime(2014, 07, 19))
                 : null;
             var underlying = contract.Underlying;
 
@@ -547,18 +547,14 @@ class GoodCustomIndicator:
             var symbols = useMirrorContract ? new[] { contract, mirrorContract, underlying } : new[] { contract, underlying };
             using var pySymbols = symbols.ToPyListUnSafe();
 
-            var symbolsHistory = overload != 4
-                ? null
-                : _algorithm.History(symbols, TimeSpan.FromDays(2), Resolution.Minute);
-
             switch (overload)
             {
                 case 1:
-                    _algorithm.WarmUpIndicator(pySymbols, pyIndicator, TimeSpan.FromDays(2));
+                    _algorithm.WarmUpIndicator(pySymbols, pyIndicator, TimeSpan.FromDays(1));
                     break;
 
                 case 2:
-                    _algorithm.WarmUpIndicator(pySymbols, pyIndicator, Resolution.Minute);
+                    _algorithm.WarmUpIndicator(pySymbols, pyIndicator, Resolution.Daily);
                     break;
 
                 default:
@@ -566,17 +562,13 @@ class GoodCustomIndicator:
             }
 
             Assert.IsTrue(indicator.IsReady);
-            Assert.AreEqual(142.1500m, indicator.Price.Current.Value);
-            Assert.AreEqual(645.5700m, indicator.UnderlyingPrice.Current.Value);
 
             if (useMirrorContract)
             {
-                Assert.AreEqual(0.4489821m, indicator.Current.Value);
-                Assert.AreEqual(0.2200m, indicator.OppositePrice.Current.Value);
+                Assert.IsNotNull(indicator.OppositePrice);
             }
             else
             {
-                Assert.AreEqual(0.4212191m, indicator.Current.Value);
                 Assert.IsNull(indicator.OppositePrice);
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Fix Python `IndicatorHistory` API for indicators based on `OptionIndicatorBase ` by fixing the indicator conversion from `PyObject`.

Also, did the same fix for the `WarmUpIndicator` API for the same cases, and added missing overloads for warming up multi-symbol indicators both in Python and C#.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #8591 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
