### PR TITLE
Fix 6N, LBS also ES,EMD,YM,NQ (older) FOP expirations

### DIFF
--- a/Common/Securities/Future/FuturesExpiryUtilityFunctions.cs
+++ b/Common/Securities/Future/FuturesExpiryUtilityFunctions.cs
@@ -430,6 +430,20 @@ namespace QuantConnect.Securities.Future
             return new DateTime(year, month, day).AddDays(-2);
         }
 
+        /// <summary>
+        /// This function returns the third Friday of the month, adjusted for holidays and weekends.
+        /// </summary>
+        public static DateTime ThirdFriday(DateTime time, Symbol contract)
+        {
+            if (contract.ID.SecurityType.IsOption())
+            {
+                return ThirdFriday(time, contract.Underlying);
+            }
+            var thirdFriday = ThirdFriday(time);
+            var holidays = GetExpirationHolidays(contract.ID.Market, contract.ID.Symbol);
+            return AddBusinessDaysIfHoliday(thirdFriday, -1, holidays);
+        }
+
         private static readonly Dictionary<string, int> ExpiriesPriorMonth = new Dictionary<string, int>
         {
             { Futures.Energy.ArgusLLSvsWTIArgusTradeMonth, 1 },

--- a/Common/Securities/FutureOption/FuturesOptionsExpiryFunctions.cs
+++ b/Common/Securities/FutureOption/FuturesOptionsExpiryFunctions.cs
@@ -39,6 +39,7 @@ namespace QuantConnect.Securities.FutureOption
         private static readonly Symbol _ozt = Symbol.CreateCanonicalOption(Symbol.Create("ZT", SecurityType.Future, Market.CBOT));
         private static readonly Symbol _ozl = Symbol.CreateCanonicalOption(Symbol.Create("ZL", SecurityType.Future, Market.CBOT));
         private static readonly Symbol _ozw = Symbol.CreateCanonicalOption(Symbol.Create("ZW", SecurityType.Future, Market.CBOT));
+        private static readonly Symbol _oym = Symbol.CreateCanonicalOption(Symbol.Create("YM", SecurityType.Future, Market.CBOT));
         private static readonly Symbol _hxe = Symbol.CreateCanonicalOption(Symbol.Create("HG", SecurityType.Future, Market.COMEX));
         private static readonly Symbol _og = Symbol.CreateCanonicalOption(Symbol.Create("GC", SecurityType.Future, Market.COMEX));
         private static readonly Symbol _so = Symbol.CreateCanonicalOption(Symbol.Create("SI", SecurityType.Future, Market.COMEX));
@@ -48,9 +49,14 @@ namespace QuantConnect.Securities.FutureOption
         private static readonly Symbol _euu = Symbol.CreateCanonicalOption(Symbol.Create("6E", SecurityType.Future, Market.CME));
         private static readonly Symbol _jpu = Symbol.CreateCanonicalOption(Symbol.Create("6J", SecurityType.Future, Market.CME));
         private static readonly Symbol _chu = Symbol.CreateCanonicalOption(Symbol.Create("6S", SecurityType.Future, Market.CME));
+        private static readonly Symbol _nzd = Symbol.CreateCanonicalOption(Symbol.Create("6N", SecurityType.Future, Market.CME));
         private static readonly Symbol _le = Symbol.CreateCanonicalOption(Symbol.Create("LE", SecurityType.Future, Market.CME));
         private static readonly Symbol _he = Symbol.CreateCanonicalOption(Symbol.Create("HE", SecurityType.Future, Market.CME));
         private static readonly Symbol _lbr = Symbol.CreateCanonicalOption(Symbol.Create("LBR", SecurityType.Future, Market.CME));
+        private static readonly Symbol _lbs = Symbol.CreateCanonicalOption(Symbol.Create("LBS", SecurityType.Future, Market.CME));
+        private static readonly Symbol _es = Symbol.CreateCanonicalOption(Symbol.Create("ES", SecurityType.Future, Market.CME));
+        private static readonly Symbol _emd = Symbol.CreateCanonicalOption(Symbol.Create("EMD", SecurityType.Future, Market.CME));
+        private static readonly Symbol _nq = Symbol.CreateCanonicalOption(Symbol.Create("NQ", SecurityType.Future, Market.CME));
 
         /// <summary>
         /// Futures options expiry functions lookup table, keyed by canonical future option Symbol
@@ -90,9 +96,16 @@ namespace QuantConnect.Securities.FutureOption
             { _euu, expiryMonth => SecondFridayBeforeThirdWednesdayOfContractMonth(_euu.Underlying, expiryMonth) },
             { _jpu, expiryMonth => SecondFridayBeforeThirdWednesdayOfContractMonth(_jpu.Underlying, expiryMonth) },
             { _chu, expiryMonth => SecondFridayBeforeThirdWednesdayOfContractMonth(_chu.Underlying, expiryMonth) },
+            { _nzd, expiryMonth => SecondFridayBeforeThirdWednesdayOfContractMonth(_nzd.Underlying, expiryMonth) },
             { _le, expiryMonth => FirstFridayOfContractMonth(_le.Underlying, expiryMonth) },
             { _he, expiryMonth => TenthBusinessDayOfContractMonth(_he.Underlying, expiryMonth) },
             { _lbr, expiryMonth => LastBusinessDayInPrecedingMonthFromContractMonth(_lbr.Underlying, expiryMonth) },
+            { _lbs, expiryMonth => LastBusinessDayInPrecedingMonthFromContractMonth(_lbs.Underlying, expiryMonth) },
+            // even though these FOPs are currently quarterly (as underlying), they had until some serial months. Expiration is the same rule for all
+            { _es, expiryMonth => FuturesExpiryUtilityFunctions.ThirdFriday(expiryMonth, _es) },
+            { _emd, expiryMonth => FuturesExpiryUtilityFunctions.ThirdFriday(expiryMonth, _emd) },
+            { _oym, expiryMonth => FuturesExpiryUtilityFunctions.ThirdFriday(expiryMonth, _oym) },
+            { _nq, expiryMonth => FuturesExpiryUtilityFunctions.ThirdFriday(expiryMonth, _nq) },
         };
 
         /// <summary>

--- a/Common/Securities/FutureOption/FuturesOptionsUnderlyingMapper.cs
+++ b/Common/Securities/FutureOption/FuturesOptionsUnderlyingMapper.cs
@@ -86,7 +86,8 @@ namespace QuantConnect.Securities.FutureOption
             { "ZO", 1 },
             { "KE", 1 },
             { "ZF", 1 },
-            { "LBR", 1 }
+            { "LBR", 1 },
+            { "LBS", 1 }
         };
 
         /// <summary>

--- a/Tests/Common/Securities/FutureOption/FuturesOptionsExpiryFunctionsTests.cs
+++ b/Tests/Common/Securities/FutureOption/FuturesOptionsExpiryFunctionsTests.cs
@@ -92,6 +92,21 @@ namespace QuantConnect.Tests.Common.Securities.FutureOption
         [TestCase("LBR", Market.CME, "202510", "20250930", "20251114")]
         [TestCase("LBR", Market.CME, "202511", "20251031", "20251114")]
         [TestCase("LBR", Market.CME, "202603", "20260227", "20260313")]
+        [TestCase("LBS", Market.CME, "202510", "20250930", "20251114")]
+        [TestCase("LBS", Market.CME, "202511", "20251031", "20251114")]
+        [TestCase("LBS", Market.CME, "202603", "20260227", "20260313")]
+        [TestCase("NQ", Market.CME, "202512", "20251219", "20251219")]
+        [TestCase("NQ", Market.CME, "202603", "20260320", "20260320")]
+        [TestCase("EMD", Market.CME, "202512", "20251219", "20251219")]
+        [TestCase("EMD", Market.CME, "202603", "20260320", "20260320")]
+        [TestCase("ES", Market.CME, "202512", "20251219", "20251219")]
+        [TestCase("ES", Market.CME, "202603", "20260320", "20260320")]
+        [TestCase("ES", Market.CME, "201601", "20160115", "20160318")]
+        [TestCase("YM", Market.CBOT, "202512", "20251219", "20251219")]
+        [TestCase("YM", Market.CBOT, "202603", "20260320", "20260320")]
+        [TestCase("6N", Market.CME, "202511", "20251107", "20251215")]
+        [TestCase("6N", Market.CME, "202512", "20251205", "20251215")]
+        [TestCase("6N", Market.CME, "202601", "20260109", "20260316")]
         public void FutureAndOptionMapping(string futureTicker, string market, string fopContractMonthYear, string expectedFop, string expectedFuture)
         {
             FuturesExpiryUtilityFunctions.BankHolidays = true;


### PR DESCRIPTION
- Fix  missing 6N, LBS
- Handle ES, EMD, YM, NQ older serial month FOP expirations


See related https://github.com/QuantConnect/Lean/pull/8998