### PR TITLE
Feat: Validation for `Market On Open` Submission Time

### DIFF
--- a/Common/Brokerages/AlpacaBrokerageModel.cs
+++ b/Common/Brokerages/AlpacaBrokerageModel.cs
@@ -96,7 +96,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(this, security, order, new(19, 0, 0), new(9, 28, 0), out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, new(19, 0, 0), new(9, 28, 0), out message))
             {
                 return false;
             }

--- a/Common/Brokerages/AlpacaBrokerageModel.cs
+++ b/Common/Brokerages/AlpacaBrokerageModel.cs
@@ -13,6 +13,7 @@
 * limitations under the License.
 */
 
+using System;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Orders.Fees;
@@ -26,6 +27,18 @@ namespace QuantConnect.Brokerages
     /// </summary>
     public class AlpacaBrokerageModel : DefaultBrokerageModel
     {
+        /// <summary>
+        /// The default start time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
+        /// Example: 19:00 (7:00 PM).
+        /// </summary>
+        private static readonly TimeOnly _mooWindowStart = new(19, 0, 0);
+
+        /// <summary>
+        /// The default end time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
+        /// Example: 09:28 (9:28 AM).
+        /// </summary>
+        private static readonly TimeOnly _mooWindowEnd = new(9, 28, 0);
+
         /// <summary>
         /// A dictionary that maps each supported <see cref="SecurityType"/> to an array of <see cref="OrderType"/> supported by Alpaca brokerage.
         /// </summary>
@@ -96,7 +109,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, new(19, 0, 0), new(9, 28, 0), out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _mooWindowStart, _mooWindowEnd, out message))
             {
                 return false;
             }

--- a/Common/Brokerages/AlpacaBrokerageModel.cs
+++ b/Common/Brokerages/AlpacaBrokerageModel.cs
@@ -96,6 +96,11 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(this, security, order, new(19, 0, 0), new(9, 28, 0), out message))
+            {
+                return false;
+            }
+
             return base.CanSubmitOrder(security, order, out message);
         }
 

--- a/Common/Brokerages/AlpacaBrokerageModel.cs
+++ b/Common/Brokerages/AlpacaBrokerageModel.cs
@@ -109,7 +109,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _mooWindowStart, _mooWindowEnd, out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrder(security, order, _mooWindowStart, _mooWindowEnd, out message))
             {
                 return false;
             }

--- a/Common/Brokerages/AlpacaBrokerageModel.cs
+++ b/Common/Brokerages/AlpacaBrokerageModel.cs
@@ -31,13 +31,13 @@ namespace QuantConnect.Brokerages
         /// The default start time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
         /// Example: 19:00 (7:00 PM).
         /// </summary>
-        private static readonly TimeOnly _mooWindowStart = new(19, 0, 0);
+        private static readonly TimeOnly _marketOnOpenOrderSafeSubmissionStartTime = new(19, 0, 0);
 
         /// <summary>
         /// The default end time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
         /// Example: 09:28 (9:28 AM).
         /// </summary>
-        private static readonly TimeOnly _mooWindowEnd = new(9, 28, 0);
+        private static readonly TimeOnly _marketOnOpenOrderSafeSubmissionEndTime = new(9, 28, 0);
 
         /// <summary>
         /// A dictionary that maps each supported <see cref="SecurityType"/> to an array of <see cref="OrderType"/> supported by Alpaca brokerage.
@@ -109,7 +109,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _mooWindowStart, _mooWindowEnd, out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _marketOnOpenOrderSafeSubmissionStartTime, _marketOnOpenOrderSafeSubmissionEndTime, out message))
             {
                 return false;
             }

--- a/Common/Brokerages/AlpacaBrokerageModel.cs
+++ b/Common/Brokerages/AlpacaBrokerageModel.cs
@@ -19,6 +19,7 @@ using QuantConnect.Securities;
 using QuantConnect.Orders.Fees;
 using System.Collections.Generic;
 using QuantConnect.Orders.TimeInForces;
+using System.Linq;
 
 namespace QuantConnect.Brokerages
 {
@@ -27,18 +28,6 @@ namespace QuantConnect.Brokerages
     /// </summary>
     public class AlpacaBrokerageModel : DefaultBrokerageModel
     {
-        /// <summary>
-        /// The default start time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
-        /// Example: 19:00 (7:00 PM).
-        /// </summary>
-        private static readonly TimeOnly _mooWindowStart = new(19, 0, 0);
-
-        /// <summary>
-        /// The default end time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
-        /// Example: 09:28 (9:28 AM).
-        /// </summary>
-        private static readonly TimeOnly _mooWindowEnd = new(9, 28, 0);
-
         /// <summary>
         /// A dictionary that maps each supported <see cref="SecurityType"/> to an array of <see cref="OrderType"/> supported by Alpaca brokerage.
         /// </summary>
@@ -52,11 +41,17 @@ namespace QuantConnect.Brokerages
         };
 
         /// <summary>
+        /// Defines the default set of <see cref="SecurityType"/> values that support <see cref="OrderType.MarketOnOpen"/> orders.
+        /// </summary>
+        private readonly IReadOnlySet<SecurityType> _defaultMarketOnOpenSupportedSecurityTypes;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AlpacaBrokerageModel"/> class
         /// </summary>
         /// <remarks>All Alpaca accounts are set up as margin accounts</remarks>
         public AlpacaBrokerageModel() : base(AccountType.Margin)
         {
+            _defaultMarketOnOpenSupportedSecurityTypes = _supportOrderTypeBySecurityType.Where(x => x.Value.Contains(OrderType.MarketOnOpen)).Select(x => x.Key).ToHashSet();
         }
 
         /// <summary>
@@ -109,7 +104,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrder(security, order, _mooWindowStart, _mooWindowEnd, out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrder(security, order, GetMarketOnOpenAllowedWindow, _defaultMarketOnOpenSupportedSecurityTypes, out message))
             {
                 return false;
             }
@@ -129,6 +124,19 @@ namespace QuantConnect.Brokerages
         {
             message = null;
             return true;
+        }
+
+        /// <summary>
+        /// Returns the allowed Market-on-Open submission window for Alpaca.
+        /// </summary>
+        /// <param name="marketHours">The market hours segment for the security.</param>
+        /// <returns>
+        /// A tuple with <c>MarketOnOpenWindowStart</c> (default 19:00 / 7:00 PM) and 
+        /// <c>MarketOnOpenWindowEnd</c>, adjusted slightly before the market open to avoid rejection.
+        /// </returns>
+        private (TimeOnly MarketOnOpenWindowStart, TimeOnly MarketOnOpenWindowEnd) GetMarketOnOpenAllowedWindow(MarketHoursSegment marketHours)
+        {
+            return (new(19, 0, 0), TimeOnly.FromTimeSpan(marketHours.Start.Add(-TimeSpan.FromMinutes(2))));
         }
     }
 }

--- a/Common/Brokerages/AlpacaBrokerageModel.cs
+++ b/Common/Brokerages/AlpacaBrokerageModel.cs
@@ -29,6 +29,12 @@ namespace QuantConnect.Brokerages
     public class AlpacaBrokerageModel : DefaultBrokerageModel
     {
         /// <summary>
+        /// The default start time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
+        /// Example: 19:00 (7:00 PM).
+        /// </summary>
+        private static readonly TimeOnly _mooWindowStart = new(19, 0, 0);
+
+        /// <summary>
         /// A dictionary that maps each supported <see cref="SecurityType"/> to an array of <see cref="OrderType"/> supported by Alpaca brokerage.
         /// </summary>
         private readonly Dictionary<SecurityType, HashSet<OrderType>> _supportOrderTypeBySecurityType = new()
@@ -136,7 +142,7 @@ namespace QuantConnect.Brokerages
         /// </returns>
         private (TimeOnly MarketOnOpenWindowStart, TimeOnly MarketOnOpenWindowEnd) GetMarketOnOpenAllowedWindow(MarketHoursSegment marketHours)
         {
-            return (new(19, 0, 0), TimeOnly.FromTimeSpan(marketHours.Start.Add(-TimeSpan.FromMinutes(2))));
+            return (_mooWindowStart, TimeOnly.FromTimeSpan(marketHours.Start.Add(-TimeSpan.FromMinutes(2))));
         }
     }
 }

--- a/Common/Brokerages/AlpacaBrokerageModel.cs
+++ b/Common/Brokerages/AlpacaBrokerageModel.cs
@@ -31,13 +31,13 @@ namespace QuantConnect.Brokerages
         /// The default start time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
         /// Example: 19:00 (7:00 PM).
         /// </summary>
-        private static readonly TimeOnly _marketOnOpenOrderSafeSubmissionStartTime = new(19, 0, 0);
+        private static readonly TimeOnly _mooWindowStart = new(19, 0, 0);
 
         /// <summary>
         /// The default end time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
         /// Example: 09:28 (9:28 AM).
         /// </summary>
-        private static readonly TimeOnly _marketOnOpenOrderSafeSubmissionEndTime = new(9, 28, 0);
+        private static readonly TimeOnly _mooWindowEnd = new(9, 28, 0);
 
         /// <summary>
         /// A dictionary that maps each supported <see cref="SecurityType"/> to an array of <see cref="OrderType"/> supported by Alpaca brokerage.
@@ -109,7 +109,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _marketOnOpenOrderSafeSubmissionStartTime, _marketOnOpenOrderSafeSubmissionEndTime, out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _mooWindowStart, _mooWindowEnd, out message))
             {
                 return false;
             }

--- a/Common/Brokerages/BrokerageExtensions.cs
+++ b/Common/Brokerages/BrokerageExtensions.cs
@@ -112,7 +112,6 @@ namespace QuantConnect.Brokerages
         /// Validates whether a <see cref="OrderType.MarketOnOpen"/> order 
         /// can be submitted at the current <see cref="Security.LocalTime"/>.
         /// </summary>
-        /// <param name="brokerageModel">The brokerage model used for validation.</param>
         /// <param name="security">The security associated with the order.</param>
         /// <param name="order">The order to validate.</param>
         /// <param name="windowStart">
@@ -129,7 +128,6 @@ namespace QuantConnect.Brokerages
         /// </param>
         /// <returns><c>true</c> if the order may be submitted within the given window; otherwise <c>false</c>.</returns>
         public static bool ValidateMarketOnOpenOrderByTime(
-            IBrokerageModel brokerageModel,
             Security security,
             Order order,
             in TimeOnly windowStart,
@@ -150,7 +148,7 @@ namespace QuantConnect.Brokerages
                 message = new BrokerageMessageEvent(
                     BrokerageMessageType.Warning,
                     "NotSupported",
-                    Messages.DefaultBrokerageModel.UnsupportedMarketOnOpenOrderTime(brokerageModel, windowStart, windowEnd)
+                    Messages.DefaultBrokerageModel.UnsupportedMarketOnOpenOrderTime(windowStart, windowEnd)
                 );
                 return false;
             }

--- a/Common/Brokerages/BrokerageExtensions.cs
+++ b/Common/Brokerages/BrokerageExtensions.cs
@@ -141,7 +141,7 @@ namespace QuantConnect.Brokerages
             if (!supportedSecurityTypes.Contains(security.Type))
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, $"UnsupportedSecurityType",
-                    $"The Brokers does not support Market-on-Open orders for security type {security.Type}");
+                    $"The broker does not support Market-on-Open orders for security type {security.Type}");
                 return false;
             }
 

--- a/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
+++ b/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
@@ -33,6 +33,18 @@ namespace QuantConnect.Brokerages
     public class InteractiveBrokersBrokerageModel : DefaultBrokerageModel
     {
         /// <summary>
+        /// The default start time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
+        /// Example: 16:00 (4:00 PM).
+        /// </summary>
+        private static readonly TimeOnly _mooWindowStart = new(16, 0, 0);
+
+        /// <summary>
+        /// The default end time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
+        /// Example: 09:28 (9:28 AM).
+        /// </summary>
+        private static readonly TimeOnly _mooWindowEnd = new(9, 28, 0);
+
+        /// <summary>
         /// The default markets for the IB brokerage
         /// </summary>
         public new static readonly IReadOnlyDictionary<SecurityType, string> DefaultMarketMap = new Dictionary<SecurityType, string>
@@ -208,7 +220,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, new(16, 0, 0), new(9, 28, 0), out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _mooWindowStart, _mooWindowEnd, out message))
             {
                 return false;
             }

--- a/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
+++ b/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
@@ -36,13 +36,13 @@ namespace QuantConnect.Brokerages
         /// The default start time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
         /// Example: 16:00 (4:00 PM).
         /// </summary>
-        private static readonly TimeOnly _mooWindowStart = new(16, 0, 0);
+        private static readonly TimeOnly _marketOnOpenOrderSafeSubmissionStartTime = new(16, 0, 0);
 
         /// <summary>
         /// The default end time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
         /// Example: 09:28 (9:28 AM).
         /// </summary>
-        private static readonly TimeOnly _mooWindowEnd = new(9, 28, 0);
+        private static readonly TimeOnly _marketOnOpenOrderSafeSubmissionEndTime = new(9, 28, 0);
 
         /// <summary>
         /// The default markets for the IB brokerage
@@ -220,7 +220,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _mooWindowStart, _mooWindowEnd, out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _marketOnOpenOrderSafeSubmissionStartTime, _marketOnOpenOrderSafeSubmissionEndTime, out message))
             {
                 return false;
             }

--- a/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
+++ b/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
@@ -36,13 +36,13 @@ namespace QuantConnect.Brokerages
         /// The default start time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
         /// Example: 16:00 (4:00 PM).
         /// </summary>
-        private static readonly TimeOnly _marketOnOpenOrderSafeSubmissionStartTime = new(16, 0, 0);
+        private static readonly TimeOnly _mooWindowStart = new(16, 0, 0);
 
         /// <summary>
         /// The default end time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
         /// Example: 09:28 (9:28 AM).
         /// </summary>
-        private static readonly TimeOnly _marketOnOpenOrderSafeSubmissionEndTime = new(9, 28, 0);
+        private static readonly TimeOnly _mooWindowEnd = new(9, 28, 0);
 
         /// <summary>
         /// The default markets for the IB brokerage
@@ -220,7 +220,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _marketOnOpenOrderSafeSubmissionStartTime, _marketOnOpenOrderSafeSubmissionEndTime, out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _mooWindowStart, _mooWindowEnd, out message))
             {
                 return false;
             }

--- a/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
+++ b/Common/Brokerages/InteractiveBrokersBrokerageModel.cs
@@ -208,6 +208,11 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, new(16, 0, 0), new(9, 28, 0), out message))
+            {
+                return false;
+            }
+
             return true;
         }
 

--- a/Common/Brokerages/TradeStationBrokerageModel.cs
+++ b/Common/Brokerages/TradeStationBrokerageModel.cs
@@ -128,6 +128,11 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(this, security, order, new(6, 0, 0), new(9, 28, 0), out message))
+            {
+                return false;
+            }
+
             return base.CanSubmitOrder(security, order, out message);
         }
 

--- a/Common/Brokerages/TradeStationBrokerageModel.cs
+++ b/Common/Brokerages/TradeStationBrokerageModel.cs
@@ -31,13 +31,13 @@ namespace QuantConnect.Brokerages
         /// The default start time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
         /// Example: 6:00 (6:00 AM).
         /// </summary>
-        private static readonly TimeOnly _mooWindowStart = new(6, 0, 0);
+        private static readonly TimeOnly _marketOnOpenOrderSafeSubmissionStartTime = new(6, 0, 0);
 
         /// <summary>
         /// The default end time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
         /// Example: 09:28 (9:28 AM).
         /// </summary>
-        private static readonly TimeOnly _mooWindowEnd = new(9, 28, 0);
+        private static readonly TimeOnly _marketOnOpenOrderSafeSubmissionEndTime = new(9, 28, 0);
 
         /// <summary>
         /// HashSet containing the security types supported by TradeStation.
@@ -141,7 +141,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _mooWindowStart, _mooWindowEnd, out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _marketOnOpenOrderSafeSubmissionStartTime, _marketOnOpenOrderSafeSubmissionEndTime, out message))
             {
                 return false;
             }

--- a/Common/Brokerages/TradeStationBrokerageModel.cs
+++ b/Common/Brokerages/TradeStationBrokerageModel.cs
@@ -28,6 +28,12 @@ namespace QuantConnect.Brokerages
     public class TradeStationBrokerageModel : DefaultBrokerageModel
     {
         /// <summary>
+        /// The default start time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
+        /// Example: 6:00 (6:00 AM).
+        /// </summary>
+        private static readonly TimeOnly _mooWindowStart = new(6, 0, 0);
+
+        /// <summary>
         /// HashSet containing the security types supported by TradeStation.
         /// </summary>
         private readonly HashSet<SecurityType> _supportSecurityTypes = new(
@@ -193,7 +199,7 @@ namespace QuantConnect.Brokerages
         /// <returns>A tuple with <c>MarketOnOpenWindowStart</c> and <c>MarketOnOpenWindowEnd</c>.</returns>
         private (TimeOnly MarketOnOpenWindowStart, TimeOnly MarketOnOpenWindowEnd) GetMarketOnOpenAllowedWindow(MarketHoursSegment marketHours)
         {
-            return (new(6, 0, 0), TimeOnly.FromTimeSpan(marketHours.Start.Add(-TimeSpan.FromMinutes(1))));
+            return (_mooWindowStart, TimeOnly.FromTimeSpan(marketHours.Start.Add(-TimeSpan.FromMinutes(1))));
         }
     }
 }

--- a/Common/Brokerages/TradeStationBrokerageModel.cs
+++ b/Common/Brokerages/TradeStationBrokerageModel.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.Brokerages
         /// The default end time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
         /// Example: 09:28 (9:28 AM).
         /// </summary>
-        private static readonly TimeOnly _mooWindowEnd = new(9, 28, 0);
+        private static readonly TimeOnly _mooWindowEnd = new(9, 29, 0);
 
         /// <summary>
         /// HashSet containing the security types supported by TradeStation.

--- a/Common/Brokerages/TradeStationBrokerageModel.cs
+++ b/Common/Brokerages/TradeStationBrokerageModel.cs
@@ -14,6 +14,7 @@
  *
 */
 
+using System;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Orders.Fees;
@@ -26,6 +27,18 @@ namespace QuantConnect.Brokerages
     /// </summary>
     public class TradeStationBrokerageModel : DefaultBrokerageModel
     {
+        /// <summary>
+        /// The default start time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
+        /// Example: 6:00 (6:00 AM).
+        /// </summary>
+        private static readonly TimeOnly _mooWindowStart = new(6, 0, 0);
+
+        /// <summary>
+        /// The default end time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
+        /// Example: 09:28 (9:28 AM).
+        /// </summary>
+        private static readonly TimeOnly _mooWindowEnd = new(9, 28, 0);
+
         /// <summary>
         /// HashSet containing the security types supported by TradeStation.
         /// </summary>
@@ -128,7 +141,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, new(6, 0, 0), new(9, 29, 0), out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _mooWindowStart, _mooWindowEnd, out message))
             {
                 return false;
             }

--- a/Common/Brokerages/TradeStationBrokerageModel.cs
+++ b/Common/Brokerages/TradeStationBrokerageModel.cs
@@ -128,7 +128,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(this, security, order, new(6, 0, 0), new(9, 28, 0), out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, new(6, 0, 0), new(9, 28, 0), out message))
             {
                 return false;
             }

--- a/Common/Brokerages/TradeStationBrokerageModel.cs
+++ b/Common/Brokerages/TradeStationBrokerageModel.cs
@@ -31,13 +31,13 @@ namespace QuantConnect.Brokerages
         /// The default start time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
         /// Example: 6:00 (6:00 AM).
         /// </summary>
-        private static readonly TimeOnly _marketOnOpenOrderSafeSubmissionStartTime = new(6, 0, 0);
+        private static readonly TimeOnly _mooWindowStart = new(6, 0, 0);
 
         /// <summary>
         /// The default end time of the <see cref="OrderType.MarketOnOpen"/> order submission window.
         /// Example: 09:28 (9:28 AM).
         /// </summary>
-        private static readonly TimeOnly _marketOnOpenOrderSafeSubmissionEndTime = new(9, 28, 0);
+        private static readonly TimeOnly _mooWindowEnd = new(9, 28, 0);
 
         /// <summary>
         /// HashSet containing the security types supported by TradeStation.
@@ -141,7 +141,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _marketOnOpenOrderSafeSubmissionStartTime, _marketOnOpenOrderSafeSubmissionEndTime, out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _mooWindowStart, _mooWindowEnd, out message))
             {
                 return false;
             }

--- a/Common/Brokerages/TradeStationBrokerageModel.cs
+++ b/Common/Brokerages/TradeStationBrokerageModel.cs
@@ -128,7 +128,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, new(6, 0, 0), new(9, 28, 0), out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, new(6, 0, 0), new(9, 29, 0), out message))
             {
                 return false;
             }

--- a/Common/Brokerages/TradeStationBrokerageModel.cs
+++ b/Common/Brokerages/TradeStationBrokerageModel.cs
@@ -141,7 +141,7 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!BrokerageExtensions.ValidateMarketOnOpenOrderByTime(security, order, _mooWindowStart, _mooWindowEnd, out message))
+            if (!BrokerageExtensions.ValidateMarketOnOpenOrder(security, order, _mooWindowStart, _mooWindowEnd, out message))
             {
                 return false;
             }

--- a/Common/Messages/Messages.Brokerages.cs
+++ b/Common/Messages/Messages.Brokerages.cs
@@ -23,6 +23,7 @@ using static QuantConnect.StringExtensions;
 using System.Collections.Generic;
 using QuantConnect.Orders.TimeInForces;
 using System.Globalization;
+using QuantConnect.Data.UniverseSelection;
 
 namespace QuantConnect
 {
@@ -145,6 +146,27 @@ namespace QuantConnect
             public static string UnsupportedUpdateQuantityOrder(IBrokerageModel brokerageModel, OrderType orderType)
             {
                 return Invariant($"Order type '{orderType}' is not supported to update quantity in the {brokerageModel.GetType().Name}.");
+            }
+
+            /// <summary>
+            /// Builds a descriptive error message when a <see cref="OrderType.MarketOnOpen"/> 
+            /// order is submitted outside the valid submission window.
+            /// </summary>
+            /// <param name="brokerageModel">The brokerage model being used. Its type name is included in the message for clarity.</param>
+            /// <param name="eveningCutoff">The start of the valid submission window.</param>
+            /// <param name="morningCutoff">The end of the valid submission window.</param>
+            /// <returns>
+            /// A formatted string describing why the order is not valid at the current time,
+            /// including the allowed submission window and suggested fixes.
+            /// </returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string UnsupportedMarketOnOpenOrderTime(
+                IBrokerageModel brokerageModel,
+                TimeSpan eveningCutoff,
+                TimeSpan morningCutoff)
+            {
+                return Invariant($"Cannot submit a {OrderType.MarketOnOpen} order at this time. Orders must be placed after {eveningCutoff:hh\\:mm} and before {morningCutoff:hh\\:mm} local exchange time. Brokerage: {brokerageModel.GetType().Name}. To fix this, consider setting DailyPreciseEndTime = false or scheduling the order with {nameof(Schedule)}.{nameof(Schedule.On)} to trigger after {eveningCutoff:hh\\:mm} or before {morningCutoff:hh\\:mm}."
+                );
             }
         }
 

--- a/Common/Messages/Messages.Brokerages.cs
+++ b/Common/Messages/Messages.Brokerages.cs
@@ -153,8 +153,8 @@ namespace QuantConnect
             /// order is submitted outside the valid submission window.
             /// </summary>
             /// <param name="brokerageModel">The brokerage model being used. Its type name is included in the message for clarity.</param>
-            /// <param name="eveningCutoff">The start of the valid submission window.</param>
-            /// <param name="morningCutoff">The end of the valid submission window.</param>
+            /// <param name="windowStart">The start of the valid submission window (typically evening of the prior day).</param>
+            /// <param name="windowEnd">The end of the valid submission window (typically morning of the next day).</param>
             /// <returns>
             /// A formatted string describing why the order is not valid at the current time,
             /// including the allowed submission window and suggested fixes.
@@ -162,10 +162,10 @@ namespace QuantConnect
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string UnsupportedMarketOnOpenOrderTime(
                 IBrokerageModel brokerageModel,
-                TimeSpan eveningCutoff,
-                TimeSpan morningCutoff)
+                in TimeOnly windowStart,
+                in TimeOnly windowEnd)
             {
-                return Invariant($"Cannot submit a {OrderType.MarketOnOpen} order at this time. Orders must be placed after {eveningCutoff:hh\\:mm} and before {morningCutoff:hh\\:mm} local exchange time. Brokerage: {brokerageModel.GetType().Name}. To fix this, consider setting DailyPreciseEndTime = false or scheduling the order with {nameof(Schedule)}.{nameof(Schedule.On)} to trigger after {eveningCutoff:hh\\:mm} or before {morningCutoff:hh\\:mm}."
+                return Invariant($"Cannot submit a {OrderType.MarketOnOpen} order at this time. Orders must be placed after {windowStart:hh\\:mm} and before {windowEnd:hh\\:mm} local exchange time. Brokerage: {brokerageModel.GetType().Name}. To fix this, consider setting DailyPreciseEndTime = false or scheduling the order with {nameof(Schedule)}.{nameof(Schedule.On)} to trigger after {windowStart:hh\\:mm} or before {windowEnd:hh\\:mm}."
                 );
             }
         }

--- a/Common/Messages/Messages.Brokerages.cs
+++ b/Common/Messages/Messages.Brokerages.cs
@@ -152,7 +152,6 @@ namespace QuantConnect
             /// Builds a descriptive error message when a <see cref="OrderType.MarketOnOpen"/> 
             /// order is submitted outside the valid submission window.
             /// </summary>
-            /// <param name="brokerageModel">The brokerage model being used. Its type name is included in the message for clarity.</param>
             /// <param name="windowStart">The start of the valid submission window (typically evening of the prior day).</param>
             /// <param name="windowEnd">The end of the valid submission window (typically morning of the next day).</param>
             /// <returns>
@@ -161,12 +160,10 @@ namespace QuantConnect
             /// </returns>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string UnsupportedMarketOnOpenOrderTime(
-                IBrokerageModel brokerageModel,
                 in TimeOnly windowStart,
                 in TimeOnly windowEnd)
             {
-                return Invariant($"Cannot submit a {OrderType.MarketOnOpen} order at this time. Orders must be placed after {windowStart:hh\\:mm} and before {windowEnd:hh\\:mm} local exchange time. Brokerage: {brokerageModel.GetType().Name}. To fix this, consider setting DailyPreciseEndTime = false or scheduling the order with {nameof(Schedule)}.{nameof(Schedule.On)} to trigger after {windowStart:hh\\:mm} or before {windowEnd:hh\\:mm}."
-                );
+                return Invariant($"MarketOnOpen submission time is invalid. Valid local times are {windowStart: hh\\:mm}–{windowEnd: hh\\:mm}. Consider setting DailyPreciseEndTime = false or using {nameof(Schedule)}.{nameof(Schedule.On)}.");
             }
         }
 

--- a/Tests/Common/Brokerages/AlpacaBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/AlpacaBrokerageModelTests.cs
@@ -28,8 +28,6 @@ namespace QuantConnect.Tests.Common.Brokerages
     [TestFixture, Parallelizable(ParallelScope.All)]
     public class AlpacaBrokerageModelTests
     {
-        private static AlpacaBrokerageModel _brokerageModel = new AlpacaBrokerageModel();
-
         private static IEnumerable<TestCaseData> OrderOusideRegularHoursTestCases
         {
             get
@@ -72,7 +70,8 @@ namespace QuantConnect.Tests.Common.Brokerages
                 _ => throw new ArgumentException($"Unsupported order type: {orderType}"),
             };
 
-            var canSubmit = _brokerageModel.CanSubmitOrder(security, order, out var message);
+            var brokerageModel = new AlpacaBrokerageModel();
+            var canSubmit = brokerageModel.CanSubmitOrder(security, order, out var message);
 
             Assert.That(canSubmit, Is.EqualTo(shouldSubmit));
         }

--- a/Tests/Common/Brokerages/AlpacaBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/AlpacaBrokerageModelTests.cs
@@ -15,7 +15,6 @@
 
 using NUnit.Framework;
 using QuantConnect.Brokerages;
-using QuantConnect.Data.Market;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Tests.Brokerages;
@@ -72,35 +71,6 @@ namespace QuantConnect.Tests.Common.Brokerages
                 OrderType.StopLimit => new StopLimitOrder(symbol, 1, 100m, 90m, DateTime.UtcNow, properties: orderProperties),
                 _ => throw new ArgumentException($"Unsupported order type: {orderType}"),
             };
-
-            var canSubmit = _brokerageModel.CanSubmitOrder(security, order, out var message);
-
-            Assert.That(canSubmit, Is.EqualTo(shouldSubmit));
-        }
-
-        [TestCase(8, 0, true, Description = "8 AM - valid submission")]
-        [TestCase(12, 0, false, Description = "12 PM - invalid submission")]
-        [TestCase(15, 30, false, Description = "3:30 PM - invalid submission")]
-        [TestCase(15, 59, false, Description = "15:59 PM - invalid submission")]
-        [TestCase(17, 0, false, Description = "5 PM - valid submission")]
-        [TestCase(19, 0, true, Description = "19 PM - valid submission")]
-        [TestCase(19, 1, true, Description = "19 PM - valid submission")]
-        [TestCase(21, 0, true, Description = "9 PM - valid submission")]
-        public void CanSubmitMarketOnOpen(int hourOfDay, int minuteOfDay, bool shouldSubmit)
-        {
-            var symbol = Symbols.SPY;
-            var algorithm = new AlgorithmStub();
-            algorithm.SetStartDate(2025, 04, 30);
-
-            var security = algorithm.AddSecurity(symbol.ID.SecurityType, symbol.ID.Symbol);
-            algorithm.SetFinishedWarmingUp();
-            security.Update([new Tick(algorithm.Time, symbol, string.Empty, string.Empty, 10m, 550m)], typeof(TradeBar));
-
-            // Set algorithm time to the given hour
-            var targetTime = algorithm.Time.Date.AddHours(hourOfDay).AddMinutes(minuteOfDay);
-            algorithm.SetDateTime(targetTime.ConvertToUtc(algorithm.TimeZone));
-
-            var order = new MarketOnOpenOrder(security.Symbol, 1, DateTime.UtcNow);
 
             var canSubmit = _brokerageModel.CanSubmitOrder(security, order, out var message);
 

--- a/Tests/Common/Brokerages/BrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/BrokerageModelTests.cs
@@ -713,30 +713,38 @@ class CustomBrokerageModel(DefaultBrokerageModel):
                 var alpaca = BrokerageName.Alpaca;
                 var ib = BrokerageName.InteractiveBrokersBrokerage;
 
-                yield return new TestCaseData(ts, new TimeSpan(8, 0, 0), true);
-                yield return new TestCaseData(alpaca, new TimeSpan(8, 0, 0), true);
-
-                yield return new TestCaseData(ts, new TimeSpan(12, 0, 0), false);
-                yield return new TestCaseData(alpaca, new TimeSpan(12, 0, 0), false);
-
-                yield return new TestCaseData(ts, new TimeSpan(15, 30, 0), false);
-                yield return new TestCaseData(alpaca, new TimeSpan(15, 30, 0), false);
+                foreach (var bn in new BrokerageName[3] { ts, alpaca, ib })
+                {
+                    yield return new TestCaseData(bn, new TimeSpan(8, 0, 0), true);
+                    yield return new TestCaseData(bn, new TimeSpan(12, 0, 0), false);
+                    yield return new TestCaseData(bn, new TimeSpan(15, 30, 0), false);
+                    yield return new TestCaseData(bn, new TimeSpan(6, 0, 0), true);
+                    yield return new TestCaseData(bn, new TimeSpan(9, 27, 59), true);
+                }
 
                 yield return new TestCaseData(ts, new TimeSpan(15, 59, 0), false);
                 yield return new TestCaseData(alpaca, new TimeSpan(15, 59, 0), false);
                 yield return new TestCaseData(ib, new TimeSpan(16, 0, 0), true);
 
                 yield return new TestCaseData(ts, new TimeSpan(17, 0, 0), false);
+                yield return new TestCaseData(alpaca, new TimeSpan(17, 0, 0), false);
+                yield return new TestCaseData(ib, new TimeSpan(17, 0, 0), true);
+
+                yield return new TestCaseData(ts, new TimeSpan(17, 59, 0), false);
                 yield return new TestCaseData(alpaca, new TimeSpan(17, 59, 0), false);
+                yield return new TestCaseData(ib, new TimeSpan(17, 59, 0), true);
 
                 yield return new TestCaseData(ts, new TimeSpan(19, 0, 0), false);
                 yield return new TestCaseData(alpaca, new TimeSpan(19, 0, 0), true);
+                yield return new TestCaseData(ib, new TimeSpan(19, 0, 0), true);
 
                 yield return new TestCaseData(ts, new TimeSpan(19, 1, 0), false);
                 yield return new TestCaseData(alpaca, new TimeSpan(19, 1, 0), true);
+                yield return new TestCaseData(ib, new TimeSpan(19, 1, 0), true);
 
                 yield return new TestCaseData(ts, new TimeSpan(21, 0, 0), false);
                 yield return new TestCaseData(alpaca, new TimeSpan(21, 0, 0), true);
+                yield return new TestCaseData(ib, new TimeSpan(21, 0, 0), true);
 
                 yield return new TestCaseData(ts, new TimeSpan(9, 28, 0), true);
                 yield return new TestCaseData(alpaca, new TimeSpan(9, 28, 0), false);
@@ -744,13 +752,7 @@ class CustomBrokerageModel(DefaultBrokerageModel):
 
                 yield return new TestCaseData(ts, new TimeSpan(5, 59, 0), false);
                 yield return new TestCaseData(alpaca, new TimeSpan(5, 59, 0), true);
-
-                yield return new TestCaseData(ts, new TimeSpan(6, 0, 0), true);
-                yield return new TestCaseData(alpaca, new TimeSpan(6, 0, 0), true);
-
-                yield return new TestCaseData(ts, new TimeSpan(9, 27, 59), true);
-                yield return new TestCaseData(alpaca, new TimeSpan(9, 27, 59), true);
-                yield return new TestCaseData(ib, new TimeSpan(9, 27, 59), true);
+                yield return new TestCaseData(ib, new TimeSpan(5, 59, 0), true);
             }
         }
 

--- a/Tests/Common/Brokerages/BrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/BrokerageModelTests.cs
@@ -711,6 +711,7 @@ class CustomBrokerageModel(DefaultBrokerageModel):
             {
                 var ts = BrokerageName.TradeStation;
                 var alpaca = BrokerageName.Alpaca;
+                var ib = BrokerageName.InteractiveBrokersBrokerage;
 
                 yield return new TestCaseData(ts, new TimeSpan(8, 0, 0), true);
                 yield return new TestCaseData(alpaca, new TimeSpan(8, 0, 0), true);
@@ -723,6 +724,7 @@ class CustomBrokerageModel(DefaultBrokerageModel):
 
                 yield return new TestCaseData(ts, new TimeSpan(15, 59, 0), false);
                 yield return new TestCaseData(alpaca, new TimeSpan(15, 59, 0), false);
+                yield return new TestCaseData(ib, new TimeSpan(16, 0, 0), true);
 
                 yield return new TestCaseData(ts, new TimeSpan(17, 0, 0), false);
                 yield return new TestCaseData(alpaca, new TimeSpan(17, 59, 0), false);
@@ -738,6 +740,7 @@ class CustomBrokerageModel(DefaultBrokerageModel):
 
                 yield return new TestCaseData(ts, new TimeSpan(9, 28, 0), true);
                 yield return new TestCaseData(alpaca, new TimeSpan(9, 28, 0), false);
+                yield return new TestCaseData(ib, new TimeSpan(9, 28, 0), false);
 
                 yield return new TestCaseData(ts, new TimeSpan(5, 59, 0), false);
                 yield return new TestCaseData(alpaca, new TimeSpan(5, 59, 0), true);
@@ -747,6 +750,7 @@ class CustomBrokerageModel(DefaultBrokerageModel):
 
                 yield return new TestCaseData(ts, new TimeSpan(9, 27, 59), true);
                 yield return new TestCaseData(alpaca, new TimeSpan(9, 27, 59), true);
+                yield return new TestCaseData(ib, new TimeSpan(9, 27, 59), true);
             }
         }
 
@@ -785,6 +789,7 @@ class CustomBrokerageModel(DefaultBrokerageModel):
             BrokerageName.TradeStation => new TradeStationBrokerageModel(),
             BrokerageName.Tastytrade => new TastytradeBrokerageModel(),
             BrokerageName.TradierBrokerage => new TradierBrokerageModel(),
+            BrokerageName.InteractiveBrokersBrokerage => new InteractiveBrokersBrokerageModel(),
             _ => throw new NotImplementedException($"{nameof(BrokerageModelTests)}.{nameof(GetBrokerageModel)}: does not support brokerage '{brokerageName}'.")
         };
 

--- a/Tests/Common/Brokerages/BrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/BrokerageModelTests.cs
@@ -715,57 +715,63 @@ class CustomBrokerageModel(DefaultBrokerageModel):
 
                 foreach (var bn in new BrokerageName[3] { ts, alpaca, ib })
                 {
-                    yield return new TestCaseData(bn, new TimeSpan(8, 0, 0), true);
-                    yield return new TestCaseData(bn, new TimeSpan(12, 0, 0), false);
-                    yield return new TestCaseData(bn, new TimeSpan(15, 30, 0), false);
-                    yield return new TestCaseData(bn, new TimeSpan(6, 0, 0), true);
-                    yield return new TestCaseData(bn, new TimeSpan(9, 27, 59), true);
+                    yield return new TestCaseData(bn, Symbols.SPY, new TimeSpan(8, 0, 0), true);
+                    yield return new TestCaseData(bn, Symbols.SPY, new TimeSpan(12, 0, 0), false);
+                    yield return new TestCaseData(bn, Symbols.SPY, new TimeSpan(15, 30, 0), false);
+                    yield return new TestCaseData(bn, Symbols.SPY, new TimeSpan(6, 0, 0), true);
+                    yield return new TestCaseData(bn, Symbols.SPY, new TimeSpan(9, 27, 59), true);
+
+                    yield return new TestCaseData(bn, Symbols.Future_CLF19_Jan2019, new TimeSpan(9, 27, 59), false).SetDescription("The Brokerage doesn't support MOO for future");
+                    yield return new TestCaseData(bn, Symbols.SBIN, new TimeSpan(5, 59, 0), false).SetDescription("Forbid Brokerage MOO NOT Market.USA");
                 }
 
-                yield return new TestCaseData(ts, new TimeSpan(15, 59, 0), false);
-                yield return new TestCaseData(alpaca, new TimeSpan(15, 59, 0), false);
-                yield return new TestCaseData(ib, new TimeSpan(16, 0, 0), true);
+                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(15, 59, 0), false);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(15, 59, 0), false);
+                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(16, 0, 0), true);
 
-                yield return new TestCaseData(ts, new TimeSpan(17, 0, 0), false);
-                yield return new TestCaseData(alpaca, new TimeSpan(17, 0, 0), false);
-                yield return new TestCaseData(ib, new TimeSpan(17, 0, 0), true);
+                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(17, 0, 0), false);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(17, 0, 0), false);
+                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(17, 0, 0), true);
 
-                yield return new TestCaseData(ts, new TimeSpan(17, 59, 0), false);
-                yield return new TestCaseData(alpaca, new TimeSpan(17, 59, 0), false);
-                yield return new TestCaseData(ib, new TimeSpan(17, 59, 0), true);
+                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(17, 59, 0), false);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(17, 59, 0), false);
+                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(17, 59, 0), true);
 
-                yield return new TestCaseData(ts, new TimeSpan(19, 0, 0), false);
-                yield return new TestCaseData(alpaca, new TimeSpan(19, 0, 0), true);
-                yield return new TestCaseData(ib, new TimeSpan(19, 0, 0), true);
+                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(19, 0, 0), false);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(19, 0, 0), true);
+                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(19, 0, 0), true);
 
-                yield return new TestCaseData(ts, new TimeSpan(19, 1, 0), false);
-                yield return new TestCaseData(alpaca, new TimeSpan(19, 1, 0), true);
-                yield return new TestCaseData(ib, new TimeSpan(19, 1, 0), true);
+                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(19, 1, 0), false);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(19, 1, 0), true);
+                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(19, 1, 0), true);
 
-                yield return new TestCaseData(ts, new TimeSpan(21, 0, 0), false);
-                yield return new TestCaseData(alpaca, new TimeSpan(21, 0, 0), true);
-                yield return new TestCaseData(ib, new TimeSpan(21, 0, 0), true);
+                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(21, 0, 0), false);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(21, 0, 0), true);
+                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(21, 0, 0), true);
 
-                yield return new TestCaseData(ts, new TimeSpan(9, 28, 0), true);
-                yield return new TestCaseData(alpaca, new TimeSpan(9, 28, 0), false);
-                yield return new TestCaseData(ib, new TimeSpan(9, 28, 0), false);
+                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(9, 28, 0), true);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(9, 28, 0), false);
+                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(9, 28, 0), false);
 
-                yield return new TestCaseData(ts, new TimeSpan(5, 59, 0), false);
-                yield return new TestCaseData(alpaca, new TimeSpan(5, 59, 0), true);
-                yield return new TestCaseData(ib, new TimeSpan(5, 59, 0), true);
+                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(5, 59, 0), false);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(5, 59, 0), true);
+                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(5, 59, 0), true);
+
+                yield return new TestCaseData(ts, Symbols.SPY_C_192_Feb19_2016, new TimeSpan(9, 28, 0), false).SetDescription("The TS doesn't support option");
+                yield return new TestCaseData(alpaca, Symbols.SPY_C_192_Feb19_2016, new TimeSpan(9, 28, 0), false).SetDescription("The Alpaca doesn't support option");
+                yield return new TestCaseData(ib, Symbols.SPY_C_192_Feb19_2016, new TimeSpan(5, 59, 0), true).SetDescription("The IB supports option");
             }
         }
 
         [TestCaseSource(nameof(MarketOnOpenOrderTimeExecutions))]
-        public void CanSubmitMarketOnOpen(BrokerageName brokerageName, TimeSpan algorithmTimeOfDay, bool shouldSubmit)
+        public void CanSubmitMarketOnOpen(BrokerageName brokerageName, Symbol symbol, TimeSpan algorithmTimeOfDay, bool shouldSubmit)
         {
             var brokerageModel = GetBrokerageModel(brokerageName);
 
-            var symbol = Symbols.SPY;
             var algorithm = new AlgorithmStub();
             algorithm.SetStartDate(2025, 04, 30);
 
-            var security = algorithm.AddSecurity(symbol.ID.SecurityType, symbol.ID.Symbol);
+            var security = algorithm.AddSecurity(symbol);
             algorithm.SetFinishedWarmingUp();
             security.Update([new Tick(algorithm.Time, symbol, string.Empty, string.Empty, 10m, 550m)], typeof(TradeBar));
 

--- a/Tests/Common/Brokerages/BrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/BrokerageModelTests.cs
@@ -722,7 +722,7 @@ class CustomBrokerageModel(DefaultBrokerageModel):
                     yield return new TestCaseData(bn, Symbols.SPY, new DateTime(2025, 04, 30, 9, 27, 59), true);
 
                     yield return new TestCaseData(bn, Symbols.Future_CLF19_Jan2019, new DateTime(2025, 04, 30, 9, 27, 59), false).SetDescription("The Brokerage doesn't support MOO for future");
-                    yield return new TestCaseData(bn, Symbols.SBIN, new DateTime(2025, 04, 30, 5, 59, 0), false).SetDescription("Forbid Brokerage MOO NOT Market.USA");
+                    yield return new TestCaseData(bn, Symbols.SBIN, new DateTime(2025, 04, 30, 9, 0, 0), true).SetDescription("Allow place order with different market");
                 }
 
                 yield return new TestCaseData(ts, Symbols.SPY, new DateTime(2025, 04, 30, 15, 59, 0), false);
@@ -777,10 +777,10 @@ class CustomBrokerageModel(DefaultBrokerageModel):
 
             var security = algorithm.AddSecurity(symbol);
             algorithm.SetFinishedWarmingUp();
-            security.Update([new Tick(algorithm.Time, symbol, string.Empty, string.Empty, 10m, 550m)], typeof(TradeBar));
-
             // Set algorithm time to the given hour
-            algorithm.SetDateTime(algorithmDateTime.ConvertToUtc(algorithm.TimeZone));
+            algorithm.SetDateTime(algorithmDateTime.ConvertToUtc(security.Exchange.TimeZone));
+
+            security.Update([new Tick(algorithm.Time, symbol, string.Empty, string.Empty, 10m, 550m)], typeof(TradeBar));
 
             var order = new MarketOnOpenOrder(security.Symbol, 1, DateTime.UtcNow);
 

--- a/Tests/Common/Brokerages/BrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/BrokerageModelTests.cs
@@ -696,6 +696,7 @@ class CustomBrokerageModel(DefaultBrokerageModel):
 
             // Initialize: Security
             var algorithm = new AlgorithmStub();
+            algorithm.SetDateTime(new DateTime(2025, 09, 16, 7, 0, 0).ConvertToUtc(algorithm.TimeZone));
             algorithm.AddEquity(AAPL.Value).Holdings.SetHoldings(209m, holdingQuantity);
             var security = algorithm.Securities[AAPL];
 

--- a/Tests/Common/Brokerages/BrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/BrokerageModelTests.cs
@@ -715,69 +715,72 @@ class CustomBrokerageModel(DefaultBrokerageModel):
 
                 foreach (var bn in new BrokerageName[3] { ts, alpaca, ib })
                 {
-                    yield return new TestCaseData(bn, Symbols.SPY, new TimeSpan(8, 0, 0), true);
-                    yield return new TestCaseData(bn, Symbols.SPY, new TimeSpan(12, 0, 0), false);
-                    yield return new TestCaseData(bn, Symbols.SPY, new TimeSpan(15, 30, 0), false);
-                    yield return new TestCaseData(bn, Symbols.SPY, new TimeSpan(6, 0, 0), true);
-                    yield return new TestCaseData(bn, Symbols.SPY, new TimeSpan(9, 27, 59), true);
+                    yield return new TestCaseData(bn, Symbols.SPY, new DateTime(2025, 04, 30, 8, 0, 0), true);
+                    yield return new TestCaseData(bn, Symbols.SPY, new DateTime(2025, 04, 30, 12, 0, 0), false);
+                    yield return new TestCaseData(bn, Symbols.SPY, new DateTime(2025, 04, 30, 15, 30, 0), false);
+                    yield return new TestCaseData(bn, Symbols.SPY, new DateTime(2025, 04, 30, 6, 0, 0), true);
+                    yield return new TestCaseData(bn, Symbols.SPY, new DateTime(2025, 04, 30, 9, 27, 59), true);
 
-                    yield return new TestCaseData(bn, Symbols.Future_CLF19_Jan2019, new TimeSpan(9, 27, 59), false).SetDescription("The Brokerage doesn't support MOO for future");
-                    yield return new TestCaseData(bn, Symbols.SBIN, new TimeSpan(5, 59, 0), false).SetDescription("Forbid Brokerage MOO NOT Market.USA");
+                    yield return new TestCaseData(bn, Symbols.Future_CLF19_Jan2019, new DateTime(2025, 04, 30, 9, 27, 59), false).SetDescription("The Brokerage doesn't support MOO for future");
+                    yield return new TestCaseData(bn, Symbols.SBIN, new DateTime(2025, 04, 30, 5, 59, 0), false).SetDescription("Forbid Brokerage MOO NOT Market.USA");
                 }
 
-                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(15, 59, 0), false);
-                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(15, 59, 0), false);
-                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(16, 0, 0), true);
+                yield return new TestCaseData(ts, Symbols.SPY, new DateTime(2025, 04, 30, 15, 59, 0), false);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new DateTime(2025, 04, 30, 15, 59, 0), false);
+                yield return new TestCaseData(ib, Symbols.SPY, new DateTime(2025, 04, 30, 16, 0, 0), true);
 
-                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(17, 0, 0), false);
-                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(17, 0, 0), false);
-                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(17, 0, 0), true);
+                yield return new TestCaseData(ts, Symbols.SPY, new DateTime(2025, 04, 30, 17, 0, 0), false);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new DateTime(2025, 04, 30, 17, 0, 0), false);
+                yield return new TestCaseData(ib, Symbols.SPY, new DateTime(2025, 04, 30, 17, 0, 0), true);
 
-                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(17, 59, 0), false);
-                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(17, 59, 0), false);
-                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(17, 59, 0), true);
+                yield return new TestCaseData(ts, Symbols.SPY, new DateTime(2025, 04, 30, 17, 59, 0), false);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new DateTime(2025, 04, 30, 17, 59, 0), false);
+                yield return new TestCaseData(ib, Symbols.SPY, new DateTime(2025, 04, 30, 17, 59, 0), true);
 
-                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(19, 0, 0), false);
-                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(19, 0, 0), true);
-                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(19, 0, 0), true);
+                yield return new TestCaseData(ts, Symbols.SPY, new DateTime(2025, 04, 30, 19, 0, 0), false);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new DateTime(2025, 04, 30, 19, 0, 0), true);
+                yield return new TestCaseData(ib, Symbols.SPY, new DateTime(2025, 04, 30, 19, 0, 0), true);
 
-                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(19, 1, 0), false);
-                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(19, 1, 0), true);
-                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(19, 1, 0), true);
+                yield return new TestCaseData(ts, Symbols.SPY, new DateTime(2025, 04, 30, 19, 1, 0), false);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new DateTime(2025, 04, 30, 19, 1, 0), true);
+                yield return new TestCaseData(ib, Symbols.SPY, new DateTime(2025, 04, 30, 19, 1, 0), true);
 
-                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(21, 0, 0), false);
-                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(21, 0, 0), true);
-                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(21, 0, 0), true);
+                yield return new TestCaseData(ts, Symbols.SPY, new DateTime(2025, 04, 30, 21, 0, 0), false);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new DateTime(2025, 04, 30, 21, 0, 0), true);
+                yield return new TestCaseData(ib, Symbols.SPY, new DateTime(2025, 04, 30, 21, 0, 0), true);
 
-                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(9, 28, 0), true);
-                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(9, 28, 0), false);
-                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(9, 28, 0), false);
+                yield return new TestCaseData(ts, Symbols.SPY, new DateTime(2025, 04, 30, 9, 28, 0), true);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new DateTime(2025, 04, 30, 9, 28, 0), false);
+                yield return new TestCaseData(ib, Symbols.SPY, new DateTime(2025, 04, 30, 9, 28, 0), false);
 
-                yield return new TestCaseData(ts, Symbols.SPY, new TimeSpan(5, 59, 0), false);
-                yield return new TestCaseData(alpaca, Symbols.SPY, new TimeSpan(5, 59, 0), true);
-                yield return new TestCaseData(ib, Symbols.SPY, new TimeSpan(5, 59, 0), true);
+                yield return new TestCaseData(ts, Symbols.SPY, new DateTime(2025, 04, 30, 5, 59, 0), false);
+                yield return new TestCaseData(alpaca, Symbols.SPY, new DateTime(2025, 04, 30, 5, 59, 0), true);
+                yield return new TestCaseData(ib, Symbols.SPY, new DateTime(2025, 04, 30, 5, 59, 0), true);
 
-                yield return new TestCaseData(ts, Symbols.SPY_C_192_Feb19_2016, new TimeSpan(9, 28, 0), false).SetDescription("The TS doesn't support option");
-                yield return new TestCaseData(alpaca, Symbols.SPY_C_192_Feb19_2016, new TimeSpan(9, 28, 0), false).SetDescription("The Alpaca doesn't support option");
-                yield return new TestCaseData(ib, Symbols.SPY_C_192_Feb19_2016, new TimeSpan(5, 59, 0), true).SetDescription("The IB supports option");
+                yield return new TestCaseData(ts, Symbols.SPY_C_192_Feb19_2016, new DateTime(2025, 04, 30, 9, 28, 0), true).SetDescription("The TS supports option");
+                yield return new TestCaseData(alpaca, Symbols.SPY_C_192_Feb19_2016, new DateTime(2025, 04, 30, 9, 28, 0), false).SetDescription("The Alpaca doesn't support option");
+                yield return new TestCaseData(ib, Symbols.SPY_C_192_Feb19_2016, new DateTime(2025, 04, 30, 5, 59, 0), true).SetDescription("The IB supports option");
+
+                yield return new TestCaseData(ts, Symbols.SPY, new DateTime(2025, 09, 13, 12, 0, 0), true).SetDescription("2025 September Saturday");
+                yield return new TestCaseData(alpaca, Symbols.SPY, new DateTime(2025, 09, 13, 12, 0, 0), true).SetDescription("2025 September Saturday");
+                yield return new TestCaseData(ib, Symbols.SPY, new DateTime(2025, 09, 13, 12, 0, 0), true).SetDescription("2025 September Saturday");
             }
         }
 
         [TestCaseSource(nameof(MarketOnOpenOrderTimeExecutions))]
-        public void CanSubmitMarketOnOpen(BrokerageName brokerageName, Symbol symbol, TimeSpan algorithmTimeOfDay, bool shouldSubmit)
+        public void CanSubmitMarketOnOpen(BrokerageName brokerageName, Symbol symbol, DateTime algorithmDateTime, bool shouldSubmit)
         {
             var brokerageModel = GetBrokerageModel(brokerageName);
 
             var algorithm = new AlgorithmStub();
-            algorithm.SetStartDate(2025, 04, 30);
+            algorithm.SetStartDate(algorithmDateTime.Date);
 
             var security = algorithm.AddSecurity(symbol);
             algorithm.SetFinishedWarmingUp();
             security.Update([new Tick(algorithm.Time, symbol, string.Empty, string.Empty, 10m, 550m)], typeof(TradeBar));
 
             // Set algorithm time to the given hour
-            var targetTime = algorithm.Time.Date.Add(algorithmTimeOfDay);
-            algorithm.SetDateTime(targetTime.ConvertToUtc(algorithm.TimeZone));
+            algorithm.SetDateTime(algorithmDateTime.ConvertToUtc(algorithm.TimeZone));
 
             var order = new MarketOnOpenOrder(security.Symbol, 1, DateTime.UtcNow);
 

--- a/Tests/Common/Brokerages/BrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/BrokerageModelTests.cs
@@ -736,7 +736,7 @@ class CustomBrokerageModel(DefaultBrokerageModel):
                 yield return new TestCaseData(ts, new TimeSpan(21, 0, 0), false);
                 yield return new TestCaseData(alpaca, new TimeSpan(21, 0, 0), true);
 
-                yield return new TestCaseData(ts, new TimeSpan(9, 28, 0), false);
+                yield return new TestCaseData(ts, new TimeSpan(9, 28, 0), true);
                 yield return new TestCaseData(alpaca, new TimeSpan(9, 28, 0), false);
 
                 yield return new TestCaseData(ts, new TimeSpan(5, 59, 0), false);

--- a/Tests/Common/Brokerages/InteractiveBrokersBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/InteractiveBrokersBrokerageModelTests.cs
@@ -137,7 +137,7 @@ namespace QuantConnect.Tests.Common.Brokerages
             var order = new MarketOnOpenOrder(security.Symbol, 1, DateTime.UtcNow);
             var result = _interactiveBrokersBrokerageModel.CanSubmitOrder(security, order, out var message);
             Assert.IsFalse(result);
-            var expectedMessage = $"The Brokers does not support Market-on-Open orders for security type {security.Type}";
+            var expectedMessage = $"The broker does not support Market-on-Open orders for security type {security.Type}";
             Assert.AreEqual(expectedMessage, message.Message);
         }
 

--- a/Tests/Common/Brokerages/InteractiveBrokersBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/InteractiveBrokersBrokerageModelTests.cs
@@ -137,7 +137,7 @@ namespace QuantConnect.Tests.Common.Brokerages
             var order = new MarketOnOpenOrder(security.Symbol, 1, DateTime.UtcNow);
             var result = _interactiveBrokersBrokerageModel.CanSubmitOrder(security, order, out var message);
             Assert.IsFalse(result);
-            var expectedMessage = "InteractiveBrokers does not support Market-on-Open orders for other security types different than Option and Equity.";
+            var expectedMessage = $"The Brokers does not support Market-on-Open orders for security type {security.Type}";
             Assert.AreEqual(expectedMessage, message.Message);
         }
 


### PR DESCRIPTION
### Description
#### New warning message for users
```
#### BrokerageModel.TradeStation

Warning - Code: NotSupported - MarketOnOpen submission time is invalid.
Valid local times are  06:00 – 09:29. Consider setting DailyPreciseEndTime = false or using Schedule.On.
```

#### InteractiveBrokers - (Market on open - [docs link](https://www.interactivebrokers.com/en/trading/ordertypes.php?m=marketOpenModal))
Enable submitting **MOO** orders between **4:00 PM and < 9:28 AM (ET)**.

<img width="1772" height="435" alt="image" src="https://github.com/user-attachments/assets/d1200a98-c08d-4f94-80db-a99fa74f4b28" />

#### Alpaca (ref `opg` - [docs link](https://docs.alpaca.markets/docs/orders-at-alpaca#time-in-force))
Enable submitting **MOO** orders between **7:00 PM and < 9:28 AM (ET)**.

<img width="1791" height="518" alt="image" src="https://github.com/user-attachments/assets/976ae3cd-55a3-4faf-8f8d-8eb7fbb29693" />

#### TradeStation, (ref `Equities FAQ` - [docs link](https://www.tradestation.com/faqs/#et_pb_tab_1))
Enable submitting **MOO** orders between **6:00 AM and < 9:29 AM (ET)**.

<img width="1557" height="353" alt="image" src="https://github.com/user-attachments/assets/6193907a-0350-4134-b511-5f80683e1848" />

<img width="1791" height="560" alt="image" src="https://github.com/user-attachments/assets/47580a32-6724-4eec-87de-25a1be7d9b27" />


The TS MOO supports:
- :white_check_mark: Equity
- :white_check_mark: FutureOption
- :white_check_mark: IndexOption
- :white_check_mark: Option
- :x: Future
> View the screenshot from the TradeStation desktop app. Also, see the attached unit test in the TS PR below.
<img width="960" height="587" alt="image" src="https://github.com/user-attachments/assets/48a6a5bd-3c5e-4139-a36f-fc038144ec9f" />


#### CharlesSchwab, ([docs link](https://www.schwab.com/learn/story/mastering-order-types-market-orders))
> Traders cannot use market orders to execute orders during extended-hours sessions, such as pre-market or after-hours sessions. **Orders placed outside of the standard market session will be considered for execution at the opening of the next standard market session.**


### Related PRs
- https://github.com/QuantConnect/Lean/pull/8737
- https://github.com/QuantConnect/Lean.Brokerages.TradeStation/pull/58
- https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/pull/194

### Related Issue
closes #8957 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Requires Documentation Change
N/a

### How Has This Been Tested?
- Write specific unit test cases for different brokerages.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
