### PR TITLE
[Perf] Short circuit TZ Conversion when same TZ is used as source and destination

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -2038,6 +2038,12 @@ namespace QuantConnect
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DateTime ConvertTo(this DateTime time, DateTimeZone from, DateTimeZone to, bool strict = false)
         {
+             // Short-circuit when source and destination timezones are identical
+            if (ReferenceEquals(from, to) || from.Equals(to))
+            {
+                return time;
+            }
+            
             if (strict)
             {
                 return from.AtStrictly(LocalDateTime.FromDateTime(time)).WithZone(to).ToDateTimeUnspecified();

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -630,6 +630,42 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual(time3Expected, time3);
         }
 
+         [Test]
+        public void ConvertTo_SameTimezone_ReturnsUnchangedTime()
+        {
+            var time = new DateTime(2024, 6, 15, 14, 30, 45, 123);
+
+            // Test with same instance (ReferenceEquals path)
+            var result1 = time.ConvertTo(TimeZones.NewYork, TimeZones.NewYork);
+            Assert.AreEqual(time, result1);
+
+            // Test with UTC
+            var result2 = time.ConvertTo(TimeZones.Utc, TimeZones.Utc);
+            Assert.AreEqual(time, result2);
+
+            // Verify milliseconds are preserved
+            Assert.AreEqual(123, result1.Millisecond);
+        }
+
+        [Test]
+        public void ConvertTo_SameTimezone_PerformanceOptimization()
+        {
+            // This test ensures the optimization doesn't break edge cases
+            var times = new[]
+            {
+                new DateTime(2014, 3, 9, 2, 30, 0),  // During DST transition gap
+                new DateTime(2014, 11, 2, 1, 30, 0), // During DST transition overlap
+                DateTime.MinValue,
+                DateTime.MaxValue
+            };
+
+            foreach (var time in times)
+            {
+                var result = time.ConvertTo(TimeZones.NewYork, TimeZones.NewYork);
+                Assert.AreEqual(time, result, $"Failed for time: {time}");
+            }
+        }
+
         [Test]
         public void ExchangeRoundDownInTimeZoneSkipsWeekends()
         {


### PR DESCRIPTION
#### Description
This PR short circuit the `Extensions.ConvertTo()` when the source and destination TZs are the same. 

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#9194 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fixed one of the many performance problems I've inspecting trying to reduce the time of the backtests with large datasets saving previous time in development and backtests. The number on the issue show the benefits with this 0 risk and 3 lines changeset.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
No doc changes.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Two tests were added.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [X] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [X] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->

Perf test:

```sharp
[MemoryDiagnoser]
[SimpleJob(RuntimeMoniker.Net10_0)]
public class TimeZoneConversionBenchmarks
{
    // NodaTime resolver used by LEAN (same as in Extensions.cs)
    private static readonly ZoneLocalMappingResolver MappingResolver =
        Resolvers.CreateMappingResolver(Resolvers.ReturnLater, Resolvers.ReturnStartOfIntervalAfter);

    // Common timezones
    private static readonly DateTimeZone SaoPaulo = DateTimeZoneProviders.Tzdb["America/Sao_Paulo"];
    private static readonly DateTimeZone Utc = DateTimeZone.Utc;

    private DateTime _testTime;
    private DateTime[] _testTimes = null!;

    [GlobalSetup]
    public void Setup()
    {
        _testTime = new DateTime(2024, 6, 15, 14, 30, 45, 123);

        // Simulate a batch of times (like parsing multiple bars)
        _testTimes = new DateTime[1000];
        var baseTime = new DateTime(2024, 6, 15, 9, 0, 0);
        for (int i = 0; i < _testTimes.Length; i++)
        {
            _testTimes[i] = baseTime.AddMinutes(i);
        }
    }

    #region Current LEAN Implementation

    /// <summary>
    /// Current LEAN implementation - always goes through NodaTime
    /// </summary>
    public static DateTime ConvertTo_Current(DateTime time, DateTimeZone from, DateTimeZone to)
    {
        return LocalDateTime.FromDateTime(time)
            .InZone(from, MappingResolver)
            .WithZone(to)
            .ToDateTimeUnspecified();
    }

    #endregion

    #region Optimized Implementation

    /// <summary>
    /// Optimized implementation - short-circuits when same timezone
    /// </summary>
    public static DateTime ConvertTo_Optimized(DateTime time, DateTimeZone from, DateTimeZone to)
    {
        // Short-circuit when source and destination timezones are identical
        if (ReferenceEquals(from, to) || from.Equals(to))
        {
            return time;
        }

        return LocalDateTime.FromDateTime(time)
            .InZone(from, MappingResolver)
            .WithZone(to)
            .ToDateTimeUnspecified();
    }

    #endregion

    #region Single Conversion Benchmarks

    [Benchmark(Baseline = true)]
    public DateTime Current_SameTimezone()
    {
        return ConvertTo_Current(_testTime, SaoPaulo, SaoPaulo);
    }

    [Benchmark]
    public DateTime Optimized_SameTimezone()
    {
        return ConvertTo_Optimized(_testTime, SaoPaulo, SaoPaulo);
    }

    [Benchmark]
    public DateTime Current_DifferentTimezone()
    {
        return ConvertTo_Current(_testTime, Utc, SaoPaulo);
    }

    [Benchmark]
    public DateTime Optimized_DifferentTimezone()
    {
        return ConvertTo_Optimized(_testTime, Utc, SaoPaulo);
    }

    [Benchmark]
    public DateTime Current_UtcToUtc()
    {
        return ConvertTo_Current(_testTime, Utc, Utc);
    }

    [Benchmark]
    public DateTime Optimized_UtcToUtc()
    {
        return ConvertTo_Optimized(_testTime, Utc, Utc);
    }

    #endregion

    #region Batch Conversion Benchmarks (simulating data parsing)

    [Benchmark]
    public void Current_Batch1000_SameTimezone()
    {
        for (int i = 0; i < _testTimes.Length; i++)
        {
            _ = ConvertTo_Current(_testTimes[i], SaoPaulo, SaoPaulo);
        }
    }

    [Benchmark]
    public void Optimized_Batch1000_SameTimezone()
    {
        for (int i = 0; i < _testTimes.Length; i++)
        {
            _ = ConvertTo_Optimized(_testTimes[i], SaoPaulo, SaoPaulo);
        }
    }

    [Benchmark]
    public void Current_Batch1000_DifferentTimezone()
    {
        for (int i = 0; i < _testTimes.Length; i++)
        {
            _ = ConvertTo_Current(_testTimes[i], Utc, SaoPaulo);
        }
    }

    [Benchmark]
    public void Optimized_Batch1000_DifferentTimezone()
    {
        for (int i = 0; i < _testTimes.Length; i++)
        {
            _ = ConvertTo_Optimized(_testTimes[i], Utc, SaoPaulo);
        }
    }

    #endregion
}
```
