### PR TITLE
Update the periods of the history in StochasticIndicatorAndSubIndicatorsWarmUpRegressionAlgorithm

### DIFF
--- a/Algorithm.CSharp/StochasticIndicatorAndSubIndicatorsWarmUpRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StochasticIndicatorAndSubIndicatorsWarmUpRegressionAlgorithm.cs
@@ -51,18 +51,23 @@ namespace QuantConnect.Algorithm.CSharp
             _stochasticHistory = new Stochastic("SECOND", 14, 3, 3);
             RegisterIndicator(_spy, _stochasticHistory, dailyConsolidator);
 
+            // The warm-up period for the Stochastic indicator is calculated as:
+            // period + kPeriod + dPeriod - 2 = 14 + 3 + 3 - 2 = 18
+            // To ensure the indicator is fully warmed up, we request a history length
+            // significantly greater than 18.
+            var periods = 50;
             // Get historical data for warming up the stochasticHistory
-            var history = History(_spy, _stochasticHistory.WarmUpPeriod, Resolution.Daily);
+            var history = History(_spy, periods, Resolution.Daily);
 
             // Warm up STO indicator
-            foreach (var bar in history.TakeLast(_stochasticHistory.WarmUpPeriod))
+            foreach (var bar in history)
             {
                 _stochasticHistory.Update(bar);
             }
 
             var indicators = new List<IIndicator>() { _stochasticIndicator, _stochasticHistory };
 
-            // Ensure both are ready
+            // Ensure both indicators are ready
             foreach (var indicator in indicators)
             {
                 if (!indicator.IsReady)
@@ -124,7 +129,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 36;
+        public int AlgorithmHistoryDataPoints => 68;
 
         /// <summary>
         /// Final status of the algorithm


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
The number of periods used in the history has been updated to a value greater than the WarmUpPeriod to ensure that the new change to the Stochastic warm-up period works properly.

#### Related Issue
#8613

#### Motivation and Context
This [comment](https://github.com/QuantConnect/Lean/pull/8613#discussion_r1990408197)

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
This has been tested using unit and regression tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
