### PR TITLE
Preserve universe selection order

### DIFF
--- a/Common/Data/UniverseSelection/Universe.cs
+++ b/Common/Data/UniverseSelection/Universe.cs
@@ -101,6 +101,14 @@ namespace QuantConnect.Data.UniverseSelection
         public Symbol Symbol => Configuration.Symbol;
 
         /// <summary>
+        /// Gets the order in which this universe was added to the algorithm.
+        /// </summary>
+        public int SelectionOrder
+        {
+            get; internal set;
+        }
+
+        /// <summary>
         /// Gets the data type of this universe
         /// </summary>
         public Type DataType => Configuration.Type;

--- a/Common/Securities/UniverseManager.cs
+++ b/Common/Securities/UniverseManager.cs
@@ -19,6 +19,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Threading;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Util;
 using Common.Util;
@@ -61,7 +62,7 @@ namespace QuantConnect.Securities
         {
             if (Dictionary.TryAdd(key, value))
             {
-                value.SelectionOrder = _nextSelectionOrder++;
+                value.SelectionOrder = Interlocked.Increment(ref _nextSelectionOrder);
                 lock (_pendingChanges)
                 {
                     _pendingChanges.Enqueue(new UniverseManagerChanged(NotifyCollectionChangedAction.Add, value));

--- a/Common/Securities/UniverseManager.cs
+++ b/Common/Securities/UniverseManager.cs
@@ -31,6 +31,7 @@ namespace QuantConnect.Securities
     public class UniverseManager : BaseExtendedDictionary<Symbol, Universe, ConcurrentDictionary<Symbol, Universe>>
     {
         private readonly Queue<UniverseManagerChanged> _pendingChanges = new();
+        private int _nextSelectionOrder;
 
         /// <summary>
         /// Event fired when a universe is added or removed
@@ -60,6 +61,7 @@ namespace QuantConnect.Securities
         {
             if (Dictionary.TryAdd(key, value))
             {
+                value.SelectionOrder = _nextSelectionOrder++;
                 lock (_pendingChanges)
                 {
                     _pendingChanges.Enqueue(new UniverseManagerChanged(NotifyCollectionChangedAction.Add, value));

--- a/Engine/DataFeeds/SubscriptionSynchronizer.cs
+++ b/Engine/DataFeeds/SubscriptionSynchronizer.cs
@@ -228,9 +228,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         // time pulse to align algorithm time with current frontier
                         yield return _timeSliceFactory.CreateTimePulse(frontierUtc);
 
-                        // trigger the smalled resolution first, so that FF res get's set once from the start correctly
-                        // while at it, let's make it determininstic and sort by universe sid later
-                        foreach (var kvp in universeData.OrderBy(x => x.Key.Configuration.Resolution).ThenBy(x => x.Key.Symbol.ID))
+                        // trigger the smallest resolution first, so that FF res gets set once from the start correctly.
+                        // For universes at the same resolution, preserve the order they were added to the algorithm.
+                        foreach (var kvp in universeData.OrderBy(x => x.Key.Configuration.Resolution)
+                                     .ThenBy(x => x.Key.SelectionOrder)
+                                     .ThenBy(x => x.Key.Symbol.ID))
                         {
                             var universe = kvp.Key;
                             var baseDataCollection = kvp.Value;

--- a/Tests/Common/Securities/UniverseManagerTests.cs
+++ b/Tests/Common/Securities/UniverseManagerTests.cs
@@ -103,9 +103,34 @@ namespace QuantConnect.Tests.Common.Securities
             manager.Remove(universe.Configuration.Symbol);
         }
 
+        [Test]
+        public void AssignsSelectionOrderWhenUniverseAdded()
+        {
+            var manager = new UniverseManager();
+            var first = CreateUniverse(Symbols.SPY);
+            var second = CreateUniverse(Symbols.AAPL);
+            var third = CreateUniverse(Symbols.IBM);
+
+            manager.Add(first.Configuration.Symbol, first);
+            manager[second.Configuration.Symbol] = second;
+            manager.Add(third.Configuration.Symbol, third);
+
+            Assert.AreEqual(0, first.SelectionOrder);
+            Assert.AreEqual(1, second.SelectionOrder);
+            Assert.AreEqual(2, third.SelectionOrder);
+        }
+
         private SubscriptionDataConfig CreateTradeBarConfig()
         {
             return new SubscriptionDataConfig(typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, true);
+        }
+
+        private Universe CreateUniverse(Symbol symbol)
+        {
+            return new FuncUniverse(
+                new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, false, false, true),
+                new UniverseSettings(Resolution.Minute, 2, true, false, TimeSpan.Zero),
+                data => data.Select(x => x.Symbol));
         }
     }
 }

--- a/Tests/Common/Securities/UniverseManagerTests.cs
+++ b/Tests/Common/Securities/UniverseManagerTests.cs
@@ -104,7 +104,7 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
-        public void AssignsSelectionOrderWhenUniverseAdded()
+        public void AssignsSelectionOrderWhenUniverseIsAdded()
         {
             var manager = new UniverseManager();
             var first = CreateUniverse(Symbols.SPY);
@@ -115,9 +115,9 @@ namespace QuantConnect.Tests.Common.Securities
             manager[second.Configuration.Symbol] = second;
             manager.Add(third.Configuration.Symbol, third);
 
-            Assert.AreEqual(0, first.SelectionOrder);
-            Assert.AreEqual(1, second.SelectionOrder);
-            Assert.AreEqual(2, third.SelectionOrder);
+            Assert.AreEqual(1, first.SelectionOrder);
+            Assert.AreEqual(2, second.SelectionOrder);
+            Assert.AreEqual(3, third.SelectionOrder);
         }
 
         private SubscriptionDataConfig CreateTradeBarConfig()


### PR DESCRIPTION
What: Preserve the order in which universes are added when same-resolution universe selection runs.

Why: Same-resolution universes were sorted by symbol ID, which could change selection behavior from the order configured by the algorithm.

How: Store a selection order on each universe when `UniverseManager` adds it, sort same-resolution universe data by that order, and assign the order atomically.

Edge cases handled: Indexer additions and direct `Add` calls both receive an order; atomic assignment avoids duplicate order values if additions overlap; symbol ID remains a stable final tie-breaker.

Tests added/updated: Added `UniverseManagerTests.AssignsSelectionOrderWhenUniverseIsAdded`. Builds passed for `Engine/QuantConnect.Lean.Engine.csproj` and `Tests/QuantConnect.Tests.csproj`; focused local test execution was blocked by the existing pythonnet GIL finalizer crash after the test host started.