### PR TITLE
Expose order ids related to statistics closed trades

### DIFF
--- a/Common/Statistics/Trade.cs
+++ b/Common/Statistics/Trade.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 
 namespace QuantConnect.Statistics
 {
@@ -105,5 +106,10 @@ namespace QuantConnect.Statistics
         ///       but it might count as a loss if the ITM amount is less than the amount received for the option.
         /// </remarks>
         public bool IsWin { get; set; }
+
+        /// <summary>
+        /// The IDs of the orders related to this trade
+        /// </summary>
+        public HashSet<int> OrderIds { get; init; } = new HashSet<int>();
     }
 }

--- a/Common/Statistics/TradeBuilder.cs
+++ b/Common/Statistics/TradeBuilder.cs
@@ -232,7 +232,8 @@ namespace QuantConnect.Statistics
                             EntryPrice = fill.FillPrice,
                             Direction = fill.FillQuantity > 0 ? TradeDirection.Long : TradeDirection.Short,
                             Quantity = fill.AbsoluteFillQuantity,
-                            TotalFees = orderFee
+                            TotalFees = orderFee,
+                            OrderIds = new HashSet<int>() { fill.OrderId }
                         }
                     },
                     MinPrice = fill.FillPrice,
@@ -255,7 +256,8 @@ namespace QuantConnect.Statistics
                     EntryPrice = fill.FillPrice,
                     Direction = fill.FillQuantity > 0 ? TradeDirection.Long : TradeDirection.Short,
                     Quantity = fill.AbsoluteFillQuantity,
-                    TotalFees = orderFee
+                    TotalFees = orderFee,
+                    OrderIds = new HashSet<int>() { fill.OrderId }
                 });
             }
             else
@@ -267,6 +269,8 @@ namespace QuantConnect.Statistics
                 {
                     var trade = position.PendingTrades[index];
                     var absoluteUnexecutedQuantity = fill.AbsoluteFillQuantity - Math.Abs(totalExecutedQuantity);
+
+                    trade.OrderIds.Add(fill.OrderId);
 
                     if (absoluteUnexecutedQuantity >= trade.Quantity)
                     {
@@ -302,7 +306,8 @@ namespace QuantConnect.Statistics
                             ProfitLoss = Math.Round((fill.FillPrice - trade.EntryPrice) * absoluteUnexecutedQuantity * (trade.Direction == TradeDirection.Long ? +1 : -1) * conversionRate * multiplier, 2),
                             TotalFees = trade.TotalFees + (orderFeeAssigned ? 0 : orderFee),
                             MAE = Math.Round((trade.Direction == TradeDirection.Long ? position.MinPrice - trade.EntryPrice : trade.EntryPrice - position.MaxPrice) * absoluteUnexecutedQuantity * conversionRate * multiplier, 2),
-                            MFE = Math.Round((trade.Direction == TradeDirection.Long ? position.MaxPrice - trade.EntryPrice : trade.EntryPrice - position.MinPrice) * absoluteUnexecutedQuantity * conversionRate * multiplier, 2)
+                            MFE = Math.Round((trade.Direction == TradeDirection.Long ? position.MaxPrice - trade.EntryPrice : trade.EntryPrice - position.MinPrice) * absoluteUnexecutedQuantity * conversionRate * multiplier, 2),
+                            OrderIds = new HashSet<int>(trade.OrderIds)
                         };
 
                         AddNewTrade(newTrade, fill);
@@ -330,7 +335,8 @@ namespace QuantConnect.Statistics
                             EntryPrice = fill.FillPrice,
                             Direction = fill.FillQuantity > 0 ? TradeDirection.Long : TradeDirection.Short,
                             Quantity = fill.AbsoluteFillQuantity,
-                            TotalFees = 0
+                            TotalFees = 0,
+                            OrderIds = new HashSet<int>() { fill.OrderId }
                         }
                     };
                     position.MinPrice = fill.FillPrice;
@@ -381,21 +387,24 @@ namespace QuantConnect.Statistics
                     var totalExitQuantity = 0m;
                     var entryAveragePrice = 0m;
                     var exitAveragePrice = 0m;
+                    var relatedOrderIds = new HashSet<int>();
 
                     while (position.PendingFills.Count > 0)
                     {
-                        if (Math.Sign(position.PendingFills[index].FillQuantity) != Math.Sign(fill.FillQuantity))
+                        var currentFill = position.PendingFills[index];
+                        if (Math.Sign(currentFill.FillQuantity) != Math.Sign(fill.FillQuantity))
                         {
                             // entry
-                            totalEntryQuantity += position.PendingFills[index].FillQuantity;
-                            entryAveragePrice += (position.PendingFills[index].FillPrice - entryAveragePrice) * position.PendingFills[index].FillQuantity / totalEntryQuantity;
+                            totalEntryQuantity += currentFill.FillQuantity;
+                            entryAveragePrice += (currentFill.FillPrice - entryAveragePrice) * currentFill.FillQuantity / totalEntryQuantity;
                         }
                         else
                         {
                             // exit
-                            totalExitQuantity += position.PendingFills[index].FillQuantity;
-                            exitAveragePrice += (position.PendingFills[index].FillPrice - exitAveragePrice) * position.PendingFills[index].FillQuantity / totalExitQuantity;
+                            totalExitQuantity += currentFill.FillQuantity;
+                            exitAveragePrice += (currentFill.FillPrice - exitAveragePrice) * currentFill.FillQuantity / totalExitQuantity;
                         }
+                        relatedOrderIds.Add(currentFill.OrderId);
                         position.PendingFills.RemoveAt(index);
 
                         if (_matchingMethod == FillMatchingMethod.LIFO && index > 0) index--;
@@ -415,6 +424,7 @@ namespace QuantConnect.Statistics
                         TotalFees = position.TotalFees,
                         MAE = Math.Round((direction == TradeDirection.Long ? position.MinPrice - entryAveragePrice : entryAveragePrice - position.MaxPrice) * Math.Abs(totalEntryQuantity) * conversionRate * multiplier, 2),
                         MFE = Math.Round((direction == TradeDirection.Long ? position.MaxPrice - entryAveragePrice : entryAveragePrice - position.MinPrice) * Math.Abs(totalEntryQuantity) * conversionRate * multiplier, 2),
+                        OrderIds = relatedOrderIds
                     };
 
                     AddNewTrade(trade, fill);
@@ -476,17 +486,19 @@ namespace QuantConnect.Statistics
                 var totalExecutedQuantity = 0m;
                 var entryPrice = 0m;
                 position.TotalFees += orderFee;
+                var relatedOrderIds = new HashSet<int> { fill.OrderId };
 
                 while (position.PendingFills.Count > 0 && Math.Abs(totalExecutedQuantity) < fill.AbsoluteFillQuantity)
                 {
+                    var currentFill = position.PendingFills[index];
                     var absoluteUnexecutedQuantity = fill.AbsoluteFillQuantity - Math.Abs(totalExecutedQuantity);
-                    if (absoluteUnexecutedQuantity >= Math.Abs(position.PendingFills[index].FillQuantity))
+                    if (absoluteUnexecutedQuantity >= Math.Abs(currentFill.FillQuantity))
                     {
                         if (_matchingMethod == FillMatchingMethod.LIFO)
-                            entryTime = position.PendingFills[index].UtcTime;
+                            entryTime = currentFill.UtcTime;
 
-                        totalExecutedQuantity -= position.PendingFills[index].FillQuantity;
-                        entryPrice -= (position.PendingFills[index].FillPrice - entryPrice) * position.PendingFills[index].FillQuantity / totalExecutedQuantity;
+                        totalExecutedQuantity -= currentFill.FillQuantity;
+                        entryPrice -= (currentFill.FillPrice - entryPrice) * currentFill.FillQuantity / totalExecutedQuantity;
                         position.PendingFills.RemoveAt(index);
 
                         if (_matchingMethod == FillMatchingMethod.LIFO && index > 0) index--;
@@ -495,9 +507,10 @@ namespace QuantConnect.Statistics
                     {
                         var executedQuantity = absoluteUnexecutedQuantity * Math.Sign(fill.FillQuantity);
                         totalExecutedQuantity += executedQuantity;
-                        entryPrice += (position.PendingFills[index].FillPrice - entryPrice) * executedQuantity / totalExecutedQuantity;
-                        position.PendingFills[index].FillQuantity += executedQuantity;
+                        entryPrice += (currentFill.FillPrice - entryPrice) * executedQuantity / totalExecutedQuantity;
+                        currentFill.FillQuantity += executedQuantity;
                     }
+                    relatedOrderIds.Add(currentFill.OrderId);
                 }
 
                 var direction = totalExecutedQuantity < 0 ? TradeDirection.Long : TradeDirection.Short;
@@ -513,7 +526,8 @@ namespace QuantConnect.Statistics
                     ProfitLoss = Math.Round((fill.FillPrice - entryPrice) * Math.Abs(totalExecutedQuantity) * Math.Sign(-totalExecutedQuantity) * conversionRate * multiplier, 2),
                     TotalFees = position.TotalFees,
                     MAE = Math.Round((direction == TradeDirection.Long ? position.MinPrice - entryPrice : entryPrice - position.MaxPrice) * Math.Abs(totalExecutedQuantity) * conversionRate * multiplier, 2),
-                    MFE = Math.Round((direction == TradeDirection.Long ? position.MaxPrice - entryPrice : entryPrice - position.MinPrice) * Math.Abs(totalExecutedQuantity) * conversionRate * multiplier, 2)
+                    MFE = Math.Round((direction == TradeDirection.Long ? position.MaxPrice - entryPrice : entryPrice - position.MinPrice) * Math.Abs(totalExecutedQuantity) * conversionRate * multiplier, 2),
+                    OrderIds = relatedOrderIds
                 };
 
                 AddNewTrade(trade, fill);

--- a/Common/Statistics/TradeBuilder.cs
+++ b/Common/Statistics/TradeBuilder.cs
@@ -270,12 +270,11 @@ namespace QuantConnect.Statistics
                     var trade = position.PendingTrades[index];
                     var absoluteUnexecutedQuantity = fill.AbsoluteFillQuantity - Math.Abs(totalExecutedQuantity);
 
-                    trade.OrderIds.Add(fill.OrderId);
-
                     if (absoluteUnexecutedQuantity >= trade.Quantity)
                     {
                         totalExecutedQuantity -= trade.Quantity * (trade.Direction == TradeDirection.Long ? +1 : -1);
                         position.PendingTrades.RemoveAt(index);
+                        trade.OrderIds.Add(fill.OrderId);
 
                         if (index > 0 && _matchingMethod == FillMatchingMethod.LIFO) index--;
 
@@ -307,7 +306,7 @@ namespace QuantConnect.Statistics
                             TotalFees = trade.TotalFees + (orderFeeAssigned ? 0 : orderFee),
                             MAE = Math.Round((trade.Direction == TradeDirection.Long ? position.MinPrice - trade.EntryPrice : trade.EntryPrice - position.MaxPrice) * absoluteUnexecutedQuantity * conversionRate * multiplier, 2),
                             MFE = Math.Round((trade.Direction == TradeDirection.Long ? position.MaxPrice - trade.EntryPrice : trade.EntryPrice - position.MinPrice) * absoluteUnexecutedQuantity * conversionRate * multiplier, 2),
-                            OrderIds = new HashSet<int>(trade.OrderIds)
+                            OrderIds = new HashSet<int>([..trade.OrderIds, fill.OrderId])
                         };
 
                         AddNewTrade(newTrade, fill);

--- a/Tests/Common/Statistics/TradeBuilderTests.cs
+++ b/Tests/Common/Statistics/TradeBuilderTests.cs
@@ -468,7 +468,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 Assert.AreEqual(1, trade2.TotalFees);
                 Assert.AreEqual(-5, trade2.MAE);
                 Assert.AreEqual(30, trade2.MFE);
-                CollectionAssert.AreEquivalent(groupingMethod == FillGroupingMethod.FlatToReduced ? [1, 3] : new[] { 1, 2, 3 }, trade2.OrderIds);
+                CollectionAssert.AreEquivalent(groupingMethod == FillGroupingMethod.FlatToReduced ? [1, 3] : new[] { 1, 3 }, trade2.OrderIds);
             }
         }
 
@@ -574,7 +574,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 Assert.AreEqual(1, trade2.TotalFees);
                 Assert.AreEqual(-30, trade2.MAE);
                 Assert.AreEqual(5, trade2.MFE);
-                CollectionAssert.AreEquivalent(groupingMethod == FillGroupingMethod.FlatToReduced ? [1, 3] : new[] { 1, 2, 3 }, trade2.OrderIds);
+                CollectionAssert.AreEquivalent(new[] { 1, 3 }, trade2.OrderIds);
             }
         }
 
@@ -1301,7 +1301,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(0, trade3.TotalFees);
                             Assert.AreEqual(-15, trade3.MAE);
                             Assert.AreEqual(20, trade3.MFE);
-                            CollectionAssert.AreEquivalent(new[] { 2, 3, 5 }, trade3.OrderIds);
+                            CollectionAssert.AreEquivalent(new[] { 2, 5 }, trade3.OrderIds);
 
                             var trade4 = builder.ClosedTrades[3];
 
@@ -1559,7 +1559,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(0, trade3.TotalFees);
                             Assert.AreEqual(-20, trade3.MAE);
                             Assert.AreEqual(15, trade3.MFE);
-                            CollectionAssert.AreEquivalent(new[] { 2, 3, 5 }, trade3.OrderIds);
+                            CollectionAssert.AreEquivalent(new[] { 2, 5 }, trade3.OrderIds);
 
                             var trade4 = builder.ClosedTrades[3];
 
@@ -2194,7 +2194,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(1, trade3.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -7.5 : -2.5, trade3.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 10 : 15, trade3.MFE);
-                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 3, 4] : new[] { 1, 3, 4 }, trade3.OrderIds);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 4] : new[] { 1, 4 }, trade3.OrderIds);
                     }
                     break;
 
@@ -2382,7 +2382,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(1, trade3.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -10 : -15, trade3.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 7.5 : 2.5, trade3.MFE);
-                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 3, 4] : new[] { 1, 3, 4 }, trade3.OrderIds);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 4] : new[] { 1, 4 }, trade3.OrderIds);
                     }
                     break;
 

--- a/Tests/Common/Statistics/TradeBuilderTests.cs
+++ b/Tests/Common/Statistics/TradeBuilderTests.cs
@@ -94,6 +94,7 @@ namespace QuantConnect.Tests.Common.Statistics
             Assert.AreEqual(2, trade.TotalFees);
             Assert.AreEqual(-5, trade.MAE);
             Assert.AreEqual(20m, trade.MFE);
+            CollectionAssert.AreEquivalent(new[] { 1, 2 }, trade.OrderIds);
         }
 
         [Test]
@@ -151,6 +152,7 @@ namespace QuantConnect.Tests.Common.Statistics
             Assert.AreEqual(2, trade.TotalFees);
             Assert.AreEqual(-20, trade.MAE);
             Assert.AreEqual(5, trade.MFE);
+            CollectionAssert.AreEquivalent(new[] { 1, 2 }, trade.OrderIds);
         }
 
         [Test]
@@ -220,6 +222,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 2 : 1, trade1.TotalFees);
                 Assert.AreEqual(-15, trade1.MAE);
                 Assert.AreEqual(20, trade1.MFE);
+                CollectionAssert.AreEquivalent(new[] { 1, 3 }, trade1.OrderIds);
 
                 var trade2 = builder.ClosedTrades[matchingMethod == FillMatchingMethod.FIFO ? 1 : 0];
 
@@ -234,6 +237,8 @@ namespace QuantConnect.Tests.Common.Statistics
                 Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 1 : 2, trade2.TotalFees);
                 Assert.AreEqual(-5, trade2.MAE);
                 Assert.AreEqual(30, trade2.MFE);
+
+                CollectionAssert.AreEquivalent(new[] { 2, 3 }, trade2.OrderIds);
             }
             else
             {
@@ -252,6 +257,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 Assert.AreEqual(3, trade.TotalFees);
                 Assert.AreEqual(-20, trade.MAE);
                 Assert.AreEqual(50, trade.MFE);
+                CollectionAssert.AreEquivalent(new[] { 1, 2, 3 }, trade.OrderIds);
             }
         }
 
@@ -322,6 +328,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 2 : 1, trade1.TotalFees);
                 Assert.AreEqual(-20, trade1.MAE);
                 Assert.AreEqual(15, trade1.MFE);
+                CollectionAssert.AreEquivalent(new[] { 1, 3 }, trade1.OrderIds);
 
                 var trade2 = builder.ClosedTrades[matchingMethod == FillMatchingMethod.FIFO ? 1 : 0];
 
@@ -336,6 +343,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 1 : 2, trade2.TotalFees);
                 Assert.AreEqual(-30, trade2.MAE);
                 Assert.AreEqual(5, trade2.MFE);
+                CollectionAssert.AreEquivalent(new[] { 2, 3 }, trade2.OrderIds);
             }
             else
             {
@@ -354,6 +362,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 Assert.AreEqual(3, trade.TotalFees);
                 Assert.AreEqual(-50, trade.MAE);
                 Assert.AreEqual(20, trade.MFE);
+                CollectionAssert.AreEquivalent(new[] { 1, 2, 3 }, trade.OrderIds);
             }
         }
 
@@ -424,6 +433,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 Assert.AreEqual(3, trade.TotalFees);
                 Assert.AreEqual(-10, trade.MAE);
                 Assert.AreEqual(60, trade.MFE);
+                CollectionAssert.AreEquivalent(new[] { 1, 2, 3 }, trade.OrderIds);
             }
             else
             {
@@ -443,6 +453,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 Assert.AreEqual(2, trade1.TotalFees);
                 Assert.AreEqual(0, trade1.MAE);
                 Assert.AreEqual(10, trade1.MFE);
+                CollectionAssert.AreEquivalent(new[] { 1, 2 }, trade1.OrderIds);
 
                 var trade2 = builder.ClosedTrades[1];
 
@@ -457,6 +468,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 Assert.AreEqual(1, trade2.TotalFees);
                 Assert.AreEqual(-5, trade2.MAE);
                 Assert.AreEqual(30, trade2.MFE);
+                CollectionAssert.AreEquivalent(groupingMethod == FillGroupingMethod.FlatToReduced ? [1, 3] : new[] { 1, 2, 3 }, trade2.OrderIds);
             }
         }
 
@@ -527,6 +539,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 Assert.AreEqual(3, trade.TotalFees);
                 Assert.AreEqual(-60, trade.MAE);
                 Assert.AreEqual(10, trade.MFE);
+                CollectionAssert.AreEquivalent(new[] { 1, 2, 3 }, trade.OrderIds);
             }
             else
             {
@@ -546,6 +559,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 Assert.AreEqual(2, trade1.TotalFees);
                 Assert.AreEqual(-10, trade1.MAE);
                 Assert.AreEqual(0, trade1.MFE);
+                CollectionAssert.AreEquivalent(new[] { 1, 2 }, trade1.OrderIds);
 
                 var trade2 = builder.ClosedTrades[1];
 
@@ -560,6 +574,7 @@ namespace QuantConnect.Tests.Common.Statistics
                 Assert.AreEqual(1, trade2.TotalFees);
                 Assert.AreEqual(-30, trade2.MAE);
                 Assert.AreEqual(5, trade2.MFE);
+                CollectionAssert.AreEquivalent(groupingMethod == FillGroupingMethod.FlatToReduced ? [1, 3] : new[] { 1, 2, 3 }, trade2.OrderIds);
             }
         }
 
@@ -629,6 +644,7 @@ namespace QuantConnect.Tests.Common.Statistics
             Assert.AreEqual(2, trade1.TotalFees);
             Assert.AreEqual(0, trade1.MAE);
             Assert.AreEqual(10, trade1.MFE);
+            CollectionAssert.AreEquivalent(new[] { 1, 2 }, trade1.OrderIds);
 
             var trade2 = builder.ClosedTrades[1];
 
@@ -643,6 +659,7 @@ namespace QuantConnect.Tests.Common.Statistics
             Assert.AreEqual(1, trade2.TotalFees);
             Assert.AreEqual(-20, trade2.MAE);
             Assert.AreEqual(15, trade2.MFE);
+            CollectionAssert.AreEquivalent(new[] { 2, 3 }, trade2.OrderIds);
         }
 
         [Test]
@@ -711,6 +728,7 @@ namespace QuantConnect.Tests.Common.Statistics
             Assert.AreEqual(2, trade1.TotalFees);
             Assert.AreEqual(-10, trade1.MAE);
             Assert.AreEqual(0, trade1.MFE);
+            CollectionAssert.AreEquivalent(new[] { 1, 2 }, trade1.OrderIds);
 
             var trade2 = builder.ClosedTrades[1];
 
@@ -725,6 +743,7 @@ namespace QuantConnect.Tests.Common.Statistics
             Assert.AreEqual(1, trade2.TotalFees);
             Assert.AreEqual(-15, trade2.MAE);
             Assert.AreEqual(20, trade2.MFE);
+            CollectionAssert.AreEquivalent(new[] { 2, 3 }, trade2.OrderIds);
         }
 
         [Test]
@@ -818,6 +837,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade1.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -5 : -15, trade1.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 30 : 20, trade1.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [1, 3] : new[] { 2, 3 }, trade1.OrderIds);
 
                         var trade2 = builder.ClosedTrades[1];
 
@@ -834,6 +854,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade2.TotalFees);
                         Assert.AreEqual(-15, trade2.MAE);
                         Assert.AreEqual(20, trade2.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 5] : new[] { 4, 5 }, trade2.OrderIds);
 
                         var trade3 = builder.ClosedTrades[2];
 
@@ -854,6 +875,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(1, trade3.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -15 : -5, trade3.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 20 : 30, trade3.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [4, 5] : new[] { 1, 5 }, trade3.OrderIds);
                     }
                     break;
 
@@ -876,6 +898,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(5, trade.TotalFees);
                         Assert.AreEqual(-35, trade.MAE);
                         Assert.AreEqual(70, trade.MFE);
+                        CollectionAssert.AreEquivalent(new[] { 1, 2, 3, 4, 5 }, trade.OrderIds);
                     }
                     break;
 
@@ -902,6 +925,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(3, trade1.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -5 : -15, trade1.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 30 : 20, trade1.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [3, 1] : new[] { 3, 2 }, trade1.OrderIds);
 
                         var trade2 = builder.ClosedTrades[1];
 
@@ -922,6 +946,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade2.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -30 : -20, trade2.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 40 : 50, trade2.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 4, 5] : new[] { 1, 4, 5 }, trade2.OrderIds);
                     }
                     break;
             }
@@ -1018,6 +1043,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade1.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -30 : -20, trade1.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 5 : 15, trade1.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [1, 3] : new[] { 2, 3 }, trade1.OrderIds);
 
                         var trade2 = builder.ClosedTrades[1];
 
@@ -1032,6 +1058,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade2.TotalFees);
                         Assert.AreEqual(-20, trade2.MAE);
                         Assert.AreEqual(15, trade2.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 5] : new[] { 4, 5 }, trade2.OrderIds);
 
                         var trade3 = builder.ClosedTrades[2];
 
@@ -1050,6 +1077,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(1, trade3.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -20 : -30, trade3.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 15 : 5, trade3.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [4, 5] : new[] { 1, 5 }, trade3.OrderIds);
                     }
                     break;
 
@@ -1072,6 +1100,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(5, trade.TotalFees);
                         Assert.AreEqual(-70, trade.MAE);
                         Assert.AreEqual(35, trade.MFE);
+                        CollectionAssert.AreEquivalent(new[] { 1, 2, 3, 4, 5 }, trade.OrderIds);
                     }
                     break;
 
@@ -1096,6 +1125,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(3, trade1.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -30 : -20, trade1.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 5 : 15, trade1.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [1, 3] : new[] { 2, 3 }, trade1.OrderIds);
 
                         var trade2 = builder.ClosedTrades[1];
 
@@ -1114,6 +1144,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade2.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -40 : -50, trade2.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 30 : 20, trade2.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 4, 5] : new[] { 1, 4, 5 }, trade2.OrderIds);
                     }
                     break;
             }
@@ -1191,6 +1222,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(2, trade1.TotalFees);
                             Assert.AreEqual(-5, trade1.MAE);
                             Assert.AreEqual(30, trade1.MFE);
+                            CollectionAssert.AreEquivalent(new[] { 1, 3 }, trade1.OrderIds);
 
                             var trade2 = builder.ClosedTrades[1];
 
@@ -1205,6 +1237,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(2, trade2.TotalFees);
                             Assert.AreEqual(-30, trade2.MAE);
                             Assert.AreEqual(40, trade2.MFE);
+                            CollectionAssert.AreEquivalent(new[] { 2, 5 }, trade2.OrderIds);
 
                             var trade3 = builder.ClosedTrades[2];
 
@@ -1219,6 +1252,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(1, trade3.TotalFees);
                             Assert.AreEqual(-15, trade3.MAE);
                             Assert.AreEqual(20, trade3.MFE);
+                            CollectionAssert.AreEquivalent(new[] { 4, 5 }, trade3.OrderIds);
                         }
                         else
                         {
@@ -1237,6 +1271,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(2, trade1.TotalFees);
                             Assert.AreEqual(-15, trade1.MAE);
                             Assert.AreEqual(20, trade1.MFE);
+                            CollectionAssert.AreEquivalent(new[] { 2, 3 }, trade1.OrderIds);
 
                             var trade2 = builder.ClosedTrades[1];
 
@@ -1251,6 +1286,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(2, trade2.TotalFees);
                             Assert.AreEqual(-15, trade2.MAE);
                             Assert.AreEqual(20, trade2.MFE);
+                            CollectionAssert.AreEquivalent(new[] { 4, 5 }, trade2.OrderIds);
 
                             var trade3 = builder.ClosedTrades[2];
 
@@ -1265,6 +1301,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(0, trade3.TotalFees);
                             Assert.AreEqual(-15, trade3.MAE);
                             Assert.AreEqual(20, trade3.MFE);
+                            CollectionAssert.AreEquivalent(new[] { 2, 3, 5 }, trade3.OrderIds);
 
                             var trade4 = builder.ClosedTrades[3];
 
@@ -1279,6 +1316,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(1, trade4.TotalFees);
                             Assert.AreEqual(-5, trade4.MAE);
                             Assert.AreEqual(30, trade4.MFE);
+                            CollectionAssert.AreEquivalent(new[] { 1, 5 }, trade4.OrderIds);
                         }
                     }
                     break;
@@ -1300,6 +1338,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(5, trade.TotalFees);
                         Assert.AreEqual(-50, trade.MAE);
                         Assert.AreEqual(90, trade.MFE);
+                        CollectionAssert.AreEquivalent(new[] { 1, 2, 3, 4, 5 }, trade.OrderIds);
                     }
                     break;
 
@@ -1324,6 +1363,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(3, trade1.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -5 : -15, trade1.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 30 : 20, trade1.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [1, 3] : new[] { 2, 3 }, trade1.OrderIds);
 
                         var trade2 = builder.ClosedTrades[1];
 
@@ -1347,6 +1387,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade2.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -45 : -35, trade2.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 60 : 70, trade2.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 4, 5] : new[] { 1, 2, 4, 5 }, trade2.OrderIds);
                     }
                     break;
             }
@@ -1439,6 +1480,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(2, trade1.TotalFees);
                             Assert.AreEqual(-30, trade1.MAE);
                             Assert.AreEqual(5, trade1.MFE);
+                            CollectionAssert.AreEquivalent(new[] { 1, 3 }, trade1.OrderIds);
 
                             var trade2 = builder.ClosedTrades[1];
 
@@ -1453,6 +1495,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(2, trade2.TotalFees);
                             Assert.AreEqual(-40, trade2.MAE);
                             Assert.AreEqual(30, trade2.MFE);
+                            CollectionAssert.AreEquivalent(new[] { 2, 5 }, trade2.OrderIds);
 
                             var trade3 = builder.ClosedTrades[2];
 
@@ -1467,6 +1510,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(1, trade3.TotalFees);
                             Assert.AreEqual(-20, trade3.MAE);
                             Assert.AreEqual(15, trade3.MFE);
+                            CollectionAssert.AreEquivalent(new[] { 4, 5 }, trade3.OrderIds);
                         }
                         else
                         {
@@ -1485,6 +1529,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(2, trade1.TotalFees);
                             Assert.AreEqual(-20, trade1.MAE);
                             Assert.AreEqual(15, trade1.MFE);
+                            CollectionAssert.AreEquivalent(new[] { 2, 3 }, trade1.OrderIds);
 
                             var trade2 = builder.ClosedTrades[1];
 
@@ -1499,6 +1544,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(2, trade2.TotalFees);
                             Assert.AreEqual(-20, trade2.MAE);
                             Assert.AreEqual(15, trade2.MFE);
+                            CollectionAssert.AreEquivalent(new[] { 4, 5 }, trade2.OrderIds);
 
                             var trade3 = builder.ClosedTrades[2];
 
@@ -1513,6 +1559,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(0, trade3.TotalFees);
                             Assert.AreEqual(-20, trade3.MAE);
                             Assert.AreEqual(15, trade3.MFE);
+                            CollectionAssert.AreEquivalent(new[] { 2, 3, 5 }, trade3.OrderIds);
 
                             var trade4 = builder.ClosedTrades[3];
 
@@ -1527,6 +1574,7 @@ namespace QuantConnect.Tests.Common.Statistics
                             Assert.AreEqual(1, trade4.TotalFees);
                             Assert.AreEqual(-30, trade4.MAE);
                             Assert.AreEqual(5, trade4.MFE);
+                            CollectionAssert.AreEquivalent(new[] { 1, 5 }, trade4.OrderIds);
                         }
                     }
                     break;
@@ -1548,6 +1596,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(5, trade.TotalFees);
                         Assert.AreEqual(-90, trade.MAE);
                         Assert.AreEqual(50, trade.MFE);
+                        CollectionAssert.AreEquivalent(new[] { 1, 2, 3, 4, 5 }, trade.OrderIds);
                     }
                     break;
 
@@ -1572,6 +1621,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(3, trade1.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -30 : -20, trade1.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 5 : 15, trade1.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [3, 1] : new[] { 2, 3 }, trade1.OrderIds);
 
                         var trade2 = builder.ClosedTrades[1];
 
@@ -1595,6 +1645,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade2.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -60 : -70, trade2.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 45 : 35, trade2.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 4, 5] : new[] { 1, 2, 4, 5 }, trade2.OrderIds);
                     }
                     break;
             }
@@ -1679,6 +1730,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade1.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -5 : -25, trade1.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 30 : 10, trade1.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [1, 4] : new[] { 3, 4 }, trade1.OrderIds);
 
                         var trade2 = builder.ClosedTrades[1];
 
@@ -1693,6 +1745,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(1, trade2.TotalFees);
                         Assert.AreEqual(-15, trade2.MAE);
                         Assert.AreEqual(20, trade2.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 4] : new[] { 2, 4 }, trade2.OrderIds);
 
                         var trade3 = builder.ClosedTrades[2];
 
@@ -1711,6 +1764,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade3.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -25 : -15, trade3.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 10 : 20, trade3.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [3, 6] : new[] { 5, 6 }, trade3.OrderIds);
 
                         var trade4 = builder.ClosedTrades[3];
 
@@ -1729,6 +1783,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(1, trade4.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -15 : -5, trade4.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 20 : 30, trade4.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [5, 6] : new[] { 1, 6 }, trade4.OrderIds);
                     }
                     break;
 
@@ -1749,6 +1804,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(6, trade.TotalFees);
                         Assert.AreEqual(-60, trade.MAE);
                         Assert.AreEqual(80, trade.MFE);
+                        CollectionAssert.AreEquivalent(new[] { 1, 2, 3, 4, 5, 6 }, trade.OrderIds);
                     }
                     break;
 
@@ -1773,6 +1829,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(4, trade1.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -20 : -40, trade1.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 50 : 30, trade1.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [1, 2, 4] : new[] { 2, 3, 4 }, trade1.OrderIds);
 
                         var trade2 = builder.ClosedTrades[1];
 
@@ -1791,6 +1848,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade2.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -40 : -20, trade2.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 30 : 50, trade2.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [3, 5, 6] : new[] { 1, 5, 6 }, trade2.OrderIds);
                     }
                     break;
             }
@@ -1893,6 +1951,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade1.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -30 : -10, trade1.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 5 : 25, trade1.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [1, 4] : new[] { 3, 4 }, trade1.OrderIds);
 
                         var trade2 = builder.ClosedTrades[1];
 
@@ -1907,6 +1966,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(1, trade2.TotalFees);
                         Assert.AreEqual(-20, trade2.MAE);
                         Assert.AreEqual(15, trade2.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 4] : new[] { 2, 4 }, trade2.OrderIds);
 
                         var trade3 = builder.ClosedTrades[2];
 
@@ -1925,6 +1985,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade3.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -10 : -20, trade3.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 25 : 15, trade3.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [3, 6] : new[] { 5, 6 }, trade3.OrderIds);
 
                         var trade4 = builder.ClosedTrades[3];
 
@@ -1943,6 +2004,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(1, trade4.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -20 : -30, trade4.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 15 : 5, trade4.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [5, 6] : new[] { 1, 6 }, trade4.OrderIds);
                     }
                     break;
 
@@ -1963,6 +2025,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(6, trade.TotalFees);
                         Assert.AreEqual(-80, trade.MAE);
                         Assert.AreEqual(60, trade.MFE);
+                        CollectionAssert.AreEquivalent(new[] { 1, 2, 3, 4, 5, 6 }, trade.OrderIds);
                     }
                     break;
 
@@ -1987,6 +2050,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(4, trade1.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -50 : -30, trade1.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 20 : 40, trade1.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [1, 2, 4] : new[] { 2, 3, 4 }, trade1.OrderIds);
 
                         var trade2 = builder.ClosedTrades[1];
 
@@ -2005,6 +2069,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade2.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -30 : -50, trade2.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 40 : 20, trade2.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [3, 5, 6] : new[] { 1, 5, 6 }, trade2.OrderIds);
                     }
                     break;
             }
@@ -2091,6 +2156,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade1.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -5 : -15, trade1.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 30 : 20, trade1.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [1, 3] : new[] { 2, 3 }, trade1.OrderIds);
 
                         var trade2 = builder.ClosedTrades[1];
 
@@ -2109,6 +2175,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(1, trade2.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -7.5 : -2.5, trade2.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 10 : 15, trade2.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 3] : new[] { 1, 3 }, trade2.OrderIds);
 
                         var trade3 = builder.ClosedTrades[2];
 
@@ -2127,6 +2194,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(1, trade3.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -7.5 : -2.5, trade3.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 10 : 15, trade3.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 3, 4] : new[] { 1, 3, 4 }, trade3.OrderIds);
                     }
                     break;
 
@@ -2147,6 +2215,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(4, trade.TotalFees);
                         Assert.AreEqual(-20, trade.MAE);
                         Assert.AreEqual(50, trade.MFE);
+                        CollectionAssert.AreEquivalent(new[] { 1, 2, 3, 4 }, trade.OrderIds);
                     }
                     break;
 
@@ -2169,6 +2238,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(3, trade1.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -12.5 : -17.5, trade1.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 40 : 35, trade1.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [1, 2, 3] : new[] { 1, 2, 3 }, trade1.OrderIds);
 
                         var trade2 = builder.ClosedTrades[1];
 
@@ -2187,6 +2257,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(1, trade2.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -7.5 : -2.5, trade2.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 10 : 15, trade2.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 4] : new[] { 1, 4 }, trade2.OrderIds);
                     }
                     break;
             }
@@ -2273,6 +2344,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(2, trade1.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -30 : -20, trade1.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 5 : 15, trade1.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [1, 3] : new[] { 2, 3 }, trade1.OrderIds);
 
                         var trade2 = builder.ClosedTrades[1];
 
@@ -2291,6 +2363,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(1, trade2.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -10 : -15, trade2.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 7.5 : 2.5, trade2.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 3] : new[] { 1, 3 }, trade2.OrderIds);
 
                         var trade3 = builder.ClosedTrades[2];
 
@@ -2309,6 +2382,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(1, trade3.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -10 : -15, trade3.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 7.5 : 2.5, trade3.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 3, 4] : new[] { 1, 3, 4 }, trade3.OrderIds);
                     }
                     break;
 
@@ -2329,6 +2403,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(4, trade.TotalFees);
                         Assert.AreEqual(-50, trade.MAE);
                         Assert.AreEqual(20, trade.MFE);
+                        CollectionAssert.AreEquivalent(new[] { 1, 2, 3, 4 }, trade.OrderIds);
                     }
                     break;
 
@@ -2351,6 +2426,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(3, trade1.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -40 : -35, trade1.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 12.5 : 17.5, trade1.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [1, 2, 3] : new[] { 1, 2, 3 }, trade1.OrderIds);
 
                         var trade2 = builder.ClosedTrades[1];
 
@@ -2369,6 +2445,7 @@ namespace QuantConnect.Tests.Common.Statistics
                         Assert.AreEqual(1, trade2.TotalFees);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? -10 : -15, trade2.MAE);
                         Assert.AreEqual(matchingMethod == FillMatchingMethod.FIFO ? 7.5 : 2.5, trade2.MFE);
+                        CollectionAssert.AreEquivalent(matchingMethod == FillMatchingMethod.FIFO ? [2, 4] : new[] { 1, 4 }, trade2.OrderIds);
                     }
                     break;
             }
@@ -2431,6 +2508,7 @@ namespace QuantConnect.Tests.Common.Statistics
             Assert.AreEqual(2, trade.TotalFees);
             Assert.AreEqual(-5 * multiplier, trade.MAE);
             Assert.AreEqual(20m * multiplier, trade.MFE);
+            CollectionAssert.AreEquivalent(new[] { 1, 2 }, trade.OrderIds);
         }
 
         [Test]
@@ -2470,7 +2548,7 @@ namespace QuantConnect.Tests.Common.Statistics
             var closingOrderDirection = orderDirection == OrderDirection.Buy ? OrderDirection.Sell : OrderDirection.Buy;
             var ticket = new OrderTicket(null, new SubmitOrderRequest(OrderType.OptionExercise, option.Type, option.Symbol, -quantity, 0, 0, time, ""));
             builder.ProcessFill(
-                new OrderEvent(1, option.Symbol, time.AddMinutes(10), OrderStatus.Filled, closingOrderDirection, 0m, -quantity, _orderFee)
+                new OrderEvent(2, option.Symbol, time.AddMinutes(10), OrderStatus.Filled, closingOrderDirection, 0m, -quantity, _orderFee)
                 {
                     IsInTheMoney = true,
                     Ticket = ticket
@@ -2494,9 +2572,10 @@ namespace QuantConnect.Tests.Common.Statistics
             Assert.AreEqual(time.AddMinutes(10), trade.ExitTime);
             Assert.AreEqual(0, trade.ExitPrice);
             Assert.AreEqual(Math.Sign(quantity) * -100000m, trade.ProfitLoss);
-            Assert.AreEqual(1m, trade.TotalFees);
+            Assert.AreEqual(2m, trade.TotalFees);
             Assert.AreEqual(orderDirection == OrderDirection.Buy ? -100000m : 0m, trade.MAE);
             Assert.AreEqual(orderDirection == OrderDirection.Buy ? 0m : 100000m, trade.MFE);
+            CollectionAssert.AreEquivalent(new[] { 1, 2 }, trade.OrderIds);
         }
 
         [TestCase(OrderDirection.Buy)]
@@ -2525,7 +2604,7 @@ namespace QuantConnect.Tests.Common.Statistics
             var closingOrderDirection = orderDirection == OrderDirection.Buy ? OrderDirection.Sell : OrderDirection.Buy;
             var ticket = new OrderTicket(null, new SubmitOrderRequest(OrderType.OptionExercise, option.Type, option.Symbol, -quantity, 0, 0, time, ""));
             builder.ProcessFill(
-                new OrderEvent(1, option.Symbol, time.AddMinutes(10), OrderStatus.Filled, closingOrderDirection, 0m, -quantity, _orderFee)
+                new OrderEvent(2, option.Symbol, time.AddMinutes(10), OrderStatus.Filled, closingOrderDirection, 0m, -quantity, _orderFee)
                 {
                     IsInTheMoney = true,
                     Ticket = ticket
@@ -2549,9 +2628,10 @@ namespace QuantConnect.Tests.Common.Statistics
             Assert.AreEqual(time.AddMinutes(10), trade.ExitTime);
             Assert.AreEqual(0, trade.ExitPrice);
             Assert.AreEqual(Math.Sign(quantity) * -100000m, trade.ProfitLoss);
-            Assert.AreEqual(1m, trade.TotalFees);
+            Assert.AreEqual(2m, trade.TotalFees);
             Assert.AreEqual(orderDirection == OrderDirection.Buy ? -100000m : 0m, trade.MAE);
             Assert.AreEqual(orderDirection == OrderDirection.Buy ? 0m : 100000m, trade.MFE);
+            CollectionAssert.AreEquivalent(new[] { 1, 2 }, trade.OrderIds);
         }
 
         [Test]
@@ -2595,7 +2675,7 @@ namespace QuantConnect.Tests.Common.Statistics
             var closingOrderDirection = orderDirection == OrderDirection.Buy ? OrderDirection.Sell : OrderDirection.Buy;
             var ticket = new OrderTicket(null, new SubmitOrderRequest(OrderType.Market, option.Type, option.Symbol, -quantity, 0, 0, time, ""));
             builder.ProcessFill(
-                new OrderEvent(1, option.Symbol, time.AddMinutes(10), OrderStatus.Filled, closingOrderDirection, finalOptionPrice, -quantity, _orderFee)
+                new OrderEvent(2, option.Symbol, time.AddMinutes(10), OrderStatus.Filled, closingOrderDirection, finalOptionPrice, -quantity, _orderFee)
                 {
                     IsInTheMoney = true,
                     Ticket = ticket,
@@ -2621,6 +2701,7 @@ namespace QuantConnect.Tests.Common.Statistics
             Assert.AreEqual(time.AddMinutes(10), trade.ExitTime);
             Assert.AreEqual(finalOptionPrice, trade.ExitPrice);
             Assert.AreEqual(expectedProfitLoss, trade.ProfitLoss);
+            CollectionAssert.AreEquivalent(new[] { 1, 2 }, trade.OrderIds);
         }
 
         private Option GetOption()


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Expose order ids related to statistics closed trades.
`TradeBuilder.ClosedTrades[*].OrderIds` now have the order ids related to each closed trade.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Close #8978 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
