### PR TITLE
Use QC_GIT_TOKEN for gh auth in stubs repo discovery

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Compute additional stubs repos
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.QC_GIT_TOKEN || secrets.GITHUB_TOKEN }}
           ADDITIONAL_STUBS_REPOS: ${{ secrets.ADDITIONAL_STUBS_REPOS }}
         run: |
           REPOS=$(python find_datasource_repos.py)


### PR DESCRIPTION
## Summary
Continuation of #9430.

The default `GITHUB_TOKEN` is scoped to the workflow's own repo, so `gh repo list` in the "Compute additional stubs repos" step only saw the public subset of `QuantConnect/Lean.DataSource.*`. Switching `GH_TOKEN` to `QC_GIT_TOKEN` — which already has the org-level access used by `ci_build_stubs.sh` to clone private repos — lets the discovery step pick up all 60 non-archived data-source repos (public + private).
