### PR TITLE
Fix #8447: serialize order value with contract multiplier

### DIFF
--- a/Common/Orders/ReadOrdersResponseJsonConverter.cs
+++ b/Common/Orders/ReadOrdersResponseJsonConverter.cs
@@ -18,6 +18,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using QuantConnect.Orders.Serialization;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Orders
 {
@@ -43,6 +44,12 @@ namespace QuantConnect.Orders
             var jObject = JObject.FromObject(orderResponse.Order);
             jObject["symbol"] = JToken.FromObject(orderResponse.Symbol);
             jObject["events"] = JToken.FromObject(orderResponse.Events);
+
+            if (TryGetSerializedOrderValue(orderResponse, out var orderValue))
+            {
+                jObject["value"] = JToken.FromObject(orderValue);
+            }
+
             jObject.WriteTo(writer);
         }
 
@@ -71,6 +78,31 @@ namespace QuantConnect.Orders
             }
 
             return new ApiOrderResponse(order, deserializedEvents ?? new(), deserializedSymbol);
+        }
+
+        private static bool TryGetSerializedOrderValue(ApiOrderResponse orderResponse, out decimal orderValue)
+        {
+            orderValue = 0;
+
+            var order = orderResponse?.Order;
+            var symbol = orderResponse?.Symbol ?? order?.Symbol;
+            if (order == null || symbol == null)
+            {
+                return false;
+            }
+
+            var defaultQuoteCurrency = string.IsNullOrWhiteSpace(order.PriceCurrency)
+                ? Currencies.USD
+                : order.PriceCurrency;
+            var symbolProperties = SymbolPropertiesDatabase.FromDataFolder().GetSymbolProperties(
+                symbol.ID.Market,
+                symbol,
+                symbol.ID.SecurityType,
+                defaultQuoteCurrency
+            );
+
+            orderValue = order.Value * symbolProperties.ContractMultiplier;
+            return true;
         }
     }
 }

--- a/Tests/Common/Orders/ReadOrdersResponseJsonConverterTests.cs
+++ b/Tests/Common/Orders/ReadOrdersResponseJsonConverterTests.cs
@@ -14,6 +14,7 @@
 */
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using QuantConnect.Orders;
 using System;
@@ -123,6 +124,16 @@ namespace QuantConnect.Tests.Common.Orders
             }
             Assert.AreEqual(jsonFormat, serializedOrder);
             Assert.AreEqual(jsonFormat.GetHashCode(), serializedOrder.GetHashCode());
+        }
+
+        [Test]
+        public void SerializesOptionOrderValueUsingContractMultiplier()
+        {
+            var order = JsonConvert.DeserializeObject<ApiOrderResponse>(_camelCaseOptionExercise, _jsonSettings);
+            var serializedOrder = JsonConvert.SerializeObject(order, _jsonSettings);
+            var jObject = JObject.Parse(serializedOrder);
+
+            Assert.AreEqual(138513.986945000m, jObject["value"]?.Value<decimal>());
         }
 
         private const string _camelCaseMarketOrder = @"{
@@ -494,7 +505,7 @@ namespace QuantConnect.Tests.Common.Orders
             },
             ""securityType"": 2,
             ""direction"": 0,
-            ""value"": 1385.139869450,
+            ""value"": 138513.986945000,
             ""orderSubmissionData"": {
                 ""bidPrice"": 138.505714984,
                 ""askPrice"": 138.513986945,
@@ -1111,7 +1122,7 @@ namespace QuantConnect.Tests.Common.Orders
     },
     ""SecurityType"": 2,
     ""Direction"": 0,
-    ""Value"": 1385.139869450,
+    ""Value"": 138513.986945000,
     ""OrderSubmissionData"": {
         ""BidPrice"": 138.505714984,
         ""AskPrice"": 138.513986945,


### PR DESCRIPTION
## What
- Fixes order JSON serialization so alue includes the symbol contract multiplier.
- Adds regression coverage for option order serialization value in ReadOrdersResponseJsonConverterTests.
- Updates option order fixture JSON values (camel and capital case) to the multiplier-adjusted value.

## Why
Issue #8447 reports that serialized order value used Order.Value (quantity * price), which omits contract multiplier and is incorrect for derivatives like options.

## How
- In ReadOrdersResponseJsonConverter.WriteJson, compute serialized value using symbol properties from SymbolPropertiesDatabase and override jObject[value] with order.Value * contractMultiplier.
- Keep existing behavior unchanged when order/symbol is unavailable.
- Add a focused unit test asserting option serialization emits the multiplier-adjusted value.

## Testing
- Attempted: dotnet test Tests/QuantConnect.Tests.csproj --filter FullyQualifiedName~ReadOrdersResponseJsonConverterTests
- Note: test execution is currently blocked in this environment by repository package vulnerability warnings (NU1902/NU1903/NU1904) that are treated as build-failing during package asset resolution.