### PR TITLE
[Cash] Fallback to crypto future pairs when spot conversion pairs are missing

### DIFF
--- a/Common/Securities/Cash.cs
+++ b/Common/Securities/Cash.cs
@@ -261,19 +261,28 @@ namespace QuantConnect.Securities
             var forexEntries = GetAvailableSymbolPropertiesDatabaseEntries(SecurityType.Forex, marketMap, markets);
             var cfdEntries = GetAvailableSymbolPropertiesDatabaseEntries(SecurityType.Cfd, marketMap, markets);
             var cryptoEntries = GetAvailableSymbolPropertiesDatabaseEntries(SecurityType.Crypto, marketMap, markets);
+            var cryptoFutureEntries = Enumerable.Empty<KeyValuePair<SecurityDatabaseKey, SymbolProperties>>();
 
-            if (marketMap.TryGetValue(SecurityType.CryptoFuture, out var cryptoFutureMarket) && cryptoFutureMarket == Market.DYDX)
+            if (marketMap.TryGetValue(SecurityType.CryptoFuture, out var cryptoFutureMarket))
             {
-                // Put additional logic for dYdX crypto futures as they don't have Crypto (Spot) market
-                // Also need to add them first to give the priority
-                // TODO: remove once dydx SPOT market will be imlemented
-                cryptoEntries = GetAvailableSymbolPropertiesDatabaseEntries(SecurityType.CryptoFuture, marketMap, markets).Concat(cryptoEntries);
+                cryptoFutureEntries = GetAvailableSymbolPropertiesDatabaseEntries(SecurityType.CryptoFuture, marketMap, markets);
+                if (cryptoFutureMarket == Market.DYDX)
+                {
+                    // Put additional logic for dYdX crypto futures as they don't have Crypto (Spot) market
+                    // Also need to add them first to give the priority
+                    // TODO: remove once dydx SPOT market will be imlemented
+                    cryptoEntries = cryptoFutureEntries.Concat(cryptoEntries);
+                }
             }
 
             var potentialEntries = forexEntries
                 .Concat(cfdEntries)
                 .Concat(cryptoEntries)
                 .ToList();
+
+            Func<KeyValuePair<SecurityDatabaseKey, SymbolProperties>, bool> matchesCurrency = x =>
+                Symbol == x.Key.Symbol.Substring(0, x.Key.Symbol.Length - x.Value.QuoteCurrency.Length) ||
+                Symbol == x.Value.QuoteCurrency;
 
             // Special case for crypto markets without direct pairs (They wont be found by the above)
             // This allows us to add cash for "StableCoins" that are 1-1 with our account currency without needing a conversion security.
@@ -284,9 +293,13 @@ namespace QuantConnect.Securities
                 return null;
             }
 
-            if (!potentialEntries.Any(x =>
-                    Symbol == x.Key.Symbol.Substring(0, x.Key.Symbol.Length - x.Value.QuoteCurrency.Length) ||
-                    Symbol == x.Value.QuoteCurrency))
+            if (!potentialEntries.Any(matchesCurrency) && cryptoFutureEntries.Any())
+            {
+                // Some brokerages list conversion pairs only in their crypto futures market (for example API3USDT on Bybit).
+                potentialEntries = potentialEntries.Concat(cryptoFutureEntries).ToList();
+            }
+
+            if (!potentialEntries.Any(matchesCurrency))
             {
                 // currency not found in any tradeable pair
                 Log.Error(Messages.Cash.NoTradablePairFoundForCurrencyConversion(Symbol, accountCurrency, marketMap.Where(kvp => ProvidesConversionRate(kvp.Key))));

--- a/Tests/Common/Securities/CashTests.cs
+++ b/Tests/Common/Securities/CashTests.cs
@@ -485,6 +485,36 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
+        public void EnsureCurrencyDataFeedForCryptoCurrency_UsesCryptoFuture_WhenSpotPairMissing()
+        {
+            var book = new CashBook
+            {
+                {Currencies.USD, new Cash(Currencies.USD, 100, 1) },
+                {"API3", new Cash("API3", 100, 0) }
+            };
+
+            var subscriptions = new SubscriptionManager(NullTimeKeeper.Instance);
+            var dataManager = new DataManagerStub(TimeKeeper);
+            subscriptions.SetDataManager(dataManager);
+            var securities = new SecurityManager(TimeKeeper);
+
+            var marketMapWithBybit = MarketMap.ToDictionary();
+            marketMapWithBybit[SecurityType.Crypto] = Market.Bybit;
+            marketMapWithBybit[SecurityType.CryptoFuture] = Market.Bybit;
+
+            book.EnsureCurrencyDataFeeds(securities, subscriptions, marketMapWithBybit, SecurityChanges.None, dataManager.SecurityService);
+
+            var api3Cash = book["API3"];
+            Assert.IsInstanceOf(typeof(SecurityCurrencyConversion), api3Cash.CurrencyConversion);
+            var conversionSymbols = api3Cash.CurrencyConversion
+                .ConversionRateSecurities
+                .Select(x => x.Symbol)
+                .ToHashSet();
+
+            Assert.IsTrue(conversionSymbols.Contains(Symbol.Create("API3USDT", SecurityType.CryptoFuture, Market.Bybit)));
+        }
+
+        [Test]
         public void UpdateModifiesConversionRateAsInvertedValue()
         {
             const int quantity = 100;


### PR DESCRIPTION
### Description
- keeps existing forex/cfd/crypto conversion lookup behavior
- adds a fallback to use crypto-future symbol properties when no conversion pair is found in spot markets
- preserves dYdX priority behavior and adds a regression test for Bybit `API3` cash conversion routing through `API3USDT` crypto futures

Closes #7753.

### Testing
- dotnet build Tests/QuantConnect.Tests.csproj --no-restore -v minimal
- dotnet test Tests/QuantConnect.Tests.csproj --filter FullyQualifiedName~CashTests.EnsureCurrencyDataFeedForCryptoCurrency_UsesCryptoFuture_WhenSpotPairMissing --no-build -v normal -m:1 (test host crashes on this machine with Python.NET GIL finalizer error before test completion)