### PR TITLE
DownloadFailed Event Raises Runtime Error

### DIFF
--- a/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/SubscriptionDataReaderSubscriptionEnumeratorFactory.cs
@@ -95,7 +95,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                     _startDateLimitedWarnings.TryAdd(args.Symbol, args.Message);
                 }
             };
-            dataReader.DownloadFailed += (sender, args) => { _resultHandler.ErrorMessage(args.Message, args.StackTrace); };
+            dataReader.DownloadFailed += (sender, args) => { _resultHandler.RuntimeError(args.Message, args.StackTrace); };
             dataReader.ReaderErrorDetected += (sender, args) => { _resultHandler.RuntimeError(args.Message, args.StackTrace); };
             dataReader.NumericalPrecisionLimited += (sender, args) =>
             {


### PR DESCRIPTION
#### Description
Treat `DownloadFailed` event as `ReaderErrorDetected` and send the error message to the RuntimeError message queue.

#### Related Issue
Closes #9269

#### Motivation and Context
Improve user notification. When they subscribe to a deprecated Nasdaq data feed, for example, they don't receive any information about it.

#### How Has This Been Tested?
N/A

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`