### PR TITLE
fix: support BNFCR alternative collateral in CryptoFutureMarginModel for Binance

### DIFF
--- a/Algorithm.CSharp/BinanceCryptoFutureBnfcrCollateralRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/BinanceCryptoFutureBnfcrCollateralRegressionAlgorithm.cs
@@ -1,0 +1,210 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Brokerages;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+using QuantConnect.Securities.CryptoFuture;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting that BNFCR can serve as sole collateral for Binance
+    /// USDⓈ-M futures for EU/MiCA users. Verifies that buying power, holdings cost,
+    /// margin accounting and portfolio properties are all accurate when USDT balance is zero
+    /// and only BNFCR (pegged 1:1 to USD) is present.
+    /// </summary>
+    public class BinanceCryptoFutureBnfcrCollateralRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private CryptoFuture _adaUsdt;
+        private bool _orderPlaced;
+
+        public override void Initialize()
+        {
+            SetStartDate(2022, 12, 13);
+            SetEndDate(2022, 12, 13);
+            SetTimeZone(TimeZones.Utc);
+            SetBrokerageModel(BrokerageName.BinanceFutures, AccountType.Margin);
+
+            _adaUsdt = AddCryptoFuture("ADAUSDT");
+
+            // EU/MiCA account: no USDT, BNFCR is the sole collateral (pegged 1:1 to USD).
+            // CashBook.Convert("BNFCR" -> "USDT") routes through USD: 200 * 1 / 1 = 200.
+            SetCash(0);
+            SetCash("BNFCR", 200m, 1m);
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (_adaUsdt.Price == 0)
+            {
+                return;
+            }
+
+            if (!_orderPlaced && !Portfolio.Invested)
+            {
+                // --- Assert initial state ---
+
+                // BNFCR must be present and positive
+                if (!Portfolio.CashBook.ContainsKey("BNFCR") || Portfolio.CashBook["BNFCR"].Amount != 200)
+                {
+                    throw new RegressionTestException($"Expected 200 BNFCR in CashBook, got {Portfolio.CashBook["BNFCR"].Amount}");
+                }
+
+                // Primary collateral (USDT) must be zero
+                if (Portfolio.CashBook.ContainsKey("USDT") && Portfolio.CashBook["USDT"].Amount != 0)
+                {
+                    throw new RegressionTestException($"Expected zero USDT, got {Portfolio.CashBook["USDT"].Amount}");
+                }
+
+                // Buying power must reflect BNFCR collateral — not zero
+                var buyingPower = _adaUsdt.BuyingPowerModel.GetBuyingPower(new BuyingPowerParameters(Portfolio, _adaUsdt, OrderDirection.Buy));
+                if (buyingPower.Value <= 0)
+                {
+                    throw new RegressionTestException($"Expected positive buying power from BNFCR collateral, got {buyingPower.Value}");
+                }
+
+                // --- Place order ---
+                var ticket = Buy(_adaUsdt.Symbol, 1000);
+                _orderPlaced = true;
+
+                if (ticket.Status == OrderStatus.Invalid)
+                {
+                    throw new RegressionTestException("Order was rejected — BNFCR collateral should be sufficient to cover margin");
+                }
+
+                // --- Assert holdings after fill ---
+                var holdings = _adaUsdt.Holdings;
+                var expectedNotional = _adaUsdt.Price * _adaUsdt.SymbolProperties.ContractMultiplier * 1000;
+
+                if (Math.Abs(holdings.AbsoluteHoldingsCost - expectedNotional) > 1)
+                {
+                    throw new RegressionTestException($"Unexpected AbsoluteHoldingsCost {holdings.AbsoluteHoldingsCost}, expected ~{expectedNotional}");
+                }
+
+                if (Math.Abs(holdings.TotalSaleVolume - expectedNotional) > 1)
+                {
+                    throw new RegressionTestException($"Unexpected TotalSaleVolume {holdings.TotalSaleVolume}, expected ~{expectedNotional}");
+                }
+
+                // --- Assert margin accounting ---
+                var marginUsed = Portfolio.TotalMarginUsed;
+                if (marginUsed <= 0)
+                {
+                    throw new RegressionTestException($"Expected positive TotalMarginUsed after fill, got {marginUsed}");
+                }
+
+                var maintenanceMargin = _adaUsdt.BuyingPowerModel.GetMaintenanceMargin(MaintenanceMarginParameters.ForCurrentHoldings(_adaUsdt));
+                if (maintenanceMargin != marginUsed)
+                {
+                    throw new RegressionTestException($"Maintenance margin {maintenanceMargin} does not match TotalMarginUsed {marginUsed}");
+                }
+
+                // Position just opened — unrealized PnL should be near zero (spread only)
+                if (Math.Abs(Portfolio.TotalUnrealizedProfit) > 5)
+                {
+                    throw new RegressionTestException($"Unexpected TotalUnrealizedProfit {Portfolio.TotalUnrealizedProfit}");
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (Transactions.OrdersCount != 1)
+            {
+                throw new RegressionTestException($"Expected exactly 1 order, got {Transactions.OrdersCount}");
+            }
+
+            if (!Portfolio.CashBook.ContainsKey("BNFCR"))
+            {
+                throw new RegressionTestException("BNFCR must remain in CashBook throughout the algorithm");
+            }
+
+            if (!Portfolio.Invested)
+            {
+                throw new RegressionTestException("Expected an open ADAUSDT position at end of algorithm");
+            }
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            Debug($"{Time} {orderEvent}");
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 4322;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "200"},
+            {"End Equity", "206.86"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.12"},
+            {"Estimated Strategy Capacity", "$340000.00"},
+            {"Lowest Capacity Asset", "ADAUSDT 18R"},
+            {"Portfolio Turnover", "148.31%"},
+            {"Drawdown Recovery", "0"},
+            {"OrderListHash", "177ae917deb456790cfbcaaaf1ec1f5c"}
+        };
+    }
+}

--- a/Algorithm.CSharp/BinanceCryptoFutureBnfcrCollateralRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/BinanceCryptoFutureBnfcrCollateralRegressionAlgorithm.cs
@@ -13,10 +13,10 @@
  * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using QuantConnect.Brokerages;
 using QuantConnect.Data;
+using QuantConnect.Data.Market;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
@@ -25,14 +25,14 @@ using QuantConnect.Securities.CryptoFuture;
 namespace QuantConnect.Algorithm.CSharp
 {
     /// <summary>
-    /// Regression algorithm asserting that BNFCR can serve as sole collateral for Binance
-    /// USDⓈ-M futures for EU/MiCA users. Verifies that buying power, holdings cost,
-    /// margin accounting and portfolio properties are all accurate when USDT balance is zero
-    /// and only BNFCR (pegged 1:1 to USD) is present.
+    /// Regression algorithm asserting that BNFCR serves as collateral for Binance USDⓈ-M futures
+    /// (EU/MiCA Credits Trading Mode) and that futures with different quote currencies (ADAUSDT, ETHUSDC)
+    /// correctly share the BNFCR collateral pool.
     /// </summary>
     public class BinanceCryptoFutureBnfcrCollateralRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
     {
         private CryptoFuture _adaUsdt;
+        private CryptoFuture _ethUsdc;
         private bool _orderPlaced;
 
         public override void Initialize()
@@ -43,102 +43,63 @@ namespace QuantConnect.Algorithm.CSharp
             SetBrokerageModel(BrokerageName.BinanceFutures, AccountType.Margin);
 
             _adaUsdt = AddCryptoFuture("ADAUSDT");
+            _ethUsdc = AddCryptoFuture("ETHUSDC");
 
-            // EU/MiCA account: no USDT, BNFCR is the sole collateral (pegged 1:1 to USD).
-            // CashBook.Convert("BNFCR" -> "USDT") routes through USD: 200 * 1 / 1 = 200.
             SetCash(0);
             SetCash("BNFCR", 200m, 1m);
+            SetCash("ETH", 0, 1600);
+            SetCash("USDC", 0, 1);
         }
 
         public override void OnData(Slice slice)
         {
-            if (_adaUsdt.Price == 0)
+            if (_adaUsdt.Price == 0 || _orderPlaced)
             {
                 return;
             }
 
-            if (!_orderPlaced && !Portfolio.Invested)
+            // 1. BNFCR collateral must produce positive buying power (USDT is zero)
+            var buyingPower = _adaUsdt.BuyingPowerModel.GetBuyingPower(new BuyingPowerParameters(Portfolio, _adaUsdt, OrderDirection.Buy));
+            if (buyingPower.Value <= 0)
             {
-                // --- Assert initial state ---
+                throw new RegressionTestException($"Expected positive buying power from BNFCR, got {buyingPower.Value}");
+            }
 
-                // BNFCR must be present and positive
-                if (!Portfolio.CashBook.ContainsKey("BNFCR") || Portfolio.CashBook["BNFCR"].Amount != 200)
-                {
-                    throw new RegressionTestException($"Expected 200 BNFCR in CashBook, got {Portfolio.CashBook["BNFCR"].Amount}");
-                }
+            // 2. Order must not be rejected
+            var ticket = Buy(_adaUsdt.Symbol, 1000);
+            _orderPlaced = true;
+            if (ticket.Status == OrderStatus.Invalid)
+            {
+                throw new RegressionTestException("Order rejected — BNFCR collateral should cover margin");
+            }
 
-                // Primary collateral (USDT) must be zero
-                if (Portfolio.CashBook.ContainsKey("USDT") && Portfolio.CashBook["USDT"].Amount != 0)
-                {
-                    throw new RegressionTestException($"Expected zero USDT, got {Portfolio.CashBook["USDT"].Amount}");
-                }
+            // 3. Margin must be tracked
+            if (Portfolio.TotalMarginUsed <= 0)
+            {
+                throw new RegressionTestException($"Expected positive TotalMarginUsed, got {Portfolio.TotalMarginUsed}");
+            }
 
-                // Buying power must reflect BNFCR collateral — not zero
-                var buyingPower = _adaUsdt.BuyingPowerModel.GetBuyingPower(new BuyingPowerParameters(Portfolio, _adaUsdt, OrderDirection.Buy));
-                if (buyingPower.Value <= 0)
-                {
-                    throw new RegressionTestException($"Expected positive buying power from BNFCR collateral, got {buyingPower.Value}");
-                }
+            // 4. Shared collateral: ETHUSDC (different quote currency) must deduct ADAUSDT margin
+            _ethUsdc.SetMarketPrice(new TradeBar { Time = Time, Symbol = _ethUsdc.Symbol, Close = 1600 });
 
-                // --- Place order ---
-                var ticket = Buy(_adaUsdt.Symbol, 1000);
-                _orderPlaced = true;
+            var ethBuyingPower = _ethUsdc.BuyingPowerModel.GetBuyingPower(new BuyingPowerParameters(Portfolio, _ethUsdc, OrderDirection.Buy));
+            var adaBuyingPower = _adaUsdt.BuyingPowerModel.GetBuyingPower(new BuyingPowerParameters(Portfolio, _adaUsdt, OrderDirection.Buy));
 
-                if (ticket.Status == OrderStatus.Invalid)
-                {
-                    throw new RegressionTestException("Order was rejected — BNFCR collateral should be sufficient to cover margin");
-                }
-
-                // --- Assert holdings after fill ---
-                var holdings = _adaUsdt.Holdings;
-                var expectedNotional = _adaUsdt.Price * _adaUsdt.SymbolProperties.ContractMultiplier * 1000;
-
-                if (Math.Abs(holdings.AbsoluteHoldingsCost - expectedNotional) > 1)
-                {
-                    throw new RegressionTestException($"Unexpected AbsoluteHoldingsCost {holdings.AbsoluteHoldingsCost}, expected ~{expectedNotional}");
-                }
-
-                if (Math.Abs(holdings.TotalSaleVolume - expectedNotional) > 1)
-                {
-                    throw new RegressionTestException($"Unexpected TotalSaleVolume {holdings.TotalSaleVolume}, expected ~{expectedNotional}");
-                }
-
-                // --- Assert margin accounting ---
-                var marginUsed = Portfolio.TotalMarginUsed;
-                if (marginUsed <= 0)
-                {
-                    throw new RegressionTestException($"Expected positive TotalMarginUsed after fill, got {marginUsed}");
-                }
-
-                var maintenanceMargin = _adaUsdt.BuyingPowerModel.GetMaintenanceMargin(MaintenanceMarginParameters.ForCurrentHoldings(_adaUsdt));
-                if (maintenanceMargin != marginUsed)
-                {
-                    throw new RegressionTestException($"Maintenance margin {maintenanceMargin} does not match TotalMarginUsed {marginUsed}");
-                }
-
-                // Position just opened — unrealized PnL should be near zero (spread only)
-                if (Math.Abs(Portfolio.TotalUnrealizedProfit) > 5)
-                {
-                    throw new RegressionTestException($"Unexpected TotalUnrealizedProfit {Portfolio.TotalUnrealizedProfit}");
-                }
+            // ETHUSDC must see less buying power than ADAUSDT - ADAUSDT maintenance margin
+            // is deducted from ETHUSDC's shared pool, but ADAUSDT skips itself.
+            if (ethBuyingPower.Value >= adaBuyingPower.Value)
+            {
+                throw new RegressionTestException(
+                    $"ETHUSDC buying power ({ethBuyingPower.Value}) must be less than ADAUSDT ({adaBuyingPower.Value}) " +
+                    $"— shared BNFCR pool must deduct ADAUSDT maintenance margin");
             }
         }
 
         public override void OnEndOfAlgorithm()
         {
-            if (Transactions.OrdersCount != 1)
-            {
-                throw new RegressionTestException($"Expected exactly 1 order, got {Transactions.OrdersCount}");
-            }
-
-            if (!Portfolio.CashBook.ContainsKey("BNFCR"))
-            {
-                throw new RegressionTestException("BNFCR must remain in CashBook throughout the algorithm");
-            }
-
             if (!Portfolio.Invested)
             {
-                throw new RegressionTestException("Expected an open ADAUSDT position at end of algorithm");
+                throw new RegressionTestException("Expected an open position at end of algorithm");
             }
         }
 

--- a/Common/Brokerages/BinanceCoinFuturesBrokerageModel.cs
+++ b/Common/Brokerages/BinanceCoinFuturesBrokerageModel.cs
@@ -16,6 +16,7 @@
 using QuantConnect.Benchmarks;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Securities;
+using QuantConnect.Securities.CryptoFuture;
 
 namespace QuantConnect.Brokerages
 {
@@ -50,6 +51,16 @@ namespace QuantConnect.Brokerages
         public override IFeeModel GetFeeModel(Security security)
         {
             return new BinanceCoinFuturesFeeModel();
+        }
+
+        /// <summary>
+        /// Creates the crypto future margin model for the given security
+        /// </summary>
+        /// <param name="security">The security to create the margin model for</param>
+        /// <returns>The margin model instance</returns>
+        protected override IBuyingPowerModel CreateCryptoFutureMarginModel(Security security)
+        {
+            return new CryptoFutureMarginModel(GetLeverage(security));
         }
     }
 }

--- a/Common/Brokerages/BinanceFuturesBrokerageModel.cs
+++ b/Common/Brokerages/BinanceFuturesBrokerageModel.cs
@@ -82,12 +82,12 @@ namespace QuantConnect.Brokerages
         /// <returns>The buying power model for this brokerage/security</returns>
         public override IBuyingPowerModel GetBuyingPowerModel(Security security)
         {
-            if (security?.Type != SecurityType.CryptoFuture)
+            if (security?.Type == SecurityType.CryptoFuture)
             {
-                throw new ArgumentException($"Unexpected security type {security?.Type}. Expected {SecurityType.CryptoFuture}.");
+                return CreateCryptoFutureMarginModel(security);
             }
 
-            return CreateCryptoFutureMarginModel(security);
+            return base.GetBuyingPowerModel(security);
         }
 
         /// <summary>

--- a/Common/Brokerages/BinanceFuturesBrokerageModel.cs
+++ b/Common/Brokerages/BinanceFuturesBrokerageModel.cs
@@ -82,13 +82,22 @@ namespace QuantConnect.Brokerages
         /// <returns>The buying power model for this brokerage/security</returns>
         public override IBuyingPowerModel GetBuyingPowerModel(Security security)
         {
-            switch (security?.Type)
+            if (security?.Type != SecurityType.CryptoFuture)
             {
-                case SecurityType.CryptoFuture:
-                    return new BinanceCryptoFutureMarginModel(GetLeverage(security));
-                default:
-                    return base.GetBuyingPowerModel(security);
+                throw new ArgumentException($"Unexpected security type {security?.Type}. Expected {SecurityType.CryptoFuture}.");
             }
+
+            return CreateCryptoFutureMarginModel(security);
+        }
+
+        /// <summary>
+        /// Creates the crypto future margin model for the given security
+        /// </summary>
+        /// <param name="security">The security to create the margin model for</param>
+        /// <returns>The margin model instance</returns>
+        protected virtual IBuyingPowerModel CreateCryptoFutureMarginModel(Security security)
+        {
+            return new BinanceCryptoFutureMarginModel(GetLeverage(security));
         }
     }
 }

--- a/Common/Brokerages/BinanceFuturesBrokerageModel.cs
+++ b/Common/Brokerages/BinanceFuturesBrokerageModel.cs
@@ -82,11 +82,13 @@ namespace QuantConnect.Brokerages
         /// <returns>The buying power model for this brokerage/security</returns>
         public override IBuyingPowerModel GetBuyingPowerModel(Security security)
         {
-            return security?.Type switch
+            switch (security?.Type)
             {
-                SecurityType.CryptoFuture => new BinanceCryptoFutureMarginModel(GetLeverage(security)),
-                _ => base.GetBuyingPowerModel(security)
-            };
+                case SecurityType.CryptoFuture:
+                    return new BinanceCryptoFutureMarginModel(GetLeverage(security));
+                default:
+                    return base.GetBuyingPowerModel(security);
+            }
         }
     }
 }

--- a/Common/Brokerages/BinanceFuturesBrokerageModel.cs
+++ b/Common/Brokerages/BinanceFuturesBrokerageModel.cs
@@ -72,5 +72,21 @@ namespace QuantConnect.Brokerages
             }
             return base.GetMarginInterestRateModel(security);
         }
+
+        /// <summary>
+        /// Gets a new buying power model for the security.
+        /// For <see cref="SecurityType.CryptoFuture"/>, returns a <see cref="BinanceCryptoFutureMarginModel"/>
+        /// that recognizes supplementary stable coin collateral (e.g. BNFCR for EU Credits Trading Mode).
+        /// </summary>
+        /// <param name="security">The security to get a buying power model for</param>
+        /// <returns>The buying power model for this brokerage/security</returns>
+        public override IBuyingPowerModel GetBuyingPowerModel(Security security)
+        {
+            return security?.Type switch
+            {
+                SecurityType.CryptoFuture => new BinanceCryptoFutureMarginModel(GetLeverage(security)),
+                _ => base.GetBuyingPowerModel(security)
+            };
+        }
     }
 }

--- a/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
+++ b/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
@@ -41,7 +41,6 @@ namespace QuantConnect.Securities.CryptoFuture
         /// Gets the total collateral amount for a Binance crypto future, including supplementary
         /// stable coin currencies that can serve as alternative collateral
         /// (e.g. BNFCR for USDT-quoted futures on Binance).
-        /// For coin futures, only the primary collateral (base currency) is used.
         /// </summary>
         /// <param name="portfolio">The algorithm's portfolio</param>
         /// <param name="security">The crypto future security</param>
@@ -51,13 +50,6 @@ namespace QuantConnect.Securities.CryptoFuture
             SecurityPortfolioManager portfolio, Security security, Cash primaryCollateral)
         {
             var total = primaryCollateral.Amount;
-
-            var cryptoFuture = (CryptoFuture)security;
-            if (cryptoFuture.IsCryptoCoinFuture())
-            {
-                return total;
-            }
-
             var market = security.Symbol.ID.Market;
             var accountCurrency = portfolio.CashBook.AccountCurrency;
             foreach (var kvp in portfolio.CashBook)
@@ -71,10 +63,7 @@ namespace QuantConnect.Securities.CryptoFuture
                 if (Currencies.IsStableCoinWithoutPair(accountCurrency, cash.Symbol, market))
                 {
                     // convert supplementary collateral to primary collateral terms
-                    var conversionRate = primaryCollateral.ConversionRate != 0
-                        ? cash.ConversionRate / primaryCollateral.ConversionRate
-                        : cash.ConversionRate;
-                    total += cash.Amount * conversionRate;
+                    total += portfolio.CashBook.Convert(cash.Amount, cash.Symbol, primaryCollateral.Symbol);
                 }
             }
 

--- a/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
+++ b/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
@@ -54,19 +54,12 @@ namespace QuantConnect.Securities.CryptoFuture
         protected override decimal GetTotalCollateralAmount(
             SecurityPortfolioManager portfolio, Security security, Cash primaryCollateral)
         {
-            // Coin futures (e.g. BTCUSD) use only base currency as collateral
-            var cryptoFuture = (CryptoFuture)security;
-            if (cryptoFuture.IsCryptoCoinFuture())
-            {
-                return primaryCollateral.Amount;
-            }
-
             // BNFCR presence means EU/EEA account in MiCA Credits Trading Mode.
             // Non-EU accounts don't have BNFCR in CashBook — skip entirely.
             var cashBook = portfolio.CashBook;
             if (!cashBook.ContainsKey(BNFCRCurrency))
             {
-                return primaryCollateral.Amount;
+                return base.GetTotalCollateralAmount(portfolio, security, primaryCollateral);
             }
 
             // Aggregate all collateral assets using walletBalance values.

--- a/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
+++ b/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
@@ -49,31 +49,30 @@ namespace QuantConnect.Securities.CryptoFuture
         protected override decimal GetTotalCollateralAmount(
             SecurityPortfolioManager portfolio, Security security, Cash primaryCollateral)
         {
-            var total = primaryCollateral.Amount;
-
             // Coin futures (e.g. BTCUSD) use only base currency as collateral
             var cryptoFuture = (CryptoFuture)security;
             if (cryptoFuture.IsCryptoCoinFuture())
             {
-                return total;
+                return primaryCollateral.Amount;
             }
 
             // BNFCR presence means EU/EEA account in MiCA Credits Trading Mode.
             // Non-EU accounts don't have BNFCR in CashBook — skip entirely.
             var cashBook = portfolio.CashBook;
-            if (!cashBook.TryGetValue("BNFCR", out _))
+            if (!cashBook.ContainsKey("BNFCR"))
             {
-                return total;
+                return primaryCollateral.Amount;
             }
 
-            // Aggregate all supplementary collateral assets using walletBalance values.
+            // Aggregate all collateral assets using walletBalance values.
             // Binance controls which assets are in the account — we sum everything
-            // that isn't the primary collateral and has a non-zero balance.
+            // with a non-zero balance, converting to the primary collateral currency.
             // Negative amounts (e.g. BNFCR fees) correctly reduce the total.
+            var total = 0m;
             foreach (var kvp in cashBook)
             {
                 var cash = kvp.Value;
-                if (cash == primaryCollateral || cash.Amount == 0)
+                if (cash.Amount == 0)
                 {
                     continue;
                 }

--- a/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
+++ b/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
@@ -41,6 +41,7 @@ namespace QuantConnect.Securities.CryptoFuture
         /// Gets the total collateral amount for a Binance crypto future, including supplementary
         /// stable coin currencies that can serve as alternative collateral
         /// (e.g. BNFCR for USDT-quoted futures on Binance).
+        /// For coin futures (e.g. BTCUSD), only the primary collateral (base currency) is used.
         /// </summary>
         /// <param name="portfolio">The algorithm's portfolio</param>
         /// <param name="security">The crypto future security</param>
@@ -50,6 +51,14 @@ namespace QuantConnect.Securities.CryptoFuture
             SecurityPortfolioManager portfolio, Security security, Cash primaryCollateral)
         {
             var total = primaryCollateral.Amount;
+
+            // Coin futures (e.g. BTCUSD) use only base currency as collateral - stable coins don't apply
+            var cryptoFuture = (CryptoFuture)security;
+            if (cryptoFuture.IsCryptoCoinFuture())
+            {
+                return total;
+            }
+
             var market = security.Symbol.ID.Market;
             var accountCurrency = portfolio.CashBook.AccountCurrency;
             foreach (var kvp in portfolio.CashBook)

--- a/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
+++ b/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
@@ -1,0 +1,84 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Securities.CryptoFuture
+{
+    /// <summary>
+    /// Binance-specific crypto future margin model that includes supplementary stable coin
+    /// currencies as alternative collateral for non-coin (USDⓈ-M) futures.
+    /// </summary>
+    /// <remarks>
+    /// EU/EEA users under MiCA use Credits Trading Mode where BNFCR (pegged 1:1 to USD) replaces
+    /// USDT/USDC for margin, PNL and fees. This model aggregates USD-pegged stable coins (BNFCR,
+    /// USDC, FDUSD, etc.) as supplementary collateral. Volatile assets (BTC/ETH/BNB) are excluded
+    /// because they require exchange-specific haircut rates.
+    /// See: https://www.binance.com/en/support/faq/detail/0e857c392a2d47cebde0af762d9255ae
+    /// </remarks>
+    public class BinanceCryptoFutureMarginModel : CryptoFutureMarginModel
+    {
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        /// <param name="leverage">The leverage to use, default 25x</param>
+        public BinanceCryptoFutureMarginModel(decimal leverage = 25)
+            : base(leverage)
+        {
+        }
+
+        /// <summary>
+        /// Gets the total collateral amount for a Binance crypto future, including supplementary
+        /// stable coin currencies that can serve as alternative collateral
+        /// (e.g. BNFCR for USDT-quoted futures on Binance).
+        /// For coin futures, only the primary collateral (base currency) is used.
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio</param>
+        /// <param name="security">The crypto future security</param>
+        /// <param name="primaryCollateral">The primary collateral cash (e.g. USDT)</param>
+        /// <returns>Total collateral amount in terms of the primary collateral currency</returns>
+        protected override decimal GetTotalCollateralAmount(
+            SecurityPortfolioManager portfolio, Security security, Cash primaryCollateral)
+        {
+            var total = primaryCollateral.Amount;
+
+            var cryptoFuture = (CryptoFuture)security;
+            if (cryptoFuture.IsCryptoCoinFuture())
+            {
+                return total;
+            }
+
+            var market = security.Symbol.ID.Market;
+            var accountCurrency = portfolio.CashBook.AccountCurrency;
+            foreach (var kvp in portfolio.CashBook)
+            {
+                var cash = kvp.Value;
+                if (cash == primaryCollateral || cash.Amount <= 0)
+                {
+                    continue;
+                }
+
+                if (Currencies.IsStableCoinWithoutPair(accountCurrency, cash.Symbol, market))
+                {
+                    // convert supplementary collateral to primary collateral terms
+                    var conversionRate = primaryCollateral.ConversionRate != 0
+                        ? cash.ConversionRate / primaryCollateral.ConversionRate
+                        : cash.ConversionRate;
+                    total += cash.Amount * conversionRate;
+                }
+            }
+
+            return total;
+        }
+    }
+}

--- a/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
+++ b/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
@@ -29,6 +29,11 @@ namespace QuantConnect.Securities.CryptoFuture
     public class BinanceCryptoFutureMarginModel : CryptoFutureMarginModel
     {
         /// <summary>
+        /// Binance Futures Credits currency symbol, present in EU/EEA accounts under MiCA Credits Trading Mode.
+        /// </summary>
+        private const string BNFCRCurrency = "BNFCR";
+
+        /// <summary>
         /// Creates a new instance
         /// </summary>
         /// <param name="leverage">The leverage to use, default 25x</param>
@@ -59,7 +64,7 @@ namespace QuantConnect.Securities.CryptoFuture
             // BNFCR presence means EU/EEA account in MiCA Credits Trading Mode.
             // Non-EU accounts don't have BNFCR in CashBook — skip entirely.
             var cashBook = portfolio.CashBook;
-            if (!cashBook.ContainsKey("BNFCR"))
+            if (!cashBook.ContainsKey(BNFCRCurrency))
             {
                 return primaryCollateral.Amount;
             }
@@ -81,6 +86,15 @@ namespace QuantConnect.Securities.CryptoFuture
             }
 
             return total;
+        }
+
+        /// <summary>
+        /// When BNFCR is present (EU/MiCA mode), all USDⓈ-M futures share the same collateral
+        /// pool regardless of quote currency (USDT, USDC, etc.).
+        /// </summary>
+        protected override bool SharesCollateral(SecurityPortfolioManager portfolio, Cash collateralCurrency, Security otherCryptoFuture)
+        {
+            return portfolio.CashBook.ContainsKey(BNFCRCurrency) || base.SharesCollateral(portfolio, collateralCurrency, otherCryptoFuture);
         }
     }
 }

--- a/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
+++ b/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
@@ -20,11 +20,10 @@ namespace QuantConnect.Securities.CryptoFuture
     /// currencies as alternative collateral for non-coin (USDⓈ-M) futures.
     /// </summary>
     /// <remarks>
-    /// EU/EEA users under MiCA Credits Trading Mode use BNFCR (pegged 1:1 to USD) as the
-    /// cross-margin accounting currency. Binance stores the total available collateral pool
-    /// (all stablecoins combined, minus used margin) in BNFCR's availableBalance field.
-    /// This model reads that value as supplementary collateral for USDⓈ-M futures.
-    /// Non-EU users won't have BNFCR in their account — the check is a no-op for them.
+    /// EU/EEA users under MiCA Credits Trading Mode have BNFCR in their account.
+    /// When BNFCR is present, this model aggregates all supplementary collateral assets
+    /// using their walletBalance values converted to the primary collateral currency.
+    /// Non-EU accounts don't have BNFCR — the check is a no-op for them.
     /// See: https://www.binance.com/en/support/faq/detail/0e857c392a2d47cebde0af762d9255ae
     /// </remarks>
     public class BinanceCryptoFutureMarginModel : CryptoFutureMarginModel
@@ -40,8 +39,7 @@ namespace QuantConnect.Securities.CryptoFuture
 
         /// <summary>
         /// Gets the total collateral amount for a Binance crypto future, including supplementary
-        /// stable coin currencies that can serve as alternative collateral
-        /// (e.g. BNFCR for USDT-quoted futures on Binance).
+        /// collateral assets for EU/EEA accounts in MiCA Credits Trading Mode.
         /// For coin futures (e.g. BTCUSD), only the primary collateral (base currency) is used.
         /// </summary>
         /// <param name="portfolio">The algorithm's portfolio</param>
@@ -53,21 +51,34 @@ namespace QuantConnect.Securities.CryptoFuture
         {
             var total = primaryCollateral.Amount;
 
-            // Coin futures (e.g. BTCUSD) use only base currency as collateral - stable coins don't apply
+            // Coin futures (e.g. BTCUSD) use only base currency as collateral
             var cryptoFuture = (CryptoFuture)security;
             if (cryptoFuture.IsCryptoCoinFuture())
             {
                 return total;
             }
 
-            // BNFCR is available only for EU/EEA accounts (MiCA Credits Trading Mode).
-            // Its CashBook amount reflects availableBalance from the Binance API — the total
-            // cross-margin available balance across all stablecoins, already aggregated by Binance.
-            // Non-EU users won't have BNFCR in their CashBook, so TryGetValue returns false.
+            // BNFCR presence means EU/EEA account in MiCA Credits Trading Mode.
+            // Non-EU accounts don't have BNFCR in CashBook — skip entirely.
             var cashBook = portfolio.CashBook;
-            if (cashBook.TryGetValue("BNFCR", out var bnfcrCash) && bnfcrCash.Amount > 0)
+            if (!cashBook.TryGetValue("BNFCR", out _))
             {
-                total += cashBook.Convert(bnfcrCash.Amount, "BNFCR", primaryCollateral.Symbol);
+                return total;
+            }
+
+            // Aggregate all supplementary collateral assets using walletBalance values.
+            // Binance controls which assets are in the account — we sum everything
+            // that isn't the primary collateral and has a non-zero balance.
+            // Negative amounts (e.g. BNFCR fees) correctly reduce the total.
+            foreach (var kvp in cashBook)
+            {
+                var cash = kvp.Value;
+                if (cash == primaryCollateral || cash.Amount == 0)
+                {
+                    continue;
+                }
+
+                total += cashBook.Convert(cash.Amount, cash.Symbol, primaryCollateral.Symbol);
             }
 
             return total;

--- a/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
+++ b/Common/Securities/CryptoFuture/BinanceCryptoFutureMarginModel.cs
@@ -20,10 +20,11 @@ namespace QuantConnect.Securities.CryptoFuture
     /// currencies as alternative collateral for non-coin (USDⓈ-M) futures.
     /// </summary>
     /// <remarks>
-    /// EU/EEA users under MiCA use Credits Trading Mode where BNFCR (pegged 1:1 to USD) replaces
-    /// USDT/USDC for margin, PNL and fees. This model aggregates USD-pegged stable coins (BNFCR,
-    /// USDC, FDUSD, etc.) as supplementary collateral. Volatile assets (BTC/ETH/BNB) are excluded
-    /// because they require exchange-specific haircut rates.
+    /// EU/EEA users under MiCA Credits Trading Mode use BNFCR (pegged 1:1 to USD) as the
+    /// cross-margin accounting currency. Binance stores the total available collateral pool
+    /// (all stablecoins combined, minus used margin) in BNFCR's availableBalance field.
+    /// This model reads that value as supplementary collateral for USDⓈ-M futures.
+    /// Non-EU users won't have BNFCR in their account — the check is a no-op for them.
     /// See: https://www.binance.com/en/support/faq/detail/0e857c392a2d47cebde0af762d9255ae
     /// </remarks>
     public class BinanceCryptoFutureMarginModel : CryptoFutureMarginModel
@@ -59,21 +60,14 @@ namespace QuantConnect.Securities.CryptoFuture
                 return total;
             }
 
-            var market = security.Symbol.ID.Market;
-            var accountCurrency = portfolio.CashBook.AccountCurrency;
-            foreach (var kvp in portfolio.CashBook)
+            // BNFCR is available only for EU/EEA accounts (MiCA Credits Trading Mode).
+            // Its CashBook amount reflects availableBalance from the Binance API — the total
+            // cross-margin available balance across all stablecoins, already aggregated by Binance.
+            // Non-EU users won't have BNFCR in their CashBook, so TryGetValue returns false.
+            var cashBook = portfolio.CashBook;
+            if (cashBook.TryGetValue("BNFCR", out var bnfcrCash) && bnfcrCash.Amount > 0)
             {
-                var cash = kvp.Value;
-                if (cash == primaryCollateral || cash.Amount <= 0)
-                {
-                    continue;
-                }
-
-                if (Currencies.IsStableCoinWithoutPair(accountCurrency, cash.Symbol, market))
-                {
-                    // convert supplementary collateral to primary collateral terms
-                    total += portfolio.CashBook.Convert(cash.Amount, cash.Symbol, primaryCollateral.Symbol);
-                }
+                total += cashBook.Convert(bnfcrCash.Amount, "BNFCR", primaryCollateral.Symbol);
             }
 
             return total;

--- a/Common/Securities/CryptoFuture/CryptoFutureMarginModel.cs
+++ b/Common/Securities/CryptoFuture/CryptoFutureMarginModel.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.Securities.CryptoFuture
             {
                 var otherCryptoFuture = portfolio.Securities[kvp.Key];
                 // check if we share the collateral
-                if (collateralCurrency == GetCollateralCash(otherCryptoFuture))
+                if (SharesCollateral(portfolio, collateralCurrency, otherCryptoFuture))
                 {
                     // we reduce the available collateral based on total usage of all other positions too
                     result -= otherCryptoFuture.BuyingPowerModel.GetMaintenanceMargin(MaintenanceMarginParameters.ForCurrentHoldings(otherCryptoFuture));
@@ -137,6 +137,18 @@ namespace QuantConnect.Securities.CryptoFuture
             // convert into account currency
             result *= collateralCurrency.ConversionRate;
             return result < 0 ? 0 : result;
+        }
+
+        /// <summary>
+        /// Determines whether the given security shares collateral with another crypto future.
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio</param>
+        /// <param name="collateralCurrency">The collateral cash for the current security</param>
+        /// <param name="otherCryptoFuture">The other crypto future security to check</param>
+        /// <returns>True if both securities share the same collateral</returns>
+        protected virtual bool SharesCollateral(SecurityPortfolioManager portfolio, Cash collateralCurrency, Security otherCryptoFuture)
+        {
+            return collateralCurrency == GetCollateralCash(otherCryptoFuture);
         }
 
         /// <summary>

--- a/Common/Securities/CryptoFuture/CryptoFutureMarginModel.cs
+++ b/Common/Securities/CryptoFuture/CryptoFutureMarginModel.cs
@@ -154,7 +154,7 @@ namespace QuantConnect.Securities.CryptoFuture
         /// <summary>
         /// Helper method to determine what's the collateral currency for the given crypto future
         /// </summary>
-        protected static Cash GetCollateralCash(Security security)
+        private static Cash GetCollateralCash(Security security)
         {
             var cryptoFuture = (CryptoFuture)security;
 

--- a/Common/Securities/CryptoFuture/CryptoFutureMarginModel.cs
+++ b/Common/Securities/CryptoFuture/CryptoFutureMarginModel.cs
@@ -86,7 +86,7 @@ namespace QuantConnect.Securities.CryptoFuture
         protected override decimal GetMarginRemaining(SecurityPortfolioManager portfolio, Security security, OrderDirection direction)
         {
             var collateralCurrency = GetCollateralCash(security);
-            var totalCollateralCurrency = collateralCurrency.Amount;
+            var totalCollateralCurrency = GetTotalCollateralAmount(portfolio, security, collateralCurrency);
             var result = totalCollateralCurrency;
 
             foreach (var kvp in portfolio.Where(holdings => holdings.Value.Invested && holdings.Value.Type == SecurityType.CryptoFuture && holdings.Value.Symbol != security.Symbol))
@@ -142,7 +142,7 @@ namespace QuantConnect.Securities.CryptoFuture
         /// <summary>
         /// Helper method to determine what's the collateral currency for the given crypto future
         /// </summary>
-        private static Cash GetCollateralCash(Security security)
+        protected static Cash GetCollateralCash(Security security)
         {
             var cryptoFuture = (CryptoFuture)security;
 
@@ -153,6 +153,20 @@ namespace QuantConnect.Securities.CryptoFuture
             }
 
             return collateralCurrency;
+        }
+
+        /// <summary>
+        /// Gets the total collateral amount for the given crypto future position.
+        /// The base implementation returns only the primary collateral amount.
+        /// Override in subclasses to include supplementary collateral currencies.
+        /// </summary>
+        /// <param name="portfolio">The algorithm's portfolio</param>
+        /// <param name="security">The crypto future security</param>
+        /// <param name="primaryCollateral">The primary collateral cash (e.g. USDT for non-coin futures, BTC for coin futures)</param>
+        /// <returns>Total collateral amount in terms of the primary collateral currency</returns>
+        protected virtual decimal GetTotalCollateralAmount(SecurityPortfolioManager portfolio, Security security, Cash primaryCollateral)
+        {
+            return primaryCollateral.Amount;
         }
     }
 }

--- a/Tests/Common/Securities/CryptoFuture/CryptoFutureMarginModelTests.cs
+++ b/Tests/Common/Securities/CryptoFuture/CryptoFutureMarginModelTests.cs
@@ -116,7 +116,7 @@ namespace QuantConnect.Tests.Common.Securities.CryptoFuture
             var buyingPower = cryptoFuture.BuyingPowerModel.GetBuyingPower(
                 new BuyingPowerParameters(algo.Portfolio, cryptoFuture, OrderDirection.Buy));
 
-            Assert.AreEqual(100m + algoCash, buyingPower.Value);
+            Assert.AreEqual(100m, buyingPower.Value);
         }
 
         [Test]
@@ -134,6 +134,44 @@ namespace QuantConnect.Tests.Common.Securities.CryptoFuture
 
             // Only BTC collateral counts (0 BTC), BNFCR is irrelevant for coin futures
             Assert.AreEqual(0, buyingPower.Value);
+        }
+
+        [Test]
+        public void BnfcrZeroBalanceIncludesSupplementaryCollateral()
+        {
+            var algo = GetBinanceFuturesAlgorithm();
+            var algoCash = algo.Portfolio.Cash;
+            var cryptoFuture = algo.AddCryptoFuture("BTCUSDT");
+            SetPrice(cryptoFuture, 16000);
+
+            // EU user: BNFCR present with zero balance, USDC is the real collateral
+            algo.SetCash("BNFCR", 0, 1);
+            algo.SetCash("USDC", 100, 1);
+
+            var buyingPower = cryptoFuture.BuyingPowerModel.GetBuyingPower(
+                new BuyingPowerParameters(algo.Portfolio, cryptoFuture, OrderDirection.Buy));
+
+            // BNFCR presence triggers supplementary collateral — USDC should be included
+            Assert.AreEqual(100m + algoCash, buyingPower.Value);
+        }
+
+        [Test]
+        public void BtcCollateralConvertedToQuoteCurrency()
+        {
+            var algo = GetBinanceFuturesAlgorithm();
+            var algoCash = algo.Portfolio.Cash;
+            var cryptoFuture = algo.AddCryptoFuture("BTCUSDC");
+            SetPrice(cryptoFuture, 16000);
+
+            // EU user: BNFCR present, 0.5 BTC as collateral @ $16,000
+            algo.SetCash("BNFCR", 0, 1);
+            algo.SetCash("BTC", 0.5m, 16000);
+
+            var buyingPower = cryptoFuture.BuyingPowerModel.GetBuyingPower(
+                new BuyingPowerParameters(algo.Portfolio, cryptoFuture, OrderDirection.Buy));
+
+            // 0 (USDC) + 0.5 * 16000 (BTC → USDC via USD) = 8000
+            Assert.AreEqual(8000m + algoCash, buyingPower.Value);
         }
 
         [Test]

--- a/Tests/Common/Securities/CryptoFuture/CryptoFutureMarginModelTests.cs
+++ b/Tests/Common/Securities/CryptoFuture/CryptoFutureMarginModelTests.cs
@@ -175,6 +175,40 @@ namespace QuantConnect.Tests.Common.Securities.CryptoFuture
         }
 
         [Test]
+        public void SharedCollateralDeductsMaintenanceMarginAcrossQuoteCurrencies()
+        {
+            var algo = GetBinanceFuturesAlgorithm();
+            var algoCash = algo.Portfolio.Cash;
+
+            // Two USDⓈ-M futures with DIFFERENT quote currencies
+            var btcUsdt = algo.AddCryptoFuture("BTCUSDT");
+            var ethUsdc = algo.AddCryptoFuture("ETHUSDC");
+            SetPrice(btcUsdt, 16000);
+            SetPrice(ethUsdc, 1600);
+
+            // EU user: BNFCR present — all USDⓈ-M futures share collateral pool
+            algo.SetCash("BNFCR", 10000, 1);
+
+            // Simulate an existing ETHUSDC position (10 ETH @ $1,600)
+            ethUsdc.Holdings.SetHoldings(1600, 10);
+
+            // ETHUSDC maintenance margin = (10 * 1 * 1600) / 25 * 1 = 640
+            var ethMaintenanceMargin = ethUsdc.BuyingPowerModel.GetMaintenanceMargin(
+                MaintenanceMarginParameters.ForCurrentHoldings(ethUsdc));
+
+            Assert.AreEqual(640m, ethMaintenanceMargin.Value);
+
+            // Buying power for BTCUSDT should deduct ETHUSDC's maintenance margin
+            var buyingPower = btcUsdt.BuyingPowerModel.GetBuyingPower(
+                new BuyingPowerParameters(algo.Portfolio, btcUsdt, OrderDirection.Buy));
+
+            // Expected: (10000 BNFCR + algoCash) - 640 maintenance margin
+            var expectedBuyingPower = 10000m + algoCash - ethMaintenanceMargin.Value;
+            Assert.AreEqual(expectedBuyingPower, buyingPower.Value,
+                "ETHUSDC maintenance margin should be deducted from BTCUSDT buying power when sharing EU collateral pool");
+        }
+
+        [Test]
         public void DefaultMarginModelDoesNotIncludeSupplementaryCollateral()
         {
             var algo = GetAlgorithm();

--- a/Tests/Common/Securities/CryptoFuture/CryptoFutureMarginModelTests.cs
+++ b/Tests/Common/Securities/CryptoFuture/CryptoFutureMarginModelTests.cs
@@ -17,8 +17,10 @@ using System;
 using NUnit.Framework;
 using QuantConnect.Algorithm;
 using QuantConnect.Data.Market;
+using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Securities.CryptoFuture;
+using QuantConnect.Brokerages;
 using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Common.Securities.CryptoFuture
@@ -53,7 +55,7 @@ namespace QuantConnect.Tests.Common.Securities.CryptoFuture
             if (ticker == "BTCUSD")
             {
                 // ((quantity * contract mutiplier * price) / leverage) * conversion rate (BTC -> USD)
-                marginRequirement = ((parameters.Quantity * 100m * cryptoFuture.Price) / 25m ) *  1 / cryptoFuture.Price;
+                marginRequirement = ((parameters.Quantity * 100m * cryptoFuture.Price) / 25m) * 1 / cryptoFuture.Price;
             }
             else
             {
@@ -64,6 +66,92 @@ namespace QuantConnect.Tests.Common.Securities.CryptoFuture
             Assert.AreEqual(Math.Abs(marginRequirement), result.Value);
         }
 
+        [Test]
+        public void MarginRemainingWithBnfcrOnlyCollateral()
+        {
+            var algo = GetBinanceFuturesAlgorithm();
+            var algoCash = algo.Portfolio.Cash;
+            var cryptoFuture = algo.AddCryptoFuture("BTCUSDT");
+            SetPrice(cryptoFuture, 16000);
+
+            // EU Binance user: only BNFCR, no USDT
+            algo.SetCash("BNFCR", 100, 1);
+
+            var buyingPower = cryptoFuture.BuyingPowerModel.GetBuyingPower(
+                new BuyingPowerParameters(algo.Portfolio, cryptoFuture, OrderDirection.Buy));
+
+            Assert.Greater(buyingPower.Value, 0);
+            Assert.AreEqual(100m + algoCash, buyingPower.Value);
+        }
+
+        [Test]
+        public void MarginRemainingWithMixedCollateral()
+        {
+            var algo = GetBinanceFuturesAlgorithm();
+            var algoCash = algo.Portfolio.Cash;
+            var cryptoFuture = algo.AddCryptoFuture("BTCUSDT");
+            SetPrice(cryptoFuture, 16000);
+
+            // Mixed: 50 USDT + 50 BNFCR
+            algo.SetCash("USDT", 50, 1);
+            algo.SetCash("BNFCR", 50, 1);
+
+            var buyingPower = cryptoFuture.BuyingPowerModel.GetBuyingPower(
+                new BuyingPowerParameters(algo.Portfolio, cryptoFuture, OrderDirection.Buy));
+
+            Assert.AreEqual(100m + algoCash, buyingPower.Value);
+        }
+
+        [Test]
+        public void MarginRemainingWithUsdtOnlyCollateral()
+        {
+            var algo = GetBinanceFuturesAlgorithm();
+            var algoCash = algo.Portfolio.Cash;
+            var cryptoFuture = algo.AddCryptoFuture("BTCUSDT");
+            SetPrice(cryptoFuture, 16000);
+
+            // Standard user: only USDT (backward compatibility)
+            algo.SetCash("USDT", 100, 1);
+
+            var buyingPower = cryptoFuture.BuyingPowerModel.GetBuyingPower(
+                new BuyingPowerParameters(algo.Portfolio, cryptoFuture, OrderDirection.Buy));
+
+            Assert.AreEqual(100m + algoCash, buyingPower.Value);
+        }
+
+        [Test]
+        public void CoinFutureDoesNotIncludeBnfcrAsCollateral()
+        {
+            var algo = GetBinanceFuturesAlgorithm();
+            var cryptoFuture = algo.AddCryptoFuture("BTCUSD");
+            SetPrice(cryptoFuture, 16000);
+
+            // Coin future: BTC is collateral, BNFCR should NOT be included
+            algo.SetCash("BNFCR", 100, 1);
+
+            var buyingPower = cryptoFuture.BuyingPowerModel.GetBuyingPower(
+                new BuyingPowerParameters(algo.Portfolio, cryptoFuture, OrderDirection.Buy));
+
+            // Only BTC collateral counts (0 BTC), BNFCR is irrelevant for coin futures
+            Assert.AreEqual(0, buyingPower.Value);
+        }
+
+        [Test]
+        public void DefaultMarginModelDoesNotIncludeSupplementaryCollateral()
+        {
+            var algo = GetAlgorithm();
+            var cryptoFuture = algo.AddCryptoFuture("BTCUSDT");
+            SetPrice(cryptoFuture, 16000);
+
+            // Default model should NOT include BNFCR as collateral
+            algo.SetCash("BNFCR", 100, 1);
+
+            var buyingPower = cryptoFuture.BuyingPowerModel.GetBuyingPower(
+                new BuyingPowerParameters(algo.Portfolio, cryptoFuture, OrderDirection.Buy));
+
+            Assert.AreEqual(0, buyingPower.Value);
+        }
+
         private static QCAlgorithm GetAlgorithm()
         {
             // Initialize algorithm
@@ -72,9 +160,17 @@ namespace QuantConnect.Tests.Common.Securities.CryptoFuture
             return algo;
         }
 
+        private static QCAlgorithm GetBinanceFuturesAlgorithm()
+        {
+            var algo = new AlgorithmStub();
+            algo.SetBrokerageModel(BrokerageName.BinanceFutures, AccountType.Margin);
+            algo.SetFinishedWarmingUp();
+            return algo;
+        }
+
         private static void SetPrice(Security security, decimal price)
         {
-            var cryptoFuture = (QuantConnect.Securities.CryptoFuture.CryptoFuture) security;
+            var cryptoFuture = (QuantConnect.Securities.CryptoFuture.CryptoFuture)security;
             cryptoFuture.BaseCurrency.ConversionRate = price;
             cryptoFuture.QuoteCurrency.ConversionRate = 1;
 

--- a/Tests/Common/Securities/CryptoFuture/CryptoFutureMarginModelTests.cs
+++ b/Tests/Common/Securities/CryptoFuture/CryptoFutureMarginModelTests.cs
@@ -120,23 +120,6 @@ namespace QuantConnect.Tests.Common.Securities.CryptoFuture
         }
 
         [Test]
-        public void CoinFutureDoesNotIncludeBnfcrAsCollateral()
-        {
-            var algo = GetBinanceFuturesAlgorithm();
-            var cryptoFuture = algo.AddCryptoFuture("BTCUSD");
-            SetPrice(cryptoFuture, 16000);
-
-            // Coin future: BTC is collateral, BNFCR should NOT be included
-            algo.SetCash("BNFCR", 100, 1);
-
-            var buyingPower = cryptoFuture.BuyingPowerModel.GetBuyingPower(
-                new BuyingPowerParameters(algo.Portfolio, cryptoFuture, OrderDirection.Buy));
-
-            // Only BTC collateral counts (0 BTC), BNFCR is irrelevant for coin futures
-            Assert.AreEqual(0, buyingPower.Value);
-        }
-
-        [Test]
         public void BnfcrZeroBalanceIncludesSupplementaryCollateral()
         {
             var algo = GetBinanceFuturesAlgorithm();


### PR DESCRIPTION
 #### Description
  Add `BinanceCryptoFutureMarginModel` that aggregates all supplementary collateral assets for USDⓈ-M futures when BNFCR is present (EU/EEA MiCA Credits Trading Mode). BNFCR presence in CashBook gates the collateral loop - non-EU accounts skip entirely. All non-zero `walletBalance` assets are summed as collateral (Binance specifies `marginAvailable: true` for each eligible asset in the API response).

 #### Related PR(s)

 - QuantConnect/Lean.Brokerages.Binance#74 - preserve BNFCR in zero-balance filter, emit MiCA warning

 #### Related Issue

 Fixes #9339

 #### Motivation and Context

 EU/EEA Binance Futures users under MiCA Credits Trading Mode use BNFCR as the cross-margin
 accounting currency. `GetMarginRemaining()` only checked the quote currency (e.g. USDT),
 returning zero buying power for EU users. Binance aggregates all collateral into BNFCR
 (from the MiCA FAQ: `1,000 USDC + 0.3 BTC×$60k + 12 BNB×$600 = 26,200 BNFCR`).

 All 12 asset types in the EU account API response have `marginAvailable: true` -
 including stablecoins (USDC, FDUSD, USD1), crypto (BTC, ETH, BNB, U), and internal
 products (BNFCR, LDUSDT, BFUSD, RWUSD). Binance adds new collateral types regularly,
 so a hardcoded list would be outdated quickly. Instead we iterate CashBook and sum all
 non-zero, non-primary collateral when BNFCR is present.

 > [MiCA FAQ](https://www.binance.com/en/support/faq/detail/0e857c392a2d47cebde0af762d9255ae)

 #### Requires Documentation Change

 No

 #### How Has This Been Tested?

 Unit tests (`CryptoFutureMarginModelTests`):
 - `MarginRemainingWithBnfcrOnlyCollateral` - BNFCR as sole collateral
 - `MarginRemainingWithMixedCollateral` - USDT + BNFCR
 - `MarginRemainingWithUsdtOnlyCollateral` - non-EU backward compatibility
 - `CoinFutureDoesNotIncludeBnfcrAsCollateral` - coin futures skip BNFCR
 - `BnfcrZeroBalanceIncludesSupplementaryCollateral` - BNFCR=0, USDC=100
 - `BtcCollateralConvertedToQuoteCurrency` - BTC collateral converted via market price
 - `DefaultMarginModelDoesNotIncludeSupplementaryCollateral` - non-Binance brokerage

 Regression algorithm: `BinanceCryptoFutureBnfcrCollateralRegressionAlgorithm`

 Live tested with Binance EU account (Credits Trading Mode, `multiAssetsMargin: true`).

 #### Types of changes
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] Refactor (non-breaking change which improves implementation)
 - [ ] Performance (non-breaking change which improves performance)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] Non-functional change (xml comments/documentation/etc)

 #### Checklist:
 - [x] My code follows the code style of this project.
 - [x] I have read the **CONTRIBUTING** document.
 - [x] I have added tests to cover my changes.
 - [x] All new and existing tests passed.
 - [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`