### PR TITLE
Fix serialized order value to include contract multiplier

### DIFF
--- a/Common/Orders/Order.cs
+++ b/Common/Orders/Order.cs
@@ -195,7 +195,7 @@ namespace QuantConnect.Orders
         /// Deprecated
         /// </summary>
         [JsonProperty(PropertyName = "value"), Obsolete("Please use Order.GetValue(security) or security.Holdings.HoldingsValue")]
-        public decimal Value => Quantity * Price;
+        public decimal Value => Quantity * Price * GetSymbolContractMultiplier();
 
         /// <summary>
         /// Gets the price data at the time the order was submitted
@@ -312,6 +312,21 @@ namespace QuantConnect.Orders
         {
             var value = GetValueImpl(security);
             return value*security.QuoteCurrency.ConversionRate*security.SymbolProperties.ContractMultiplier;
+        }
+
+        private decimal GetSymbolContractMultiplier()
+        {
+            if (Symbol == null || Symbol == Symbol.Empty || string.IsNullOrEmpty(Symbol.ID.Market))
+            {
+                return 1m;
+            }
+
+            return SymbolPropertiesDatabase.FromDataFolder().GetSymbolProperties(
+                Symbol.ID.Market,
+                Symbol,
+                Symbol.SecurityType,
+                Currencies.NullCurrency
+            ).ContractMultiplier;
         }
 
         /// <summary>

--- a/Tests/Common/Orders/OrderTests.cs
+++ b/Tests/Common/Orders/OrderTests.cs
@@ -44,6 +44,25 @@ namespace QuantConnect.Tests.Common.Orders
             Assert.AreEqual(parameters.ExpectedValue, value);
         }
 
+        [Test]
+        public void ValueIncludesOptionContractMultiplier()
+        {
+            var order = new MarketOrder(Symbols.SPY_C_192_Feb19_2016, -5, DateTime.UtcNow)
+            {
+                Price = 9.1m
+            };
+
+            var symbolProperties = SymbolPropertiesDatabase.FromDataFolder().GetSymbolProperties(
+                order.Symbol.ID.Market,
+                order.Symbol,
+                order.Symbol.SecurityType,
+                Currencies.USD
+            );
+
+            Assert.Greater(symbolProperties.ContractMultiplier, 1m);
+            Assert.AreEqual(order.Quantity * order.Price * symbolProperties.ContractMultiplier, order.Value);
+        }
+
         [TestCase(OrderDirection.Sell, 300, 0.1, true, 270)]
         [TestCase(OrderDirection.Sell, 300, 30, false, 270)]
         [TestCase(OrderDirection.Buy, 300, 0.1, true, 330)]


### PR DESCRIPTION
## What\n- update Order.Value to include the symbol contract multiplier\n- add a regression test (ValueIncludesOptionContractMultiplier) to verify option order values include contract sizing\n\n## Why\nIssue #8447 reports serialized order alue for options ignoring the contract multiplier (for example, reporting -45.5 instead of -4550 for -5 contracts at 9.1).\n\n## How\n- compute Order.Value as Quantity * Price * ContractMultiplier using SymbolPropertiesDatabase lookup for the order symbol\n- default to multiplier 1 when symbol data is unavailable\n- add a focused unit test with an option contract to validate multiplier application\n\n## Validation\n- dotnet build Tests\\QuantConnect.Tests.csproj -c Debug succeeds\n- dotnet test ... --filter FullyQualifiedName=QuantConnect.Tests.Common.Orders.OrderTests.ValueIncludesOptionContractMultiplier currently aborts in this environment due a known Python.NET GIL finalizer test-host crash (unrelated to this patch)\n\nCloses #8447