### PR TITLE
Allow Receiving Broadcast from Source Project

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -3526,7 +3526,9 @@ namespace QuantConnect.Algorithm
             {
                 payload["$type"] = typeName;
             }
-            return _api.BroadcastLiveCommand(ProjectId, payload);
+            return _api.BroadcastLiveCommand(Globals.OrganizationID, 
+                AlgorithmMode == AlgorithmMode.Live ? ProjectId : null, 
+                payload);
         }
 
         private static Symbol GetCanonicalOptionSymbol(Symbol symbol)

--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -1065,10 +1065,11 @@ namespace QuantConnect.Api
         /// <summary>
         /// Broadcast a live command
         /// </summary>
-        /// <param name="sourceProjectId">Project for the live instance we want to source the command from</param>
+        /// <param name="organizationId">Organization ID of the projects we would like to broadcast the command to</param>
+        /// <param name="excludeProjectId">Project for the live instance we want to exclude from the broadcast list</param>
         /// <param name="command">The command to run</param>
         /// <returns><see cref="RestResponse"/></returns>
-        public RestResponse BroadcastLiveCommand(int sourceProjectId, object command)
+        public RestResponse BroadcastLiveCommand(string organizationId, int? excludeProjectId, object command)
         {
             var request = new RestRequest("live/commands/broadcast", Method.POST)
             {
@@ -1077,7 +1078,8 @@ namespace QuantConnect.Api
 
             request.AddParameter("application/json", JsonConvert.SerializeObject(new
             {
-                sourceProjectId,
+                organizationId,
+                excludeProjectId,
                 command
             }), ParameterType.RequestBody);
 

--- a/Common/Interfaces/IApi.cs
+++ b/Common/Interfaces/IApi.cs
@@ -544,9 +544,10 @@ namespace QuantConnect.Interfaces
         /// <summary>
         /// Broadcast a live command
         /// </summary>
-        /// <param name="sourceProjectId">Project for the live instance we want to source the command from</param>
+        /// <param name="organizationId">Organization ID of the projects we would like to broadcast the command to</param>
+        /// <param name="excludeProjectId">Project for the live instance we want to exclude from the broadcast list</param>
         /// <param name="command">The command to run</param>
         /// <returns><see cref="RestResponse"/></returns>
-        public RestResponse BroadcastLiveCommand(int sourceProjectId, object command);
+        public RestResponse BroadcastLiveCommand(string organizationId, int? excludeProjectId, object command);
     }
 }

--- a/Tests/Api/CommandTests.cs
+++ b/Tests/Api/CommandTests.cs
@@ -67,7 +67,8 @@ namespace QuantConnect.Tests.API
         [TestCase("MyCommand2")]
         [TestCase("MyCommand3")]
         [TestCase("")]
-        public void BroadcastCommand(string commandType)
+        [TestCase("", true)]
+        public void BroadcastCommand(string commandType, bool excludeProject = false)
         {
             var command = new Dictionary<string, object>
             {
@@ -81,8 +82,8 @@ namespace QuantConnect.Tests.API
             {
                 // allow algo to be deployed and prices to be set so we can trade
                 Thread.Sleep(TimeSpan.FromSeconds(10));
-                // Our project will not receive the broadcast but we can still use it to send a command
-                var result = _apiClient.BroadcastLiveCommand(projectId, command);
+                // Our project will not receive the broadcast, unless we pass null value, but we can still use it to send a command
+                var result = _apiClient.BroadcastLiveCommand(Globals.OrganizationID, excludeProject ? projectId : null, command);
                 Assert.IsTrue(result.Success);
             }
             finally


### PR DESCRIPTION
#### Description
Allow Receiving Broadcast from Source Project.
In Research, `BroadcastCommand` sends a message to all live algorithms, including the source project, which is excluded in Live deployments.

#### Motivation and Context
Improve user remote control.

#### Requires Documentation Change
Yes. Update QC API.

#### How Has This Been Tested?
Unit tests and QuantConnect Cloud.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`