### PR TITLE
feat: add optional adanos market sentiment custom data example

### DIFF
--- a/Algorithm.Python/AdanosMarketSentimentAlgorithm.py
+++ b/Algorithm.Python/AdanosMarketSentimentAlgorithm.py
@@ -18,7 +18,8 @@ from AlgorithmImports import *
 ### <summary>
 ### Demonstrates consuming optional Adanos market sentiment snapshots as custom equity data.
 ### This example is intended for live or research workflows that query current structured sentiment
-### from Adanos. Historical backtests should first persist daily snapshots to a local file or ObjectStore.
+### from Adanos. Historical backtests should first persist daily snapshots to a local file or ObjectStore
+### to avoid look-ahead bias from querying a current REST endpoint.
 ### Parameters:
 ### - adanos-api-key: required to enable requests
 ### - adanos-source: one of news, reddit, x, polymarket
@@ -34,6 +35,11 @@ class AdanosMarketSentimentAlgorithm(QCAlgorithm):
         self.set_start_date(2024, 1, 1)
         self.set_end_date(2024, 1, 31)
         self.set_cash(100000)
+
+        if not self.live_mode:
+            self.debug("This example is intended for live or research use with current Adanos snapshots.")
+            self.quit()
+            return
 
         api_key = self.get_parameter("adanos-api-key")
         if not api_key:

--- a/Algorithm.Python/AdanosMarketSentimentAlgorithm.py
+++ b/Algorithm.Python/AdanosMarketSentimentAlgorithm.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 import json
+from typing import cast
 
 from AlgorithmImports import *
 
@@ -58,10 +59,10 @@ class AdanosMarketSentimentAlgorithm(QCAlgorithm):
         if not data.contains_key(self._sentiment_symbol):
             return
 
-        sentiment = data[self._sentiment_symbol]
+        sentiment = cast(AdanosSentiment, data[self._sentiment_symbol])
         buzz_score = float(sentiment.value)
-        bullish_percent = float(sentiment["BullishPercent"])
-        sentiment_score = float(sentiment["SentimentScore"])
+        bullish_percent = float(sentiment.bullish_percent)
+        sentiment_score = float(sentiment.sentiment_score)
 
         self.set_runtime_statistic("Adanos Buzz", f"{buzz_score:.1f}")
         self.set_runtime_statistic("Adanos Bullish %", f"{bullish_percent:.0f}")
@@ -77,6 +78,12 @@ class AdanosSentiment(PythonData):
     _lookback_days = 30
     _source_name = "news"
     _supported_sources = {"news", "reddit", "x", "polymarket"}
+    bullish_percent: int
+    sentiment_score: float
+    activity_count: int
+    coverage_count: int
+    trend: str
+    ticker: str
 
     @classmethod
     def configure(cls, api_key: str, source_name: str = "news", lookback_days: int = 30) -> None:
@@ -112,13 +119,19 @@ class AdanosSentiment(PythonData):
         point.time = self._extract_time(payload.get("daily_trend"), date)
         point.end_time = point.time + timedelta(days=1)
         point.value = float(payload.get("buzz_score") or 0.0)
+        point.sentiment_score = float(payload.get("sentiment_score") or 0.0)
+        point.bullish_percent = int(payload.get("bullish_pct") or 0)
+        point.activity_count = self._activity_count(payload)
+        point.coverage_count = self._coverage_count(payload)
+        point.trend = payload.get("trend") or "unknown"
+        point.ticker = payload.get("ticker") or self._resolve_ticker(config.symbol)
         point["BuzzScore"] = float(payload.get("buzz_score") or 0.0)
-        point["SentimentScore"] = float(payload.get("sentiment_score") or 0.0)
-        point["BullishPercent"] = int(payload.get("bullish_pct") or 0)
-        point["ActivityCount"] = self._activity_count(payload)
-        point["CoverageCount"] = self._coverage_count(payload)
-        point["Trend"] = payload.get("trend") or "unknown"
-        point["Ticker"] = payload.get("ticker") or self._resolve_ticker(config.symbol)
+        point["SentimentScore"] = point.sentiment_score
+        point["BullishPercent"] = point.bullish_percent
+        point["ActivityCount"] = point.activity_count
+        point["CoverageCount"] = point.coverage_count
+        point["Trend"] = point.trend
+        point["Ticker"] = point.ticker
         return point
 
     @staticmethod

--- a/Algorithm.Python/AdanosMarketSentimentAlgorithm.py
+++ b/Algorithm.Python/AdanosMarketSentimentAlgorithm.py
@@ -1,0 +1,149 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from AlgorithmImports import *
+
+### <summary>
+### Demonstrates consuming optional Adanos market sentiment snapshots as custom equity data.
+### This example is intended for live or research workflows that query current structured sentiment
+### from Adanos. Historical backtests should first persist daily snapshots to a local file or ObjectStore.
+### Parameters:
+### - adanos-api-key: required to enable requests
+### - adanos-source: one of news, reddit, x, polymarket
+### - adanos-lookback-days: lookback window for the stock sentiment endpoint
+### </summary>
+### <meta name="tag" content="using data" />
+### <meta name="tag" content="custom data" />
+### <meta name="tag" content="alternative data" />
+### <meta name="tag" content="sentiment" />
+class AdanosMarketSentimentAlgorithm(QCAlgorithm):
+
+    def initialize(self) -> None:
+        self.set_start_date(2024, 1, 1)
+        self.set_end_date(2024, 1, 31)
+        self.set_cash(100000)
+
+        api_key = self.get_parameter("adanos-api-key")
+        if not api_key:
+            self.debug("Set the 'adanos-api-key' parameter to enable this optional custom data example.")
+            self.quit()
+            return
+
+        source_name = self.get_parameter("adanos-source", "news")
+        lookback_days = int(self.get_parameter("adanos-lookback-days", 30))
+        AdanosSentiment.configure(api_key, source_name, lookback_days)
+
+        self._equity_symbol = self.add_equity("AAPL", Resolution.DAILY).symbol
+        self._sentiment_symbol = self.add_data(AdanosSentiment, self._equity_symbol, Resolution.DAILY).symbol
+
+    def on_data(self, data: Slice) -> None:
+        if not data.contains_key(self._sentiment_symbol):
+            return
+
+        sentiment = data[self._sentiment_symbol]
+        buzz_score = float(sentiment.value)
+        bullish_percent = float(sentiment["BullishPercent"])
+        sentiment_score = float(sentiment["SentimentScore"])
+
+        self.set_runtime_statistic("Adanos Buzz", f"{buzz_score:.1f}")
+        self.set_runtime_statistic("Adanos Bullish %", f"{bullish_percent:.0f}")
+
+        if not self.portfolio.invested and buzz_score >= 60 and bullish_percent >= 55 and sentiment_score > 0:
+            self.set_holdings(self._equity_symbol, 1)
+        elif self.portfolio.invested and (buzz_score < 40 or sentiment_score < 0):
+            self.liquidate(self._equity_symbol)
+
+
+class AdanosSentiment(PythonData):
+    _api_key = None
+    _lookback_days = 30
+    _source_name = "news"
+    _supported_sources = {"news", "reddit", "x", "polymarket"}
+
+    @classmethod
+    def configure(cls, api_key: str, source_name: str = "news", lookback_days: int = 30) -> None:
+        cls._api_key = api_key
+        normalized_source = (source_name or "news").lower()
+        cls._source_name = normalized_source if normalized_source in cls._supported_sources else "news"
+        cls._lookback_days = max(1, int(lookback_days))
+
+    def get_source(self, config: SubscriptionDataConfig, date: datetime, is_live_mode: bool) -> SubscriptionDataSource:
+        ticker = self._resolve_ticker(config.symbol)
+        url = (
+            f"https://api.adanos.org/{self._source_name}/stocks/v1/stock/"
+            f"{ticker}?days={self._lookback_days}"
+        )
+        headers = {"X-API-Key": self._api_key}
+        return SubscriptionDataSource(url, SubscriptionTransportMedium.REST, FileFormat.CSV, headers)
+
+    def reader(self, config: SubscriptionDataConfig, line: str, date: datetime, is_live_mode: bool) -> BaseData:
+        if not line:
+            return None
+
+        try:
+            payload = json.loads(line)
+        except ValueError:
+            return None
+
+        if not payload.get("found"):
+            return None
+
+        point = AdanosSentiment()
+        point.symbol = config.symbol
+
+        point.time = self._extract_time(payload.get("daily_trend"), date)
+        point.end_time = point.time + timedelta(days=1)
+        point.value = float(payload.get("buzz_score") or 0.0)
+        point["BuzzScore"] = float(payload.get("buzz_score") or 0.0)
+        point["SentimentScore"] = float(payload.get("sentiment_score") or 0.0)
+        point["BullishPercent"] = int(payload.get("bullish_pct") or 0)
+        point["ActivityCount"] = self._activity_count(payload)
+        point["CoverageCount"] = self._coverage_count(payload)
+        point["Trend"] = payload.get("trend") or "unknown"
+        point["Ticker"] = payload.get("ticker") or self._resolve_ticker(config.symbol)
+        return point
+
+    @staticmethod
+    def _resolve_ticker(symbol: Symbol) -> str:
+        if getattr(symbol, "has_underlying", False) and symbol.underlying is not None:
+            return symbol.underlying.value.upper()
+        return symbol.value.upper()
+
+    @staticmethod
+    def _extract_time(daily_trend, fallback: datetime) -> datetime:
+        if daily_trend:
+            first = daily_trend[0]
+            date_str = first.get("date")
+            if date_str:
+                return datetime.strptime(date_str, "%Y-%m-%d")
+        return fallback
+
+    @staticmethod
+    def _activity_count(payload: dict) -> int:
+        return int(
+            payload.get("mentions")
+            or payload.get("trade_count")
+            or payload.get("unique_tweets")
+            or 0
+        )
+
+    @staticmethod
+    def _coverage_count(payload: dict) -> int:
+        return int(
+            payload.get("source_count")
+            or payload.get("subreddit_count")
+            or payload.get("market_count")
+            or 0
+        )

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -171,6 +171,7 @@
     <None Include="BasicTemplateOptionsHistoryAlgorithm.py" />
     <None Include="BasicTemplateOptionStrategyAlgorithm.py" />
     <None Include="BasicTemplateOptionTradesAlgorithm.py" />
+    <None Include="AdanosMarketSentimentAlgorithm.py" />
     <None Include="BrokerageModelAlgorithm.py" />
     <None Include="BubbleAlgorithm.py" />
     <None Include="build.sh">

--- a/Tests/Python/PythonDataTests.cs
+++ b/Tests/Python/PythonDataTests.cs
@@ -281,6 +281,46 @@ class CustomDataClass(PythonDataTests.TestPythonData):
             }
         }
 
+        [Test]
+        public void AdanosSentimentFallsBackToNewsForUnsupportedSource()
+        {
+            using (Py.GIL())
+            {
+                dynamic module = LoadModuleFromFile("AdanosMarketSentimentAlgorithm");
+                dynamic adanosSentimentType = module.GetAttr("AdanosSentiment");
+                adanosSentimentType.configure("test-api-key", "unsupported", 7);
+
+                var data = new PythonData(adanosSentimentType());
+                var type = Extensions.CreateType(adanosSentimentType);
+                var config = new SubscriptionDataConfig(type, Symbols.AAPL, Resolution.Daily, DateTimeZone.Utc,
+                    DateTimeZone.Utc, false, false, false, isCustom: true);
+
+                var source = data.GetSource(config, new DateTime(2026, 4, 9), false);
+
+                Assert.AreEqual("https://api.adanos.org/news/stocks/v1/stock/AAPL?days=7", source.Source);
+            }
+        }
+
+        [Test]
+        public void AdanosSentimentReaderReturnsNullWhenTickerIsNotFound()
+        {
+            using (Py.GIL())
+            {
+                dynamic module = LoadModuleFromFile("AdanosMarketSentimentAlgorithm");
+                dynamic adanosSentimentType = module.GetAttr("AdanosSentiment");
+                adanosSentimentType.configure("test-api-key", "news", 30);
+
+                var data = new PythonData(adanosSentimentType());
+                var type = Extensions.CreateType(adanosSentimentType);
+                var config = new SubscriptionDataConfig(type, Symbols.AAPL, Resolution.Daily, DateTimeZone.Utc,
+                    DateTimeZone.Utc, false, false, false, isCustom: true);
+
+                var result = data.Reader(config, "{\"ticker\":\"AAPL\",\"found\":false}", new DateTime(2026, 4, 9), false);
+
+                Assert.IsNull(result);
+            }
+        }
+
         private static BaseData GetDataFromModule(dynamic testModule)
         {
             var type = Extensions.CreateType(testModule.GetAttr("CustomDataTest"));

--- a/Tests/Python/PythonDataTests.cs
+++ b/Tests/Python/PythonDataTests.cs
@@ -14,6 +14,8 @@
 */
 
 using System;
+using System.IO;
+using System.Linq;
 using NodaTime;
 using Python.Runtime;
 using NUnit.Framework;
@@ -225,6 +227,60 @@ class CustomDataClass(PythonDataTests.TestPythonData):
             }
         }
 
+        [Test]
+        public void AdanosSentimentGetSourceIncludesApiKeyHeader()
+        {
+            using (Py.GIL())
+            {
+                dynamic module = LoadModuleFromFile("AdanosMarketSentimentAlgorithm");
+                dynamic adanosSentimentType = module.GetAttr("AdanosSentiment");
+                adanosSentimentType.configure("test-api-key", "news", 14);
+
+                var data = new PythonData(adanosSentimentType());
+                var type = Extensions.CreateType(adanosSentimentType);
+                var config = new SubscriptionDataConfig(type, Symbols.AAPL, Resolution.Daily, DateTimeZone.Utc,
+                    DateTimeZone.Utc, false, false, false, isCustom: true);
+
+                var source = data.GetSource(config, new DateTime(2026, 4, 9), false);
+
+                Assert.AreEqual(SubscriptionTransportMedium.Rest, source.TransportMedium);
+                Assert.AreEqual("https://api.adanos.org/news/stocks/v1/stock/AAPL?days=14", source.Source);
+                Assert.IsTrue(source.Headers.Any(entry => entry.Key == "X-API-Key" && entry.Value == "test-api-key"));
+            }
+        }
+
+        [Test]
+        public void AdanosSentimentReaderParsesStructuredPayload()
+        {
+            using (Py.GIL())
+            {
+                dynamic module = LoadModuleFromFile("AdanosMarketSentimentAlgorithm");
+                dynamic adanosSentimentType = module.GetAttr("AdanosSentiment");
+                adanosSentimentType.configure("test-api-key", "news", 30);
+
+                var data = new PythonData(adanosSentimentType());
+                var type = Extensions.CreateType(adanosSentimentType);
+                var config = new SubscriptionDataConfig(type, Symbols.AAPL, Resolution.Daily, DateTimeZone.Utc,
+                    DateTimeZone.Utc, false, false, false, isCustom: true);
+
+                const string line = "{\"ticker\":\"AAPL\",\"found\":true,\"buzz_score\":67.5,\"mentions\":42," +
+                                    "\"sentiment_score\":0.35,\"bullish_pct\":61,\"source_count\":8,\"trend\":\"rising\"," +
+                                    "\"daily_trend\":[{\"date\":\"2026-04-08\",\"mentions\":12,\"sentiment_score\":0.22}]}";
+
+                var result = (PythonData)data.Reader(config, line, new DateTime(2026, 4, 9), false);
+
+                Assert.NotNull(result);
+                Assert.AreEqual(Symbols.AAPL, result.Symbol);
+                Assert.AreEqual(67.5m, result.Value);
+                Assert.AreEqual(new DateTime(2026, 4, 8), result.Time);
+                Assert.AreEqual(61, Convert.ToInt32(result["BullishPercent"]));
+                Assert.AreEqual(42, Convert.ToInt32(result["ActivityCount"]));
+                Assert.AreEqual(8, Convert.ToInt32(result["CoverageCount"]));
+                Assert.AreEqual("rising", result.GetProperty("Trend"));
+                Assert.AreEqual("AAPL", result.GetProperty("Ticker"));
+            }
+        }
+
         private static BaseData GetDataFromModule(dynamic testModule)
         {
             var type = Extensions.CreateType(testModule.GetAttr("CustomDataTest"));
@@ -232,6 +288,16 @@ class CustomDataClass(PythonDataTests.TestPythonData):
             var config = new SubscriptionDataConfig(type, Symbols.SPY, Resolution.Daily, DateTimeZone.Utc,
                 DateTimeZone.Utc, false, false, false, isCustom: true);
             return customDataTest.Reader(config, "something", DateTime.UtcNow, false);
+        }
+
+        private static dynamic LoadModuleFromFile(string moduleName)
+        {
+            var filePath = Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, $"../../../Algorithm.Python/{moduleName}.py"));
+            dynamic importlibUtil = Py.Import("importlib.util");
+            dynamic spec = importlibUtil.spec_from_file_location(moduleName, filePath);
+            dynamic module = importlibUtil.module_from_spec(spec);
+            spec.loader.exec_module(module);
+            return module;
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR adds an optional Python custom data example for consuming structured Adanos market sentiment snapshots in LEAN.

It includes:
- a new `Algorithm.Python/AdanosMarketSentimentAlgorithm.py` example
- a project entry in `QuantConnect.Algorithm.Python.csproj`
- focused `PythonDataTests` coverage for the new custom data type

## Why

LEAN already has strong support for custom data via `AddData<T>` / `PythonData`, and this change keeps the integration in that example-oriented path rather than introducing a new core data provider.

Adanos is used here as structured alternative data for equities:
- current buzz score
- bullish percentage
- sentiment score
- simple activity / coverage counts

## Design notes

- The example is strictly optional and parameter-driven.
- No requests are made unless `adanos-api-key` is provided.
- The example now exits early outside live mode, because querying a current REST endpoint in a historical backtest would introduce look-ahead bias. The intended historical workflow is to persist daily snapshots first and then replay them from a local file or ObjectStore.
- The core LEAN data feed and provider stack are untouched.

## Parameters

- `adanos-api-key` – required to enable requests
- `adanos-source` – one of `news`, `reddit`, `x`, `polymarket`
- `adanos-lookback-days` – lookback window passed through to the stock sentiment endpoint

## Validation

Added focused tests in `Tests/Python/PythonDataTests.cs` for:
- request header propagation
- structured payload parsing
- unsupported source fallback
- `found=false` null handling
