### PR TITLE
Fix capacity snapshot selection for zero-capacity symbols

### DIFF
--- a/Common/CapacityEstimate.cs
+++ b/Common/CapacityEstimate.cs
@@ -146,36 +146,40 @@ namespace QuantConnect
                 }
 
                 var smallestAsset = _capacityBySymbol.Values
+                    .Where(c => c.Trades > 0 && c.MarketCapacityDollarVolume > 0)
                     .OrderBy(c => c.MarketCapacityDollarVolume)
-                    .First();
+                    .FirstOrDefault();
 
-                _smallestAssetSymbol = smallestAsset.Security.Symbol;
-
-                // When there is no trading, rely on the portfolio holdings
-                var percentageOfSaleVolume = totalSaleVolume != 0
-                    ? smallestAsset.SaleVolume / totalSaleVolume
-                    : 0;
-
-                var buyingPowerUsed = smallestAsset.Security.MarginModel.GetReservedBuyingPowerForPosition(new ReservedBuyingPowerForPositionParameters(smallestAsset.Security))
-                    .AbsoluteUsedBuyingPower * smallestAsset.Security.Leverage;
-
-                var percentageOfHoldings = buyingPowerUsed / totalPortfolioValue;
-
-                var scalingFactor = Math.Max(percentageOfSaleVolume, percentageOfHoldings);
-                var dailyMarketCapacityDollarVolume = smallestAsset.MarketCapacityDollarVolume / smallestAsset.Trades;
-
-                var newCapacity = scalingFactor == 0
-                    ? _capacity.Value
-                    : dailyMarketCapacityDollarVolume / scalingFactor;
-
-                // Weight our capacity based on previous value if we have one
-                if (_capacity.Value != 0)
+                if (smallestAsset != null)
                 {
-                    newCapacity = (0.33m * newCapacity) + (_capacity.Value * 0.66m);
-                }
+                    _smallestAssetSymbol = smallestAsset.Security.Symbol;
 
-                // Set our new capacity value
-                Capacity = newCapacity;
+                    // When there is no trading, rely on the portfolio holdings
+                    var percentageOfSaleVolume = totalSaleVolume != 0
+                        ? smallestAsset.SaleVolume / totalSaleVolume
+                        : 0;
+
+                    var buyingPowerUsed = smallestAsset.Security.MarginModel.GetReservedBuyingPowerForPosition(new ReservedBuyingPowerForPositionParameters(smallestAsset.Security))
+                        .AbsoluteUsedBuyingPower * smallestAsset.Security.Leverage;
+
+                    var percentageOfHoldings = buyingPowerUsed / totalPortfolioValue;
+
+                    var scalingFactor = Math.Max(percentageOfSaleVolume, percentageOfHoldings);
+                    var dailyMarketCapacityDollarVolume = smallestAsset.MarketCapacityDollarVolume / smallestAsset.Trades;
+
+                    var newCapacity = scalingFactor == 0
+                        ? _capacity.Value
+                        : dailyMarketCapacityDollarVolume / scalingFactor;
+
+                    // Weight our capacity based on previous value if we have one
+                    if (_capacity.Value != 0)
+                    {
+                        newCapacity = (0.33m * newCapacity) + (_capacity.Value * 0.66m);
+                    }
+
+                    // Set our new capacity value
+                    Capacity = newCapacity;
+                }
 
                 foreach (var capacity in _capacityBySymbol.Select(pair => pair.Value).ToList())
                 {

--- a/Tests/Common/CapacityEstimateTests.cs
+++ b/Tests/Common/CapacityEstimateTests.cs
@@ -1,0 +1,70 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Orders;
+using QuantConnect.Orders.Fees;
+using QuantConnect.Securities;
+using QuantConnect.Tests.Engine.DataFeeds;
+
+namespace QuantConnect.Tests.Common
+{
+    [TestFixture]
+    public class CapacityEstimateTests
+    {
+        [Test]
+        public void UpdateMarketCapacitySkipsSymbolsWithoutMarketCapacityData()
+        {
+            var algorithm = new AlgorithmStub();
+            algorithm.SetStartDate(2020, 1, 1);
+            algorithm.SetEndDate(2020, 1, 10);
+
+            var security = algorithm.AddEquity("SPY", Resolution.Minute);
+            security.BuyingPowerModel = new ThrowingBuyingPowerModel();
+
+            var utcTime = new DateTime(2020, 1, 2, 15, 0, 0, DateTimeKind.Utc);
+            algorithm.SetDateTime(utcTime);
+            algorithm.SetCurrentSlice(new Slice(utcTime, Enumerable.Empty<BaseData>(), utcTime));
+
+            var capacityEstimate = new CapacityEstimate(algorithm);
+            capacityEstimate.OnOrderEvent(new OrderEvent(
+                orderId: 1,
+                symbol: security.Symbol,
+                utcTime: utcTime,
+                status: OrderStatus.Filled,
+                direction: OrderDirection.Buy,
+                fillPrice: 100m,
+                fillQuantity: 1m,
+                orderFee: OrderFee.Zero));
+
+            Assert.DoesNotThrow(() => capacityEstimate.UpdateMarketCapacity(forceProcess: true));
+        }
+
+        private class ThrowingBuyingPowerModel : SecurityMarginModel
+        {
+            public ThrowingBuyingPowerModel() : base(1m)
+            {
+            }
+
+            public override ReservedBuyingPowerForPosition GetReservedBuyingPowerForPosition(ReservedBuyingPowerForPositionParameters parameters)
+            {
+                throw new InvalidOperationException("Reserved buying power should not be queried for symbols without market capacity data.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
Fixes an edge case in CapacityEstimate.UpdateMarketCapacity where snapshot selection could pick a symbol with no valid market-capacity data (Trades == 0 or MarketCapacityDollarVolume == 0).

This could cause a stale/delisted zero-capacity symbol to drive snapshot logic and trigger unnecessary margin model calls.

### Changes
- Filter snapshot candidates to symbols with usable capacity inputs:
  - Trades > 0
  - MarketCapacityDollarVolume > 0
- Use FirstOrDefault() for candidate selection and skip scaling logic when no valid candidate exists.
- Preserve existing reset/removal housekeeping for symbol capacity entries.
- Add regression test:
  - CapacityEstimateTests.UpdateMarketCapacitySkipsSymbolsWithoutMarketCapacityData
  - Verifies we do not query reserved buying power for symbols without market-capacity data.

### Validation
- dotnet build Tests/QuantConnect.Tests.csproj --no-restore -v minimal ✅
- dotnet test Tests/QuantConnect.Tests.csproj --filter FullyQualifiedName~CapacityEstimateTests.UpdateMarketCapacitySkipsSymbolsWithoutMarketCapacityData --no-build -v normal -m:1 ⚠️
  - Test host aborts in this environment due Python.NET GIL finalizer crash:
    - System.InvalidOperationException: GIL must always be released...

Closes #6523