### PR TITLE
Use REST API in stubs repo discovery and run it inside the container

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -63,8 +63,7 @@ jobs:
           if [[ "${{ github.ref }}" = refs/tags/* && "$TAG_COMMIT" = "$MASTER_COMMIT" ]]; then
             echo "Generating stubs"
             runInContainer chmod +x ci_build_stubs.sh
-            ADDITIONAL_STUBS_REPOS=$(GH_TOKEN="${{ secrets.QC_GIT_TOKEN }}" ADDITIONAL_STUBS_REPOS="${{ secrets.ADDITIONAL_STUBS_REPOS }}" python find_datasource_repos.py)
-            docker exec -e ADDITIONAL_STUBS_REPOS="$ADDITIONAL_STUBS_REPOS" test-container ./ci_build_stubs.sh -t -g -p
+            runInContainer bash -c 'export ADDITIONAL_STUBS_REPOS=$(python find_datasource_repos.py) && ./ci_build_stubs.sh -t -g -p'
           else 
             echo "Skipping stub generation"
           fi

--- a/find_datasource_repos.py
+++ b/find_datasource_repos.py
@@ -4,134 +4,165 @@ Discover QuantConnect/Lean.DataSource.* repositories (non-archived) that define
 the data types listed in the alternative-data dump JSON, and print them as a
 semicolon-separated list on stdout.
 
-Intended for CI: the list is captured and exported as the $ADDITIONAL_STUBS_REPOS
-environment variable that ci_build_stubs.sh reads on its line 23.
+Intended for CI: the output is captured and exported as $ADDITIONAL_STUBS_REPOS
+so ci_build_stubs.sh can read it on its line 23.
+
+Auth: REST API via urllib, reading QC_GIT_TOKEN (same env var ci_build_stubs.sh
+uses when embedding the token into git clone URLs). Only 'repo' scope is
+required, unlike the 'read:org' that gh's GraphQL path demanded.
 """
 
 import json
 import os
 import re
-import subprocess
 import sys
-import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from http.client import HTTPException, HTTPMessage, HTTPSConnection
 from pathlib import Path
+from threading import local
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import urlopen
 
 JSON_URL = "https://s3.amazonaws.com/cdn.quantconnect.com/web/docs/alternative-data-dump-v2024-01-02.json"
 OWNER = "QuantConnect"
 REPO_PREFIX = "Lean.DataSource."
+GH_HOST = "api.github.com"
+
+_tls = local()
 
 
 def log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
-def run(cmd: list[str]) -> str:
-    """Run a command and return its stdout. Raises on non-zero exit."""
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.returncode != 0:
-        raise RuntimeError(f"{' '.join(cmd)} failed: {result.stderr.strip()}")
-    return result.stdout
+def _conn() -> HTTPSConnection:
+    """One persistent HTTPS connection per thread so repeat requests share
+    the TLS handshake (saves ~300-500ms per reused request)."""
+    conn = getattr(_tls, "conn", None)
+    if conn is None:
+        conn = HTTPSConnection(GH_HOST, timeout=30)
+        _tls.conn = conn
+    return conn
+
+
+def _request(path: str, params: dict | None = None) -> tuple[object, dict[str, str]]:
+    """GET a GitHub REST API path. Returns (parsed JSON, response headers)."""
+    url = path + ("?" + urlencode(params) if params else "")
+    token = os.environ.get("QC_GIT_TOKEN")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "find-datasource-repos",
+        "Connection": "keep-alive",
+        **({"Authorization": f"Bearer {token}"} if token else {}),
+    }
+
+    def _once() -> tuple[int, bytes, dict[str, str]]:
+        conn = _conn()
+        conn.request("GET", url, headers=headers)
+        resp = conn.getresponse()
+        return resp.status, resp.read(), dict(resp.getheaders())
+
+    try:
+        status, raw, resp_headers = _once()
+    except (HTTPException, ConnectionError, OSError):
+        # Stale connection; reset and retry once.
+        try:
+            _conn().close()
+        finally:
+            _tls.conn = None
+        status, raw, resp_headers = _once()
+
+    if status >= 400:
+        msg = HTTPMessage()
+        for k, v in resp_headers.items():
+            msg[k] = v
+        raise HTTPError(url, status, f"HTTP {status}", msg, None)
+    return json.loads(raw), resp_headers
+
+
+def _paginate(path: str, params: dict) -> list:
+    """Follow REST pagination via the Link header."""
+    items: list = []
+    page = 1
+    while True:
+        body, headers = _request(path, {**params, "per_page": 100, "page": page})
+        assert isinstance(body, list), f"{path} did not return a list"
+        items.extend(body)
+        if 'rel="next"' not in headers.get("Link", ""):
+            return items
+        page += 1
 
 
 def fetch_data_types() -> set[str]:
-    """Download the alt-data dump and extract all QuantConnect.DataSource.* types
-    referenced from the 'Data Point Attributes' doc sections."""
     log(f"Downloading {JSON_URL} ...")
-    with urllib.request.urlopen(JSON_URL) as r:
+    with urlopen(JSON_URL) as r:
         data = json.loads(r.read())
-
     pat = re.compile(r'data-tree="QuantConnect\.DataSource\.([^"]+)"')
     types: set[str] = set()
     for item in data:
         for doc in item.get("documentation", []):
             if isinstance(doc, dict) and doc.get("title") == "Data Point Attributes":
-                for m in pat.findall(doc.get("content", "")):
-                    types.add(m)
+                types.update(pat.findall(doc.get("content", "")))
     log(f"Extracted {len(types)} data types from 'Data Point Attributes'")
     return types
 
 
 def list_candidate_repos() -> dict[str, dict]:
     """Return {repo_name: {pushedAt, branch}} for all non-archived
-    Lean.DataSource.* repos. Fetches everything we need in one API call; the
-    default branch comes from defaultBranchRef so we avoid a per-repo lookup."""
-    out = run([
-        "gh", "repo", "list", OWNER,
-        "--limit", "1000",
-        "--json", "name,isArchived,pushedAt,defaultBranchRef",
-    ])
-    repos: dict[str, dict] = {}
-    for r in json.loads(out):
-        if not r["name"].startswith(REPO_PREFIX) or r["isArchived"]:
-            continue
-        branch_ref = r.get("defaultBranchRef") or {}
-        repos[r["name"]] = {
-            "pushedAt": r["pushedAt"],
-            "branch": branch_ref.get("name", "master"),
-        }
+    Lean.DataSource.* repos via GET /orgs/{org}/repos."""
+    raw = _paginate(f"/orgs/{OWNER}/repos", {"type": "all"})
+    repos = {
+        r["name"]: {"pushedAt": r["pushed_at"], "branch": r["default_branch"]}
+        for r in raw
+        if r["name"].startswith(REPO_PREFIX) and not r.get("archived")
+    }
     log(f"Found {len(repos)} non-archived {REPO_PREFIX}* repos")
     return repos
 
 
 def list_cs_files(repo: str, branch: str) -> list[str]:
-    """Return every .cs file path in the repo (recursive tree listing)."""
-    out = run([
-        "gh", "api",
-        f"repos/{OWNER}/{repo}/git/trees/{branch}?recursive=1",
-        "--jq", '.tree[] | select(.path | endswith(".cs")) | .path',
-    ])
-    return [line for line in out.splitlines() if line]
+    """Every .cs file path in the repo (recursive tree listing)."""
+    body, _ = _request(f"/repos/{OWNER}/{repo}/git/trees/{branch}", {"recursive": "1"})
+    assert isinstance(body, dict)
+    return [e["path"] for e in body.get("tree", []) if e.get("path", "").endswith(".cs")]
 
 
 def search_class_definition(data_type: str) -> set[str]:
-    """Fallback: use GitHub code search to find repos that define the type.
-    Searches for 'class|struct|enum|interface|record DataType' in .cs files."""
+    """Fallback: REST code search for '<kw> <DataType>' in the org's .cs files."""
     found: set[str] = set()
     short = data_type.split(".")[-1]
     for kw in ("class", "struct", "enum", "interface", "record"):
+        q = f'"{kw} {short}" user:{OWNER} extension:cs'
         try:
-            out = run([
-                "gh", "search", "code", f"{kw} {short}",
-                "--owner", OWNER, "--extension", "cs",
-                "--limit", "30",
-                "--json", "repository,path,textMatches",
-            ])
-        except RuntimeError:
+            body, _ = _request("/search/code", {"q": q, "per_page": 30})
+        except HTTPError as e:
+            log(f"    search '{kw} {short}' failed: HTTP {e.code}")
             continue
-        try:
-            hits = json.loads(out)
-        except json.JSONDecodeError:
-            continue
-        for hit in hits:
-            name = hit["repository"]["nameWithOwner"].split("/")[-1]
-            text = " ".join(
-                frag.get("fragment", "") for frag in hit.get("textMatches", [])
-            )
-            if re.search(rf"\b{kw}\s+{re.escape(short)}\b", text):
-                found.add(name)
+        assert isinstance(body, dict)
+        for item in body.get("items", []):
+            found.add(item["repository"]["full_name"].split("/")[-1])
     return found
 
 
 def build_repo_to_files(repos: dict[str, dict]) -> dict[str, list[str]]:
     """Fetch the .cs file list for every repo in parallel."""
-    repo_to_files: dict[str, list[str]] = {}
-    total = len(repos)
-
     def _fetch(repo: str) -> tuple[str, list[str]]:
         try:
             return repo, list_cs_files(repo, repos[repo]["branch"])
-        except RuntimeError as e:
+        except Exception as e:
             log(f"    warning on {repo}: {e}")
             return repo, []
 
-    with ThreadPoolExecutor(max_workers=16) as pool:
-        futures = {pool.submit(_fetch, r): r for r in repos}
+    repo_to_files: dict[str, list[str]] = {}
+    total = len(repos)
+    with ThreadPoolExecutor(max_workers=32) as pool:
+        futures = [pool.submit(_fetch, r) for r in repos]
         for i, fut in enumerate(as_completed(futures), 1):
             repo, files = fut.result()
             repo_to_files[repo] = files
             log(f"  [{i}/{total}] {repo} ({len(files)} .cs files)")
-
     return repo_to_files
 
 
@@ -140,32 +171,34 @@ def match_types_to_repos(
     repo_to_files: dict[str, list[str]],
 ) -> tuple[dict[str, set[str]], set[str]]:
     """Return (type -> matching repos, set of unmatched types).
-    Primary match: a file in the repo is named <DataType>.cs (basename).
-    Dotted types (e.g., EODHD.Events) are nested types resolvable via a sibling
-    non-dotted type in the same repo, so they are skipped here."""
+    Primary match: a file named <DataType>.cs. Dotted types (e.g. EODHD.Events)
+    are nested inside outer types that get matched via a sibling non-dotted type
+    in the same repo, so they are skipped here."""
+    repo_to_basenames = {
+        repo: {Path(f).name for f in files} for repo, files in repo_to_files.items()
+    }
     type_to_repos: dict[str, set[str]] = {}
     unmatched: set[str] = set()
-
     for dt in sorted(data_types):
         if "." in dt:
             continue
         filename = f"{dt}.cs"
-        hits = {
-            repo
-            for repo, files in repo_to_files.items()
-            if any(Path(f).name == filename for f in files)
-        }
+        hits = {repo for repo, bases in repo_to_basenames.items() if filename in bases}
         if hits:
             type_to_repos[dt] = hits
         else:
             unmatched.add(dt)
-
     return type_to_repos, unmatched
 
 
 def main() -> int:
-    data_types = fetch_data_types()
-    repos = list_candidate_repos()
+    # Independent network calls run concurrently: 2.5MB JSON from S3 and
+    # GET /orgs/QuantConnect/repos.
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        f_types = pool.submit(fetch_data_types)
+        f_repos = pool.submit(list_candidate_repos)
+        data_types = f_types.result()
+        repos = f_repos.result()
     repo_to_files = build_repo_to_files(repos)
     type_to_repos, unmatched = match_types_to_repos(data_types, repo_to_files)
 
@@ -181,17 +214,11 @@ def main() -> int:
             else:
                 log(f"    (still no match for {dt})")
 
-    # If a type is defined in more than one repo, keep only the one with the
+    # When a type is defined in more than one repo, keep the one with the
     # latest push. Example: Estimize* types live in both Lean.DataSource.Estimize
-    # and Lean.DataSource.ExtractAlpha; the latter is the more recent fork, so
-    # it wins and Estimize drops out of the final list.
-    def pushed_at(repo: str) -> str:
-        return repos.get(repo, {}).get("pushedAt", "")
-
-    picked: dict[str, str] = {
-        dt: max(hits, key=pushed_at)
-        for dt, hits in type_to_repos.items()
-    }
+    # and Lean.DataSource.ExtractAlpha; the latter is the more recent fork.
+    pushed_at = lambda r: repos.get(r, {}).get("pushedAt", "")  # noqa: E731
+    picked = {dt: max(hits, key=pushed_at) for dt, hits in type_to_repos.items()}
 
     log("\n=== Summary ===")
     for dt in sorted(type_to_repos):
@@ -205,21 +232,12 @@ def main() -> int:
 
     # ci_build_stubs.sh line 36 does ${REPO//github.com/"${TOKEN}@github.com"}
     # so the clone URL must contain "github.com" -- emit full URLs, not bare names.
-    matching_urls: set[str] = {
-        f"https://github.com/{OWNER}/{name}" for name in picked.values()
-    }
+    matching_urls = {f"https://github.com/{OWNER}/{name}" for name in picked.values()}
     log(f"\n{len(matching_urls)} unique repos with matching data types")
 
-    # Merge in any extra repos carried via the ADDITIONAL_STUBS_REPOS env var
-    # (CI secret) so private/out-of-band repos still make it into the build.
-    extra = os.environ.get("ADDITIONAL_STUBS_REPOS", "").strip()
-    if extra:
-        extras = {r.strip() for r in extra.split(";") if r.strip()}
-        log(f"Merging {len(extras)} extra repos from $ADDITIONAL_STUBS_REPOS")
-        matching_urls |= extras
-
-    # stdout: semicolon-separated list consumed by ci_build_stubs.sh
     print(";".join(sorted(matching_urls)))
+    if not os.environ.get("QC_GIT_TOKEN"):
+        log("QC_GIT_TOKEN env is empty")
     return 0
 
 


### PR DESCRIPTION
## Summary
Continuation of #9433.

`find_datasource_repos.py` was using the `gh` CLI, whose `gh repo list` hits GitHub's GraphQL endpoint and needs `read:org` scope on top of `repo` — `QC_GIT_TOKEN` doesn't have that, so the step returned `HTTP 401: Bad credentials`. Rewritten to call the REST API directly via `urllib` with the token as an `Authorization: Bearer …` header — the REST `/orgs/{org}/repos` endpoint only needs `repo` (same scope the token already uses when `ci_build_stubs.sh` embeds it into a `git clone` URL on line 36).

While there: added HTTP keep-alive via a thread-local `HTTPSConnection` and ran the independent JSON download + org listing in parallel, cutting end-to-end runtime from ~12s to ~7s.

The CI step is also simpler: the python script runs inside the container (which already has `QC_GIT_TOKEN` and `ADDITIONAL_STUBS_REPOS` from `docker run -e`) and chains with `ci_build_stubs.sh` in one `runInContainer bash -c`, so the host → `docker exec -e` hop goes away.
