### PR TITLE
Feature: support `MOO` in `CharlesSchwabBrokerageModel`

### DIFF
--- a/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
+++ b/Algorithm.CSharp/OrderTicketDemoAlgorithm.cs
@@ -473,7 +473,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// </summary>
         private void MarketOnOpenOrders()
         {
-            if (TimeIs(8, 12 + 2, 0))
+            if (TimeIs(8, 14 + 2, 0))
             {
                 Log("Submitting MarketOnOpenOrder");
 
@@ -651,30 +651,30 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "12"},
             {"Average Win", "0%"},
             {"Average Loss", "-0.01%"},
-            {"Compounding Annual Return", "77.184%"},
+            {"Compounding Annual Return", "73.899%"},
             {"Drawdown", "0.100%"},
             {"Expectancy", "-1"},
             {"Start Equity", "100000"},
-            {"End Equity", "100734.03"},
-            {"Net Profit", "0.734%"},
-            {"Sharpe Ratio", "12.597"},
-            {"Sortino Ratio", "464.862"},
-            {"Probabilistic Sharpe Ratio", "99.521%"},
+            {"End Equity", "100709.93"},
+            {"Net Profit", "0.710%"},
+            {"Sharpe Ratio", "12.469"},
+            {"Sortino Ratio", "429.347"},
+            {"Probabilistic Sharpe Ratio", "99.495%"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "0.2"},
-            {"Beta", "0.195"},
-            {"Annual Standard Deviation", "0.047"},
+            {"Alpha", "0.188"},
+            {"Beta", "0.189"},
+            {"Annual Standard Deviation", "0.045"},
             {"Annual Variance", "0.002"},
-            {"Information Ratio", "-7.724"},
-            {"Tracking Error", "0.18"},
-            {"Treynor Ratio", "3.002"},
+            {"Information Ratio", "-7.802"},
+            {"Tracking Error", "0.181"},
+            {"Treynor Ratio", "2.971"},
             {"Total Fees", "$9.00"},
-            {"Estimated Strategy Capacity", "$49000000.00"},
+            {"Estimated Strategy Capacity", "$50000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
-            {"Portfolio Turnover", "7.18%"},
-            {"OrderListHash", "d4518e5689a107e5843022b4dd990fda"}
+            {"Portfolio Turnover", "7.01%"},
+            {"OrderListHash", "236df5da8408fdd11445a88425ea9ab7"}
         };
     }
 }

--- a/Algorithm.Python/OrderTicketDemoAlgorithm.py
+++ b/Algorithm.Python/OrderTicketDemoAlgorithm.py
@@ -359,7 +359,7 @@ class OrderTicketDemoAlgorithm(QCAlgorithm):
         '''MarketOnOpenOrders are always executed at the next
         market's opening price. The only properties that can
         be updated are the quantity and order tag properties.'''
-        if self.time_is(8, 12 + 2, 0):
+        if self.time_is(8, 14 + 2, 0):
             self.log("Submitting MarketOnOpenOrder")
 
             # its EOD, let's submit a market on open order to short even more!

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -1144,6 +1144,11 @@ namespace QuantConnect.Algorithm
                 {
                     throw new InvalidOperationException($"Market never closes for this symbol {security.Symbol}, can no submit a {nameof(OrderType.MarketOnOpen)} order.");
                 }
+
+                if (security.Exchange.Hours.IsOpen(security.LocalTime, false))
+                {
+                    return OrderResponse.Error(request, OrderResponseErrorCode.MarketOnOpenNotAllowedDuringRegularHours, $"Cannot submit a {nameof(OrderType.MarketOnOpen)} order while the market is open.");
+                }
             }
             else if (request.OrderType == OrderType.MarketOnClose)
             {

--- a/Common/Brokerages/CharlesSchwabBrokerageModel.cs
+++ b/Common/Brokerages/CharlesSchwabBrokerageModel.cs
@@ -48,7 +48,8 @@ namespace QuantConnect.Brokerages
                 OrderType.StopMarket,
                 OrderType.ComboMarket,
                 OrderType.ComboLimit,
-                OrderType.MarketOnClose
+                OrderType.MarketOnClose,
+                OrderType.MarketOnOpen
             });
 
         /// <summary>

--- a/Common/Orders/OrderResponseErrorCode.cs
+++ b/Common/Orders/OrderResponseErrorCode.cs
@@ -193,6 +193,12 @@ namespace QuantConnect.Orders
         /// <summary>
         /// Option order is invalid due to underlying stock split (-34)
         /// </summary>
-        OptionOrderOnStockSplit = -34
+        OptionOrderOnStockSplit = -34,
+
+        /// <summary>
+        /// The Market On Open order was submitted during regular market hours, 
+        /// which is not allowed. This order type must be submitted before the market opens.
+        /// </summary>
+        MarketOnOpenNotAllowedDuringRegularHours = -35
     }
 }

--- a/Tests/Algorithm/CashModelAlgorithmTradingTests.cs
+++ b/Tests/Algorithm/CashModelAlgorithmTradingTests.cs
@@ -678,6 +678,7 @@ namespace QuantConnect.Tests.Algorithm
             }
             else
             {
+                algo.SetDateTime(new DateTime(2025, 04, 26, 18, 30, 0).ConvertToUtc(algo.TimeZone));
                 algo.MarketOnOpenOrder(symbol, 1);
                 algo.MarketOnOpenOrder(symbol, 1.0);
                 algo.MarketOnOpenOrder(symbol, 1.0m);

--- a/Tests/Common/Orders/OrderTicketTests.cs
+++ b/Tests/Common/Orders/OrderTicketTests.cs
@@ -16,6 +16,7 @@
 using System;
 using NUnit.Framework;
 using QuantConnect.Orders;
+using QuantConnect.Data.Market;
 using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Common.Orders
@@ -100,6 +101,50 @@ namespace QuantConnect.Tests.Common.Orders
             Assert.AreEqual(1000, ticket.SubmitRequest.Quantity);
             Assert.AreEqual("Pepe", ticket.SubmitRequest.Tag);
             Assert.AreEqual("This operation is not allowed in Initialize or during warm up: OrderRequest.Submit. Please move this code to the OnWarmupFinished() method.", ticket.SubmitRequest.Response.ErrorMessage);
+        }
+
+        [TestCase(8, 0, true, Description = "8 AM - valid submission")]
+        [TestCase(12, 0, false, Description = "12 PM - invalid submission")]
+        [TestCase(15, 30, false, Description = "3:30 PM - invalid submission")]
+        [TestCase(15, 59, false, Description = "15:59 PM - invalid submission")]
+        [TestCase(17, 0, true, Description = "5 PM - valid submission")]
+        [TestCase(21, 0, true, Description = "9 PM - valid submission")]
+        public void MarketOnOpenOrderSubmissionRespectsAllowedTimeRange(int hourOfDay, int minuteOfDay, bool shouldBeValid)
+        {
+            var symbol = Symbols.SPY;
+            var algorithm = new AlgorithmStub();
+            algorithm.SetStartDate(2025, 04, 30);
+
+            var security = algorithm.AddSecurity(symbol.ID.SecurityType, symbol.ID.Symbol);
+            algorithm.SetFinishedWarmingUp();
+            security.Update([new Tick(algorithm.Time, symbol, string.Empty, string.Empty, 10m, 550m)], typeof(TradeBar));
+
+            // Set algorithm time to the given hour
+            var targetTime = algorithm.Time.Date.AddHours(hourOfDay).AddMinutes(minuteOfDay);
+            algorithm.SetDateTime(targetTime.ConvertToUtc(algorithm.TimeZone));
+
+            var order = new MarketOnOpenOrder(security.Symbol, 1, DateTime.UtcNow);
+
+            var request = algorithm.SubmitOrderRequest(new SubmitOrderRequest(
+                order.Type,
+                security.Type,
+                security.Symbol,
+                order.Quantity,
+                0m,
+                0m,
+                order.Time,
+                string.Empty));
+
+            if (shouldBeValid)
+            {
+                Assert.AreEqual(OrderStatus.New, request.Status, $"Expected order at {hourOfDay}:00 to be valid.");
+                Assert.AreEqual(1, request.OrderId);
+            }
+            else
+            {
+                Assert.AreEqual(OrderStatus.Invalid, request.Status, $"Expected order at {hourOfDay}:00 to be invalid.");
+                Assert.AreEqual(-10, request.OrderId);
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
The PR ensures validation that restricts the ability to place MOO orders in **regular market hours**.
|        Broker       	| MOO Order Allowed After 	|                                                                      Notes                                                                      	|
|:-------------------:	|:-----------------------:	|:-----------------------------------------------------------------------------------------------------------------------------------------------:	|
| Interactive Brokers 	| 4:00 PM (ET)            	| Standard support after market close.                                                                                                            	|
|      Charles Schwab 	| 4:00 PM (ET)            	| Matches post-close MOO submission timing.                                                                                                       	|
|        TradeStation 	| 8:00 AM – 9:29 AM (ET)  	| [source](sohttps://help.tradestation.com/09_01/tradestationhelp/routes/auto.htm#:~:text=OPG%20(At%20the%20Opening),after%209%3A29%20A.M.%20ET.) 	|
|        TerminalLink 	| ❓ TBD                   	| Timing for MOO support still to be confirmed.                                                                                                   	|
|              Alpaca 	| 7:00 PM (ET)            	| MOO orders accepted after market close.                                                                                                         	|
> Nasdaq MOO (and LOO) orders must be submitted prior to 09:28 ET.

![1](https://github.com/user-attachments/assets/1a980492-cc5f-4eef-896a-f766ff6b94df)


#### Related PRs
- https://github.com/QuantConnect/Lean.Brokerages.CharlesSchwab/pull/48

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/QuantConnect/Lean.Brokerages.CharlesSchwab/issues/46

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I help users use `MOO` `orderType` more intuitively.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/a

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Test that MOO doesn't support during regular market hours.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
