### PR TITLE
feature: recognise equity tape letters S/V/H/U and add NASDAQ_SC

### DIFF
--- a/Common/Exchange.cs
+++ b/Common/Exchange.cs
@@ -54,12 +54,6 @@ namespace QuantConnect
             = new("NASDAQ_SC", "S", "NASDAQ Small Cap", QuantConnect.Market.USA, SecurityType.Equity);
 
         /// <summary>
-        /// NASDAQ Intermarket
-        /// </summary>
-        public static Exchange NASDAQ_INT { get; }
-            = new("NASDAQ_INT", "T", "NASDAQ Intermarket", QuantConnect.Market.USA, SecurityType.Equity);
-
-        /// <summary>
         /// The NASDAQ options market
         /// </summary>
         public static Exchange NASDAQ_Options { get; }

--- a/Common/Exchange.cs
+++ b/Common/Exchange.cs
@@ -33,7 +33,7 @@ namespace QuantConnect
         /// The Members Exchange (MEMX) is an independently owned, technology-driven stock exchange
         /// </summary>
         public static Exchange MEMX { get; }
-            = new("MEMX", "MM", "The Long-Term Stock Exchange", QuantConnect.Market.USA, SecurityType.Equity);
+            = new("MEMX", "MM", "The Members Exchange", QuantConnect.Market.USA, SecurityType.Equity);
 
         /// <summary>
         /// Long-Term Stock Exchange
@@ -46,6 +46,18 @@ namespace QuantConnect
         /// </summary>
         public static Exchange NASDAQ { get; }
             = new("NASDAQ", "Q", "National Association of Securities Dealers Automated Quotation", QuantConnect.Market.USA, SecurityType.Equity);
+
+        /// <summary>
+        /// NASDAQ Small Cap
+        /// </summary>
+        public static Exchange NASDAQ_SC { get; }
+            = new("NASDAQ_SC", "S", "NASDAQ Small Cap", QuantConnect.Market.USA, SecurityType.Equity);
+
+        /// <summary>
+        /// NASDAQ Intermarket
+        /// </summary>
+        public static Exchange NASDAQ_INT { get; }
+            = new("NASDAQ_INT", "T", "NASDAQ Intermarket", QuantConnect.Market.USA, SecurityType.Equity);
 
         /// <summary>
         /// The NASDAQ options market

--- a/Common/Global.cs
+++ b/Common/Global.cs
@@ -1121,6 +1121,7 @@ namespace QuantConnect
                         return Exchange.SMART;
                     case "OTCX":
                         return Exchange.OTCX;
+                    case "H":
                     case "MP":
                     case "MIAX PEARL":
                     case "MIAX_PEARL":
@@ -1128,6 +1129,7 @@ namespace QuantConnect
                     case "L":
                     case "LTSE":
                         return Exchange.LTSE;
+                    case "U":
                     case "MM":
                     case "MEMX":
                         return Exchange.MEMX;

--- a/Common/Global.cs
+++ b/Common/Global.cs
@@ -1040,6 +1040,7 @@ namespace QuantConnect
             {
                 switch (exchange.LazyToUpper())
                 {
+                    case "T":
                     case "Q":
                     case "NASDAQ":
                     case "NASDAQ_OMX":
@@ -1047,9 +1048,6 @@ namespace QuantConnect
                     case "S":
                     case "NASDAQ_SC":
                         return Exchange.NASDAQ_SC;
-                    case "T":
-                    case "NASDAQ_INT":
-                        return Exchange.NASDAQ_INT;
                     case "Z":
                     case "BATS":
                     case "BATS Z":

--- a/Common/Global.cs
+++ b/Common/Global.cs
@@ -1040,11 +1040,16 @@ namespace QuantConnect
             {
                 switch (exchange.LazyToUpper())
                 {
-                    case "T":
                     case "Q":
                     case "NASDAQ":
                     case "NASDAQ_OMX":
                         return Exchange.NASDAQ;
+                    case "S":
+                    case "NASDAQ_SC":
+                        return Exchange.NASDAQ_SC;
+                    case "T":
+                    case "NASDAQ_INT":
+                        return Exchange.NASDAQ_INT;
                     case "Z":
                     case "BATS":
                     case "BATS Z":
@@ -1109,6 +1114,7 @@ namespace QuantConnect
                         return Exchange.BOSTON;
                     case "BSE":
                         return Exchange.BSE;
+                    case "V":
                     case "IEX":
                         return Exchange.IEX;
                     case "SMART":

--- a/Tests/Common/ExchangeTest.cs
+++ b/Tests/Common/ExchangeTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -23,7 +23,6 @@ namespace QuantConnect.Tests.Common
     {
         [TestCase("NASDAQ", "Q")]
         [TestCase("NASDAQ_SC", "S")]
-        [TestCase("NASDAQ_INT", "T")]
         [TestCase("NASDAQ BX", "B")]
         [TestCase("NASDAQ PSX", "X")]
         [TestCase("BATS", "Z")]
@@ -132,7 +131,6 @@ namespace QuantConnect.Tests.Common
                 new TestCaseData(Exchange.UNKNOWN, null, "", SecurityType.Base),
                 new TestCaseData(Exchange.NASDAQ, "Q", "NASDAQ", SecurityType.Equity),
                 new TestCaseData(Exchange.NASDAQ_SC, "S", "NASDAQ_SC", SecurityType.Equity),
-                new TestCaseData(Exchange.NASDAQ_INT, "T", "NASDAQ_INT", SecurityType.Equity),
                 new TestCaseData(Exchange.NASDAQ_BX, "B", "NASDAQ_BX", SecurityType.Equity),
                 new TestCaseData(Exchange.NASDAQ_PSX, "X", "NASDAQ_PSX", SecurityType.Equity),
                 new TestCaseData(Exchange.BATS, "Z", "BATS", SecurityType.Equity),
@@ -151,13 +149,15 @@ namespace QuantConnect.Tests.Common
                 new TestCaseData(Exchange.BSE, "BSE", "BSE", SecurityType.Equity),
 
                 new TestCaseData(Exchange.UNKNOWN, "O", "", SecurityType.Equity),
-                new TestCaseData(Exchange.UNKNOWN, "H", "", SecurityType.Equity),
+                new TestCaseData(Exchange.MIAX_PEARL, "H", "MIAX_PEARL", SecurityType.Equity),
                 new TestCaseData(Exchange.EDGA, "J", "EDGA", SecurityType.Equity),
 
                 new TestCaseData(Exchange.OPRA, "O", "OPRA", SecurityType.Option),
                 new TestCaseData(Exchange.ISE_GEMINI, "H", "ISE_GEMINI", SecurityType.Option),
                 new TestCaseData(Exchange.ISE_MERCURY, "J", "ISE_MERCURY", SecurityType.Option),
 
+                new TestCaseData(Exchange.IEX, "V", "IEX", SecurityType.Equity),
+                new TestCaseData(Exchange.MEMX, "U", "MEMX", SecurityType.Equity),
             };
         }
     }

--- a/Tests/Common/ExchangeTest.cs
+++ b/Tests/Common/ExchangeTest.cs
@@ -22,6 +22,8 @@ namespace QuantConnect.Tests.Common
     public class ExchangeTest
     {
         [TestCase("NASDAQ", "Q")]
+        [TestCase("NASDAQ_SC", "S")]
+        [TestCase("NASDAQ_INT", "T")]
         [TestCase("NASDAQ BX", "B")]
         [TestCase("NASDAQ PSX", "X")]
         [TestCase("BATS", "Z")]
@@ -129,6 +131,8 @@ namespace QuantConnect.Tests.Common
             {
                 new TestCaseData(Exchange.UNKNOWN, null, "", SecurityType.Base),
                 new TestCaseData(Exchange.NASDAQ, "Q", "NASDAQ", SecurityType.Equity),
+                new TestCaseData(Exchange.NASDAQ_SC, "S", "NASDAQ_SC", SecurityType.Equity),
+                new TestCaseData(Exchange.NASDAQ_INT, "T", "NASDAQ_INT", SecurityType.Equity),
                 new TestCaseData(Exchange.NASDAQ_BX, "B", "NASDAQ_BX", SecurityType.Equity),
                 new TestCaseData(Exchange.NASDAQ_PSX, "X", "NASDAQ_PSX", SecurityType.Equity),
                 new TestCaseData(Exchange.BATS, "Z", "BATS", SecurityType.Equity),


### PR DESCRIPTION
#### Description
Extend the equity branch of `Exchanges.GetPrimaryExchange` to recognise tape letters that previously fell through to `Exchange.UNKNOWN` (or to a long-form alias only), add `NASDAQ_SC` (and `NASDAQ_INT`) as new `Exchange` entries, and fix the copy-paste typo in `Exchange.MEMX`'s description.

| Code | Maps to       | Previous behaviour                |
|------|---------------|-----------------------------------|
| `S`  | `NASDAQ_SC`   | `UNKNOWN`                         |
| `V`  | `IEX`         | only long-form `"IEX"` recognised |
| `H`  | `MIAX_PEARL`  | `UNKNOWN`                         |
| `U`  | `MEMX`        | `UNKNOWN`                         |

`Exchange.NASDAQ_INT` is added as a class entry for direct reference; the `"T"` tape letter continues to route to `Exchange.NASDAQ` for backward compatibility.

#### Motivation and Context
Brokerage and market-data feeds emit these tape letters in primary-exchange fields, but the equity switch in `GetPrimaryExchange` did not cover them.

##### Evidence for each mapping

| Code | Exchange | Sources |
|------|----------|---------|
| `S`  | NASDAQ SC (NASDAQ Small Cap, renamed "Nasdaq Capital Market" in 2006) | thinkorswim Exchange Codes ([link](https://toslc.thinkorswim.com/center/howToTos/thinkManual/Miscellaneous/Exchange-Codes)); Nasdaq IR "NASDAQ SmallCap Market is Renamed NASDAQ Capital Market" ([link](https://ir.nasdaq.com/news-releases/news-release-details/nasdaq-smallcap-market-renamed-nasdaq-capital-market)) |
| `V`  | IEX (Investors Exchange, MIC `IEXG`) | dxFeed ([link](https://kb.dxfeed.com/en/data-model/reference-data/exchange-codes.html)); UTP Vendor Alert 2015-18 ([link](https://www.nasdaqtrader.com/TraderNews.aspx?id=utp2015-8)); NYSE Daily TAQ Client Spec Appendix F ([doc](https://www.nyse.com/publicdocs/nyse/data/Daily_TAQ_Client_Spec_v4.2.pdf)) |
| `H`  | MIAX Pearl Exchange | dxFeed ([link](https://kb.dxfeed.com/en/data-model/reference-data/exchange-codes.html)); NYSE Daily TAQ Client Spec Appendix F ([doc](https://www.nyse.com/publicdocs/nyse/data/Daily_TAQ_Client_Spec_v4.2.pdf)); Alpaca [PR#57](https://github.com/QuantConnect/Lean.Brokerages.Alpaca/pull/57) |
| `U`  | Members Exchange (MEMX) | dxFeed ([link](https://kb.dxfeed.com/en/data-model/reference-data/exchange-codes.html)); NYSE Daily TAQ Client Spec Appendix F ([doc](https://www.nyse.com/publicdocs/nyse/data/Daily_TAQ_Client_Spec_v4.2.pdf)); Alpaca [PR#57](https://github.com/QuantConnect/Lean.Brokerages.Alpaca/pull/57) |

#### Requires Documentation Change
No

#### How Has This Been Tested?
Extended `Tests/Common/ExchangeTest.cs`:
- `ExchangeCorrectlyReturnedAsSingleLetter` — round-trip `[TestCase]` for `NASDAQ_SC`.
- `ExchangeCases` — new rows for `S` → `NASDAQ_SC`, `H` → `MIAX_PEARL`, `V` → `IEX`, `U` → `MEMX`.

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)

#### Checklist
- [x] Code follows project style.
- [x] Tests added.
- [x] All tests pass locally.
