### PR TITLE
Fix-ScheduledUniverse-GetTriggerTimes-endTimeUtc-bound-handling

### DIFF
--- a/Algorithm.CSharp/EmaCrossAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/EmaCrossAlphaModelFrameworkRegressionAlgorithm.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "38"},
             {"Average Win", "0.36%"},
             {"Average Loss", "-0.17%"},
-            {"Compounding Annual Return", "68.881%"},
+            {"Compounding Annual Return", "69.878%"},
             {"Drawdown", "0.900%"},
             {"Expectancy", "1.552"},
             {"Start Equity", "100000"},

--- a/Algorithm.CSharp/HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm.cs
@@ -56,7 +56,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "69"},
             {"Average Win", "0.18%"},
             {"Average Loss", "-0.15%"},
-            {"Compounding Annual Return", "42.429%"},
+            {"Compounding Annual Return", "42.996%"},
             {"Drawdown", "0.900%"},
             {"Expectancy", "0.367"},
             {"Start Equity", "100000"},

--- a/Algorithm.CSharp/MacdAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MacdAlphaModelFrameworkRegressionAlgorithm.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "29"},
             {"Average Win", "0.36%"},
             {"Average Loss", "-0.49%"},
-            {"Compounding Annual Return", "30.410%"},
+            {"Compounding Annual Return", "30.800%"},
             {"Drawdown", "1.800%"},
             {"Expectancy", "0.335"},
             {"Start Equity", "100000"},

--- a/Algorithm.CSharp/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.cs
@@ -99,7 +99,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "6"},
             {"Average Win", "0.99%"},
             {"Average Loss", "-0.84%"},
-            {"Compounding Annual Return", "24.021%"},
+            {"Compounding Annual Return", "25.943%"},
             {"Drawdown", "0.800%"},
             {"Expectancy", "0.089"},
             {"Start Equity", "100000"},

--- a/Algorithm.CSharp/RsiAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RsiAlphaModelFrameworkRegressionAlgorithm.cs
@@ -58,7 +58,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "28"},
             {"Average Win", "0.14%"},
             {"Average Loss", "-0.08%"},
-            {"Compounding Annual Return", "0.234%"},
+            {"Compounding Annual Return", "0.237%"},
             {"Drawdown", "1.900%"},
             {"Expectancy", "0.186"},
             {"Start Equity", "100000"},

--- a/Algorithm.CSharp/ScheduledUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ScheduledUniverseRegressionAlgorithm.cs
@@ -108,7 +108,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "1"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "-87.920%"},
+            {"Compounding Annual Return", "0%"},
             {"Drawdown", "1.700%"},
             {"Expectancy", "0"},
             {"Start Equity", "100000"},

--- a/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
@@ -214,7 +214,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "59"},
             {"Average Win", "0.28%"},
             {"Average Loss", "-0.20%"},
-            {"Compounding Annual Return", "73.882%"},
+            {"Compounding Annual Return", "75.392%"},
             {"Drawdown", "1.100%"},
             {"Expectancy", "0.749"},
             {"Start Equity", "100000"},

--- a/Algorithm.CSharp/TimeRulesDefaultTimeZoneRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TimeRulesDefaultTimeZoneRegressionAlgorithm.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 throw new RegressionTestException($"Unexpected universe selection call count: {_selectionMethodCallCount}");
             }
-            if (_scheduleEventEveryCallCount != 130)
+            if (_scheduleEventEveryCallCount != 127)
             {
                 throw new RegressionTestException($"Unexpected scheduled event call count: {_scheduleEventEveryCallCount}");
             }

--- a/Common/Data/UniverseSelection/ScheduledUniverse.cs
+++ b/Common/Data/UniverseSelection/ScheduledUniverse.cs
@@ -107,7 +107,10 @@ namespace QuantConnect.Data.UniverseSelection
         /// </summary>
         /// <param name="startTimeUtc">The start time of the range in UTC</param>
         /// <param name="endTimeUtc">The end time of the range in UTC</param>
-        /// <returns>An enumerator of UTC DateTimes that defines when this universe will be invoked</returns>
+        /// <returns>
+        /// An enumerator of UTC DateTimes that defines when this universe will be invoked,
+        /// including trigger times at both bounds when they match the configured date/time rules.
+        /// </returns>
         public IEnumerable<DateTime> GetTriggerTimes(DateTime startTimeUtc, DateTime endTimeUtc, MarketHoursDatabase marketHoursDatabase)
         {
             var startTimeLocal = startTimeUtc.ConvertFromUtc(Configuration.ExchangeTimeZone);
@@ -115,27 +118,32 @@ namespace QuantConnect.Data.UniverseSelection
 
             // define date/time rule enumerable
             var dates = _dateRule.GetDates(startTimeLocal, endTimeLocal);
-            var times = _timeRule.CreateUtcEventTimes(dates).GetEnumerator();
+            using var times = _timeRule.CreateUtcEventTimes(dates).GetEnumerator();
 
             // Make sure and filter out any times before our start time
             // GH #5440
+            var hasNext = false;
             do
             {
-                if (!times.MoveNext())
+                hasNext = times.MoveNext();
+            }
+            while (hasNext && times.Current < startTimeUtc);
+
+            if (!hasNext)
+            {
+                yield break;
+            }
+
+            // Start yielding times within the requested time range
+            do
+            {
+                if (times.Current > endTimeUtc)
                 {
-                    times.Dispose();
                     yield break;
                 }
-            }
-            while (times.Current < startTimeUtc);
-
-            // Start yielding times
-            do
-            {
                 yield return times.Current;
             }
             while (times.MoveNext());
-            times.Dispose();
         }
 
         private static SubscriptionDataConfig CreateConfiguration(DateTimeZone timeZone, IDateRule dateRule, ITimeRule timeRule)

--- a/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
+++ b/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
@@ -107,5 +107,26 @@ namespace QuantConnect.Tests.Common.Data.UniverseSelection
             // Assert that its empty
             Assert.IsTrue(!triggerTimesUtc.Any());
         }
+
+        [Test]
+        public void TimeTriggeredRespectsEndTimeUtcTimePart()
+        {
+            var start = new DateTime(2025, 1, 1, 10, 0, 0);
+            var end = new DateTime(2025, 1, 8, 15, 32, 0);
+
+            using var universe = new ScheduledUniverse(
+                _dateRules.EveryDay(),
+                _timeRules.Every(TimeSpan.FromMinutes(1)),
+                _ => new List<Symbol>());
+
+            var startUtc = start.ConvertToUtc(_timezone);
+            var endUtc = end.ConvertToUtc(_timezone);
+            var triggerTimesUtc = universe.GetTriggerTimes(startUtc, endUtc, MarketHoursDatabase.AlwaysOpen).ToList();
+
+            Assert.IsNotEmpty(triggerTimesUtc);
+            Assert.That(triggerTimesUtc.All(x => x >= startUtc && x <= endUtc), Is.True);
+            Assert.AreEqual(endUtc, triggerTimesUtc.Last());
+            Assert.That(triggerTimesUtc.Any(x => x > endUtc), Is.False);
+        }
     }
 }


### PR DESCRIPTION
Fixes #9349.

Summary
- ScheduledUniverse.GetTriggerTimes now stops yielding once the next trigger is greater than endTimeUtc.
- Start and end bounds are now documented as inclusive when matching a trigger time.
- Added ScheduledUniverseTests.TimeTriggeredRespectsEndTimeUtcTimePart regression test.

Validation
- dotnet build Tests\QuantConnect.Tests.csproj --no-restore passed.
- dotnet test with ScheduledUniverseTests filter builds but test host crashes in this environment due missing local data path and pythonnet GIL finalizer issue.
