### PR TITLE
Ignore get_settlement_model obsolete overload mypy warning 

### DIFF
--- a/run_syntax_check.py
+++ b/run_syntax_check.py
@@ -72,6 +72,8 @@ def should_ignore(line: str, prev_line_ignored: bool) -> bool:
         'Module has no attribute "JsonConvert"',
         'Too many arguments for "update" of "IndicatorBase"',
         'Signature of "update" incompatible with supertype "IndicatorBase"',
+        # stubs include the obsolete overload GetSettlementModel(Security, AccountType), mypy requires the override to be compatible with both
+        'Signature of "get_settlement_model" incompatible with supertype',
         'has incompatible type "Symbol"; expected "str"',
         # This methods take an indicator and consolidator which might be instances of custom
         # indicator/consolidator Python classes that don't inherit from PythonIndicator or IDataConsolidator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
The stubs expose an obsolete `GetSettlementModel(Security, AccountType)` overload, which causes mypy to flag overrides that only declare the current single argument signature. Added it to the ignore list in `run_syntax_check.py`

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested by running the script locally

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
