### PR TITLE
Make IResultHandler.RuntimeError stop the algorithm

### DIFF
--- a/Engine/DataFeeds/Enumerators/SubscriptionFilterEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/SubscriptionFilterEnumerator.cs
@@ -62,7 +62,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
             filter.DataFilterError += (sender, exception) =>
             {
                 Log.Error(exception, "WrapForDataFeed");
-                resultHandler.RuntimeError("Runtime error applying data filter. Assuming filter pass: " + exception.Message, exception.StackTrace);
+                resultHandler.ErrorMessage("Runtime error applying data filter. Assuming filter pass: " + exception.Message, exception.StackTrace);
             };
             return filter;
         }

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -951,6 +951,7 @@ namespace QuantConnect.Lean.Engine.Results
         {
             State["RuntimeError"] = error;
             State["StackTrace"] = stack;
+            Algorithm?.SetStatus(AlgorithmStatus.RuntimeError);
         }
 
         /// <summary>

--- a/Tests/Engine/Results/BaseResultsHandlerTests.cs
+++ b/Tests/Engine/Results/BaseResultsHandlerTests.cs
@@ -82,6 +82,19 @@ namespace QuantConnect.Tests.Engine.Results
             Assert.AreEqual(Path.Combine(tempPath, $"{id}-log.txt"), saveLocation);
         }
 
+        [Test]
+        public void SetAlgorithmStateSetsAlgorithmRuntimeErrorStatus()
+        {
+            _baseResultsHandler = new BaseResultsHandlerTestable(AlgorithmId);
+            var algorithm = new QCAlgorithm();
+            algorithm.SetStatus(AlgorithmStatus.Running);
+            _baseResultsHandler.SetAlgorithm(algorithm, 100000);
+
+            _baseResultsHandler.SetAlgorithmStateForTest("error", "stack");
+
+            Assert.AreEqual(AlgorithmStatus.RuntimeError, algorithm.Status);
+        }
+
         [TestCase(100)]
         [TestCase(-100)]
         [TestCase(0)]
@@ -199,6 +212,12 @@ namespace QuantConnect.Tests.Engine.Results
                 ResultsDestinationFolder = folder;
             }
             public string GetResultsDestinationFolder => ResultsDestinationFolder;
+
+            public void SetAlgorithmStateForTest(string error, string stack)
+            {
+                SetAlgorithmState(error, stack);
+            }
+
             protected override void Run()
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
## Summary
- make `RuntimeError()` transition the algorithm status to `RuntimeError` through `BaseResultsHandler.SetAlgorithmState`
- add a regression test proving `SetAlgorithmState` marks the algorithm status as runtime error
- keep the data filter "assume pass" path non-fatal by switching it from `RuntimeError` to `ErrorMessage`

## Testing
- unable to run local tests in this environment because `dotnet` is not installed

Closes #9273