### PR TITLE
Fill MarketOnClose orders at or after market close

### DIFF
--- a/Common/Orders/Fills/EquityFillModel.cs
+++ b/Common/Orders/Fills/EquityFillModel.cs
@@ -594,6 +594,8 @@ namespace QuantConnect.Orders.Fills
                 return fill;
             }
 
+            // LocalTime has reached or passed market close, proceed to fill
+
             var subscribedTypes = GetSubscribedTypes(asset);
 
             if (subscribedTypes.Contains(typeof(Tick)))

--- a/Common/Orders/Fills/EquityFillModel.cs
+++ b/Common/Orders/Fills/EquityFillModel.cs
@@ -641,13 +641,6 @@ namespace QuantConnect.Orders.Fills
                     fill.FillPrice = tick.Price;
                 }
             }
-            // make sure the exchange is open/normal market hours before filling
-            // It will return true if the last bar opens before the market closes
-            // If closed but LocalTime equals close time, still allow fill since it's considered valid timing for MOC orders
-            else if (!IsExchangeOpen(asset, false) && asset.LocalTime != nextMarketClose)
-            {
-                return fill;
-            }
             else if (subscribedTypes.Contains(typeof(TradeBar)))
             {
                 fill.FillPrice = asset.Cache.GetData<TradeBar>()?.Close ?? 0;

--- a/Common/Orders/Fills/EquityFillModel.cs
+++ b/Common/Orders/Fills/EquityFillModel.cs
@@ -643,7 +643,8 @@ namespace QuantConnect.Orders.Fills
             }
             // make sure the exchange is open/normal market hours before filling
             // It will return true if the last bar opens before the market closes
-            else if (!IsExchangeOpen(asset, false))
+            // If closed but LocalTime equals close time, still allow fill since it's considered valid timing for MOC orders
+            else if (!IsExchangeOpen(asset, false) && asset.LocalTime != nextMarketClose)
             {
                 return fill;
             }

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -802,8 +802,6 @@ namespace QuantConnect.Orders.Fills
             {
                 return fill;
             }
-            // make sure the exchange is open/normal market hours before filling
-            if (!IsExchangeOpen(asset, false) && asset.LocalTime != nextMarketClose) return fill;
 
             fill.FillPrice = GetPricesCheckingPythonWrapper(asset, order.Direction).Close;
             fill.Status = OrderStatus.Filled;
@@ -1095,14 +1093,11 @@ namespace QuantConnect.Orders.Fills
                 }
 
                 var barSpan = currentBar.EndTime - currentBar.Time;
-                // Round down in case LocalTime is just a bit past the bar end
-                var roundedLocalTime = asset.LocalTime.RoundDown(barSpan);
-
                 var isOnCurrentBar = barSpan > Time.OneHour
                     // for fill purposes we consider the market open for daily bars if we are in the same day
                     ? asset.LocalTime.Date == currentBar.EndTime.Date
                     // for other resolution bars, market is considered open if we are within the bar time
-                    : roundedLocalTime <= currentBar.EndTime;
+                    : asset.LocalTime <= currentBar.EndTime;
 
                 return isOnCurrentBar && asset.Exchange.IsOpenDuringBar(currentBar.Time, currentBar.EndTime, isExtendedMarketHours);
             }

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -803,6 +803,8 @@ namespace QuantConnect.Orders.Fills
                 return fill;
             }
 
+            // LocalTime has reached or passed market close, proceed to fill
+
             fill.FillPrice = GetPricesCheckingPythonWrapper(asset, order.Direction).Close;
             fill.Status = OrderStatus.Filled;
             //Calculate the model slippage: e.g. 0.01c

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -1094,12 +1094,13 @@ namespace QuantConnect.Orders.Fills
                     return false;
                 }
 
+                var tolerance = TimeSpan.FromTicks(1000);
                 var barSpan = currentBar.EndTime - currentBar.Time;
                 var isOnCurrentBar = barSpan > Time.OneHour
                     // for fill purposes we consider the market open for daily bars if we are in the same day
                     ? asset.LocalTime.Date == currentBar.EndTime.Date
                     // for other resolution bars, market is considered open if we are within the bar time
-                    : asset.LocalTime <= currentBar.EndTime;
+                    : asset.LocalTime <= currentBar.EndTime + tolerance;
 
                 return isOnCurrentBar && asset.Exchange.IsOpenDuringBar(currentBar.Time, currentBar.EndTime, isExtendedMarketHours);
             }

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -1094,13 +1094,15 @@ namespace QuantConnect.Orders.Fills
                     return false;
                 }
 
-                var tolerance = TimeSpan.FromTicks(1000);
                 var barSpan = currentBar.EndTime - currentBar.Time;
+                // Round down in case LocalTime is just a bit past the bar end
+                var roundedLocalTime = asset.LocalTime.RoundDown(barSpan);
+
                 var isOnCurrentBar = barSpan > Time.OneHour
                     // for fill purposes we consider the market open for daily bars if we are in the same day
                     ? asset.LocalTime.Date == currentBar.EndTime.Date
                     // for other resolution bars, market is considered open if we are within the bar time
-                    : asset.LocalTime <= currentBar.EndTime + tolerance;
+                    : roundedLocalTime <= currentBar.EndTime;
 
                 return isOnCurrentBar && asset.Exchange.IsOpenDuringBar(currentBar.Time, currentBar.EndTime, isExtendedMarketHours);
             }

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -803,7 +803,7 @@ namespace QuantConnect.Orders.Fills
                 return fill;
             }
             // make sure the exchange is open/normal market hours before filling
-            if (!IsExchangeOpen(asset, false)) return fill;
+            if (!IsExchangeOpen(asset, false) && asset.LocalTime != nextMarketClose) return fill;
 
             fill.FillPrice = GetPricesCheckingPythonWrapper(asset, order.Direction).Close;
             fill.Status = OrderStatus.Filled;

--- a/Tests/Common/Orders/Fills/EquityFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/EquityFillModelTests.cs
@@ -1348,13 +1348,7 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 new SecurityCache()
             );
 
-            var timeOffset = resolution switch
-            {
-                Resolution.Second => TimeSpan.FromSeconds(1),
-                Resolution.Minute => TimeSpan.FromMinutes(1),
-                Resolution.Hour => TimeSpan.FromHours(1),
-                _ => TimeSpan.FromTicks(1)
-            };
+            var timeOffset = resolution.ToTimeSpan();
 
             var desiredTime = new DateTime(2025, 7, 8, 16, 0, 0);
             // Submit MOC order an hour before close


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Update MarketOnCloseFill condition to fill when asset.LocalTime is at or after market close, simplifying the logic and ensuring correct behavior.

#### Related Issue
Closes #8769

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests and paper trading

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
