### PR TITLE
Fix indicator warm-up window seed

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -4455,6 +4455,7 @@ namespace QuantConnect.Algorithm
         {
             // Reset the indicator
             indicator.Reset();
+            indicator.Window.Reset();
 
             var properties = indicator.GetType()
                 .GetProperties()

--- a/Tests/Algorithm/AlgorithmIndicatorsTests.cs
+++ b/Tests/Algorithm/AlgorithmIndicatorsTests.cs
@@ -94,6 +94,22 @@ namespace QuantConnect.Tests.Algorithm
             interestRateProviderMock.Verify(x => x.GetInterestRate(reference), Times.Once);
         }
 
+        [Test]
+        public void WarmUpIndicatorDoesNotLeaveDefaultValueInWindow()
+        {
+            var indicator = new RateOfChange(1);
+            indicator.Window.Size = 5;
+
+            _algorithm.SetDateTime(new DateTime(2013, 10, 11));
+
+            _algorithm.WarmUpIndicator(_equity, indicator, Resolution.Minute);
+
+            Assert.IsTrue(indicator.IsReady);
+            Assert.AreEqual(indicator.Samples, indicator.Window.Count);
+            Assert.IsFalse(indicator.Window.Any(x => x.EndTime == DateTime.MinValue));
+            Assert.AreEqual(indicator.Current, indicator.Window[0]);
+        }
+
         [TestCase("Span", Language.CSharp)]
         [TestCase("Count", Language.CSharp)]
         [TestCase("StartAndEndDate", Language.CSharp)]


### PR DESCRIPTION
What: Clear indicator windows after reset during indicator history warm-up.

Why: `IndicatorHistory` and `WarmUpIndicator` could leave the reset default value in an expanded public indicator window before replaying historical samples.

How: Reset the indicator window immediately after `indicator.Reset()` in the history replay path so only real historical samples populate the public window.

Edge cases handled: Expanded windows no longer retain `DateTime.MinValue` seed points; the current indicator value remains at `Window[0]` after warm-up.

Tests added/updated: Added `AlgorithmIndicatorsTests.WarmUpIndicatorDoesNotLeaveDefaultValueInWindow`. Build validation completed for `Algorithm/QuantConnect.Algorithm.csproj` and `Indicators/QuantConnect.Indicators.csproj`; focused local test execution was blocked by Windows Application Control on the test assembly.