### PR TITLE
Fix #8474: include Python on_warmup_finished guidance in warmup order error message

### DIFF
--- a/Common/Messages/Messages.Orders.cs
+++ b/Common/Messages/Messages.Orders.cs
@@ -366,7 +366,7 @@ namespace QuantConnect
             public static string WarmingUp(Orders.OrderRequest request)
             {
                 return Invariant($@"This operation is not allowed in Initialize or during warm up: OrderRequest.{
-                    request.OrderRequestType}. Please move this code to the OnWarmupFinished() method.");
+                    request.OrderRequestType}. Please move this code to the OnWarmupFinished() method. In Python, use on_warmup_finished().");
             }
         }
 

--- a/Tests/Common/Orders/OrderTicketTests.cs
+++ b/Tests/Common/Orders/OrderTicketTests.cs
@@ -100,7 +100,7 @@ namespace QuantConnect.Tests.Common.Orders
             Assert.AreEqual(orderRequest.OrderId, ticket.SubmitRequest.OrderId);
             Assert.AreEqual(1000, ticket.SubmitRequest.Quantity);
             Assert.AreEqual("Pepe", ticket.SubmitRequest.Tag);
-            Assert.AreEqual("This operation is not allowed in Initialize or during warm up: OrderRequest.Submit. Please move this code to the OnWarmupFinished() method.", ticket.SubmitRequest.Response.ErrorMessage);
+            Assert.AreEqual("This operation is not allowed in Initialize or during warm up: OrderRequest.Submit. Please move this code to the OnWarmupFinished() method. In Python, use on_warmup_finished().", ticket.SubmitRequest.Response.ErrorMessage);
         }
 
         [TestCase(8, 0, true, Description = "8 AM - valid submission")]


### PR DESCRIPTION
## What
This PR updates the warmup order rejection message to include Python snake_case guidance.

## Why
Issue #8474 reports that Python users see guidance using only C# method naming (OnWarmupFinished()), which is confusing for Python algorithms.

## How
- Updated Messages.OrderResponse.WarmingUp(...) to append Python-specific guidance: In Python, use on_warmup_finished().
- Updated the existing unit test expectation in OrderTicketTests.TestInvalidWarmingUp.

## Files
- Common/Messages/Messages.Orders.cs
- Tests/Common/Orders/OrderTicketTests.cs

Closes #8474