### PR TITLE
Improve portfolio margin chart

### DIFF
--- a/Common/BaseSeries.cs
+++ b/Common/BaseSeries.cs
@@ -258,25 +258,45 @@ namespace QuantConnect
     /// </summary>
     public enum SeriesType
     {
+        /// <summary>
         /// Line Plot for Value Types (0)
+        /// </summary>
         Line,
+        /// <summary>
         /// Scatter Plot for Chart Distinct Types (1)
+        /// </summary>
         Scatter,
+        /// <summary>
         /// Charts (2)
+        /// </summary>
         Candle,
+        /// <summary>
         /// Bar chart (3)
+        /// </summary>
         Bar,
+        /// <summary>
         /// Flag indicators (4)
+        /// </summary>
         Flag,
+        /// <summary>
         /// 100% area chart showing relative proportions of series values at each time index (5)
+        /// </summary>
         StackedArea,
+        /// <summary>
         /// Pie chart (6)
+        /// </summary>
         Pie,
+        /// <summary>
         /// Treemap Plot (7)
+        /// </summary>
         Treemap,
+        /// <summary>
         /// Heatmap Plot (9) -- NOTE: 8 is reserved
+        /// </summary>
         Heatmap = 9,
+        /// <summary>
         /// Scatter 3D Plot (10)
+        /// </summary>
         Scatter3d
     }
 }

--- a/Common/Securities/Positions/PortfolioMarginChart.cs
+++ b/Common/Securities/Positions/PortfolioMarginChart.cs
@@ -30,7 +30,7 @@ namespace QuantConnect.Securities.Positions
     {
         private static string PortfolioMarginTooltip = "{SERIES_NAME}: {VALUE}%";
         private static string PortfolioMarginIndexName = "Margin Used (%)";
-        private static readonly int _portfolioMarginSeriesCount = Configuration.Config.GetInt("portfolio-margin-series-count", 5);
+        private static readonly int _portfolioMarginSeriesCount = Configuration.Config.GetInt("portfolio-margin-series-count", 40);
 
         /// <summary>
         /// Helper method to add the portfolio margin series into the given chart
@@ -114,7 +114,7 @@ namespace QuantConnect.Securities.Positions
         {
             if (!portfolioChart.Series.TryGetValue(seriesName, out var series))
             {
-                series = portfolioChart.Series[seriesName] = new Series(seriesName, SeriesType.StackedArea, 0, "%")
+                series = portfolioChart.Series[seriesName] = new Series(seriesName, SeriesType.Bar, 0, "%")
                 {
                     Color = color,
                     Tooltip = PortfolioMarginTooltip,

--- a/Common/SeriesSampler.cs
+++ b/Common/SeriesSampler.cs
@@ -108,6 +108,10 @@ namespace QuantConnect
             foreach (var series in chart.Series.Values)
             {
                 var sampledSeries = Sample(series, start, stop);
+                if (sampledSeries.Values.Count == 0)
+                {
+                    continue;
+                }
                 sampledChart.AddSeries(sampledSeries);
             }
             return sampledChart;

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -192,6 +192,7 @@ namespace QuantConnect.Lean.Engine.Results
                         if (updates.Name == PortfolioMarginKey)
                         {
                             PortfolioMarginChart.RemoveSinglePointSeries(updates);
+                            updates = updates.Aggregate(SeriesType.StackedArea);
                         }
                     }
                 }

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -618,7 +618,7 @@ namespace QuantConnect.Lean.Engine.Results
             {
                 if (!Charts.TryGetValue(PortfolioMarginKey, out var chart))
                 {
-                    chart = new Chart(PortfolioMarginKey);
+                    chart = new Chart(PortfolioMarginKey) { LegendDisabled = true };
                     Charts.AddOrUpdate(PortfolioMarginKey, chart);
                 }
                 PortfolioMarginChart.AddSample(chart, state, MapFileProvider, DateTime.UtcNow.Date);

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -61,7 +61,7 @@ namespace QuantConnect.Lean.Engine.Results
         private DateTime _nextPortfolioMarginUpdate;
         private DateTime _previousPortfolioMarginUpdate;
         private readonly TimeSpan _samplePortfolioPeriod;
-        private readonly Chart _intradayPortfolioState = new(PortfolioMarginKey);
+        private readonly Chart _intradayPortfolioState = new(PortfolioMarginKey) { LegendDisabled = true };
 
         /// <summary>
         /// The earliest time of next dump to the status file


### PR DESCRIPTION
- Minor improvements for portfolio margin chart
  -  backtests will stream aggregate view using stacked aread
  - on zoom, detailed chart view will use stacked bars
  - increasing margin series limits from 5 to 40