### PR TITLE
Log the Number of Active Subscriptions Before and After Warm Up #8779

### DIFF
--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -651,6 +651,7 @@ namespace QuantConnect.Lean.Engine
             {
                 nextWarmupStatusTime = DateTime.UtcNow.AddSeconds(1);
                 algorithm.Debug("Algorithm starting warm up...");
+                algorithm.Debug($"Subscriptions count: {algorithm.SubscriptionManager.Count}");
                 results.SendStatusUpdate(AlgorithmStatus.History, $"{warmingUpPercent}");
             }
             else
@@ -699,6 +700,7 @@ namespace QuantConnect.Lean.Engine
                     // we trigger this callback here and not internally in the algorithm so that we can go through python if required
                     algorithm.OnWarmupFinished();
                     algorithm.Debug("Algorithm finished warming up.");
+                    algorithm.Debug($"Subscriptions count: {algorithm.SubscriptionManager.Count}");
                     results.SendStatusUpdate(AlgorithmStatus.Running, "100");
                 }
                 yield return timeSlice;

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -133,7 +133,7 @@ namespace QuantConnect.Lean.Engine
 
             var pendingDelistings = new List<Delisting>();
             var splitWarnings = new List<Split>();
-            
+
             //Initialize Properties:
             AlgorithmId = job.AlgorithmId;
 
@@ -166,7 +166,7 @@ namespace QuantConnect.Lean.Engine
             //Loop over the queues: get a data collection, then pass them all into relevent methods in the algorithm.
             Log.Trace($"AlgorithmManager.Run(): Begin DataStream - Start: {algorithm.StartDate} Stop: {algorithm.EndDate} Time: {algorithm.Time} Warmup: {algorithm.IsWarmingUp}");
             foreach (var timeSlice in Stream(algorithm, synchronizer, results, token))
-            {   
+            {
                 // reset our timer on each loop
                 TimeLimit.StartNewTimeStep();
 

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -133,8 +133,6 @@ namespace QuantConnect.Lean.Engine
 
             var pendingDelistings = new List<Delisting>();
             var splitWarnings = new List<Split>();
-
-            var logSubscriptionsCountOnce = false; 
             
             //Initialize Properties:
             AlgorithmId = job.AlgorithmId;
@@ -169,12 +167,6 @@ namespace QuantConnect.Lean.Engine
             Log.Trace($"AlgorithmManager.Run(): Begin DataStream - Start: {algorithm.StartDate} Stop: {algorithm.EndDate} Time: {algorithm.Time} Warmup: {algorithm.IsWarmingUp}");
             foreach (var timeSlice in Stream(algorithm, synchronizer, results, token))
             {   
-                if (algorithm.IsWarmingUp && !logSubscriptionsCountOnce)
-                {
-                    Log.Trace($"AlgorithmManager.Run(): Subscriptions count before warm up: {algorithm.SubscriptionManager.Count}");
-                    logSubscriptionsCountOnce = true;
-                }
-
                 // reset our timer on each loop
                 TimeLimit.StartNewTimeStep();
 
@@ -655,6 +647,7 @@ namespace QuantConnect.Lean.Engine
             var nextWarmupStatusTime = DateTime.MinValue;
             var warmingUp = algorithm.IsWarmingUp;
             var warmingUpPercent = 0;
+            var logSubscriptionCountFlag = false; 
             if (warmingUp)
             {
                 nextWarmupStatusTime = DateTime.UtcNow.AddSeconds(1);
@@ -698,6 +691,11 @@ namespace QuantConnect.Lean.Engine
                             algorithm.Debug($"Processing algorithm warm-up request {warmingUpPercent}%...");
                             results.SendStatusUpdate(AlgorithmStatus.History, $"{warmingUpPercent}");
                         }
+                    }
+                    if (!logSubscriptionCountFlag)
+                    {
+                        Log.Trace($"AlgorithmManager.Stream(): Subscriptions count before warm up: {algorithm.SubscriptionManager.Count}");
+                        logSubscriptionCountFlag = true;
                     }
                 }
                 else if (warmingUp)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Log the Number of Active Subscriptions (including internal) Before and After Warm Up 
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #8779
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
NA

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
Yes

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by running WarmupAlgorithm.cs 

Log: 
TRACE:: Debug: Algorithm starting warm up...
TRACE:: Debug: Subscriptions count: 3
….
TRACE:: Debug: Algorithm finished warming up.
TRACE:: Debug: Subscriptions count: 4

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
