### PR TITLE
Fix: Add obsolete flag to AddUniverse coarse+fine

### DIFF
--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -471,7 +471,7 @@ namespace QuantConnect.Algorithm
         {
             if (!_coarseFineUniverseObsoleteLogSent)
             {
-                Log("Warning: AddUniverse(coarseSelector, fineSelector) is obsolete, please use AddUniverse(Func<IEnumerable<Fundamental>, IEnumerable<Symbol>> selector) instead.");
+                Debug("Warning: AddUniverse(coarseSelector, fineSelector) is obsolete, please use AddUniverse(Func<IEnumerable<Fundamental>, IEnumerable<Symbol>> selector) instead.");
                 _coarseFineUniverseObsoleteLogSent = true;
             }
 


### PR DESCRIPTION
#### Description
Marked `AddUniverse(Func<IEnumerable<CoarseFundamental>, IEnumerable<Symbol>> coarseSelector, Func<IEnumerable<FineFundamental>, IEnumerable<Symbol>> fineSelector)` as obsolete. Recommended users to use `AddUniverse(Func<IEnumerable<Fundamental>, IEnumerable<Symbol>> selector)` instead and altered the docs accordingly.

#### Related Issue
Closes https://github.com/QuantConnect/Lean/issues/8812

#### Motivation and Context
As the method which uses the coarseSelector and the fineSelector is obsolete, users should be directed to the single selector version.

#### Requires Documentation Change
This requires updates in the docs, because they refer to `coarse` in other methods, when they shouldn't.

#### How Has This Been Tested?
No unit tests have been created for this, only simple manual tests were run to verify that no syntax errors were commited.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. (N/A as the usage of `Obsolete` is not tested throughout the repo)
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
