### PR TITLE
Security initialization on re-addition

### DIFF
--- a/Algorithm.CSharp/RawPricesUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RawPricesUniverseRegressionAlgorithm.cs
@@ -91,12 +91,12 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 135;
+        public long DataPoints => 156;
 
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 30;
+        public int AlgorithmHistoryDataPoints => 150;
 
         /// <summary>
         /// Final status of the algorithm
@@ -108,33 +108,33 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
         {
-            {"Total Orders", "12"},
-            {"Average Win", "0.34%"},
-            {"Average Loss", "-0.14%"},
-            {"Compounding Annual Return", "4.586%"},
-            {"Drawdown", "0.700%"},
-            {"Expectancy", "0.158"},
+            {"Total Orders", "57"},
+            {"Average Win", "0.18%"},
+            {"Average Loss", "-0.24%"},
+            {"Compounding Annual Return", "-47.380%"},
+            {"Drawdown", "2.500%"},
+            {"Expectancy", "-0.352"},
             {"Start Equity", "50000"},
-            {"End Equity", "50090.17"},
-            {"Net Profit", "0.180%"},
-            {"Sharpe Ratio", "5.991"},
-            {"Sortino Ratio", "0"},
-            {"Probabilistic Sharpe Ratio", "99.393%"},
-            {"Loss Rate", "67%"},
-            {"Win Rate", "33%"},
-            {"Profit-Loss Ratio", "2.47"},
-            {"Alpha", "0.17"},
-            {"Beta", "0.029"},
-            {"Annual Standard Deviation", "0.028"},
-            {"Annual Variance", "0.001"},
-            {"Information Ratio", "2.734"},
-            {"Tracking Error", "0.098"},
-            {"Treynor Ratio", "5.803"},
+            {"End Equity", "48726.48"},
+            {"Net Profit", "-2.547%"},
+            {"Sharpe Ratio", "-3.372"},
+            {"Sortino Ratio", "-3.889"},
+            {"Probabilistic Sharpe Ratio", "10.352%"},
+            {"Loss Rate", "63%"},
+            {"Win Rate", "37%"},
+            {"Profit-Loss Ratio", "0.75"},
+            {"Alpha", "-0.208"},
+            {"Beta", "0.815"},
+            {"Annual Standard Deviation", "0.086"},
+            {"Annual Variance", "0.007"},
+            {"Information Ratio", "-4.871"},
+            {"Tracking Error", "0.039"},
+            {"Treynor Ratio", "-0.357"},
             {"Total Fees", "$0.00"},
-            {"Estimated Strategy Capacity", "$99000000.00"},
+            {"Estimated Strategy Capacity", "$230000000.00"},
             {"Lowest Capacity Asset", "AIG R735QTJ8XC9X"},
-            {"Portfolio Turnover", "15.96%"},
-            {"OrderListHash", "d915ae36ce856457b32ebbfce4581281"}
+            {"Portfolio Turnover", "77.40%"},
+            {"OrderListHash", "4fb8ffbdfd2cce69ac28b0d0992d7198"}
         };
     }
 }

--- a/Algorithm.CSharp/SecurityInitializationOnReAdditionForManuallyAddedFutureContractRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SecurityInitializationOnReAdditionForManuallyAddedFutureContractRegressionAlgorithm.cs
@@ -1,0 +1,88 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm testing the behavior of the algorithm when a security is removed and re-added.
+    /// It asserts that the securities are marked as non-tradable when removed and that they are tradable when re-added.
+    /// It also asserts that the algorithm receives the correct security changed events for the added and removed securities.
+    ///
+    /// Additionally, it tests that the security is initialized after every addition, and no more.
+    ///
+    /// This specific algorithm tests this behavior for manually added future contracts.
+    /// </summary>
+    public class SecurityInitializationOnReAdditionForManuallyAddedFutureContractRegressionAlgorithm : SecurityInitializationOnReAdditionForEquityRegressionAlgorithm
+    {
+        private static readonly Symbol _futureContractSymbol = QuantConnect.Symbol.CreateFuture(Futures.Indices.SP500EMini, Market.CME, new DateTime(2013, 12, 20));
+
+        protected override DateTime StartTimeToUse => new DateTime(2013, 10, 07);
+
+        protected override DateTime EndTimeToUse => new DateTime(2013, 10, 17);
+
+        protected override Security AddSecurity()
+        {
+            return AddFutureContract(_futureContractSymbol, Resolution.Daily);
+        }
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public override long DataPoints => 85;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public override int AlgorithmHistoryDataPoints => 48;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-9.029"},
+            {"Tracking Error", "0.155"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/SecurityInitializationOnReAdditionForManuallyAddedOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SecurityInitializationOnReAdditionForManuallyAddedOptionRegressionAlgorithm.cs
@@ -24,6 +24,8 @@ namespace QuantConnect.Algorithm.CSharp
     /// It asserts that the securities are marked as non-tradable when removed and that they are tradable when re-added.
     /// It also asserts that the algorithm receives the correct security changed events for the added and removed securities.
     ///
+    /// Additionally, it tests that the security is initialized after every addition, and no more.
+    ///
     /// This specific algorithm tests this behavior for manually added option contracts.
     /// </summary>
     public class SecurityInitializationOnReAdditionForManuallyAddedOptionRegressionAlgorithm : SecurityInitializationOnReAdditionForEquityRegressionAlgorithm
@@ -36,13 +38,46 @@ namespace QuantConnect.Algorithm.CSharp
             342.9m,
             new DateTime(2014, 07, 19));
 
+        private int _securityAdditionsCount;
+
         protected override DateTime StartTimeToUse => new DateTime(2014, 06, 04);
 
         protected override DateTime EndTimeToUse => new DateTime(2014, 06, 20);
 
         protected override Security AddSecurity()
         {
+            _securityAdditionsCount++;
             return AddOptionContract(_optionContractSymbol, Resolution.Daily);
+        }
+
+        protected override void AssertSecurityInitializationCount(Dictionary<Security, int> securityInializationCounts, Security security)
+        {
+            // The first time the contract is added, the underlying equity will be added and initialized as well.
+            // The following times the contract is added, the underlying equity will not be added again.
+            var expectedSecuritiesInitialized = 1;
+            if (_securityAdditionsCount == 1)
+            {
+                expectedSecuritiesInitialized = 2;
+            }
+
+            if (securityInializationCounts.Count != expectedSecuritiesInitialized)
+            {
+                throw new RegressionTestException($"Expected {expectedSecuritiesInitialized} security to be initialized. " +
+                    $"Got {securityInializationCounts.Count}");
+            }
+
+            if (!securityInializationCounts.TryGetValue(security, out var count) || count != 1)
+            {
+                throw new RegressionTestException($"Expected the option contract to be initialized once and once only, " +
+                    $"but was initialized {count} times");
+            }
+
+            if (expectedSecuritiesInitialized == 2 &&
+                !securityInializationCounts.TryGetValue(Securities[security.Symbol.Underlying], out count) || count != 1)
+            {
+                throw new RegressionTestException($"Expected the underlying security to be initialized once and once only, " +
+                    $"but was initialized {count} times");
+            }
         }
 
         /// <summary>
@@ -53,7 +88,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public override int AlgorithmHistoryDataPoints => 0;
+        public override int AlgorithmHistoryDataPoints => 5;
 
         /// <summary>
         /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm

--- a/Algorithm.CSharp/SecurityInitializationOnReAdditionForSelectedOptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SecurityInitializationOnReAdditionForSelectedOptionRegressionAlgorithm.cs
@@ -28,6 +28,8 @@ namespace QuantConnect.Algorithm.CSharp
     /// It asserts that the securities are marked as non-tradable when removed and that they are tradable when re-added.
     /// It also asserts that the algorithm receives the correct security changed events for the added and removed securities.
     ///
+    /// Additionally, it tests that the security is initialized after every addition, and no more.
+    ///
     /// This specific algorithm tests this behavior for option contracts that are selected, deselected and re-selected.
     /// </summary>
     public class SecurityInitializationOnReAdditionForSelectedOptionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
@@ -37,11 +39,30 @@ namespace QuantConnect.Algorithm.CSharp
         private bool _selectSingle;
         private int _selectionsCount;
 
+        private Dictionary<Security, int> _securityInializationCounts = new();
+
         public override void Initialize()
         {
             SetStartDate(2014, 06, 04);
             SetEndDate(2014, 06, 20);
             SetCash(100000);
+
+            var seeder = new FuncSecuritySeeder((security) =>
+            {
+                if (security is Option option)
+                {
+                    if (!_securityInializationCounts.TryGetValue(security, out var count))
+                    {
+                        count = 0;
+                    }
+                    _securityInializationCounts[security] = count + 1;
+                }
+
+                Debug($"[{Time}] Seeding {security.Symbol}");
+                return GetLastKnownPrices(security);
+            });
+
+            SetSecurityInitializer(security => seeder.SeedSecurity(security));
 
             var equitySymbol = QuantConnect.Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
 
@@ -55,6 +76,7 @@ namespace QuantConnect.Algorithm.CSharp
             option.SetFilter(u => u.Contracts(contracts =>
             {
                 _selectionsCount++;
+                _securityInializationCounts.Clear();
 
                 List<Symbol> selected;
                 if (_selectSingle)
@@ -89,6 +111,12 @@ namespace QuantConnect.Algorithm.CSharp
                 {
                     throw new RegressionTestException($"Expected the security to be not tradable. Symbol: {security.Symbol}");
                 }
+            }
+
+            var addedContracts = changes.AddedSecurities.OfType<Option>().ToList();
+            if (addedContracts.Any(x => !_securityInializationCounts.TryGetValue(x, out var count) || count != 1))
+            {
+                throw new RegressionTestException($"Expected all contracts to be initialized. Added: {string.Join(", ", addedContracts.Select(x => x.Symbol.Value))}, Initialized: {string.Join(", ", _securityInializationCounts.Select(x => $"{x.Key.Symbol.Value} - {x.Value}"))}");
             }
 
             // The first contract will be selected always, so we expect it to be added only once
@@ -161,7 +189,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 0;
+        public int AlgorithmHistoryDataPoints => 5;
 
         /// <summary>
         /// Final status of the algorithm

--- a/Algorithm.CSharp/SecurityInitializationOnReAdditionForUniverseSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SecurityInitializationOnReAdditionForUniverseSelectionRegressionAlgorithm.cs
@@ -1,0 +1,201 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm testing the behavior of the algorithm when a security is removed and re-added.
+    /// It asserts that the securities are marked as non-tradable when removed and that they are tradable when re-added.
+    /// It also asserts that the algorithm receives the correct security changed events for the added and removed securities.
+    ///
+    /// Additionally, it tests that the security is initialized after every addition, and no more.
+    ///
+    /// This specific algorithm tests this behavior for securities selected, deselected and re-selected from universes.
+    /// </summary>
+    public class SecurityInitializationOnReAdditionForUniverseSelectionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private List<Symbol> _symbolsToSelect;
+        private List<Symbol> _selectedSymbols;
+        private int _selectionsCount;
+
+        private Dictionary<Security, int> _securityInializationCounts = new();
+
+        public override void Initialize()
+        {
+            SetStartDate(2014, 03, 24);
+            SetEndDate(2014, 04, 07);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Daily;
+
+            var seeder = new FuncSecuritySeeder((security) =>
+            {
+                if (!_securityInializationCounts.TryGetValue(security, out var count))
+                {
+                    count = 0;
+                }
+                _securityInializationCounts[security] = count + 1;
+
+                Debug($"[{Time}] Seeding {security.Symbol}");
+                return GetLastKnownPrices(security);
+            });
+
+            SetSecurityInitializer(security => seeder.SeedSecurity(security));
+
+            _symbolsToSelect = new List<Symbol>()
+            {
+                QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA),
+                QuantConnect.Symbol.Create("IWM", SecurityType.Equity, Market.USA),
+                QuantConnect.Symbol.Create("QQQ", SecurityType.Equity, Market.USA),
+                QuantConnect.Symbol.Create("AIG", SecurityType.Equity, Market.USA),
+                QuantConnect.Symbol.Create("BAC", SecurityType.Equity, Market.USA),
+                QuantConnect.Symbol.Create("IBM", SecurityType.Equity, Market.USA),
+            };
+
+            AddUniverse("MyUniverse", Resolution.Daily, SelectionFunction);
+        }
+
+        private IEnumerable<string> SelectionFunction(DateTime dateTime)
+        {
+            _securityInializationCounts.Clear();
+            _selectionsCount++;
+
+            _selectedSymbols = _symbolsToSelect.Skip(dateTime.Day % 2 == 0 ? 0 : 3).Take(3).ToList();
+            return _selectedSymbols.Select(x => x.Value);
+        }
+
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            foreach (var security in changes.AddedSecurities)
+            {
+                if (!security.IsTradable)
+                {
+                    throw new RegressionTestException($"Expected the security to be tradable. Symbol: {security.Symbol}");
+                }
+            }
+
+            foreach (var security in changes.RemovedSecurities)
+            {
+                if (security.IsTradable)
+                {
+                    throw new RegressionTestException($"Expected the security to be not tradable. Symbol: {security.Symbol}");
+                }
+            }
+
+            if (changes.AddedSecurities.Count != _selectedSymbols.Count ||
+                changes.AddedSecurities.Any(x => !_selectedSymbols.Contains(x.Symbol)))
+            {
+                throw new RegressionTestException($"Expected the added securities to be the selected ones. " +
+                    $"Added: {string.Join(", ", changes.AddedSecurities.Select(x => x.Symbol.Value))}, " +
+                    $"Selected: {string.Join(", ", _selectedSymbols)}");
+            }
+
+            if (changes.AddedSecurities.Count != _securityInializationCounts.Count ||
+                changes.AddedSecurities.Any(x => !_securityInializationCounts.TryGetValue(x, out var count) || count != 1))
+            {
+                throw new RegressionTestException($"Expected all contracts to be initialized. " +
+                    $"Added: {string.Join(", ", changes.AddedSecurities.Select(x => x.Symbol.Value))}, " +
+                    $"Initialized: {string.Join(", ", _securityInializationCounts.Select(x => $"{x.Key.Symbol.Value} - {x.Value}"))}");
+            }
+
+            if (changes.RemovedSecurities.Count > 0)
+            {
+                var expectedDeselectedSymbols = _symbolsToSelect.Where(x => !_selectedSymbols.Contains(x)).ToList();
+
+                if (changes.RemovedSecurities.Count != expectedDeselectedSymbols.Count ||
+                    changes.RemovedSecurities.Any(x => !expectedDeselectedSymbols.Contains(x.Symbol)))
+                {
+                    throw new RegressionTestException($"Expected the removed securities to be the deselected ones. " +
+                        $"Removed: {string.Join(", ", changes.RemovedSecurities.Select(x => x.Symbol.Value))}, " +
+                        $"Deselected: {string.Join(", ", expectedDeselectedSymbols)}");
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_selectionsCount < 2)
+            {
+                throw new RegressionTestException("Expected at least two selections");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 128;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 150;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0.97"},
+            {"Tracking Error", "0.097"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -55,6 +55,11 @@ namespace QuantConnect.Securities
         private readonly HashSet<SubscriptionDataConfig> _subscriptionsBag;
 
         /// <summary>
+        /// Flag to keep track of initialized securities, to avoid double initialization.
+        /// </summary>
+        internal bool IsInitialized { get; set; }
+
+        /// <summary>
         /// This securities <see cref="IShortableProvider"/>
         /// </summary>
         public IShortableProvider ShortableProvider { get; private set; }
@@ -1179,6 +1184,7 @@ namespace QuantConnect.Securities
         /// </summary>
         public virtual void Reset()
         {
+            IsInitialized = false;
             IsTradable = false;
 
             // Reset the subscriptions

--- a/Common/Securities/SecurityService.cs
+++ b/Common/Securities/SecurityService.cs
@@ -87,6 +87,8 @@ namespace QuantConnect.Securities
                     existingSecurity.MakeTradable();
                 }
 
+                InitializeSecurity(initializeSecurity, existingSecurity);
+
                 return existingSecurity;
             }
 
@@ -220,10 +222,7 @@ namespace QuantConnect.Securities
             security.AddData(configList);
 
             // invoke the security initializer
-            if (initializeSecurity)
-            {
-                _securityInitializerProvider.SecurityInitializer.Initialize(security);
-            }
+            InitializeSecurity(initializeSecurity, security);
 
             CheckCanonicalSecurityModels(security);
 
@@ -317,6 +316,15 @@ namespace QuantConnect.Securities
                     _modelsMismatchWarningSent = true;
                     _algorithm.Debug($"Warning: Security {security.Symbol} its canonical security {security.Symbol.Canonical} have at least one model of different types (fill, fee, buying power, margin interest rate, slippage, volatility, settlement). To avoid this, consider using a security initializer to set the right models to each security type according to your algorithm's requirements.");
                 }
+            }
+        }
+
+        private void InitializeSecurity(bool initializeSecurity, Security security)
+        {
+            if (initializeSecurity && !security.IsInitialized)
+            {
+                _securityInitializerProvider.SecurityInitializer.Initialize(security);
+                security.IsInitialized = true;
             }
         }
     }

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -478,6 +478,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                             // it is expected that this function is called while in sync with the algo thread,
                             // so we can make direct edits to the security here.
                             // We only clear the cache once the subscription is removed from the data stack
+                            // Note: Security.Reset() won't clear the cache, it only clears the data subscription
+                            // and marks it as non-tradable, because in some cases the cache needs to be kept,
+                            // like when delisting, which could lead to a liquidation or option exercise.
                             member.Cache.Reset();
 
                             _algorithm.Securities.Remove(member.Symbol);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Ensure securities are initialized every time they are added or re-added, including scenarios like manual removal and re-addition and deselection and re-selection by universes, like options or custom universes.
Also make sure initialization happens only once for each security on addition.

##### Performance tests:

Since now the securities are being initialized every time they are re-added (either manually or by being selected by a universe), we expect to have minor performance impacts on algorithms that are doing selection.

**Daily coarse selection: 50 top equities by dollar volume and their options:**

```csharp
public override void Initialize()
{
    SetStartDate(2014, 01, 01);
    SetEndDate(2014, 03, 01);
    SetCash(100000);

    UniverseSettings.Resolution = Resolution.Daily;

    var seeder = new FuncSecuritySeeder(security => GetLastKnownPrices(security));
    SetSecurityInitializer(security => seeder.SeedSecurity(security));

    var universe = AddUniverse(coarse => coarse.OrderByDescending(x => x.DollarVolume).Take(50).Select(x => x.Symbol));

    AddUniverseOptions(universe, u => u.Expiration(0, 7));
}
```

Master: ~136s on avg
PR: ~146s on avg (~7% slower)

**Daily coarse selection: randomly selecting 50 out 200 top equities by dollar volume and their options:**

```csharp
var universe = AddUniverse(coarse => coarse.OrderByDescending(x => x.DollarVolume).Take(200).OrderBy(_ => random.Next()).Take(50).Select(x => x.Symbol));
AddUniverseOptions(universe, u => u.Expiration(0, 7));
```

Note: selecting 50 randomly so we force some equities are de-selected and re-selected each day, which forces more security initializations.

Master: ~166s on avg
PR: ~191s on avg (~7% slower)

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Part of #7929 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Regression algorithms

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
