### PR TITLE
Minor fix for schedule universe to always be 8 am ny

### DIFF
--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -55,12 +55,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private SubscriptionCollection _subscriptions;
         private IFactorFileProvider _factorFileProvider;
         private IDataChannelProvider _channelProvider;
-        // in live trading we delay scheduled universe selection between 11 & 12 hours after midnight UTC so that we allow new selection data to be piped in
-        // NY goes from -4/-5 UTC time, so:
-        // 11 UTC - 4 => 7am NY
-        // 12 UTC - 4 => 8am NY
-        private readonly TimeSpan _scheduledUniverseUtcTimeShift = TimeSpan.FromMinutes(11 * 60 + DateTime.UtcNow.Second);
         private readonly HashSet<string> _unsupportedConfigurations = new();
+
+        // in live trading we delay scheduled universe selection to 8 am NY, but NY goes from -4/-5 UTC time, so we adjust it
+        private static ReferenceWrapper<DateTime> _lastUtcDateShiftUpdate;
+        private static ReferenceWrapper<TimeSpan> _scheduledUniverseUtcTimeShift;
 
         /// <summary>
         /// Public flag indicator that the thread is still busy.
@@ -389,7 +388,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             enumerator = AddScheduleWrapper(request, enumerator, new PredicateTimeProvider(_frontierTimeProvider, (currentUtcDateTime) => {
                 // will only let time advance after it's passed the live time shift frontier
-                return currentUtcDateTime.TimeOfDay > _scheduledUniverseUtcTimeShift;
+                return currentUtcDateTime.TimeOfDay > GetScheduledUniverseUtcTimeShift(currentUtcDateTime);
             }));
 
             enumerator = GetWarmupEnumerator(request, enumerator);
@@ -400,6 +399,20 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             subscription = new Subscription(request, subscriptionDataEnumerator, tzOffsetProvider);
 
             return subscription;
+        }
+
+        public static TimeSpan GetScheduledUniverseUtcTimeShift(DateTime currentUtcDateTime)
+        {
+            var currentDate = currentUtcDateTime.Date;
+            if (currentDate != _lastUtcDateShiftUpdate?.Value)
+            {
+                // on every date change, we will update the scheduled time shift to be 8am NY time, which is 12-13 UTC depending on DST
+                _lastUtcDateShiftUpdate = new(currentDate);
+                _scheduledUniverseUtcTimeShift = new(currentDate.ConvertFromUtc(TimeZones.NewYork).Date.AddHours(8).ConvertToUtc(TimeZones.NewYork).TimeOfDay
+                    // some minor randomness
+                    + TimeSpan.FromSeconds(DateTime.UtcNow.Second));
+            }
+            return _scheduledUniverseUtcTimeShift.Value;
         }
 
         /// <summary>

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -2899,6 +2899,17 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             }
         }
 
+        [TestCase(0, 13)]
+        [TestCase(2, 13)]
+        [TestCase(10, 12)]
+        [TestCase(100, 12)]
+        [TestCase(280, 13)]
+        public void UniverseScheduleUtcShitft(int dateShitft, int expectedTimeShift)
+        {
+            var result = LiveTradingDataFeed.GetScheduledUniverseUtcTimeShift(new DateTime(2026, 3, 1).AddDays(dateShitft));
+            Assert.AreEqual(expectedTimeShift, (int)result.TotalHours);
+        }
+
         private IDataFeed RunDataFeed(Resolution resolution = Resolution.Second, List<string> equities = null, List<string> forex = null, List<string> crypto = null,
             Func<FuncDataQueueHandler, IEnumerable<BaseData>> getNextTicksFunction = null,
             Func<Symbol, bool, string, IEnumerable<Symbol>> lookupSymbolsFunction = null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Avoid schedule universe running 7 or 8 NY depending on daylight savings, now will always run 8 am NY. Adding unit tests

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Consistent universe schedule in live trading
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
