### PR TITLE
Refactor SubscriptionDataConfigTypeFilter method

### DIFF
--- a/Algorithm.CSharp/TickHistoryRequestWithoutTickSubscriptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TickHistoryRequestWithoutTickSubscriptionRegressionAlgorithm.cs
@@ -77,7 +77,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 531220;
+        public int AlgorithmHistoryDataPoints => 5978528;
 
         /// <summary>
         /// Final status of the algorithm

--- a/Algorithm.CSharp/TickHistoryRequestWithoutTickSubscriptionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TickHistoryRequestWithoutTickSubscriptionRegressionAlgorithm.cs
@@ -77,7 +77,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 5978528;
+        public int AlgorithmHistoryDataPoints => 531220;
 
         /// <summary>
         /// Final status of the algorithm

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -1192,7 +1192,6 @@ namespace QuantConnect.Algorithm
 
                         // Reuse settings from reference subscription if available
                         // fallback to UniverseSettings/defaults otherwise
-                        var fillForward = referenceSubscription?.FillDataForward ?? UniverseSettings.FillForward;
                         var extendedMarketHours = referenceSubscription?.ExtendedMarketHours ?? UniverseSettings.ExtendedMarketHours;
                         var dataNormalizationMode = referenceSubscription?.DataNormalizationMode ?? UniverseSettings.GetUniverseNormalizationModeOrDefault(symbol.SecurityType);
                         var dataMappingMode = referenceSubscription?.DataMappingMode ?? DataMappingMode.OpenInterest;
@@ -1204,7 +1203,7 @@ namespace QuantConnect.Algorithm
                             res,
                             entry.DataTimeZone,
                             entry.ExchangeHours.TimeZone,
-                            fillForward,
+                            UniverseSettings.FillForward,
                             extendedMarketHours,
                             true,
                             false,

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -1053,7 +1053,10 @@ namespace QuantConnect.Algorithm
                 // lets make sure to respect the order of the data types
                 .ThenByDescending(config => GetTickTypeOrder(config.SecurityType, config.TickType));
 
-            var matchingSubscriptions = subscriptions.Where(s => SubscriptionDataConfigTypeFilter(type, s.Type));
+            var matchingSubscriptions =
+                typeof(Tick).IsAssignableFrom(type) && !typeof(OpenInterest).IsAssignableFrom(type)
+                ? Enumerable.Empty<SubscriptionDataConfig>()
+                : subscriptions.Where(s => SubscriptionDataConfigTypeFilter(type, s.Type));
 
             var internalConfig = new List<SubscriptionDataConfig>();
             var userConfig = new List<SubscriptionDataConfig>();
@@ -1207,17 +1210,7 @@ namespace QuantConnect.Algorithm
 
             var targetIsGenericType = targetType == typeof(BaseData);
 
-            if (typeof(OpenInterest).IsAssignableFrom(targetType))
-            {
-                return targetType.IsAssignableFrom(configType) && !targetIsGenericType;
-            }
-
-            if (typeof(Tick).IsAssignableFrom(targetType))
-            {
-                return configType == typeof(TradeBar) || configType == typeof(QuoteBar) || typeof(Tick).IsAssignableFrom(configType);
-            }
-
-            return targetType.IsAssignableFrom(configType);
+            return targetType.IsAssignableFrom(configType) && (!targetIsGenericType || configType != typeof(OpenInterest));
         }
 
         private SecurityExchangeHours GetExchangeHours(Symbol symbol, Type type = null)

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -1212,7 +1212,12 @@ namespace QuantConnect.Algorithm
                 return targetType.IsAssignableFrom(configType) && !targetIsGenericType;
             }
 
-            return targetType.IsAssignableFrom(configType) || targetType == typeof(Tick);
+            if (typeof(Tick).IsAssignableFrom(targetType))
+            {
+                return configType == typeof(TradeBar) || configType == typeof(QuoteBar) || typeof(Tick).IsAssignableFrom(configType);
+            }
+
+            return targetType.IsAssignableFrom(configType);
         }
 
         private SecurityExchangeHours GetExchangeHours(Symbol symbol, Type type = null)

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -1207,7 +1207,12 @@ namespace QuantConnect.Algorithm
 
             var targetIsGenericType = targetType == typeof(BaseData);
 
-            return targetType.IsAssignableFrom(configType) && (!targetIsGenericType || configType != typeof(OpenInterest));
+            if (typeof(OpenInterest).IsAssignableFrom(targetType))
+            {
+                return targetType.IsAssignableFrom(configType) && !targetIsGenericType;
+            }
+
+            return targetType.IsAssignableFrom(configType) || targetType == typeof(Tick);
         }
 
         private SecurityExchangeHours GetExchangeHours(Symbol symbol, Type type = null)

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -3626,6 +3626,32 @@ def get_history(algorithm, security):
             }
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TickHistoryReturnsConsistentResultsWithOrWithoutContract(bool addFutureContract)
+        {
+            var start = new DateTime(2013, 10, 09);
+            _algorithm = GetAlgorithm(start);
+            _algorithm.SetEndDate(2013, 10, 10);
+
+            var symbol = Symbol.CreateFuture(Futures.Metals.Gold, Market.COMEX, new DateTime(2013, 10, 29));
+
+            if (addFutureContract)
+            {
+                var future = _algorithm.AddFutureContract(symbol, Resolution.Minute);
+            }
+
+            var history = _algorithm.History([symbol], TimeSpan.FromDays(3), Resolution.Tick).ToList();
+            var typedTickHistory = _algorithm.History<Tick>([symbol], TimeSpan.FromDays(3), Resolution.Tick).ToList();
+
+            var extractedTicks = history.Select(x => x.Get<Tick>()).Where(x => x.Count > 0).ToList();
+
+            Assert.IsTrue(history.Count > 0);
+            Assert.IsTrue(typedTickHistory.Count > 0);
+            Assert.AreEqual(extractedTicks.Count, typedTickHistory.Count);
+            Assert.AreEqual(71703, extractedTicks.Count);
+        }
+
         private static IEnumerable<TestCaseData> GetCustomNonOptionDataHistoryForOptionConfigTestCases()
         {
             foreach (var language in new[] { Language.CSharp, Language.Python })

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -3626,13 +3626,18 @@ def get_history(algorithm, security):
             }
         }
 
-        [TestCase(true, Resolution.Tick)]
-        [TestCase(true, Resolution.Second)]
-        [TestCase(true, Resolution.Minute)]
-        [TestCase(true, Resolution.Hour)]
-        [TestCase(true, Resolution.Daily)]
-        [TestCase(false, null)]
-        public void TickHistoryReturnsConsistentResultsWithOrWithoutContract(bool addFutureContract, Resolution resolution)
+        [TestCase(true, Resolution.Tick, true)]
+        [TestCase(true, Resolution.Second, true)]
+        [TestCase(true, Resolution.Minute, true)]
+        [TestCase(true, Resolution.Hour, true)]
+        [TestCase(true, Resolution.Daily, true)]
+        [TestCase(true, Resolution.Tick, false)]
+        [TestCase(true, Resolution.Second, false)]
+        [TestCase(true, Resolution.Minute, false)]
+        [TestCase(true, Resolution.Hour, false)]
+        [TestCase(true, Resolution.Daily, false)]
+        [TestCase(false, null, false)]
+        public void TickHistoryReturnsConsistentResultsWithOrWithoutContract(bool addFutureContract, Resolution resolution, bool extendedMarketHours)
         {
             var start = new DateTime(2013, 10, 09);
             _algorithm = GetAlgorithm(start);
@@ -3642,11 +3647,11 @@ def get_history(algorithm, security):
 
             if (addFutureContract)
             {
-                _algorithm.AddFutureContract(symbol, resolution);
+                _algorithm.AddFutureContract(symbol, resolution, extendedMarketHours: extendedMarketHours);
             }
 
-            var history = _algorithm.History([symbol], TimeSpan.FromDays(3), Resolution.Tick).ToList();
-            var typedTickHistory = _algorithm.History<Tick>([symbol], TimeSpan.FromDays(3), Resolution.Tick).ToList();
+            var history = _algorithm.History([symbol], TimeSpan.FromDays(2), Resolution.Tick).ToList();
+            var typedTickHistory = _algorithm.History<Tick>([symbol], TimeSpan.FromDays(2), Resolution.Tick).ToList();
 
             var extractedTicks = history
                 .Select(x => x.Get<Tick>())
@@ -3666,22 +3671,36 @@ def get_history(algorithm, security):
 
             Assert.IsTrue(typedTickHistory.Count > 0);
             Assert.AreEqual(extractedTicks.Count, typedTickHistory.Count);
-            Assert.AreEqual(71703, extractedTicks.Count);
             Assert.IsTrue(quoteTicks.Count > 0);
             Assert.IsTrue(tradeTicks.Count > 0);
             Assert.AreEqual(typedQuoteTicks.Count, quoteTicks.Count);
-            Assert.AreEqual(71688, typedQuoteTicks.Count);
             Assert.AreEqual(typedTradeTicks.Count, tradeTicks.Count);
-            Assert.AreEqual(15, typedTradeTicks.Count);
+            if (extendedMarketHours)
+            {
+                Assert.AreEqual(156802, extractedTicks.Count);
+                Assert.AreEqual(156781, typedQuoteTicks.Count);
+                Assert.AreEqual(21, typedTradeTicks.Count);
+            }
+            else
+            {
+                Assert.AreEqual(71703, extractedTicks.Count);
+                Assert.AreEqual(71688, typedQuoteTicks.Count);
+                Assert.AreEqual(15, typedTradeTicks.Count);
+            }
         }
 
-        [TestCase(true, Resolution.Tick)]
-        [TestCase(true, Resolution.Second)]
-        [TestCase(true, Resolution.Minute)]
-        [TestCase(true, Resolution.Hour)]
-        [TestCase(true, Resolution.Daily)]
-        [TestCase(false, null)]
-        public void TickHistoryReturnsConsistentResultsWithOrWithoutEquity(bool addEquity, Resolution resolution)
+        [TestCase(true, Resolution.Tick, true)]
+        [TestCase(true, Resolution.Second, true)]
+        [TestCase(true, Resolution.Minute, true)]
+        [TestCase(true, Resolution.Hour, true)]
+        [TestCase(true, Resolution.Daily, true)]
+        [TestCase(true, Resolution.Tick, false)]
+        [TestCase(true, Resolution.Second, false)]
+        [TestCase(true, Resolution.Minute, false)]
+        [TestCase(true, Resolution.Hour, false)]
+        [TestCase(true, Resolution.Daily, false)]
+        [TestCase(false, null, false)]
+        public void TickHistoryReturnsConsistentResultsWithOrWithoutEquity(bool addEquity, Resolution resolution, bool extendedMarketHours)
         {
             var start = new DateTime(2013, 10, 09);
             _algorithm = GetAlgorithm(start);
@@ -3690,11 +3709,11 @@ def get_history(algorithm, security):
             var symbol = Symbol.Create("SPY", SecurityType.Equity, Market.USA);
             if (addEquity)
             {
-                _algorithm.AddEquity("SPY", resolution);
+                _algorithm.AddEquity("SPY", resolution, extendedMarketHours: extendedMarketHours);
             }
 
-            var history = _algorithm.History([symbol], TimeSpan.FromMinutes(485), Resolution.Tick).ToList();
-            var typedTickHistory = _algorithm.History<Tick>([symbol], TimeSpan.FromMinutes(485), Resolution.Tick).ToList();
+            var history = _algorithm.History([symbol], TimeSpan.FromMinutes(481), Resolution.Tick).ToList();
+            var typedTickHistory = _algorithm.History<Tick>([symbol], TimeSpan.FromMinutes(481), Resolution.Tick).ToList();
 
             var extractedTicks = history
                 .Select(x => x.Get<Tick>())
@@ -3714,13 +3733,23 @@ def get_history(algorithm, security):
 
             Assert.IsTrue(typedTickHistory.Count > 0);
             Assert.AreEqual(extractedTicks.Count, typedTickHistory.Count);
-            Assert.AreEqual(24868, extractedTicks.Count);
             Assert.IsTrue(quoteTicks.Count > 0);
             Assert.IsTrue(tradeTicks.Count > 0);
             Assert.AreEqual(typedQuoteTicks.Count, quoteTicks.Count);
-            Assert.AreEqual(14778, typedQuoteTicks.Count);
             Assert.AreEqual(typedTradeTicks.Count, tradeTicks.Count);
-            Assert.AreEqual(10090, typedTradeTicks.Count);
+
+            if (extendedMarketHours)
+            {
+                Assert.AreEqual(24334, extractedTicks.Count);
+                Assert.AreEqual(17010, typedQuoteTicks.Count);
+                Assert.AreEqual(7324, typedTradeTicks.Count);
+            }
+            else
+            {
+                Assert.AreEqual(5642, extractedTicks.Count);
+                Assert.AreEqual(3111, typedQuoteTicks.Count);
+                Assert.AreEqual(2531, typedTradeTicks.Count);
+            }
         }
 
         private static IEnumerable<TestCaseData> GetCustomNonOptionDataHistoryForOptionConfigTestCases()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Refactor `SubscriptionDataConfigTypeFilter` to ensure requests for OpenInterest or its derived types only match OpenInterest, and added explicit support for Tick type filtering. Previously, a `History<Tick>` call would only return `OpenInterest` since it inherits from `Tick`, but now it returns `Trade`, `Quote`, and `OpenInterest` if `targetType = Tick`

#### Related Issue
Closes #8692

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit test.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
