### PR TITLE
Keep time of day on open interest consolidator

### DIFF
--- a/Common/Data/Consolidators/OpenInterestConsolidator.cs
+++ b/Common/Data/Consolidators/OpenInterestConsolidator.cs
@@ -24,6 +24,8 @@ namespace QuantConnect.Data.Consolidators
     /// </summary>
     public class OpenInterestConsolidator : PeriodCountConsolidatorBase<Tick, OpenInterest>
     {
+        private bool _hourOrDailyConsolidation;
+
         /// <summary>
         /// Create a new OpenInterestConsolidator for the desired resolution
         /// </summary>
@@ -41,6 +43,7 @@ namespace QuantConnect.Data.Consolidators
         public OpenInterestConsolidator(TimeSpan period)
             : base(period)
         {
+            _hourOrDailyConsolidation = period >= Time.OneHour;
         }
 
         /// <summary>
@@ -104,7 +107,7 @@ namespace QuantConnect.Data.Consolidators
                 workingBar = new OpenInterest
                 {
                     Symbol = data.Symbol,
-                    Time = GetRoundedBarTime(data),
+                    Time = _hourOrDailyConsolidation ? data.EndTime : GetRoundedBarTime(data),
                     Value = data.Value
                 };
 
@@ -113,6 +116,13 @@ namespace QuantConnect.Data.Consolidators
             {
                 //Update the working bar
                 workingBar.Value = data.Value;
+
+                // If we are consolidating hourly or daily, we need to update the time of the working bar
+                // for the end time to match the last data point time
+                if (_hourOrDailyConsolidation)
+                {
+                    workingBar.Time = data.EndTime;
+                }
             }
         }
     }

--- a/Common/Data/Consolidators/OpenInterestConsolidator.cs
+++ b/Common/Data/Consolidators/OpenInterestConsolidator.cs
@@ -25,6 +25,7 @@ namespace QuantConnect.Data.Consolidators
     public class OpenInterestConsolidator : PeriodCountConsolidatorBase<Tick, OpenInterest>
     {
         private bool _hourOrDailyConsolidation;
+        // Keep track of the last input to detect hour or date change
         private Tick _lastInput;
 
         /// <summary>
@@ -137,12 +138,12 @@ namespace QuantConnect.Data.Consolidators
         {
             if (_lastInput != null &&
                 _hourOrDailyConsolidation &&
-                Period.HasValue &&
+                // Detect hour or date change
                 ((Period == Time.OneHour && data.EndTime.Hour != _lastInput.EndTime.Hour) ||
-                    ((Period == Time.OneDay && data.EndTime.Date != _lastInput.EndTime.Date))) &&
-                data.EndTime - _lastInput.EndTime < Period)
+                 (Period == Time.OneDay && data.EndTime.Date != _lastInput.EndTime.Date)))
             {
-                // Date change, force consolidation, no need to wait for the whole period to pass
+                // Date or hour change, force consolidation, no need to wait for the whole period to pass.
+                // Force consolidation by scanning at a time after the end of the period
                 Scan(_lastInput.EndTime.Add(Period.Value + Time.OneSecond));
             }
 

--- a/Tests/Common/Data/OpenInterestConsolidatorTests.cs
+++ b/Tests/Common/Data/OpenInterestConsolidatorTests.cs
@@ -1,0 +1,158 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.Market;
+using QuantConnect.Logging;
+
+namespace QuantConnect.Tests.Common.Data
+{
+    [TestFixture]
+    public class OpenInterestConsolidatorTests : BaseConsolidatorTests
+    {
+        [TestCaseSource(nameof(HourAndDailyTestValues))]
+        public void HourAndDailyConsolidationKeepsTimeOfDay(TimeSpan period, List<(OpenInterest, bool)> data)
+        {
+            using var consolidator = new OpenInterestConsolidator(period);
+
+            var consolidatedOpenInterest = (OpenInterest)null;
+            consolidator.DataConsolidated += (sender, consolidated) =>
+            {
+                Log.Debug($"{consolidated.EndTime} - {consolidated}");
+                consolidatedOpenInterest = consolidated;
+            };
+
+            var prevData = (OpenInterest)null;
+            foreach (var (openInterest, shouldConsolidate) in data)
+            {
+                consolidator.Update(openInterest);
+
+                if (shouldConsolidate)
+                {
+                    Assert.IsNotNull(consolidatedOpenInterest);
+                    Assert.AreEqual(prevData.Symbol, consolidatedOpenInterest.Symbol);
+                    Assert.AreEqual(prevData.Value, consolidatedOpenInterest.Value);
+                    Assert.AreEqual(prevData.EndTime, consolidatedOpenInterest.EndTime);
+                    consolidatedOpenInterest = null;
+                }
+                else
+                {
+                    Assert.IsNull(consolidatedOpenInterest);
+                }
+
+                prevData = openInterest;
+            }
+        }
+
+        protected override IDataConsolidator CreateConsolidator()
+        {
+            return new OpenInterestConsolidator(TimeSpan.FromDays(1));
+        }
+
+        protected override IEnumerable<IBaseData> GetTestValues()
+        {
+            var time = new DateTime(2015, 04, 13, 8, 31, 0);
+            return new List<OpenInterest>()
+            {
+                new OpenInterest(){ Time = time, Symbol = Symbols.SPY, Value = 10 },
+                new OpenInterest(){ Time = time.AddMinutes(1), Symbol = Symbols.SPY, Value = 12 },
+                new OpenInterest(){ Time = time.AddMinutes(2), Symbol = Symbols.SPY, Value = 10 },
+                new OpenInterest(){ Time = time.AddMinutes(3), Symbol = Symbols.SPY, Value = 5 },
+                new OpenInterest(){ Time = time.AddMinutes(4), Symbol = Symbols.SPY, Value = 15 },
+                new OpenInterest(){ Time = time.AddMinutes(5), Symbol = Symbols.SPY, Value = 20 },
+                new OpenInterest(){ Time = time.AddMinutes(6), Symbol = Symbols.SPY, Value = 18 },
+                new OpenInterest(){ Time = time.AddMinutes(7), Symbol = Symbols.SPY, Value = 12 },
+                new OpenInterest(){ Time = time.AddMinutes(8), Symbol = Symbols.SPY, Value = 25 },
+                new OpenInterest(){ Time = time.AddMinutes(9), Symbol = Symbols.SPY, Value = 30 },
+                new OpenInterest(){ Time = time.AddMinutes(10), Symbol = Symbols.SPY, Value = 26 },
+            };
+        }
+
+        private static IEnumerable<TestCaseData> HourAndDailyTestValues()
+        {
+            var symbol = Symbols.SPY_C_192_Feb19_2016;
+            var time = new DateTime(2015, 04, 13, 6, 30, 0);
+            var period = Time.OneDay;
+
+            yield return new TestCaseData(
+                period,
+                new List<(OpenInterest, bool)>()
+                {
+                    (new OpenInterest(time, symbol, 10), false),
+                    (new OpenInterest(time.AddDays(1), symbol, 11), true),
+                    (new OpenInterest(time.AddDays(2), symbol, 12), true),
+                    (new OpenInterest(time.AddDays(3), symbol, 13), true),
+                    (new OpenInterest(time.AddDays(4), symbol, 14), true),
+                    (new OpenInterest(time.AddDays(5), symbol, 15), true),
+                });
+
+            yield return new TestCaseData(
+                period,
+                new List<(OpenInterest, bool)>()
+                {
+                    (new OpenInterest(time, symbol, 10), false),
+                    (new OpenInterest(time.AddDays(1), symbol, 11), true),
+                    // Same date, should not consolidate
+                    (new OpenInterest(time.AddDays(1).AddMinutes(1), symbol, 12), false),
+                    // Same date, should not consolidate
+                    (new OpenInterest(time.AddDays(1).AddMinutes(2), symbol, 13), false),
+                    // Same date, should not consolidate
+                    (new OpenInterest(time.AddDays(1).AddMinutes(3), symbol, 14), false),
+                    // Not the full period passed but different date, should consolidate
+                    (new OpenInterest(time.AddDays(2).AddHours(-1), symbol, 15), true),
+                    (new OpenInterest(time.AddDays(3).AddHours(-2), symbol, 16), true),
+                    (new OpenInterest(time.AddDays(4).AddHours(-3), symbol, 17), true),
+                    (new OpenInterest(time.AddDays(5).AddHours(-4), symbol, 18), true),
+                });
+
+            period = Time.OneHour;
+
+            yield return new TestCaseData(
+                period,
+                new List<(OpenInterest, bool)>()
+                {
+                    (new OpenInterest(time, symbol, 10), false),
+                    (new OpenInterest(time.AddHours(1), symbol, 11), true),
+                    (new OpenInterest(time.AddHours(2), symbol, 12), true),
+                    (new OpenInterest(time.AddHours(3), symbol, 13), true),
+                    (new OpenInterest(time.AddHours(4), symbol, 14), true),
+                    (new OpenInterest(time.AddHours(5), symbol, 15), true),
+                });
+
+            yield return new TestCaseData(
+                period,
+                new List<(OpenInterest, bool)>()
+                {
+                    (new OpenInterest(time, symbol, 10), false),
+                    (new OpenInterest(time.AddHours(1), symbol, 11), true),
+                    // Same date, should not consolidate
+                    (new OpenInterest(time.AddHours(1).AddMinutes(5), symbol, 12), false),
+                    // Same date, should not consolidate
+                    (new OpenInterest(time.AddHours(1).AddMinutes(10), symbol, 13), false),
+                    // Same date, should not consolidate
+                    (new OpenInterest(time.AddHours(1).AddMinutes(15), symbol, 14), false),
+                    // Not the full period passed but different date, should consolidate
+                    (new OpenInterest(time.AddHours(2).AddMinutes(-5), symbol, 15), true),
+                    (new OpenInterest(time.AddHours(3).AddMinutes(-10), symbol, 16), true),
+                    (new OpenInterest(time.AddHours(4).AddMinutes(-15), symbol, 17), true),
+                    (new OpenInterest(time.AddHours(5).AddMinutes(-20), symbol, 18), true),
+                });
+        }
+    }
+}

--- a/Tests/Common/Data/OpenInterestConsolidatorTests.cs
+++ b/Tests/Common/Data/OpenInterestConsolidatorTests.cs
@@ -139,6 +139,18 @@ namespace QuantConnect.Tests.Common.Data
                 period,
                 new List<(OpenInterest, bool)>()
                 {
+                    (new OpenInterest(time.AddHours(0.5).AddMinutes(10), symbol, 10), false),
+                    (new OpenInterest(time.AddHours(2.5).AddMinutes(20), symbol, 11), true),
+                    (new OpenInterest(time.AddHours(4.5).AddMinutes(30), symbol, 12), true),
+                    (new OpenInterest(time.AddHours(6.5).AddMinutes(40), symbol, 13), true),
+                    (new OpenInterest(time.AddHours(8.5), symbol, 14), true),
+                    (new OpenInterest(time.AddHours(10.5).AddMinutes(50), symbol, 15), true),
+                });
+
+            yield return new TestCaseData(
+                period,
+                new List<(OpenInterest, bool)>()
+                {
                     (new OpenInterest(time, symbol, 10), false),
                     (new OpenInterest(time.AddHours(1), symbol, 11), true),
                     // Same date, should not consolidate


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Open interest data are treated as ticks and not as bars, so when consolidating hour and daily data we can keep the original time of day instead of rounding down to the nearest hour or day. This allows to get the correct historical data, including the start time.

For instance, a request for OI daily data starting on 2025/03/24 should include the data point for the 24th and it's currentl being filtered out by the history provider because the data end time is set to that same timestamp, which is the same as the start time. If we keep the actual time of day, the result will include that point as expected.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
