### PR TITLE
Filter out default datetime values from the DataFrame

### DIFF
--- a/Common/Python/PandasConverter.cs
+++ b/Common/Python/PandasConverter.cs
@@ -274,8 +274,11 @@ namespace QuantConnect.Python
 
             foreach (var point in points)
             {
-                index.Add(point.EndTime);
-                values.Add((double) point.Value);
+                if (point.EndTime != default)
+                {
+                    index.Add(point.EndTime);
+                    values.Add((double)point.Value);
+                }
             }
             pyDict.SetItem(key.ToLowerInvariant(), _pandas.Series(values, index));
         }

--- a/Indicators/ZigZag.cs
+++ b/Indicators/ZigZag.cs
@@ -134,6 +134,7 @@ namespace QuantConnect.Indicators
             if (_lastPivot == null)
             {
                 UpdatePivot(input, true);
+                HighPivot.Update(input.EndTime, 0);
                 return decimal.Zero;
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Some sub-indicators within an indicator (e.g., ZigZag) may retain a default DateTime value if they are not updated. When this default value is used as an index in the resulting DataFrame, it can appear in the output and cause confusion.

This issue was observed in the ZigZag indicator. The solution involved explicitly setting a default DateTime for LowPivot and HighPivot, and adding a safeguard in PandasConverter.cs to filter out any entries with default DateTime values before constructing the DataFrame.

#### Related Issue
Closes #8815

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
