### PR TITLE
Restrict supported order types in Bitfinex brokerage

### DIFF
--- a/Algorithm.CSharp/BitfinexSupportedOrderTypesRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/BitfinexSupportedOrderTypesRegressionAlgorithm.cs
@@ -1,0 +1,151 @@
+
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Brokerages;
+using QuantConnect.Data;
+using System.Collections.Generic;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm for testing supported order types on the Bitfinex brokerage. 
+    /// Verifies that Limit, Market, and StopMarket orders are accepted, 
+    /// and ensures that any unsupported order types, such as StopLimit and LimitIfTouched, are properly rejected.
+    /// </summary>
+    public class BitfinexSupportedOrderTypesRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _symbol;
+        private bool _hasTestedOrderTypes;
+        private List<OrderTicket> _validTickets = new List<OrderTicket>();
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 02);
+            SetEndDate(2013, 10, 03);
+            SetBrokerageModel(BrokerageName.Bitfinex, AccountType.Margin);
+            _symbol = AddCrypto("BTCUSD", Resolution.Hour).Symbol;
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (!Portfolio.Invested)
+            {
+                // Test supported order types
+                var ticket1 = LimitOrder(_symbol, 0.1m, Securities[_symbol].AskPrice);
+                var ticket2 = MarketOrder(_symbol, 0.1m);
+                var ticket3 = StopMarketOrder(_symbol, -0.1m, Securities[_symbol].BidPrice * 0.9m);
+
+                _validTickets.Add(ticket1);
+                _validTickets.Add(ticket2);
+                _validTickets.Add(ticket3);
+                if (ticket1.Status == OrderStatus.Invalid || ticket2.Status == OrderStatus.Invalid || ticket3.Status == OrderStatus.Invalid)
+                {
+                    throw new RegressionTestException("One or more supported order types were marked as invalid unexpectedly.");
+                }
+
+                // This should fail as Bitfinex doesn't support StopLimit orders
+                var ticket4 = StopLimitOrder(_symbol, -0.1m, Securities[_symbol].BidPrice * 0.9m, Securities[_symbol].BidPrice * 0.89m);
+                if (ticket4.Status != OrderStatus.Invalid)
+                {
+                    throw new RegressionTestException($"StopLimitOrder was expected to be invalid, but received status: {ticket4.Status}");
+                }
+                // This should also fail as Bitfinex doesn't support LimitIfTouched orders
+                var ticket5 = LimitIfTouchedOrder(_symbol, 0.1m, Securities[_symbol].BidPrice * 0.95m, Securities[_symbol].BidPrice * 0.96m);
+                if (ticket5.Status != OrderStatus.Invalid)
+                {
+                    throw new RegressionTestException($"LimitIfTouchedOrder was expected to be invalid, but received status: {ticket5.Status}");
+                }
+                _hasTestedOrderTypes = true;
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            foreach (var ticket in _validTickets)
+            {
+                if (ticket.Status != OrderStatus.Filled)
+                {
+                    throw new RegressionTestException($"Unexpected order status. Ticket {ticket}");
+                }
+            }
+            if (!_hasTestedOrderTypes)
+            {
+                throw new RegressionTestException("Order type tests were not executed during the algorithm run.");
+            }
+        }
+
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 126;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 28;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "5"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000.00"},
+            {"End Equity", "99995.18"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.07"},
+            {"Estimated Strategy Capacity", "$120000000.00"},
+            {"Lowest Capacity Asset", "BTCUSD E3"},
+            {"Portfolio Turnover", "0.02%"},
+            {"OrderListHash", "92d0c4f26788f4403856cb9349334a2a"}
+        };
+    }
+}

--- a/Common/Brokerages/BitfinexBrokerageModel.cs
+++ b/Common/Brokerages/BitfinexBrokerageModel.cs
@@ -104,7 +104,7 @@ namespace QuantConnect.Brokerages
             }
 
             // Check if the requested quantity is valid
-            var requestedQuantity = (decimal) request.Quantity;
+            var requestedQuantity = (decimal)request.Quantity;
             return IsValidOrderSize(security, requestedQuantity, out message);
         }
 
@@ -132,6 +132,12 @@ namespace QuantConnect.Brokerages
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
                     Messages.DefaultBrokerageModel.UnsupportedSecurityType(this, security));
 
+                return false;
+            }
+            if (order.Type != OrderType.Market && order.Type != OrderType.Limit && order.Type != OrderType.StopMarket)
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "UnsupportedOrderType",
+                    Messages.DefaultBrokerageModel.UnsupportedOrderType(this, order, [OrderType.Market, OrderType.Limit, OrderType.StopMarket]));
                 return false;
             }
             return base.CanSubmitOrder(security, order, out message);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Updated Bitfinex brokerage model to explicitly define supported order types (Market, Limit, StopMarket) and reject unsupported types with proper warning messages.

#### Related Issue
Closes #8673

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using a regression algorithm.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
