### PR TITLE
Feature: new property `AccountType`

### DIFF
--- a/Common/Orders/EzeOrderProperties.cs
+++ b/Common/Orders/EzeOrderProperties.cs
@@ -48,12 +48,14 @@ namespace QuantConnect.Orders
         /// <param name="route">The trading route name (optional).</param>
         /// <param name="account">The trading account with specific permissions (optional).</param>
         /// <param name="notes">Optional notes about the order.</param>
-        public EzeOrderProperties(string route = default, string account = default, string notes = default)
+        /// <param name="accountType">The account type for the order (e.g., "119" for margin orders) (optional).</param>
+        public EzeOrderProperties(string route = default, string account = default, string notes = default, string accountType = default)
             : base()
         {
             Route = route;
             Account = account;
             Notes = notes;
+            AccountType = accountType;
         }
     }
 }


### PR DESCRIPTION
#### Description
Added a new property `AccountType` to the `EzeOrderProperties class` to support specifying the account type for orders in Eze EMS.

> This is primarily required for marking **margin** orders (AccountType= 119) when submitting orders via the system.

#### Related Issue
N/a

#### Motivation and Context
Eze support recommended setting `order.ExtendedFields["ACCT_TYPE"] = "119"` to correctly process margin orders. Adding this property allows the application to store and use this value directly in the order properties, making it easier to manage and submit orders correctly.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
- Created instances of `EzeOrderProperties` and verified that AccountType can be set and retrieved correctly.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
