### PR TITLE
Fix QuantBook Option/Future history api date range

### DIFF
--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -420,7 +420,7 @@ namespace QuantConnect.Research
                         // only add underlying if not present
                         AddIndex(symbol.Underlying.Value, resolutionToUseForUnderlying, fillForward: fillForward);
                     }
-                    else if(symbol.Underlying.SecurityType == SecurityType.Future && symbol.Underlying.IsCanonical())
+                    else if (symbol.Underlying.SecurityType == SecurityType.Future && symbol.Underlying.IsCanonical())
                     {
                         AddFuture(symbol.Underlying.ID.Symbol, resolutionToUseForUnderlying, fillForward: fillForward,
                             extendedMarketHours: extendedMarketHours);
@@ -435,13 +435,11 @@ namespace QuantConnect.Research
                 var allSymbols = new HashSet<Symbol>();
                 var optionFilterUniverse = new OptionFilterUniverse(option);
 
-                foreach (var date in QuantConnect.Time.EachTradeableDay(option, start, end.Value.AddDays(-1), extendedMarketHours))
+                foreach (var (date, chainData, underlyingData) in GetChainHistory<OptionUniverse>(option, start, end.Value, extendedMarketHours))
                 {
-                    var universeData = GetChainHistory<OptionUniverse>(symbol, date, out var underlyingData);
-
                     if (underlyingData is not null)
                     {
-                        optionFilterUniverse.Refresh(universeData, underlyingData, underlyingData.EndTime);
+                        optionFilterUniverse.Refresh(chainData, underlyingData, underlyingData.EndTime);
                         allSymbols.UnionWith(option.ContractFilter.Filter(optionFilterUniverse).Select(x => x.Symbol));
                     }
                 }
@@ -499,13 +497,9 @@ namespace QuantConnect.Research
                 // canonical symbol, lets find the contracts
                 var future = Securities[symbol] as Future;
 
-                for (var date = start; date < end; date = date.AddDays(1))
+                foreach (var (date, chainData, underlyingData) in GetChainHistory<FutureUniverse>(future, start, end.Value, extendedMarketHours))
                 {
-                    if (future.Exchange.DateIsOpen(date, extendedMarketHours))
-                    {
-                        var universeData = GetChainHistory<FutureUniverse>(future.Symbol, date, out _);
-                        allSymbols.UnionWith(future.ContractFilter.Filter(new FutureFilterUniverse(universeData, date)).Select(x => x.Symbol));
-                    }
+                    allSymbols.UnionWith(future.ContractFilter.Filter(new FutureFilterUniverse(chainData, date)).Select(x => x.Symbol));
                 }
             }
             else
@@ -880,6 +874,21 @@ namespace QuantConnect.Research
 
             underlyingData = null;
             return Enumerable.Empty<T>();
+        }
+
+        /// <summary>
+        /// Helper method to get option/future chain historical data for a given date range
+        /// </summary>
+        private IEnumerable<(DateTime Date, IEnumerable<T> ChainData, BaseData UnderlyingData)> GetChainHistory<T>(
+            Security security, DateTime start, DateTime end, bool extendedMarketHours)
+            where T : BaseChainUniverseData
+        {
+            var lastDate = start.Date == end.Date ? end.Date : end.AddDays(-1);
+            foreach (var date in QuantConnect.Time.EachTradeableDay(security, start, lastDate, extendedMarketHours))
+            {
+                var universeData = GetChainHistory<T>(security.Symbol, date, out var underlyingData);
+                yield return (date, universeData, underlyingData);
+            }
         }
 
         /// <summary>

--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -883,8 +883,7 @@ namespace QuantConnect.Research
             Security security, DateTime start, DateTime end, bool extendedMarketHours)
             where T : BaseChainUniverseData
         {
-            var lastDate = start.Date == end.Date ? end.Date : end.AddDays(-1);
-            foreach (var date in QuantConnect.Time.EachTradeableDay(security, start, lastDate, extendedMarketHours))
+            foreach (var date in QuantConnect.Time.EachTradeableDay(security, start.Date, end.Date, extendedMarketHours))
             {
                 var universeData = GetChainHistory<T>(security.Symbol, date, out var underlyingData);
                 yield return (date, universeData, underlyingData);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Adjust end time properly for `QuantBook.OptionHistory` and `QuantBook.FutureHistory` to include the whole date when the given end time includes a time of day after midnight.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Calling `QuantBook.OptionHistory()` or `QuantBook.FutureHistory()` with a time range where the end time is not midnight but includes a time of day (e.g. 03/02/2025 15:00pm), must include option/future data for March 2nd, but was being limited to the end of day of the previous date.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
