### PR TITLE
Fix fundamental security direct access timestamp

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -3379,7 +3379,7 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(SecuritiesAndPortfolio)]
         public Fundamental Fundamentals(Symbol symbol)
         {
-            return new Fundamental(Time, symbol) { EndTime = Time };
+            return Fundamental.ForDate(Time, symbol);
         }
 
         /// <summary>

--- a/Common/Data/Fundamental/Fundamental.cs
+++ b/Common/Data/Fundamental/Fundamental.cs
@@ -72,6 +72,18 @@ namespace QuantConnect.Data.Fundamental
         }
 
         /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        /// <param name="time">The current time</param>
+        /// <param name="symbol">The associated symbol</param>
+        public static Fundamental ForDate(DateTime time, Symbol symbol)
+        {
+            // Important: set EndTime to time so that time is previous day midnight, if we just set time, EndTime would be NEXT day midnight.
+            // Note: data for T date is available on T+1 date, fundamental selection also handles this, see BaseDataCollectionSubscriptionEnumeratorFactory
+            return new Fundamental(time, symbol) { EndTime = time };
+        }
+
+        /// <summary>
         /// Return the URL string source of the file. This will be converted to a stream
         /// </summary>
         public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -597,7 +597,7 @@ namespace QuantConnect.Securities
         {
             get
             {
-                return new Fundamental(LocalTime, Symbol);
+                return Fundamental.ForDate(LocalTime, Symbol);
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Fix the date used by fundamental data accessed directly through security. Updating regression algorithm asserting behavior

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`Security.Fundamental` was shifted by a day, end time was tomorrow
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
