### PR TITLE
Fix QuantBook start/end date validation in research

### DIFF
--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -223,6 +223,40 @@ namespace QuantConnect.Research
         }
 
         /// <summary>
+        /// Set the start date for research and validate it against the configured end date.
+        /// </summary>
+        public new void SetStartDate(DateTime start)
+        {
+            base.SetStartDate(start);
+            ValidateStartEndDateRange();
+        }
+
+        /// <summary>
+        /// Wrapper for SetStartDate(DateTime)
+        /// </summary>
+        public new void SetStartDate(int year, int month, int day)
+        {
+            SetStartDate(new DateTime(year, month, day));
+        }
+
+        /// <summary>
+        /// Set the end date for research and validate it against the configured start date.
+        /// </summary>
+        public new void SetEndDate(DateTime end)
+        {
+            base.SetEndDate(end);
+            ValidateStartEndDateRange();
+        }
+
+        /// <summary>
+        /// Wrapper for SetEndDate(DateTime)
+        /// </summary>
+        public new void SetEndDate(int year, int month, int day)
+        {
+            SetEndDate(new DateTime(year, month, day));
+        }
+
+        /// <summary>
         /// Python implementation of GetFundamental, get fundamental data for input symbols or tickers
         /// </summary>
         /// <param name="input">The symbols or tickers to retrieve fundamental data for</param>
@@ -1086,6 +1120,14 @@ namespace QuantConnect.Research
             }
 
             return symbol;
+        }
+
+        private void ValidateStartEndDateRange()
+        {
+            if (EndDate < StartDate)
+            {
+                throw new ArgumentException("Please select an algorithm end date greater than start date.");
+            }
         }
 
         private static void RecycleMemory()

--- a/Tests/Research/QuantBookTests.cs
+++ b/Tests/Research/QuantBookTests.cs
@@ -17,6 +17,7 @@ using NUnit.Framework;
 using QuantConnect.Research;
 using QuantConnect.Configuration;
 using Newtonsoft.Json.Linq;
+using System;
 
 namespace QuantConnect.Tests.Research
 {
@@ -49,6 +50,26 @@ namespace QuantConnect.Tests.Research
 
             var qb = new QuantBook();
             Assert.AreEqual(deploymentTarget, qb.DeploymentTarget);
+        }
+
+        [Test]
+        public void ThrowsWhenSettingStartDateAfterEndDate()
+        {
+            var qb = new QuantBook();
+            qb.SetEndDate(new DateTime(1998, 2, 1));
+
+            var ex = Assert.Throws<ArgumentException>(() => qb.SetStartDate(new DateTime(2022, 2, 1)));
+            Assert.AreEqual("Please select an algorithm end date greater than start date.", ex.Message);
+        }
+
+        [Test]
+        public void ThrowsWhenSettingStartDateAfterEndDateUsingIntegerOverloads()
+        {
+            var qb = new QuantBook();
+            qb.SetEndDate(1998, 2, 1);
+
+            var ex = Assert.Throws<ArgumentException>(() => qb.SetStartDate(2022, 2, 1));
+            Assert.AreEqual("Please select an algorithm end date greater than start date.", ex.Message);
         }
     }
 }


### PR DESCRIPTION
## What\n- add QuantBook-specific SetStartDate/SetEndDate wrappers that validate date bounds after each assignment\n- throw ArgumentException when EndDate < StartDate with the expected user-facing message\n- add regression tests for both DateTime and integer overloads\n\n## Why\nIssue #6593 reports that research notebooks accept incompatible start/end dates without raising an error. This can lead to confusing behavior when users configure date ranges in the wrong order.\n\n## How\n- hide the base date setter methods in QuantBook using 
ew overloads and delegate to ase setters\n- call a shared private validator after each setter to enforce a valid range\n- assert the exact exception message in QuantBookTests for both overload paths\n\nCloses #6593