### PR TITLE
Add tag parameter, update CancelOpenOrders and Liquidate calls

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -99,6 +99,11 @@ namespace QuantConnect.Algorithm
         /// </summary>
         protected const int MaxTagsCount = 100;
 
+        /// <summary>
+        /// The tag is used for the RemoveSecurity method
+        /// </summary>
+        protected const string RemovedTag = "Removed";
+
         private readonly TimeKeeper _timeKeeper;
         private LocalTimeKeeper _localTimeKeeper;
 
@@ -2511,13 +2516,13 @@ namespace QuantConnect.Algorithm
             if (!IsWarmingUp)
             {
                 // cancel open orders
-                Transactions.CancelOpenOrders(security.Symbol, tag: nameof(RemoveSecurity));
+                Transactions.CancelOpenOrders(security.Symbol, tag: RemovedTag);
             }
 
             // liquidate if invested
             if (security.Invested)
             {
-                Liquidate(symbol: security.Symbol, tag: nameof(RemoveSecurity));
+                Liquidate(symbol: security.Symbol, tag: RemovedTag);
             }
 
             // Mark security as not tradable

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2511,13 +2511,13 @@ namespace QuantConnect.Algorithm
             if (!IsWarmingUp)
             {
                 // cancel open orders
-                Transactions.CancelOpenOrders(security.Symbol);
+                Transactions.CancelOpenOrders(security.Symbol, tag: nameof(RemoveSecurity));
             }
 
             // liquidate if invested
             if (security.Invested)
             {
-                Liquidate(security.Symbol);
+                Liquidate(symbol: security.Symbol, tag: nameof(RemoveSecurity));
             }
 
             // Mark security as not tradable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Added tag parameter, updated CancelOpenOrders and Liquidate calls in QCAlgorithm

#### Related Issue
this PR fixes [bug-8786](https://github.com/QuantConnect/Lean/issues/8786)

#### Motivation and Context
The RemoveSecurity has a tag parameter. The tag will be used in the CancelOpenOrders and Liquidate to inform the user of the cause of cancellation/liquidation.
If we see a Liquidate tag, we don't know if it came from RemoveSecurity or Liquidate methods

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
N/A

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
