### PR TITLE
Fill-forward previous universe files for manual chains fetching when current missing

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -3718,7 +3718,7 @@ namespace QuantConnect.Algorithm
                     history = History<T>([symbol], periods++).FirstOrDefault();
                 }
 
-                var chain = history != null ? history.Values.Single().Cast<T>() : Enumerable.Empty<T>();
+                var chain = history != null && history.Count > 0 ? history.Values.Single().Cast<T>() : Enumerable.Empty<T>();
                 yield return KeyValuePair.Create(symbol, chain);
             }
         }

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -3709,8 +3709,7 @@ namespace QuantConnect.Algorithm
         private IEnumerable<KeyValuePair<Symbol, IEnumerable<T>>> GetChainsData<T>(IEnumerable<Symbol> canonicalSymbols)
             where T : BaseChainUniverseData
         {
-            var data = new List<KeyValuePair<Symbol, IEnumerable<T>>>();
-            Parallel.ForEach(canonicalSymbols, symbol =>
+            foreach (var symbol in canonicalSymbols)
             {
                 var history = (DataDictionary<T>)null;
                 var periods = 1;
@@ -3720,10 +3719,8 @@ namespace QuantConnect.Algorithm
                 }
 
                 var chain = history != null ? history.Values.Single().Cast<T>() : Enumerable.Empty<T>();
-                data.Add(KeyValuePair.Create(symbol, chain));
-            });
-
-            return data;
+                yield return KeyValuePair.Create(symbol, chain);
+            }
         }
     }
 }

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -3711,6 +3711,10 @@ namespace QuantConnect.Algorithm
         {
             foreach (var symbol in canonicalSymbols)
             {
+                // We will add a safety measure in case the universe file for the current time is not available:
+                // we will use the latest available universe file within the last 3 trading dates.
+                // This is useful in cases like live trading when the algorithm is deployed at a time of day when
+                // the universe file is not available yet.
                 var history = (DataDictionary<T>)null;
                 var periods = 1;
                 while ((history == null || history.Count == 0) && periods <= 3)

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -3449,7 +3449,7 @@ namespace QuantConnect.Algorithm
             {
                 foreach (var (symbol, contracts) in futureChainsData)
                 {
-                    var chain = new FuturesChain(symbol, time, contracts.Cast<FutureUniverse>(), flatten);
+                    var chain = new FuturesChain(symbol, time, contracts, flatten);
                     chains.Add(symbol, chain);
                 }
             }

--- a/Common/Data/Market/FuturesChain.cs
+++ b/Common/Data/Market/FuturesChain.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Data.Market
         {
             foreach (var contractData in contracts)
             {
-                if (contractData.Symbol.ID.Date < time) continue;
+                if (contractData.Symbol.ID.Date.Date < time.Date) continue;
                 Contracts[contractData.Symbol] = new FuturesContract(contractData);
             }
         }

--- a/Common/Data/Market/FuturesChain.cs
+++ b/Common/Data/Market/FuturesChain.cs
@@ -48,6 +48,7 @@ namespace QuantConnect.Data.Market
         {
             foreach (var contractData in contracts)
             {
+                if (contractData.Symbol.ID.Date < time) continue;
                 Contracts[contractData.Symbol] = new FuturesContract(contractData);
             }
         }

--- a/Common/Data/Market/OptionChain.cs
+++ b/Common/Data/Market/OptionChain.cs
@@ -51,8 +51,9 @@ namespace QuantConnect.Data.Market
         {
             foreach (var contractData in contracts)
             {
-                Contracts[contractData.Symbol] = OptionContract.Create(contractData, symbolProperties);
                 Underlying ??= contractData.Underlying;
+                if (contractData.Symbol.ID.Date < time) continue;
+                Contracts[contractData.Symbol] = OptionContract.Create(contractData, symbolProperties);
             }
         }
 

--- a/Common/Data/Market/OptionChain.cs
+++ b/Common/Data/Market/OptionChain.cs
@@ -52,7 +52,7 @@ namespace QuantConnect.Data.Market
             foreach (var contractData in contracts)
             {
                 Underlying ??= contractData.Underlying;
-                if (contractData.Symbol.ID.Date < time) continue;
+                if (contractData.Symbol.ID.Date.Date < time.Date) continue;
                 Contracts[contractData.Symbol] = OptionContract.Create(contractData, symbolProperties);
             }
         }

--- a/Engine/DataFeeds/BacktestingChainProvider.cs
+++ b/Engine/DataFeeds/BacktestingChainProvider.cs
@@ -70,7 +70,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             // Use this GetEntry extension method since it's data type dependent, so we get the correct entry for the option universe
             var marketHoursEntry = marketHoursDataBase.GetEntry(canonicalSymbol, new[] { universeType });
 
-            var previousTradingDate = Time.GetStartTimeForTradeBars(marketHoursEntry.ExchangeHours, date, Time.OneDay, 1,
+            var previousTradingDate = Time.GetStartTimeForTradeBars(marketHoursEntry.ExchangeHours, date, Time.OneDay, 2,
                 extendedMarketHours: false, marketHoursEntry.DataTimeZone);
             var request = new HistoryRequest(
                 previousTradingDate.ConvertToUtc(marketHoursEntry.ExchangeHours.TimeZone),
@@ -89,14 +89,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             var symbols = history == null || history.Count == 0
                 ? Enumerable.Empty<Symbol>()
-                : history.GetUniverseData().SelectMany(x => x.Values.Single()).Select(x => x.Symbol);
+                : history.TakeLast(1).GetUniverseData().SelectMany(x => x.Values.Single()).Select(x => x.Symbol);
 
             if (canonicalSymbol.SecurityType.IsOption())
             {
-                return symbols.Where(symbol => symbol.SecurityType.IsOption());
+                symbols = symbols.Where(symbol => symbol.SecurityType.IsOption());
             }
 
-            return symbols;
+            return symbols.Where(symbol => symbol.ID.Date >= date.Date);
         }
 
         /// <summary>

--- a/Engine/DataFeeds/BacktestingChainProvider.cs
+++ b/Engine/DataFeeds/BacktestingChainProvider.cs
@@ -70,6 +70,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             // Use this GetEntry extension method since it's data type dependent, so we get the correct entry for the option universe
             var marketHoursEntry = marketHoursDataBase.GetEntry(canonicalSymbol, new[] { universeType });
 
+            // We will add a safety measure in case the universe file for the current time is not available:
+            // we will use the latest available universe file within the last 3 trading dates.
+            // This is useful in cases like live trading when the algorithm is deployed at a time of day when
+            // the universe file is not available yet.
             var history = (List<Slice>)null;
             var periods = 1;
             while ((history == null || history.Count == 0) && periods <= 3)

--- a/Tests/Algorithm/AlgorithmChainsTests.cs
+++ b/Tests/Algorithm/AlgorithmChainsTests.cs
@@ -16,10 +16,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NodaTime;
 using NUnit.Framework;
 using Python.Runtime;
 using QuantConnect.Algorithm;
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Securities;
 using QuantConnect.Tests.Engine.DataFeeds;
@@ -41,13 +44,10 @@ namespace QuantConnect.Tests.Algorithm
             _algorithm.SetHistoryProvider(TestGlobals.HistoryProvider);
             _algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(_algorithm));
 
-            var initParameters = new ChainProviderInitializeParameters(TestGlobals.MapFileProvider, TestGlobals.HistoryProvider);
-            _optionChainProvider = new BacktestingOptionChainProvider();
-            _optionChainProvider.Initialize(initParameters);
+            _optionChainProvider = GetOptionChainProvider(TestGlobals.HistoryProvider);
             _algorithm.SetOptionChainProvider(_optionChainProvider);
 
-            _futureChainProvider = new BacktestingFutureChainProvider();
-            _futureChainProvider.Initialize(initParameters);
+            _futureChainProvider = GetFutureChainProvider(TestGlobals.HistoryProvider);
             _algorithm.SetFutureChainProvider(_futureChainProvider);
         }
 
@@ -380,6 +380,65 @@ namespace QuantConnect.Tests.Algorithm
             AssertMultiChainsDataFrame<FuturesContract>(flatten, symbols, dataFrame, expectedFuturesChains, isOptionChain: false);
         }
 
+        private static TestCaseData[] FillForwardTestData => new[] { true, false }
+            .Select(useAlgorithmApi => new TestCaseData[]
+            {
+                new(Symbols.SPY_Option_Chain, new DateTime(2024, 01, 03), useAlgorithmApi),
+                new(Symbol.CreateCanonicalOption(Symbols.SPX), new DateTime(2021, 01, 08), useAlgorithmApi),
+                new(Symbol.CreateCanonicalOption(Symbols.CreateFutureSymbol(Futures.Indices.SP500EMini, new DateTime(2020, 03, 20))),
+                    new DateTime(2020, 01, 07),
+                    useAlgorithmApi),
+                new(Symbols.ES_Future_Chain, new DateTime(2020, 01, 07), useAlgorithmApi)
+            })
+            .SelectMany(x => x)
+            .ToArray();
+
+        [TestCaseSource(nameof(FillForwardTestData))]
+        public void FillForwardsChainFromPreviousTradableDateIfCurrentOneIsNotAvailable(Symbol symbol, DateTime dateTime, bool useAlgorithmApi)
+        {
+            var historyProvider = new FillForwardTestHistoryProvider(_algorithm.HistoryProvider);
+            _algorithm.SetHistoryProvider(historyProvider);
+            _algorithm.SetOptionChainProvider(GetOptionChainProvider(historyProvider));
+            _algorithm.SetFutureChainProvider(GetFutureChainProvider(historyProvider));
+
+            var exchange = MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+            _algorithm.SetTimeZone(exchange.TimeZone);
+
+            // Get the previous tradable date chain
+            var prevTradableDate = exchange.GetPreviousTradingDay(dateTime);
+
+            historyProvider.SimulateMissingFile = false;
+            historyProvider.RequestDateTime = prevTradableDate;
+            var prevDateChain = GetChain(symbol, prevTradableDate, useAlgorithmApi);
+
+            // Get the current date chain, which should be fill-forwarded from the previous date
+            // because the universe file for the current date is missing
+            historyProvider.SimulateMissingFile = true;
+            historyProvider.RequestDateTime = dateTime;
+            var currentDateChain = GetChain(symbol, dateTime, useAlgorithmApi);
+
+            Assert.IsNotEmpty(currentDateChain);
+            Assert.IsNotEmpty(prevDateChain);
+            CollectionAssert.IsSubsetOf(currentDateChain, prevDateChain);
+            CollectionAssert.AreEquivalent(currentDateChain, prevDateChain.Where(symbol => symbol.ID.Date >= dateTime));
+        }
+
+        private List<Symbol> GetChain(Symbol symbol, DateTime date, bool useAlgorithmApi)
+        {
+            if (useAlgorithmApi)
+            {
+                _algorithm.SetDateTime(date.ConvertToUtc(_algorithm.TimeZone));
+
+                return symbol.SecurityType == SecurityType.Future
+                    ? _algorithm.FuturesChain(symbol).Select(x => x.Symbol).ToList()
+                    : _algorithm.OptionChain(symbol).Select(x => x.Symbol).ToList();
+            }
+
+            return symbol.SecurityType == SecurityType.Future
+                ? _algorithm.FutureChainProvider.GetFutureContractList(symbol, date).ToList()
+                : _algorithm.OptionChainProvider.GetOptionContractList(symbol, date).ToList();
+        }
+
         private static void AssertMultiChainsDataFrame<T>(bool flatten, Symbol[] symbols, PyObject dataFrame,
             Dictionary<Symbol, List<Symbol>> expectedChains, bool isOptionChain)
             where T : BaseContract
@@ -418,6 +477,86 @@ namespace QuantConnect.Tests.Algorithm
                     }
                 });
             }
+        }
+
+        private class FillForwardTestHistoryProvider : IHistoryProvider
+        {
+            private readonly IHistoryProvider _historyProvider;
+
+            public DateTime RequestDateTime { get; set; }
+
+            public bool SimulateMissingFile { get; set; }
+
+            public int DataPointCount => _historyProvider.DataPointCount;
+
+            public event EventHandler<InvalidConfigurationDetectedEventArgs> InvalidConfigurationDetected
+            {
+                add { _historyProvider.InvalidConfigurationDetected += value; }
+                remove { _historyProvider.InvalidConfigurationDetected -= value; }
+            }
+
+            public event EventHandler<NumericalPrecisionLimitedEventArgs> NumericalPrecisionLimited
+            {
+                add { _historyProvider.NumericalPrecisionLimited += value; }
+                remove { _historyProvider.NumericalPrecisionLimited -= value; }
+            }
+
+            public event EventHandler<DownloadFailedEventArgs> DownloadFailed
+            {
+                add { _historyProvider.DownloadFailed += value; }
+                remove { _historyProvider.DownloadFailed -= value; }
+            }
+
+            public event EventHandler<ReaderErrorDetectedEventArgs> ReaderErrorDetected
+            {
+                add { _historyProvider.ReaderErrorDetected += value; }
+                remove { _historyProvider.ReaderErrorDetected -= value; }
+            }
+
+            public event EventHandler<StartDateLimitedEventArgs> StartDateLimited
+            {
+                add { _historyProvider.StartDateLimited += value; }
+                remove { _historyProvider.StartDateLimited -= value; }
+            }
+
+            public FillForwardTestHistoryProvider(IHistoryProvider historyProvider)
+            {
+                _historyProvider = historyProvider;
+            }
+
+            public IEnumerable<Slice> GetHistory(IEnumerable<HistoryRequest> requests, DateTimeZone sliceTimeZone)
+            {
+                // This test history provider will always be used for single requests
+                var historyRequests = requests.ToList();
+                Assert.AreEqual(1, historyRequests.Count);
+
+                var history = _historyProvider.GetHistory(historyRequests, sliceTimeZone).ToList();
+                Assert.AreEqual(2, history.Count);
+
+                // Let's ditch the last one to simulate a missing universe file
+                return SimulateMissingFile ? history.Take(1) : history;
+            }
+
+            public void Initialize(HistoryProviderInitializeParameters parameters)
+            {
+                _historyProvider.Initialize(parameters);
+            }
+        }
+
+        private static BacktestingOptionChainProvider GetOptionChainProvider(IHistoryProvider historyProvider)
+        {
+            var initParameters = new ChainProviderInitializeParameters(TestGlobals.MapFileProvider, historyProvider);
+            var optionChainProvider = new BacktestingOptionChainProvider();
+            optionChainProvider.Initialize(initParameters);
+            return optionChainProvider;
+        }
+
+        private static BacktestingFutureChainProvider GetFutureChainProvider(IHistoryProvider historyProvider)
+        {
+            var initParameters = new ChainProviderInitializeParameters(TestGlobals.MapFileProvider, historyProvider);
+            var futureChainProvider = new BacktestingFutureChainProvider();
+            futureChainProvider.Initialize(initParameters);
+            return futureChainProvider;
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
 
When fetching chains manually, using `QCAlgorithm`'s `FuturesChain()`/`OptionChain()` or the option/future chain provider, if the option/future universe file for the current date is not available, we use the previous one and fill-forward it, excluding the contracts that may have expired. We go back up to 3 days before failing and returning an empty chain.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #8688 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This is useful in live trading, when an algorithm might be deployed at a time of day before the universe files have been generated. So instead of returning empty chain, we return the contracts available from the previous trading day.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
