### PR TITLE
Use C# generic history api for custom Python universe

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -1141,9 +1141,15 @@ namespace QuantConnect.Algorithm
                     var isCustom = Extensions.IsCustomDataType(symbol, type);
                     var entry = MarketHoursDatabase.GetEntry(symbol, new[] { type });
 
+                    // If the type is PythonData, we want to check what types are actually associated with the symbol
+                    if (!_customPythonDataTypes.TryGetValue(symbol, out var dataType))
+                    {
+                        dataType = type;
+                    }
+
                     // we were giving a specific type let's fetch it
                     return new[] { new SubscriptionDataConfig(
-                        type,
+                        dataType,
                         symbol,
                         resolution.Value,
                         entry.DataTimeZone,
@@ -1152,7 +1158,7 @@ namespace QuantConnect.Algorithm
                         UniverseSettings.ExtendedMarketHours,
                         true,
                         isCustom,
-                        LeanData.GetCommonTickTypeForCommonDataTypes(type, symbol.SecurityType),
+                        LeanData.GetCommonTickTypeForCommonDataTypes(dataType, symbol.SecurityType),
                         true,
                         UniverseSettings.GetUniverseNormalizationModeOrDefault(symbol.SecurityType))};
                 }

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -40,6 +40,8 @@ namespace QuantConnect.Algorithm
     {
         private readonly Dictionary<IntPtr, PythonIndicator> _pythonIndicators = new Dictionary<IntPtr, PythonIndicator>();
 
+        private Dictionary<Symbol, Type> _customPythonDataTypes = new Dictionary<Symbol, Type>();
+
         /// <summary>
         /// PandasConverter for this Algorithm
         /// </summary>
@@ -263,6 +265,12 @@ namespace QuantConnect.Algorithm
         {
             var alias = symbol.ID.Symbol;
             SymbolCache.Set(alias, symbol);
+
+            // Cache the data type for custom python data to keep reference to the actual created type
+            if (dataType.IsAssignableTo(typeof(PythonData)))
+            {
+                CacheCustomPythonDataType(symbol, dataType);
+            }
 
             if (timeZone != null)
             {
@@ -1886,6 +1894,11 @@ namespace QuantConnect.Algorithm
                 }
             }
             return history;
+        }
+
+        private void CacheCustomPythonDataType(Symbol symbol, Type dataType)
+        {
+            _customPythonDataTypes[symbol] = dataType;
         }
     }
 }

--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -697,6 +697,7 @@ namespace QuantConnect.Algorithm
                 }
                 // same as 'AddData<>' 'T' type will be treated as custom/base data type with always open market hours
                 universeSymbol = QuantConnect.Symbol.Create(name, SecurityType.Base, market, baseDataType: dataType);
+                CacheCustomPythonDataType(universeSymbol, dataType);
             }
             var marketHoursDbEntry = MarketHoursDatabase.GetEntry(universeSymbol, new[] { dataType });
             var dataTimeZone = marketHoursDbEntry.DataTimeZone;

--- a/Tests/Research/QuantBookHistoryTests.cs
+++ b/Tests/Research/QuantBookHistoryTests.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using QuantConnect.Research;
 using QuantConnect.Logging;
 using QuantConnect.Data.Fundamental;
+using QuantConnect.Python;
 
 namespace QuantConnect.Tests.Research
 {
@@ -683,6 +684,130 @@ def getHistory():
                 var isHistoryEmpty = pyHistory.GetAttr("empty").GetAndDispose<bool?>();
                 Assert.IsFalse(isHistoryEmpty);
                 Assert.IsFalse(pyHistory.HasAttr("data"));
+            }
+        }
+
+        [Test]
+        public void CustomPythonUniverseHistoryCanBeFetchedUsingCSharpApi()
+        {
+            using (Py.GIL())
+            {
+                var testModule = PyModule.FromString("CustomPythonUniverseHistoryCanBeFetchedUsingCSharpApi",
+                    @"
+from AlgorithmImports import *
+
+
+class StockDataSource(PythonData):
+
+    def get_source(self,
+         config: SubscriptionDataConfig,
+         date: datetime,
+         is_live: bool) -> SubscriptionDataSource:
+        return SubscriptionDataSource(""https://raw.githubusercontent.com/QuantConnect/Documentation/master/Resources/datasets/custom-data/csv-universe-example.csv"", SubscriptionTransportMedium.REMOTE_FILE, FileFormat.CSV)
+
+    def reader(self,
+         config: SubscriptionDataConfig,
+         line: str,
+         date: datetime,
+         is_live: bool) -> BaseData:
+
+        if not (line.strip() and line[0].isdigit()): return None
+
+        stocks = StockDataSource()
+        stocks.symbol = config.symbol
+
+        try:
+            csv = line.split(',')
+            stocks.time = datetime.strptime(csv[0], ""%Y%m%d"")
+            stocks.end_time = stocks.time + timedelta(days=1)
+            stocks[""Symbols""] = csv[1:]
+
+        except ValueError:
+            # Do nothing
+            return None
+
+        return stocks
+
+def universe_selector(data):
+        return [x.symbol for x in data]
+
+def add_universe(qb):
+    return qb.add_universe(StockDataSource, ""universe-stock-data-source"", Resolution.DAILY, universe_selector)
+
+def get_history(qb, universe):
+    return list(qb.history[StockDataSource](universe.symbol, datetime(2018, 1, 1), datetime(2018, 6, 1), Resolution.DAILY))
+");
+
+                dynamic getUniverse = testModule.GetAttr("add_universe");
+                dynamic getHistory = testModule.GetAttr("get_history");
+
+                var qb = new QuantBook();
+                var universe = getUniverse(qb);
+                var history = getHistory(qb, universe).As<List<PythonData>>() as List<PythonData>;
+                Assert.IsNotEmpty(history);
+            }
+        }
+
+        [Test]
+        public void CustomPythonDataHistoryCanBeFetchedUsingCSharpApi()
+        {
+            using (Py.GIL())
+            {
+                var testModule = PyModule.FromString("CustomPythCustomPythonDataHistoryCanBeFetchedUsingCSharpApionUniverseHistoryCanBeFetchedUsingCSharpApi",
+                    @"
+from AlgorithmImports import *
+
+
+class MyCustomDataType(PythonData):
+
+    def get_source(self,
+         config: SubscriptionDataConfig,
+         date: datetime,
+         is_live: bool) -> SubscriptionDataSource:
+        return SubscriptionDataSource(""https://raw.githubusercontent.com/QuantConnect/Documentation/master/Resources/datasets/custom-data/csv-data-example.csv"", SubscriptionTransportMedium.REMOTE_FILE)
+
+    def reader(self,
+         config: SubscriptionDataConfig,
+         line: str,
+         date: datetime,
+         is_live: bool) -> BaseData:
+
+        if not (line.strip()):
+            return None
+
+        index = MyCustomDataType()
+        index.symbol = config.symbol
+
+        try:
+            data = line.split(',')
+            index.time = datetime.strptime(data[0], ""%Y-%m-%d"")
+            index.end_time = index.time + timedelta(days=1)
+            index.value = data[4]
+            index[""open""] = float(data[1])
+            index[""high""] = float(data[2])
+            index[""low""] = float(data[3])
+            index[""close""] = float(data[4])
+
+        except ValueError:
+            # Do nothing
+            return None
+
+        return index
+
+def add_data(qb):
+    return qb.add_data(MyCustomDataType, ""MyCustomDataType"", Resolution.DAILY)
+
+def get_history(qb, security):
+    return list(qb.history[MyCustomDataType](security.symbol, datetime(2014, 1, 1), datetime(2014, 6, 1), Resolution.DAILY))
+");
+
+                dynamic getCustomSecurity = testModule.GetAttr("add_data");
+                dynamic getHistory = testModule.GetAttr("get_history");
+
+                var qb = new QuantBook();
+                var security = getCustomSecurity(qb);
+                var history = getHistory(qb, security).As<List<PythonData>>() as List<PythonData>;
+                Assert.IsNotEmpty(history);
             }
         }
     }

--- a/Tests/Research/QuantBookHistoryTests.cs
+++ b/Tests/Research/QuantBookHistoryTests.cs
@@ -22,7 +22,6 @@ using System.Linq;
 using QuantConnect.Research;
 using QuantConnect.Logging;
 using QuantConnect.Data.Fundamental;
-using QuantConnect.Python;
 
 namespace QuantConnect.Tests.Research
 {
@@ -684,104 +683,6 @@ def getHistory():
                 var isHistoryEmpty = pyHistory.GetAttr("empty").GetAndDispose<bool?>();
                 Assert.IsFalse(isHistoryEmpty);
                 Assert.IsFalse(pyHistory.HasAttr("data"));
-            }
-        }
-
-        [Test]
-        public void CustomPythonUniverseHistoryCanBeFetchedUsingCSharpApi()
-        {
-            using (Py.GIL())
-            {
-                var testModule = PyModule.FromString("CustomPythonUniverseHistoryCanBeFetchedUsingCSharpApi",
-                    @"
-from AlgorithmImports import *
-
-
-class StockDataSource(PythonData):
-
-    def get_source(self, config: SubscriptionDataConfig, date: datetime, is_live: bool) -> SubscriptionDataSource:
-        source = ""../../TestData/daily-stock-picker-backtest.csv""
-        return SubscriptionDataSource(source, SubscriptionTransportMedium.LocalFile, FileFormat.Csv)
-
-    def reader(self, config: SubscriptionDataConfig, line: str, date: datetime, is_live: bool) -> BaseData:
-        if not (line.strip() and line[0].isdigit()): return None
-
-        stocks = StockDataSource()
-        stocks.symbol = config.symbol
-
-        try:
-            csv = line.split(',')
-            stocks.time = datetime.strptime(csv[0], ""%Y%m%d"")
-            stocks.end_time = stocks.time + timedelta(days=1)
-            stocks[""Symbols""] = csv[1:]
-
-        except ValueError:
-            # Do nothing
-            return None
-
-        return stocks
-
-def universe_selector(data):
-        return [x.symbol for x in data]
-
-def add_universe(qb):
-    return qb.add_universe(StockDataSource, ""universe-stock-data-source"", Resolution.DAILY, universe_selector)
-
-def get_history(qb, universe):
-    return list(qb.history[StockDataSource](universe.symbol, datetime(2018, 1, 1), datetime(2018, 6, 1), Resolution.DAILY))
-");
-
-                dynamic getUniverse = testModule.GetAttr("add_universe");
-                dynamic getHistory = testModule.GetAttr("get_history");
-
-                var qb = new QuantBook();
-                var universe = getUniverse(qb);
-                var history = getHistory(qb, universe).As<List<PythonData>>() as List<PythonData>;
-                Assert.IsNotEmpty(history);
-            }
-        }
-
-        [Test]
-        public void CustomPythonDataHistoryCanBeFetchedUsingCSharpApi()
-        {
-            using (Py.GIL())
-            {
-                var testModule = PyModule.FromString("CustomPythonDataHistoryCanBeFetchedUsingCSharpApi",
-                    @"
-from AlgorithmImports import *
-from QuantConnect.Tests import *
-
-class MyCustomDataType(PythonData):
-
-    def get_source(self, config: SubscriptionDataConfig, date: datetime, is_live: bool) -> SubscriptionDataSource:
-        fileName = LeanData.GenerateZipFileName(Symbols.SPY, date, Resolution.MINUTE, config.TickType)
-        source = f'{Globals.DataFolder}equity/usa/minute/spy/{fileName}'
-        return SubscriptionDataSource(source, SubscriptionTransportMedium.LocalFile, FileFormat.Csv)
-
-    def reader(self, config: SubscriptionDataConfig, line: str, date: datetime, is_live: bool) -> BaseData:
-        data = line.split(',')
-        result = MyCustomDataType()
-        result.DataType = MarketDataType.Base
-        result.Symbol = config.Symbol
-        result.Time = date + timedelta(milliseconds=int(data[0]))
-        result.Value = 1
-
-        return result
-
-def add_data(qb):
-    return qb.add_data(MyCustomDataType, ""MyCustomDataType"", Resolution.DAILY)
-
-def get_history(qb, security):
-    return list(qb.history[MyCustomDataType](security.symbol, datetime(2013, 10, 7), datetime(2013, 10, 8), Resolution.MINUTE))
-");
-
-                dynamic getCustomSecurity = testModule.GetAttr("add_data");
-                dynamic getHistory = testModule.GetAttr("get_history");
-
-                var qb = new QuantBook();
-                var security = getCustomSecurity(qb);
-                var history = getHistory(qb, security).As<List<PythonData>>() as List<PythonData>;
-                Assert.IsNotEmpty(history);
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Cache custom universe and security Python data types in order to be able to get the correct config for history requests when pythonnet resolves custom data types to `PythonData` for generic arguments, causing loss of reference of the actual Python type.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #8477 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
