### PR TITLE
Fix #8268: align PortfolioStatistics win/loss metric definitions

### DIFF
--- a/Common/Api/Backtest.cs
+++ b/Common/Api/Backtest.cs
@@ -239,7 +239,7 @@ namespace QuantConnect.Api
         public decimal? Drawdown { get; set; }
 
         /// <summary>
-        /// The ratio of the number of losing trades to the total number of trades
+        /// The ratio of the number of losing transactions to the total number of transactions
         /// </summary>
         public decimal? LossRate { get; set; }
 
@@ -279,7 +279,7 @@ namespace QuantConnect.Api
         public decimal? TreynorRatio { get; set; }
 
         /// <summary>
-        /// The ratio of the number of winning trades to the total number of trades
+        /// The ratio of the number of winning transactions to the total number of transactions
         /// </summary>
         public decimal? WinRate { get; set; }
 

--- a/Common/Securities/SecurityTransactionManager.cs
+++ b/Common/Securities/SecurityTransactionManager.cs
@@ -67,7 +67,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Trade record of profits and losses for each trade statistics calculations
+        /// Transaction record of profits and losses for each statistics calculation
         /// </summary>
         /// <remarks>Will return a shallow copy, modifying the returned container
         /// will have no effect <see cref="AddTransactionRecord"/></remarks>
@@ -111,7 +111,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Trade record of profits and losses for each trade statistics calculations that are considered winning trades
+        /// Transaction record of profits and losses that are considered winning transactions
         /// </summary>
         public Dictionary<DateTime, decimal> WinningTransactions
         {
@@ -125,7 +125,7 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
-        /// Trade record of profits and losses for each trade statistics calculations that are considered losing trades
+        /// Transaction record of profits and losses that are considered losing transactions
         /// </summary>
         public Dictionary<DateTime, decimal> LosingTransactions
         {

--- a/Common/Statistics/AlgorithmPerformance.cs
+++ b/Common/Statistics/AlgorithmPerformance.cs
@@ -43,7 +43,7 @@ namespace QuantConnect.Statistics
         /// Initializes a new instance of the <see cref="AlgorithmPerformance"/> class
         /// </summary>
         /// <param name="trades">The list of closed trades</param>
-        /// <param name="profitLoss">Trade record of profits and losses</param>
+        /// <param name="profitLoss">Transaction record of profits and losses</param>
         /// <param name="equity">The list of daily equity values</param>
         /// <param name="portfolioTurnover">The algorithm portfolio turnover</param>
         /// <param name="listPerformance">The list of algorithm performance values</param>

--- a/Common/Statistics/PerformanceMetrics.cs
+++ b/Common/Statistics/PerformanceMetrics.cs
@@ -36,12 +36,12 @@ namespace QuantConnect.Statistics
         public const string AnnualVariance = "Annual Variance";
 
         /// <summary>
-        /// The average rate of return for losing trades
+        /// The average rate of return for losing transactions
         /// </summary>
         public const string AverageLoss = "Average Loss";
 
         /// <summary>
-        /// The average rate of return for winning trades
+        /// The average rate of return for winning transactions
         /// </summary>
         public const string AverageWin = "Average Win";
 
@@ -86,7 +86,7 @@ namespace QuantConnect.Statistics
         public const string InformationRatio = "Information Ratio";
 
         /// <summary>
-        /// The ratio of the number of losing trades to the total number of trades
+        /// The ratio of the number of losing transactions to the total number of transactions
         /// </summary>
         public const string LossRate = "Loss Rate";
 
@@ -142,9 +142,9 @@ namespace QuantConnect.Statistics
         public const string TreynorRatio = "Treynor Ratio";
 
         /// <summary>
-        /// The ratio of the number of winning trades to the total number of trades
+        /// The ratio of the number of winning transactions to the total number of transactions
         /// </summary>
-        /// <remarks>If the total number of trades is zero, WinRate is set to zero</remarks>
+        /// <remarks>If the total number of transactions is zero, WinRate is set to zero</remarks>
         public const string WinRate = "Win Rate";
 
         /// <summary>

--- a/Common/Statistics/PortfolioStatistics.cs
+++ b/Common/Statistics/PortfolioStatistics.cs
@@ -30,13 +30,13 @@ namespace QuantConnect.Statistics
     public class PortfolioStatistics
     {
         /// <summary>
-        /// The average rate of return for winning trades
+        /// The average rate of return for winning transactions
         /// </summary>
         [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal AverageWinRate { get; set; }
 
         /// <summary>
-        /// The average rate of return for losing trades
+        /// The average rate of return for losing transactions
         /// </summary>
         [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal AverageLossRate { get; set; }
@@ -49,16 +49,16 @@ namespace QuantConnect.Statistics
         public decimal ProfitLossRatio { get; set; }
 
         /// <summary>
-        /// The ratio of the number of winning trades to the total number of trades
+        /// The ratio of the number of winning transactions to the total number of transactions
         /// </summary>
-        /// <remarks>If the total number of trades is zero, WinRate is set to zero</remarks>
+        /// <remarks>If the total number of transactions is zero, WinRate is set to zero</remarks>
         [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal WinRate { get; set; }
 
         /// <summary>
-        /// The ratio of the number of losing trades to the total number of trades
+        /// The ratio of the number of losing transactions to the total number of transactions
         /// </summary>
-        /// <remarks>If the total number of trades is zero, LossRate is set to zero</remarks>
+        /// <remarks>If the total number of transactions is zero, LossRate is set to zero</remarks>
         [JsonConverter(typeof(JsonRoundingConverter))]
         public decimal LossRate { get; set; }
 
@@ -195,7 +195,7 @@ namespace QuantConnect.Statistics
         /// <summary>
         /// Initializes a new instance of the <see cref="PortfolioStatistics"/> class
         /// </summary>
-        /// <param name="profitLoss">Trade record of profits and losses</param>
+        /// <param name="profitLoss">Transaction record of profits and losses</param>
         /// <param name="equity">The list of daily equity values</param>
         /// <param name="portfolioTurnover">The algorithm portfolio turnover</param>
         /// <param name="listPerformance">The list of algorithm performance values</param>
@@ -204,10 +204,10 @@ namespace QuantConnect.Statistics
         /// <param name="riskFreeInterestRateModel">The risk free interest rate model to use</param>
         /// <param name="tradingDaysPerYear">The number of trading days per year</param>
         /// <param name="winCount">
-        /// The number of wins, including ITM options with profitLoss less than 0.
+        /// The number of winning transactions, including ITM options with profitLoss less than 0.
         /// If this and <paramref name="lossCount"/> are null, they will be calculated from <paramref name="profitLoss"/>
         /// </param>
-        /// <param name="lossCount">The number of losses</param>
+        /// <param name="lossCount">The number of losing transactions</param>
         public PortfolioStatistics(
             SortedDictionary<DateTime, decimal> profitLoss,
             SortedDictionary<DateTime, decimal> equity,

--- a/Common/Statistics/StatisticsBuilder.cs
+++ b/Common/Statistics/StatisticsBuilder.cs
@@ -32,7 +32,7 @@ namespace QuantConnect.Statistics
         /// Generates the statistics and returns the results
         /// </summary>
         /// <param name="trades">The list of closed trades</param>
-        /// <param name="profitLoss">Trade record of profits and losses</param>
+        /// <param name="profitLoss">Transaction record of profits and losses</param>
         /// <param name="pointsEquity">The list of daily equity values</param>
         /// <param name="pointsPerformance">The list of algorithm performance values</param>
         /// <param name="pointsBenchmark">The list of benchmark values</param>
@@ -84,7 +84,7 @@ namespace QuantConnect.Statistics
         /// <param name="fromDate">The initial date of the range</param>
         /// <param name="toDate">The final date of the range</param>
         /// <param name="trades">The list of closed trades</param>
-        /// <param name="profitLoss">Trade record of profits and losses</param>
+        /// <param name="profitLoss">Transaction record of profits and losses</param>
         /// <param name="equity">The list of daily equity values</param>
         /// <param name="pointsPerformance">The list of algorithm performance values</param>
         /// <param name="pointsBenchmark">The list of benchmark values</param>
@@ -154,7 +154,7 @@ namespace QuantConnect.Statistics
         /// <param name="firstDate">The first date of the total period</param>
         /// <param name="lastDate">The last date of the total period</param>
         /// <param name="trades">The list of closed trades</param>
-        /// <param name="profitLoss">Trade record of profits and losses</param>
+        /// <param name="profitLoss">Transaction record of profits and losses</param>
         /// <param name="equity">The list of daily equity values</param>
         /// <param name="pointsPerformance">The list of algorithm performance values</param>
         /// <param name="pointsBenchmark">The list of benchmark values</param>

--- a/Tests/Common/Statistics/PortfolioStatisticsTests.cs
+++ b/Tests/Common/Statistics/PortfolioStatisticsTests.cs
@@ -60,6 +60,42 @@ namespace QuantConnect.Tests.Common.Statistics
             Assert.AreEqual(1.4673913043478260869565217388m, statistics.ProfitLossRatio);
         }
 
+        [Test]
+        public void WinLossRatesCanDifferFromAverageRatesWhenUsingTransactionClassification()
+        {
+            var startTime = _startTime;
+            var profitLoss = new SortedDictionary<DateTime, decimal>
+            {
+                { startTime, -50m },
+                { startTime.AddMinutes(1), 50m }
+            };
+            var equity = new SortedDictionary<DateTime, decimal>
+            {
+                { startTime, 100m },
+                { startTime.AddDays(1), 100m }
+            };
+
+            var statistics = new PortfolioStatistics(
+                profitLoss,
+                equity,
+                new SortedDictionary<DateTime, decimal>(),
+                new List<double> { 0, 0 },
+                new List<double> { 0, 0 },
+                100m,
+                new InterestRateProvider(),
+                _tradingDaysPerYear,
+                winCount: 2,
+                lossCount: 0);
+
+            // Average rates are based on signed transaction profit/loss values and running capital.
+            Assert.AreEqual(1m, statistics.AverageWinRate);
+            Assert.AreEqual(-0.5m, statistics.AverageLossRate);
+
+            // Win/loss rates can use transaction classification (for example, ITM assignment).
+            Assert.AreEqual(1m, statistics.WinRate);
+            Assert.AreEqual(0m, statistics.LossRate);
+        }
+
 
         public static IEnumerable<TestCaseData> StatisticsCases
         {


### PR DESCRIPTION
## What
- Clarifies PortfolioStatistics metric XML docs to refer to **transactions** (not trades) for:
  - `AverageWinRate`
  - `AverageLossRate`
  - `WinRate`
  - `LossRate`
- Propagates the same terminology to related API/statistics docs (`PerformanceMetrics`, `BacktestSummary`, and supporting constructor/parameter docs).
- Adds a regression test in `PortfolioStatisticsTests` that demonstrates the intended behavior when transaction classification differs from signed profit/loss.

## Why
Issue #8268 points out a mismatch between the metric definitions and how PortfolioStatistics is actually computed. The implementation uses transaction record values and transaction classification counts, so the docs should reflect that behavior to avoid misleading users.

## How
- Updated XML comments and parameter docs from "trades" to "transactions" in relevant statistics and API types.
- Added `WinLossRatesCanDifferFromAverageRatesWhenUsingTransactionClassification` to verify:
  - average rates come from signed transaction profit/loss and running capital
  - win/loss rates can follow provided transaction classification counts

## Testing
- `dotnet build Tests/QuantConnect.Tests.csproj --no-restore -p:NuGetAudit=false -p:TreatWarningsAsErrors=false`
- `dotnet test Tests/QuantConnect.Tests.csproj --no-build --filter "Name=WinLossRatesCanDifferFromAverageRatesWhenUsingTransactionClassification"` *(test host crashes in this environment with Python.NET GIL finalizer error unrelated to these changes)*

Closes #8268