### PR TITLE
Remove fill warnings from order tags

### DIFF
--- a/Algorithm.CSharp/AddBetaIndicatorNewAssetsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddBetaIndicatorNewAssetsRegressionAlgorithm.cs
@@ -145,7 +145,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$87000.00"},
             {"Lowest Capacity Asset", "BTCUSD 2XR"},
             {"Portfolio Turnover", "2.22%"},
-            {"OrderListHash", "4fcffc45d82203bb6ded8a0e86070b4f"}
+            {"OrderListHash", "9fce77ef8817cf0159897fc64d01f5e9"}
         };
     }
 }

--- a/Algorithm.CSharp/AddOptionContractExpiresRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddOptionContractExpiresRegressionAlgorithm.cs
@@ -160,7 +160,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$5700000.00"},
             {"Lowest Capacity Asset", "AOL VRKS95ENLBYE|AOL R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.55%"},
-            {"OrderListHash", "24191a4a3bf11c07622a21266618193d"}
+            {"OrderListHash", "fc5ab25181a01ca5ce39212f60eb0ecd"}
         };
     }
 }

--- a/Algorithm.CSharp/BacktestingBrokerageRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/BacktestingBrokerageRegressionAlgorithm.cs
@@ -339,7 +339,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "17.02%"},
-            {"OrderListHash", "b1e5e72fb766ab894204bc4b1300912b"}
+            {"OrderListHash", "a7ce5ff2bbe0fe273cf1631ea5a73fa6"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateContinuousFutureAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateContinuousFutureAlgorithm.cs
@@ -160,7 +160,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$7100000.00"},
             {"Lowest Capacity Asset", "ES VMKLFZIH2MTD"},
             {"Portfolio Turnover", "2.33%"},
-            {"OrderListHash", "04670183a0a4c9160167415aa5102499"}
+            {"OrderListHash", "223735440010fcec5889bb7becacfa82"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateContinuousFutureWithExtendedMarketAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateContinuousFutureWithExtendedMarketAlgorithm.cs
@@ -166,7 +166,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$890000000.00"},
             {"Lowest Capacity Asset", "ES VMKLFZIH2MTD"},
             {"Portfolio Turnover", "2.32%"},
-            {"OrderListHash", "f60fc7dcba2c1ff077afeb191aee5008"}
+            {"OrderListHash", "1504a8892da8d8c0650018732f315753"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateFutureRolloverAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFutureRolloverAlgorithm.cs
@@ -219,7 +219,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "ES VMKLFZIH2MTD"},
             {"Portfolio Turnover", "0.13%"},
-            {"OrderListHash", "7c8700a9baa24f6f76d866e7d88cc19c"}
+            {"OrderListHash", "a6ccce3a1a7f549f887d83e84bfa878d"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateFuturesDailyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesDailyAlgorithm.cs
@@ -170,7 +170,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "ES VRJST036ZY0X"},
             {"Portfolio Turnover", "0.92%"},
-            {"OrderListHash", "c0713abdc4fb059c2be797fce36e4f36"}
+            {"OrderListHash", "ddaa9dd20647fdbc4811d6e64bb30a40"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateFuturesHourlyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesHourlyAlgorithm.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$8000.00"},
             {"Lowest Capacity Asset", "ES VP274HSU1AF5"},
             {"Portfolio Turnover", "20.14%"},
-            {"OrderListHash", "dedcc487d64e2f601990fc70393c89ed"}
+            {"OrderListHash", "f6482c8757f82cb9f4c058e3ed6bc494"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateFuturesWithExtendedMarketDailyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesWithExtendedMarketDailyAlgorithm.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "ES VRJST036ZY0X"},
             {"Portfolio Turnover", "0.87%"},
-            {"OrderListHash", "8b8b733248a21fc717079be54b2e844c"}
+            {"OrderListHash", "741a26424d2210171ad849d92fc75d23"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateFuturesWithExtendedMarketHourlyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFuturesWithExtendedMarketHourlyAlgorithm.cs
@@ -74,7 +74,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$3000.00"},
             {"Lowest Capacity Asset", "ES VP274HSU1AF5"},
             {"Portfolio Turnover", "56.73%"},
-            {"OrderListHash", "424536177e9be5895bab50638ef43a9d"}
+            {"OrderListHash", "6ce7812de5c98744cc35169a86a24325"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateHourlyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateHourlyAlgorithm.cs
@@ -118,7 +118,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$110000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "19.96%"},
-            {"OrderListHash", "966f8355817adbc8c724d1062691a60b"}
+            {"OrderListHash", "60747dce5c2aed393b7dccc258d2c9b5"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateIndexHourlyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateIndexHourlyAlgorithm.cs
@@ -66,7 +66,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$300000.00"},
             {"Lowest Capacity Asset", "SPX XL80P3GHDZXQ|SPX 31"},
             {"Portfolio Turnover", "24.63%"},
-            {"OrderListHash", "44325fc1fdebb8e54f64a3f6e8a4bcd7"}
+            {"OrderListHash", "5595ab834c2584c1d124ad575e88cc1a"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateIndexOptionsDailyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateIndexOptionsDailyAlgorithm.cs
@@ -110,7 +110,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "SPX XL80P59H5E6M|SPX 31"},
             {"Portfolio Turnover", "0.00%"},
-            {"OrderListHash", "285cec32c0947f0e8cf90ccb672cfa43"}
+            {"OrderListHash", "8340619d603921c1ce261287890b9c1c"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateIndexOptionsHourlyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateIndexOptionsHourlyAlgorithm.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "SPX XL80P59H5E6M|SPX 31"},
             {"Portfolio Turnover", "0.00%"},
-            {"OrderListHash", "75e6584cb26058b09720c3a828b9fbda"}
+            {"OrderListHash", "1c5f424cfe62777733ee68a20320bb8d"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateIndiaAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateIndiaAlgorithm.cs
@@ -128,7 +128,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "₹61000000000.00"},
             {"Lowest Capacity Asset", "YESBANK UL"},
             {"Portfolio Turnover", "0.00%"},
-            {"OrderListHash", "7a0257f08e3bb9143b825e07ab47fea0"}
+            {"OrderListHash", "06f782c83dd633dac6f228b91273ba26"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateIndiaIndexAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateIndiaIndexAlgorithm.cs
@@ -152,7 +152,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "₹84000.00"},
             {"Lowest Capacity Asset", "JUNIORBEES UL"},
             {"Portfolio Turnover", "0.04%"},
-            {"OrderListHash", "79ab9ec506959c562be8b3cdbb174c39"}
+            {"OrderListHash", "8790bec8175539e6d92e01608ac57733"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateOptionsDailyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsDailyAlgorithm.cs
@@ -165,7 +165,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$72000.00"},
             {"Lowest Capacity Asset", "AAPL W78ZEO2985GM|AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.02%"},
-            {"OrderListHash", "b3125e0af79da0f5eea4cfda09806324"}
+            {"OrderListHash", "5e20fad3461ac9998afe8d76ad43b25c"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateOptionsFilterUniverseAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFilterUniverseAlgorithm.cs
@@ -142,7 +142,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "15.08%"},
-            {"OrderListHash", "db6a1134ad325bce31c2bdd2e87ff5f4"}
+            {"OrderListHash", "f68f6d64a5721ee148bc3c643f8d1b7f"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateOptionsFrameworkAlgorithm.cs
@@ -182,7 +182,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "13.50%"},
-            {"OrderListHash", "cf14a7ce9c86e6844051820fd4c9394c"}
+            {"OrderListHash", "d40c84371facba5dac8a2c919ea75807"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateSPXWeeklyIndexOptionsAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateSPXWeeklyIndexOptionsAlgorithm.cs
@@ -146,7 +146,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$580000.00"},
             {"Lowest Capacity Asset", "SPXW 31K54PVWHUJHQ|SPX 31"},
             {"Portfolio Turnover", "0.40%"},
-            {"OrderListHash", "07a085baedb37bb7c8d460558ea77e88"}
+            {"OrderListHash", "db5e3681c5fa1888262f2370a9b14c11"}
         };
     }
 }

--- a/Algorithm.CSharp/BasicTemplateSPXWeeklyIndexOptionsStrategyAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateSPXWeeklyIndexOptionsStrategyAlgorithm.cs
@@ -152,7 +152,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$13000000.00"},
             {"Lowest Capacity Asset", "SPXW XKX6S2GM9PGU|SPX 31"},
             {"Portfolio Turnover", "0.28%"},
-            {"OrderListHash", "c1a9bc141ae25c9542b93a887e79dafe"}
+            {"OrderListHash", "17764ae9e216d003b1f3ce68d15b68ef"}
         };
     }
 }

--- a/Algorithm.CSharp/CoinbaseCryptoYearMarketTradingRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CoinbaseCryptoYearMarketTradingRegressionAlgorithm.cs
@@ -142,7 +142,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$71000.00"},
             {"Lowest Capacity Asset", "BTCUSD 2XR"},
             {"Portfolio Turnover", "0.29%"},
-            {"OrderListHash", "179b672b3c1024bbe49dd3b4974232f1"}
+            {"OrderListHash", "a0058926f4ca5b009cfcc9096506a548"}
         };
     }
 }

--- a/Algorithm.CSharp/ContinuousBackMonthRawFutureRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ContinuousBackMonthRawFutureRegressionAlgorithm.cs
@@ -182,7 +182,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$76000000.00"},
             {"Lowest Capacity Asset", "ES VP274HSU1AF5"},
             {"Portfolio Turnover", "0.91%"},
-            {"OrderListHash", "7e45786e43b159c7edfcdf0aa0876deb"}
+            {"OrderListHash", "a472060eeb87c7474d25f7035fa150c4"}
         };
     }
 }

--- a/Algorithm.CSharp/ContinuousFutureBackMonthRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ContinuousFutureBackMonthRegressionAlgorithm.cs
@@ -198,7 +198,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$230000000.00"},
             {"Lowest Capacity Asset", "ES VP274HSU1AF5"},
             {"Portfolio Turnover", "1.39%"},
-            {"OrderListHash", "795bfb3ab8565e759e98e43a49b0a91d"}
+            {"OrderListHash", "6a5b2e6b3f140e9bb7f32c07cbf5f36c"}
         };
     }
 }

--- a/Algorithm.CSharp/ContinuousFutureRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ContinuousFutureRegressionAlgorithm.cs
@@ -216,7 +216,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$2600000000.00"},
             {"Lowest Capacity Asset", "ES VMKLFZIH2MTD"},
             {"Portfolio Turnover", "1.88%"},
-            {"OrderListHash", "1287c3b983c5bac6491bb5ac296c4b55"}
+            {"OrderListHash", "1973b0beb9bc5e618e0387d960553d7a"}
         };
     }
 }

--- a/Algorithm.CSharp/CustomBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomBenchmarkRegressionAlgorithm.cs
@@ -117,7 +117,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$66000000.00"},
             {"Lowest Capacity Asset", "AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "20.08%"},
-            {"OrderListHash", "ae85de0e28b44116de68c56ca141c00f"}
+            {"OrderListHash", "fa51af977e55213dc007a38a3d681b62"}
         };
     }
 }

--- a/Algorithm.CSharp/CustomBuyingPowerModelAlgorithm.cs
+++ b/Algorithm.CSharp/CustomBuyingPowerModelAlgorithm.cs
@@ -144,7 +144,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$150000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "26.62%"},
-            {"OrderListHash", "c5ca1a8b0ce57cfeadd9eddf8abdd80c"}
+            {"OrderListHash", "dae7e349316dce7621bc1f8be86ccd0d"}
         };
     }
 }

--- a/Algorithm.CSharp/CustomDataBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataBenchmarkRegressionAlgorithm.cs
@@ -111,7 +111,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$180000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "24.86%"},
-            {"OrderListHash", "c07a9cae88eb3f47309fbf18216bc3cf"}
+            {"OrderListHash", "8c07dafc84c73401fa0c7709b6baf802"}
         };
 
         public class ExampleCustomData : BaseData

--- a/Algorithm.CSharp/CustomDataUsingMapFileRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomDataUsingMapFileRegressionAlgorithm.cs
@@ -162,7 +162,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "NWSA.CustomDataUsingMapping T3MO1488O0H0"},
             {"Portfolio Turnover", "16.62%"},
-            {"OrderListHash", "a605ae85beeb854fde8d7b7eff9040ac"}
+            {"OrderListHash", "fe95edf1a3eabc0ac044b85eb833da5a"}
         };
 
         /// <summary>

--- a/Algorithm.CSharp/CustomMarginInterestRateModelAlgorithm.cs
+++ b/Algorithm.CSharp/CustomMarginInterestRateModelAlgorithm.cs
@@ -159,7 +159,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$150000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "3.19%"},
-            {"OrderListHash", "91660550269bce594c61fbf9159807d2"}
+            {"OrderListHash", "c0205e9d3d1bfdee958fecccb36413ec"}
         };
     }
 }

--- a/Algorithm.CSharp/CustomOptionAssignmentRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomOptionAssignmentRegressionAlgorithm.cs
@@ -85,7 +85,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$4800000.00"},
             {"Lowest Capacity Asset", "GOOCV 305RBQ20WHPNQ|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "26.72%"},
-            {"OrderListHash", "a0e8659f340ecf7faa1cc5a0da2760ba"}
+            {"OrderListHash", "fb2bef182af109f6441ae739d826f39f"}
         };
     }
 }

--- a/Algorithm.CSharp/CustomOptionExerciseModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/CustomOptionExerciseModelRegressionAlgorithm.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$87000.00"},
             {"Lowest Capacity Asset", "GOOCV 305RBQ20WHPNQ|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "10.93%"},
-            {"OrderListHash", "3c5f9544f697725475491434f18803e6"}
+            {"OrderListHash", "8133cb99a1a9f9e9335bc98def3cc624"}
         };
     }
 }

--- a/Algorithm.CSharp/DelistedIndexOptionDivestedRegression.cs
+++ b/Algorithm.CSharp/DelistedIndexOptionDivestedRegression.cs
@@ -163,7 +163,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$1000000.00"},
             {"Lowest Capacity Asset", "SPX 31KC0UJFONTBI|SPX 31"},
             {"Portfolio Turnover", "1.24%"},
-            {"OrderListHash", "d1d242c46f1715249551f5da81d467d4"}
+            {"OrderListHash", "4d70dc21785d91df8755e1499f3f68e1"}
         };
     }
 }

--- a/Algorithm.CSharp/DelistingFutureOptionDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DelistingFutureOptionDailyRegressionAlgorithm.cs
@@ -61,7 +61,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$5900000.00"},
             {"Lowest Capacity Asset", "DC V5E8PHPRCHJ8|DC V5E8P9SH0U0X"},
             {"Portfolio Turnover", "0.00%"},
-            {"OrderListHash", "069941549b3386b9f33320aef06537bc"}
+            {"OrderListHash", "ee378f2fa7c88c07073f1df16061609f"}
         };
     }
 }

--- a/Algorithm.CSharp/DelistingFutureOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DelistingFutureOptionRegressionAlgorithm.cs
@@ -148,7 +148,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$1400000000.00"},
             {"Lowest Capacity Asset", "DC V5E8PHPRCHJ8|DC V5E8P9SH0U0X"},
             {"Portfolio Turnover", "0.00%"},
-            {"OrderListHash", "67b64c13cbc4aad88111503cf7b789bc"}
+            {"OrderListHash", "6448bae646ab35724a0cd23936d94a48"}
         };
     }
 }

--- a/Algorithm.CSharp/DuplicateOptionAssignmentRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DuplicateOptionAssignmentRegressionAlgorithm.cs
@@ -256,7 +256,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$1300000.00"},
             {"Lowest Capacity Asset", "GOOCV 305RBQ20WHPNQ|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "7.07%"},
-            {"OrderListHash", "f0ce9bade48d8eb13a1dbd77aeeb485c"}
+            {"OrderListHash", "fff8641650865d3ac20351d33ac9b204"}
         };
     }
 }

--- a/Algorithm.CSharp/EmaCrossAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/EmaCrossAlphaModelFrameworkRegressionAlgorithm.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$9600000.00"},
             {"Lowest Capacity Asset", "AIG R735QTJ8XC9X"},
             {"Portfolio Turnover", "17.26%"},
-            {"OrderListHash", "90302b5e51106c74b6efdc0ca42fcb55"}
+            {"OrderListHash", "49a74c348d955700aa5b230f596ed85b"}
         };
     }
 }

--- a/Algorithm.CSharp/EquityMarginCallAlgorithm.cs
+++ b/Algorithm.CSharp/EquityMarginCallAlgorithm.cs
@@ -139,7 +139,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$8000.00"},
             {"Lowest Capacity Asset", "GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "2904.79%"},
-            {"OrderListHash", "fd4d435c47fe44b4b2b867eee3bd5f69"}
+            {"OrderListHash", "80d456f6613030d3ff67b6c59dba5707"}
         };
     }
 }

--- a/Algorithm.CSharp/EquitySplitHoldingsHourRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/EquitySplitHoldingsHourRegressionAlgorithm.cs
@@ -61,7 +61,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$68000000.00"},
             {"Lowest Capacity Asset", "AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "14.24%"},
-            {"OrderListHash", "2dfd8b59a3479fdfc7535ed1564dcfc3"}
+            {"OrderListHash", "82c9f6d69e0c1ddcfd1861248634e6d7"}
         };
     }
 }

--- a/Algorithm.CSharp/EuropeanOptionsCannotBeExercisedBeforeExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/EuropeanOptionsCannotBeExercisedBeforeExpiryRegressionAlgorithm.cs
@@ -185,7 +185,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$1700000.00"},
             {"Lowest Capacity Asset", "SPX XL80P3HB5O6M|SPX 31"},
             {"Portfolio Turnover", "0.35%"},
-            {"OrderListHash", "2917a6c396e5ea4f4eea1220ad422d54"}
+            {"OrderListHash", "c511179c15aa167365cc1acb91b20bf3"}
         };
     }
 }

--- a/Algorithm.CSharp/ExtendedMarketTradingRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ExtendedMarketTradingRegressionAlgorithm.cs
@@ -144,7 +144,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$14000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "1.44%"},
-            {"OrderListHash", "ee17a1434ec69d64c82c0953b0a50a71"}
+            {"OrderListHash", "ac13139c0d75afb3d39a5143eb506658"}
         };
     }
 }

--- a/Algorithm.CSharp/FillOutsideHoursDailyResolutionAlgorithm.cs
+++ b/Algorithm.CSharp/FillOutsideHoursDailyResolutionAlgorithm.cs
@@ -84,7 +84,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.07%"},
-            {"OrderListHash", "5c41586528fa33bcbf8435de35d239ec"}
+            {"OrderListHash", "2d975133eed041a4062bb802855a0e63"}
         };
     }
 }

--- a/Algorithm.CSharp/FillOutsideHoursHourResolutionAlgorithm.cs
+++ b/Algorithm.CSharp/FillOutsideHoursHourResolutionAlgorithm.cs
@@ -84,7 +84,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$51000000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.07%"},
-            {"OrderListHash", "2f894ad23cfeecf9b21a9fe6afb9db61"}
+            {"OrderListHash", "2c05d63210efddda66bbf5b84dcc4812"}
         };
     }
 }

--- a/Algorithm.CSharp/ForwardDataOnlyFillModelAlgorithm.cs
+++ b/Algorithm.CSharp/ForwardDataOnlyFillModelAlgorithm.cs
@@ -137,7 +137,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$62000000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.00%"},
-            {"OrderListHash", "3bdd97240dba0b3795cfabe08b872c0e"}
+            {"OrderListHash", "86f6dc102fded318c6264e36a56567b7"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionBuySellCallIntradayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionBuySellCallIntradayRegressionAlgorithm.cs
@@ -155,7 +155,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$120000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UPBIJ7O|ES XFH59UK0MYO1"},
             {"Portfolio Turnover", "3.67%"},
-            {"OrderListHash", "e47aef0b25234f05253cc95bc23c34ee"}
+            {"OrderListHash", "c4be2f5b6bff9e6fae4a675a973e2f27"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallITMExpiryRegressionAlgorithm.cs
@@ -243,7 +243,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$120000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UPBIJ7O|ES XFH59UK0MYO1"},
             {"Portfolio Turnover", "1.94%"},
-            {"OrderListHash", "b1fa09f62b683f53ab91030371dc87f4"}
+            {"OrderListHash", "0fcfb38b639ae544952fd313fbc76077"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionCallITMGreeksExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallITMGreeksExpiryRegressionAlgorithm.cs
@@ -208,7 +208,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$24000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UPBIJ7O|ES XFH59UK0MYO1"},
             {"Portfolio Turnover", "12.22%"},
-            {"OrderListHash", "5ba444f9228ff24cee3dec47ca2af674"}
+            {"OrderListHash", "355dbab2e93d7a62b073b6e6cd4557c2"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionCallOTMExpiryRegressionAlgorithm.cs
@@ -219,7 +219,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$180000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UPHGV9G|ES XFH59UK0MYO1"},
             {"Portfolio Turnover", "0.02%"},
-            {"OrderListHash", "05037896a5cd73b851835dbec26518c6"}
+            {"OrderListHash", "1d3c36cec32b24e8911d87d7b9730192"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionChainFullDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionChainFullDataRegressionAlgorithm.cs
@@ -121,7 +121,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "ES XCZJLCGM383O|ES XCZJLC9NOB29"},
             {"Portfolio Turnover", "112.25%"},
-            {"OrderListHash", "f18259d04c2d899e7162b88e10239eb8"}
+            {"OrderListHash", "2bef4eb69857dcfbda06009e2b712ac2"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionChainsMultipleFullDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionChainsMultipleFullDataRegressionAlgorithm.cs
@@ -141,7 +141,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "ES XCZJLCGM383O|ES XCZJLC9NOB29"},
             {"Portfolio Turnover", "49.52%"},
-            {"OrderListHash", "9b39296a82d51d51fa1df02aad39d804"}
+            {"OrderListHash", "4e1e5bc330f892d94a23a887d002133e"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionDailyRegressionAlgorithm.cs
@@ -162,7 +162,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "DC V5E8P9VAH3IC|DC V5E8P9SH0U0X"},
             {"Portfolio Turnover", "2.09%"},
-            {"OrderListHash", "fecc411b8967075513a8422a572f4144"}
+            {"OrderListHash", "433cdac4909d2ce4c4f50e1cab9cda17"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionMultipleContractsInDifferentContractMonthsWithSameUnderlyingFutureRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionMultipleContractsInDifferentContractMonthsWithSameUnderlyingFutureRegressionAlgorithm.cs
@@ -152,7 +152,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$31000000.00"},
             {"Lowest Capacity Asset", "OG 31BFX0QKBVPGG|GC XE1Y0ZJ8NQ8T"},
             {"Portfolio Turnover", "2.65%"},
-            {"OrderListHash", "82e3ec4837c53db0254b0e6329d1937b"}
+            {"OrderListHash", "06e076b1b516ea2c7a67401867467740"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionPutITMExpiryRegressionAlgorithm.cs
@@ -244,7 +244,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$79000000.00"},
             {"Lowest Capacity Asset", "ES 31EL5FAOOQON8|ES XFH59UK0MYO1"},
             {"Portfolio Turnover", "1.98%"},
-            {"OrderListHash", "23672cfe0080c982f8d4d5fb08f78421"}
+            {"OrderListHash", "20da5994dd627b414fb7b589eefa4d5c"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionPutOTMExpiryRegressionAlgorithm.cs
@@ -217,7 +217,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$290000000.00"},
             {"Lowest Capacity Asset", "ES 31EL5FBZBMXES|ES XFH59UK0MYO1"},
             {"Portfolio Turnover", "0.03%"},
-            {"OrderListHash", "eef2c31ccf8dc73b74e321ba30fd652b"}
+            {"OrderListHash", "c00499f16e60faf91708e5c1c4fcf851"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionShortCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortCallITMExpiryRegressionAlgorithm.cs
@@ -228,7 +228,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$13000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UP5K75W|ES XFH59UK0MYO1"},
             {"Portfolio Turnover", "1.79%"},
-            {"OrderListHash", "67d74f57dc9cd489ade4db3740fb5687"}
+            {"OrderListHash", "ea7c72a493aa29a52a5f782fc741d391"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionShortCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortCallOTMExpiryRegressionAlgorithm.cs
@@ -211,7 +211,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$100000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UPNF7B8|ES XFH59UK0MYO1"},
             {"Portfolio Turnover", "0.01%"},
-            {"OrderListHash", "18f4574575cadc142af8f98ae8ba332b"}
+            {"OrderListHash", "2b83fbaa9c10a1a9c65ecd779bd40b94"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionShortPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortPutITMExpiryRegressionAlgorithm.cs
@@ -225,7 +225,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$12000000.00"},
             {"Lowest Capacity Asset", "ES 31EL5FAOUP0P0|ES XFH59UK0MYO1"},
             {"Portfolio Turnover", "1.87%"},
-            {"OrderListHash", "2cdcb5b0f324dab4d547a1b349001661"}
+            {"OrderListHash", "cc0e2d8195b87d37b842de7224eac8f0"}
         };
     }
 }

--- a/Algorithm.CSharp/FutureOptionShortPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureOptionShortPutOTMExpiryRegressionAlgorithm.cs
@@ -210,7 +210,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$110000000.00"},
             {"Lowest Capacity Asset", "ES 31EL5FAJQ6SBO|ES XFH59UK0MYO1"},
             {"Portfolio Turnover", "0.02%"},
-            {"OrderListHash", "8369987468288cb41a5cd153c201fe43"}
+            {"OrderListHash", "a4f512c607cf1ec56f3d76ede17728dd"}
         };
     }
 }

--- a/Algorithm.CSharp/FuturesAndFuturesOptionsExpiryTimeAndLiquidationRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FuturesAndFuturesOptionsExpiryTimeAndLiquidationRegressionAlgorithm.cs
@@ -221,7 +221,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$16000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UK0MYO1"},
             {"Portfolio Turnover", "1.04%"},
-            {"OrderListHash", "11e3eb690ab669b9ff2de6c0e31f58ae"}
+            {"OrderListHash", "873800e40d1b38b08fc1764cd578bb4a"}
         };
     }
 }

--- a/Algorithm.CSharp/FuturesFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FuturesFrameworkRegressionAlgorithm.cs
@@ -228,7 +228,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$410000.00"},
             {"Lowest Capacity Asset", "ES VRJST036ZY0X"},
             {"Portfolio Turnover", "766.37%"},
-            {"OrderListHash", "cdaa87b62e159eaa3b0da65b305e89bd"}
+            {"OrderListHash", "97cfbcf973995ceb72b937f0f4684f88"}
         };
     }
 }

--- a/Algorithm.CSharp/HSIFutureDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HSIFutureDailyRegressionAlgorithm.cs
@@ -74,7 +74,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "HSI VL6DN7UV65S9"},
             {"Portfolio Turnover", "1590.77%"},
-            {"OrderListHash", "ca159879e35579b71717638fe2a6844c"}
+            {"OrderListHash", "46fc4362ac20b63ea361ff8d8ad38d90"}
         };
     }
 }

--- a/Algorithm.CSharp/HSIFutureHourRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HSIFutureHourRegressionAlgorithm.cs
@@ -204,7 +204,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$120000000.00"},
             {"Lowest Capacity Asset", "HSI VL6DN7UV65S9"},
             {"Portfolio Turnover", "7099.25%"},
-            {"OrderListHash", "da41f273d264b6b1fec2cfa106f3b446"}
+            {"OrderListHash", "f7382e07fdf6b8a39ee00ea5092fa831"}
         };
     }
 }

--- a/Algorithm.CSharp/HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$6000000.00"},
             {"Lowest Capacity Asset", "AIG R735QTJ8XC9X"},
             {"Portfolio Turnover", "65.87%"},
-            {"OrderListHash", "15bd0a959060b7ec5d77646e7e585f04"}
+            {"OrderListHash", "d527d869fde7539958e06050ee7d9951"}
         };
     }
 }

--- a/Algorithm.CSharp/HourResolutionMappingEventRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HourResolutionMappingEventRegressionAlgorithm.cs
@@ -127,7 +127,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$2400000.00"},
             {"Lowest Capacity Asset", "SPWR TDQZFPKOZ5UT"},
             {"Portfolio Turnover", "2.34%"},
-            {"OrderListHash", "22aace3d4bb618a825254b8bf14d6340"}
+            {"OrderListHash", "cc6e8f0ec77d9ed25118562e954bb781"}
         };
     }
 }

--- a/Algorithm.CSharp/HourReverseSplitRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HourReverseSplitRegressionAlgorithm.cs
@@ -106,7 +106,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$1000000000.00"},
             {"Lowest Capacity Asset", "VXX U9R0H3K6HVMT"},
             {"Portfolio Turnover", "0.40%"},
-            {"OrderListHash", "800c24f28a0838bffa738202fe37cf56"}
+            {"OrderListHash", "b159c44453935e5c9be375454153c9ee"}
         };
     }
 }

--- a/Algorithm.CSharp/HourSplitRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HourSplitRegressionAlgorithm.cs
@@ -146,7 +146,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$160000000000.00"},
             {"Lowest Capacity Asset", "AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.01%"},
-            {"OrderListHash", "21df8a4979f3a8b7abcffb471a0a4bb7"}
+            {"OrderListHash", "fded8f29d111ed771b99bc6b296f776c"}
         };
     }
 }

--- a/Algorithm.CSharp/InceptionDateSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/InceptionDateSelectionRegressionAlgorithm.cs
@@ -137,7 +137,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$7000000.00"},
             {"Lowest Capacity Asset", "IBM R735QTJ8XC9X"},
             {"Portfolio Turnover", "14.45%"},
-            {"OrderListHash", "2ad4096d1a84660aca48ce080141cd23"}
+            {"OrderListHash", "27cdeff9728c1a42239ea1b5b2c335dc"}
         };
     }
 }

--- a/Algorithm.CSharp/IndexOptionBuySellCallIntradayRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionBuySellCallIntradayRegressionAlgorithm.cs
@@ -161,7 +161,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "SPX XL80P3HB5O6M|SPX 31"},
             {"Portfolio Turnover", "0.51%"},
-            {"OrderListHash", "a2727181076b3e50ec8bb46becc6e365"}
+            {"OrderListHash", "ff967a551873aa872879d0a11d043679"}
         };
     }
 }

--- a/Algorithm.CSharp/IndexOptionCallITMExpiryDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallITMExpiryDailyRegressionAlgorithm.cs
@@ -76,7 +76,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "SPX XL80P3GHDZXQ|SPX 31"},
             {"Portfolio Turnover", "1.90%"},
-            {"OrderListHash", "0ed3bb17fee63ef42628f05f0c88c13c"}
+            {"OrderListHash", "fce4ce6f25578a0ec8e7efa272b2dd02"}
         };
     }
 }

--- a/Algorithm.CSharp/IndexOptionCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallITMExpiryRegressionAlgorithm.cs
@@ -213,7 +213,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "SPX XL80P3GHDZXQ|SPX 31"},
             {"Portfolio Turnover", "1.95%"},
-            {"OrderListHash", "20262d435700651ba19602afb7040730"}
+            {"OrderListHash", "da367473fff3a12856ba2194d2bb2006"}
         };
     }
 }

--- a/Algorithm.CSharp/IndexOptionCallITMGreeksExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallITMGreeksExpiryRegressionAlgorithm.cs
@@ -199,7 +199,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$59000000.00"},
             {"Lowest Capacity Asset", "SPX XL80P3GHDZXQ|SPX 31"},
             {"Portfolio Turnover", "2.19%"},
-            {"OrderListHash", "025b99be4e9008421548aa498fece11e"}
+            {"OrderListHash", "1a742c2ab3442846f82ddb3728f814ef"}
         };
     }
 }

--- a/Algorithm.CSharp/IndexOptionCallOTMExpiryDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallOTMExpiryDailyRegressionAlgorithm.cs
@@ -76,7 +76,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "SPX XL80P59H5E6M|SPX 31"},
             {"Portfolio Turnover", "0.00%"},
-            {"OrderListHash", "3cfa774d70e5d7e9dcd5e56a047d7c80"}
+            {"OrderListHash", "adfa67772fb1a7f40d65922cbe180c8e"}
         };
     }
 }

--- a/Algorithm.CSharp/IndexOptionCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallOTMExpiryRegressionAlgorithm.cs
@@ -221,7 +221,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$22000.00"},
             {"Lowest Capacity Asset", "SPX XL80P59H5E6M|SPX 31"},
             {"Portfolio Turnover", "0.00%"},
-            {"OrderListHash", "3cfa774d70e5d7e9dcd5e56a047d7c80"}
+            {"OrderListHash", "adfa67772fb1a7f40d65922cbe180c8e"}
         };
     }
 }

--- a/Algorithm.CSharp/IndexOptionPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionPutITMExpiryRegressionAlgorithm.cs
@@ -228,7 +228,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "SPX 31KC0UJHC75TA|SPX 31"},
             {"Portfolio Turnover", "1.94%"},
-            {"OrderListHash", "57774fcbb602a956f77b17b73fb3665a"}
+            {"OrderListHash", "318a374cfedd073d468f69c53f827323"}
         };
     }
 }

--- a/Algorithm.CSharp/IndexOptionPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionPutOTMExpiryRegressionAlgorithm.cs
@@ -212,7 +212,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "SPX 31KC0UJFONTBI|SPX 31"},
             {"Portfolio Turnover", "0.01%"},
-            {"OrderListHash", "8618508bbc8d9b2f29f0ca183f128dfc"}
+            {"OrderListHash", "2a1eac1c8ef2e2696a7390231fc6073d"}
         };
     }
 }

--- a/Algorithm.CSharp/IndexOptionScaledStrikeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionScaledStrikeRegressionAlgorithm.cs
@@ -102,13 +102,39 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Final status of the algorithm
         /// </summary>
-        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.RuntimeError;
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
+            {"Total Orders", "4"},
+            {"Average Win", "174.10%"},
+            {"Average Loss", "-0.03%"},
+            {"Compounding Annual Return", "79228162514264337593543950335%"},
+            {"Drawdown", "2.100%"},
+            {"Expectancy", "2901.176"},
+            {"Start Equity", "100000"},
+            {"End Equity", "274018.3"},
+            {"Net Profit", "174.018%"},
+            {"Sharpe Ratio", "6.74816637965336E+27"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "95.428%"},
+            {"Loss Rate", "50%"},
+            {"Win Rate", "50%"},
+            {"Profit-Loss Ratio", "5803.35"},
+            {"Alpha", "7.922816251426434E+28"},
+            {"Beta", "4.566"},
+            {"Annual Standard Deviation", "11.741"},
+            {"Annual Variance", "137.844"},
+            {"Information Ratio", "6.749778840887739E+27"},
+            {"Tracking Error", "11.738"},
+            {"Treynor Ratio", "1.7351225556608623E+28"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$7000.00"},
+            {"Lowest Capacity Asset", "NQX 31M220FF62ZSE|NDX 31"},
+            {"Portfolio Turnover", "6.40%"},
             {"OrderListHash", "0de4f8d2fcbb87307e5fe01c060dd44a"}
         };
     }

--- a/Algorithm.CSharp/IndexOptionScaledStrikeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionScaledStrikeRegressionAlgorithm.cs
@@ -102,40 +102,14 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Final status of the algorithm
         /// </summary>
-        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.RuntimeError;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Orders", "4"},
-            {"Average Win", "174.10%"},
-            {"Average Loss", "-0.03%"},
-            {"Compounding Annual Return", "79228162514264337593543950335%"},
-            {"Drawdown", "2.100%"},
-            {"Expectancy", "2901.176"},
-            {"Start Equity", "100000"},
-            {"End Equity", "274018.3"},
-            {"Net Profit", "174.018%"},
-            {"Sharpe Ratio", "6.74816637965336E+27"},
-            {"Sortino Ratio", "0"},
-            {"Probabilistic Sharpe Ratio", "95.428%"},
-            {"Loss Rate", "50%"},
-            {"Win Rate", "50%"},
-            {"Profit-Loss Ratio", "5803.35"},
-            {"Alpha", "7.922816251426434E+28"},
-            {"Beta", "4.566"},
-            {"Annual Standard Deviation", "11.741"},
-            {"Annual Variance", "137.844"},
-            {"Information Ratio", "6.749778840887739E+27"},
-            {"Tracking Error", "11.738"},
-            {"Treynor Ratio", "1.7351225556608623E+28"},
-            {"Total Fees", "$0.00"},
-            {"Estimated Strategy Capacity", "$7000.00"},
-            {"Lowest Capacity Asset", "NQX 31M220FF62ZSE|NDX 31"},
-            {"Portfolio Turnover", "6.40%"},
-            {"OrderListHash", "ec6881b180c68e6c7a48f6596c73e83d"}
+            {"OrderListHash", "0de4f8d2fcbb87307e5fe01c060dd44a"}
         };
     }
 }

--- a/Algorithm.CSharp/IndexOptionShortCallITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionShortCallITMExpiryRegressionAlgorithm.cs
@@ -226,7 +226,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "SPX XL80P3GHDZXQ|SPX 31"},
             {"Portfolio Turnover", "0.19%"},
-            {"OrderListHash", "09247dc36edb4572a9d128d72dee2e96"}
+            {"OrderListHash", "1b0b0418d3290ea45c38f6c4db8285d2"}
         };
     }
 }

--- a/Algorithm.CSharp/IndexOptionShortCallOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionShortCallOTMExpiryRegressionAlgorithm.cs
@@ -206,7 +206,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$22000.00"},
             {"Lowest Capacity Asset", "SPX XL80P59H5E6M|SPX 31"},
             {"Portfolio Turnover", "0.00%"},
-            {"OrderListHash", "8fbc0a49b64de5da9ff2beb923c7039b"}
+            {"OrderListHash", "0b702d78062c1c50372b42bcd6ed2981"}
         };
     }
 }

--- a/Algorithm.CSharp/IndexOptionShortPutITMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionShortPutITMExpiryRegressionAlgorithm.cs
@@ -229,7 +229,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "SPX 31KC0UJHC75TA|SPX 31"},
             {"Portfolio Turnover", "0.19%"},
-            {"OrderListHash", "866b410a4dba58b41e0d2b7198c85a6e"}
+            {"OrderListHash", "5fa3290876b6616eb338fedccd65fd6f"}
         };
     }
 }

--- a/Algorithm.CSharp/IndexOptionShortPutOTMExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionShortPutOTMExpiryRegressionAlgorithm.cs
@@ -205,7 +205,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "SPX 31KC0UJFONTBI|SPX 31"},
             {"Portfolio Turnover", "0.01%"},
-            {"OrderListHash", "a84fccbda439e0f88201488eff464f74"}
+            {"OrderListHash", "b11d26454cf946dae38b484863698248"}
         };
     }
 }

--- a/Algorithm.CSharp/InsufficientBuyingPowerForAutomaticExerciseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/InsufficientBuyingPowerForAutomaticExerciseRegressionAlgorithm.cs
@@ -214,7 +214,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$2400000.00"},
             {"Lowest Capacity Asset", "GOOCV 305RBQ20WHPNQ|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "54.01%"},
-            {"OrderListHash", "0d84251bbf98ebbe616d35acdd959c85"}
+            {"OrderListHash", "97d1c3373a72ec15038949710e7c7a62"}
         };
     }
 }

--- a/Algorithm.CSharp/InteractiveBrokersBrokerageDisablesIndexOptionsExerciseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/InteractiveBrokersBrokerageDisablesIndexOptionsExerciseRegressionAlgorithm.cs
@@ -188,7 +188,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$1700000.00"},
             {"Lowest Capacity Asset", "SPX XL80P3HB5O6M|SPX 31"},
             {"Portfolio Turnover", "0.16%"},
-            {"OrderListHash", "d0ff308d240d80eb3774f0307a64ac7e"}
+            {"OrderListHash", "e83502aa04c68dbd42a1f670cd81833f"}
         };
     }
 }

--- a/Algorithm.CSharp/InternalSubscriptionHistoryRequestAlgorithm.cs
+++ b/Algorithm.CSharp/InternalSubscriptionHistoryRequestAlgorithm.cs
@@ -123,7 +123,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$66000000.00"},
             {"Lowest Capacity Asset", "AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "20.08%"},
-            {"OrderListHash", "ae85de0e28b44116de68c56ca141c00f"}
+            {"OrderListHash", "fa51af977e55213dc007a38a3d681b62"}
         };
     }
 }

--- a/Algorithm.CSharp/LimitFillRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/LimitFillRegressionAlgorithm.cs
@@ -121,7 +121,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$180000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "9.86%"},
-            {"OrderListHash", "387e7d88f9e43449dfdf7a7b7db5984a"}
+            {"OrderListHash", "b25621656830fb81b093f3c315830ea3"}
         };
     }
 }

--- a/Algorithm.CSharp/MacdAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MacdAlphaModelFrameworkRegressionAlgorithm.cs
@@ -77,7 +77,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$7500000.00"},
             {"Lowest Capacity Asset", "AIG R735QTJ8XC9X"},
             {"Portfolio Turnover", "16.15%"},
-            {"OrderListHash", "25aaba3290376cc6d5e00a4ca4d3f20f"}
+            {"OrderListHash", "028da9558692fed9991723beeb8eeb23"}
         };
     }
 }

--- a/Algorithm.CSharp/ManualContinuousFuturesPositionRolloverRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ManualContinuousFuturesPositionRolloverRegressionAlgorithm.cs
@@ -147,7 +147,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$2900000000.00"},
             {"Lowest Capacity Asset", "ES VMKLFZIH2MTD"},
             {"Portfolio Turnover", "1.37%"},
-            {"OrderListHash", "4b28a221076b82e98fbbcb38c22b3013"}
+            {"OrderListHash", "7591ea8b91c4aa958b305555fea96862"}
         };
     }
 }

--- a/Algorithm.CSharp/MappedBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MappedBenchmarkRegressionAlgorithm.cs
@@ -104,7 +104,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$180000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "2.30%"},
-            {"OrderListHash", "143471e58b05b0414bef2692a4776962"}
+            {"OrderListHash", "a27fe8cbd54877fe74d0536e685196fa"}
         };
     }
 }

--- a/Algorithm.CSharp/MaximumDrawdownPercentPerSecurityFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MaximumDrawdownPercentPerSecurityFrameworkRegressionAlgorithm.cs
@@ -68,7 +68,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$74000000.00"},
             {"Lowest Capacity Asset", "AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "6.66%"},
-            {"OrderListHash", "90cee73c60e9769050bfd8f0c192cdea"}
+            {"OrderListHash", "ab2645a4eeb3bbd6b2862df5260d86b4"}
         };
     }
 }

--- a/Algorithm.CSharp/MaximumDrawdownPercentPortfolioFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MaximumDrawdownPercentPortfolioFrameworkRegressionAlgorithm.cs
@@ -72,7 +72,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$57000000.00"},
             {"Lowest Capacity Asset", "AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "6.63%"},
-            {"OrderListHash", "63a7d75043456cdd8c518f77df8f024f"}
+            {"OrderListHash", "bad8a363acf7188f901bd4ebc1897d31"}
         };
     }
 }

--- a/Algorithm.CSharp/MaximumUnrealizedProfitPercentPerSecurityFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MaximumUnrealizedProfitPercentPerSecurityFrameworkRegressionAlgorithm.cs
@@ -68,7 +68,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$46000000.00"},
             {"Lowest Capacity Asset", "AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "6.62%"},
-            {"OrderListHash", "9333eb1583a74e97965049e47d9b93a4"}
+            {"OrderListHash", "e954f20bd08ee776fa710a325715354e"}
         };
     }
 }

--- a/Algorithm.CSharp/NullOptionAssignmentRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/NullOptionAssignmentRegressionAlgorithm.cs
@@ -71,7 +71,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "26.71%"},
-            {"OrderListHash", "1a992ecaf12fab7862144531205c016a"}
+            {"OrderListHash", "2d12d0562e5fc5c45cf8b59398ed59b0"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
@@ -135,7 +135,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$710000.00"},
             {"Lowest Capacity Asset", "GOOCV 305RBQ20WHPNQ|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "218.80%"},
-            {"OrderListHash", "84dbd164000f9fb9096c14cbcd0b3e15"}
+            {"OrderListHash", "29afd40aab156229739653124c4cab4f"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionAssignmentStatisticsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionAssignmentStatisticsRegressionAlgorithm.cs
@@ -309,7 +309,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "50.31%"},
-            {"OrderListHash", "c8fafa07bb56dc1a253690449787df54"}
+            {"OrderListHash", "eaa9f229fb4efb0beaccbbd71881268a"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionEquityStrategyMatcherRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionEquityStrategyMatcherRegressionAlgorithm.cs
@@ -155,7 +155,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "GOOCV W78ZFMEBBB2E|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "274.86%"},
-            {"OrderListHash", "81a0b19f7e6148834e9a3902fa1d059d"}
+            {"OrderListHash", "003871a1f5e8ed7352d41c4b66fe8944"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionExerciseAssignRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExerciseAssignRegressionAlgorithm.cs
@@ -162,7 +162,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "30.10%"},
-            {"OrderListHash", "a152bbda350acd1f7a219ea799634392"}
+            {"OrderListHash", "c32a840b8e572bce151e319354df0723"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionExerciseOnExpiryAndNonTradableDateRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExerciseOnExpiryAndNonTradableDateRegressionAlgorithm.cs
@@ -155,7 +155,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$8000.00"},
             {"Lowest Capacity Asset", "SPXW Y9T7LPL1X0TQ|SPX 31"},
             {"Portfolio Turnover", "0.02%"},
-            {"OrderListHash", "6d154a036e1268579b585278636c3a8e"}
+            {"OrderListHash", "764432f8c2753cb2d5120a98997da47a"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionExerciseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionExerciseRegressionAlgorithm.cs
@@ -156,7 +156,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$420000.00"},
             {"Lowest Capacity Asset", "AAPL 2ZQA0P58YFYIU|AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "66.12%"},
-            {"OrderListHash", "e448ec4e631d4215a2cae661e3a219ed"}
+            {"OrderListHash", "046413f5ee0d4c200e5a98d823ae5a61"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionOTMExpiryOrderHasZeroPriceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionOTMExpiryOrderHasZeroPriceRegressionAlgorithm.cs
@@ -163,7 +163,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Final status of the algorithm
         /// </summary>
-        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.RuntimeError;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
@@ -179,24 +179,24 @@ namespace QuantConnect.Algorithm.CSharp
             {"Start Equity", "100000"},
             {"End Equity", "96148.58"},
             {"Net Profit", "-3.851%"},
-            {"Sharpe Ratio", "-1.221"},
+            {"Sharpe Ratio", "-1.223"},
             {"Sortino Ratio", "0"},
-            {"Probabilistic Sharpe Ratio", "0.131%"},
+            {"Probabilistic Sharpe Ratio", "0.133%"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "-0.063"},
+            {"Alpha", "-0.064"},
             {"Beta", "0.003"},
             {"Annual Standard Deviation", "0.052"},
             {"Annual Variance", "0.003"},
-            {"Information Ratio", "-0.198"},
+            {"Information Ratio", "-0.15"},
             {"Tracking Error", "0.377"},
-            {"Treynor Ratio", "-23.065"},
+            {"Treynor Ratio", "-23.374"},
             {"Total Fees", "$1.42"},
             {"Estimated Strategy Capacity", "$180000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UPHGV9G|ES XFH59UK0MYO1"},
             {"Portfolio Turnover", "0.02%"},
-            {"OrderListHash", "05037896a5cd73b851835dbec26518c6"}
+            {"OrderListHash", "1d3c36cec32b24e8911d87d7b9730192"}
         };
     }
 }

--- a/Algorithm.CSharp/OptionOTMExpiryOrderHasZeroPriceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionOTMExpiryOrderHasZeroPriceRegressionAlgorithm.cs
@@ -163,7 +163,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Final status of the algorithm
         /// </summary>
-        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.RuntimeError;
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
@@ -179,19 +179,19 @@ namespace QuantConnect.Algorithm.CSharp
             {"Start Equity", "100000"},
             {"End Equity", "96148.58"},
             {"Net Profit", "-3.851%"},
-            {"Sharpe Ratio", "-1.223"},
+            {"Sharpe Ratio", "-1.221"},
             {"Sortino Ratio", "0"},
-            {"Probabilistic Sharpe Ratio", "0.133%"},
+            {"Probabilistic Sharpe Ratio", "0.131%"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "-0.064"},
+            {"Alpha", "-0.063"},
             {"Beta", "0.003"},
             {"Annual Standard Deviation", "0.052"},
             {"Annual Variance", "0.003"},
-            {"Information Ratio", "-0.15"},
+            {"Information Ratio", "-0.198"},
             {"Tracking Error", "0.377"},
-            {"Treynor Ratio", "-23.374"},
+            {"Treynor Ratio", "-23.065"},
             {"Total Fees", "$1.42"},
             {"Estimated Strategy Capacity", "$180000000.00"},
             {"Lowest Capacity Asset", "ES XFH59UPHGV9G|ES XFH59UK0MYO1"},

--- a/Algorithm.CSharp/OptionOTMExpiryOrderHasZeroPriceRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionOTMExpiryOrderHasZeroPriceRegressionAlgorithm.cs
@@ -21,6 +21,7 @@ using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
+using QuantConnect.Util;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -44,6 +45,7 @@ namespace QuantConnect.Algorithm.CSharp
         private Symbol _expectedContract;
 
         private decimal _cashAfterMarketOrder;
+        private string _firstOptionExerciseOrderEventMessage;
 
         public override void Initialize()
         {
@@ -108,6 +110,11 @@ namespace QuantConnect.Algorithm.CSharp
                         $"but was the fill price was {orderEvent.FillPrice} and IsInTheMoney = {orderEvent.IsInTheMoney}");
                 }
             }
+
+            if (Transactions.GetOrderById(orderEvent.OrderId).Type == OrderType.OptionExercise && _firstOptionExerciseOrderEventMessage == default)
+            {
+                _firstOptionExerciseOrderEventMessage = orderEvent.Message;
+            }
         }
 
         /// <summary>
@@ -134,7 +141,7 @@ namespace QuantConnect.Algorithm.CSharp
             }
 
             var exerciseOrder = orders.Find(x => x.Type == OrderType.OptionExercise);
-            if (!exerciseOrder.Tag.Contains("OTM", StringComparison.InvariantCulture) || exerciseOrder.Price != 0)
+            if (!_firstOptionExerciseOrderEventMessage.Contains("OTM", StringComparison.InvariantCulture) || exerciseOrder.Price != 0)
             {
                 throw new RegressionTestException($"Expected the OTM exercise order to have price = 0, but was: {exerciseOrder.Price}");
             }

--- a/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
+++ b/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
@@ -674,7 +674,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$49000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "7.18%"},
-            {"OrderListHash", "d1ed6571d5895f4c951d287b2903f561"}
+            {"OrderListHash", "d4518e5689a107e5843022b4dd990fda"}
         };
     }
 }

--- a/Algorithm.CSharp/RegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionAlgorithm.cs
@@ -126,7 +126,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$39000000.00"},
             {"Lowest Capacity Asset", "AIG R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.16%"},
-            {"OrderListHash", "8adab69b1043f4bb77c8570b5d63ce77"}
+            {"OrderListHash", "f63bd4cd4e69db4d2b3ba5cc0e3bd284"}
         };
     }
 }

--- a/Algorithm.CSharp/RegressionTests/Collective2IndexOptionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionTests/Collective2IndexOptionAlgorithm.cs
@@ -151,7 +151,7 @@ namespace QuantConnect.Algorithm.CSharp.RegressionTests
             {"Estimated Strategy Capacity", "$8000.00"},
             {"Lowest Capacity Asset", "SPXW XKX6S2GM9PGU|SPX 31"},
             {"Portfolio Turnover", "0.01%"},
-            {"OrderListHash", "5b50a3d9e0afad859c3f7e2580a4f3be"}
+            {"OrderListHash", "44d9880b19d4709447faf505d24aad7f"}
         };
     }
 }

--- a/Algorithm.CSharp/RegressionTests/Universes/ETFConstituentUniverseCompositeDelistingRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionTests/Universes/ETFConstituentUniverseCompositeDelistingRegressionAlgorithm.cs
@@ -194,7 +194,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$160000000.00"},
             {"Lowest Capacity Asset", "AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.83%"},
-            {"OrderListHash", "d38318f2dd0a38f11ef4e4fd704706a7"}
+            {"OrderListHash", "527cba5cfdcac4b0f667bb354e80a1fe"}
         };
     }
 }

--- a/Algorithm.CSharp/RegressionTests/Universes/ETFConstituentUniverseFilterFunctionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionTests/Universes/ETFConstituentUniverseFilterFunctionRegressionAlgorithm.cs
@@ -237,7 +237,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$130000000.00"},
             {"Lowest Capacity Asset", "AIG R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.13%"},
-            {"OrderListHash", "0c0cb7214d49cee63fc08115f62fe357"}
+            {"OrderListHash", "7231bcc4d5304546a25e4dcc9f11ed5f"}
         };
     }
 }

--- a/Algorithm.CSharp/RegressionTests/Universes/ETFConstituentUniverseFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionTests/Universes/ETFConstituentUniverseFrameworkRegressionAlgorithm.cs
@@ -261,7 +261,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$1400000000.00"},
             {"Lowest Capacity Asset", "IBM R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.12%"},
-            {"OrderListHash", "2b2f7874b8056f64f08974ad50aae71d"}
+            {"OrderListHash", "5d1e80a607d65ba4c7329f6f0b86999f"}
         };
     }
 }

--- a/Algorithm.CSharp/RegressionTests/Universes/ETFConstituentUniverseMappedCompositeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionTests/Universes/ETFConstituentUniverseMappedCompositeRegressionAlgorithm.cs
@@ -200,7 +200,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$74000000.00"},
             {"Lowest Capacity Asset", "AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.80%"},
-            {"OrderListHash", "69695fb7639b0c1bf243eec7425a9bd2"}
+            {"OrderListHash", "0737aa7f8928927464e9068b1d500e7f"}
         };
     }
 }

--- a/Algorithm.CSharp/RegressionTests/Universes/ETFConstituentUniverseRSIAlphaModelAlgorithm.cs
+++ b/Algorithm.CSharp/RegressionTests/Universes/ETFConstituentUniverseRSIAlphaModelAlgorithm.cs
@@ -244,7 +244,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$440000000.00"},
             {"Lowest Capacity Asset", "AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "11.16%"},
-            {"OrderListHash", "d41a5ba07ca662d7bfbeace8a05b34aa"}
+            {"OrderListHash", "8a25d215ea8cd5781953695e8ae93e56"}
         };
     }
 }

--- a/Algorithm.CSharp/RsiAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RsiAlphaModelFrameworkRegressionAlgorithm.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$30000000.00"},
             {"Lowest Capacity Asset", "NB R735QTJ8XC9X"},
             {"Portfolio Turnover", "14.67%"},
-            {"OrderListHash", "3b73135c5883e22b5a0d3902699cc732"}
+            {"OrderListHash", "ddd8bbb62bc3d6306d7e388d383c872a"}
         };
     }
 }

--- a/Algorithm.CSharp/ScaledFillForwardDataRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ScaledFillForwardDataRegressionAlgorithm.cs
@@ -139,7 +139,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$26000.00"},
             {"Lowest Capacity Asset", "AOL R735QTJ8XC9X"},
             {"Portfolio Turnover", "12.68%"},
-            {"OrderListHash", "607f85b69d45d427242a614b9619c502"}
+            {"OrderListHash", "409eed1832c1cf1db6afaa160e85c639"}
         };
     }
 }

--- a/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
@@ -237,7 +237,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$2600000.00"},
             {"Lowest Capacity Asset", "EURUSD 8G"},
             {"Portfolio Turnover", "87.56%"},
-            {"OrderListHash", "83c4317adaf75381b4c61138091abeb1"}
+            {"OrderListHash", "9af211e68f600642a2aaa58f3bec6380"}
         };
     }
 }

--- a/Algorithm.CSharp/SplitOnTradeBuilderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SplitOnTradeBuilderRegressionAlgorithm.cs
@@ -162,7 +162,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$61000000.00"},
             {"Lowest Capacity Asset", "AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "21.61%"},
-            {"OrderListHash", "859e58c90d9e044632326db8d128ea98"}
+            {"OrderListHash", "be48105b9ce730de7bd4e4908f8c3ef5"}
         };
     }
 }

--- a/Algorithm.CSharp/StatisticsResultsAlgorithm.cs
+++ b/Algorithm.CSharp/StatisticsResultsAlgorithm.cs
@@ -229,8 +229,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$1100000.00"},
             {"Lowest Capacity Asset", "IBM R735QTJ8XC9X"},
             {"Portfolio Turnover", "549.26%"},
-            {"Most Traded Security Trade Count", "63"},
             {"Most Traded Security", "IBM"},
+            {"Most Traded Security Trade Count", "63"},
             {"OrderListHash", "8dd77e35338a81410a5b68dc8345f402"}
         };
     }

--- a/Algorithm.CSharp/StopLossOnOrderEventRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/StopLossOnOrderEventRegressionAlgorithm.cs
@@ -116,7 +116,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$18000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "5.79%"},
-            {"OrderListHash", "4113054204a032b871734430f2fbdcb5"}
+            {"OrderListHash", "d448232662a0cada4bf83ef8334bcb5b"}
         };
     }
 }

--- a/Algorithm.CSharp/TickDataFilteringAlgorithm.cs
+++ b/Algorithm.CSharp/TickDataFilteringAlgorithm.cs
@@ -122,7 +122,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "99.58%"},
-            {"OrderListHash", "21ca432fd48d13ca3ee65ee494e035db"}
+            {"OrderListHash", "96e039d2b3ee8fccf0e161367ee78629"}
         };
     }
 

--- a/Algorithm.CSharp/TimeInForceAlgorithm.cs
+++ b/Algorithm.CSharp/TimeInForceAlgorithm.cs
@@ -191,7 +191,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$44000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.87%"},
-            {"OrderListHash", "b6aadbb31403e1864cd0ebf4190808b8"}
+            {"OrderListHash", "a0588650916ed396fb5793375118e7b3"}
         };
     }
 }

--- a/Algorithm.CSharp/TrailingStopRiskFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TrailingStopRiskFrameworkRegressionAlgorithm.cs
@@ -68,7 +68,7 @@ namespace QuantConnect.Algorithm.CSharp
             { "Estimated Strategy Capacity", "$74000000.00" },
             { "Lowest Capacity Asset", "AAPL R735QTJ8XC9X" },
             { "Portfolio Turnover", "6.66%" },
-            { "OrderListHash", "90cee73c60e9769050bfd8f0c192cdea" }
+            { "OrderListHash", "ab2645a4eeb3bbd6b2862df5260d86b4" }
         };
     }
 }

--- a/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/UpdateOrderRegressionAlgorithm.cs
@@ -239,7 +239,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$1000000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.50%"},
-            {"OrderListHash", "a6482ce8abd669338eaced3104226c1b"}
+            {"OrderListHash", "290d228f253e9cf8b6d7de194664ce55"}
         };
     }
 }

--- a/Algorithm.CSharp/WarmupLowerResolutionSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WarmupLowerResolutionSelectionRegressionAlgorithm.cs
@@ -150,7 +150,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$120000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "7.75%"},
-            {"OrderListHash", "55334cbd9695552a3c6f761dac9a1366"}
+            {"OrderListHash", "520072ff9cd8239e46c8cf78b67ed4c7"}
         };
     }
 }

--- a/Algorithm.CSharp/WeeklyUniverseSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WeeklyUniverseSelectionRegressionAlgorithm.cs
@@ -140,7 +140,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$5600000.00"},
             {"Lowest Capacity Asset", "IBM R735QTJ8XC9X"},
             {"Portfolio Turnover", "25.73%"},
-            {"OrderListHash", "be43a1fcf446160ac42b8838a9f8c10a"}
+            {"OrderListHash", "1c1b9bae86e4ff7598b34ce40a2410e8"}
         };
     }
 }

--- a/Algorithm.CSharp/ZeroedBenchmarkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ZeroedBenchmarkRegressionAlgorithm.cs
@@ -114,7 +114,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$110000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
             {"Portfolio Turnover", "49.90%"},
-            {"OrderListHash", "966f8355817adbc8c724d1062691a60b"}
+            {"OrderListHash", "60747dce5c2aed393b7dccc258d2c9b5"}
         };
 
         internal class TestBrokerageModel : DefaultBrokerageModel

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1161,19 +1161,6 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                         case OrderStatus.PartiallyFilled:
                         case OrderStatus.Filled:
                             order.LastFillTime = orderEvent.UtcTime;
-
-                            // append fill message to order tag, for additional information
-                            if (orderEvent.Status == OrderStatus.Filled && !string.IsNullOrWhiteSpace(orderEvent.Message))
-                            {
-                                if (string.IsNullOrWhiteSpace(order.Tag))
-                                {
-                                    order.Tag = orderEvent.Message;
-                                }
-                                else
-                                {
-                                    order.Tag += " - " + orderEvent.Message;
-                                }
-                            }
                             break;
 
                         case OrderStatus.UpdateSubmitted:

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -1732,39 +1732,6 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             Assert.IsTrue(ticket.HasOrder);
         }
 
-        [Test]
-        public void FillMessageIsAddedToOrderTag()
-        {
-            // Initializes the transaction handler
-            var transactionHandler = new TestBrokerageTransactionHandler();
-            using var brokerage = new BacktestingBrokerage(_algorithm);
-            transactionHandler.Initialize(_algorithm, brokerage, new BacktestingResultHandler());
-
-            // Creates a market order
-            var security = _algorithm.Securities[_symbol];
-            var price = 1.12m;
-            security.SetMarketPrice(new Tick(DateTime.UtcNow.AddDays(-1), security.Symbol, price, price, price));
-            var orderRequest = new SubmitOrderRequest(OrderType.Market, security.Type, security.Symbol, 1000, 0, 0, DateTime.UtcNow, "TestTag");
-
-            // Mock the order processor
-            var orderProcessorMock = new Mock<IOrderProcessor>();
-            orderProcessorMock.Setup(m => m.GetOrderTicket(It.IsAny<int>())).Returns(new OrderTicket(_algorithm.Transactions, orderRequest));
-            _algorithm.Transactions.SetOrderProcessor(orderProcessorMock.Object);
-
-            Assert.AreEqual(transactionHandler.GetOpenOrders().Count, 0);
-            // Submit and process the market order
-            var orderTicket = transactionHandler.Process(orderRequest);
-            transactionHandler.HandleOrderRequest(orderRequest);
-            Assert.IsTrue(orderTicket.Status == OrderStatus.Submitted);
-
-            brokerage.Scan();
-            Assert.IsTrue(orderTicket.Status == OrderStatus.Filled);
-
-            var order = transactionHandler.GetOrderById(orderTicket.OrderId);
-            Assert.IsTrue(order.Tag.Contains("TestTag"));
-            Assert.IsTrue(order.Tag.Contains("Warning: fill at stale price"));
-        }
-
         [Test, Parallelizable(ParallelScope.None)]
         public void IncrementalOrderId()
         {

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -1784,9 +1784,9 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
         // Long Put --> OTM (expired worthless)
         [TestCase(1, OptionRight.Put, 455, 100, 460, 1, 0, 100, "OTM")]
         // Short Call --> ITM (assigned)
-        [TestCase(-1, OptionRight.Call, 450, 100, 455, 2, 0, 0, "Automatic Assignment")]
+        [TestCase(-1, OptionRight.Call, 450, 100, 455, 2, 0, 0, null)]
         // Short Put --> ITM (assigned)
-        [TestCase(-1, OptionRight.Put, 455, 100, 450, 2, 0, 200, "Automatic Assignment")]
+        [TestCase(-1, OptionRight.Put, 455, 100, 450, 2, 0, 200, null)]
         // Long Call --> ITM (auto-exercised)
         [TestCase(1, OptionRight.Call, 450, 100, 455, 2, 0, 200, "Automatic Exercise")]
         // Long Put --> ITM (auto-exercised)
@@ -1832,7 +1832,10 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             Assert.IsTrue(ticket.HasOrder);
 
             Assert.AreEqual(expectedOrderEvents, ticket.OrderEvents.Count);
-            Assert.AreEqual(1, ticket.OrderEvents.Count(x => x.Message.Contains(expectedMessage, StringComparison.InvariantCulture)));
+            if (expectedMessage != null)
+            {
+                Assert.AreEqual(1, ticket.OrderEvents.Count(x => x.Message.Contains(expectedMessage, StringComparison.InvariantCulture)));
+            }
 
             Assert.AreEqual(expectedUnderlyingPosition, algorithm.Portfolio[equity.Symbol].Quantity);
             Assert.AreEqual(expectedOptionPosition, algorithm.Portfolio[optionSymbol].Quantity);
@@ -1985,13 +1988,13 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
         }
 
         // Short Call --> ITM (assigned early - full)
-        [TestCase(-1, OptionRight.Call, 450, 100, 455, 2, 0, 0, "Automatic Assignment")]
+        [TestCase(-1, OptionRight.Call, 450, 100, 455, 2, 0, 0)]
         // Short Put --> ITM (assigned early - full)
-        [TestCase(-1, OptionRight.Put, 455, 100, 450, 2, 0, 200, "Automatic Assignment")]
+        [TestCase(-1, OptionRight.Put, 455, 100, 450, 2, 0, 200)]
         // Short Call --> ITM (assigned early - partial)
-        [TestCase(-3, OptionRight.Call, 450, 300, 455, 2, -1, 100, "Automatic Assignment")]
+        [TestCase(-3, OptionRight.Call, 450, 300, 455, 2, -1, 100)]
         // Short Put --> ITM (assigned early - partial)
-        [TestCase(-3, OptionRight.Put, 455, 100, 450, 2, -1, 300, "Automatic Assignment")]
+        [TestCase(-3, OptionRight.Put, 455, 100, 450, 2, -1, 300)]
         public void EarlyAssignmentEmitsOrderEvents(
             int initialOptionPosition,
             OptionRight optionRight,
@@ -2033,7 +2036,6 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             Assert.IsTrue(ticket.HasOrder);
 
             Assert.AreEqual(expectedOrderEvents, ticket.OrderEvents.Count);
-            Assert.AreEqual(1, ticket.OrderEvents.Count(x => x.Message.Contains(expectedMessage, StringComparison.InvariantCulture)));
 
             Assert.AreEqual(expectedUnderlyingPosition, algorithm.Portfolio[equity.Symbol].Quantity);
             Assert.AreEqual(expectedOptionPosition, algorithm.Portfolio[optionSymbol].Quantity);
@@ -2048,13 +2050,13 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
         }
 
         // Short Call --> ITM (assigned early - full)
-        [TestCase(-2, OptionRight.Call, 450, 100, 455, 2, 0, 0, "Automatic Assignment")]
+        [TestCase(-2, OptionRight.Call, 450, 100, 455, 2, 0, 0)]
         // Short Put --> ITM (assigned early - full)
-        [TestCase(-2, OptionRight.Put, 455, 100, 450, 2, 0, 200, "Automatic Assignment")]
+        [TestCase(-2, OptionRight.Put, 455, 100, 450, 2, 0, 200)]
         // Short Call --> ITM (assigned early - partial)
-        [TestCase(-3, OptionRight.Call, 450, 300, 455, 2, -1, 200, "Automatic Assignment")]
+        [TestCase(-3, OptionRight.Call, 450, 300, 455, 2, -1, 200)]
         // Short Put --> ITM (assigned early - partial)
-        [TestCase(-3, OptionRight.Put, 455, 100, 450, 2, -1, 200, "Automatic Assignment")]
+        [TestCase(-3, OptionRight.Put, 455, 100, 450, 2, -1, 200)]
         public void EarlyAssignmentEmitsOrderEventsEvenIfOldBuyOrderPresent(
             int initialOptionPosition,
             OptionRight optionRight,
@@ -2111,7 +2113,6 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             Assert.IsTrue(ticket.HasOrder);
 
             Assert.AreEqual(expectedOrderEvents, ticket.OrderEvents.Count);
-            Assert.AreEqual(1, ticket.OrderEvents.Count(x => x.Message.Contains(expectedMessage, StringComparison.InvariantCulture)));
 
             Assert.AreEqual(expectedUnderlyingPosition, algorithm.Portfolio[equity.Symbol].Quantity);
             Assert.AreEqual(expectedOptionPosition, algorithm.Portfolio[optionSymbol].Quantity);

--- a/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
+++ b/Tests/Engine/BrokerageTransactionHandlerTests/BrokerageTransactionHandlerTests.cs
@@ -2003,8 +2003,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             decimal underlyingPrice,
             int expectedOrderEvents,
             int expectedOptionPosition,
-            int expectedUnderlyingPosition,
-            string expectedMessage
+            int expectedUnderlyingPosition
             )
         {
             var algorithm = new TestAlgorithm();
@@ -2065,8 +2064,7 @@ namespace QuantConnect.Tests.Engine.BrokerageTransactionHandlerTests
             decimal underlyingPrice,
             int expectedOrderEvents,
             int expectedOptionPosition,
-            int expectedUnderlyingPosition,
-            string expectedMessage
+            int expectedUnderlyingPosition
             )
         {
             var algorithm = new TestAlgorithm();

--- a/Tests/Python/PythonOptionTests.cs
+++ b/Tests/Python/PythonOptionTests.cs
@@ -98,7 +98,7 @@ namespace QuantConnect.Tests.Python
                     {"Tracking Error", "0"},
                     {"Treynor Ratio", "0"},
                     {"Total Fees", "$1.00"},
-                    {"OrderListHash", "133c6a56631cf3d8a089c3095a25ee81"}
+                    {"OrderListHash", "5992d2e5c087de07814404f81762e2ac"}
                     },
                     Language.Python,
                     AlgorithmStatus.Completed);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Remove fill warnings from tags because they are already in the fill events
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #8517 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, order tags will have no more redundant fill warnings information
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There was already one unit test asserting the fill warning message, in the order's tag, was correct. Since we are removing those warnings from the orders tags, we are also deleting that test
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
