### PR TITLE
Fix DataManager creating invalid data type subscriptions

### DIFF
--- a/Algorithm.CSharp/AuxiliaryDataHandlersRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AuxiliaryDataHandlersRegressionAlgorithm.cs
@@ -119,7 +119,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 17270;
+        public long DataPoints => 15347;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/EquityOptionsUniverseSettingsRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/EquityOptionsUniverseSettingsRegressionAlgorithm.cs
@@ -103,7 +103,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public virtual long DataPoints => 4276;
+        public virtual long DataPoints => 4275;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/FundamentalRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FundamentalRegressionAlgorithm.cs
@@ -222,7 +222,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 70972;
+        public long DataPoints => 70954;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -266,7 +266,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Lowest Capacity Asset", "IBM R735QTJ8XC9X"},
             {"Portfolio Turnover", "0.45%"},
             {"Drawdown Recovery", "4"},
-            {"OrderListHash", "63a37fcfe86bca2e037d9dbb9c531e43"}
+            {"OrderListHash", "6870238e07de15cc14e0116c5094e535"}
         };
     }
 }

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -584,7 +584,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
                 else
                 {
-                    dataTypes = LookupSubscriptionConfigDataTypes(symbol.SecurityType, resolution ?? Resolution.Minute, symbol.IsCanonical());
+                    dataTypes = LookupSubscriptionConfigDataTypes(symbol.SecurityType, resolution ?? _algorithm.UniverseSettings.Resolution, symbol.IsCanonical());
                 }
             }
 
@@ -594,7 +594,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
 
             var resolutionWasProvided = resolution.HasValue;
-            var validDataTypes = new List<Tuple<Type, TickType>>();
             foreach (var typeTuple in dataTypes)
             {
                 var baseInstance = typeTuple.Item1.GetBaseDataInstance();
@@ -614,11 +613,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                                     $"The data type default resolution '{defaultResolution}' will be used instead");
                                 _unsupportedUniverseSettingsResolutionWarningSent = true;
                             }
-                        }
-                        else if (!_liveMode && !LeanData.IsValidConfiguration(symbol.SecurityType, res, typeTuple.Item2))
-                        {
-                            // skip data types not valid for this security type/resolution combination in backtesting
-                            continue;
                         }
                         else
                         {
@@ -651,9 +645,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         }
                     }
                 }
-                validDataTypes.Add(typeTuple);
             }
-            dataTypes = validDataTypes;
             var marketHoursDbEntry = _marketHoursDatabase.GetEntry(symbol, dataTypes.Select(tuple => tuple.Item1));
 
             var exchangeHours = marketHoursDbEntry.ExchangeHours;

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -575,7 +575,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             )
         {
             var dataTypes = subscriptionDataTypes;
-            if(dataTypes == null)
+            if (dataTypes == null)
             {
                 if (symbol.SecurityType == SecurityType.Base && SecurityIdentifier.TryGetCustomDataTypeInstance(symbol.ID.Symbol, out var type))
                 {
@@ -594,6 +594,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
 
             var resolutionWasProvided = resolution.HasValue;
+            var validDataTypes = new List<Tuple<Type, TickType>>();
             foreach (var typeTuple in dataTypes)
             {
                 var baseInstance = typeTuple.Item1.GetBaseDataInstance();
@@ -613,6 +614,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                                     $"The data type default resolution '{defaultResolution}' will be used instead");
                                 _unsupportedUniverseSettingsResolutionWarningSent = true;
                             }
+                        }
+                        else if (!_liveMode && !LeanData.IsValidConfiguration(symbol.SecurityType, res, typeTuple.Item2))
+                        {
+                            // skip data types not valid for this security type/resolution combination in backtesting
+                            continue;
                         }
                         else
                         {
@@ -637,17 +643,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     if (!_liveMode)
                     {
                         var supportedResolutions = baseInstance.SupportedResolutions();
-                        if (supportedResolutions.Contains(resolution.Value))
+                        if (!supportedResolutions.Contains(resolution.Value))
                         {
-                            continue;
+                            throw new ArgumentException($"Sorry {resolution.ToStringInvariant()} is not a supported resolution for {typeTuple.Item1.Name}" +
+                                                        $" and SecurityType.{symbol.SecurityType.ToStringInvariant()}." +
+                                                        $" Please change your AddData to use one of the supported resolutions ({string.Join(",", supportedResolutions)}).");
                         }
-
-                        throw new ArgumentException($"Sorry {resolution.ToStringInvariant()} is not a supported resolution for {typeTuple.Item1.Name}" +
-                                                    $" and SecurityType.{symbol.SecurityType.ToStringInvariant()}." +
-                                                    $" Please change your AddData to use one of the supported resolutions ({string.Join(",", supportedResolutions)}).");
                     }
                 }
+                validDataTypes.Add(typeTuple);
             }
+            dataTypes = validDataTypes;
             var marketHoursDbEntry = _marketHoursDatabase.GetEntry(symbol, dataTypes.Select(tuple => tuple.Item1));
 
             var exchangeHours = marketHoursDbEntry.ExchangeHours;
@@ -670,24 +676,24 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
 
             var result = (from subscriptionDataType in dataTypes
-                let dataType = subscriptionDataType.Item1
-                let tickType = subscriptionDataType.Item2
-                select new SubscriptionDataConfig(
-                    dataType,
-                    symbol,
-                    resolution.Value,
-                    marketHoursDbEntry.DataTimeZone,
-                    exchangeHours.TimeZone,
-                    fillForward,
-                    extendedMarketHours,
-                    // if the subscription data types were not provided and the tick type is OpenInterest we make it internal
-                    subscriptionDataTypes == null && tickType == TickType.OpenInterest || isInternalFeed,
-                    isCustomData,
-                    isFilteredSubscription: isFilteredSubscription,
-                    tickType: tickType,
-                    dataNormalizationMode: dataNormalizationMode,
-                    dataMappingMode: dataMappingMode,
-                    contractDepthOffset: contractDepthOffset)).ToList();
+                          let dataType = subscriptionDataType.Item1
+                          let tickType = subscriptionDataType.Item2
+                          select new SubscriptionDataConfig(
+                              dataType,
+                              symbol,
+                              resolution.Value,
+                              marketHoursDbEntry.DataTimeZone,
+                              exchangeHours.TimeZone,
+                              fillForward,
+                              extendedMarketHours,
+                              // if the subscription data types were not provided and the tick type is OpenInterest we make it internal
+                              subscriptionDataTypes == null && tickType == TickType.OpenInterest || isInternalFeed,
+                              isCustomData,
+                              isFilteredSubscription: isFilteredSubscription,
+                              tickType: tickType,
+                              dataNormalizationMode: dataNormalizationMode,
+                              dataMappingMode: dataMappingMode,
+                              contractDepthOffset: contractDepthOffset)).ToList();
 
             for (int i = 0; i < result.Count; i++)
             {
@@ -730,7 +736,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             var result = availableDataType
                 .Select(tickType => new Tuple<Type, TickType>(LeanData.GetDataType(resolution, tickType), tickType)).ToList();
 
-            if(symbolSecurityType == SecurityType.CryptoFuture)
+            if (symbolSecurityType == SecurityType.CryptoFuture)
             {
                 result.Add(new Tuple<Type, TickType>(typeof(MarginInterestRate), TickType.Quote));
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
When UniverseSettings.Resolution is Daily, DataManager.Add() was creating invalid QuoteBar/Daily/Equity subscriptions, causing log spam from QuoteBar.Reader() trying to parse TradeBar files as QuoteBar format

#### Motivation and Context
Prevent log spam in CI caused by `QuoteBar.Reader()`

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
