### PR TITLE
Review Collective2 Implemention

### DIFF
--- a/Common/Algorithm/Framework/Portfolio/SignalExports/Collective2SignalExport.cs
+++ b/Common/Algorithm/Framework/Portfolio/SignalExports/Collective2SignalExport.cs
@@ -58,6 +58,22 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
         private IAlgorithm _algorithm;
 
         /// <summary>
+        /// C2 accepts only standard minilots (10,000 currency units).
+        /// The smallest quantity C2 trades is "1" which is a mini-lot. 
+        /// Thus, the smallest trade a strategy manager can type into C2 is, for example,
+        /// MarketOrder("EURUSD", 1m)
+        /// which will trade 10,000 Euros.
+        /// No fractions nor numbers smaller than 1 are accepted by C2.
+        /// https://support.collective2.com/hc/en-us/articles/360038042774-Forex-minilots
+        /// </summary>
+        private const int _forexMinilots = 10000;
+
+        /// <summary>
+        /// Flag to track if the minilot warning has already been printed.
+        /// </summary>
+        private bool _isForexMinilotsWarningPrinted;
+
+        /// <summary>
         /// Flag to track if the warning has already been printed.
         /// </summary>
         private bool _isZeroPriceWarningPrinted;
@@ -87,7 +103,6 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
         /// </summary>
         private static Lazy<RateGate> _dailyRateLimiter = new Lazy<RateGate>(() => new RateGate(20000, TimeSpan.FromDays(1)));
 
-
         /// <summary>
         /// Collective2SignalExport constructor. It obtains the entry information for Collective2 API requests.
         /// See API documentation at https://trade.collective2.com/c2-api
@@ -101,6 +116,9 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
             _unknownSecurityTypes = new HashSet<SecurityType>();
             _apiKey = apiKey;
             _systemId = systemId;
+
+            // SetDesiredPositions: The list of positions that must exist in the strategy. 
+            // https://api-docs.collective2.com/apis/general/swagger/strategies/c2_api_strategies/setdesiredpositions_post#strategies/c2_api_strategies/setdesiredpositions_post/t=request&path=positions
             Destination = new Uri(useWhiteLabelApi
                 ? "https://api4-wl.collective2.com/Strategies/SetDesiredPositions"
                 : "https://api4-general.collective2.com/Strategies/SetDesiredPositions");
@@ -165,20 +183,26 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
                     continue;
                 }
 
-                positions.Add(new Collective2Position
+                var exchangeSymbol = new C2ExchangeSymbol
                 {
-                    ExchangeSymbol = new C2ExchangeSymbol
-                    {
-                        Symbol = GetSymbol(target.Symbol),
-                        Currency = parameters.Algorithm.AccountCurrency,
-                        SecurityExchange = GetMICExchangeCode(target.Symbol),
-                        SecurityType = securityType,
-                        MaturityMonthYear = maturityMonthYear,
-                        PutOrCall = GetPutOrCallValue(target.Symbol),
-                        StrikePrice = GetStrikePrice(target.Symbol)
-                    },
-                    Quantity = ConvertPercentageToQuantity(_algorithm, target),
-                });
+                    Symbol = GetSymbol(target.Symbol),
+                    Currency = GetCurrency(_algorithm, target.Symbol),
+                    SecurityExchange = GetMICExchangeCode(target.Symbol),
+                    SecurityType = securityType,
+                    MaturityMonthYear = maturityMonthYear,
+                    PutOrCall = GetPutOrCallValue(target.Symbol),
+                    StrikePrice = GetStrikePrice(target.Symbol)
+                };
+
+                // Quantity must be non-zero.
+                // To close a position, simply omit it from the Positions array.
+                var quantity = ConvertPercentageToQuantity(_algorithm, target);
+                if (quantity == 0)
+                {
+                    continue;
+                }
+
+                positions.Add(new() { ExchangeSymbol = exchangeSymbol, Quantity = quantity });
             }
 
             return true;
@@ -192,10 +216,11 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
         /// <returns>Number of shares hold of the given position</returns>
         protected int ConvertPercentageToQuantity(IAlgorithm algorithm, PortfolioTarget target)
         {
+            var securityExists = algorithm.Securities.TryGetValue(target.Symbol, out var security);
             var numberShares = PortfolioTarget.Percent(algorithm, target.Symbol, target.Quantity);
             if (numberShares == null)
             {
-                if (algorithm.Securities.TryGetValue(target.Symbol, out var security) && security.Price == 0 && target.Quantity == 0)
+                if (securityExists && security.Price == 0 && target.Quantity == 0)
                 {
                     if (!_isZeroPriceWarningPrinted)
                     {
@@ -207,7 +232,19 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
                 throw new InvalidOperationException($"Collective2 failed to calculate target quantity for {target}");
             }
 
-            return (int)numberShares.Quantity;
+            var quantity = (int)numberShares.Quantity;
+
+            if (securityExists && security.Type == SecurityType.Forex)
+            {
+                quantity /= _forexMinilots;
+                if (!_isForexMinilotsWarningPrinted && quantity == 0)
+                {
+                    _isForexMinilotsWarningPrinted = true;
+                    algorithm.Debug($"Warning: Collective2 failed to calculate target quantity for {target}. The smallest quantity C2 trades is \"1\" which is a mini-lot (10,000 currency units), and the target quantity is {numberShares.Quantity}. Will return 0 for all similar cases.");
+                }
+            }
+
+            return quantity;
         }
 
         /// <summary>
@@ -223,7 +260,8 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
                 Positions = positions,
             };
 
-            var jsonMessage = JsonConvert.SerializeObject(payload);
+            var settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
+            var jsonMessage = JsonConvert.SerializeObject(payload, settings);
             return jsonMessage;
         }
 
@@ -324,6 +362,14 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
             {
                 return symbol.ID.Symbol;
             }
+        }
+
+        /// <summary>
+        /// Returns the Symbol currency. USD for Forex.
+        /// </summary>
+        private string GetCurrency(IAlgorithm algorithm, Symbol symbol)
+        {
+            return symbol.ID.SecurityType == SecurityType.Forex ? "USD" : algorithm.Securities[symbol].QuoteCurrency.Symbol;
         }
 
         private string GetMICExchangeCode(Symbol symbol)
@@ -566,12 +612,6 @@ namespace QuantConnect.Algorithm.Framework.Portfolio.SignalExports
             /// </summary>
             [JsonProperty(PropertyName = "strikePrice")]
             public decimal? StrikePrice { get; set; }
-
-            /// <summary>
-            /// The multiplier to apply to the Exchange price to get the C2-formatted price. Default is 1
-            /// </summary>
-            [JsonProperty(PropertyName = "priceMultiplier")]
-            public decimal PriceMultiplier { get; set; } = 1;
         }
     }
 }


### PR DESCRIPTION
#### Description
According to `SetDesiredPositions` [API](https://api-docs.collective2.com/apis/general/swagger/strategies/c2_api_strategies/setdesiredpositions_post#strategies/c2_api_strategies/setdesiredpositions_post/t=request&path=positions), the quantity must be non-zero. To close a position, send a stop order to close the position.

The current for all assets, except FOREX, is the quote currency.
Stop sending null (e.g.: maturity for Equity) and remove `priceMultiplier`.

FOREX:
- Observe the [C2 minilot](https://support.collective2.com/hc/en-us/articles/360038042774-Forex-minilots)
- Currency is always USD

Unit tests:
- Increase the initial cash to accommodate FOREX minilot
- Additional message for minilot warning
- Fix currencies

#### Motivation and Context
Fixes C2 implementation 

#### Requires Documentation Change
Yes. We should mention the minilot for FOREX because it will surprise users.

#### How Has This Been Tested?
Unit tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`