### PR TITLE
Fix serialized order value to include contract multiplier

### DIFF
--- a/Common/Orders/Order.cs
+++ b/Common/Orders/Order.cs
@@ -195,7 +195,7 @@ namespace QuantConnect.Orders
         /// Deprecated
         /// </summary>
         [JsonProperty(PropertyName = "value"), Obsolete("Please use Order.GetValue(security) or security.Holdings.HoldingsValue")]
-        public decimal Value => Quantity * Price;
+        public decimal Value => Quantity * Price * GetSymbolContractMultiplier();
 
         /// <summary>
         /// Gets the price data at the time the order was submitted
@@ -312,6 +312,21 @@ namespace QuantConnect.Orders
         {
             var value = GetValueImpl(security);
             return value*security.QuoteCurrency.ConversionRate*security.SymbolProperties.ContractMultiplier;
+        }
+
+        private decimal GetSymbolContractMultiplier()
+        {
+            if (Symbol == null || Symbol == Symbol.Empty || string.IsNullOrEmpty(Symbol.ID.Market))
+            {
+                return 1m;
+            }
+
+            return SymbolPropertiesDatabase.FromDataFolder().GetSymbolProperties(
+                Symbol.ID.Market,
+                Symbol,
+                Symbol.SecurityType,
+                Currencies.NullCurrency
+            ).ContractMultiplier;
         }
 
         /// <summary>

--- a/Tests/Common/Orders/OrderTests.cs
+++ b/Tests/Common/Orders/OrderTests.cs
@@ -44,6 +44,25 @@ namespace QuantConnect.Tests.Common.Orders
             Assert.AreEqual(parameters.ExpectedValue, value);
         }
 
+        [Test]
+        public void ValueIncludesOptionContractMultiplier()
+        {
+            var order = new MarketOrder(Symbols.SPY_C_192_Feb19_2016, -5, DateTime.UtcNow)
+            {
+                Price = 9.1m
+            };
+
+            var symbolProperties = SymbolPropertiesDatabase.FromDataFolder().GetSymbolProperties(
+                order.Symbol.ID.Market,
+                order.Symbol,
+                order.Symbol.SecurityType,
+                Currencies.USD
+            );
+
+            Assert.Greater(symbolProperties.ContractMultiplier, 1m);
+            Assert.AreEqual(order.Quantity * order.Price * symbolProperties.ContractMultiplier, order.Value);
+        }
+
         [TestCase(OrderDirection.Sell, 300, 0.1, true, 270)]
         [TestCase(OrderDirection.Sell, 300, 30, false, 270)]
         [TestCase(OrderDirection.Buy, 300, 0.1, true, 330)]

--- a/Tests/Common/Orders/ReadOrdersResponseJsonConverterTests.cs
+++ b/Tests/Common/Orders/ReadOrdersResponseJsonConverterTests.cs
@@ -16,6 +16,7 @@
 using Newtonsoft.Json;
 using NUnit.Framework;
 using QuantConnect.Orders;
+using QuantConnect.Securities;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -100,7 +101,13 @@ namespace QuantConnect.Tests.Common.Orders
             Assert.AreEqual(TimeInForce.GoodTilCanceled.ToString(), order.Properties.TimeInForce.ToString(), "Failed in Order.Properties.TimeInForce");
             Assert.AreEqual(securityType, order.SecurityType, "Failed in Order.SecurityType");
             Assert.AreEqual(OrderDirection.Buy, order.Direction, "Failed in Order.Direction");
-            Assert.AreEqual(1385.139869450m, order.Value, "Failed in Order.Value");
+            var symbolProperties = SymbolPropertiesDatabase.FromDataFolder().GetSymbolProperties(
+                order.Symbol.ID.Market,
+                order.Symbol,
+                order.SecurityType,
+                Currencies.USD
+            );
+            Assert.AreEqual(order.Quantity * order.Price * symbolProperties.ContractMultiplier, order.Value, "Failed in Order.Value");
             Assert.AreEqual(138.505714984m, order.OrderSubmissionData.BidPrice, "Failed in Order.OrderSubmissionData.BidPrice");
             Assert.AreEqual(138.513986945m, order.OrderSubmissionData.AskPrice, "Failed in Order.OrderSubmissionData.AskPrice");
             Assert.AreEqual(138.505714984m, order.OrderSubmissionData.LastPrice, "Failed in Order.OrderSubmissionData.LastPrice");
@@ -494,7 +501,7 @@ namespace QuantConnect.Tests.Common.Orders
             },
             ""securityType"": 2,
             ""direction"": 0,
-            ""value"": 1385.139869450,
+            ""value"": 138513.986945,
             ""orderSubmissionData"": {
                 ""bidPrice"": 138.505714984,
                 ""askPrice"": 138.513986945,
@@ -613,7 +620,7 @@ namespace QuantConnect.Tests.Common.Orders
             },
             ""securityType"": 2,
             ""direction"": 0,
-            ""value"": 1385.139869450,
+            ""value"": 138513.986945,
             ""orderSubmissionData"": {
                 ""bidPrice"": 138.505714984,
                 ""askPrice"": 138.513986945,
@@ -685,7 +692,7 @@ namespace QuantConnect.Tests.Common.Orders
             },
             ""securityType"": 2,
             ""direction"": 0,
-            ""value"": 1385.139869450,
+            ""value"": 138513.986945,
             ""orderSubmissionData"": {
                 ""bidPrice"": 138.505714984,
                 ""askPrice"": 138.513986945,
@@ -758,7 +765,7 @@ namespace QuantConnect.Tests.Common.Orders
             },
             ""securityType"": 2,
             ""direction"": 0,
-            ""value"": 1385.139869450,
+            ""value"": 138513.986945,
             ""orderSubmissionData"": {
                 ""bidPrice"": 138.505714984,
                 ""askPrice"": 138.513986945,
@@ -1111,7 +1118,7 @@ namespace QuantConnect.Tests.Common.Orders
     },
     ""SecurityType"": 2,
     ""Direction"": 0,
-    ""Value"": 1385.139869450,
+    ""Value"": 138513.986945,
     ""OrderSubmissionData"": {
         ""BidPrice"": 138.505714984,
         ""AskPrice"": 138.513986945,
@@ -1191,7 +1198,7 @@ namespace QuantConnect.Tests.Common.Orders
     },
     ""SecurityType"": 2,
     ""Direction"": 0,
-    ""Value"": 1385.139869450,
+    ""Value"": 138513.986945,
     ""OrderSubmissionData"": {
         ""BidPrice"": 138.505714984,
         ""AskPrice"": 138.513986945,
@@ -1244,7 +1251,7 @@ namespace QuantConnect.Tests.Common.Orders
     },
     ""SecurityType"": 2,
     ""Direction"": 0,
-    ""Value"": 1385.139869450,
+    ""Value"": 138513.986945,
     ""OrderSubmissionData"": {
         ""BidPrice"": 138.505714984,
         ""AskPrice"": 138.513986945,
@@ -1298,7 +1305,7 @@ namespace QuantConnect.Tests.Common.Orders
     },
     ""SecurityType"": 2,
     ""Direction"": 0,
-    ""Value"": 1385.139869450,
+    ""Value"": 138513.986945,
     ""OrderSubmissionData"": {
         ""BidPrice"": 138.505714984,
         ""AskPrice"": 138.513986945,


### PR DESCRIPTION
## What
This PR fixes serialized `Order.value` so it includes the symbol contract multiplier (for example, options use 100x) instead of using only `Quantity * Price`.

Changes:
- `Order.Value` now multiplies by the symbol contract multiplier looked up from `SymbolPropertiesDatabase`.
- Added regression coverage in `OrderTests` for option orders.
- Updated `ReadOrdersResponseJsonConverterTests` fixtures and assertions so option order values are validated with multiplier-aware expectations.

## Why
Issue #8447 reports option orders being serialized with values that ignore contract multipliers.
Example from the issue: an option order with price `9.1` and quantity `-5` was serialized as `-45.5`, but should reflect multiplier-adjusted value (`-4550` for 100x contracts).

## How
- `Order.Value` now computes:
  - `Quantity * Price * ContractMultiplier`
- Added `ValueIncludesOptionContractMultiplier` test to verify option behavior.
- Updated converter tests so:
  - expected `value` for option fixtures reflects multiplier-adjusted value
  - generic `Order.Value` assertion computes expected value via symbol properties (instead of hardcoded `1385.139869450` for every security type)

## Validation
- `dotnet build Common/QuantConnect.csproj -c Debug`
- `dotnet build Tests/QuantConnect.Tests.csproj -c Debug --no-restore`
- Attempted targeted tests with `dotnet test --filter ...`, but in this local environment the test host intermittently crashes at shutdown with Python.NET GIL finalizer error (`System.InvalidOperationException: GIL must always be released...`).

Closes #8447
