### PR TITLE
fix CandlestickSeries constructor

### DIFF
--- a/Common/CandlestickSeries.cs
+++ b/Common/CandlestickSeries.cs
@@ -72,9 +72,8 @@ namespace QuantConnect
         /// <param name="name">Name of the chart series</param>
         /// <param name="unit">Unit of the series</param>
         public CandlestickSeries(string name, string unit)
-            : base(name, 0, unit)
+            : base(name, SeriesType.Candle, unit)
         {
-            SeriesType = SeriesType.Candle;
         }
 
         /// <summary>

--- a/Common/SeriesSampler.cs
+++ b/Common/SeriesSampler.cs
@@ -239,7 +239,7 @@ namespace QuantConnect
             var startIndex = candlesticks.FindIndex(x => x.Time > nextSampleTime) - 1;
             if (startIndex < 0)
             {
-                // there's not value before the start, just return identity
+                // there's no value before the start, just return identity
                 return GetIdentitySeries(sampledSeries, series, start, stop, truncateValues);
             }
             if (candlesticks[startIndex].Time == nextSampleTime && nextSampleTime <= stop)

--- a/Common/Util/SeriesJsonConverter.cs
+++ b/Common/Util/SeriesJsonConverter.cs
@@ -99,7 +99,7 @@ namespace QuantConnect.Util
 
                 default:
                     writer.WritePropertyName("values");
-                    serializer.Serialize(writer, (value as BaseSeries).Values);
+                    serializer.Serialize(writer, baseSeries.Values);
                     break;
             }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
Likely a copy-pasta error from Series, where index=0 is passed to BaseSeries constructor, only now it was passed as SeriesType, which is subsequently set in CandlestickSeries constructor.


#### Motivation and Context

Code is functional as-is, but it makes no sense to pass `0` as seriestype to base(), and then immediately set it to correct value .

#### Requires Documentation Change
No

#### How Has This Been Tested?
N/A

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
    - non-functional change
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
