### PR TITLE
Replaced DotNetZip with DotNetZip.Original

### DIFF
--- a/Compression/QuantConnect.Compression.csproj
+++ b/Compression/QuantConnect.Compression.csproj
@@ -29,7 +29,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="DotNetZip" Version="1.16.0" />
+    <PackageReference Include="DotNetZip.Original" Version="2025.1.26" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
#### Description
Replaced no longer maintained [DotNetZip](https://github.com/DinoChiesa/DotNetZip) library which is no longer maintained and has a [Directory Traveral vulnerability with HIGH severity](https://github.com/advisories/GHSA-xhg6-9j5j-w4vf) (CVSS 8.6).

DotNetZip is replaced with [DotNetZip.Original](https://github.com/DinoChiesa/DotNetZip-2025) which is courtesy of, and maintained by, the original author of DotNetZip. 

#### Related Issue
#8795 

#### Motivation and Context
Replacing unmaintained library with a new and updated library.

#### Requires Documentation Change
No need of Documentation Change.

#### How Has This Been Tested?
I tested the changes by building the project and running all the existing tests on my local machine. The build was successful, and all current tests passed, confirming that my changes did not break existing functionality.

However, I have not yet written specific tests for the new library integration. I'm currently looking for guidance on how to write effective tests for it.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
