### PR TITLE
Fix bug in ClassicRenkoConsolidator

### DIFF
--- a/Algorithm.CSharp/ClassicRenkoConsolidatorWithFuturesQuoteTickTypeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ClassicRenkoConsolidatorWithFuturesQuoteTickTypeRegressionAlgorithm.cs
@@ -1,0 +1,57 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using QuantConnect.Data;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.Market;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This algorithm tests the Classic Renko Consolidator with future quote tick data.
+    /// It checks if valid quote data (non-zero Bid/Ask prices) is received during the algorithm's execution.
+    /// If consolidation does not happen, a RegressionTestException is thrown
+    /// </summary>
+    public class ClassicRenkoConsolidatorWithFuturesQuoteTickTypeRegressionAlgorithm : ClassicRenkoConsolidatorFuturesTickTypesRegressionAlgorithm
+    {
+        private bool _hasNonZeroBidPrice;
+        private bool _hasNonZeroAskPrice;
+        protected override TickType TickType => TickType.Quote;
+        protected override ClassicRenkoConsolidator GetConsolidator()
+        {
+            Func<IBaseData, decimal> selector = data =>
+            {
+                var tick = data as Tick;
+                _hasNonZeroBidPrice |= tick.BidPrice != 0;
+                _hasNonZeroAskPrice |= tick.AskPrice != 0;
+                return tick.AskPrice * 10;
+            };
+
+            var consolidator = new ClassicRenkoConsolidator(BucketSize, selector);
+            return consolidator;
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_hasNonZeroBidPrice || !_hasNonZeroAskPrice)
+            {
+                throw new RegressionTestException("No valid Quote tick data found: fields (Bid/Ask) were zero.");
+            }
+            base.OnEndOfAlgorithm();
+        }
+    }
+}

--- a/Algorithm.CSharp/ClassicRenkoConsolidatorWithFuturesTickTypesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ClassicRenkoConsolidatorWithFuturesTickTypesRegressionAlgorithm.cs
@@ -1,0 +1,143 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities.Future;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// This algorithm tests the functionality of the Classic Renko Consolidator with future trade tick data.
+    /// It checks if data consolidation occurs as expected for the given time period. If consolidation does not happen, a RegressionTestException is thrown.
+    /// </summary>
+    public class ClassicRenkoConsolidatorFuturesTickTypesRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Dictionary<Symbol, ClassicRenkoConsolidator> _consolidators = new Dictionary<Symbol, ClassicRenkoConsolidator>();
+        private Future _goldFuture;
+        private bool _itWasConsolidated;
+        protected virtual TickType TickType => TickType.Trade;
+        protected decimal BucketSize { get; set; }
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 7);
+            SetEndDate(2013, 10, 9);
+
+            _goldFuture = AddFuture("GC", Resolution.Tick, Market.COMEX);
+            _goldFuture.SetFilter(0, 180);
+            BucketSize = 2000m;
+        }
+
+        private void OnConsolidated(object sender, TradeBar bar)
+        {
+            _itWasConsolidated = true;
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (!_consolidators.ContainsKey(_goldFuture.Mapped))
+            {
+                var consolidator = GetConsolidator();
+                consolidator.DataConsolidated += OnConsolidated;
+                SubscriptionManager.AddConsolidator(_goldFuture.Mapped, consolidator, TickType);
+                _consolidators[_goldFuture.Mapped] = consolidator;
+            }
+        }
+
+        protected virtual ClassicRenkoConsolidator GetConsolidator()
+        {
+            Func<IBaseData, decimal> selector = data =>
+            {
+                var tick = data as Tick;
+                return tick.Quantity * tick.Price;
+            };
+
+            var consolidator = new ClassicRenkoConsolidator(BucketSize, selector);
+            return consolidator;
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_itWasConsolidated)
+            {
+                throw new RegressionTestException("ClassicRenko did not consolidate any data.");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 1082920;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "5.524"},
+            {"Tracking Error", "0.136"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Common/Data/SubscriptionManager.cs
+++ b/Common/Data/SubscriptionManager.cs
@@ -177,7 +177,7 @@ namespace QuantConnect.Data
             foreach (var subscription in subscriptions)
             {
                 // we need to be able to pipe data directly from the data feed into the consolidator
-                if (IsSubscriptionValidForConsolidator(subscription, consolidator, tickType))
+                if (IsSubscriptionValidForConsolidator(subscription, consolidator, tickType) && subscription.TickType == tickType)
                 {
                     subscription.Consolidators.Add(consolidator);
 


### PR DESCRIPTION
… add regression algorithms


<!--- Provide a general summary of your changes in the Title above -->

#### Description
Added a missing condition in SubscriptionManager.AddConsolidator to ensure the consolidator is only attached to subscriptions matching the provided TickType. Previously, consolidators could be added to any subscription with a compatible input type, even if the TickType did not match, leading to unexpected behavior when multiple subscriptions (e.g., Quote and Trade) existed for the same symbol

#### Related Issue
Closes #8639 

#### Motivation and Context
This change ensures more precise matching between data subscriptions and consolidators, particularly when a specific TickType is specified.

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
Verified using regression algorithms involving futures with both Trade and Quote subscriptions.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
