### PR TITLE
Add missing IB dependencies

### DIFF
--- a/DockerfileLeanFoundation
+++ b/DockerfileLeanFoundation
@@ -341,12 +341,13 @@ RUN apt-get update && apt install -y xvfb wkhtmltopdf && \
 RUN wget -q https://cdn.quantconnect.com/fonts/foundation.zip && unzip -q foundation.zip && rm foundation.zip \
     && mv "lean fonts/"* /usr/share/fonts/truetype/ && rm -rf "lean fonts/" "__MACOSX/"
 
-# Install IB Gateway: Installs to /root/ibgateway
-RUN mkdir -p /root/ibgateway && \
-    wget -q https://cdn.quantconnect.com/interactive/ibgateway-stable-standalone-linux-x64.v10.30.1t.sh && \
-    chmod 777 ibgateway-stable-standalone-linux-x64.v10.30.1t.sh && \
-    ./ibgateway-stable-standalone-linux-x64.v10.30.1t.sh -q -dir /root/ibgateway && \
-    rm ibgateway-stable-standalone-linux-x64.v10.30.1t.sh
+# Install IB Gateway and it's dependencies: Installs to /root/ibgateway
+RUN apt-get update && apt-get -y install libasound2 libnss3 libnspr4 && apt-get clean && apt-get autoclean && apt-get autoremove --purge -y && rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /root/ibgateway && \
+    wget -q https://cdn.quantconnect.com/interactive/ibgateway-stable-standalone-linux-x64.v10.30.1u.sh && \
+    chmod 777 ibgateway-stable-standalone-linux-x64.v10.30.1u.sh && \
+    ./ibgateway-stable-standalone-linux-x64.v10.30.1u.sh -q -dir /root/ibgateway && \
+    rm ibgateway-stable-standalone-linux-x64.v10.30.1u.sh
 
 # label definitions
 LABEL strict_python_version=3.11.11


### PR DESCRIPTION
See https://github.com/QuantConnect/Lean/pull/8586

IB Gateway is throwing exceptions for some account types:
```
java.util.concurrent.CompletionException: com.teamdev.jxbrowser.engine.MissingDependencyException: Missing dependencies have been detected:
	chromium => libasound.so.2 libnssutil3.so libnss3.so libsmime3.so libnspr4.so 
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:273)
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:280)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1592)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```