### PR TITLE
Adds Missing Indicator Constructor Overloads Without name Parameter

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -1435,7 +1435,7 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(Indicators)]
         public VolumeProfile VP(Symbol symbol, int period = 2, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m, Resolution resolution = Resolution.Daily, Func<IBaseData, TradeBar> selector = null)
         {
-            var name = CreateIndicatorName(symbol, $"VP({period},{valueAreaVolumePercentage},{valueAreaVolumePercentage})", resolution);
+            var name = CreateIndicatorName(symbol, $"VP({period},{valueAreaVolumePercentage},{priceRangeRoundOff})", resolution);
             var marketProfile = new VolumeProfile(name, period, valueAreaVolumePercentage, priceRangeRoundOff);
             InitializeIndicator(marketProfile, resolution, selector, symbol);
 
@@ -1456,7 +1456,7 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(Indicators)]
         public TimeProfile TP(Symbol symbol, int period = 2, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m, Resolution resolution = Resolution.Daily, Func<IBaseData, TradeBar> selector = null)
         {
-            var name = CreateIndicatorName(symbol, $"TP({period},{valueAreaVolumePercentage},{valueAreaVolumePercentage})", resolution);
+            var name = CreateIndicatorName(symbol, $"TP({period},{valueAreaVolumePercentage},{priceRangeRoundOff})", resolution);
             var marketProfile = new TimeProfile(name, period, valueAreaVolumePercentage, priceRangeRoundOff);
             InitializeIndicator(marketProfile, resolution, selector, symbol);
 

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -1435,7 +1435,7 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(Indicators)]
         public VolumeProfile VP(Symbol symbol, int period = 2, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m, Resolution resolution = Resolution.Daily, Func<IBaseData, TradeBar> selector = null)
         {
-            var name = CreateIndicatorName(symbol, $"VP({period})", resolution);
+            var name = CreateIndicatorName(symbol, $"VP({period},{valueAreaVolumePercentage},{valueAreaVolumePercentage})", resolution);
             var marketProfile = new VolumeProfile(name, period, valueAreaVolumePercentage, priceRangeRoundOff);
             InitializeIndicator(marketProfile, resolution, selector, symbol);
 
@@ -1456,7 +1456,7 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(Indicators)]
         public TimeProfile TP(Symbol symbol, int period = 2, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m, Resolution resolution = Resolution.Daily, Func<IBaseData, TradeBar> selector = null)
         {
-            var name = CreateIndicatorName(symbol, $"TP({period})", resolution);
+            var name = CreateIndicatorName(symbol, $"TP({period},{valueAreaVolumePercentage},{valueAreaVolumePercentage})", resolution);
             var marketProfile = new TimeProfile(name, period, valueAreaVolumePercentage, priceRangeRoundOff);
             InitializeIndicator(marketProfile, resolution, selector, symbol);
 

--- a/Indicators/AccelerationBands.cs
+++ b/Indicators/AccelerationBands.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -69,8 +69,10 @@ namespace QuantConnect.Indicators
         /// </summary>
         /// <param name="period">The period of the three moving average (middle, upper and lower band).</param>
         /// <param name="width">A coefficient specifying the distance between the middle band and upper or lower bands.</param>
-        public AccelerationBands(int period, decimal width)
-            : this($"ABANDS({period},{width})", period, width)
+        /// <param name="movingAverageType">Type of the moving average.</param>
+        public AccelerationBands(int period, decimal width,
+            MovingAverageType movingAverageType = MovingAverageType.Simple)
+            : this($"ABANDS({period},{width},{movingAverageType})", period, width, movingAverageType)
         {
         }
 

--- a/Indicators/AdvanceDeclineDifference.cs
+++ b/Indicators/AdvanceDeclineDifference.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Initializes a new instance of the <see cref="AdvanceDeclineDifference"/> class
         /// </summary>
-        public AdvanceDeclineDifference(string name)
+        public AdvanceDeclineDifference(string name = "A/D Difference")
             : base(name, (entries) => entries.Count(), (advance, decline) => advance - decline) { }
     }
 }

--- a/Indicators/AdvanceDeclineRatio.cs
+++ b/Indicators/AdvanceDeclineRatio.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Initializes a new instance of the <see cref="AdvanceDeclineRatio"/> class
         /// </summary>
-        public AdvanceDeclineRatio(string name)
+        public AdvanceDeclineRatio(string name = "A/D Ratio")
             : base(name, (entries) => entries.Count(), (advance, decline) => decline == 0m ? advance : advance / decline) { }
     }
 }

--- a/Indicators/AdvanceDeclineVolumeRatio.cs
+++ b/Indicators/AdvanceDeclineVolumeRatio.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Initializes a new instance of the <see cref="AdvanceDeclineVolumeRatio"/> class
         /// </summary>
-        public AdvanceDeclineVolumeRatio(string name)
+        public AdvanceDeclineVolumeRatio(string name = "A/D Volume Rate")
             : base(name, (entries) => entries.Sum(x => x.Volume), (advance, decline) => decline == 0m ? advance : advance / decline) { }
     }
 }

--- a/Indicators/ArmsIndex.cs
+++ b/Indicators/ArmsIndex.cs
@@ -40,7 +40,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Initializes a new instance of the <see cref="ArmsIndex"/> class
         /// </summary>
-        public ArmsIndex(string name) : base(name)
+        public ArmsIndex(string name = "TRIN") : base(name)
         {
             ADRatio = new AdvanceDeclineRatio(name + "_A/D Ratio");
             ADVRatio = new AdvanceDeclineVolumeRatio(name + "_A/D Volume Ratio");

--- a/Indicators/ChaikinMoneyFlow.cs
+++ b/Indicators/ChaikinMoneyFlow.cs
@@ -67,11 +67,20 @@ namespace QuantConnect.Indicators
         /// <param name="name">A name for the indicator</param>
         /// <param name="period">The period over which to perform computation</param>
         public ChaikinMoneyFlow(string name, int period)
-            : base($"CMF({name})")
+            : base(name)
         {
             WarmUpPeriod = period;
             _flowRatioSum = new Sum(period);
             _volumeSum = new Sum(period);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ChaikinMoneyFlow class
+        /// </summary>
+        /// <param name="period">The period over which to perform computation</param>
+        public ChaikinMoneyFlow(int period)
+            : this($"CMF({period})", period)
+        {
         }
 
         /// <summary>

--- a/Indicators/DerivativeOscillator.cs
+++ b/Indicators/DerivativeOscillator.cs
@@ -54,6 +54,18 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
+        /// Initializes a new instance of the IndicatorDerivativeOscillator class with the specified name and periods.
+        /// </summary>
+        /// <param name="rsiPeriod">The period for the RSI calculation</param>
+        /// <param name="smoothingRsiPeriod">The period for the smoothing RSI</param>
+        /// <param name="doubleSmoothingRsiPeriod">The period for the double smoothing RSI</param>
+        /// <param name="signalLinePeriod">The period for the signal line</param>
+        public DerivativeOscillator(int rsiPeriod, int smoothingRsiPeriod, int doubleSmoothingRsiPeriod, int signalLinePeriod)
+            : this($"DO({rsiPeriod},{smoothingRsiPeriod},{doubleSmoothingRsiPeriod},{signalLinePeriod})", rsiPeriod, smoothingRsiPeriod, doubleSmoothingRsiPeriod, signalLinePeriod)
+        {
+        }
+
+        /// <summary>
         /// Computes the next value for the derivative oscillator indicator from the given state
         /// </summary>
         /// <param name="input">The input value to this indicator on this time step</param>

--- a/Indicators/FilteredIdentity.cs
+++ b/Indicators/FilteredIdentity.cs
@@ -41,11 +41,27 @@ namespace QuantConnect.Indicators
             _filter = filter ?? (x => true);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the FilteredIdentity indicator with the specified name
+        /// </summary>
+        /// <param name="filter">Filters the IBaseData send into the indicator, if null defaults to true (x => true) which means no filter</param>
+        public FilteredIdentity(Func<IBaseData, bool> filter) : this("", filter) { }
+
+        /// <summary>
+        /// Initializes a new instance of the FilteredIdentity indicator with the specified name
+        /// </summary>
+        /// <param name="name">The name of the indicator</param>
+        /// <param name="filter">Filters the IBaseData send into the indicator, if null defaults to true (x => true) which means no filter</param>
         public FilteredIdentity(string name, PyObject filter)
             : this(name, filter.SafeAs<Func<IBaseData, bool>>())
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the FilteredIdentity indicator with the specified name
+        /// </summary>
+        /// <param name="filter">Filters the IBaseData send into the indicator, if null defaults to true (x => true) which means no filter</param>
+        public FilteredIdentity(PyObject filter) : this("", filter) { }
 
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized

--- a/Indicators/Identity.cs
+++ b/Indicators/Identity.cs
@@ -25,7 +25,7 @@ namespace QuantConnect.Indicators
         ///     Initializes a new instance of the Identity indicator with the specified name
         /// </summary>
         /// <param name="name">The name of the indicator</param>
-        public Identity(string name)
+        public Identity(string name = "")
             : base(name)
         {
         }

--- a/Indicators/IntradayVwap.cs
+++ b/Indicators/IntradayVwap.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 
@@ -22,7 +22,7 @@ namespace QuantConnect.Indicators
         /// Initializes a new instance of the <see cref="IntradayVwap"/> class
         /// </summary>
         /// <param name="name">The name of the indicator</param>
-        public IntradayVwap(string name)
+        public IntradayVwap(string name = "VWAP")
             : base(name)
         {
         }

--- a/Indicators/SqueezeMomentum.cs
+++ b/Indicators/SqueezeMomentum.cs
@@ -51,6 +51,18 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="SqueezeMomentum"/> class.
+        /// </summary>
+        /// <param name="bollingerPeriod">The period used for the Bollinger Bands calculation.</param>
+        /// <param name="bollingerMultiplier">The multiplier for the Bollinger Bands width.</param>
+        /// <param name="keltnerPeriod">The period used for the Average True Range (ATR) calculation in Keltner Channels.</param>
+        /// <param name="keltnerMultiplier">The multiplier applied to the ATR for calculating Keltner Channels.</param>
+        public SqueezeMomentum(int bollingerPeriod, decimal bollingerMultiplier, int keltnerPeriod, decimal keltnerMultiplier)
+            : this($"SM({bollingerPeriod},{bollingerMultiplier},{keltnerPeriod},{keltnerMultiplier})", bollingerPeriod, bollingerMultiplier, keltnerPeriod, keltnerMultiplier)
+        {
+        }
+
+        /// <summary>
         /// Gets the warm-up period required for the indicator to be ready.
         /// This is determined by the warm-up period of the Bollinger Bands indicator.
         /// </summary>

--- a/Indicators/TimeProfile.cs
+++ b/Indicators/TimeProfile.cs
@@ -29,7 +29,7 @@ namespace QuantConnect.Indicators
         /// <param name="valueAreaVolumePercentage">The percentage of volume contained in the value area</param>
         /// <param name="priceRangeRoundOff">How many digits you want to round and the precision.
         public TimeProfile(int period = 2, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m)
-            : this($"TP({period},{valueAreaVolumePercentage},{valueAreaVolumePercentage})", period, valueAreaVolumePercentage, priceRangeRoundOff)
+            : this($"TP({period},{valueAreaVolumePercentage},{priceRangeRoundOff})", period, valueAreaVolumePercentage, priceRangeRoundOff)
         {
         }
 

--- a/Indicators/TimeProfile.cs
+++ b/Indicators/TimeProfile.cs
@@ -26,8 +26,10 @@ namespace QuantConnect.Indicators
         /// Creates a new TimeProfile indicator with the specified period
         /// </summary>
         /// <param name="period">The period of this indicator</param>
-        public TimeProfile(int period = 2)
-            : this($"TP({period})", period)
+        /// <param name="valueAreaVolumePercentage">The percentage of volume contained in the value area</param>
+        /// <param name="priceRangeRoundOff">How many digits you want to round and the precision.
+        public TimeProfile(int period = 2, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m)
+            : this($"TP({period},{valueAreaVolumePercentage},{valueAreaVolumePercentage})", period, valueAreaVolumePercentage, priceRangeRoundOff)
         {
         }
 
@@ -39,7 +41,7 @@ namespace QuantConnect.Indicators
         /// <param name="valueAreaVolumePercentage">The percentage of volume contained in the value area</param>
         /// <param name="priceRangeRoundOff">How many digits you want to round and the precision.
         /// i.e 0.01 round to two digits exactly.</param>
-        public TimeProfile(string name, int period, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m)
+        public TimeProfile(string name, int period = 2, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m)
             : base(name, period, valueAreaVolumePercentage, priceRangeRoundOff)
         { }
 

--- a/Indicators/VolumeProfile.cs
+++ b/Indicators/VolumeProfile.cs
@@ -26,8 +26,10 @@ namespace QuantConnect.Indicators
         /// Creates a new VolumeProfile indicator with the specified period
         /// </summary>
         /// <param name="period">The period of the indicator</param>
-        public VolumeProfile(int period = 2)
-            : this($"VP({period})", period)
+        /// <param name="valueAreaVolumePercentage">The percentage of volume contained in the value area</param>
+        /// <param name="priceRangeRoundOff">How many digits you want to round and the precision.
+        public VolumeProfile(int period = 2, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m)
+            : this($"VP({period},{valueAreaVolumePercentage},{valueAreaVolumePercentage})", period, valueAreaVolumePercentage, priceRangeRoundOff)
         {
         }
 
@@ -39,7 +41,7 @@ namespace QuantConnect.Indicators
         /// <param name="valueAreaVolumePercentage">The percentage of volume contained in the value area</param>
         /// <param name="priceRangeRoundOff">How many digits you want to round and the precision.
         /// i.e 0.01 round to two digits exactly.</param>
-        public VolumeProfile(string name, int period, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m)
+        public VolumeProfile(string name, int period = 2, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m)
             : base(name, period, valueAreaVolumePercentage, priceRangeRoundOff)
         { }
 

--- a/Indicators/VolumeProfile.cs
+++ b/Indicators/VolumeProfile.cs
@@ -29,7 +29,7 @@ namespace QuantConnect.Indicators
         /// <param name="valueAreaVolumePercentage">The percentage of volume contained in the value area</param>
         /// <param name="priceRangeRoundOff">How many digits you want to round and the precision.
         public VolumeProfile(int period = 2, decimal valueAreaVolumePercentage = 0.70m, decimal priceRangeRoundOff = 0.05m)
-            : this($"VP({period},{valueAreaVolumePercentage},{valueAreaVolumePercentage})", period, valueAreaVolumePercentage, priceRangeRoundOff)
+            : this($"VP({period},{valueAreaVolumePercentage},{priceRangeRoundOff})", period, valueAreaVolumePercentage, priceRangeRoundOff)
         {
         }
 


### PR DESCRIPTION
#### Description
Adds missing indicator constructor overloads without `name` parameter.

#### Related Issue
N/A

#### Motivation and Context
Standardization and Documentation

#### Requires Documentation Change
Regenerate Indicator code snippets and images.

#### How Has This Been Tested?
Compilation and unit tests

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`