### PR TITLE
Prevent QuantBook composer reset on notebook initialization

### DIFF
--- a/Engine/Initializer.cs
+++ b/Engine/Initializer.cs
@@ -26,6 +26,9 @@ namespace QuantConnect.Lean.Engine
     /// </summary>
     public static class Initializer
     {
+        private static LeanEngineSystemHandlers _systemHandlers;
+        private static LeanEngineAlgorithmHandlers _algorithmHandlers;
+
         /// <summary>
         /// Basic common Lean initialization
         /// </summary>
@@ -62,12 +65,15 @@ namespace QuantConnect.Lean.Engine
         /// </summary>
         public static LeanEngineSystemHandlers GetSystemHandlers()
         {
-            var systemHandlers = LeanEngineSystemHandlers.FromConfiguration(Composer.Instance);
+            if (_systemHandlers == null)
+            {
+                _systemHandlers = LeanEngineSystemHandlers.FromConfiguration(Composer.Instance);
 
-            //Setup packeting, queue and controls system: These don't do much locally.
-            systemHandlers.Initialize();
+                //Setup packeting, queue and controls system: These don't do much locally.
+                _systemHandlers.Initialize();
+            }
 
-            return systemHandlers;
+            return _systemHandlers;
         }
 
         /// <summary>
@@ -75,7 +81,21 @@ namespace QuantConnect.Lean.Engine
         /// </summary>
         public static LeanEngineAlgorithmHandlers GetAlgorithmHandlers(bool researchMode = false)
         {
-            return LeanEngineAlgorithmHandlers.FromConfiguration(Composer.Instance, researchMode);
+            if (_algorithmHandlers == null)
+            {
+                _algorithmHandlers = LeanEngineAlgorithmHandlers.FromConfiguration(Composer.Instance, researchMode);
+            }
+
+            return _algorithmHandlers;
+        }
+
+        /// <summary>
+        /// Reset the handlers to null, so they are recreated on the next request
+        /// </summary>
+        public static void ResetHandlers()
+        {
+            _systemHandlers = null;
+            _algorithmHandlers = null;
         }
     }
 }

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -38,7 +38,6 @@ using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Lean.Engine.Setup;
 using QuantConnect.Indicators;
 using QuantConnect.Scheduling;
-using System.Collections;
 
 namespace QuantConnect.Research
 {
@@ -51,6 +50,12 @@ namespace QuantConnect.Research
         private IDataCacheProvider _dataCacheProvider;
         private IDataProvider _dataProvider;
         private static bool _isPythonNotebook;
+
+        /// <summary>
+        /// Indicates whether the Lean system and algorithm handlers have already been initialized,
+        /// preventing the QuantBook to reset the composer and handlers on re-creation.
+        /// </summary>
+        public static bool HandlersInitialized { get; set; }
 
         static QuantBook()
         {
@@ -115,10 +120,20 @@ namespace QuantConnect.Research
                 // Sets PandasConverter
                 SetPandasConverter();
 
+                Composer composer;
+                if (HandlersInitialized)
+                {
+                    // Reset the flag so we reset the composer on QuantBook re-creation
+                    HandlersInitialized = false;
+                    composer = Composer.Instance;
+                }
+                else
+                {
                 // Reset our composer; needed for re-creation of QuantBook
                 Composer.Instance.Reset();
-                var composer = Composer.Instance;
+                    composer = Composer.Instance;
                 Config.Reset();
+                }
 
                 // Create our handlers with our composer instance
                 var systemHandlers = LeanEngineSystemHandlers.FromConfiguration(composer);

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -869,11 +869,8 @@ namespace QuantConnect.Research
         {
             if (_systemHandlers != null && _algorithmHandlers != null)
             {
-                Logging.Log.Trace("\n\n-------------------- QuantBook.PrepareForInstantiation(): Skipping resetting composer and handlers.\n");
                 return;
             }
-
-            Logging.Log.Trace("\n\n********************** QuantBook.PrepareForInstantiation(): Resetting composer and handlers.\n");
 
             Composer.Instance.Reset();
             Config.Reset();

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -875,12 +875,9 @@ namespace QuantConnect.Research
             Composer.Instance.Reset();
             Config.Reset();
 
-            // Create our handlers with our composer instance
+            Initializer.ResetHandlers();
             _systemHandlers = Initializer.GetSystemHandlers();
-            // init the API
-            _systemHandlers.Initialize();
-
-            _algorithmHandlers = Initializer.GetAlgorithmHandlers(researchMode: true);
+            _algorithmHandlers = Initializer.GetAlgorithmHandlers();
         }
 
         /// <summary>

--- a/Research/QuantConnect.csx
+++ b/Research/QuantConnect.csx
@@ -85,3 +85,5 @@ using QuantConnect.Lean.Engine;
 Config.Reset();
 Initializer.Start();
 QuantBook.PrepareForInstantiation();
+Api api = (Api)Initializer.GetSystemHandlers().Api;
+var algorithmHandlers = Initializer.GetAlgorithmHandlers(researchMode: true);

--- a/Research/QuantConnect.csx
+++ b/Research/QuantConnect.csx
@@ -86,3 +86,4 @@ Config.Reset();
 Initializer.Start();
 Api api = (Api)Initializer.GetSystemHandlers().Api;
 var algorithmHandlers = Initializer.GetAlgorithmHandlers(researchMode: true);
+QuantBook.HandlersInitialized = true;

--- a/Research/QuantConnect.csx
+++ b/Research/QuantConnect.csx
@@ -84,6 +84,4 @@ using QuantConnect.Lean.Engine;
 
 Config.Reset();
 Initializer.Start();
-Api api = (Api)Initializer.GetSystemHandlers().Api;
-var algorithmHandlers = Initializer.GetAlgorithmHandlers(researchMode: true);
-QuantBook.HandlersInitialized = true;
+QuantBook.PrepareForInstantiation();

--- a/Research/start.py
+++ b/Research/start.py
@@ -36,8 +36,9 @@ Config.Reset()
 Initializer.Start()
 api = Initializer.GetSystemHandlers().Api
 algorithmHandlers = Initializer.GetAlgorithmHandlers(researchMode=True)
+QuantBook.HandlersInitialized = True
 
-# Required to configure pythonpath with additional paths the user may have 
+# Required to configure pythonpath with additional paths the user may have
 # set in the config, like a project library.
 PythonInitializer.Initialize(False)
 

--- a/Research/start.py
+++ b/Research/start.py
@@ -34,9 +34,7 @@ AddReference("Fasterflect")
 
 Config.Reset()
 Initializer.Start()
-api = Initializer.GetSystemHandlers().Api
-algorithmHandlers = Initializer.GetAlgorithmHandlers(researchMode=True)
-QuantBook.HandlersInitialized = True
+QuantBook.PrepareForInstantiation()
 
 # Required to configure pythonpath with additional paths the user may have
 # set in the config, like a project library.

--- a/Research/start.py
+++ b/Research/start.py
@@ -35,6 +35,8 @@ AddReference("Fasterflect")
 Config.Reset()
 Initializer.Start()
 QuantBook.PrepareForInstantiation()
+api = Initializer.GetSystemHandlers().Api
+algorithmHandlers = Initializer.GetAlgorithmHandlers(researchMode=True)
 
 # Required to configure pythonpath with additional paths the user may have
 # set in the config, like a project library.

--- a/Tests/AlgorithmRunner.cs
+++ b/Tests/AlgorithmRunner.cs
@@ -64,6 +64,7 @@ namespace QuantConnect.Tests
             SymbolCache.Clear();
             TextSubscriptionDataSourceReader.ClearCache();
             MarketOnCloseOrder.SubmissionTimeBuffer = MarketOnCloseOrder.DefaultSubmissionTimeBuffer;
+            Initializer.ResetHandlers();
 
             // clean up object storage
             var objectStorePath = LocalObjectStore.DefaultObjectStore;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Introduce new static flag `HandlersInitialized` to the `QuantBook` class so that it is prevented from resetting the composer on first creation, since the notebook initializers will set it to true after they initialize the composer and the Lean system and algorithm handlers.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #8375 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Research notebooks

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
