### PR TITLE
Prevent duplicate price rounding warnings

### DIFF
--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -54,7 +54,9 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
         private int _totalOrderCount;
 
         // this bool is used to check if the warning message for the rounding of order quantity has been displayed for the first time
-        private bool _firstRoundOffMessage = false;
+        private bool _firstRoundOffMessage;
+        // this bool is used to check if the warning message for price rounding has been displayed for the first time
+        private bool _hasLoggedPriceRoundingWarning;
 
         // this value is used for determining how confident we are in our cash balance update
         private long _lastFillTimeTicks;
@@ -1914,11 +1916,12 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
         private void SendWarningOnPriceChange(string priceType, decimal priceRound, decimal priceOriginal)
         {
-            if (!priceOriginal.Equals(priceRound))
+            if (!priceOriginal.Equals(priceRound) && !_hasLoggedPriceRoundingWarning)
             {
                 _algorithm.Error(
                     $"Warning: To meet brokerage precision requirements, order {priceType.ToStringInvariant()} was rounded to {priceRound.ToStringInvariant()} from {priceOriginal.ToStringInvariant()}"
                 );
+                _hasLoggedPriceRoundingWarning = true;
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Adds warning suppression to log price rounding messages only once per session instead of per order

#### Related Issue
Closes #9019 

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
