### PR TITLE
Fix: UnsettledCash Handling in Lean and Refactor PerformCashSync from Brokerage

### DIFF
--- a/Common/Securities/Equity/Equity.cs
+++ b/Common/Securities/Equity/Equity.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Securities.Equity
         /// <summary>
         /// The default time of day for settlement
         /// </summary>
-        public static readonly TimeSpan DefaultSettlementTime = new TimeSpan(8, 0, 0);
+        public static readonly TimeSpan DefaultSettlementTime = new TimeSpan(6, 0, 0);
 
         /// <summary>
         /// Checks if the equity is a shortable asset. Note that this does not

--- a/Common/Securities/Future/Future.cs
+++ b/Common/Securities/Future/Future.cs
@@ -57,7 +57,7 @@ namespace QuantConnect.Securities.Future
         /// <summary>
         /// The default time of day for settlement
         /// </summary>
-        public static readonly TimeSpan DefaultSettlementTime = new TimeSpan(8, 0, 0);
+        public static readonly TimeSpan DefaultSettlementTime = new TimeSpan(6, 0, 0);
 
         /// <summary>
         /// Constructor for the Future security

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -45,7 +45,7 @@ namespace QuantConnect.Securities.Option
         /// <summary>
         /// The default time of day for settlement
         /// </summary>
-        public static readonly TimeSpan DefaultSettlementTime = new (8, 0, 0);
+        public static readonly TimeSpan DefaultSettlementTime = new (6, 0, 0);
 
         /// <summary>
         /// Constructor for the option security

--- a/Tests/Brokerages/Models/PaperBrokerageWithManualCashBalance.cs
+++ b/Tests/Brokerages/Models/PaperBrokerageWithManualCashBalance.cs
@@ -1,0 +1,75 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using QuantConnect.Packets;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+using System.Collections.Generic;
+using QuantConnect.Brokerages.Paper;
+
+namespace QuantConnect.Tests.Brokerages.Models;
+
+/// <summary>
+/// A customized PaperBrokerage implementation that allows manual control over the cash balance.
+/// </summary>
+internal class PaperBrokerageWithManualCashBalance : PaperBrokerage
+{
+    private decimal _cashBalance;
+
+    /// <summary>
+    /// Gets the current cash balance.
+    /// </summary>
+    public decimal CashBalance => _cashBalance;
+
+    /// <summary>
+    /// Increases the cash balance by the specified amount.
+    /// </summary>
+    /// <param name="amount">The amount to add to the cash balance.</param>
+    public void IncreaseCashBalance(decimal amount)
+    {
+        _cashBalance += amount;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ManualCashBalancePaperBrokerage"/> class
+    /// with the specified algorithm, job packet, and initial cash balance.
+    /// </summary>
+    /// <param name="algorithm">The algorithm instance.</param>
+    /// <param name="job">The live node job packet.</param>
+    /// <param name="initialCashBalance">The initial cash balance.</param>
+    public PaperBrokerageWithManualCashBalance(IAlgorithm algorithm, LiveNodePacket job, decimal initialCashBalance) : base(algorithm, job)
+    {
+        _cashBalance = initialCashBalance;
+    }
+
+    /// <summary>
+    /// Reduces the cash balance by the specified amount.
+    /// </summary>
+    /// <param name="amount">The amount to subtract from the cash balance.</param>
+    public void DecreaseCashBalance(decimal amount)
+    {
+        _cashBalance -= amount;
+    }
+
+    /// <summary>
+    /// Gets the current cash balances held in the account.
+    /// </summary>
+    /// <returns>A list containing the current cash balance in USD.</returns>
+    public override List<CashAmount> GetCashBalance()
+    {
+        return [new CashAmount(_cashBalance, Currencies.USD)];
+    }
+}

--- a/Tests/Brokerages/Paper/PaperBrokerageTests.cs
+++ b/Tests/Brokerages/Paper/PaperBrokerageTests.cs
@@ -229,7 +229,10 @@ namespace QuantConnect.Tests.Brokerages.Paper
 
             // Brokerage UnsettledCash + Lean UnsettledCash
             Assert.Greater(algorithm.Portfolio.TotalPortfolioValue, initialCashBalance);
-            Assert.AreEqual(algorithm.Portfolio.TotalPortfolioValue, initialCashBalance + Math.Abs(sellQuantity) * security.Price);
+            var orderRequestMarginRemaining = algorithm.Portfolio.TotalMarginUsed * 2 + algorithm.Portfolio.MarginRemaining;
+            var wrongGuessTotalPortfolioValue = initialCashBalance + Math.Abs(sellQuantity) * security.Price;
+            Assert.AreEqual(wrongGuessTotalPortfolioValue, orderRequestMarginRemaining);
+            Assert.AreEqual(algorithm.Portfolio.TotalPortfolioValue, orderRequestMarginRemaining);
         }
 
         class NullSynchronizer : ISynchronizer


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
When users sell securities, the proceeds are initially moved into unsettled cash (following T+1 settlement rules, etc.). Lean periodically calls PerformCashSync() to update user balances from the brokerage. However, there is a timing mismatch:
- The brokerage marks cash as settled before Lean performs its cash synchronization.
- As a result, Lean incorrectly shows extra cash because it hasn't yet processed the actual cash settlement update.

#### Solution
This PR adjusts the handling of cash settlement timing in Lean:
- Lean calls `Brokerage.PerformCashSync()` daily at approximately `11:45:00.0557560Z (UTC)`, which is **6:45 AM New York time**.
- Previously, Lean settled cash using a default settlement time that occurred after the brokerage's balance update.
- With this fix, we update `DefaultSettlementTime` to **6:00 AM New York time**, ensuring that unsettled cash in Lean is settled _before_ we sync with the brokerage.

This change ensures Lean’s view of settled cash is aligned with the brokerage data at the time of synchronization.

#### Additional info
When Interactive brokerage settled cash to user account:
![image](https://github.com/user-attachments/assets/149a4f61-5be2-43b1-b17e-63e9fbc03bcf)

Log of incorrect calculations in Charles Schwab.
![CS_Margin](https://github.com/user-attachments/assets/e7e0b28d-3ad3-46f7-98b8-c3fade67ca3b)

#### Related PRs
- https://github.com/QuantConnect/Lean/pull/8657

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fix ensures that users' cash balances in Lean correctly match their brokerage accounts at all times, avoiding misleading extra cash availability.
It improves accuracy, reduces confusion for users, and aligns Lean’s behavior more closely with real-world brokerage operations.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/a

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Specific TestCase with PaperBrokerage.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
