### PR TITLE
Fix Python object lifetime in report rendering paths

### DIFF
--- a/Report/ReportElements/ExposureReportElement.cs
+++ b/Report/ReportElements/ExposureReportElement.cs
@@ -98,16 +98,16 @@ namespace QuantConnect.Report.ReportElements
             var base64 = "";
             using (Py.GIL())
             {
-                var time = backtestFrame.RowKeys.ToList().ToPython();
-                var longSecurities = longBacktestFrame.ColumnKeys.Select(x => x.Item1.ToStringInvariant()).ToList().ToPython();
-                var shortSecurities = shortBacktestFrame.ColumnKeys.Select(x => x.Item1.ToStringInvariant()).ToList().ToPython();
-                var longData = longBacktestFrame.ColumnKeys.Select(x => longBacktestFrame[x].Values.ToList().ToPython()).ToPython();
-                var shortData = shortBacktestFrame.ColumnKeys.Select(x => shortBacktestFrame[x].Values.ToList().ToPython()).ToPython();
-                var liveTime = liveFrame.RowKeys.ToList().ToPython();
-                var liveLongSecurities = longLiveFrame.ColumnKeys.Select(x => x.Item1.ToStringInvariant()).ToList().ToPython();
-                var liveShortSecurities = shortLiveFrame.ColumnKeys.Select(x => x.Item1.ToStringInvariant()).ToList().ToPython();
-                var liveLongData = longLiveFrame.ColumnKeys.Select(x => longLiveFrame[x].Values.ToList().ToPython()).ToPython();
-                var liveShortData = shortLiveFrame.ColumnKeys.Select(x => shortLiveFrame[x].Values.ToList().ToPython()).ToPython();
+                using var time = backtestFrame.RowKeys.ToList().ToPython();
+                using var longSecurities = longBacktestFrame.ColumnKeys.Select(x => x.Item1.ToStringInvariant()).ToList().ToPython();
+                using var shortSecurities = shortBacktestFrame.ColumnKeys.Select(x => x.Item1.ToStringInvariant()).ToList().ToPython();
+                using var longData = longBacktestFrame.ColumnKeys.Select(x => longBacktestFrame[x].Values.ToList().ToPython()).ToPython();
+                using var shortData = shortBacktestFrame.ColumnKeys.Select(x => shortBacktestFrame[x].Values.ToList().ToPython()).ToPython();
+                using var liveTime = liveFrame.RowKeys.ToList().ToPython();
+                using var liveLongSecurities = longLiveFrame.ColumnKeys.Select(x => x.Item1.ToStringInvariant()).ToList().ToPython();
+                using var liveShortSecurities = shortLiveFrame.ColumnKeys.Select(x => x.Item1.ToStringInvariant()).ToList().ToPython();
+                using var liveLongData = longLiveFrame.ColumnKeys.Select(x => longLiveFrame[x].Values.ToList().ToPython()).ToPython();
+                using var liveShortData = shortLiveFrame.ColumnKeys.Select(x => shortLiveFrame[x].Values.ToList().ToPython()).ToPython();
 
                 base64 = Charting.GetExposure(
                     time,

--- a/Report/ReportElements/MonthlyReturnsReportElement.cs
+++ b/Report/ReportElements/MonthlyReturnsReportElement.cs
@@ -63,7 +63,7 @@ namespace QuantConnect.Report.ReportElements
             var base64 = "";
             using (Py.GIL())
             {
-                var backtestResults = new PyDict();
+                using var backtestResults = new PyDict();
                 foreach (var kvp in backtestMonthlyReturns.GroupBy(kvp => kvp.Key.Year).GetObservations())
                 {
                     var key = kvp.Key.ToStringInvariant();
@@ -82,10 +82,12 @@ namespace QuantConnect.Report.ReportElements
                         values.Add(double.NaN);
                     }
 
-                    backtestResults.SetItem(key.ToPython(), values.ToPython());
+                    using var pyKey = key.ToPython();
+                    using var pyValues = values.ToPython();
+                    backtestResults.SetItem(pyKey, pyValues);
                 }
 
-                var liveResults = new PyDict();
+                using var liveResults = new PyDict();
                 foreach (var kvp in liveMonthlyReturns.GroupBy(kvp => kvp.Key.Year).GetObservations())
                 {
                     var key = kvp.Key.ToStringInvariant();
@@ -104,7 +106,9 @@ namespace QuantConnect.Report.ReportElements
                         values.Add(double.NaN);
                     }
 
-                    liveResults.SetItem(key.ToPython(), values.ToPython());
+                    using var pyKey = key.ToPython();
+                    using var pyValues = values.ToPython();
+                    liveResults.SetItem(pyKey, pyValues);
                 }
 
                 base64 = Charting.GetMonthlyReturns(backtestResults, liveResults);


### PR DESCRIPTION
## What
This PR addresses the crash in `ExposureReportWorksForEverySecurityType` by tightening Python object lifetime management in report rendering code.

Changes:
- `MonthlyReturnsReportElement.Render()`
  - Dispose `PyDict` instances (`backtestResults`, `liveResults`) deterministically.
  - Dispose temporary Python objects created via `ToPython()` before/after `SetItem` calls.
- `ExposureReportElement.Render()`
  - Dispose all Python objects created from managed collections (`time`, `long/short securities`, `long/short data`, and live equivalents).

## Why
Issue #9203 reports intermittent native crashes (`0xC0000005`) in Python runtime invocation while report charts are being generated. The failing stack points to report rendering paths that create many `PyObject` wrappers. Ensuring deterministic disposal reduces stale references and unmanaged pressure during interop calls.

## How
- Replaced non-disposed local `PyObject`/`PyDict` instances with `using var` scoped lifetimes inside existing `Py.GIL()` blocks.
- Kept behavior and data transformation logic unchanged.

## Validation
- `dotnet build Report/QuantConnect.Report.csproj -c Debug` (passes)
- Targeted test command attempted:
  - `dotnet test Tests/QuantConnect.Tests.csproj -c Debug --filter "FullyQualifiedName=QuantConnect.Tests.Report.ReportChartTests.ExposureReportWorksForEverySecurityType"`
  - In this local environment, execution is blocked by Windows Application Control policy (`FileLoadException 0x800711C7`) before test execution. Build is successful and CI should run the test in a policy-allowed environment.

Closes #9203
