### PR TITLE
Apply option expiration filters per date in QuantBook.OptionHistory

### DIFF
--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -398,7 +398,6 @@ namespace QuantConnect.Research
             // Load a canonical option Symbol if the user provides us with an underlying Symbol
             symbol = GetOptionSymbolForHistoryRequest(symbol, null, resolution, fillForward);
 
-            IEnumerable<Symbol> symbols;
             if (symbol.IsCanonical())
             {
                 // canonical symbol, lets find the contracts
@@ -438,28 +437,37 @@ namespace QuantConnect.Research
                     }
                 }
 
-                var allSymbols = new HashSet<Symbol>();
+                var historyRequests = CreateDateRangeHistoryRequests(new[] { symbol.Underlying }, start, end.Value,
+                    resolution, fillForward, extendedMarketHours).ToList();
                 var optionFilterUniverse = new OptionFilterUniverse(option);
-
                 foreach (var (date, chainData, underlyingData) in GetChainHistory<OptionUniverse>(option, start, end.Value, extendedMarketHours))
                 {
                     if (underlyingData is not null)
                     {
                         optionFilterUniverse.Refresh(chainData, underlyingData, underlyingData.EndTime);
-                        allSymbols.UnionWith(option.ContractFilter.Filter(optionFilterUniverse).Select(x => x.Symbol));
+                        var filteredSymbols = option.ContractFilter.Filter(optionFilterUniverse).Select(x => x.Symbol).ToList();
+                        if (filteredSymbols.Count == 0)
+                        {
+                            continue;
+                        }
+
+                        var requestStart = date.Date < start ? start : date.Date;
+                        var requestEnd = date.Date.AddDays(1) > end.Value ? end.Value : date.Date.AddDays(1);
+                        if (requestStart >= requestEnd)
+                        {
+                            continue;
+                        }
+
+                        historyRequests.AddRange(CreateDateRangeHistoryRequests(filteredSymbols, requestStart, requestEnd,
+                            resolution, fillForward, extendedMarketHours));
                     }
                 }
 
-                var distinctSymbols = allSymbols.Distinct().Select(x => new OptionUniverse() { Symbol = x, Time = start });
-                symbols = allSymbols.Concat(new[] { symbol.Underlying });
-            }
-            else
-            {
-                // the symbol is a contract
-                symbols = new List<Symbol> { symbol };
+                return new OptionHistory(History(historyRequests));
             }
 
-            return new OptionHistory(History(symbols, start, end.Value, resolution, fillForward, extendedMarketHours));
+            // the symbol is a contract
+            return new OptionHistory(History(new List<Symbol> { symbol }, start, end.Value, resolution, fillForward, extendedMarketHours));
         }
 
         /// <summary>

--- a/Tests/Research/QuantBookHistoryTests.cs
+++ b/Tests/Research/QuantBookHistoryTests.cs
@@ -306,6 +306,38 @@ namespace QuantConnect.Tests.Research
         }
 
         [Test]
+        public void OptionHistoryRespectsExpirationFilterPerDate()
+        {
+            var qb = new QuantBook();
+            var historyProvider = new TestHistoryProvider(qb.HistoryProvider);
+            qb.SetHistoryProvider(historyProvider);
+
+            var spxw = qb.AddIndexOption(Symbols.SPX, "SPXW");
+            spxw.SetFilter(u => u.WeeklysOnly().CallsOnly().Expiration(1, 2).Strikes(-1, 1));
+
+            var start = new DateTime(2021, 1, 4);
+            var end = new DateTime(2021, 1, 6);
+            var history = qb.OptionHistory(spxw.Symbol, start, end, Resolution.Daily, fillForward: false, extendedMarketHours: false);
+
+            var optionData = history.SelectMany(slice => slice.AllData.Where(data => data.Symbol.SecurityType == SecurityType.IndexOption)).ToList();
+            Assert.IsNotEmpty(optionData);
+
+            Assert.IsTrue(optionData.All(data =>
+            {
+                var dte = (data.Symbol.ID.Date.Date - data.EndTime.Date).TotalDays;
+                return dte >= 1 && dte <= 2;
+            }), "Expected all contracts to satisfy the configured [1,2] day expiration window.");
+
+            var optionContractRequests = historyProvider.HistoryRequests
+                .Where(request => request.Symbol.SecurityType == SecurityType.IndexOption && request.DataType != typeof(OptionUniverse))
+                .ToList();
+
+            Assert.IsNotEmpty(optionContractRequests);
+            Assert.IsTrue(optionContractRequests.All(request => request.EndTimeLocal - request.StartTimeLocal <= TimeSpan.FromDays(1)),
+                "Expected option contract history requests to be bounded to one day so filters are applied per date.");
+        }
+
+        [Test]
         public void OptionUnderlyingSymbolQuantBookHistory()
         {
             var qb = new QuantBook();


### PR DESCRIPTION
### Description
Fixes QuantBook.OptionHistory for canonical options so expiration filtering is respected per date.

Previously, the implementation collected a union of filtered contracts across the whole date range and then requested history for that full range for every selected contract. This could return contracts outside the intended DTE window on individual dates and over-fetch large option chains.

### Changes
- In QuantBook.OptionHistory(Symbol symbol, DateTime start, DateTime? end, ...) for canonical option symbols:
  - Keep a full-range history request for the underlying symbol.
  - For each tradeable date, apply the contract filter to that date's option chain.
  - Create option-contract history requests bounded to that date window only ([date, date+1) clipped to requested range).
  - Execute aggregated requests via History(historyRequests).
- Added regression test:
  - QuantBookHistoryTests.OptionHistoryRespectsExpirationFilterPerDate
  - Verifies:
    - Returned option data respects Expiration(1, 2) on each date.
    - Option contract history requests are bounded to <= 1 day windows (instead of full-range per contract requests).

### Validation
- dotnet build Tests/QuantConnect.Tests.csproj --no-restore -v minimal /p:RunAnalyzers=false ✅
- dotnet test Tests/QuantConnect.Tests.csproj --no-build --filter FullyQualifiedName~QuantConnect.Tests.Research.QuantBookHistoryTests.OptionHistoryRespectsExpirationFilterPerDate -v normal -m:1 ⚠️
  - Aborted in this environment due known Python.NET host-process crash:
  - System.InvalidOperationException: GIL must always be released...

Closes #8932