### PR TITLE
Add ObjectStore limit properties

### DIFF
--- a/Common/Interfaces/IObjectStore.cs
+++ b/Common/Interfaces/IObjectStore.cs
@@ -29,12 +29,12 @@ namespace QuantConnect.Interfaces
         /// <summary>
         /// Gets the maximum storage limit in bytes
         /// </summary>
-        long StorageLimit { get; }
+        long MaxSize { get; }
 
         /// <summary>
         /// Gets the maximum number of files allowed
         /// </summary>
-        int StorageFileCount { get; }
+        int MaxFiles { get; }
 
         /// <summary>
         /// Event raised each time there's an error

--- a/Common/Storage/ObjectStore.cs
+++ b/Common/Storage/ObjectStore.cs
@@ -33,12 +33,12 @@ namespace QuantConnect.Storage
         /// <summary>
         /// Gets the maximum storage limit in bytes
         /// </summary>
-        public long StorageLimit => _store.StorageLimit;
+        public long MaxSize => _store.MaxSize;
 
         /// <summary>
         /// Gets the maximum number of files allowed
         /// </summary>
-        public int StorageFileCount => _store.StorageFileCount;
+        public int MaxFiles => _store.MaxFiles;
 
         /// <summary>
         /// Event raised each time there's an error

--- a/Engine/Storage/LocalObjectStore.cs
+++ b/Engine/Storage/LocalObjectStore.cs
@@ -25,6 +25,7 @@ using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
 using QuantConnect.Packets;
+using QuantConnect.Storage;
 using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.Storage
@@ -37,12 +38,12 @@ namespace QuantConnect.Lean.Engine.Storage
         /// <summary>
         /// Gets the maximum storage limit in bytes
         /// </summary>
-        public long StorageLimit => Controls?.StorageLimit ?? 0;
+        public long MaxSize => Controls?.StorageLimit ?? 0;
 
         /// <summary>
         /// Gets the maximum number of files allowed
         /// </summary>
-        public int StorageFileCount => Controls?.StorageFileCount ?? 0;
+        public int MaxFiles => Controls?.StorageFileCount ?? 0;
 
         /// <summary>
         /// No read permissions error message
@@ -388,20 +389,20 @@ namespace QuantConnect.Lean.Engine.Storage
             }
 
             // Verify we are within FileCount limit
-            if (fileCount > StorageFileCount)
+            if (fileCount > MaxFiles)
             {
-                var message = $"You have reached the ObjectStore limit for files it can save: {fileCount}/{StorageFileCount}. " +
-                $"Unable to save the new file. You can find the limit with the ObjectStore.StorageFileCount property.";
+                var message = $"You have reached the ObjectStore limit for files it can save: {fileCount}/{MaxFiles}. " +
+                $"Unable to save the new file. You can find the limit with the ObjectStore.{nameof(ObjectStore.MaxFiles)} property.";
                 Log.Error($"LocalObjectStore.InternalSaveBytes(): {message} File: '{path}'");
                 OnErrorRaised(new StorageLimitExceededException(message));
                 return false;
             }
 
             // Verify we are within Storage limit
-            if (expectedStorageSizeBytes > StorageLimit)
+            if (expectedStorageSizeBytes > MaxSize)
             {
-                var message = $"You have reached the ObjectStore storage capacity limit: {BytesToMb(expectedStorageSizeBytes)}MB/{BytesToMb(StorageLimit)}MB. " +
-                $"Unable to save the new file. You can find the limit with the ObjectStore.StorageLimit property.";
+                var message = $"You have reached the ObjectStore storage capacity limit: {BytesToMb(expectedStorageSizeBytes)}MB/{BytesToMb(MaxSize)}MB. " +
+                $"Unable to save the new file. You can find the limit with the ObjectStore.{nameof(ObjectStore.MaxSize)} property.";
                 Log.Error($"LocalObjectStore.InternalSaveBytes(): {message} File: '{path}'");
                 OnErrorRaised(new StorageLimitExceededException(message));
                 return false;

--- a/Tests/Common/Storage/LocalObjectStoreTests.cs
+++ b/Tests/Common/Storage/LocalObjectStoreTests.cs
@@ -915,8 +915,8 @@ namespace QuantConnect.Tests.Common.Storage
             using var store = new TestLocalObjectStore();
             store.Initialize(1, 2, "token", controls);
 
-            Assert.AreEqual(536870912, store.StorageLimit);
-            Assert.AreEqual(500, store.StorageFileCount);
+            Assert.AreEqual(536870912, store.MaxSize);
+            Assert.AreEqual(500, store.MaxFiles);
         }
 
         [Test]
@@ -925,8 +925,8 @@ namespace QuantConnect.Tests.Common.Storage
             using var store = new TestLocalObjectStore();
             store.Initialize(1, 2, "token", new Controls());
 
-            Assert.AreEqual(10737418240, store.StorageLimit);
-            Assert.AreEqual(10000, store.StorageFileCount);
+            Assert.AreEqual(10737418240, store.MaxSize);
+            Assert.AreEqual(10000, store.MaxFiles);
         }
 
         [TestCase(1, false)]
@@ -958,10 +958,10 @@ namespace QuantConnect.Tests.Common.Storage
             localStore.Initialize(1, 2, "token", new Controls());
             using var objectStore = new ObjectStore(localStore);
 
-            Assert.AreEqual(localStore.StorageLimit, objectStore.StorageLimit);
-            Assert.AreEqual(localStore.StorageFileCount, objectStore.StorageFileCount);
+            Assert.AreEqual(localStore.MaxSize, objectStore.MaxSize);
+            Assert.AreEqual(localStore.MaxFiles, objectStore.MaxFiles);
             Assert.AreEqual(localStore.Count(), objectStore.Count());
-            Assert.AreEqual(localStore.Count() == localStore.StorageFileCount, objectStore.Count() == objectStore.StorageFileCount);
+            Assert.AreEqual(localStore.Count() == localStore.MaxFiles, objectStore.Count() == objectStore.MaxFiles);
         }
 
         private static void DummyMachineLearning(string outputFile, string content)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Exposes ObjectStore storage limits (StorageLimit, StorageFileCount, Count) as public properties and improves error messages.

#### Related Issue
Closes #8774 

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit test.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
