### PR TITLE
Fix OSI option ticker parsing for symbols containing dots (e.g. BRK.B)

### DIFF
--- a/Common/SymbolRepresentation.cs
+++ b/Common/SymbolRepresentation.cs
@@ -34,7 +34,7 @@ namespace QuantConnect
     public static class SymbolRepresentation
     {
         // Define the regex as a private readonly static field and compile it
-        private static readonly Regex _optionTickerRegex = new Regex(@"^([A-Z0-9]+)\s*(\d{6})([CP])(\d{8})$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex _optionTickerRegex = new Regex(@"^([A-Z0-9\.]+)\s*(\d{6})([CP])(\d{8})$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         /// <summary>
         /// Class contains future ticker properties returned by ParseFutureTicker()

--- a/Tests/Common/SymbolRepresentationTests.cs
+++ b/Tests/Common/SymbolRepresentationTests.cs
@@ -50,6 +50,7 @@ namespace QuantConnect.Tests.Common
         [TestCase("DAX   250715C01000000", SecurityType.IndexOption, OptionStyle.European, "DAX", "DAX", "DAX", 1000.00, "2025-07-15")]
         [TestCase("FTSE  230122C00750000", SecurityType.IndexOption, OptionStyle.European, "FTSE", "FTSE", "FTSE", 750.00, "2023-01-22")]
         [TestCase("ES20H20  200320P03290000", SecurityType.FutureOption, OptionStyle.American, "ES20H20", "ES", "ES20H20", 3290.00, "2020-03-20")]
+        [TestCase("BRK.B   260206C00495000", SecurityType.Option, OptionStyle.American, "BRK.B", "BRK.B", "BRK.B", 495.00, "2026-02-06")]
         public void ParseOptionTickerOSI(string optionStr, SecurityType securityType, OptionStyle optionStyle,
             string expectedTargetOptionTicker, string expectedUnderlyingTicker, string expectedUnderlyingMappedTicker,
             decimal expectedStrikePrice, string expectedDate)


### PR DESCRIPTION
## Summary
- Fixes #9341: `Symbol.ParseOptionTickerOSI` throws `Invalid ticker format` for tickers with dots (e.g. `BRK.B 260206C00495000`)
- Extends `_optionTickerRegex` from `[A-Z0-9]+` to `[A-Z0-9\.]+` to accept dots in the underlying ticker
- Adds the failing test case from the issue

## Test plan
- [x] `ParseOptionTickerOSI("BRK.B   260206C00495000", ...)` now parses correctly
- [x] All existing `ParseOptionTickerOSI` test cases continue to pass