### PR TITLE
Add PyObject overload constructor to FilteredIdentity

### DIFF
--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -976,8 +976,7 @@ namespace QuantConnect.Algorithm
         {
             var name = CreateIndicatorName(symbol, fieldName ?? "close", resolution);
             var pyselector = PythonUtil.ToFunc<IBaseData, IBaseDataBar>(selector);
-            var pyfilter = PythonUtil.ToFunc<IBaseData, bool>(filter);
-            var filteredIdentity = new FilteredIdentity(name, pyfilter);
+            var filteredIdentity = new FilteredIdentity(name, filter);
             RegisterIndicator(symbol, filteredIdentity, resolution, pyselector);
             return filteredIdentity;
         }
@@ -997,8 +996,7 @@ namespace QuantConnect.Algorithm
         {
             var name = $"{symbol}({fieldName ?? "close"}_{resolution.ToStringInvariant(null)})";
             var pyselector = PythonUtil.ToFunc<IBaseData, IBaseDataBar>(selector);
-            var pyfilter = PythonUtil.ToFunc<IBaseData, bool>(filter);
-            var filteredIdentity = new FilteredIdentity(name, pyfilter);
+            var filteredIdentity = new FilteredIdentity(name, filter);
             RegisterIndicator(symbol, filteredIdentity, ResolveConsolidator(symbol, resolution), pyselector);
             return filteredIdentity;
         }

--- a/Indicators/FilteredIdentity.cs
+++ b/Indicators/FilteredIdentity.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using Python.Runtime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using System;
@@ -39,6 +40,12 @@ namespace QuantConnect.Indicators
             // default our filter to true (do not filter)
             _filter = filter ?? (x => true);
         }
+
+        public FilteredIdentity(string name, PyObject filter)
+            : this(name, filter.ConvertToDelegate<Func<IBaseData, bool>>())
+        {
+        }
+
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized

--- a/Tests/Indicators/FilteredIdentityTests.cs
+++ b/Tests/Indicators/FilteredIdentityTests.cs
@@ -1,0 +1,63 @@
+using System;
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Indicators;
+
+namespace QuantConnect.Tests.Indicators
+{
+    /// <summary>
+    /// Test class for QuantConnect.Indicators.FilteredIdentity
+    /// </summary>
+    [TestFixture]
+    public class FilteredIdentityTests
+    {
+        [TestCase("lambda")]
+        [TestCase("function")]
+        public void FilteredIdentityWorksWithPythonFilter(string filterType)
+        {
+            using (Py.GIL())
+            {
+                string filterCode = filterType == "lambda"
+                    ? "filter = lambda x: x.Close > x.Open"
+                    : "filter = filter";
+
+                string functionCode = filterType == "function"
+                    ? @"
+def filter(data):
+    return data.Close > data.Open
+"
+                    : "";
+
+                var testModule = PyModule.FromString("TestFilteredIdentity",
+                    $@"
+from AlgorithmImports import *
+from QuantConnect.Tests import *
+
+{functionCode}
+
+def rolling_window_with_tuple():
+    test = FilteredIdentity(Symbols.SPY, {filterCode})
+    tradeBar1 = TradeBar()
+    tradeBar1.Close = 100
+    tradeBar1.Open = 50
+    tradeBar2 = TradeBar()
+    tradeBar2.Close = 20
+    tradeBar2.Open = 50
+    tradeBar3 = TradeBar()
+    tradeBar3.Close = 300
+    tradeBar3.Open = 50
+    test.Update(tradeBar1)
+    test.Update(tradeBar2)
+    test.Update(tradeBar3)
+    return test
+");
+
+                var test = testModule.GetAttr("rolling_window_with_tuple").Invoke();
+                var filteredIdentity = test.As<FilteredIdentity>();
+                Assert.AreEqual(3, filteredIdentity.Samples);
+                Assert.AreEqual(300, filteredIdentity.Current.Value);
+                Assert.AreEqual(100, filteredIdentity.Previous.Value);
+            }
+        }
+    }
+}

--- a/Tests/Indicators/FilteredIdentityTests.cs
+++ b/Tests/Indicators/FilteredIdentityTests.cs
@@ -1,4 +1,18 @@
-using System;
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 using NUnit.Framework;
 using Python.Runtime;
 using QuantConnect.Indicators;
@@ -35,7 +49,7 @@ from QuantConnect.Tests import *
 
 {functionCode}
 
-def rolling_window_with_tuple():
+def test_filtered_identity():
     test = FilteredIdentity(Symbols.SPY, {filterCode})
     tradeBar1 = TradeBar()
     tradeBar1.Close = 100
@@ -52,7 +66,7 @@ def rolling_window_with_tuple():
     return test
 ");
 
-                var test = testModule.GetAttr("rolling_window_with_tuple").Invoke();
+                var test = testModule.GetAttr("test_filtered_identity").Invoke();
                 var filteredIdentity = test.As<FilteredIdentity>();
                 Assert.AreEqual(3, filteredIdentity.Samples);
                 Assert.AreEqual(300, filteredIdentity.Current.Value);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
Added a new constructor to `FilteredIdentity` to support initialization with a Python defined filter using a `PyObject`.

#### Related Issue
Closes #8790 

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
