### PR TITLE
Fix: missed `OrderStatus` in Brokerage `OrderTestParameters`

### DIFF
--- a/Tests/Brokerages/LimitIfTouchedOrderTestParameters.cs
+++ b/Tests/Brokerages/LimitIfTouchedOrderTestParameters.cs
@@ -42,6 +42,7 @@ namespace QuantConnect.Tests.Brokerages
             return new LimitIfTouchedOrder(Symbol, -Math.Abs(quantity), _lowLimit, _highLimit, DateTime.UtcNow,
                 properties: Properties)
             {
+                Status = OrderStatus.New,
                 OrderSubmissionData = OrderSubmissionData
             };
         }
@@ -51,6 +52,7 @@ namespace QuantConnect.Tests.Brokerages
             return new LimitIfTouchedOrder(Symbol, Math.Abs(quantity), _highLimit, _lowLimit, DateTime.UtcNow,
                 properties: Properties)
             {
+                Status = OrderStatus.New,
                 OrderSubmissionData = OrderSubmissionData
             };
         }

--- a/Tests/Brokerages/LimitOrderTestParameters.cs
+++ b/Tests/Brokerages/LimitOrderTestParameters.cs
@@ -36,6 +36,7 @@ namespace QuantConnect.Tests.Brokerages
         {
             return new LimitOrder(Symbol, -Math.Abs(quantity), _highLimit, DateTime.Now, properties: Properties)
             {
+                Status = OrderStatus.New,
                 OrderSubmissionData = OrderSubmissionData
             };
         }
@@ -44,6 +45,7 @@ namespace QuantConnect.Tests.Brokerages
         {
             return new LimitOrder(Symbol, Math.Abs(quantity), _lowLimit, DateTime.Now, properties: Properties)
             {
+                Status = OrderStatus.New,
                 OrderSubmissionData = OrderSubmissionData
             };
         }

--- a/Tests/Brokerages/MarketOrderTestParameters.cs
+++ b/Tests/Brokerages/MarketOrderTestParameters.cs
@@ -30,6 +30,7 @@ namespace QuantConnect.Tests.Brokerages
         {
             return new MarketOrder(Symbol, -Math.Abs(quantity), DateTime.Now, properties: Properties)
             {
+                Status = OrderStatus.New,
                 OrderSubmissionData = OrderSubmissionData
             };
         }
@@ -38,6 +39,7 @@ namespace QuantConnect.Tests.Brokerages
         {
             return new MarketOrder(Symbol, Math.Abs(quantity), DateTime.Now, properties: Properties)
             {
+                Status = OrderStatus.New,
                 OrderSubmissionData = OrderSubmissionData
             };
         }

--- a/Tests/Brokerages/StopLimitOrderTestParameters.cs
+++ b/Tests/Brokerages/StopLimitOrderTestParameters.cs
@@ -35,6 +35,7 @@ namespace QuantConnect.Tests.Brokerages
         {
             return new StopLimitOrder(Symbol, -Math.Abs(quantity), _lowLimit, _highLimit, DateTime.Now, properties: Properties)
             {
+                Status = OrderStatus.New,
                 OrderSubmissionData = OrderSubmissionData
             };
         }
@@ -43,6 +44,7 @@ namespace QuantConnect.Tests.Brokerages
         {
             return new StopLimitOrder(Symbol, Math.Abs(quantity), _highLimit, _lowLimit, DateTime.Now, properties: Properties)
             {
+                Status = OrderStatus.New,
                 OrderSubmissionData = OrderSubmissionData
             };
         }

--- a/Tests/Brokerages/StopMarketOrderTestParameters.cs
+++ b/Tests/Brokerages/StopMarketOrderTestParameters.cs
@@ -35,6 +35,7 @@ namespace QuantConnect.Tests.Brokerages
         {
             return new StopMarketOrder(Symbol, -Math.Abs(quantity), _lowLimit, DateTime.Now, properties: Properties)
             {
+                Status = OrderStatus.New,
                 OrderSubmissionData = OrderSubmissionData
             };
         }
@@ -43,6 +44,7 @@ namespace QuantConnect.Tests.Brokerages
         {
             return new StopMarketOrder(Symbol, Math.Abs(quantity), _highLimit, DateTime.Now, properties: Properties)
             {
+                Status = OrderStatus.New,
                 OrderSubmissionData = OrderSubmissionData
             };
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Missed `OrderStatus` in `OrderTestParameters`. When we create a test order in brokerage, `OrderStatus` is always equal to `None`. This is incorrect because when we create a new Lean Order, it must have `OrderStatus = New`.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/a

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix bugs and simplify the process of testing in microservices.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/a

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Launch test in brokerage and inspect their order status before Status is not `Submitted`.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
