### PR TITLE
Fix ScheduledUniverse trigger times to respect endTimeUtc

### DIFF
--- a/Common/Data/UniverseSelection/ScheduledUniverse.cs
+++ b/Common/Data/UniverseSelection/ScheduledUniverse.cs
@@ -107,7 +107,10 @@ namespace QuantConnect.Data.UniverseSelection
         /// </summary>
         /// <param name="startTimeUtc">The start time of the range in UTC</param>
         /// <param name="endTimeUtc">The end time of the range in UTC</param>
-        /// <returns>An enumerator of UTC DateTimes that defines when this universe will be invoked</returns>
+        /// <returns>
+        /// An enumerator of UTC DateTimes that defines when this universe will be invoked,
+        /// including events that fall exactly on <paramref name="startTimeUtc"/> or <paramref name="endTimeUtc"/>.
+        /// </returns>
         public IEnumerable<DateTime> GetTriggerTimes(DateTime startTimeUtc, DateTime endTimeUtc, MarketHoursDatabase marketHoursDatabase)
         {
             var startTimeLocal = startTimeUtc.ConvertFromUtc(Configuration.ExchangeTimeZone);
@@ -115,27 +118,31 @@ namespace QuantConnect.Data.UniverseSelection
 
             // define date/time rule enumerable
             var dates = _dateRule.GetDates(startTimeLocal, endTimeLocal);
-            var times = _timeRule.CreateUtcEventTimes(dates).GetEnumerator();
+            using var times = _timeRule.CreateUtcEventTimes(dates).GetEnumerator();
 
             // Make sure and filter out any times before our start time
             // GH #5440
-            do
+            while (true)
             {
                 if (!times.MoveNext())
                 {
-                    times.Dispose();
+                    yield break;
+                }
+                if (times.Current >= startTimeUtc)
+                {
+                    break;
+                }
+            }
+
+            // Start yielding times while respecting the upper bound.
+            while (times.Current <= endTimeUtc)
+            {
+                yield return times.Current;
+                if (!times.MoveNext())
+                {
                     yield break;
                 }
             }
-            while (times.Current < startTimeUtc);
-
-            // Start yielding times
-            do
-            {
-                yield return times.Current;
-            }
-            while (times.MoveNext());
-            times.Dispose();
         }
 
         private static SubscriptionDataConfig CreateConfiguration(DateTimeZone timeZone, IDateRule dateRule, ITimeRule timeRule)

--- a/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
+++ b/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
@@ -107,5 +107,29 @@ namespace QuantConnect.Tests.Common.Data.UniverseSelection
             // Assert that its empty
             Assert.IsTrue(!triggerTimesUtc.Any());
         }
+
+        [Test]
+        public void TriggerTimesRespectEndTimeUtc()
+        {
+            using var universe = new ScheduledUniverse(
+                _dateRules.EveryDay(),
+                _timeRules.Every(TimeSpan.FromMinutes(1)),
+                _ => new List<Symbol>()
+            );
+
+            var start = new DateTime(2000, 1, 5, 10, 0, 0);
+            var end = new DateTime(2000, 1, 5, 15, 32, 0);
+
+            var triggerTimesLocal = universe
+                .GetTriggerTimes(start.ConvertToUtc(_timezone), end.ConvertToUtc(_timezone), MarketHoursDatabase.AlwaysOpen)
+                .Select(time => time.ConvertFromUtc(_timezone))
+                .ToList();
+
+            Assert.IsNotEmpty(triggerTimesLocal);
+            Assert.AreEqual(start, triggerTimesLocal.First(), "Start boundary should be included when it matches a trigger time");
+            Assert.AreEqual(end, triggerTimesLocal.Last(), "End boundary should be included when it matches a trigger time");
+            Assert.IsTrue(triggerTimesLocal.All(time => time >= start && time <= end), "All trigger times should be within [start, end]");
+            Assert.AreEqual((int)(end - start).TotalMinutes + 1, triggerTimesLocal.Count);
+        }
     }
 }


### PR DESCRIPTION
﻿## What
- Fix `ScheduledUniverse.GetTriggerTimes` to stop emitting trigger times after `endTimeUtc`.
- Clarify XML documentation that trigger times on exact start/end boundaries are included.
- Add regression coverage for intraday `TimeRules.Every(...)` schedules to ensure results stay within `[start, end]`.

## Why
Issue #9349 reports that `ScheduledUniverse.GetTriggerTimes` returns all trigger times on the end date, including times after `endTimeUtc`.

## How
- Keep existing start-bound filtering behavior (`>= startTimeUtc`).
- Add explicit upper-bound filtering when yielding (`<= endTimeUtc`).
- Add `ScheduledUniverseTests.TriggerTimesRespectEndTimeUtc` to assert:
  - start boundary inclusion when matching a trigger time,
  - end boundary inclusion when matching a trigger time,
  - no returned times outside `[start, end]`.

## Validation
- `dotnet build ./Common/QuantConnect.csproj -c Release --no-restore`
- `dotnet build ./Tests/QuantConnect.Tests.csproj -c Release --no-restore`
- Attempted: `dotnet test ./Tests/QuantConnect.Tests.csproj --filter "FullyQualifiedName~ScheduledUniverseTests"`
  - In this environment, test host aborts at shutdown with a known Python.NET GIL finalizer crash (`System.InvalidOperationException: GIL must always be released...`).

Closes #9349
