### PR TITLE
Add ExecutionId to OrderEvent and SerializedOrderEvent

### DIFF
--- a/Common/Orders/OrderEvent.cs
+++ b/Common/Orders/OrderEvent.cs
@@ -228,6 +228,13 @@ namespace QuantConnect.Orders
         }
 
         /// <summary>
+        /// Unique execution identifier from the brokerage
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [ProtoMember(20)]
+        public string ExecutionId { get; set; }
+
+        /// <summary>
         /// The order ticket associated to the order
         /// </summary>
         [JsonIgnore]
@@ -362,7 +369,8 @@ namespace QuantConnect.Orders
                 StopPrice = serializedOrderEvent.StopPrice,
                 FillPriceCurrency = serializedOrderEvent.FillPriceCurrency,
                 Id = serializedOrderEvent.OrderEventId,
-                Quantity = serializedOrderEvent.Quantity
+                Quantity = serializedOrderEvent.Quantity,
+                ExecutionId = serializedOrderEvent.ExecutionId
             };
 
             return orderEvent;

--- a/Common/Orders/Serialization/SerializedOrderEvent.cs
+++ b/Common/Orders/Serialization/SerializedOrderEvent.cs
@@ -151,6 +151,12 @@ namespace QuantConnect.Orders.Serialization
         public bool IsInTheMoney { get; set; }
 
         /// <summary>
+        /// Unique execution identifier from the brokerage
+        /// </summary>
+        [JsonProperty("executionId", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string ExecutionId { get; set; }
+
+        /// <summary>
         /// Empty constructor required for JSON converter.
         /// </summary>
         public SerializedOrderEvent()
@@ -185,6 +191,7 @@ namespace QuantConnect.Orders.Serialization
             Quantity = orderEvent.Quantity;
             StopPrice = orderEvent.StopPrice;
             LimitPrice = orderEvent.LimitPrice;
+            ExecutionId = orderEvent.ExecutionId;
         }
 
         #region BackwardsCompatibility
@@ -299,6 +306,14 @@ namespace QuantConnect.Orders.Serialization
             set
             {
                 IsInTheMoney = value;
+            }
+        }
+        [JsonProperty("execution-id", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        string OldExecutionId
+        {
+            set
+            {
+                ExecutionId = value;
             }
         }
         #endregion


### PR DESCRIPTION
#### Description
Add `ExecutionId` property to `OrderEvent` and `SerializedOrderEvent` classes to store the unique execution identifier provided by brokerages.

Changes:
- Add `ExecutionId` property to `OrderEvent` (ProtoMember 20, JsonProperty with DefaultValueHandling.Ignore)
- Add `ExecutionId` property to `SerializedOrderEvent` with backward compatibility setter for `execution-id`
- Update `FromSerialized` method to map ExecutionId
- Update `SerializedOrderEvent` constructor to copy ExecutionId from OrderEvent

#### Related Issue
Closes #9133

#### Motivation and Context
Algorithms that maintain virtual position trackers (e.g., for pairs trading, multi-leg strategies) need unique execution identifiers to keep positions in sync with the brokerage. This enables deduplication and reconciliation logic in user algorithms.

#### Requires Documentation Change
No documentation changes required. This is an optional field that brokerages can populate.

#### How Has This Been Tested?
- Build passes with no errors
- Property follows existing patterns in OrderEvent/SerializedOrderEvent

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`