### PR TITLE
Extend LSMA to accept benchmark reference

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -1366,6 +1366,25 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Creates and registers a new Least Squares Moving Average instance.
+        /// </summary>
+        /// <param name="symbol">The symbol whose LSMA we seek.</param>
+        /// <param name="reference">The reference symbol to regress against.</param>
+        /// <param name="period">The LSMA period. Normally 14.</param>
+        /// <param name="resolution">The resolution.</param>
+        /// <param name="selector">Selects a value from the BaseData to send into the indicator, if null defaults to casting the input value to a TradeBar.</param>
+        /// <returns>A LeastSquaredMovingAverage configured with the specified period and reference symbol</returns>
+        [DocumentationAttribute(Indicators)]
+        public LeastSquaresMovingAverage LSMA(Symbol symbol, Symbol reference, int period, Resolution? resolution = null, Func<IBaseData, decimal> selector = null)
+        {
+            var name = CreateIndicatorName(symbol, $"LSMA({period})", resolution);
+            var leastSquaresMovingAverage = new LeastSquaresMovingAverage(name, reference, period);
+            InitializeIndicator(leastSquaresMovingAverage, resolution, selector, symbol, reference);
+
+            return leastSquaresMovingAverage;
+        }
+
+        /// <summary>
         /// Creates a new LinearWeightedMovingAverage indicator.  This indicator will linearly distribute
         /// the weights across the periods.
         /// </summary>

--- a/Indicators/LeastSquaresMovingAverage.cs
+++ b/Indicators/LeastSquaresMovingAverage.cs
@@ -34,6 +34,36 @@ namespace QuantConnect.Indicators
         private readonly double[] _t;
 
         /// <summary>
+        /// Reference symbol to use as the regression x-axis, when provided.
+        /// </summary>
+        private readonly Symbol _referenceSymbol = Symbol.Empty;
+
+        /// <summary>
+        /// Window of matched reference data points.
+        /// </summary>
+        private readonly RollingWindow<IndicatorDataPoint> _referenceWindow;
+
+        /// <summary>
+        /// Target symbol inferred from the first non-reference input.
+        /// </summary>
+        private Symbol _targetSymbol = Symbol.Empty;
+
+        /// <summary>
+        /// Pending target input waiting for a matching reference input time.
+        /// </summary>
+        private IndicatorDataPoint _targetInput;
+
+        /// <summary>
+        /// Pending reference input waiting for a matching target input time.
+        /// </summary>
+        private IndicatorDataPoint _referenceInput;
+
+        /// <summary>
+        /// Last computed value, returned while waiting for matched target/reference inputs.
+        /// </summary>
+        private decimal _lastComputedValue;
+
+        /// <summary>
         /// The point where the regression line crosses the y-axis (price-axis)
         /// </summary>
         public IndicatorBase<IndicatorDataPoint> Intercept { get; }
@@ -44,9 +74,14 @@ namespace QuantConnect.Indicators
         public IndicatorBase<IndicatorDataPoint> Slope { get; }
 
         /// <summary>
+        /// Gets a flag indicating when this indicator is ready and fully initialized
+        /// </summary>
+        public override bool IsReady => base.IsReady && (_referenceWindow == null || _referenceWindow.IsReady);
+
+        /// <summary>
         /// Required period, in data points, for the indicator to be ready and fully initialized.
         /// </summary>
-        public int WarmUpPeriod => Period;
+        public override int WarmUpPeriod => Period;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LeastSquaresMovingAverage"/> class.
@@ -64,10 +99,76 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Initializes a new instance of the <see cref="LeastSquaresMovingAverage"/> class.
         /// </summary>
+        /// <param name="name">The name of this indicator</param>
+        /// <param name="referenceSymbol">The reference symbol to regress against</param>
+        /// <param name="period">The number of data points to hold in the window</param>
+        public LeastSquaresMovingAverage(string name, Symbol referenceSymbol, int period)
+            : this(name, period)
+        {
+            _referenceSymbol = referenceSymbol;
+            _referenceWindow = new RollingWindow<IndicatorDataPoint>(period);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeastSquaresMovingAverage"/> class.
+        /// </summary>
         /// <param name="period">The number of data points to hold in the window.</param>
         public LeastSquaresMovingAverage(int period)
             : this($"LSMA({period})", period)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeastSquaresMovingAverage"/> class.
+        /// </summary>
+        /// <param name="referenceSymbol">The reference symbol to regress against</param>
+        /// <param name="period">The number of data points to hold in the window</param>
+        public LeastSquaresMovingAverage(Symbol referenceSymbol, int period)
+            : this($"LSMA({period},{referenceSymbol})", referenceSymbol, period)
+        {
+        }
+
+        /// <summary>
+        /// Computes the next value of this indicator from the given state
+        /// </summary>
+        /// <param name="input">The input given to the indicator</param>
+        /// <returns>
+        /// A new value for this indicator
+        /// </returns>
+        protected override decimal ComputeNextValue(IndicatorDataPoint input)
+        {
+            if (_referenceWindow == null)
+            {
+                return base.ComputeNextValue(input);
+            }
+
+            if (input.Symbol == _referenceSymbol)
+            {
+                _referenceInput = input;
+            }
+            else
+            {
+                if (_targetSymbol == Symbol.Empty)
+                {
+                    _targetSymbol = input.Symbol;
+                }
+                else if (input.Symbol != _targetSymbol)
+                {
+                    throw new ArgumentException($"The input symbol {input.Symbol} is not the target or reference symbol.");
+                }
+
+                _targetInput = input;
+            }
+
+            if (_targetInput != null && _referenceInput != null && _targetInput.EndTime == _referenceInput.EndTime)
+            {
+                _referenceWindow.Add(_referenceInput);
+                _lastComputedValue = base.ComputeNextValue(_targetInput);
+                _targetInput = null;
+                _referenceInput = null;
+            }
+
+            return _lastComputedValue;
         }
 
         /// <summary>
@@ -88,13 +189,30 @@ namespace QuantConnect.Indicators
                 .OrderBy(i => i.EndTime)
                 .Select(i => Convert.ToDouble(i.Value))
                 .ToArray();
-            // Fit OLS
-            var ols = Fit.Line(x: _t, y: series);
-            Intercept.Update(input.EndTime, (decimal)ols.Item1);
-            Slope.Update(input.EndTime, (decimal)ols.Item2);
+
+            decimal x = Period;
+            double intercept;
+            double slope;
+
+            if (_referenceWindow != null && _referenceWindow.IsReady)
+            {
+                var xValues = _referenceWindow
+                    .OrderBy(i => i.EndTime)
+                    .Select(i => Convert.ToDouble(i.Value))
+                    .ToArray();
+                x = _referenceWindow[0].Value;
+                (intercept, slope) = Fit.Line(x: xValues, y: series);
+            }
+            else
+            {
+                (intercept, slope) = Fit.Line(x: _t, y: series);
+            }
+
+            Intercept.Update(input.EndTime, intercept.SafeDecimalCast());
+            Slope.Update(input.EndTime, slope.SafeDecimalCast());
 
             // Calculate the fitted value corresponding to the input
-            return Intercept.Current.Value + Slope.Current.Value * Period;
+            return Intercept.Current.Value + Slope.Current.Value * x;
         }
 
         /// <summary>
@@ -104,6 +222,11 @@ namespace QuantConnect.Indicators
         {
             Intercept.Reset();
             Slope.Reset();
+            _referenceWindow?.Reset();
+            _targetInput = null;
+            _referenceInput = null;
+            _targetSymbol = Symbol.Empty;
+            _lastComputedValue = 0m;
             base.Reset();
         }
     }

--- a/Tests/Indicators/LeastSquaresMovingAverageTests.cs
+++ b/Tests/Indicators/LeastSquaresMovingAverageTests.cs
@@ -72,6 +72,92 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
+        public void WithReferenceRegressesAgainstBenchmarkWhenTargetArrivesFirst()
+        {
+            var indicator = new LeastSquaresMovingAverage("LSMA", Symbols.SPY, 3);
+
+            UpdatePair(indicator, 1, 3, targetFirst: true);
+            Assert.IsFalse(indicator.IsReady);
+
+            UpdatePair(indicator, 2, 5, targetFirst: true);
+            Assert.IsFalse(indicator.IsReady);
+
+            UpdatePair(indicator, 3, 7, targetFirst: true);
+
+            Assert.IsTrue(indicator.IsReady);
+            Assert.AreEqual(1m, Math.Round(indicator.Intercept.Current.Value, 8));
+            Assert.AreEqual(2m, Math.Round(indicator.Slope.Current.Value, 8));
+            Assert.AreEqual(7m, Math.Round(indicator.Current.Value, 8));
+        }
+
+        [Test]
+        public void WithReferenceRegressesAgainstBenchmarkWhenReferenceArrivesFirst()
+        {
+            var indicator = new LeastSquaresMovingAverage("LSMA", Symbols.SPY, 3);
+
+            UpdatePair(indicator, 5, 11, targetFirst: false);
+            Assert.IsFalse(indicator.IsReady);
+
+            UpdatePair(indicator, 6, 13, targetFirst: false);
+            Assert.IsFalse(indicator.IsReady);
+
+            UpdatePair(indicator, 7, 15, targetFirst: false);
+
+            Assert.IsTrue(indicator.IsReady);
+            Assert.AreEqual(1m, Math.Round(indicator.Intercept.Current.Value, 8));
+            Assert.AreEqual(2m, Math.Round(indicator.Slope.Current.Value, 8));
+            Assert.AreEqual(15m, Math.Round(indicator.Current.Value, 8));
+        }
+
+        [Test]
+        public void WithReferenceWaitsForMatchingTimes()
+        {
+            var indicator = new LeastSquaresMovingAverage("LSMA", Symbols.SPY, 2);
+            var time = DateTime.UtcNow;
+
+            indicator.Update(new IndicatorDataPoint(Symbols.AAPL, time, 3));
+            indicator.Update(new IndicatorDataPoint(Symbols.SPY, time.AddMinutes(1), 2));
+
+            Assert.IsFalse(indicator.IsReady);
+            Assert.AreEqual(0m, indicator.Current.Value);
+
+            indicator.Update(new IndicatorDataPoint(Symbols.AAPL, time.AddMinutes(1), 5));
+
+            Assert.IsFalse(indicator.IsReady);
+            Assert.AreEqual(5m, indicator.Current.Value);
+
+            UpdatePair(indicator, 3, 7, time.AddMinutes(2), targetFirst: true);
+
+            Assert.IsTrue(indicator.IsReady);
+            Assert.AreEqual(1m, Math.Round(indicator.Intercept.Current.Value, 8));
+            Assert.AreEqual(2m, Math.Round(indicator.Slope.Current.Value, 8));
+            Assert.AreEqual(7m, Math.Round(indicator.Current.Value, 8));
+        }
+
+        [Test]
+        public void WithReferenceResetsProperly()
+        {
+            var indicator = new LeastSquaresMovingAverage("LSMA", Symbols.SPY, 3);
+
+            UpdatePair(indicator, 1, 3, targetFirst: true);
+            UpdatePair(indicator, 2, 5, targetFirst: true);
+            UpdatePair(indicator, 3, 7, targetFirst: true);
+
+            Assert.IsTrue(indicator.IsReady);
+
+            indicator.Reset();
+
+            TestHelper.AssertIndicatorIsInDefaultState(indicator);
+
+            UpdatePair(indicator, 4, 9, targetFirst: false);
+            UpdatePair(indicator, 5, 11, targetFirst: false);
+            UpdatePair(indicator, 6, 13, targetFirst: false);
+
+            Assert.IsTrue(indicator.IsReady);
+            Assert.AreEqual(13m, Math.Round(indicator.Current.Value, 8));
+        }
+
+        [Test]
         public override void ResetsProperly()
         {
             var indicator = CreateIndicator();
@@ -107,6 +193,28 @@ namespace QuantConnect.Tests.Indicators
 
             indicator.Update(time.AddMinutes(period.Value - 1), Prices[period.Value - 1]);
             Assert.IsTrue(indicator.IsReady);
+        }
+
+        private static void UpdatePair(LeastSquaresMovingAverage indicator, decimal referenceValue, decimal targetValue, bool targetFirst)
+        {
+            UpdatePair(indicator, referenceValue, targetValue, DateTime.UtcNow.AddMinutes((double)referenceValue), targetFirst);
+        }
+
+        private static void UpdatePair(LeastSquaresMovingAverage indicator, decimal referenceValue, decimal targetValue, DateTime time, bool targetFirst)
+        {
+            var target = new IndicatorDataPoint(Symbols.AAPL, time, targetValue);
+            var reference = new IndicatorDataPoint(Symbols.SPY, time, referenceValue);
+
+            if (targetFirst)
+            {
+                indicator.Update(target);
+                indicator.Update(reference);
+            }
+            else
+            {
+                indicator.Update(reference);
+                indicator.Update(target);
+            }
         }
     }
 }


### PR DESCRIPTION
What: Extend `LeastSquaresMovingAverage` to regress a target symbol against a benchmark reference symbol.

Why: Issue #6984 requested an LSMA overload that accepts a benchmark reference instead of only regressing target values against a fixed time index.

How: Added reference-symbol constructors, a `QCAlgorithm.LSMA` overload, matched target/reference timestamp buffering, and reference-value regression when paired samples are ready.

Edge cases handled: Target-first and reference-first updates are supported; mismatched timestamps wait for a matching pair; reset clears pending target/reference state; unexpected target symbols are rejected.

Tests added/updated: Added LSMA reference-mode tests for target-first updates, reference-first updates, timestamp matching, and reset behavior. Build validation completed for `Tests/QuantConnect.Tests.csproj`; focused local test execution was blocked by the existing pythonnet GIL finalizer crash before test execution.