### PR TITLE
Disable extended market hours for universe history requests

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2017,7 +2017,8 @@ namespace QuantConnect.Algorithm
                             continuousContractSymbol.ID.Symbol,
                             continuousContractSymbol.ID.SecurityType,
                             security.Exchange.Hours);
-                        AddUniverse(new ContinuousContractUniverse(security, continuousUniverseSettings, LiveMode, new SubscriptionDataConfig(canonicalConfig, symbol: continuousContractSymbol)));
+                        AddUniverse(new ContinuousContractUniverse(security, continuousUniverseSettings, LiveMode,
+                            new SubscriptionDataConfig(canonicalConfig, symbol: continuousContractSymbol, extendedHours: extendedMarketHours)));
 
                         universe = new FuturesChainUniverse((Future)security, settings);
                     }
@@ -2372,7 +2373,7 @@ namespace QuantConnect.Algorithm
                     Resolution = underlyingConfigs.GetHighestResolution(),
                     ExtendedMarketHours = extendedMarketHours
                 };
-                universe = AddUniverse(new OptionContractUniverse(new SubscriptionDataConfig(configs.First(), symbol: universeSymbol), settings));
+                universe = AddUniverse(new OptionContractUniverse(new SubscriptionDataConfig(configs.First(), symbol: universeSymbol, extendedHours: extendedMarketHours), settings));
             }
 
             // update the universe

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2020,7 +2020,7 @@ namespace QuantConnect.Algorithm
                         AddUniverse(new ContinuousContractUniverse(security, continuousUniverseSettings, LiveMode,
                             new SubscriptionDataConfig(canonicalConfig, symbol: continuousContractSymbol,
                                 // We can use any data type here, since we are not going to use the data.
-                                // We just don't want to use the OptionUniverse type because it will force disable extended market hours
+                                // We just don't want to use the FutureUniverse type because it will force disable extended market hours
                                 objectType: typeof(Tick), extendedHours: extendedMarketHours)));
 
                         universe = new FuturesChainUniverse((Future)security, settings);

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -3347,7 +3347,7 @@ namespace QuantConnect.Algorithm
         public OptionChains OptionChains(IEnumerable<Symbol> symbols, bool flatten = false)
         {
             var canonicalSymbols = symbols.Select(GetCanonicalOptionSymbol).ToList();
-            var optionChainsData = History(canonicalSymbols, 1, extendedMarketHours: false).GetUniverseData()
+            var optionChainsData = History(canonicalSymbols, 1).GetUniverseData()
                 .Select(x => (x.Keys.Single(), x.Values.Single().Cast<OptionUniverse>()));
 
             var time = Time.Date;
@@ -3397,7 +3397,7 @@ namespace QuantConnect.Algorithm
         public FuturesChains FuturesChains(IEnumerable<Symbol> symbols, bool flatten = false)
         {
             var canonicalSymbols = symbols.Select(GetCanonicalFutureSymbol).ToList();
-            var futureChainsData = History<FutureUniverse>(canonicalSymbols, 1, extendedMarketHours: false)
+            var futureChainsData = History<FutureUniverse>(canonicalSymbols, 1)
                 .SelectMany(dict => dict.Select(kvp => (kvp.Key, kvp.Value.Cast<FutureUniverse>())));
 
             var time = Time.Date;

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2018,7 +2018,10 @@ namespace QuantConnect.Algorithm
                             continuousContractSymbol.ID.SecurityType,
                             security.Exchange.Hours);
                         AddUniverse(new ContinuousContractUniverse(security, continuousUniverseSettings, LiveMode,
-                            new SubscriptionDataConfig(canonicalConfig, symbol: continuousContractSymbol, extendedHours: extendedMarketHours)));
+                            new SubscriptionDataConfig(canonicalConfig, symbol: continuousContractSymbol,
+                                // We can use any data type here, since we are not going to use the data.
+                                // We just don't want to use the OptionUniverse type because it will force disable extended market hours
+                                objectType: typeof(Tick), extendedHours: extendedMarketHours)));
 
                         universe = new FuturesChainUniverse((Future)security, settings);
                     }
@@ -2373,7 +2376,10 @@ namespace QuantConnect.Algorithm
                     Resolution = underlyingConfigs.GetHighestResolution(),
                     ExtendedMarketHours = extendedMarketHours
                 };
-                universe = AddUniverse(new OptionContractUniverse(new SubscriptionDataConfig(configs.First(), symbol: universeSymbol, extendedHours: extendedMarketHours), settings));
+                universe = AddUniverse(new OptionContractUniverse(new SubscriptionDataConfig(configs.First(),
+                    // We can use any data type here, since we are not going to use the data.
+                    // We just don't want to use the OptionUniverse type because it will force disable extended market hours
+                    symbol: universeSymbol, objectType: typeof(Tick), extendedHours: extendedMarketHours), settings));
             }
 
             // update the universe

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -3347,7 +3347,7 @@ namespace QuantConnect.Algorithm
         public OptionChains OptionChains(IEnumerable<Symbol> symbols, bool flatten = false)
         {
             var canonicalSymbols = symbols.Select(GetCanonicalOptionSymbol).ToList();
-            var optionChainsData = History(canonicalSymbols, 1).GetUniverseData()
+            var optionChainsData = History(canonicalSymbols, 1, extendedMarketHours: false).GetUniverseData()
                 .Select(x => (x.Keys.Single(), x.Values.Single().Cast<OptionUniverse>()));
 
             var time = Time.Date;
@@ -3397,7 +3397,7 @@ namespace QuantConnect.Algorithm
         public FuturesChains FuturesChains(IEnumerable<Symbol> symbols, bool flatten = false)
         {
             var canonicalSymbols = symbols.Select(GetCanonicalFutureSymbol).ToList();
-            var futureChainsData = History<FutureUniverse>(canonicalSymbols, 1)
+            var futureChainsData = History<FutureUniverse>(canonicalSymbols, 1, extendedMarketHours: false)
                 .SelectMany(dict => dict.Select(kvp => (kvp.Key, kvp.Value.Cast<FutureUniverse>())));
 
             var time = Time.Date;
@@ -3560,8 +3560,8 @@ namespace QuantConnect.Algorithm
             {
                 payload["$type"] = typeName;
             }
-            return _api.BroadcastLiveCommand(Globals.OrganizationID, 
-                AlgorithmMode == AlgorithmMode.Live ? ProjectId : null, 
+            return _api.BroadcastLiveCommand(Globals.OrganizationID,
+                AlgorithmMode == AlgorithmMode.Live ? ProjectId : null,
                 payload);
         }
 

--- a/Common/Data/HistoryRequest.cs
+++ b/Common/Data/HistoryRequest.cs
@@ -18,7 +18,7 @@ using System;
 using NodaTime;
 using QuantConnect.Securities;
 using System.Collections.Generic;
-using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Util;
 
 namespace QuantConnect.Data
 {
@@ -67,8 +67,7 @@ namespace QuantConnect.Data
             }
             set
             {
-                // We don't have universe files for extended market hours dates only (like Sundays for some futures)
-                _includeExtendedMarketHours = value && !DataType.IsAssignableTo(typeof(BaseChainUniverseData));
+                _includeExtendedMarketHours = value && LeanData.SupportsExtendedMarketHours(DataType);
             }
         }
 

--- a/Common/Data/HistoryRequest.cs
+++ b/Common/Data/HistoryRequest.cs
@@ -18,6 +18,7 @@ using System;
 using NodaTime;
 using QuantConnect.Securities;
 using System.Collections.Generic;
+using QuantConnect.Data.UniverseSelection;
 
 namespace QuantConnect.Data
 {
@@ -27,6 +28,7 @@ namespace QuantConnect.Data
     public class HistoryRequest : BaseDataRequest
     {
         private Resolution? _fillForwardResolution;
+        private bool _includeExtendedMarketHours;
 
         /// <summary>
         /// Gets the symbol to request data for
@@ -57,7 +59,18 @@ namespace QuantConnect.Data
         /// <summary>
         /// Gets whether or not to include extended market hours data, set to false for only normal market hours
         /// </summary>
-        public bool IncludeExtendedMarketHours { get; set; }
+        public bool IncludeExtendedMarketHours
+        {
+            get
+            {
+                return _includeExtendedMarketHours;
+            }
+            set
+            {
+                // We don't have universe files for extended market hours dates only (like Sundays for some futures)
+                _includeExtendedMarketHours = value && !DataType.IsAssignableTo(typeof(BaseChainUniverseData));
+            }
+        }
 
         /// <summary>
         /// Gets the time zone of the time stamps on the raw input data

--- a/Common/Data/HistoryRequestFactory.cs
+++ b/Common/Data/HistoryRequestFactory.cs
@@ -168,7 +168,7 @@ namespace QuantConnect.Data
         {
             var isExtendedMarketHours = false;
             // hour resolution does no have extended market hours data. Same for chain universes
-            if (resolution != Resolution.Hour && !dataType.IsAssignableTo(typeof(BaseChainUniverseData)))
+            if (resolution != Resolution.Hour && LeanData.SupportsExtendedMarketHours(dataType))
             {
                 if (extendedMarketHours.HasValue)
                 {

--- a/Common/Data/HistoryRequestFactory.cs
+++ b/Common/Data/HistoryRequestFactory.cs
@@ -15,6 +15,7 @@
 
 using System;
 using NodaTime;
+using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
 using QuantConnect.Util;
@@ -166,8 +167,8 @@ namespace QuantConnect.Data
             bool? extendedMarketHours = null)
         {
             var isExtendedMarketHours = false;
-            // hour resolution does no have extended market hours data
-            if (resolution != Resolution.Hour)
+            // hour resolution does no have extended market hours data. Same for chain universes
+            if (resolution != Resolution.Hour && !dataType.IsAssignableTo(typeof(BaseChainUniverseData)))
             {
                 if (extendedMarketHours.HasValue)
                 {

--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -302,7 +302,6 @@ namespace QuantConnect.Data
             PriceScaleFactor = config.PriceScaleFactor;
             SumOfDividends = config.SumOfDividends;
             Consolidators = config.Consolidators;
-            ExtendedMarketHours = extendedHours ?? config.ExtendedMarketHours;
         }
 
         /// <summary>

--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -222,7 +222,7 @@ namespace QuantConnect.Data
             Resolution = resolution;
             _sid = symbol.ID;
             Symbol = symbol;
-            ExtendedMarketHours = extendedHours;
+            ExtendedMarketHours = extendedHours && LeanData.SupportsExtendedMarketHours(Type);
             PriceScaleFactor = 1;
             IsInternalFeed = isInternalFeed;
             IsCustomData = isCustom;
@@ -302,6 +302,7 @@ namespace QuantConnect.Data
             PriceScaleFactor = config.PriceScaleFactor;
             SumOfDividends = config.SumOfDividends;
             Consolidators = config.Consolidators;
+            ExtendedMarketHours = extendedHours ?? config.ExtendedMarketHours;
         }
 
         /// <summary>

--- a/Common/Util/LeanData.cs
+++ b/Common/Util/LeanData.cs
@@ -872,7 +872,8 @@ namespace QuantConnect.Util
 
             if (tickType == null)
             {
-                if (securityType == SecurityType.Forex || securityType == SecurityType.Cfd) {
+                if (securityType == SecurityType.Forex || securityType == SecurityType.Cfd)
+                {
                     tickType = TickType.Quote;
                 }
                 else
@@ -1589,24 +1590,34 @@ namespace QuantConnect.Util
         /// <param name="fileName">File name extracted</param>
         /// <param name="entryName">Entry name extracted</param>
         public static void ParseKey(string key, out string fileName, out string entryName)
-         {
-             // Default scenario, no entryName included in key
-             entryName = null; // default to all entries
-             fileName = key;
+        {
+            // Default scenario, no entryName included in key
+            entryName = null; // default to all entries
+            fileName = key;
 
-             if (key == null)
-             {
-                 return;
-             }
+            if (key == null)
+            {
+                return;
+            }
 
-             // Try extracting an entry name; Anything after a # sign
-             var hashIndex = key.LastIndexOf("#", StringComparison.Ordinal);
-             if (hashIndex != -1)
-             {
-                 entryName = key.Substring(hashIndex + 1);
-                 fileName = key.Substring(0, hashIndex);
-             }
-         }
+            // Try extracting an entry name; Anything after a # sign
+            var hashIndex = key.LastIndexOf("#", StringComparison.Ordinal);
+            if (hashIndex != -1)
+            {
+                entryName = key.Substring(hashIndex + 1);
+                fileName = key.Substring(0, hashIndex);
+            }
+        }
+
+        /// <summary>
+        /// Helper method to determine if the specified data type supports extended market hours
+        /// </summary>
+        /// <param name="dataType">The data type</param>
+        /// <returns>Whether the specified data type supports extended market hours</returns>
+        public static bool SupportsExtendedMarketHours(Type dataType)
+        {
+            return !dataType.IsAssignableTo(typeof(BaseChainUniverseData));
+        }
 
         /// <summary>
         /// Helper method to aggregate ticks or bars into lower frequency resolutions

--- a/Tests/Algorithm/AlgorithmAddSecurityTests.cs
+++ b/Tests/Algorithm/AlgorithmAddSecurityTests.cs
@@ -16,6 +16,7 @@
 
 using NUnit.Framework;
 using QuantConnect.Algorithm;
+using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Securities;
 using QuantConnect.Securities.Cfd;
@@ -26,7 +27,6 @@ using QuantConnect.Securities.Forex;
 using QuantConnect.Securities.Future;
 using QuantConnect.Securities.IndexOption;
 using QuantConnect.Securities.Option;
-using QuantConnect.Securities.Positions;
 using QuantConnect.Tests.Engine.DataFeeds;
 using System;
 using System.Collections.Generic;
@@ -124,7 +124,16 @@ namespace QuantConnect.Tests.Algorithm
             [ValueSource(nameof(FuturesTestCases))] Func<QCAlgorithm, Security> getFuture)
         {
             var future = _algo.AddFuture(Futures.Indices.VIX, Resolution.Minute, extendedMarketHours: extendedMarketHours);
-            Assert.That(_algo.SubscriptionManager.Subscriptions.Where(x => x.Symbol == future.Symbol).Select(x => x.ExtendedMarketHours),
+            var subscriptions = _algo.SubscriptionManager.Subscriptions.Where(x => x.Symbol == future.Symbol).ToList();
+
+            var universeSubscriptions = subscriptions.Where(x => x.Type == typeof(FutureUniverse)).ToList();
+            Assert.AreEqual(1, universeSubscriptions.Count);
+            // Universe does not support extended market hours
+            Assert.IsFalse(universeSubscriptions[0].ExtendedMarketHours);
+
+            var nonUniverseSubscriptions = subscriptions.Where(x => x.Type != typeof(FutureUniverse)).ToList();
+            Assert.Greater(nonUniverseSubscriptions.Count, 0);
+            Assert.That(nonUniverseSubscriptions.Select(x => x.ExtendedMarketHours),
                 Has.All.EqualTo(extendedMarketHours));
         }
 

--- a/Tests/Algorithm/AlgorithmChainsTests.cs
+++ b/Tests/Algorithm/AlgorithmChainsTests.cs
@@ -19,9 +19,7 @@ using System.Linq;
 using NUnit.Framework;
 using Python.Runtime;
 using QuantConnect.Algorithm;
-using QuantConnect.Data;
 using QuantConnect.Data.Market;
-using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Securities;
 using QuantConnect.Tests.Engine.DataFeeds;
@@ -211,36 +209,64 @@ namespace QuantConnect.Tests.Algorithm
         private static IEnumerable<TestCaseData> GetOptionChainApisTestData()
         {
             var indexSymbol = Symbols.SPX;
-            yield return new TestCaseData(indexSymbol, new DateTime(2015, 12, 23, 23, 0, 0));
-            yield return new TestCaseData(indexSymbol, new DateTime(2015, 12, 24, 0, 0, 0));
-            yield return new TestCaseData(indexSymbol, new DateTime(2015, 12, 24, 1, 0, 0));
-            yield return new TestCaseData(indexSymbol, new DateTime(2015, 12, 24, 2, 0, 0));
-            yield return new TestCaseData(indexSymbol, new DateTime(2015, 12, 24, 6, 0, 0));
-            yield return new TestCaseData(indexSymbol, new DateTime(2015, 12, 24, 12, 0, 0));
-            yield return new TestCaseData(indexSymbol, new DateTime(2015, 12, 24, 16, 0, 0));
-
             var equitySymbol = Symbols.GOOG;
-            yield return new TestCaseData(equitySymbol, new DateTime(2015, 12, 24, 0, 0, 0));
-            yield return new TestCaseData(equitySymbol, new DateTime(2015, 12, 24, 1, 0, 0));
-            yield return new TestCaseData(equitySymbol, new DateTime(2015, 12, 24, 2, 0, 0));
-            yield return new TestCaseData(equitySymbol, new DateTime(2015, 12, 24, 6, 0, 0));
-            yield return new TestCaseData(equitySymbol, new DateTime(2015, 12, 24, 12, 0, 0));
-            yield return new TestCaseData(equitySymbol, new DateTime(2015, 12, 24, 16, 0, 0));
-
             var futureSymbol = Symbol.CreateFuture(Futures.Indices.SP500EMini, Market.CME, new DateTime(2020, 6, 19));
-            yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 04, 23, 0, 0));
-            yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 05, 0, 0, 0));
-            yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 05, 1, 0, 0));
-            yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 05, 2, 0, 0));
-            yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 05, 6, 0, 0));
-            yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 05, 12, 0, 0));
-            yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 05, 16, 0, 0));
+
+            foreach (var withSecurityAdded in new[] { true, false })
+            {
+                var extendedMarketHoursCases = withSecurityAdded ? [true, false] : new[] { false };
+                foreach (var withExtendedMarketHours in extendedMarketHoursCases)
+                {
+                    yield return new TestCaseData(indexSymbol, new DateTime(2015, 12, 23, 23, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(indexSymbol, new DateTime(2015, 12, 24, 0, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(indexSymbol, new DateTime(2015, 12, 24, 1, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(indexSymbol, new DateTime(2015, 12, 24, 2, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(indexSymbol, new DateTime(2015, 12, 24, 6, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(indexSymbol, new DateTime(2015, 12, 24, 12, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(indexSymbol, new DateTime(2015, 12, 24, 16, 0, 0), withSecurityAdded, withExtendedMarketHours);
+
+                    yield return new TestCaseData(equitySymbol, new DateTime(2015, 12, 24, 0, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(equitySymbol, new DateTime(2015, 12, 24, 1, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(equitySymbol, new DateTime(2015, 12, 24, 2, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(equitySymbol, new DateTime(2015, 12, 24, 6, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(equitySymbol, new DateTime(2015, 12, 24, 12, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(equitySymbol, new DateTime(2015, 12, 24, 16, 0, 0), withSecurityAdded, withExtendedMarketHours);
+
+                    yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 04, 23, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 05, 0, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 05, 1, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 05, 2, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 05, 6, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 05, 12, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 05, 16, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 06, 0, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 06, 1, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 06, 2, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 06, 6, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 06, 12, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                    yield return new TestCaseData(futureSymbol, new DateTime(2020, 01, 06, 16, 0, 0), withSecurityAdded, withExtendedMarketHours);
+                }
+            }
         }
 
         [TestCaseSource(nameof(GetOptionChainApisTestData))]
-        public void OptionChainApisAreConsistent(Symbol symbol, DateTime dateTime)
+        public void OptionChainApisAreConsistent(Symbol symbol, DateTime dateTime, bool withSecurityAdded, bool withExtendedMarketHours)
         {
             _algorithm.SetDateTime(dateTime.ConvertToUtc(_algorithm.TimeZone));
+
+            if (withSecurityAdded)
+            {
+                if (symbol.SecurityType == SecurityType.Future)
+                {
+                    var future = _algorithm.AddFuture(symbol.ID.Symbol, extendedMarketHours: withExtendedMarketHours);
+                    _algorithm.AddFutureOption(future.Symbol);
+                    _algorithm.AddFutureContract(symbol, extendedMarketHours: withExtendedMarketHours);
+                }
+                else
+                {
+                    _algorithm.AddSecurity(symbol, extendedMarketHours: withExtendedMarketHours);
+                }
+            }
 
             var exchange  = MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
             var chainFromAlgorithmApi = _algorithm.OptionChain(symbol).Select(x => x.Symbol).ToList();
@@ -262,26 +288,30 @@ namespace QuantConnect.Tests.Algorithm
             {
                 foreach (var withFutureAdded in new[] { true, false })
                 {
-                    yield return new TestCaseData(symbol, new DateTime(2013, 10, 06, 23, 0, 0), withFutureAdded);
-                    yield return new TestCaseData(symbol, new DateTime(2013, 10, 07, 0, 0, 0), withFutureAdded);
-                    yield return new TestCaseData(symbol, new DateTime(2013, 10, 07, 1, 0, 0), withFutureAdded);
-                    yield return new TestCaseData(symbol, new DateTime(2013, 10, 07, 2, 0, 0), withFutureAdded);
-                    yield return new TestCaseData(symbol, new DateTime(2013, 10, 07, 6, 0, 0), withFutureAdded);
-                    yield return new TestCaseData(symbol, new DateTime(2013, 10, 07, 12, 0, 0), withFutureAdded);
-                    yield return new TestCaseData(symbol, new DateTime(2013, 10, 07, 16, 0, 0), withFutureAdded);
+                    var extendedMarketHoursCases = withFutureAdded ? [true, false] : new[] { false };
+                    foreach (var withExtendedMarketHours in extendedMarketHoursCases)
+                    {
+                        yield return new TestCaseData(symbol, new DateTime(2013, 10, 06, 23, 0, 0), withFutureAdded, withExtendedMarketHours);
+                        yield return new TestCaseData(symbol, new DateTime(2013, 10, 07, 0, 0, 0), withFutureAdded, withExtendedMarketHours);
+                        yield return new TestCaseData(symbol, new DateTime(2013, 10, 07, 1, 0, 0), withFutureAdded, withExtendedMarketHours);
+                        yield return new TestCaseData(symbol, new DateTime(2013, 10, 07, 2, 0, 0), withFutureAdded, withExtendedMarketHours);
+                        yield return new TestCaseData(symbol, new DateTime(2013, 10, 07, 6, 0, 0), withFutureAdded, withExtendedMarketHours);
+                        yield return new TestCaseData(symbol, new DateTime(2013, 10, 07, 12, 0, 0), withFutureAdded, withExtendedMarketHours);
+                        yield return new TestCaseData(symbol, new DateTime(2013, 10, 07, 16, 0, 0), withFutureAdded, withExtendedMarketHours);
+                    }
                 }
             }
         }
 
         [TestCaseSource(nameof(GetFutureChainApisTestData))]
-        public void FuturesChainApisAreConsistent(Symbol symbol, DateTime dateTime, bool withFutureAdded)
+        public void FuturesChainApisAreConsistent(Symbol symbol, DateTime dateTime, bool withFutureAdded, bool withExtendedMarketHours)
         {
             _algorithm.SetDateTime(dateTime.ConvertToUtc(_algorithm.TimeZone));
 
             if (withFutureAdded)
             {
                 // It should work regardless of whether the future is added to the algorithm
-                _algorithm.AddFuture("ES");
+                _algorithm.AddFuture(symbol.ID.Symbol, extendedMarketHours: withExtendedMarketHours);
             }
 
             var exchange = MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Disable extended market hours for universe history requests used for fetching options and futures chains in QCAlgorithm's `OptionChain`/`OptionChains` and `FuturesChain`/`FuturesChains` methods.

We do this because universe files are not generated on extended market hours only days, like Sundays for some futures. 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #8663 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
