### PR TITLE
Defer cash-account buy orders until reducing fills in ImmediateExecutionModel

### DIFF
--- a/Algorithm/Execution/ImmediateExecutionModel.cs
+++ b/Algorithm/Execution/ImmediateExecutionModel.cs
@@ -17,6 +17,8 @@ using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Algorithm.Framework.Portfolio;
+using System;
+using System.Linq;
 
 namespace QuantConnect.Algorithm.Framework.Execution
 {
@@ -48,19 +50,31 @@ namespace QuantConnect.Algorithm.Framework.Execution
             // for performance we if empty, OrderByMarginImpact and ClearFulfilled are expensive to call
             if (!_targetsCollection.IsEmpty)
             {
+                var isCashAccount = algorithm.BrokerageModel.AccountType == AccountType.Cash;
+                var hasOpenPositionReducingOrder = isCashAccount && HasOpenPositionReducingOrder(algorithm);
+
                 foreach (var target in _targetsCollection.OrderByMarginImpact(algorithm))
                 {
                     var security = algorithm.Securities[target.Symbol];
 
                     // calculate remaining quantity to be ordered
                     var quantity = OrderSizing.GetUnorderedQuantity(algorithm, target, security, true);
+                    var isPositionReducingOrder = IsPositionReducingOrder(security.Holdings.Quantity, quantity);
 
                     if (quantity != 0)
                     {
+                        // In cash accounts, submit position-reducing orders first and wait for them to fill before
+                        // submitting cash-consuming orders. This avoids transient insufficient buying power rejects.
+                        if (hasOpenPositionReducingOrder && !isPositionReducingOrder)
+                        {
+                            continue;
+                        }
+
                         if (security.BuyingPowerModel.AboveMinimumOrderMarginPortfolioPercentage(security, quantity,
                             algorithm.Portfolio, algorithm.Settings.MinimumOrderMarginPortfolioPercentage))
                         {
                             algorithm.MarketOrder(security, quantity, Asynchronous, target.Tag);
+                            hasOpenPositionReducingOrder = hasOpenPositionReducingOrder || isPositionReducingOrder;
                         }
                         else if (!PortfolioTarget.MinimumOrderMarginPercentageWarningSent.HasValue)
                         {
@@ -72,6 +86,26 @@ namespace QuantConnect.Algorithm.Framework.Execution
 
                 _targetsCollection.ClearFulfilled(algorithm);
             }
+        }
+
+        private static bool HasOpenPositionReducingOrder(QCAlgorithm algorithm)
+        {
+            return algorithm.Transactions.GetOpenOrders().Any(order =>
+            {
+                if (!algorithm.Securities.TryGetValue(order.Symbol, out var security))
+                {
+                    return false;
+                }
+
+                return IsPositionReducingOrder(security.Holdings.Quantity, order.Quantity);
+            });
+        }
+
+        private static bool IsPositionReducingOrder(decimal holdingsQuantity, decimal orderQuantity)
+        {
+            return holdingsQuantity != 0m
+                   && orderQuantity != 0m
+                   && Math.Sign(holdingsQuantity) != Math.Sign(orderQuantity);
         }
 
         /// <summary>

--- a/Algorithm/Execution/ImmediateExecutionModel.py
+++ b/Algorithm/Execution/ImmediateExecutionModel.py
@@ -31,12 +31,21 @@ class ImmediateExecutionModel(ExecutionModel):
         # for performance we check count value, OrderByMarginImpact and ClearFulfilled are expensive to call
         self.targets_collection.add_range(targets)
         if not self.targets_collection.is_empty:
+            is_cash_account = algorithm.brokerage_model.account_type == AccountType.Cash
+            has_open_position_reducing_order = is_cash_account and self._has_open_position_reducing_order(algorithm)
+
             for target in self.targets_collection.order_by_margin_impact(algorithm):
                 security = algorithm.securities[target.symbol]
                 # calculate remaining quantity to be ordered
                 quantity = OrderSizing.get_unordered_quantity(algorithm, target, security, True)
+                is_position_reducing_order = self._is_position_reducing_order(security.holdings.quantity, quantity)
 
                 if quantity != 0:
+                    # In cash accounts, submit position-reducing orders first and wait for them to fill before
+                    # submitting cash-consuming orders. This avoids transient insufficient buying power rejects.
+                    if has_open_position_reducing_order and not is_position_reducing_order:
+                        continue
+
                     above_minimum_portfolio = BuyingPowerModelExtensions.above_minimum_order_margin_portfolio_percentage(
                         security.buying_power_model,
                         security,
@@ -45,8 +54,23 @@ class ImmediateExecutionModel(ExecutionModel):
                         algorithm.settings.minimum_order_margin_portfolio_percentage)
                     if above_minimum_portfolio:
                         algorithm.market_order(security, quantity, self.asynchronous, target.tag)
+                        has_open_position_reducing_order = has_open_position_reducing_order or is_position_reducing_order
                     elif not PortfolioTarget.minimum_order_margin_percentage_warning_sent:
                         # will trigger the warning if it has not already been sent
                         PortfolioTarget.minimum_order_margin_percentage_warning_sent = False
 
             self.targets_collection.clear_fulfilled(algorithm)
+
+    @staticmethod
+    def _has_open_position_reducing_order(algorithm):
+        for order in algorithm.transactions.get_open_orders():
+            if order.symbol not in algorithm.securities:
+                continue
+            security = algorithm.securities[order.symbol]
+            if ImmediateExecutionModel._is_position_reducing_order(security.holdings.quantity, order.quantity):
+                return True
+        return False
+
+    @staticmethod
+    def _is_position_reducing_order(holdings_quantity, order_quantity):
+        return holdings_quantity != 0 and order_quantity != 0 and holdings_quantity * order_quantity < 0

--- a/Tests/Algorithm/Framework/Execution/ImmediateExecutionModelTests.cs
+++ b/Tests/Algorithm/Framework/Execution/ImmediateExecutionModelTests.cs
@@ -31,6 +31,7 @@ using QuantConnect.Orders;
 using QuantConnect.Orders.Fees;
 using QuantConnect.Python;
 using QuantConnect.Securities;
+using QuantConnect.Brokerages;
 using QuantConnect.Tests.Common.Data.UniverseSelection;
 using QuantConnect.Tests.Engine.DataFeeds;
 
@@ -220,6 +221,69 @@ namespace QuantConnect.Tests.Algorithm.Framework.Execution
                 // Remaining quantity for non-filled order = targetQuantity = 80
                 // Quantity submitted = newTargetQuantity - targetQuantity = 100 - 80 = 20
                 Assert.AreEqual(newTargetQuantity - targetQuantity, orderProcessor.GetOpenOrders().OrderByDescending(o => o.Id).First().Quantity);
+            }
+            finally
+            {
+                orderProcessor.Exit();
+                brokerage.Dispose();
+            }
+        }
+
+        [TestCase(Language.CSharp)]
+        [TestCase(Language.Python)]
+        public void CashAccountSubmitsReducingOrdersBeforeIncreasingOrders(Language language)
+        {
+            var algorithm = new AlgorithmStub();
+            algorithm.SetBrokerageModel(BrokerageName.Coinbase, AccountType.Cash);
+
+            var aapl = algorithm.AddEquity(Symbols.AAPL.Value);
+            var spy = algorithm.AddEquity(Symbols.SPY.Value);
+            aapl.SetMarketPrice(new TradeBar { Value = 100m });
+            spy.SetMarketPrice(new TradeBar { Value = 100m });
+
+            aapl.Holdings.SetHoldings(100m, 10m);
+            algorithm.SetFinishedWarmingUp();
+
+            var orderProcessor = GetAndSetBrokerageTransactionHandler(algorithm, out var brokerage);
+
+            try
+            {
+                var model = GetExecutionModel(language, true);
+                algorithm.SetExecution(model);
+
+                var targets = new IPortfolioTarget[]
+                {
+                    new PortfolioTarget(Symbols.AAPL, 0m),
+                    new PortfolioTarget(Symbols.SPY, 10m)
+                };
+
+                model.Execute(algorithm, targets);
+                orderProcessor.ProcessSynchronousEvents();
+
+                var openOrders = orderProcessor.GetOpenOrders().OrderBy(o => o.Id).ToList();
+                Assert.AreEqual(1, openOrders.Count);
+                Assert.AreEqual(Symbols.AAPL, openOrders[0].Symbol);
+                Assert.Less(openOrders[0].Quantity, 0m);
+
+                var sellOrder = openOrders[0];
+                brokerage.OnOrderEvent(new OrderEvent(
+                    sellOrder.Id,
+                    sellOrder.Symbol,
+                    algorithm.UtcTime,
+                    OrderStatus.Filled,
+                    OrderDirection.Sell,
+                    100m,
+                    sellOrder.Quantity,
+                    OrderFee.Zero));
+                orderProcessor.ProcessSynchronousEvents();
+
+                model.Execute(algorithm, Array.Empty<IPortfolioTarget>());
+                orderProcessor.ProcessSynchronousEvents();
+
+                var orders = orderProcessor.GetOrders().OrderBy(o => o.Id).ToList();
+                Assert.AreEqual(2, orders.Count);
+                Assert.AreEqual(Symbols.SPY, orders[1].Symbol);
+                Assert.Greater(orders[1].Quantity, 0m);
             }
             finally
             {


### PR DESCRIPTION
### Description
In cash accounts, ImmediateExecutionModel could submit sell and buy market orders in the same execution pass. In live trading this can cause transient insufficient buying power rejects because the sell has not filled yet.

This change makes ImmediateExecutionModel (C# and Python) defer cash-consuming orders while there are open position-reducing orders.

### Changes
- ImmediateExecutionModel (C#):
  - Detect cash accounts.
  - Detect open position-reducing orders.
  - Skip non-reducing targets while reducing orders are still open.
- ImmediateExecutionModel.py:
  - Mirrors the same behavior for Python framework users.
- Added regression test:
  - ImmediateExecutionModelTests.CashAccountSubmitsReducingOrdersBeforeIncreasingOrders
  - Verifies first execution only submits the reducing order, and after fill event, subsequent execution submits the increasing order.

### Validation
- dotnet build Tests/QuantConnect.Tests.csproj --no-restore -v minimal /p:RunAnalyzers=false ✅
- dotnet test Tests/QuantConnect.Tests.csproj --no-build --filter FullyQualifiedName~ImmediateExecutionModelTests.CashAccountSubmitsReducingOrdersBeforeIncreasingOrders -v normal -m:1 ⚠️
  - Aborted by environment-level Python.NET crash before assertions:
  - System.InvalidOperationException: GIL must always be released, and it must be released from the same thread that acquired it.

Closes #9231