### PR TITLE
Ensure Indicator.Current retains the Symbol from the latest input data

### DIFF
--- a/Indicators/IndicatorBase.cs
+++ b/Indicators/IndicatorBase.cs
@@ -273,7 +273,7 @@ namespace QuantConnect.Indicators
                 {
                     if (typeof(T) == typeof(IndicatorDataPoint))
                     {
-                        input = new IndicatorDataPoint(input.EndTime, input.Value);
+                        input = new IndicatorDataPoint(input.Symbol, input.EndTime, input.Value);
                     }
                     else
                     {
@@ -285,7 +285,7 @@ namespace QuantConnect.Indicators
                 var nextResult = ValidateAndComputeNextValue((T)input);
                 if (nextResult.Status == IndicatorStatus.Success)
                 {
-                    Current = new IndicatorDataPoint(input.EndTime, nextResult.Value);
+                    Current = new IndicatorDataPoint(input.Symbol, input.EndTime, nextResult.Value);
 
                     // let others know we've produced a new data point
                     OnUpdated(Current);

--- a/Tests/Indicators/AdvanceDeclineDifferenceTests.cs
+++ b/Tests/Indicators/AdvanceDeclineDifferenceTests.cs
@@ -272,6 +272,29 @@ namespace QuantConnect.Tests.Indicators
             }
         }
 
+        [Test]
+        public override void IndicatorShouldHaveSymbolAfterUpdates()
+        {
+            var indicator = CreateIndicator();
+            var reference = System.DateTime.Today;
+
+            for (int i = 0; i < 10; i++)
+            {
+                indicator.Update(new TradeBar() { Symbol = Symbols.AAPL, Close = 1, Volume = 1, Time = reference.AddMinutes(1) });
+                indicator.Update(new TradeBar() { Symbol = Symbols.IBM, Close = 1, Volume = 1, Time = reference.AddMinutes(1) });
+                indicator.Update(new TradeBar() { Symbol = Symbols.GOOG, Close = 1, Volume = 1, Time = reference.AddMinutes(1) });
+
+                // indicator is not ready yet
+                indicator.Update(new TradeBar() { Symbol = Symbols.AAPL, Close = 2, Volume = 1, Time = reference.AddMinutes(2) });
+                indicator.Update(new TradeBar() { Symbol = Symbols.IBM, Close = 0.5m, Volume = 1, Time = reference.AddMinutes(2) });
+                indicator.Update(new TradeBar() { Symbol = Symbols.GOOG, Close = 3, Volume = 1, Time = reference.AddMinutes(2) });
+
+                // indicator is ready
+                // The last update used Symbol.GOOG, so the indicator's current Symbol should be GOOG
+                Assert.AreEqual(Symbols.GOOG, indicator.Current.Symbol);
+            }
+        }
+
         protected override string TestFileName => "arms_data.txt";
 
         protected override string TestColumnName => "A/D Difference";

--- a/Tests/Indicators/AlphaIndicatorTests.cs
+++ b/Tests/Indicators/AlphaIndicatorTests.cs
@@ -429,5 +429,25 @@ namespace QuantConnect.Tests.Indicators
                 previousValue = indicator.Current.Value;
             }
         }
+
+        [Test]
+        public override void IndicatorShouldHaveSymbolAfterUpdates()
+        {
+            var period = 5;
+            var indicator = new Beta(Symbols.AAPL, Symbols.SPX, period);
+
+            for (var i = 0; i < 2 * period; i++)
+            {
+                var startTime = _reference.AddDays(1 + i);
+                var endTime = startTime.AddDays(1);
+                // Update with the first symbol (AAPL) — indicator.Current.Symbol should reflect this update
+                indicator.Update(new TradeBar() { Symbol = Symbols.AAPL, Low = 1, High = 2, Volume = 100, Close = 1000 + i * 10, Time = startTime, EndTime = endTime });
+                Assert.AreEqual(Symbols.AAPL, indicator.Current.Symbol);
+
+                // Update with the second symbol (SPX) — indicator.Current.Symbol should now be SPX
+                indicator.Update(new TradeBar() { Symbol = Symbols.SPX, Low = 1, High = 2, Volume = 100, Close = 1000 + (i * 15), Time = startTime, EndTime = endTime });
+                Assert.AreEqual(Symbols.SPX, indicator.Current.Symbol);
+            }
+        }
     }
 }

--- a/Tests/Indicators/BetaIndicatorTests.cs
+++ b/Tests/Indicators/BetaIndicatorTests.cs
@@ -292,5 +292,25 @@ namespace QuantConnect.Tests.Indicators
                 previousValue = indicator.Current.Value;
             }
         }
+
+        [Test]
+        public override void IndicatorShouldHaveSymbolAfterUpdates()
+        {
+            var period = 5;
+            var indicator = new Beta(Symbols.SPY, Symbols.AAPL, period);
+
+            for (var i = 0; i < 2 * period; i++)
+            {
+                var startTime = _reference.AddDays(1 + i);
+                var endTime = startTime.AddDays(1);
+                // Update with the first symbol (SPY) — indicator.Current.Symbol should reflect this update
+                indicator.Update(new TradeBar() { Symbol = Symbols.SPY, Low = 1, High = 2, Volume = 100, Close = 1000 + i * 10, Time = startTime, EndTime = endTime });
+                Assert.AreEqual(Symbols.SPY, indicator.Current.Symbol);
+
+                // Update with the first symbol (AAPL) — indicator.Current.Symbol should reflect this update
+                indicator.Update(new TradeBar() { Symbol = Symbols.AAPL, Low = 1, High = 2, Volume = 100, Close = 1000 + (i * 15), Time = startTime, EndTime = endTime });
+                Assert.AreEqual(Symbols.AAPL, indicator.Current.Symbol);
+            }
+        }
     }
 }

--- a/Tests/Indicators/CommonIndicatorTests.cs
+++ b/Tests/Indicators/CommonIndicatorTests.cs
@@ -243,6 +243,24 @@ namespace QuantConnect.Tests.Indicators
             }
         }
 
+        [Test]
+        public virtual void IndicatorShouldHaveSymbolAfterUpdates()
+        {
+            var indicator = CreateIndicator();
+            var period = (indicator as IIndicatorWarmUpPeriodProvider)?.WarmUpPeriod;
+
+            var startDate = new DateTime(2024, 1, 1);
+
+            for (var i = 0; i < 2 * period; i++)
+            {
+                // Feed input data to the indicator, each input uses Symbol.SPY
+                indicator.Update(GetInput(startDate, i));
+
+                // The indicator should retain the symbol from the input (SPY)
+                Assert.AreEqual(Symbols.SPY, indicator.Current.Symbol);
+            }
+        }
+
         protected virtual void IndicatorValueIsNotZeroAfterReceiveRenkoBars(IndicatorBase indicator)
         {
             Assert.AreNotEqual(0, indicator.Current.Value);

--- a/Tests/Indicators/IndicatorTests.cs
+++ b/Tests/Indicators/IndicatorTests.cs
@@ -332,6 +332,15 @@ namespace QuantConnect.Tests.Indicators
             Assert.AreEqual(defaultValue, indicator.Previous);
         }
 
+        [Test]
+        public void IndicatorShouldRetainSymbolWhenUpdatedWithDifferentDataType()
+        {
+            var target = new TestIndicator();
+            var date = new DateTime(2020, 1, 1);
+            target.Update(new Tick(date, Symbols.SPY, 1, 1));
+            Assert.AreEqual(Symbols.SPY, target.Current.Symbol);
+        }
+
         private static void TestComparisonOperators<TValue>()
         {
             var indicator = new TestIndicator();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
This PR updates the Indicator behavior so that its Current value now tracks the Symbol of the most recently received input data.

#### Related Issue
Closes #8743

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was testest using unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
