### PR TITLE
FixComposer Assembly Resolution

### DIFF
--- a/Algorithm.CSharp/Benchmarks/EmptySPXOptionChainBenchmark.cs
+++ b/Algorithm.CSharp/Benchmarks/EmptySPXOptionChainBenchmark.cs
@@ -24,11 +24,11 @@ namespace QuantConnect.Algorithm.CSharp.Benchmarks
         public override void Initialize()
         {
             SetStartDate(2018, 1, 1);
-            SetEndDate(2020, 1, 1);
+            SetEndDate(2020, 6, 1);
 
             var index = AddIndex("SPX");
             var option = AddOption(index);
-            option.SetFilter(-10, +10, 0, 30);
+            option.SetFilter(x => x.IncludeWeeklys().Strikes(-30, 30).Expiration(0, 7));
         }
     }
 }

--- a/Algorithm.Python/Benchmarks/EmptySPXOptionChainBenchmark.py
+++ b/Algorithm.Python/Benchmarks/EmptySPXOptionChainBenchmark.py
@@ -17,7 +17,7 @@ class EmptySPXOptionChainBenchmark(QCAlgorithm):
 
     def initialize(self):
         self.set_start_date(2018, 1, 1)
-        self.set_end_date(2020, 1, 1)
+        self.set_end_date(2020, 6, 1)
         self._index = self.add_index("SPX")
         option = self.add_option(self._index)
-        option.set_filter(-10, +10, timedelta(0), timedelta(30))
+        option.set_filter(lambda u: u.include_weeklys().strikes(-30, 30).expiration(0, 7))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Revert part of the changes at https://github.com/QuantConnect/Lean/pull/9064/files. We need to load all dependencies before any C# algorithm is tried to load, else will fail to load algorithm
- Enhance new benchmark algorithm EmptySPXOptionChainBenchmark 
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See related https://github.com/QuantConnect/Lean/pull/9065
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
N/A
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Reproducing bug, C# and Py backtest and algorithm, live trading
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
