### PR TITLE
Add regression algo for indicator updates: Resolution.Daily vs TimeSpan.FromDays(1)

### DIFF
--- a/Algorithm.CSharp/DailyResolutionVsTimeSpanNoPreciseEndRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DailyResolutionVsTimeSpanNoPreciseEndRegressionAlgorithm.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Tests indicator behavior with "DailyPreciseEndTime" disabled, making indicator values equal at all times.
+    /// </summary>
+    public class DailyResolutionVsTimeSpanNoPreciseEndRegressionAlgorithm : DailyResolutionVsTimeSpanRegressionAlgorithm
+    {
+        /// <summary>
+        /// Disables precise end time, considering the full day instead.
+        /// </summary>
+        protected override void SetDailyPreciseEndTime()
+        {
+            // By default, DailyPreciseEndTime is true
+            Settings.DailyPreciseEndTime = false;
+        }
+
+        protected override void CompareValuesDuringMarketHours()
+        {
+            var value1 = RelativeStrengthIndex1.Current.Value;
+            var value2 = RelativeStrengthIndex2.Current.Value;
+            if (value1 != value2)
+            {
+                throw new RegressionTestException("The values must be equal during market hours");
+            }
+        }
+
+        protected override void CompareValuesAfterMarketHours()
+        {
+            var value1 = RelativeStrengthIndex1.Current.Value;
+            var value2 = RelativeStrengthIndex2.Current.Value;
+
+            if (value1 != value2)
+            {
+                throw new RegressionTestException("The values must be equal after market hours");
+            }
+        }
+
+    }
+}

--- a/Algorithm.CSharp/DailyResolutionVsTimeSpanNoPreciseEndRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DailyResolutionVsTimeSpanNoPreciseEndRegressionAlgorithm.cs
@@ -1,7 +1,19 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -11,14 +23,8 @@ namespace QuantConnect.Algorithm.CSharp
     /// </summary>
     public class DailyResolutionVsTimeSpanNoPreciseEndRegressionAlgorithm : DailyResolutionVsTimeSpanRegressionAlgorithm
     {
-        /// <summary>
-        /// Disables precise end time, considering the full day instead.
-        /// </summary>
-        protected override void SetDailyPreciseEndTime()
-        {
-            // By default, DailyPreciseEndTime is true
-            Settings.DailyPreciseEndTime = false;
-        }
+        // Disables precise end time, considering the full day instead.
+        protected override bool DailyPreciseEndTime => false;
 
         protected override void SetupFirstIndicatorUpdatedHandler()
         {
@@ -27,7 +33,7 @@ namespace QuantConnect.Algorithm.CSharp
                 var updatedTime = Time;
 
                 // RSI1 should update at midnight when precise end time is disabled
-                if (!(updatedTime.Hour == 0 && updatedTime.Minute == 0 && updatedTime.Second == 0))
+                if (updatedTime.TimeOfDay != new TimeSpan(0, 0, 0))
                 {
                     throw new RegressionTestException($"{RelativeStrengthIndex1.Name} must have updated at midnight, but it was updated at {updatedTime}");
                 }
@@ -44,6 +50,18 @@ namespace QuantConnect.Algorithm.CSharp
                     throw new RegressionTestException("RSI1 and RSI2 must have same value");
                 }
             };
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (RelativeStrengthIndex1.Current.Value != RelativeStrengthIndex2.Current.Value)
+            {
+                throw new RegressionTestException("RSI1 and RSI2 must have same value");
+            }
+            if (RelativeStrengthIndex1.Samples <= 20 || RelativeStrengthIndex2.Samples != RelativeStrengthIndex1.Samples)
+            {
+                throw new RegressionTestException("The number of samples must be the same and greater than 20");
+            }
         }
     }
 }

--- a/Algorithm.CSharp/DailyResolutionVsTimeSpanRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DailyResolutionVsTimeSpanRegressionAlgorithm.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Indicators;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This algorithm tests the behavior of indicators with different update mechanisms based on resolution and time span.
+    /// </summary>
+    public class DailyResolutionVsTimeSpanRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _spy;
+        private RelativeStrengthIndex _relativeStrengthIndex1;
+        private RelativeStrengthIndex _relativeStrengthIndex2;
+        private bool _dataPointsReceived;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 01, 01);
+            SetEndDate(2013, 01, 5);
+
+            _spy = AddEquity("SPY", Resolution.Hour).Symbol;
+
+            // First RSI: Updates at market close (4 PM) using daily resolution (9:30 AM to 4 PM)
+            _relativeStrengthIndex1 = new RelativeStrengthIndex(14, MovingAverageType.Wilders);
+            RegisterIndicator(_spy, _relativeStrengthIndex1, Resolution.Daily);
+
+            // Second RSI: Updates every 24 hours (from 12:00 AM to 12:00 AM) using a time span
+            _relativeStrengthIndex2 = new RelativeStrengthIndex(14, MovingAverageType.Wilders);
+            RegisterIndicator(_spy, _relativeStrengthIndex2, TimeSpan.FromDays(1));
+
+            // Warm up indicators with historical data
+            var history = History<TradeBar>(_spy, 20, Resolution.Daily).ToList();
+            foreach (var bar in history)
+            {
+                _relativeStrengthIndex1.Update(bar.EndTime, bar.Close);
+                _relativeStrengthIndex2.Update(bar.EndTime, bar.Close);
+            }
+            if (!_relativeStrengthIndex1.IsReady || !_relativeStrengthIndex2.IsReady)
+            {
+                throw new RegressionTestException("Indicators not ready.");
+            }
+            // During market hours, both RSI values should be equal because neither has been updated 
+            Schedule.On(DateRules.EveryDay(), TimeRules.At(12, 0, 0), CompareValuesDuringMarketHours);
+
+            // After market hours, the first RSI should have updated at 4 PM, so the values should differ.
+            Schedule.On(DateRules.EveryDay(), TimeRules.At(17, 0, 0), CompareValuesAfterMarketHours);
+        }
+
+        private void CompareValuesDuringMarketHours()
+        {
+            var value1 = _relativeStrengthIndex1.Current.Value;
+            var value2 = _relativeStrengthIndex2.Current.Value;
+            if (value1 != value2)
+            {
+                throw new RegressionTestException("The values must be equal during market hours");
+            }
+        }
+
+        private void CompareValuesAfterMarketHours()
+        {
+            var value1 = _relativeStrengthIndex1.Current.Value;
+            var value2 = _relativeStrengthIndex2.Current.Value;
+
+            if (value1 == value2 && _dataPointsReceived == true)
+            {
+                throw new RegressionTestException("The values must be different after market hours");
+            }
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (slice.ContainsKey(_spy))
+            {
+                _dataPointsReceived = true;
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_dataPointsReceived)
+            {
+                throw new RegressionTestException("No data points received");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 50;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 20;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-38.725"},
+            {"Tracking Error", "0.232"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/DailyResolutionVsTimeSpanWithMinuteEquityAlgorithm.cs
+++ b/Algorithm.CSharp/DailyResolutionVsTimeSpanWithMinuteEquityAlgorithm.cs
@@ -1,0 +1,68 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class DailyResolutionVsTimeSpanWithMinuteEquityAlgorithm : DailyResolutionVsTimeSpanRegressionAlgorithm
+    {
+        protected override void InitializeBaseSettings()
+        {
+            SetStartDate(2013, 10, 04);
+            SetEndDate(2013, 10, 05);
+            Spy = AddEquity("SPY", Resolution.Minute).Symbol;
+        }
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public override long DataPoints => 795;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/DailyResolutionVsTimeSpanWithSecondEquityAlgorithm.cs
+++ b/Algorithm.CSharp/DailyResolutionVsTimeSpanWithSecondEquityAlgorithm.cs
@@ -1,0 +1,68 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class DailyResolutionVsTimeSpanWithSecondResolutionEquityAlgorithm : DailyResolutionVsTimeSpanRegressionAlgorithm
+    {
+        protected override void InitializeBaseSettings()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 08);
+            Spy = AddEquity("SPY", Resolution.Second).Symbol;
+        }
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public override long DataPoints => 93622;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/DailyResolutionVsTimeSpanWithTickResolutionEquityAlgorithm.cs
+++ b/Algorithm.CSharp/DailyResolutionVsTimeSpanWithTickResolutionEquityAlgorithm.cs
@@ -1,0 +1,67 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class DailyResolutionVsTimeSpanWithTickResolutionEquityAlgorithm : DailyResolutionVsTimeSpanRegressionAlgorithm
+    {
+        protected override void InitializeBaseSettings()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 08);
+            Spy = AddEquity("SPY", Resolution.Tick).Symbol;
+        }
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public override long DataPoints => 6877089;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
This PR adds a regression test to compare indicator updates using Resolution.Daily vs. TimeSpan.FromDays(1). It verifies that indicators behave differently after market hours due to distinct update mechanisms.

However, this behavior is due to Settings.DailyPreciseEndTime being `true` by default. If set to false (`Settings.DailyPreciseEndTime = false`), both indicators will take the full day as a reference, resulting in identical values.

#### Related Issue
Closes #8415
Closes #8416

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
N/A

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
