### PR TITLE
Fix dataType assignment logic in GetMatchingSubscriptions

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -1140,7 +1140,9 @@ namespace QuantConnect.Algorithm
                     var entry = MarketHoursDatabase.GetEntry(symbol, new[] { type });
 
                     // Retrieve the associated data type from the universe if available, otherwise, use the provided type
-                    var dataType = UniverseManager.TryGetValue(symbol, out var universe) ? universe.DataType : type;
+                    var dataType = UniverseManager.TryGetValue(symbol, out var universe) && type.IsAssignableFrom(universe.DataType)
+                        ? universe.DataType
+                        : type;
 
                     // Determine resolution using the data type
                     resolution = GetResolution(symbol, resolution, dataType);

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -3556,16 +3556,16 @@ def get_history(algorithm, security):
             }
         }
 
-        [TestCase("CreateSymbol")]
-        [TestCase("AddFuture")]
-        public void HistoryHandlesSymbolChangedEventsCorrectly(string symbolSource)
+        [TestCase(true)]
+        [TestCase(false)]
+        public void HistoryHandlesSymbolChangedEventsCorrectly(bool useCreateSymbol)
         {
             var start = new DateTime(2021, 1, 1);
             _algorithm = GetAlgorithm(start);
             _algorithm.SetEndDate(2021, 1, 5);
 
             Symbol symbol;
-            if (symbolSource == "CreateSymbol")
+            if (useCreateSymbol)
             {
                 symbol = Symbol.Create(Futures.Indices.SP500EMini, SecurityType.Future, Market.CME);
             }

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -348,7 +348,8 @@ def getTradesOnlyHistory(algorithm, symbol, start):
                 var ticks = allHistory.OfType<Tick>().Where(e => e.TickType == TickType.Quote).ToList();
                 spyFlag = ticks.Any(e => e.Symbol == spy);
                 ibmFlag = ticks.Any(e => e.Symbol == ibm);
-            } else
+            }
+            else
             {
                 var allHistory = algorithm.History(new[] { spy, ibm }, TimeSpan.FromDays(1), historyResolution).SelectMany(slice => slice.AllData).ToList();
                 // Checking for QuoteBar data for SPY and IBM
@@ -3552,6 +3553,34 @@ def get_history(algorithm, security):
                 var security = getCustomSecurity(algorithm);
                 var history = getHistory(algorithm, security).As<List<PythonData>>() as List<PythonData>;
                 Assert.IsNotEmpty(history);
+            }
+        }
+
+        [Test]
+        public void HistoryHandlesSymbolChangedEventsCorrectly()
+        {
+            var start = new DateTime(2021, 1, 1);
+            _algorithm = GetAlgorithm(start);
+            _algorithm.SetEndDate(2021, 1, 5);
+
+            var future = _algorithm.AddFuture(
+                      Futures.Indices.SP500EMini,
+                      dataMappingMode: DataMappingMode.OpenInterest,
+                      dataNormalizationMode: DataNormalizationMode.BackwardsRatio,
+                      contractDepthOffset: 0);
+
+            // Retrieve historical SymbolChangedEvent data for the future
+            var history = _algorithm.History<SymbolChangedEvent>(future.Symbol, TimeSpan.FromDays(365)).ToList();
+
+            // Ensure the history contains symbol change events
+            Assert.IsNotEmpty(history);
+
+            // Verify each event has valid old and new symbols, and they are different
+            foreach (var symbolChangedEvent in history)
+            {
+                Assert.IsNotNull(symbolChangedEvent.OldSymbol);
+                Assert.IsNotNull(symbolChangedEvent.NewSymbol);
+                Assert.AreNotEqual(symbolChangedEvent.OldSymbol, symbolChangedEvent.NewSymbol);
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Fixed dataType assignment logic to ensure correct type selection when type is assignable from universe.DataType

#### Related Issue
Closes #8633

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
A new unit test was created to validate the dataType assignment logic.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
