### PR TITLE
Add support for negative indexing in RollingWindow

### DIFF
--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -150,7 +150,7 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="i">the index, i</param>
         /// <returns>the ith most recent entry</returns>
-        public T this [int i]
+        public T this[int i]
         {
             get
             {
@@ -160,7 +160,11 @@ namespace QuantConnect.Indicators
 
                     if (i < 0)
                     {
-                        throw new ArgumentOutOfRangeException(nameof(i), i, Messages.RollingWindow.IndexOutOfSizeRange);
+                        if (_size + i < 0)
+                        {
+                            throw new ArgumentOutOfRangeException(nameof(i), i, Messages.RollingWindow.IndexOutOfSizeRange);
+                        }
+                        i = _size + i;
                     }
 
                     if (i > _list.Count - 1)
@@ -190,7 +194,11 @@ namespace QuantConnect.Indicators
 
                     if (i < 0)
                     {
-                        throw new ArgumentOutOfRangeException(nameof(i), i, Messages.RollingWindow.IndexOutOfSizeRange);
+                        if (_size + i < 0)
+                        {
+                            throw new ArgumentOutOfRangeException(nameof(i), i, Messages.RollingWindow.IndexOutOfSizeRange);
+                        }
+                        i = _size + i;
                     }
 
                     if (i > _list.Count - 1)
@@ -258,7 +266,7 @@ namespace QuantConnect.Indicators
                     temp[i] = _list[GetListIndex(i, count, _tail)];
                 }
 
-                return ((IEnumerable<T>) temp).GetEnumerator();
+                return ((IEnumerable<T>)temp).GetEnumerator();
             }
             finally
             {

--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -160,7 +160,11 @@ namespace QuantConnect.Indicators
 
                     if (i < 0)
                     {
-                        i = (_size + i < 0) ? ~i : _size + i;
+                        if (_size + i < 0)
+                        {
+                            throw new ArgumentOutOfRangeException(nameof(i), i, Messages.RollingWindow.IndexOutOfSizeRange);
+                        }
+                        i = _size + i;
                     }
 
                     if (i > _list.Count - 1)
@@ -190,7 +194,11 @@ namespace QuantConnect.Indicators
 
                     if (i < 0)
                     {
-                        i = (_size + i < 0) ? ~i : _size + i;
+                        if (_size + i < 0)
+                        {
+                            throw new ArgumentOutOfRangeException(nameof(i), i, Messages.RollingWindow.IndexOutOfSizeRange);
+                        }
+                        i = _size + i;
                     }
 
                     if (i > _list.Count - 1)

--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -160,11 +160,7 @@ namespace QuantConnect.Indicators
 
                     if (i < 0)
                     {
-                        if (_size + i < 0)
-                        {
-                            throw new ArgumentOutOfRangeException(nameof(i), i, Messages.RollingWindow.IndexOutOfSizeRange);
-                        }
-                        i = _size + i;
+                        i = (_size + i < 0) ? ~i : _size + i;
                     }
 
                     if (i > _list.Count - 1)
@@ -194,11 +190,7 @@ namespace QuantConnect.Indicators
 
                     if (i < 0)
                     {
-                        if (_size + i < 0)
-                        {
-                            throw new ArgumentOutOfRangeException(nameof(i), i, Messages.RollingWindow.IndexOutOfSizeRange);
-                        }
-                        i = _size + i;
+                        i = (_size + i < 0) ? ~i : _size + i;
                     }
 
                     if (i > _list.Count - 1)

--- a/Tests/Indicators/RollingWindowTests.cs
+++ b/Tests/Indicators/RollingWindowTests.cs
@@ -179,12 +179,12 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
-        public void ThrowsWhenIndexIsNegative()
+        public void DoesNotThrowWhenIndexIsNegative()
         {
             var window = new RollingWindow<int>(1);
             Assert.IsFalse(window.IsReady);
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => { var x = window[-1]; });
+            Assert.DoesNotThrow(() => { var x = window[-1]; });
         }
 
         [Test]
@@ -376,18 +376,19 @@ namespace QuantConnect.Tests.Indicators
             Assert.AreEqual(window[window.Count - 1], window[-1]);
 
             // Verify full reverse access using negative indices
-            Assert.AreEqual(7, window[-1]);
-            Assert.AreEqual(-2, window[-2]);
-            Assert.AreEqual(5, window[-3]);
-            Assert.AreEqual(1, window[-4]);
-            Assert.AreEqual(4, window[-5]);
+            for (int i = 0; i < window.Count; i++)
+            {
+                Assert.AreEqual(window[window.Count - 1 - i], window[~i]);
+            }
 
-            // Verify that accessing out-of-bounds negative index throws
-            Assert.Throws<ArgumentOutOfRangeException>(() => { var x = window[-6]; });
-
-            // Overwrite the most recent value using a positive index
-            window[window.Count - 1] = -100;
-            Assert.AreEqual(-100, window[-1]);
+            // Create 5 new values by assigning beyond the current range and update the oldest value
+            window[-(window.Count + 5)] = 10;
+            Assert.AreEqual(window[-1], 10);
+            for (int i = 0; i < 5; i++)
+            {
+                Assert.AreEqual(0, window[i]);
+            }
+            Assert.AreEqual(10, window.Count);
 
             // Overwrite all values using negative indices
             for (int i = 1; i <= window.Count; i++)
@@ -396,11 +397,10 @@ namespace QuantConnect.Tests.Indicators
             }
 
             // Verify final state of the window after overwrite
-            Assert.AreEqual(1, window[-1]);
-            Assert.AreEqual(2, window[-2]);
-            Assert.AreEqual(3, window[-3]);
-            Assert.AreEqual(4, window[-4]);
-            Assert.AreEqual(5, window[-5]);
+            for (int i = 0; i < window.Count; i++)
+            {
+                Assert.AreEqual(window[window.Count - 1 - i], window[~i]);
+            }
         }
     }
 }

--- a/Tests/Indicators/RollingWindowTests.cs
+++ b/Tests/Indicators/RollingWindowTests.cs
@@ -359,6 +359,14 @@ namespace QuantConnect.Tests.Indicators
         public void RollingWindowSupportsNegativeIndices()
         {
             var window = new RollingWindow<int>(5);
+
+            // At initialization, all values should be 0, whether accessed with positive or negative indices.
+            for (int i = 0; i < window.Size; i++)
+            {
+                Assert.AreEqual(0, window[0]);
+                Assert.AreEqual(0, window[~i]);
+            }
+
             // Add two elements and test negative indexing before window is full
             window.Add(7);
             window.Add(-2);
@@ -381,15 +389,6 @@ namespace QuantConnect.Tests.Indicators
                 Assert.AreEqual(window[window.Count - 1 - i], window[~i]);
             }
 
-            // Create 5 new values by assigning beyond the current range and update the oldest value
-            window[-(window.Count + 5)] = 10;
-            Assert.AreEqual(window[-1], 10);
-            for (int i = 0; i < 5; i++)
-            {
-                Assert.AreEqual(0, window[i]);
-            }
-            Assert.AreEqual(10, window.Count);
-
             // Overwrite all values using negative indices
             for (int i = 1; i <= window.Count; i++)
             {
@@ -400,6 +399,73 @@ namespace QuantConnect.Tests.Indicators
             for (int i = 0; i < window.Count; i++)
             {
                 Assert.AreEqual(window[window.Count - 1 - i], window[~i]);
+            }
+        }
+
+        [Test]
+        public void NegativeIndexThrowsWhenExceedingWindowSize()
+        {
+            var window = new RollingWindow<int>(3);
+
+            // Fill window completely
+            window.Add(10);
+            window.Add(20);
+            window.Add(30);
+
+            // Valid negative indices
+            Assert.AreEqual(10, window[-1]);
+            Assert.AreEqual(20, window[-2]);
+            Assert.AreEqual(30, window[-3]);
+
+            // Invalid negative indices (exceeding window size)
+            Assert.Throws<ArgumentOutOfRangeException>(() => { var x = window[-4]; });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { var x = window[-5]; });
+        }
+
+        [Test]
+        public void SetterThrowsForInvalidNegativeIndices()
+        {
+            var window = new RollingWindow<int>(2);
+            window.Add(1);
+            window.Add(2);
+
+            // Valid sets
+            window[-1] = 20;
+            window[-2] = 10;
+
+            // Verify valid changes were made
+            Assert.AreEqual(10, window[0]);
+            Assert.AreEqual(20, window[1]);
+
+            // Invalid sets
+            Assert.Throws<ArgumentOutOfRangeException>(() => window[-3] = 30);
+            Assert.Throws<ArgumentOutOfRangeException>(() => window[-4] = 40);
+        }
+
+        [Test]
+        public void MixedPositiveAndNegativeIndexBehavior()
+        {
+            var window = new RollingWindow<int>(4);
+
+            // Fill window with test data
+            for (int i = 1; i <= 4; i++)
+            {
+                window.Add(i * 10);
+            }
+
+            // Test all valid positions
+            for (int i = 0; i < 4; i++)
+            {
+                var positiveIndexValue = window[i];
+                var negativeIndexValue = window[-(4 - i)];
+                Assert.AreEqual(positiveIndexValue, negativeIndexValue);
+            }
+
+            // Test invalid positions
+            var testCases = new[] { -5, -10, int.MinValue };
+            foreach (var index in testCases)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => { var x = window[index]; });
             }
         }
     }

--- a/Tests/Indicators/RollingWindowTests.cs
+++ b/Tests/Indicators/RollingWindowTests.cs
@@ -354,5 +354,53 @@ namespace QuantConnect.Tests.Indicators
             Assert.AreEqual(dataCount, window.Count);
             CollectionAssert.AreEqual(values.Take(smallerSize), window);
         }
+
+        [Test]
+        public void RollingWindowSupportsNegativeIndices()
+        {
+            var window = new RollingWindow<int>(5);
+            // Add two elements and test negative indexing before window is full
+            window.Add(7);
+            window.Add(-2);
+            Assert.AreEqual(0, window[-1]);
+            Assert.AreEqual(2, window.Count);
+            Assert.IsFalse(window.IsReady);
+
+            // Fill the window to capacity
+            window.Add(5);
+            window.Add(1);
+            window.Add(4);
+            Assert.IsTrue(window.IsReady);
+
+            // Test that -1 is the same as Count - 1
+            Assert.AreEqual(window[window.Count - 1], window[-1]);
+
+            // Verify full reverse access using negative indices
+            Assert.AreEqual(7, window[-1]);
+            Assert.AreEqual(-2, window[-2]);
+            Assert.AreEqual(5, window[-3]);
+            Assert.AreEqual(1, window[-4]);
+            Assert.AreEqual(4, window[-5]);
+
+            // Verify that accessing out-of-bounds negative index throws
+            Assert.Throws<ArgumentOutOfRangeException>(() => { var x = window[-6]; });
+
+            // Overwrite the most recent value using a positive index
+            window[window.Count - 1] = -100;
+            Assert.AreEqual(-100, window[-1]);
+
+            // Overwrite all values using negative indices
+            for (int i = 1; i <= window.Count; i++)
+            {
+                window[-i] = i;
+            }
+
+            // Verify final state of the window after overwrite
+            Assert.AreEqual(1, window[-1]);
+            Assert.AreEqual(2, window[-2]);
+            Assert.AreEqual(3, window[-3]);
+            Assert.AreEqual(4, window[-4]);
+            Assert.AreEqual(5, window[-5]);
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Adds support for negative indexing in RollingWindow<T>, allowing access to elements from the end.

#### Related Issue
Closes #8742

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit test.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
