### PR TITLE
Avoid empty public constructor from being removed

### DIFF
--- a/Engine/DataFeeds/DataPermissionManager.cs
+++ b/Engine/DataFeeds/DataPermissionManager.cs
@@ -20,6 +20,7 @@ using QuantConnect.Util;
 using QuantConnect.Logging;
 using QuantConnect.Packets;
 using QuantConnect.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace QuantConnect.Lean.Engine.DataFeeds
 {
@@ -33,6 +34,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// </summary>
         public IDataChannelProvider DataChannelProvider { get; private set; }
 
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(DataPermissionManager))]
         public DataPermissionManager()
         {
         }


### PR DESCRIPTION
- Avoid empty public constructor from being removed, required for composer use case. In some cases starting from net8 the public constructors are being trimmed

See related https://github.com/QuantConnect/Lean/pull/8835