### PR TITLE
Fix: Replace colon with dash in backtest names for API CI

### DIFF
--- a/Tests/Api/ApiTestBase.cs
+++ b/Tests/Api/ApiTestBase.cs
@@ -96,7 +96,7 @@ namespace QuantConnect.Tests.API
 
             // Create a backtest
             Log.Debug("ApiTestBase.Setup(): Creating test backtest");
-            var backtestName = $"{DateTime.UtcNow.ToStringInvariant("u")} API Backtest";
+            var backtestName = $"{DateTime.UtcNow.ToStringInvariant("yyyy-MM-dd HH-mm-ss")} API Backtest";
             var backtest = ApiClient.CreateBacktest(TestProject.ProjectId, compile.CompileId, backtestName);
             if (!backtest.Success)
             {

--- a/Tests/Api/ProjectTests.cs
+++ b/Tests/Api/ProjectTests.cs
@@ -278,7 +278,7 @@ namespace QuantConnect.Tests.API
             Assert.AreEqual(CompileState.BuildError, compileError.State); //Resulting in build fail.
 
             // Using our successful compile; launch a backtest!
-            var backtestName = $"{DateTime.UtcNow.ToStringInvariant("u")} API Backtest";
+            var backtestName = $"{DateTime.UtcNow.ToStringInvariant("yyyy-MM-dd HH-mm-ss")} API Backtest";
             var backtest = ApiClient.CreateBacktest(project.Projects.First().ProjectId, compileSuccess.CompileId, backtestName);
             Assert.IsTrue(backtest.Success);
 
@@ -320,7 +320,7 @@ namespace QuantConnect.Tests.API
                 Assert.AreEqual(backtestName, backtestRead.Name);
 
                 //Update the note and make sure its been updated:
-                var newNote = DateTime.Now.ToStringInvariant("u");
+                var newNote = DateTime.Now.ToStringInvariant("yyyy-MM-dd HH-mm-ss");
                 var noteBacktest = ApiClient.UpdateBacktest(project.Projects.First().ProjectId, backtest.BacktestId, note: newNote);
                 Assert.IsTrue(noteBacktest.Success);
                 backtestRead = ApiClient.ReadBacktest(project.Projects.First().ProjectId, backtest.BacktestId);
@@ -370,7 +370,7 @@ namespace QuantConnect.Tests.API
             backtestRead = WaitForBacktestCompletion(ApiClient, project.ProjectId, backtest.BacktestId);
             var backtestOrdersRead = ApiClient.ReadBacktestOrders(project.ProjectId, backtest.BacktestId);
             string stringRepresentation;
-            foreach(var backtestOrder in backtestOrdersRead)
+            foreach (var backtestOrder in backtestOrdersRead)
             {
                 stringRepresentation = backtestOrder.ToString();
                 Assert.IsTrue(ApiTestBase.IsValidJson(stringRepresentation));
@@ -409,7 +409,7 @@ namespace QuantConnect.Tests.API
         {
             // We will be using the existing TestBacktest for this test
             var originalName = TestBacktest.Name;
-            var newName = $"{originalName} - Amended - {DateTime.UtcNow.ToStringInvariant("u")}";
+            var newName = $"{originalName} - Amended - {DateTime.UtcNow.ToStringInvariant("yyyy-MM-dd HH-mm-ss")}";
 
             // Update the backtest name
             var updateResult = ApiClient.UpdateBacktest(TestProject.ProjectId, TestBacktest.BacktestId, name: newName);
@@ -643,7 +643,7 @@ namespace QuantConnect.Tests.API
                 Assert.IsTrue(readLiveLogs.Length >= 0, "The length of the logs was negative!");
                 Assert.IsTrue(readLiveLogs.DeploymentOffset >= 0, "The deploymentOffset");
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 // Delete the project in case of an error
                 Assert.IsTrue(ApiClient.DeleteProject(projectId).Success);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Updates timestamp format from 'u' to 'yyyy-MM-dd HH-mm-ss' in backtest names, fixing CI failures.

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
