### PR TITLE
Add tag to RemoveSecurity method

### DIFF
--- a/Algorithm.CSharp/AddFutureContractWithContinuousRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddFutureContractWithContinuousRegressionAlgorithm.cs
@@ -159,7 +159,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Lowest Capacity Asset", "ES VMKLFZIH2MTD"},
             {"Portfolio Turnover", "66.80%"},
             {"Drawdown Recovery", "0"},
-            {"OrderListHash", "579e2e83dd7e5e7648c47e9eff132460"}
+            {"OrderListHash", "39f1e15c27212d8fdd58aeb7fb2b93cc"}
         };
     }
 }

--- a/Algorithm.CSharp/AddOptionContractFromUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddOptionContractFromUniverseRegressionAlgorithm.cs
@@ -213,7 +213,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Lowest Capacity Asset", "AOL VRKS95ENLBYE|AOL R735QTJ8XC9X"},
             {"Portfolio Turnover", "1.14%"},
             {"Drawdown Recovery", "0"},
-            {"OrderListHash", "cde7b518b7ad6d86cff6e5e092d9a413"}
+            {"OrderListHash", "90aa4bf345a6ba5ea2b0b14e32d1598f"}
         };
     }
 }

--- a/Algorithm.CSharp/AddRemoveOptionUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddRemoveOptionUniverseRegressionAlgorithm.cs
@@ -249,7 +249,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Lowest Capacity Asset", "GOOCV 305RBQ2BZBZT2|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "2.58%"},
             {"Drawdown Recovery", "0"},
-            {"OrderListHash", "09f766c470a8bcf4bb6862da52bf25a7"}
+            {"OrderListHash", "12037c87de17d6e62eadd99c70a0685e"}
         };
     }
 }

--- a/Algorithm.CSharp/AddRemoveSecurityRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AddRemoveSecurityRegressionAlgorithm.cs
@@ -154,7 +154,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Lowest Capacity Asset", "AIG R735QTJ8XC9X"},
             {"Portfolio Turnover", "29.88%"},
             {"Drawdown Recovery", "2"},
-            {"OrderListHash", "6061ecfbb89eb365dff913410d279b7c"}
+            {"OrderListHash", "f04b3521256c7d6740966bc3df34e7b1"}
         };
     }
 }

--- a/Algorithm.CSharp/ConsolidateWithSizeAttributeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ConsolidateWithSizeAttributeRegressionAlgorithm.cs
@@ -209,6 +209,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Estimated Strategy Capacity", "$0"},
             {"Lowest Capacity Asset", ""},
             {"Portfolio Turnover", "0%"},
+            {"Drawdown Recovery", "0"},
             {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
         };
     }

--- a/Algorithm.CSharp/DelayedSettlementAfterManualSecurityRemovalAlgorithm.cs
+++ b/Algorithm.CSharp/DelayedSettlementAfterManualSecurityRemovalAlgorithm.cs
@@ -149,7 +149,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Lowest Capacity Asset", "GOOCV WHEA9CWI9A86|GOOCV VP83T1ZUHROL"},
             {"Portfolio Turnover", "11.63%"},
             {"Drawdown Recovery", "0"},
-            {"OrderListHash", "0a3ff33e46a1ca590b9163b07fcd7e0c"}
+            {"OrderListHash", "65ac4f8e4de760fec3809bf1aa3e0e9c"}
         };
     }
 }

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -99,6 +99,11 @@ namespace QuantConnect.Algorithm
         /// </summary>
         protected const int MaxTagsCount = 100;
 
+        /// <summary>
+        /// The tag is used for the RemoveSecurity method
+        /// </summary>
+        protected const string RemovedTag = "Removed";
+
         private readonly TimeKeeper _timeKeeper;
         private LocalTimeKeeper _localTimeKeeper;
 
@@ -2511,13 +2516,13 @@ namespace QuantConnect.Algorithm
             if (!IsWarmingUp)
             {
                 // cancel open orders
-                Transactions.CancelOpenOrders(security.Symbol, tag: nameof(RemoveSecurity));
+                Transactions.CancelOpenOrders(security.Symbol, tag: RemovedTag);
             }
 
             // liquidate if invested
             if (security.Invested)
             {
-                Liquidate(symbol: security.Symbol, tag: nameof(RemoveSecurity));
+                Liquidate(symbol: security.Symbol, tag: RemovedTag);
             }
 
             // Mark security as not tradable

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -99,11 +99,6 @@ namespace QuantConnect.Algorithm
         /// </summary>
         protected const int MaxTagsCount = 100;
 
-        /// <summary>
-        /// The tag is used for the RemoveSecurity method
-        /// </summary>
-        protected const string RemovedTag = "Removed";
-
         private readonly TimeKeeper _timeKeeper;
         private LocalTimeKeeper _localTimeKeeper;
 
@@ -2504,8 +2499,9 @@ namespace QuantConnect.Algorithm
         /// open orders and then liquidate any existing holdings
         /// </summary>
         /// <param name="symbol">The symbol of the security to be removed</param>
+        /// <param name="tag">Optional tag to indicate the cause of removal</param>
         [DocumentationAttribute(AddingData)]
-        public bool RemoveSecurity(Symbol symbol)
+        public bool RemoveSecurity(Symbol symbol, string tag = null)
         {
             Security security;
             if (!Securities.TryGetValue(symbol, out security))
@@ -2513,16 +2509,17 @@ namespace QuantConnect.Algorithm
                 return false;
             }
 
+            tag ??= "Removed";
             if (!IsWarmingUp)
             {
                 // cancel open orders
-                Transactions.CancelOpenOrders(security.Symbol, tag: RemovedTag);
+                Transactions.CancelOpenOrders(security.Symbol, tag);
             }
 
             // liquidate if invested
             if (security.Invested)
             {
-                Liquidate(symbol: security.Symbol, tag: RemovedTag);
+                Liquidate(symbol: security.Symbol, tag: tag);
             }
 
             // Mark security as not tradable

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2511,13 +2511,13 @@ namespace QuantConnect.Algorithm
             if (!IsWarmingUp)
             {
                 // cancel open orders
-                Transactions.CancelOpenOrders(security.Symbol);
+                Transactions.CancelOpenOrders(security.Symbol, tag: nameof(RemoveSecurity));
             }
 
             // liquidate if invested
             if (security.Invested)
             {
-                Liquidate(security.Symbol);
+                Liquidate(symbol: security.Symbol, tag: nameof(RemoveSecurity));
             }
 
             // Mark security as not tradable

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2487,11 +2487,12 @@ namespace QuantConnect.Algorithm
         /// open orders and then liquidate any existing holdings
         /// </summary>
         /// <param name="symbol">The symbol of the security to be removed</param>
+        /// <param name="tag">Optional tag to indicate the cause of removal</param>
         /// <remarks>Sugar syntax for <see cref="AddOptionContract"/></remarks>
         [DocumentationAttribute(AddingData)]
-        public bool RemoveOptionContract(Symbol symbol)
+        public bool RemoveOptionContract(Symbol symbol, string tag = null)
         {
-            return RemoveSecurity(symbol);
+            return RemoveSecurity(symbol, tag);
         }
 
         /// <summary>
@@ -2538,7 +2539,7 @@ namespace QuantConnect.Algorithm
                         var underlying = Securities[symbol.Underlying];
                         if (!otherUniverses.Any(u => u.Members.ContainsKey(underlying.Symbol)))
                         {
-                            RemoveSecurity(underlying.Symbol);
+                            RemoveSecurity(underlying.Symbol, tag);
                         }
                     }
 
@@ -2548,7 +2549,7 @@ namespace QuantConnect.Algorithm
                     {
                         if (!otherUniverses.Any(u => u.Members.ContainsKey(child.Symbol)) && !child.Symbol.IsCanonical())
                         {
-                            RemoveSecurity(child.Symbol);
+                            RemoveSecurity(child.Symbol, tag);
                         }
                     }
 

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -1002,7 +1002,8 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// open orders and then liquidate any existing holdings
         /// </summary>
         /// <param name="symbol">The symbol of the security to be removed</param>
-        public bool RemoveSecurity(Symbol symbol) => _baseAlgorithm.RemoveSecurity(symbol);
+        /// <param name="tag">Optional tag to indicate the cause of removal</param>
+        public bool RemoveSecurity(Symbol symbol, string tag = null) => _baseAlgorithm.RemoveSecurity(symbol, tag);
 
         /// <summary>
         /// Set the algorithm Id for this backtest or live run. This can be used to identify the order and equity records.

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -755,7 +755,8 @@ namespace QuantConnect.Interfaces
         /// open orders and then liquidate any existing holdings
         /// </summary>
         /// <param name="symbol">The symbol of the security to be removed</param>
-        bool RemoveSecurity(Symbol symbol);
+        /// <param name="tag">Optional tag to indicate the cause of removal</param>
+        bool RemoveSecurity(Symbol symbol, string tag = null);
 
         /// <summary>
         /// Sets the account currency cash symbol this algorithm is to manage, as well as


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Add a tag parameter to RemoveSecurity and update calls to CancelOpenOrders and Liquidate.

#### Related Issue
Closes #8786

#### Motivation and Context
This PR finalizes the contribution from the original [PR](https://github.com/QuantConnect/Lean/pull/8926) by adding a `tag` parameter to `RemoveSecurity` and updating regression algorithms.

#### Requires Documentation Change
N/A

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
