### PR TITLE
Use EndTime for indicator updates across all indicators

### DIFF
--- a/Indicators/AccelerationBands.cs
+++ b/Indicators/AccelerationBands.cs
@@ -115,9 +115,9 @@ namespace QuantConnect.Indicators
         {
             var coefficient = _width * (input.High - input.Low).SafeDivision(input.High + input.Low);
 
-            LowerBand.Update(input.Time, input.Low * (1 - coefficient));
-            UpperBand.Update(input.Time, input.High * (1 + coefficient));
-            MiddleBand.Update(input.Time, input.Close);
+            LowerBand.Update(input.EndTime, input.Low * (1 - coefficient));
+            UpperBand.Update(input.EndTime, input.High * (1 + coefficient));
+            MiddleBand.Update(input.EndTime, input.Close);
 
             return MiddleBand.Current.Value;
         }

--- a/Indicators/Alpha.cs
+++ b/Indicators/Alpha.cs
@@ -112,7 +112,7 @@ namespace QuantConnect.Indicators
             {
                 throw new ArgumentException("The beta period must be equal or greater than 2.");
             }
-            
+
             _targetSymbol = targetSymbol;
             _referenceSymbol = referenceSymbol;
             _alphaPeriod = alphaPeriod;
@@ -122,7 +122,7 @@ namespace QuantConnect.Indicators
             _referenceROC = new RateOfChange($"{name}_ReferenceROC", alphaPeriod);
 
             _beta = new Beta($"{name}_Beta", _targetSymbol, _referenceSymbol, betaPeriod);
-            
+
             WarmUpPeriod = alphaPeriod >= betaPeriod ? alphaPeriod + 1 : betaPeriod + 1;
 
             _alpha = 0m;
@@ -179,7 +179,7 @@ namespace QuantConnect.Indicators
             : this(name, targetSymbol, referenceSymbol, period, period, new ConstantRiskFreeRateInterestRateModel(riskFreeRate ?? 0m))
         {
         }
-        
+
         /// <summary>
         /// Creates a new Alpha indicator with the specified target, reference, and period values
         /// </summary>
@@ -298,7 +298,7 @@ namespace QuantConnect.Indicators
             }
 
             _beta.Update(input);
-            
+
             if (_targetROC.Samples == _referenceROC.Samples && _referenceROC.Samples > 0)
             {
                 ComputeAlpha();
@@ -321,7 +321,7 @@ namespace QuantConnect.Indicators
             var targetMean = _targetROC.Current.Value / _alphaPeriod;
             var referenceMean = _referenceROC.Current.Value / _alphaPeriod;
 
-            var riskFreeRate = _riskFreeInterestRateModel.GetInterestRate(_targetROC.Current.Time);
+            var riskFreeRate = _riskFreeInterestRateModel.GetInterestRate(_targetROC.Current.EndTime);
 
             _alpha = targetMean - (riskFreeRate + _beta.Current.Value * (referenceMean - riskFreeRate));
         }

--- a/Indicators/AroonOscillator.cs
+++ b/Indicators/AroonOscillator.cs
@@ -89,8 +89,8 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IBaseDataBar input)
         {
-            AroonUp.Update(input.Time, input.High);
-            AroonDown.Update(input.Time, input.Low);
+            AroonUp.Update(input.EndTime, input.High);
+            AroonDown.Update(input.EndTime, input.Low);
 
             return AroonUp.Current.Value - AroonDown.Current.Value;
         }

--- a/Indicators/AugenPriceSpike.cs
+++ b/Indicators/AugenPriceSpike.cs
@@ -97,7 +97,7 @@ namespace QuantConnect.Indicators
                 logPoint = Math.Log((double)previousPoint / (double)previousPoint2);
             }
 
-            _standardDeviation.Update(input.Time, (decimal)logPoint);
+            _standardDeviation.Update(input.EndTime, (decimal)logPoint);
 
             if (!_rollingData.IsReady) { return 0m; }
             if (!_standardDeviation.IsReady) { return 0m; }

--- a/Indicators/AwesomeOscillator.cs
+++ b/Indicators/AwesomeOscillator.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Indicators
         /// <param name="fastPeriod">The period of the fast moving average associated with the AO</param>
         /// <param name="slowPeriod">The period of the slow moving average associated with the AO</param>
         /// <param name="type">The type of moving average used when computing the fast and slow term. Defaults to simple moving average.</param>
-        public AwesomeOscillator(int fastPeriod, int slowPeriod, MovingAverageType type=MovingAverageType.Simple)
+        public AwesomeOscillator(int fastPeriod, int slowPeriod, MovingAverageType type = MovingAverageType.Simple)
             : this($"AO({fastPeriod},{slowPeriod},{type})", fastPeriod, slowPeriod, type)
         {
         }
@@ -66,7 +66,7 @@ namespace QuantConnect.Indicators
         /// <param name="fastPeriod">The period of the fast moving average associated with the AO</param>
         /// <param name="slowPeriod">The period of the slow moving average associated with the AO</param>
         /// <param name="type">The type of moving average used when computing the fast and slow term. Defaults to simple moving average.</param>
-        public AwesomeOscillator(string name, int fastPeriod, int slowPeriod,  MovingAverageType type=MovingAverageType.Simple)
+        public AwesomeOscillator(string name, int fastPeriod, int slowPeriod, MovingAverageType type = MovingAverageType.Simple)
             : base(name)
         {
             SlowAo = type.AsIndicator(slowPeriod);
@@ -82,8 +82,8 @@ namespace QuantConnect.Indicators
         protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             var presentValue = (input.High + input.Low) / 2;
-            SlowAo.Update(input.Time, presentValue);
-            FastAo.Update(input.Time, presentValue);
+            SlowAo.Update(input.EndTime, presentValue);
+            FastAo.Update(input.EndTime, presentValue);
 
             return IsReady ? FastAo - SlowAo : 0m;
         }

--- a/Indicators/CommodityChannelIndex.cs
+++ b/Indicators/CommodityChannelIndex.cs
@@ -95,8 +95,8 @@ namespace QuantConnect.Indicators
         {
             var typicalPrice = (input.High + input.Low + input.Close) / 3.0m;
 
-            TypicalPriceAverage.Update(input.Time, typicalPrice);
-            TypicalPriceMeanDeviation.Update(input.Time, typicalPrice);
+            TypicalPriceAverage.Update(input.EndTime, typicalPrice);
+            TypicalPriceMeanDeviation.Update(input.EndTime, typicalPrice);
 
             // compare this to zero, since if the mean deviation is very small we can get
             // precision errors due to non-floating point math

--- a/Indicators/CoppockCurve.cs
+++ b/Indicators/CoppockCurve.cs
@@ -42,7 +42,7 @@ namespace QuantConnect.Indicators
         /// Initializes a new instance of the <see cref="CoppockCurve" /> indicator with its default values.
         /// </summary>
         public CoppockCurve()
-            : this(11,14,10)
+            : this(11, 14, 10)
         {
         }
 
@@ -101,7 +101,7 @@ namespace QuantConnect.Indicators
             {
                 return decimal.Zero;
             }
-            _lwma.Update(input.Time, _shortRoc.Current.Value + _longRoc.Current.Value);
+            _lwma.Update(input.EndTime, _shortRoc.Current.Value + _longRoc.Current.Value);
             return _lwma.Current.Value;
         }
     }

--- a/Indicators/DeMarkerIndicator.cs
+++ b/Indicators/DeMarkerIndicator.cs
@@ -105,8 +105,8 @@ namespace QuantConnect.Indicators
                 deMin = Math.Max(_lastLow - input.Low, 0);
             }
 
-            _maxMA.Update(input.Time, deMax);
-            _minMA.Update(input.Time, deMin);
+            _maxMA.Update(input.EndTime, deMax);
+            _minMA.Update(input.EndTime, deMin);
             _lastHigh = input.High;
             _lastLow = input.Low;
 

--- a/Indicators/DonchianChannel.cs
+++ b/Indicators/DonchianChannel.cs
@@ -97,8 +97,8 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator, which by convention is the mean value of the upper band and lower band.</returns>
         protected override decimal ComputeNextValue(IBaseDataBar input)
         {
-            UpperBand.Update(input.Time, input.High);
-            LowerBand.Update(input.Time, input.Low);
+            UpperBand.Update(input.EndTime, input.High);
+            LowerBand.Update(input.EndTime, input.Low);
             return (UpperBand + LowerBand) / 2;
         }
 

--- a/Indicators/EaseOfMovementValue.cs
+++ b/Indicators/EaseOfMovementValue.cs
@@ -71,15 +71,15 @@ namespace QuantConnect.Indicators
         /// <returns>A a value for this indicator</returns>
         protected override decimal ComputeNextValue(TradeBar input)
         {
-            if (_previousHighMaximum == 0 && _previousLowMinimum == 0) 
+            if (_previousHighMaximum == 0 && _previousLowMinimum == 0)
             {
                 _previousHighMaximum = input.High;
                 _previousLowMinimum = input.Low;
-            } 
+            }
 
             if (input.Volume == 0 || input.High == input.Low)
             {
-                _sma.Update(input.Time, 0);
+                _sma.Update(input.EndTime, 0);
                 return _sma.Current.Value;
             }
 
@@ -89,7 +89,7 @@ namespace QuantConnect.Indicators
             _previousHighMaximum = input.High;
             _previousLowMinimum = input.Low;
 
-            _sma.Update(input.Time, midValue / midRatio);
+            _sma.Update(input.EndTime, midValue / midRatio);
 
             return _sma.Current.Value;
         }

--- a/Indicators/FisherTransform.cs
+++ b/Indicators/FisherTransform.cs
@@ -89,8 +89,8 @@ namespace QuantConnect.Indicators
         protected override decimal ComputeNextValue(IBaseDataBar input)
         {
             var price = (input.Low + input.High) / 2m;
-            _medianMin.Update(input.Time, price);
-            _medianMax.Update(input.Time, price);
+            _medianMin.Update(input.EndTime, price);
+            _medianMax.Update(input.EndTime, price);
 
             if (!IsReady) return 0;
 

--- a/Indicators/HeikinAshi.cs
+++ b/Indicators/HeikinAshi.cs
@@ -94,29 +94,29 @@ namespace QuantConnect.Indicators
         {
             if (!IsReady)
             {
-                Open.Update(input.Time, (input.Open + input.Close) / 2);
-                Close.Update(input.Time, (input.Open + input.High + input.Low + input.Close) / 4);
-                High.Update(input.Time, input.High);
-                Low.Update(input.Time, input.Low);
+                Open.Update(input.EndTime, (input.Open + input.Close) / 2);
+                Close.Update(input.EndTime, (input.Open + input.High + input.Low + input.Close) / 4);
+                High.Update(input.EndTime, input.High);
+                Low.Update(input.EndTime, input.Low);
             }
             else
             {
-                Open.Update(input.Time, (Open.Current.Value + Close.Current.Value) / 2);
-                Close.Update(input.Time, (input.Open + input.High + input.Low + input.Close) / 4);
-                High.Update(input.Time, Math.Max(input.High, Math.Max(Open.Current.Value, Close.Current.Value)));
-                Low.Update(input.Time, Math.Min(input.Low, Math.Min(Open.Current.Value, Close.Current.Value)));
+                Open.Update(input.EndTime, (Open.Current.Value + Close.Current.Value) / 2);
+                Close.Update(input.EndTime, (input.Open + input.High + input.Low + input.Close) / 4);
+                High.Update(input.EndTime, Math.Max(input.High, Math.Max(Open.Current.Value, Close.Current.Value)));
+                Low.Update(input.EndTime, Math.Min(input.Low, Math.Min(Open.Current.Value, Close.Current.Value)));
             }
 
             var volume = 0.0m;
             if (input is TradeBar)
             {
-                volume = ((TradeBar) input).Volume;
+                volume = ((TradeBar)input).Volume;
             }
             else if (input is RenkoBar)
             {
-                volume = ((RenkoBar) input).Volume;
+                volume = ((RenkoBar)input).Volume;
             }
-            Volume.Update(input.Time, volume);
+            Volume.Update(input.EndTime, volume);
 
             return Close.Current.Value;
         }

--- a/Indicators/HullMovingAverage.cs
+++ b/Indicators/HullMovingAverage.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Indicators
         {
             if (period < 2) throw new ArgumentException("The Hull Moving Average period should be greater or equal to 2", nameof(period));
             _slowWma = new LinearWeightedMovingAverage(period);
-            _fastWma = new LinearWeightedMovingAverage((int) Math.Round(period * 1d / 2));
+            _fastWma = new LinearWeightedMovingAverage((int)Math.Round(period * 1d / 2));
             var k = (int)Math.Round(Math.Sqrt(period));
             _hullMa = new LinearWeightedMovingAverage(k);
             WarmUpPeriod = period + k - 1;
@@ -85,7 +85,7 @@ namespace QuantConnect.Indicators
             _slowWma.Update(input);
             if (_fastWma.IsReady && _slowWma.IsReady)
             {
-                _hullMa.Update(new IndicatorDataPoint(input.Time, 2 * _fastWma.Current.Value - _slowWma.Current.Value));
+                _hullMa.Update(new IndicatorDataPoint(input.EndTime, 2 * _fastWma.Current.Value - _slowWma.Current.Value));
             }
             return _hullMa.Current.Value;
         }

--- a/Indicators/IchimokuKinkoHyo.cs
+++ b/Indicators/IchimokuKinkoHyo.cs
@@ -210,25 +210,25 @@ namespace QuantConnect.Indicators
         /// <param name="input">The input given to the indicator</param>
         protected override decimal ComputeNextValue(IBaseDataBar input)
         {
-            TenkanMaximum.Update(input.Time, input.High);
-            TenkanMinimum.Update(input.Time, input.Low);
-            Tenkan.Update(input.Time, input.Close);
-            if (Tenkan.IsReady) DelayedTenkanSenkouA.Update(input.Time, Tenkan.Current.Value);
+            TenkanMaximum.Update(input.EndTime, input.High);
+            TenkanMinimum.Update(input.EndTime, input.Low);
+            Tenkan.Update(input.EndTime, input.Close);
+            if (Tenkan.IsReady) DelayedTenkanSenkouA.Update(input.EndTime, Tenkan.Current.Value);
 
-            KijunMaximum.Update(input.Time, input.High);
-            KijunMinimum.Update(input.Time, input.Low);
-            Kijun.Update(input.Time, input.Close);
-            if (Kijun.IsReady) DelayedKijunSenkouA.Update(input.Time, Kijun.Current.Value);
+            KijunMaximum.Update(input.EndTime, input.High);
+            KijunMinimum.Update(input.EndTime, input.Low);
+            Kijun.Update(input.EndTime, input.Close);
+            if (Kijun.IsReady) DelayedKijunSenkouA.Update(input.EndTime, Kijun.Current.Value);
 
-            SenkouA.Update(input.Time, input.Close);
+            SenkouA.Update(input.EndTime, input.Close);
 
-            SenkouB.Update(input.Time, input.Close);
-            SenkouBMaximum.Update(input.Time, input.High);
-            if (SenkouBMaximum.IsReady) DelayedMaximumSenkouB.Update(input.Time, SenkouBMaximum.Current.Value);
-            SenkouBMinimum.Update(input.Time, input.Low);
-            if (SenkouBMinimum.IsReady) DelayedMinimumSenkouB.Update(input.Time, SenkouBMinimum.Current.Value);
+            SenkouB.Update(input.EndTime, input.Close);
+            SenkouBMaximum.Update(input.EndTime, input.High);
+            if (SenkouBMaximum.IsReady) DelayedMaximumSenkouB.Update(input.EndTime, SenkouBMaximum.Current.Value);
+            SenkouBMinimum.Update(input.EndTime, input.Low);
+            if (SenkouBMinimum.IsReady) DelayedMinimumSenkouB.Update(input.EndTime, SenkouBMinimum.Current.Value);
 
-            Chikou.Update(input.Time, input.Close);
+            Chikou.Update(input.EndTime, input.Close);
 
             return input.Close;
         }

--- a/Indicators/ImpliedVolatility.cs
+++ b/Indicators/ImpliedVolatility.cs
@@ -226,7 +226,7 @@ namespace QuantConnect.Indicators
         /// <returns>The input is returned unmodified.</returns>
         protected override decimal ComputeIndicator()
         {
-            var time = Price.Current.Time;
+            var time = Price.Current.EndTime;
 
             RiskFreeRate.Update(time, _riskFreeInterestRateModel.GetInterestRate(time));
             DividendYield.Update(time, _dividendYieldModel.GetDividendYield(time, UnderlyingPrice.Current.Value));
@@ -314,7 +314,7 @@ namespace QuantConnect.Indicators
         }
 
         private void GetRootFindingMethodParameters(Symbol optionSymbol, double strike, double timeTillExpiry, double optionPrice,
-            double underlyingPrice, double riskFreeRate,  double dividendYield, OptionPricingModelType optionModel,
+            double underlyingPrice, double riskFreeRate, double dividendYield, OptionPricingModelType optionModel,
             out double accuracy, out double lowerBound, out double upperBound)
         {
             // Set the accuracy as a factor of the option price when possible

--- a/Indicators/LeastSquaresMovingAverage.cs
+++ b/Indicators/LeastSquaresMovingAverage.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Indicators
         /// The point where the regression line crosses the y-axis (price-axis)
         /// </summary>
         public IndicatorBase<IndicatorDataPoint> Intercept { get; }
-        
+
         /// <summary>
         /// The regression line slope
         /// </summary>
@@ -85,13 +85,13 @@ namespace QuantConnect.Indicators
 
             // Sort the window by time, convert the observations to double and transform it to an array
             var series = window
-                .OrderBy(i => i.Time)
+                .OrderBy(i => i.EndTime)
                 .Select(i => Convert.ToDouble(i.Value))
                 .ToArray();
             // Fit OLS
             var ols = Fit.Line(x: _t, y: series);
-            Intercept.Update(input.Time, (decimal)ols.Item1);
-            Slope.Update(input.Time, (decimal)ols.Item2);
+            Intercept.Update(input.EndTime, (decimal)ols.Item1);
+            Slope.Update(input.EndTime, (decimal)ols.Item2);
 
             // Calculate the fitted value corresponding to the input
             return Intercept.Current.Value + Slope.Current.Value * Period;

--- a/Indicators/MassIndex.cs
+++ b/Indicators/MassIndex.cs
@@ -85,10 +85,10 @@ namespace QuantConnect.Indicators
         /// </returns>
         protected override decimal ComputeNextValue(TradeBar input)
         {
-            _ema1.Update(input.Time, input.High - input.Low);
+            _ema1.Update(input.EndTime, input.High - input.Low);
             if (_ema2.IsReady)
             {
-                _sum.Update(input.Time, _ema1.Current.Value.SafeDivision(_ema2.Current.Value));
+                _sum.Update(input.EndTime, _ema1.Current.Value.SafeDivision(_ema2.Current.Value));
             }
 
             if (!_sum.IsReady)

--- a/Indicators/McGinleyDynamic.cs
+++ b/Indicators/McGinleyDynamic.cs
@@ -73,7 +73,7 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IReadOnlyWindow<IndicatorDataPoint> window, IndicatorDataPoint input)
         {
-            _rollingSum.Update(input.Time, input.Value);
+            _rollingSum.Update(input.EndTime, input.Value);
             if (!IsReady)
             {
                 return 0;

--- a/Indicators/MoneyFlowIndex.cs
+++ b/Indicators/MoneyFlowIndex.cs
@@ -101,8 +101,8 @@ namespace QuantConnect.Indicators
             var typicalPrice = (input.High + input.Low + input.Close) / 3.0m;
             var moneyFlow = typicalPrice * input.Volume;
 
-            PositiveMoneyFlow.Update(input.Time, typicalPrice > PreviousTypicalPrice ? moneyFlow : 0.0m);
-            NegativeMoneyFlow.Update(input.Time, typicalPrice < PreviousTypicalPrice ? moneyFlow : 0.0m);
+            PositiveMoneyFlow.Update(input.EndTime, typicalPrice > PreviousTypicalPrice ? moneyFlow : 0.0m);
+            NegativeMoneyFlow.Update(input.EndTime, typicalPrice < PreviousTypicalPrice ? moneyFlow : 0.0m);
             PreviousTypicalPrice = typicalPrice;
 
             var totalMoneyFlow = PositiveMoneyFlow.Current.Value + NegativeMoneyFlow.Current.Value;

--- a/Indicators/MovingAverageConvergenceDivergence.cs
+++ b/Indicators/MovingAverageConvergenceDivergence.cs
@@ -81,7 +81,7 @@ namespace QuantConnect.Indicators
             {
                 throw new ArgumentException("MovingAverageConvergenceDivergence: fastPeriod must be less than slowPeriod", $"{nameof(fastPeriod)}, {nameof(slowPeriod)}");
             }
-            
+
             Fast = type.AsIndicator(name + "_Fast", fastPeriod);
             Slow = type.AsIndicator(name + "_Slow", slowPeriod);
             Signal = type.AsIndicator(name + "_Signal", signalPeriod);
@@ -103,9 +103,9 @@ namespace QuantConnect.Indicators
 
             if (fastReady && slowReady)
             {
-                if (Signal.Update(input.Time, macd))
+                if (Signal.Update(input.EndTime, macd))
                 {
-                    Histogram.Update(input.Time, macd - Signal.Current.Value);
+                    Histogram.Update(input.EndTime, macd - Signal.Current.Value);
                 }
             }
 

--- a/Indicators/PremierStochasticOscillator.cs
+++ b/Indicators/PremierStochasticOscillator.cs
@@ -92,7 +92,7 @@ namespace QuantConnect.Indicators
 
             var k = _stochastic.FastStoch.Current.Value;
             var nsk = 0.1m * (k - 50);
-            if (!_firstSmoothingEma.Update(new IndicatorDataPoint(input.Time, nsk)))
+            if (!_firstSmoothingEma.Update(new IndicatorDataPoint(input.EndTime, nsk)))
             {
                 return decimal.Zero;
             }

--- a/Indicators/RelativeStrengthIndex.cs
+++ b/Indicators/RelativeStrengthIndex.cs
@@ -84,13 +84,13 @@ namespace QuantConnect.Indicators
         {
             if (_previousInput != null && input.Value >= _previousInput.Value)
             {
-                AverageGain.Update(input.Time, input.Value - _previousInput.Value);
-                AverageLoss.Update(input.Time, 0m);
+                AverageGain.Update(input.EndTime, input.Value - _previousInput.Value);
+                AverageLoss.Update(input.EndTime, 0m);
             }
             else if (_previousInput != null && input.Value < _previousInput.Value)
             {
-                AverageGain.Update(input.Time, 0m);
-                AverageLoss.Update(input.Time, _previousInput.Value - input.Value);
+                AverageGain.Update(input.EndTime, 0m);
+                AverageLoss.Update(input.EndTime, _previousInput.Value - input.Value);
             }
 
             _previousInput = input;

--- a/Indicators/RelativeVigorIndex.cs
+++ b/Indicators/RelativeVigorIndex.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Indicators
         /// Gets the band of Ranges for the RVI.
         /// </summary>
         private IndicatorBase<IndicatorDataPoint> RangeBand { get; }
-        
+
         /// <summary>
         /// A signal line which behaves like a slowed version of the RVI.
         /// </summary>
@@ -89,7 +89,7 @@ namespace QuantConnect.Indicators
             Signal = new RelativeVigorIndexSignal($"{name}_S");
             _previousInputs = new RollingWindow<IBaseDataBar>(3);
         }
-        
+
         /// <summary>
         /// Computes the next value of this indicator from the given state
         /// </summary>
@@ -107,18 +107,18 @@ namespace QuantConnect.Indicators
                 var f = _previousInputs[0].High - _previousInputs[0].Low;
                 var g = _previousInputs[1].High - _previousInputs[1].Low;
                 var h = _previousInputs[2].High - _previousInputs[2].Low;
-                CloseBand.Update(input.Time, (a + 2 * (b + c) + d) / 6);
-                RangeBand.Update(input.Time, (e + 2 * (f + g) + h) / 6);
-                
+                CloseBand.Update(input.EndTime, (a + 2 * (b + c) + d) / 6);
+                RangeBand.Update(input.EndTime, (e + 2 * (f + g) + h) / 6);
+
                 if (CloseBand.IsReady && RangeBand.IsReady && RangeBand != 0m)
                 {
                     _previousInputs.Add(input);
                     var rvi = CloseBand / RangeBand;
-                    Signal?.Update(input.Time, rvi); // Checks for null before updating.
+                    Signal?.Update(input.EndTime, rvi); // Checks for null before updating.
                     return rvi;
                 }
             }
-            
+
             _previousInputs.Add(input);
             return 0m;
         }

--- a/Indicators/SchaffTrendCycle.cs
+++ b/Indicators/SchaffTrendCycle.cs
@@ -21,7 +21,7 @@ namespace QuantConnect.Indicators
     /// This indicator creates the Schaff Trend Cycle
     /// </summary>
     public class SchaffTrendCycle : Indicator, IIndicatorWarmUpPeriodProvider
-    {   
+    {
         // MACD Variables
         private readonly MovingAverageConvergenceDivergence _MACD;
         private readonly IndicatorBase<IndicatorDataPoint> _maximum;
@@ -100,11 +100,11 @@ namespace QuantConnect.Indicators
             _MACD.Update(input);
 
             // Update our Stochastics K, automatically updates our Stochastics D variable which is a smoothed version of K
-            var MACD_K = new IndicatorDataPoint(input.Time, ComputeStoch(_MACD.Current.Value, _maximum.Current.Value, _minimum.Current.Value));
+            var MACD_K = new IndicatorDataPoint(input.EndTime, ComputeStoch(_MACD.Current.Value, _maximum.Current.Value, _minimum.Current.Value));
             _K.Update(MACD_K);
 
             // With our Stochastic D values calculate PF 
-            var PF = new IndicatorDataPoint(input.Time, ComputeStoch(_D.Current.Value, _maximumD.Current.Value, _minimumD.Current.Value));
+            var PF = new IndicatorDataPoint(input.EndTime, ComputeStoch(_D.Current.Value, _maximumD.Current.Value, _minimumD.Current.Value));
             _PF.Update(PF);
 
             return _PFF.Current.Value;

--- a/Indicators/SharpeRatio.cs
+++ b/Indicators/SharpeRatio.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Indicator to store the calculation of the sharpe ratio
         /// </summary>
-        protected IndicatorBase Ratio { get; set;  }
+        protected IndicatorBase Ratio { get; set; }
 
         /// <summary>
         /// Indicator to store the numerator of the Sharpe ratio calculation
@@ -153,7 +153,7 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IndicatorDataPoint input)
         {
-            RiskFreeRate.Update(input.Time, _riskFreeInterestRateModel.GetInterestRate(input.Time));
+            RiskFreeRate.Update(input.EndTime, _riskFreeInterestRateModel.GetInterestRate(input.EndTime));
             RateOfChange.Update(input);
             return Ratio;
         }

--- a/Indicators/SimpleMovingAverage.cs
+++ b/Indicators/SimpleMovingAverage.cs
@@ -67,7 +67,7 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IReadOnlyWindow<IndicatorDataPoint> window, IndicatorDataPoint input)
         {
-            RollingSum.Update(input.Time, input.Value);
+            RollingSum.Update(input.EndTime, input.Value);
             return RollingSum.Current.Value / window.Count;
         }
 

--- a/Indicators/Stochastics.cs
+++ b/Indicators/Stochastics.cs
@@ -110,8 +110,8 @@ namespace QuantConnect.Indicators
         /// <param name="input">The input given to the indicator</param>
         protected override decimal ComputeNextValue(IBaseDataBar input)
         {
-            _maximum.Update(input.Time, input.High);
-            _minimum.Update(input.Time, input.Low);
+            _maximum.Update(input.EndTime, input.High);
+            _minimum.Update(input.EndTime, input.Low);
             FastStoch.Update(input);
             StochK.Update(input);
             StochD.Update(input);
@@ -140,7 +140,7 @@ namespace QuantConnect.Indicators
 
                 var numerator = input.Close - _minimum.Current.Value;
                 fastStoch = numerator / denominator;
-                _sumFastK.Update(input.Time, fastStoch);
+                _sumFastK.Update(input.EndTime, fastStoch);
             }
             return fastStoch * 100;
         }
@@ -158,7 +158,7 @@ namespace QuantConnect.Indicators
             if (_sumFastK.IsReady)
             {
                 stochK = _sumFastK.Current.Value / constantK;
-                _sumSlowK.Update(input.Time, stochK);
+                _sumSlowK.Update(input.EndTime, stochK);
             }
             return stochK * 100;
         }

--- a/Indicators/TrueStrengthIndex.cs
+++ b/Indicators/TrueStrengthIndex.cs
@@ -104,8 +104,8 @@ namespace QuantConnect.Indicators
 
             var priceChange = input.Price - _prevClose;
             _prevClose = input.Price;
-            _priceChangeEma.Update(input.Time, priceChange);
-            _absPriceChangeEma.Update(input.Time, Math.Abs(priceChange));
+            _priceChangeEma.Update(input.EndTime, priceChange);
+            _absPriceChangeEma.Update(input.EndTime, Math.Abs(priceChange));
 
             return _tsi.Current.Value;
         }

--- a/Indicators/VolumeWeightedMovingAverage.cs
+++ b/Indicators/VolumeWeightedMovingAverage.cs
@@ -66,13 +66,13 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(TradeBar input)
         {
-            _rollingSumPriceMultipliedByVolume.Update(input.Time, input.Close * input.Volume);
-            _rollingSumVolume.Update(input.Time, input.Volume);
+            _rollingSumPriceMultipliedByVolume.Update(input.EndTime, input.Close * input.Volume);
+            _rollingSumVolume.Update(input.EndTime, input.Volume);
             var sumVolume = _rollingSumVolume.Current.Value;
             if (sumVolume != 0)
             {
                 return _rollingSumPriceMultipliedByVolume.Current.Value / sumVolume;
-            }                
+            }
             return input.Close;
         }
 

--- a/Indicators/Vortex.cs
+++ b/Indicators/Vortex.cs
@@ -94,8 +94,8 @@ namespace QuantConnect.Indicators
                 var plusVMValue = Math.Abs(input.High - _previousInput.Low);
                 var minusVMValue = Math.Abs(input.Low - _previousInput.High);
 
-                _plusVMSum.Update(input.Time, plusVMValue);
-                _minusVMSum.Update(input.Time, minusVMValue);
+                _plusVMSum.Update(input.EndTime, plusVMValue);
+                _minusVMSum.Update(input.EndTime, minusVMValue);
             }
 
             _previousInput = input;

--- a/Indicators/WilliamsPercentR.cs
+++ b/Indicators/WilliamsPercentR.cs
@@ -38,8 +38,8 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady => Maximum.IsReady && Minimum.IsReady; 
-        
+        public override bool IsReady => Maximum.IsReady && Minimum.IsReady;
+
         /// <summary>
         /// Required period, in data points, for the indicator to be ready and fully initialized.
         /// </summary>
@@ -84,8 +84,8 @@ namespace QuantConnect.Indicators
         /// <returns>A new value for this indicator</returns>
         protected override decimal ComputeNextValue(IBaseDataBar input)
         {
-            Minimum.Update(input.Time, input.Low);
-            Maximum.Update(input.Time, input.High);
+            Minimum.Update(input.EndTime, input.Low);
+            Maximum.Update(input.EndTime, input.High);
 
             if (!IsReady) return 0;
 

--- a/Indicators/ZeroLagExponentialMovingAverage.cs
+++ b/Indicators/ZeroLagExponentialMovingAverage.cs
@@ -83,7 +83,7 @@ namespace QuantConnect.Indicators
         {
             if (_delayedPrice.Update(input))
             {
-                _ema.Update(input.Time, input.Value + (input.Value - _delayedPrice.Current));
+                _ema.Update(input.EndTime, input.Value + (input.Value - _delayedPrice.Current));
                 return _ema.Current.Value;
             }
             return 0;

--- a/Tests/Algorithm/AlgorithmIndicatorsTests.cs
+++ b/Tests/Algorithm/AlgorithmIndicatorsTests.cs
@@ -744,5 +744,27 @@ def create_consolidator():
                 }
             }
         }
+
+        [Test]
+        public void IchimokuIndicatorHistoryDataFrameDoesNotContainNaNInCurrentColumn()
+        {
+            var referenceSymbol = Symbol.Create("IBM", SecurityType.Equity, Market.USA);
+            _algorithm.SetDateTime(new DateTime(2013, 10, 11));
+            var history = _algorithm.History(new[] { referenceSymbol }, TimeSpan.FromDays(5), Resolution.Minute);
+            var indicator = new IchimokuKinkoHyo(9, 26, 17, 52, 26, 26);
+            var indicatorValues = _algorithm.IndicatorHistory(indicator, history);
+            indicatorValues.Current.Add(new IndicatorDataPoint(referenceSymbol, default(DateTime), 1));
+
+            dynamic dataframe = indicatorValues.DataFrame;
+            using (Py.GIL())
+            {
+                var currentColumn = dataframe["current"];
+                foreach (PyObject value in currentColumn)
+                {
+                    double doubleValue = value.As<double>();
+                    Assert.IsFalse(double.IsNaN(doubleValue));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Revised all indicators to use `EndTime` instead of `Time` during updates to ensure correct timestamp alignment, as indicators represent values at the end of each bar. 

#### Related Issue
Closes #8791 

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
