### PR TITLE
Fix serialized order value to include contract multiplier

### DIFF
--- a/Common/Orders/Order.cs
+++ b/Common/Orders/Order.cs
@@ -195,7 +195,7 @@ namespace QuantConnect.Orders
         /// Deprecated
         /// </summary>
         [JsonProperty(PropertyName = "value"), Obsolete("Please use Order.GetValue(security) or security.Holdings.HoldingsValue")]
-        public decimal Value => Quantity * Price;
+        public decimal Value => Quantity * Price * GetSymbolContractMultiplier();
 
         /// <summary>
         /// Gets the price data at the time the order was submitted
@@ -312,6 +312,21 @@ namespace QuantConnect.Orders
         {
             var value = GetValueImpl(security);
             return value*security.QuoteCurrency.ConversionRate*security.SymbolProperties.ContractMultiplier;
+        }
+
+        private decimal GetSymbolContractMultiplier()
+        {
+            if (Symbol == null || Symbol == Symbol.Empty || string.IsNullOrEmpty(Symbol.ID.Market))
+            {
+                return 1m;
+            }
+
+            return SymbolPropertiesDatabase.FromDataFolder().GetSymbolProperties(
+                Symbol.ID.Market,
+                Symbol,
+                Symbol.SecurityType,
+                Currencies.NullCurrency
+            ).ContractMultiplier;
         }
 
         /// <summary>

--- a/Tests/Common/Orders/OrderTests.cs
+++ b/Tests/Common/Orders/OrderTests.cs
@@ -44,6 +44,25 @@ namespace QuantConnect.Tests.Common.Orders
             Assert.AreEqual(parameters.ExpectedValue, value);
         }
 
+        [Test]
+        public void ValueIncludesOptionContractMultiplier()
+        {
+            var order = new MarketOrder(Symbols.SPY_C_192_Feb19_2016, -5, DateTime.UtcNow)
+            {
+                Price = 9.1m
+            };
+
+            var symbolProperties = SymbolPropertiesDatabase.FromDataFolder().GetSymbolProperties(
+                order.Symbol.ID.Market,
+                order.Symbol,
+                order.Symbol.SecurityType,
+                Currencies.USD
+            );
+
+            Assert.Greater(symbolProperties.ContractMultiplier, 1m);
+            Assert.AreEqual(order.Quantity * order.Price * symbolProperties.ContractMultiplier, order.Value);
+        }
+
         [TestCase(OrderDirection.Sell, 300, 0.1, true, 270)]
         [TestCase(OrderDirection.Sell, 300, 30, false, 270)]
         [TestCase(OrderDirection.Buy, 300, 0.1, true, 330)]

--- a/Tests/Common/Orders/ReadOrdersResponseJsonConverterTests.cs
+++ b/Tests/Common/Orders/ReadOrdersResponseJsonConverterTests.cs
@@ -16,6 +16,7 @@
 using Newtonsoft.Json;
 using NUnit.Framework;
 using QuantConnect.Orders;
+using QuantConnect.Securities;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -100,7 +101,13 @@ namespace QuantConnect.Tests.Common.Orders
             Assert.AreEqual(TimeInForce.GoodTilCanceled.ToString(), order.Properties.TimeInForce.ToString(), "Failed in Order.Properties.TimeInForce");
             Assert.AreEqual(securityType, order.SecurityType, "Failed in Order.SecurityType");
             Assert.AreEqual(OrderDirection.Buy, order.Direction, "Failed in Order.Direction");
-            Assert.AreEqual(1385.139869450m, order.Value, "Failed in Order.Value");
+            var symbolProperties = SymbolPropertiesDatabase.FromDataFolder().GetSymbolProperties(
+                order.Symbol.ID.Market,
+                order.Symbol,
+                order.SecurityType,
+                Currencies.USD
+            );
+            Assert.AreEqual(order.Quantity * order.Price * symbolProperties.ContractMultiplier, order.Value, "Failed in Order.Value");
             Assert.AreEqual(138.505714984m, order.OrderSubmissionData.BidPrice, "Failed in Order.OrderSubmissionData.BidPrice");
             Assert.AreEqual(138.513986945m, order.OrderSubmissionData.AskPrice, "Failed in Order.OrderSubmissionData.AskPrice");
             Assert.AreEqual(138.505714984m, order.OrderSubmissionData.LastPrice, "Failed in Order.OrderSubmissionData.LastPrice");
@@ -494,7 +501,7 @@ namespace QuantConnect.Tests.Common.Orders
             },
             ""securityType"": 2,
             ""direction"": 0,
-            ""value"": 1385.139869450,
+            ""value"": 138513.986945,
             ""orderSubmissionData"": {
                 ""bidPrice"": 138.505714984,
                 ""askPrice"": 138.513986945,
@@ -613,7 +620,7 @@ namespace QuantConnect.Tests.Common.Orders
             },
             ""securityType"": 2,
             ""direction"": 0,
-            ""value"": 1385.139869450,
+            ""value"": 138513.986945,
             ""orderSubmissionData"": {
                 ""bidPrice"": 138.505714984,
                 ""askPrice"": 138.513986945,
@@ -685,7 +692,7 @@ namespace QuantConnect.Tests.Common.Orders
             },
             ""securityType"": 2,
             ""direction"": 0,
-            ""value"": 1385.139869450,
+            ""value"": 138513.986945,
             ""orderSubmissionData"": {
                 ""bidPrice"": 138.505714984,
                 ""askPrice"": 138.513986945,
@@ -758,7 +765,7 @@ namespace QuantConnect.Tests.Common.Orders
             },
             ""securityType"": 2,
             ""direction"": 0,
-            ""value"": 1385.139869450,
+            ""value"": 138513.986945,
             ""orderSubmissionData"": {
                 ""bidPrice"": 138.505714984,
                 ""askPrice"": 138.513986945,
@@ -1111,7 +1118,7 @@ namespace QuantConnect.Tests.Common.Orders
     },
     ""SecurityType"": 2,
     ""Direction"": 0,
-    ""Value"": 1385.139869450,
+    ""Value"": 138513.986945,
     ""OrderSubmissionData"": {
         ""BidPrice"": 138.505714984,
         ""AskPrice"": 138.513986945,
@@ -1191,7 +1198,7 @@ namespace QuantConnect.Tests.Common.Orders
     },
     ""SecurityType"": 2,
     ""Direction"": 0,
-    ""Value"": 1385.139869450,
+    ""Value"": 138513.986945,
     ""OrderSubmissionData"": {
         ""BidPrice"": 138.505714984,
         ""AskPrice"": 138.513986945,
@@ -1244,7 +1251,7 @@ namespace QuantConnect.Tests.Common.Orders
     },
     ""SecurityType"": 2,
     ""Direction"": 0,
-    ""Value"": 1385.139869450,
+    ""Value"": 138513.986945,
     ""OrderSubmissionData"": {
         ""BidPrice"": 138.505714984,
         ""AskPrice"": 138.513986945,
@@ -1298,7 +1305,7 @@ namespace QuantConnect.Tests.Common.Orders
     },
     ""SecurityType"": 2,
     ""Direction"": 0,
-    ""Value"": 1385.139869450,
+    ""Value"": 138513.986945,
     ""OrderSubmissionData"": {
         ""BidPrice"": 138.505714984,
         ""AskPrice"": 138.513986945,


### PR DESCRIPTION
﻿## What
- Fix serialized `Order.value` to include symbol contract multiplier.
- Add a regression test for option order value multiplier behavior.
- Update order JSON converter tests/fixtures to assert multiplier-adjusted values.

## Why
Issue #8447 reports option order values being serialized without applying contract multiplier (for example `-45.5` instead of `-4550` for 5 option contracts at 9.1).

## How
- Update `Order.Value` to compute `Quantity * Price * ContractMultiplier`.
- Retrieve multiplier from `SymbolPropertiesDatabase` for the order symbol.
- Default to multiplier `1` when symbol context is unavailable.

## Validation
- Attempted targeted tests for `OrderTests` and `ReadOrdersResponseJsonConverterTests`.
- In this local environment, `dotnet test` aborts due a Python.NET GIL finalizer crash in the test host shutdown path (`System.InvalidOperationException: GIL must always be released...`), which appears unrelated to this patch.

Closes #8447
