### PR TITLE
Improve schedule rules symbol handling

### DIFF
--- a/Algorithm.CSharp/DefaultSchedulingSymbolRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DefaultSchedulingSymbolRegressionAlgorithm.cs
@@ -1,0 +1,128 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using QuantConnect.Interfaces;
+using System.Collections.Generic;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting a default symbol is created using equity market when scheduling if none found
+    /// </summary>
+    public class DefaultSchedulingSymbolRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private bool _implicitChecked;
+        private bool _explicitChecked;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 11);
+
+            // implicitly figured usa equity
+            Schedule.On(DateRules.Tomorrow, TimeRules.AfterMarketOpen("AAPL"), () =>
+            {
+                _implicitChecked = true;
+                if (Time.TimeOfDay != new TimeSpan(9, 30, 0))
+                {
+                    throw new RegressionTestException($"Unexpected time of day {Time.TimeOfDay}");
+                }
+            });
+
+            // picked up from cache
+            AddIndex("SPX");
+            Schedule.On(DateRules.Tomorrow, TimeRules.BeforeMarketClose("SPX", extendedMarketClose: true), () =>
+            {
+                _explicitChecked = true;
+                if (Time.TimeOfDay != new TimeSpan(16, 15, 0))
+                {
+                    throw new RegressionTestException($"Unexpected time of day {Time.TimeOfDay}");
+                }
+            });
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_explicitChecked || !_implicitChecked)
+            {
+                throw new RegressionTestException("Failed to run expected checks!");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 43;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-8.91"},
+            {"Tracking Error", "0.223"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"Drawdown Recovery", "0"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.Python/DefaultSchedulingSymbolRegressionAlgorithm.py
+++ b/Algorithm.Python/DefaultSchedulingSymbolRegressionAlgorithm.py
@@ -1,0 +1,44 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression algorithm asserting a default symbol is created using equity market when scheduling if none found
+### </summary>
+class DefaultSchedulingSymbolRegressionAlgorithm(QCAlgorithm):
+    def initialize(self):
+        '''Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.'''
+        self.set_start_date(2013, 10, 7)
+        self.set_end_date(2013, 10, 11)
+
+        # implicitly figured usa equity
+        self.schedule.on(self.date_rules.tomorrow, self.time_rules.after_market_open("AAPL"), self._implicit_check)
+
+        # picked up from cache
+        self.add_index("SPX")
+        self.schedule.on(self.date_rules.tomorrow, self.time_rules.before_market_close("SPX", extended_market_close = True), self._explicit_check)
+
+    def _implicit_check(self):
+        self._implicitChecked = True
+        if self.time.time() != time(9, 30, 0):
+            raise RegressionTestException(f"Unexpected time of day {self.time.time()}")
+
+    def _explicit_check(self):
+        self._explicitChecked = True
+        if self.time.time() != time(16, 15, 0):
+            raise RegressionTestException(f"Unexpected time of day {self.time.time()}")
+
+    def on_end_of_algorithm(self):
+        if not self._explicitChecked or not self._implicitChecked:
+            raise RegressionTestException("Failed to run expected checks!")

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -58,7 +58,6 @@ using QuantConnect.Commands;
 using Newtonsoft.Json;
 using QuantConnect.Securities.Index;
 using QuantConnect.Api;
-using System.Threading.Tasks;
 
 namespace QuantConnect.Algorithm
 {
@@ -224,7 +223,7 @@ namespace QuantConnect.Algorithm
             UniverseSettings = new UniverseSettings(Resolution.Minute, Security.NullLeverage, true, false, TimeSpan.FromDays(1));
 
             // initialize our scheduler, this acts as a liason to the real time handler
-            Schedule = new ScheduleManager(Securities, TimeZone, MarketHoursDatabase);
+            Schedule = new ScheduleManager(this, Securities, TimeZone, MarketHoursDatabase);
 
             // initialize the trade builder
             SetTradeBuilder(new TradeBuilder(FillGroupingMethod.FillToFill, FillMatchingMethod.FIFO));

--- a/Common/Scheduling/ScheduleManager.cs
+++ b/Common/Scheduling/ScheduleManager.cs
@@ -15,11 +15,12 @@
 */
 
 using System;
-using System.Collections.Generic;
 using NodaTime;
-using QuantConnect.Securities;
-using QuantConnect.Logging;
 using Python.Runtime;
+using QuantConnect.Logging;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+using System.Collections.Generic;
 
 namespace QuantConnect.Scheduling
 {
@@ -47,14 +48,15 @@ namespace QuantConnect.Scheduling
         /// <summary>
         /// Initializes a new instance of the <see cref="ScheduleManager"/> class
         /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
         /// <param name="securities">Securities manager containing the algorithm's securities</param>
         /// <param name="timeZone">The algorithm's time zone</param>
         /// <param name="marketHoursDatabase">The market hours database instance to use</param>
-        public ScheduleManager(SecurityManager securities, DateTimeZone timeZone, MarketHoursDatabase marketHoursDatabase)
+        public ScheduleManager(IAlgorithm algorithm, SecurityManager securities, DateTimeZone timeZone, MarketHoursDatabase marketHoursDatabase)
         {
             _securities = securities;
-            DateRules = new DateRules(securities, timeZone, marketHoursDatabase);
-            TimeRules = new TimeRules(securities, timeZone, marketHoursDatabase);
+            DateRules = new DateRules(algorithm, securities, timeZone, marketHoursDatabase);
+            TimeRules = new TimeRules(algorithm, securities, timeZone, marketHoursDatabase);
 
             // used for storing any events before the event schedule is set
             _preInitializedEvents = new List<ScheduledEvent>();

--- a/Common/Scheduling/TimeRules.cs
+++ b/Common/Scheduling/TimeRules.cs
@@ -17,6 +17,7 @@
 using System;
 using NodaTime;
 using System.Linq;
+using QuantConnect.Interfaces;
 using QuantConnect.Securities;
 using System.Collections.Generic;
 using static QuantConnect.StringExtensions;
@@ -31,11 +32,12 @@ namespace QuantConnect.Scheduling
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeRules"/> helper class
         /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
         /// <param name="securities">The security manager</param>
         /// <param name="timeZone">The algorithm's default time zone</param>
         /// <param name="marketHoursDatabase">The market hours database instance to use</param>
-        public TimeRules(SecurityManager securities, DateTimeZone timeZone, MarketHoursDatabase marketHoursDatabase)
-            : base(securities, timeZone, marketHoursDatabase)
+        public TimeRules(IAlgorithm algorithm, SecurityManager securities, DateTimeZone timeZone, MarketHoursDatabase marketHoursDatabase)
+            : base(algorithm, securities, timeZone, marketHoursDatabase)
         {
         }
 
@@ -160,10 +162,28 @@ namespace QuantConnect.Scheduling
         /// <param name="minutesBeforeOpen">The minutes before market open that the event should fire</param>
         /// <param name="extendedMarketOpen">True to use extended market open, false to use regular market open</param>
         /// <returns>A time rule that fires the specified number of minutes before the symbol's market open</returns>
+        public ITimeRule BeforeMarketOpen(string symbol, double minutesBeforeOpen = 0, bool extendedMarketOpen = false) => BeforeMarketOpen(GetSymbol(symbol), minutesBeforeOpen, extendedMarketOpen);
+
+        /// <summary>
+        /// Specifies an event should fire at market open +- <paramref name="minutesBeforeOpen"/>
+        /// </summary>
+        /// <param name="symbol">The symbol whose market open we want an event for</param>
+        /// <param name="minutesBeforeOpen">The minutes before market open that the event should fire</param>
+        /// <param name="extendedMarketOpen">True to use extended market open, false to use regular market open</param>
+        /// <returns>A time rule that fires the specified number of minutes before the symbol's market open</returns>
         public ITimeRule BeforeMarketOpen(Symbol symbol, double minutesBeforeOpen = 0, bool extendedMarketOpen = false)
         {
             return AfterMarketOpen(symbol, minutesBeforeOpen * (-1), extendedMarketOpen);
         }
+
+        /// <summary>
+        /// Specifies an event should fire at market open +- <paramref name="minutesAfterOpen"/>
+        /// </summary>
+        /// <param name="symbol">The symbol whose market open we want an event for</param>
+        /// <param name="minutesAfterOpen">The minutes after market open that the event should fire</param>
+        /// <param name="extendedMarketOpen">True to use extended market open, false to use regular market open</param>
+        /// <returns>A time rule that fires the specified number of minutes after the symbol's market open</returns>
+        public ITimeRule AfterMarketOpen(string symbol, double minutesAfterOpen = 0, bool extendedMarketOpen = false) => AfterMarketOpen(GetSymbol(symbol), minutesAfterOpen, extendedMarketOpen);
 
         /// <summary>
         /// Specifies an event should fire at market open +- <paramref name="minutesAfterOpen"/>
@@ -199,10 +219,28 @@ namespace QuantConnect.Scheduling
         /// <param name="minutesAfterClose">The time after market close that the event should fire</param>
         /// <param name="extendedMarketClose">True to use extended market close, false to use regular market close</param>
         /// <returns>A time rule that fires the specified number of minutes after the symbol's market close</returns>
+        public ITimeRule AfterMarketClose(string symbol, double minutesAfterClose = 0, bool extendedMarketClose = false) => AfterMarketClose(GetSymbol(symbol), minutesAfterClose, extendedMarketClose);
+
+        /// <summary>
+        /// Specifies an event should fire at the market close +- <paramref name="minutesAfterClose"/>
+        /// </summary>
+        /// <param name="symbol">The symbol whose market close we want an event for</param>
+        /// <param name="minutesAfterClose">The time after market close that the event should fire</param>
+        /// <param name="extendedMarketClose">True to use extended market close, false to use regular market close</param>
+        /// <returns>A time rule that fires the specified number of minutes after the symbol's market close</returns>
         public ITimeRule AfterMarketClose(Symbol symbol, double minutesAfterClose = 0, bool extendedMarketClose = false)
         {
             return BeforeMarketClose(symbol, minutesAfterClose * (-1), extendedMarketClose);
         }
+
+        /// <summary>
+        /// Specifies an event should fire at the market close +- <paramref name="minutesBeforeClose"/>
+        /// </summary>
+        /// <param name="symbol">The symbol whose market close we want an event for</param>
+        /// <param name="minutesBeforeClose">The time before market close that the event should fire</param>
+        /// <param name="extendedMarketClose">True to use extended market close, false to use regular market close</param>
+        /// <returns>A time rule that fires the specified number of minutes before the symbol's market close</returns>
+        public ITimeRule BeforeMarketClose(string symbol, double minutesBeforeClose = 0, bool extendedMarketClose = false) => BeforeMarketClose(GetSymbol(symbol), minutesBeforeClose, extendedMarketClose);
 
         /// <summary>
         /// Specifies an event should fire at the market close +- <paramref name="minutesBeforeClose"/>

--- a/Common/SecurityIdentifier.cs
+++ b/Common/SecurityIdentifier.cs
@@ -846,16 +846,12 @@ namespace QuantConnect
 
         private static void CacheSid(string key, SecurityIdentifier identifier)
         {
-            lock (SecurityIdentifierCache)
+            // limit the cache size to help with memory usage
+            if (SecurityIdentifierCache.Count >= 600000)
             {
-                // limit the cache size to help with memory usage
-                if (SecurityIdentifierCache.Count >= 600000)
-                {
-                    SecurityIdentifierCache.Clear();
-                }
-
-                SecurityIdentifierCache[key] = identifier;
+                SecurityIdentifierCache.Clear();
             }
+            SecurityIdentifierCache[key] = identifier;
         }
 
         /// <summary>

--- a/Engine/Results/IResultHandler.cs
+++ b/Engine/Results/IResultHandler.cs
@@ -21,7 +21,6 @@ using System.ComponentModel.Composition;
 using QuantConnect.Brokerages;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
-using QuantConnect.Lean.Engine.TransactionHandlers;
 using QuantConnect.Orders;
 using QuantConnect.Packets;
 using QuantConnect.Statistics;

--- a/Tests/Algorithm/Framework/Portfolio/PortfolioConstructionModelTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/PortfolioConstructionModelTests.cs
@@ -303,7 +303,7 @@ def RebalanceFunc(time):
         public void RebalanceFunctionDateRules(Language language)
         {
             var mhdb = MarketHoursDatabase.FromDataFolder();
-            var dateRules = new DateRules(new SecurityManager(
+            var dateRules = new DateRules(null, new SecurityManager(
                 new TimeKeeper(new DateTime(2015, 1, 1), DateTimeZone.Utc)), DateTimeZone.Utc, mhdb);
 
             TestPortfolioConstructionModel constructionModel;

--- a/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
+++ b/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
@@ -41,8 +41,8 @@ namespace QuantConnect.Tests.Common.Data.UniverseSelection
             _securities = new SecurityManager(_timekeeper);
 
             var mhdb = MarketHoursDatabase.FromDataFolder();
-            _dateRules = new DateRules(_securities, _timezone, mhdb);
-            _timeRules = new TimeRules(_securities, _timezone, mhdb);
+            _dateRules = new DateRules(null, _securities, _timezone, mhdb);
+            _timeRules = new TimeRules(null, _securities, _timezone, mhdb);
         }
 
         [Test]

--- a/Tests/Common/Scheduling/DateRulesTests.cs
+++ b/Tests/Common/Scheduling/DateRulesTests.cs
@@ -1047,7 +1047,7 @@ wrongCustomDateRule = 1
                 )
             );
 
-            var rules = new DateRules(manager, TimeZones.NewYork, mhdb);
+            var rules = new DateRules(null, manager, TimeZones.NewYork, mhdb);
             return rules;
         }
     }

--- a/Tests/Common/Scheduling/TimeRulesTests.cs
+++ b/Tests/Common/Scheduling/TimeRulesTests.cs
@@ -492,7 +492,7 @@ wrongCustomTimeRule = ""hello""
                     new SecurityCache()
                 )
             );
-            var rules = new TimeRules(manager, dateTimeZone, mhdb);
+            var rules = new TimeRules(null, manager, dateTimeZone, mhdb);
             return rules;
         }
 
@@ -517,7 +517,7 @@ wrongCustomTimeRule = ""hello""
                     new SecurityCache()
                 )
             );
-            var rules = new TimeRules(manager, dateTimeZone, mhdb);
+            var rules = new TimeRules(null, manager, dateTimeZone, mhdb);
             return rules;
         }
     }

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -1720,7 +1720,7 @@ class TestPythonDerivedClass(PythonData):
         public void DateRulesToFunc()
         {
             var mhdb = MarketHoursDatabase.FromDataFolder();
-            var dateRules = new DateRules(new SecurityManager(
+            var dateRules = new DateRules(null, new SecurityManager(
                 new TimeKeeper(new DateTime(2015, 1, 1), DateTimeZone.Utc)), DateTimeZone.Utc, mhdb);
             var first = new DateTime(2015, 1, 10);
             var second = new DateTime(2015, 1, 30);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- When scheduling if a ticker is given for an non existing symbol, will assume USA equity symbol. Adding regression tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related https://github.com/QuantConnect/pythonnet/pull/107
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Improve user friendliness, specially for AI
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New and existing tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
