### PR TITLE
[Futures] Allow reducing leveraged targets during delta buying-power liquidation

### DIFF
--- a/Common/Securities/Future/FutureMarginModel.cs
+++ b/Common/Securities/Future/FutureMarginModel.cs
@@ -111,13 +111,39 @@ namespace QuantConnect.Securities.Future
         public override GetMaximumOrderQuantityResult GetMaximumOrderQuantityForTargetBuyingPower(
             GetMaximumOrderQuantityForTargetBuyingPowerParameters parameters)
         {
-            if (Math.Abs(parameters.TargetBuyingPower) > 1)
+            if (Math.Abs(parameters.TargetBuyingPower) > 1
+                && !IsReducingExistingExposure(parameters))
             {
                 throw new InvalidOperationException(
                     "Futures do not allow specifying a leveraged target, since they are traded using margin which already is leveraged. " +
                     $"Possible target buying power goes from -1 to 1, target provided is: {parameters.TargetBuyingPower}");
             }
             return base.GetMaximumOrderQuantityForTargetBuyingPower(parameters);
+        }
+
+        /// <summary>
+        /// Futures can temporarily exceed 100% target buying power during margin call liquidation requests.
+        /// In these cases we allow leveraged targets only when they reduce existing exposure.
+        /// </summary>
+        private bool IsReducingExistingExposure(GetMaximumOrderQuantityForTargetBuyingPowerParameters parameters)
+        {
+            var totalPortfolioValue = parameters.Portfolio.TotalPortfolioValue;
+            if (totalPortfolioValue == 0)
+            {
+                return false;
+            }
+
+            var currentMargin = this.GetInitialMarginRequirement(
+                parameters.Security, parameters.Security.Holdings.Quantity
+            );
+            if (currentMargin == 0)
+            {
+                return false;
+            }
+
+            var targetMargin = parameters.TargetBuyingPower * totalPortfolioValue;
+            return Math.Sign(targetMargin) == Math.Sign(currentMargin)
+                && Math.Abs(targetMargin) <= Math.Abs(currentMargin);
         }
 
         /// <summary>

--- a/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/FutureMarginBuyingPowerModelTests.cs
@@ -396,6 +396,43 @@ namespace QuantConnect.Tests.Common.Securities
                     0)));
         }
 
+        [Test]
+        public void GetMaximumOrderQuantityForDeltaBuyingPower_AllowsReducingLeveragedTarget()
+        {
+            var algorithm = new QCAlgorithm();
+            algorithm.SetFinishedWarmingUp();
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
+
+            var ticker = QuantConnect.Securities.Futures.Financials.EuroDollar;
+            var futureSecurity = algorithm.AddFuture(ticker);
+            Update(futureSecurity, 100, algorithm);
+
+            algorithm.Portfolio.SetCash(1000);
+            futureSecurity.Holdings.SetHoldings(100, 10);
+            algorithm.Portfolio.InvalidateTotalPortfolioValue();
+
+            var usedBuyingPower = futureSecurity.BuyingPowerModel.GetReservedBuyingPowerForPosition(
+                new ReservedBuyingPowerForPositionParameters(futureSecurity)).AbsoluteUsedBuyingPower;
+            var totalPortfolioValue = algorithm.Portfolio.TotalPortfolioValue;
+            var targetBuyingPower = 1.1m * totalPortfolioValue;
+            var deltaBuyingPower = targetBuyingPower - usedBuyingPower;
+
+            Assert.Greater(Math.Abs(usedBuyingPower / totalPortfolioValue), 1m);
+            Assert.Less(deltaBuyingPower, 0m);
+
+            Assert.DoesNotThrow(() =>
+            {
+                var result = futureSecurity.BuyingPowerModel.GetMaximumOrderQuantityForDeltaBuyingPower(
+                    new GetMaximumOrderQuantityForDeltaBuyingPowerParameters(
+                        algorithm.Portfolio,
+                        futureSecurity,
+                        deltaBuyingPower,
+                        0
+                    ));
+                Assert.Less(result.Quantity, 0m);
+            });
+        }
+
         [TestCase(1)]
         [TestCase(0.5)]
         [TestCase(-1)]


### PR DESCRIPTION
### Description
- allows FutureMarginModel leveraged target requests (`|target| > 1`) only when they reduce existing exposure
- keeps the existing exception behavior for leveraged requests that increase exposure
- adds a regression test for the delta-buying-power path used by margin liquidation

Closes #5604.

### Testing
- dotnet build Tests/QuantConnect.Tests.csproj --no-restore -v minimal
- dotnet test Tests/QuantConnect.Tests.csproj --filter FullyQualifiedName~FutureMarginBuyingPowerModelTests.GetMaximumOrderQuantityForDeltaBuyingPower_AllowsReducingLeveragedTarget --no-build -v normal -m:1 (test host crashes on this machine with Python.NET GIL finalizer error before test completion)