### PR TITLE
Minor fix for period history api 

### DIFF
--- a/Common/Data/HistoryRequestFactory.cs
+++ b/Common/Data/HistoryRequestFactory.cs
@@ -167,8 +167,8 @@ namespace QuantConnect.Data
             bool? extendedMarketHours = null)
         {
             var isExtendedMarketHours = false;
-            // hour resolution does no have extended market hours data. Same for chain universes
-            if (resolution != Resolution.Hour && LeanData.SupportsExtendedMarketHours(dataType))
+            // hour and daily resolution does no have extended market hours data. Same for chain universes
+            if (resolution < Resolution.Hour && LeanData.SupportsExtendedMarketHours(dataType))
             {
                 if (extendedMarketHours.HasValue)
                 {

--- a/Common/Time.cs
+++ b/Common/Time.cs
@@ -692,7 +692,7 @@ namespace QuantConnect
             {
                 var previous = current;
                 current = current - barSize;
-                if (exchangeHours.IsOpen(current, previous, extendedMarketHours))
+                if (exchangeHours.IsOpen(current, previous, barSize < Time.OneHour && extendedMarketHours))
                 {
                     i++;
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Minor fix for period history api to exclude extended hours only days (like Sundays for Futures) in date range calculated for period history request, given that we don't have daily data on those dates.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #8951 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
