### PR TITLE
Include contract multiplier in serialized option order value

### DIFF
--- a/Common/Orders/ReadOrdersResponseJsonConverter.cs
+++ b/Common/Orders/ReadOrdersResponseJsonConverter.cs
@@ -18,6 +18,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using QuantConnect.Orders.Serialization;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Orders
 {
@@ -43,6 +44,10 @@ namespace QuantConnect.Orders
             var jObject = JObject.FromObject(orderResponse.Order);
             jObject["symbol"] = JToken.FromObject(orderResponse.Symbol);
             jObject["events"] = JToken.FromObject(orderResponse.Events);
+            if (TryGetSerializedOrderValue(orderResponse, out var orderValue))
+            {
+                jObject["value"] = JToken.FromObject(orderValue);
+            }
             jObject.WriteTo(writer);
         }
 
@@ -71,6 +76,37 @@ namespace QuantConnect.Orders
             }
 
             return new ApiOrderResponse(order, deserializedEvents ?? new(), deserializedSymbol);
+        }
+
+        private static bool TryGetSerializedOrderValue(ApiOrderResponse orderResponse, out decimal orderValue)
+        {
+            orderValue = 0;
+
+            var order = orderResponse?.Order;
+            var symbol = orderResponse?.Symbol ?? order?.Symbol;
+            if (order == null || symbol == null)
+            {
+                return false;
+            }
+
+            orderValue = order.Value;
+            if (symbol == Symbol.Empty || string.IsNullOrWhiteSpace(symbol.ID.Market) || symbol.SecurityType != SecurityType.Option)
+            {
+                return true;
+            }
+
+            var quoteCurrency = string.IsNullOrWhiteSpace(order.PriceCurrency)
+                ? Currencies.USD
+                : order.PriceCurrency;
+            var symbolProperties = SymbolPropertiesDatabase.FromDataFolder().GetSymbolProperties(
+                symbol.ID.Market,
+                symbol,
+                symbol.SecurityType,
+                quoteCurrency
+            );
+
+            orderValue *= symbolProperties.ContractMultiplier;
+            return true;
         }
     }
 }

--- a/Tests/Common/Orders/ReadOrdersResponseJsonConverterTests.cs
+++ b/Tests/Common/Orders/ReadOrdersResponseJsonConverterTests.cs
@@ -14,8 +14,10 @@
 */
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using QuantConnect.Orders;
+using QuantConnect.Securities;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -123,6 +125,21 @@ namespace QuantConnect.Tests.Common.Orders
             }
             Assert.AreEqual(jsonFormat, serializedOrder);
             Assert.AreEqual(jsonFormat.GetHashCode(), serializedOrder.GetHashCode());
+        }
+
+        [Test]
+        public void SerializesOptionOrderValueUsingContractMultiplier()
+        {
+            var order = JsonConvert.DeserializeObject<ApiOrderResponse>(_camelCaseOptionExercise, _jsonSettings);
+            var serializedOrder = JsonConvert.SerializeObject(order, _jsonSettings);
+            var symbolProperties = SymbolPropertiesDatabase.FromDataFolder().GetSymbolProperties(
+                order.Symbol.ID.Market,
+                order.Symbol,
+                order.Symbol.SecurityType,
+                Currencies.USD
+            );
+
+            Assert.AreEqual(order.Order.Value * symbolProperties.ContractMultiplier, JObject.Parse(serializedOrder)["value"]?.Value<decimal>());
         }
 
         private const string _camelCaseMarketOrder = @"{
@@ -494,7 +511,7 @@ namespace QuantConnect.Tests.Common.Orders
             },
             ""securityType"": 2,
             ""direction"": 0,
-            ""value"": 1385.139869450,
+            ""value"": 138513.986945000,
             ""orderSubmissionData"": {
                 ""bidPrice"": 138.505714984,
                 ""askPrice"": 138.513986945,
@@ -1111,7 +1128,7 @@ namespace QuantConnect.Tests.Common.Orders
     },
     ""SecurityType"": 2,
     ""Direction"": 0,
-    ""Value"": 1385.139869450,
+    ""Value"": 138513.986945000,
     ""OrderSubmissionData"": {
         ""BidPrice"": 138.505714984,
         ""AskPrice"": 138.513986945,


### PR DESCRIPTION
## What
- fix serialized/exported `value` for option orders in `ReadOrdersResponseJsonConverter`
- add a regression test covering option order serialization value
- update option order JSON fixtures to match multiplier-aware serialized output

## Why
Issue #8447 reports that exported order `value` omits the option contract multiplier, so option orders are serialized with `quantity * price` instead of `quantity * price * contract multiplier`.

## How
- keep the fix local to serialization
- preserve existing behavior for non-option orders
- when serializing option orders, compute `value` as `order.Value * contractMultiplier`

## Testing
- `dotnet build Tests/QuantConnect.Tests.csproj --no-restore -v minimal`
- `dotnet test Tests/QuantConnect.Tests.csproj --no-build --no-restore --filter FullyQualifiedName=QuantConnect.Tests.Common.Orders.ReadOrdersResponseJsonConverterTests.SerializesOptionOrderValueUsingContractMultiplier -v minimal`
- targeted regression test passed locally: 1 passed, 0 failed
