### PR TITLE
Fix #6982: Implement Covariance indicator

### DIFF
--- a/Indicators/Covariance.cs
+++ b/Indicators/Covariance.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Indicators
+{
+    /// <summary>
+    /// Rolling (sample) covariance between two numeric time series X and Y.
+    /// Maintains rolling sums for O(1) updates over a fixed lookback period.
+    ///
+    /// Cov(X,Y) = (sum(xy) - sum(x) * sum(y) / n) / (n - 1), for n >= 2.
+    /// </summary>
+    public class Covariance
+    {
+        private readonly int _period;
+        private readonly Queue<decimal> _x = new();
+        private readonly Queue<decimal> _y = new();
+
+        // rolling sums
+        private decimal _sumX, _sumY, _sumXY;
+
+        /// <summary>Latest covariance value (0 until enough samples).</summary>
+        public decimal Value { get; private set; }
+
+        /// <summary>Number of samples required.</summary>
+        public int Period => _period;
+
+        /// <summary>True when the rolling window is full.</summary>
+        public bool IsReady => _x.Count == _period;
+
+        /// <summary>Last update time.</summary>
+        public DateTime Time { get; private set; }
+
+        public Covariance(int period)
+        {
+            if (period < 2)
+                throw new ArgumentOutOfRangeException(nameof(period), "Covariance period must be >= 2.");
+            _period = period;
+        }
+
+        /// <summary>
+        /// Update with a new pair (x_t, y_t) at the provided time.
+        /// Returns the latest covariance value.
+        /// </summary>
+        public decimal Update(DateTime time, decimal x, decimal y)
+        {
+            Time = time;
+
+            // add new
+            _x.Enqueue(x);
+            _y.Enqueue(y);
+            _sumX  += x;
+            _sumY  += y;
+            _sumXY += x * y;
+
+            // remove oldest if exceeding period
+            if (_x.Count > _period)
+            {
+                var oldX = _x.Dequeue();
+                var oldY = _y.Dequeue();
+                _sumX  -= oldX;
+                _sumY  -= oldY;
+                _sumXY -= oldX * oldY;
+            }
+
+            var n = _x.Count; // == _y.Count
+            if (n >= 2)
+            {
+                // sample covariance
+                Value = (_sumXY - (_sumX * _sumY) / n) / (n - 1);
+            }
+            else
+            {
+                Value = 0m;
+            }
+
+            return Value;
+        }
+
+        /// <summary>Reset internal state.</summary>
+        public void Reset()
+        {
+            _x.Clear();
+            _y.Clear();
+            _sumX = _sumY = _sumXY = 0m;
+            Value = 0m;
+            Time = default;
+        }
+    }
+}

--- a/Tests/QuantConnect.Tests/Indicators/CovarianceTests.cs
+++ b/Tests/QuantConnect.Tests/Indicators/CovarianceTests.cs
@@ -1,0 +1,73 @@
+using System;
+using NUnit.Framework;
+using QuantConnect.Indicators;
+
+namespace QuantConnect.Tests.Indicators
+{
+    [TestFixture]
+    public class CovarianceTests
+    {
+        [Test]
+        public void BecomesReadyAfterPeriod()
+        {
+            var period = 5;
+            var cov = new Covariance(period);
+
+            var t0 = new DateTime(2020, 1, 1);
+            for (int i = 0; i < period - 1; i++)
+            {
+                cov.Update(t0.AddDays(i), i + 1, 2*(i + 1));
+                Assert.IsFalse(cov.IsReady, "Should not be ready before period samples");
+            }
+
+            cov.Update(t0.AddDays(period - 1), period, 2*period);
+            Assert.IsTrue(cov.IsReady, "Should be ready at exactly 'period' samples");
+        }
+
+        [Test]
+        public void MatchesExpectedSampleCovarianceForLinearRelation()
+        {
+            // x = 1,2,3,4,5; y = 2x
+            // sample var(x) over 1..5 is 2.5; cov(x,y) = 2 * var(x) = 5.0
+            var cov = new Covariance(5);
+
+            var t0 = new DateTime(2020, 1, 1);
+            for (int i = 0; i < 5; i++)
+            {
+                var x = i + 1;
+                var y = 2 * x;
+                cov.Update(t0.AddDays(i), x, y);
+            }
+
+            Assert.IsTrue(cov.IsReady);
+            Assert.AreEqual(5.0m, Math.Round(cov.Value, 6));
+        }
+
+        [Test]
+        public void ResetsProperly()
+        {
+            var cov = new Covariance(3);
+            var t0 = new DateTime(2020, 1, 1);
+
+            cov.Update(t0, 1, 2);
+            cov.Update(t0.AddDays(1), 2, 4);
+            cov.Update(t0.AddDays(2), 3, 6);
+
+            Assert.IsTrue(cov.IsReady);
+            Assert.AreNotEqual(0m, cov.Value);
+
+            cov.Reset();
+
+            Assert.IsFalse(cov.IsReady);
+            Assert.AreEqual(0m, cov.Value);
+            Assert.AreEqual(default(DateTime), cov.Time);
+        }
+
+        [Test]
+        public void ThrowsOnInvalidPeriod()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Covariance(1));
+            Assert.DoesNotThrow(() => new Covariance(2));
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #6982.

Summary
- Adds `Indicators/Covariance.cs`: rolling sample covariance with O(1) updates.
- Adds tests in `Tests/QuantConnect.Tests/Indicators/CovarianceTests.cs` for readiness, correctness, reset, and invalid period.

Verification
- Built with `dotnet build -c Release`.
- Ran: `dotnet test Tests/QuantConnect.Tests/QuantConnect.Tests.csproj -c Release --filter "Name~Covariance"`

Note
- I’m applying for the QuantConnect **Data Engineering** position and selected this as my “good first issue” contribution.
