### PR TITLE
Improve SecurityHolding.TotalCloseProfit for Outside Market Hours

### DIFF
--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -536,6 +536,12 @@ namespace QuantConnect.Securities
         public virtual decimal Price => Cache.Price;
 
         /// <summary>
+        /// Gets the last price observed during regular market hours.
+        /// Remains frozen when the exchange is closed
+        /// </summary>
+        public decimal LastMarketPrice { get; private set; }
+
+        /// <summary>
         /// Leverage for this Security.
         /// </summary>
         public virtual decimal Leverage => Holdings.Leverage;
@@ -1130,6 +1136,10 @@ namespace QuantConnect.Securities
             if (data is OpenInterest || data.Price == 0m) return;
             Holdings.UpdateMarketPrice(Price);
             VolatilityModel.Update(this, data);
+            if (Price != 0 && _localTimeKeeper != null && Exchange.ExchangeOpen)
+            {
+                LastMarketPrice = Price;
+            }
         }
 
         /// <summary>

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -1136,7 +1136,7 @@ namespace QuantConnect.Securities
             if (data is OpenInterest || data.Price == 0m) return;
             Holdings.UpdateMarketPrice(Price);
             VolatilityModel.Update(this, data);
-            if (Price != 0 && _localTimeKeeper != null && Exchange.ExchangeOpen)
+            if (_localTimeKeeper != null && Exchange.ExchangeOpen)
             {
                 LastMarketPrice = Price;
             }

--- a/Common/Securities/SecurityHolding.cs
+++ b/Common/Securities/SecurityHolding.cs
@@ -179,7 +179,7 @@ namespace QuantConnect.Securities
         /// </summary>
         public virtual decimal UnleveredHoldingsCost
         {
-            get { return HoldingsCost/Leverage; }
+            get { return HoldingsCost / Leverage; }
         }
 
         /// <summary>
@@ -358,7 +358,7 @@ namespace QuantConnect.Securities
             get
             {
                 if (AbsoluteHoldingsCost == 0) return 0m;
-                return UnrealizedProfit/AbsoluteHoldingsCost;
+                return UnrealizedProfit / AbsoluteHoldingsCost;
             }
         }
 
@@ -420,7 +420,7 @@ namespace QuantConnect.Securities
         /// </summary>
         public virtual void SetHoldings(decimal averagePrice, int quantity)
         {
-            SetHoldings(averagePrice, (decimal) quantity);
+            SetHoldings(averagePrice, (decimal)quantity);
         }
 
         /// <summary>
@@ -494,13 +494,22 @@ namespace QuantConnect.Securities
                 feesInAccountCurrency = _currencyConverter.ConvertToAccountCurrency(liquidationFees).Amount;
             }
 
-            // if we are long, we would need to sell against the bid
-            var price = IsLong ? _security.BidPrice : _security.AskPrice;
-            if (price == 0)
+            // Outside market hours, use last trade price to avoid unreliable bid/ask spreads.
+            decimal price;
+            if (!_security.Exchange.ExchangeOpen && _security.Type != SecurityType.Future)
             {
-                // Bid/Ask prices can both be equal to 0. This usually happens when we request our holdings from
-                // the brokerage, but only the last trade price was provided.
                 price = _security.Price;
+            }
+            else
+            {
+                // if we are long, we would need to sell against the bid
+                price = IsLong ? _security.BidPrice : _security.AskPrice;
+                if (price == 0)
+                {
+                    // Bid/Ask prices can both be equal to 0. This usually happens when we request our holdings from
+                    // the brokerage, but only the last trade price was provided.
+                    price = _security.Price;
+                }
             }
 
             var entryValue = GetQuantityValue(quantityToUse, entryPrice ?? AveragePrice).InAccountCurrency;

--- a/Common/Securities/SecurityHolding.cs
+++ b/Common/Securities/SecurityHolding.cs
@@ -494,22 +494,18 @@ namespace QuantConnect.Securities
                 feesInAccountCurrency = _currencyConverter.ConvertToAccountCurrency(liquidationFees).Amount;
             }
 
-            // Outside market hours, use last trade price to avoid unreliable bid/ask spreads.
-            decimal price;
-            if (!_security.Exchange.ExchangeOpen && _security.Type != SecurityType.Future)
-            {
-                price = _security.Price;
-            }
-            else
+            // Outside market hours, bid/ask spreads are unreliable so price stays 0 and falls back to last trade price. Futures are excluded since they support extended hours trading.
+            var price = 0m;
+            if (_security.Type == SecurityType.Future || _security.Exchange.ExchangeOpen)
             {
                 // if we are long, we would need to sell against the bid
                 price = IsLong ? _security.BidPrice : _security.AskPrice;
-                if (price == 0)
-                {
-                    // Bid/Ask prices can both be equal to 0. This usually happens when we request our holdings from
-                    // the brokerage, but only the last trade price was provided.
-                    price = _security.Price;
-                }
+            }
+            if (price == 0)
+            {
+                // Bid/Ask prices can both be equal to 0. This usually happens when we request our holdings from
+                // the brokerage, but only the last trade price was provided.
+                price = _security.Price;
             }
 
             var entryValue = GetQuantityValue(quantityToUse, entryPrice ?? AveragePrice).InAccountCurrency;

--- a/Common/Securities/SecurityHolding.cs
+++ b/Common/Securities/SecurityHolding.cs
@@ -496,7 +496,7 @@ namespace QuantConnect.Securities
 
             // if we are long, we would need to sell against the bid
             var price = IsLong ? _security.BidPrice : _security.AskPrice;
-            if (price == 0 || (!_security.Exchange.ExchangeOpen && _security.LastMarketPrice != 0))
+            if (price == 0 || (!_security.Exchange.ExchangeOpen && _security.LastMarketPrice != 0 && _security.Type != SecurityType.Future))
             {
                 // Bid/Ask prices can both be equal to 0. This usually happens when we request our holdings from
                 // the brokerage, but only the last trade price was provided. Outside market hours, bid/ask spreads

--- a/Common/Securities/SecurityHolding.cs
+++ b/Common/Securities/SecurityHolding.cs
@@ -494,18 +494,14 @@ namespace QuantConnect.Securities
                 feesInAccountCurrency = _currencyConverter.ConvertToAccountCurrency(liquidationFees).Amount;
             }
 
-            // Outside market hours, bid/ask spreads are unreliable so price stays 0 and falls back to last trade price. Futures are excluded since they support extended hours trading.
-            var price = 0m;
-            if (_security.Type == SecurityType.Future || _security.Exchange.ExchangeOpen)
-            {
-                // if we are long, we would need to sell against the bid
-                price = IsLong ? _security.BidPrice : _security.AskPrice;
-            }
-            if (price == 0)
+            // if we are long, we would need to sell against the bid
+            var price = IsLong ? _security.BidPrice : _security.AskPrice;
+            if (price == 0 || (!_security.Exchange.ExchangeOpen && _security.LastMarketPrice != 0))
             {
                 // Bid/Ask prices can both be equal to 0. This usually happens when we request our holdings from
-                // the brokerage, but only the last trade price was provided.
-                price = _security.Price;
+                // the brokerage, but only the last trade price was provided. Outside market hours, bid/ask spreads
+                // widen significantly, so we prefer the last price observed during regular market hours
+                price = _security.LastMarketPrice != 0 ? _security.LastMarketPrice : _security.Price;
             }
 
             var entryValue = GetQuantityValue(quantityToUse, entryPrice ?? AveragePrice).InAccountCurrency;

--- a/Tests/Common/Securities/SecurityHoldingTests.cs
+++ b/Tests/Common/Securities/SecurityHoldingTests.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -82,35 +82,64 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(firstPrice, second.PreviousAveragePrice);
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public void TotalCloseProfitRespectMarketHours(bool isMarketOpen)
+        [Test]
+        public void TotalCloseProfitUsesLastMarketPriceWhenExchangeCloses()
         {
-            var security = GetSecurity<QuantConnect.Securities.Equity.Equity>(Symbols.SPY, Resolution.Daily, isMarketOpen);
+            // Exchange open 09:30-16:00 New York every day (standard equity hours)
+            var segment = new MarketHoursSegment(MarketHoursState.Market, new TimeSpan(9, 30, 0), TimeSpan.FromHours(16));
+            var days = Enum.GetValues<DayOfWeek>().Cast<DayOfWeek>();
+            var exchangeHours = new SecurityExchangeHours(
+                TimeZones.NewYork,
+                Enumerable.Empty<DateTime>(),
+                days.ToDictionary(d => d, d => new LocalMarketHours(d, segment)),
+                new Dictionary<DateTime, TimeSpan>(),
+                new Dictionary<DateTime, TimeSpan>());
+
+            var security = GetSecurityWithExchangeHours(exchangeHours);
+
+            // 9:30 -> market open, set price 100 → LastMarketPrice = 100
+            var openTime = new DateTime(2024, 1, 15, 9, 30, 0);
+            var timeKeeper = new TimeKeeper(openTime.ConvertToUtc(TimeZones.NewYork));
+            security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+            security.SetMarketPrice(new Tick { Time = openTime, Symbol = security.Symbol, TickType = TickType.Trade, Value = 100m });
+
+            Assert.AreEqual(100m, security.LastMarketPrice);
+
+            // 16:00:01 -> market closed, tick arrives with inflated bid/ask spread
+            var afterClose = new DateTime(2024, 1, 15, 16, 0, 1);
+            timeKeeper.SetUtcDateTime(afterClose.ConvertToUtc(TimeZones.NewYork));
+            security.SetMarketPrice(new Tick(afterClose, security.Symbol, 0m, 80m, 120m));
+
+            // LastMarketPrice must be frozen at 100
+            Assert.AreEqual(100m, security.LastMarketPrice);
+
+            // TotalCloseProfit must use 100 (LastMarketPrice), not bid=80
             var holding = new SecurityHolding(security, new IdentityCurrencyConverter(Currencies.USD));
-
-            var averagePrice = 100m;
-            var bid = 90m;
-            var ask = 110m;
-            var lastTradePrice = 105m;
-
-            var quoteTick = new Tick(DateTime.Now, security.Symbol, 0m, bid, ask);
-            var tradeTick = new Tick { Time = DateTime.Now, Symbol = security.Symbol, TickType = TickType.Trade, Value = lastTradePrice };
-
-            security.SetMarketPrice(quoteTick);
-            security.SetMarketPrice(tradeTick);
-
-            var expectedLong = isMarketOpen ? (bid - averagePrice) * 100m : (lastTradePrice - averagePrice) * 100m;
-            var expectedShort = isMarketOpen ? (ask - averagePrice) * -100m : (lastTradePrice - averagePrice) * -100m;
-
-            holding.SetHoldings(averagePrice, 100m);
-            Assert.AreEqual(expectedLong, holding.TotalCloseProfit(includeFees: false));
-
-            holding.SetHoldings(averagePrice, -100m);
-            Assert.AreEqual(expectedShort, holding.TotalCloseProfit(includeFees: false));
+            holding.SetHoldings(100m, 100m);
+            Assert.AreEqual(0m, holding.TotalCloseProfit(includeFees: false));
         }
 
-        private Security GetSecurity<T>(Symbol symbol, Resolution resolution, bool marketAlwaysOpen = true)
+        private Security GetSecurityWithExchangeHours(SecurityExchangeHours exchangeHours)
+        {
+            var config = new SubscriptionDataConfig(
+                typeof(QuantConnect.Securities.Equity.Equity),
+                Symbols.SPY,
+                Resolution.Daily,
+                TimeZones.NewYork,
+                TimeZones.NewYork,
+                true, true, false);
+
+            return new Security(
+                exchangeHours,
+                config,
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache());
+        }
+
+        private Security GetSecurity<T>(Symbol symbol, Resolution resolution)
         {
             var subscriptionDataConfig = new SubscriptionDataConfig(
                 typeof(T),
@@ -122,24 +151,8 @@ namespace QuantConnect.Tests.Common.Securities
                 true,
                 false);
 
-            SecurityExchangeHours exchangeHours;
-            if (marketAlwaysOpen)
-            {
-                exchangeHours = SecurityExchangeHours.AlwaysOpen(TimeZones.Utc);
-            }
-            else
-            {
-                var days = Enum.GetValues(typeof(DayOfWeek)).Cast<DayOfWeek>();
-                exchangeHours = new SecurityExchangeHours(
-                    TimeZones.Utc,
-                    Enumerable.Empty<DateTime>(),
-                    days.ToDictionary(d => d, d => LocalMarketHours.ClosedAllDay(d)),
-                    new Dictionary<DateTime, TimeSpan>(),
-                    new Dictionary<DateTime, TimeSpan>());
-            }
-
             var security = new Security(
-                exchangeHours,
+                SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
                 subscriptionDataConfig,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),

--- a/Tests/Common/Securities/SecurityHoldingTests.cs
+++ b/Tests/Common/Securities/SecurityHoldingTests.cs
@@ -89,23 +89,28 @@ namespace QuantConnect.Tests.Common.Securities
             var security = GetSecurity<QuantConnect.Securities.Equity.Equity>(Symbols.SPY, Resolution.Daily, isMarketOpen);
             var holding = new SecurityHolding(security, new IdentityCurrencyConverter(Currencies.USD));
 
-            var last = 100m;
+            var averagePrice = 100m;
             var bid = 90m;
             var ask = 110m;
+            var lastTradePrice = 105m;
 
-            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, last, bid, ask));
+            var quoteTick = new Tick(DateTime.Now, security.Symbol, 0m, bid, ask);
+            var tradeTick = new Tick { Time = DateTime.Now, Symbol = security.Symbol, TickType = TickType.Trade, Value = lastTradePrice };
 
-            var expectedLong = isMarketOpen ? (bid - last) * 100m : 0m;
-            var expectedShort = isMarketOpen ? (ask - last) * -100m : 0m;
+            security.SetMarketPrice(quoteTick);
+            security.SetMarketPrice(tradeTick);
 
-            holding.SetHoldings(last, 100m);
+            var expectedLong = isMarketOpen ? (bid - averagePrice) * 100m : (lastTradePrice - averagePrice) * 100m;
+            var expectedShort = isMarketOpen ? (ask - averagePrice) * -100m : (lastTradePrice - averagePrice) * -100m;
+
+            holding.SetHoldings(averagePrice, 100m);
             Assert.AreEqual(expectedLong, holding.TotalCloseProfit(includeFees: false));
 
-            holding.SetHoldings(last, -100m);
+            holding.SetHoldings(averagePrice, -100m);
             Assert.AreEqual(expectedShort, holding.TotalCloseProfit(includeFees: false));
         }
 
-        private Security GetSecurity<T>(Symbol symbol, Resolution resolution, bool isMarketOpen = true)
+        private Security GetSecurity<T>(Symbol symbol, Resolution resolution, bool marketAlwaysOpen = true)
         {
             var subscriptionDataConfig = new SubscriptionDataConfig(
                 typeof(T),
@@ -118,7 +123,7 @@ namespace QuantConnect.Tests.Common.Securities
                 false);
 
             SecurityExchangeHours exchangeHours;
-            if (isMarketOpen)
+            if (marketAlwaysOpen)
             {
                 exchangeHours = SecurityExchangeHours.AlwaysOpen(TimeZones.Utc);
             }

--- a/Tests/Common/Securities/SecurityHoldingTests.cs
+++ b/Tests/Common/Securities/SecurityHoldingTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -82,7 +82,30 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(firstPrice, second.PreviousAveragePrice);
         }
 
-        private Security GetSecurity<T>(Symbol symbol, Resolution resolution)
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TotalCloseProfitRespectMarketHours(bool isMarketOpen)
+        {
+            var security = GetSecurity<QuantConnect.Securities.Equity.Equity>(Symbols.SPY, Resolution.Daily, isMarketOpen);
+            var holding = new SecurityHolding(security, new IdentityCurrencyConverter(Currencies.USD));
+
+            var last = 100m;
+            var bid = 90m;
+            var ask = 110m;
+
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, last, bid, ask));
+
+            var expectedLong = isMarketOpen ? (bid - last) * 100m : 0m;
+            var expectedShort = isMarketOpen ? (ask - last) * -100m : 0m;
+
+            holding.SetHoldings(last, 100m);
+            Assert.AreEqual(expectedLong, holding.TotalCloseProfit(includeFees: false));
+
+            holding.SetHoldings(last, -100m);
+            Assert.AreEqual(expectedShort, holding.TotalCloseProfit(includeFees: false));
+        }
+
+        private Security GetSecurity<T>(Symbol symbol, Resolution resolution, bool isMarketOpen = true)
         {
             var subscriptionDataConfig = new SubscriptionDataConfig(
                 typeof(T),
@@ -94,8 +117,24 @@ namespace QuantConnect.Tests.Common.Securities
                 true,
                 false);
 
+            SecurityExchangeHours exchangeHours;
+            if (isMarketOpen)
+            {
+                exchangeHours = SecurityExchangeHours.AlwaysOpen(TimeZones.Utc);
+            }
+            else
+            {
+                var days = Enum.GetValues(typeof(DayOfWeek)).Cast<DayOfWeek>();
+                exchangeHours = new SecurityExchangeHours(
+                    TimeZones.Utc,
+                    Enumerable.Empty<DateTime>(),
+                    days.ToDictionary(d => d, d => LocalMarketHours.ClosedAllDay(d)),
+                    new Dictionary<DateTime, TimeSpan>(),
+                    new Dictionary<DateTime, TimeSpan>());
+            }
+
             var security = new Security(
-                SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
+                exchangeHours,
                 subscriptionDataConfig,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Outside market hours, bid/ask spreads widen significantly causing TotalCloseProfit to report incorrect P&L values. This fix introduces `LastMarketPrice` on Security, which freezes at the last price observed during regular market hours. TotalCloseProfit then uses this value instead of bid/ask when the exchange is closed.

#### Related Issue
Closes #8878
Closes #8797 

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
