### PR TITLE
Update RVI signal when range band is zero

### DIFF
--- a/Indicators/RelativeVigorIndex.cs
+++ b/Indicators/RelativeVigorIndex.cs
@@ -107,14 +107,17 @@ namespace QuantConnect.Indicators
                 var f = _previousInputs[0].High - _previousInputs[0].Low;
                 var g = _previousInputs[1].High - _previousInputs[1].Low;
                 var h = _previousInputs[2].High - _previousInputs[2].Low;
-                CloseBand.Update(input.EndTime, (a + 2 * (b + c) + d) / 6);
-                RangeBand.Update(input.EndTime, (e + 2 * (f + g) + h) / 6);
 
-                if (CloseBand.IsReady && RangeBand.IsReady && RangeBand != 0m)
+                CloseBand.Update(input.EndTime, (a + 2 * (b + c) + d) / 6m);
+                RangeBand.Update(input.EndTime, (e + 2 * (f + g) + h) / 6m);
+
+                if (CloseBand.IsReady && RangeBand.IsReady)
                 {
                     _previousInputs.Add(input);
-                    var rvi = CloseBand / RangeBand;
-                    Signal?.Update(input.EndTime, rvi); // Checks for null before updating.
+                    var rvi = RangeBand != 0m ? CloseBand / RangeBand : 0m;
+
+                    Signal.Update(input.EndTime, rvi);
+
                     return rvi;
                 }
             }
@@ -132,7 +135,7 @@ namespace QuantConnect.Indicators
             CloseBand.Reset();
             RangeBand.Reset();
             _previousInputs.Reset();
-            Signal?.Reset();
+            Signal.Reset();
         }
     }
 }

--- a/Tests/Indicators/RelativeVigorIndexTests.cs
+++ b/Tests/Indicators/RelativeVigorIndexTests.cs
@@ -37,8 +37,8 @@ namespace QuantConnect.Tests.Indicators
         {
             var rvi = CreateIndicator();
             TestHelper.TestIndicator(rvi, TestFileName, "RVI_S",
-                (ind, expected) => Assert.AreEqual(expected, 
-                    (double) ((RelativeVigorIndex) ind).Signal.Current.Value, 0.06));
+                (ind, expected) => Assert.AreEqual(expected,
+                    (double)((RelativeVigorIndex)ind).Signal.Current.Value, 0.06));
         }
 
         [Test]
@@ -48,17 +48,40 @@ namespace QuantConnect.Tests.Indicators
             for (int i = 0; i < 13; i++)
             {
                 var tradeBar = new TradeBar
-                    {
-                        Open = 0m,
-                        Close = 0m,
-                        High = 0m,
-                        Low = 0m,
-                        Volume = 1
-                    };
-                    rvi.Update(tradeBar);
+                {
+                    Open = 0m,
+                    Close = 0m,
+                    High = 0m,
+                    Low = 0m,
+                    Volume = 1
+                };
+                rvi.Update(tradeBar);
             }
             Assert.AreEqual(rvi.Current.Value, 0m);
-            Assert.AreEqual(((RelativeVigorIndex) rvi).Signal.Current.Value, 0m);
+            Assert.AreEqual(((RelativeVigorIndex)rvi).Signal.Current.Value, 0m);
+        }
+
+        [Test]
+        public void SignalUpdatesOnFlatMarket()
+        {
+            var rvi = new RelativeVigorIndex("RVI", 10);
+            var referenceTime = System.DateTime.Today;
+
+            for (int i = 0; i < 30; i++)
+            {
+                rvi.Update(new TradeBar
+                {
+                    Time = referenceTime.AddMinutes(i),
+                    Open = 105m,
+                    High = 105m,
+                    Low = 105m,
+                    Close = 105m,
+                    Volume = 1000
+                });
+            }
+
+            var signalSamples = rvi.Signal.Samples;
+            Assert.AreEqual(18, signalSamples);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Ensures the RVI signal is updated even when the range band is zero

#### Related Issue
Closes #9180

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
