### PR TITLE
Configurable Map Zip Provider Lookback

### DIFF
--- a/Common/Data/Auxiliary/LocalZipMapFileProvider.cs
+++ b/Common/Data/Auxiliary/LocalZipMapFileProvider.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using QuantConnect.Configuration;
 using QuantConnect.Util;
 using QuantConnect.Logging;
 using System.Threading.Tasks;
@@ -27,6 +28,8 @@ namespace QuantConnect.Data.Auxiliary
     /// </summary>
     public class LocalZipMapFileProvider : IMapFileProvider
     {
+        // To prevent infinite recursion if something is wrong with the zip files, we look back a maximum of 30 days by default
+        private readonly int _lookback = Config.GetInt("map-file-zip-lookback-days", 30);
         private Dictionary<AuxiliaryDataKey, MapFileResolver> _cache;
         private IDataProvider _dataProvider;
         private object _lock;
@@ -50,7 +53,7 @@ namespace QuantConnect.Data.Auxiliary
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="LocalDiskFactorFileProvider"/>
+        /// Creates a new instance of the <see cref="LocalZipMapFileProvider"/>
         /// </summary>
         public LocalZipMapFileProvider()
         {
@@ -68,7 +71,7 @@ namespace QuantConnect.Data.Auxiliary
             {
                 return;
             }
-            
+
             _dataProvider = dataProvider;
             StartExpirationTask();
         }
@@ -94,7 +97,7 @@ namespace QuantConnect.Data.Auxiliary
         }
 
         /// <summary>
-        /// Helper method that will clear any cached factor files in a daily basis, this is useful for live trading
+        /// Helper method that will clear any cached map files on a daily basis, this is useful for live trading
         /// </summary>
         protected virtual void StartExpirationTask()
         {
@@ -112,35 +115,26 @@ namespace QuantConnect.Data.Auxiliary
             var timestamp = DateTime.UtcNow.ConvertFromUtc(TimeZones.NewYork);
             var todayNewYork = timestamp.Date;
             var yesterdayNewYork = todayNewYork.AddDays(-1);
-
+            var endDate = yesterdayNewYork.AddDays(-_lookback);
+            
             // start the search with yesterday, today's file will be available tomorrow
-            var count = 0;
-            var date = yesterdayNewYork;
-            do
+            for (var date = yesterdayNewYork; date >= endDate; date = date.AddDays(-1))
             {
                 var zipFileName = MapFileZipHelper.GetMapFileZipFileName(market, date, auxiliaryDataKey.SecurityType);
 
                 // Fetch a stream for our zip from our data provider
                 var stream = _dataProvider.Fetch(zipFileName);
 
-                // If we found a file we can read it 
-                if (stream != null)
-                {
-                    Log.Trace("LocalZipMapFileProvider.Get({0}): Fetched map files for: {1} NY", market, date.ToShortDateString());
-                    var result =  new MapFileResolver(MapFileZipHelper.ReadMapFileZip(stream, market, auxiliaryDataKey.SecurityType));
-                    stream.DisposeSafely();
-                    return result;
-                }
+                // If we didn't find a file, continue to the next date
+                if (stream == null) continue;
 
-                // prevent infinite recursion if something is wrong
-                if (count++ > 30)
-                {
-                    throw new InvalidOperationException($"LocalZipMapFileProvider couldn't find any map files going all the way back to {date} for {market}");
-                }
-
-                date = date.AddDays(-1);
+                Log.Trace($"LocalZipMapFileProvider.Get({market}): Fetched map files for: {date.ToShortDateString()} NY ({(date - todayNewYork).Days} days ago).");
+                var result = new MapFileResolver(MapFileZipHelper.ReadMapFileZip(stream, market, auxiliaryDataKey.SecurityType));
+                stream.DisposeSafely();
+                return result;
             }
-            while (true);
+
+            throw new InvalidOperationException($"LocalZipMapFileProvider couldn't find any map files going all the way back to {endDate.ToShortDateString()} for {market}, lookback limit is {_lookback} days");
         }
     }
 }


### PR DESCRIPTION
#### Description
Adds config `map-file-zip-lookback-days` to increase the hard-coded default of 30 days.

#### Related Issue
N/A.

#### Motivation and Context
We need it for the Docs CI.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Running LEAN locally. The behavior doesn't change. If we add the key to 300, I find a Zip file from Aug 2025 I've downloaded in Aug.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`