### PR TITLE
Fix EndTime for consolidated bars in count-based consolidator

### DIFF
--- a/Common/Data/Consolidators/OpenInterestConsolidator.cs
+++ b/Common/Data/Consolidators/OpenInterestConsolidator.cs
@@ -119,6 +119,12 @@ namespace QuantConnect.Data.Consolidators
                 //Update the working bar
                 workingBar.Value = data.Value;
 
+                if (!IsTimeBased)
+                {
+                    // When using count-based consolidation, set EndTime to the last input's EndTime
+                    workingBar.EndTime = data.EndTime;
+                }
+
                 // If we are consolidating hourly or daily, we need to update the time of the working bar
                 // for the end time to match the last data point time
                 if (_hourOrDailyConsolidation)

--- a/Common/Data/Consolidators/QuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/QuoteBarConsolidator.cs
@@ -96,9 +96,8 @@ namespace QuantConnect.Data.Consolidators
             }
             else if (!IsTimeBased)
             {
-                // we should only increment the period after the first data we get, else we would be accouting twice for the inital bars period
-                // because in the `if` above we are already providing the `data.Period` as argument. See test 'AggregatesNewCountQuoteBarProperly' which assert period
-                workingBar.Period += data.Period;
+                // When using count-based consolidation, set EndTime to the last input's EndTime
+                workingBar.EndTime = data.EndTime;
             }
 
             // update the bid and ask

--- a/Common/Data/Consolidators/TradeBarConsolidator.cs
+++ b/Common/Data/Consolidators/TradeBarConsolidator.cs
@@ -113,7 +113,11 @@ namespace QuantConnect.Data.Consolidators
                 //Aggregate the working bar
                 workingBar.Close = data.Close;
                 workingBar.Volume += data.Volume;
-                if (!IsTimeBased) workingBar.Period += data.Period;
+                if (!IsTimeBased)
+                {
+                    // When using count-based consolidation, set EndTime to the last input's EndTime
+                    workingBar.EndTime = data.EndTime;
+                }
                 if (data.Low < workingBar.Low) workingBar.Low = data.Low;
                 if (data.High > workingBar.High) workingBar.High = data.High;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
This change adjusts how `EndTime` is set in count-based consolidators. Previously, `EndTime` was calculated as `Time + Period`. Now, the `EndTime` of the consolidated bar reflects the `EndTime` of the latest bar.

#### Related Issue
Closes #8789

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
