### PR TITLE
Adds BroadcastCommand Method

### DIFF
--- a/Algorithm.CSharp/CallbackCommandRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CallbackCommandRegressionAlgorithm.cs
@@ -50,6 +50,14 @@ namespace QuantConnect.Algorithm.CSharp
 
             var commandLink2 = Link(new { Symbol = "SPY", Parameters = new Dictionary<string, int>() { { "Quantity", 10 } } });
             Notify.Email("email@address", "Untyped Command Event", $"Signal Y trade\nFollow link to trigger: {commandLink2}");
+
+            // We need to create a project on QuantConnect to test the BroadcastCommand method
+            // and use the ProjectId in the BroadcastCommand call
+            ProjectId = 21805137;
+
+            // All live deployments receive the broadcasts below
+            var broadcastResult = BroadcastCommand(potentialCommand);
+            var broadcastResult2 = BroadcastCommand(new { Symbol = "SPY", Parameters = new Dictionary<string, int>() { { "Quantity", 10 } } });
         }
 
         /// <summary>

--- a/Algorithm.Python/CallbackCommandRegressionAlgorithm.py
+++ b/Algorithm.Python/CallbackCommandRegressionAlgorithm.py
@@ -94,6 +94,14 @@ class CallbackCommandRegressionAlgorithm(QCAlgorithm):
             raise ValueError(f'Invalid link was generated! {untyped_command_link}')
         self.notify.email("email@address", "Untyped Command Event", f"Signal Y trade\nFollow link to trigger: {untyped_command_link}")
 
+        # We need to create a project on QuantConnect to test the broadcast_command method
+        # and use the project_id in the broadcast_command call
+        self.project_id = 21805137;
+
+        # All live deployments receive the broadcasts below
+        broadcast_result = self.broadcast_command(potential_command);
+        broadcast_result2 = self.broadcast_command({ "symbol": "SPY", "parameters": { "quantity": 10 } });
+
     def on_command(self, data):
         self.debug(f"on_command: {str(data)}")
         self.buy(data.symbol, data.parameters["quantity"])

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -1749,13 +1749,7 @@ namespace QuantConnect.Algorithm
         public RestResponse BroadcastCommand(PyObject command)
         {
             var payload = ConvertCommandToPayload(command, out var typeName);
-
-            if (_registeredCommands.ContainsKey(typeName))
-            {
-                payload["$type"] = typeName;
-            }
-
-            return _api.BroadcastLiveCommand(ProjectId, payload);
+            return SendBroadcast(typeName, payload);
         }
 
         /// <summary>

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -3415,6 +3415,17 @@ namespace QuantConnect.Algorithm
         /// <returns><see cref="RestResponse"/></returns>
         public RestResponse BroadcastCommand(object command)
         {
+            var typeName = command.GetType().Name;
+            if (command is Command || typeName.Contains("AnonymousType", StringComparison.InvariantCultureIgnoreCase))
+            {
+                if (_registeredCommands.ContainsKey(typeName))
+                {
+                    var serialized = JsonConvert.SerializeObject(command);
+                    var payload = JsonConvert.DeserializeObject<Dictionary<string, object>>(serialized);
+                    payload["$type"] = typeName;
+                    return _api.BroadcastLiveCommand(ProjectId, payload);
+                }
+            }
             return _api.BroadcastLiveCommand(ProjectId, command);
         }
 

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -57,6 +57,7 @@ using Python.Runtime;
 using QuantConnect.Commands;
 using Newtonsoft.Json;
 using QuantConnect.Securities.Index;
+using QuantConnect.Api;
 
 namespace QuantConnect.Algorithm
 {
@@ -3405,6 +3406,16 @@ namespace QuantConnect.Algorithm
                 var commandInstance = JsonConvert.DeserializeObject<T>(command.Payload);
                 return commandInstance.Run(this);
             };
+        }
+
+        /// <summary>
+        /// Broadcast a live command
+        /// </summary>
+        /// <param name="command">The target command</param>
+        /// <returns><see cref="RestResponse"/></returns>
+        public RestResponse BroadcastCommand(object command)
+        {
+            return _api.BroadcastLiveCommand(ProjectId, command);
         }
 
         /// <summary>

--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -1063,6 +1063,29 @@ namespace QuantConnect.Api
         }
 
         /// <summary>
+        /// Broadcast a live command
+        /// </summary>
+        /// <param name="sourceProjectId">Project for the live instance we want to source the command from</param>
+        /// <param name="command">The command to run</param>
+        /// <returns><see cref="RestResponse"/></returns>
+        public RestResponse BroadcastLiveCommand(int sourceProjectId, object command)
+        {
+            var request = new RestRequest("live/commands/broadcast", Method.POST)
+            {
+                RequestFormat = DataFormat.Json,
+            };
+
+            request.AddParameter("application/json", JsonConvert.SerializeObject(new
+            {
+                sourceProjectId,
+                command
+            }), ParameterType.RequestBody);
+
+            ApiConnection.TryRequest(request, out RestResponse result);
+            return result;
+        }
+
+        /// <summary>
         /// Gets the logs of a specific live algorithm
         /// </summary>
         /// <param name="projectId">Project Id of the live running algorithm</param>

--- a/Common/Interfaces/IApi.cs
+++ b/Common/Interfaces/IApi.cs
@@ -540,5 +540,13 @@ namespace QuantConnect.Interfaces
         /// Gets a list of LEAN versions with their corresponding basic descriptions
         /// </summary>
         public VersionsResponse ReadLeanVersions();
+
+        /// <summary>
+        /// Broadcast a live command
+        /// </summary>
+        /// <param name="sourceProjectId">Project for the live instance we want to source the command from</param>
+        /// <param name="command">The command to run</param>
+        /// <returns><see cref="RestResponse"/></returns>
+        public RestResponse BroadcastLiveCommand(int sourceProjectId, object command);
     }
 }

--- a/Tests/Api/CommandTests.cs
+++ b/Tests/Api/CommandTests.cs
@@ -63,6 +63,35 @@ namespace QuantConnect.Tests.API
             }
         }
 
+        [TestCase("MyCommand")]
+        [TestCase("MyCommand2")]
+        [TestCase("MyCommand3")]
+        [TestCase("")]
+        public void BroadcastCommand(string commandType)
+        {
+            var command = new Dictionary<string, object>
+            {
+                { "quantity", 0.1 },
+                { "target", "BTCUSD" },
+                { "$type", commandType }
+            };
+
+            var projectId = RunLiveAlgorithm();
+            try
+            {
+                // allow algo to be deployed and prices to be set so we can trade
+                Thread.Sleep(TimeSpan.FromSeconds(10));
+                // Our project will not receive the broadcast but we can still use it to send a command
+                var result = _apiClient.BroadcastLiveCommand(projectId, command);
+                Assert.IsTrue(result.Success);
+            }
+            finally
+            {
+                _apiClient.StopLiveAlgorithm(projectId);
+                _apiClient.DeleteProject(projectId);
+            }
+        }
+
         private int RunLiveAlgorithm()
         {
             var settings = new Dictionary<string, object>()


### PR DESCRIPTION
#### Description
Send a command to all live algorithms.

#### Motivation and Context
New feature. Allows communication between projects.

#### Requires Documentation Change
Yes. Live Trading > Commands and Live Trading > Arbitrage.

#### How Has This Been Tested?
Unit tests and regression algorithms
![Captura de ecrã 2025-03-05 192720](https://github.com/user-attachments/assets/a23f7346-881c-4cc5-8cfc-fb5e35cea78f)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`