### PR TITLE
Fix manual session warm-up with daily bars

### DIFF
--- a/Common/Data/Market/Session.cs
+++ b/Common/Data/Market/Session.cs
@@ -106,6 +106,18 @@ namespace QuantConnect.Data.Market
         /// <param name="data">The new data to update the session with</param>
         public void Update(BaseData data)
         {
+            if (data is IBaseDataBar && data.EndTime - data.Time >= Time.OneDay)
+            {
+                var sessionBar = new SessionBar(_tickType)
+                {
+                    Time = data.Time.Date,
+                    Symbol = _symbol
+                };
+                sessionBar.Update(data, null);
+                Add(sessionBar);
+                return;
+            }
+
             _consolidator?.Update(data);
         }
 

--- a/Tests/Indicators/SessionTests.cs
+++ b/Tests/Indicators/SessionTests.cs
@@ -137,6 +137,33 @@ namespace QuantConnect.Tests.Indicators
             }
         }
 
+        [Test]
+        public void DailyQuoteBarsPopulateSessionDirectly()
+        {
+            var symbol = Symbols.EURUSD;
+            var session = GetSession(symbol, TickType.Quote, 10);
+            var start = new DateTime(2024, 9, 16);
+
+            for (var i = 0; i < 5; i++)
+            {
+                var time = start.AddDays(i);
+                session.Update(new QuoteBar(
+                    time,
+                    symbol,
+                    new Bar(1.10m + i, 1.11m + i, 1.09m + i, 1.105m + i),
+                    0,
+                    new Bar(1.12m + i, 1.13m + i, 1.11m + i, 1.125m + i),
+                    0,
+                    Time.OneDay));
+            }
+
+            Assert.AreEqual(6, session.Samples);
+            Assert.AreEqual(start.AddDays(4), session[0].Time);
+            Assert.AreEqual(start.AddDays(5), session[0].EndTime);
+            Assert.AreEqual(5.11m, session[0].Open);
+            Assert.AreEqual(5.115m, session[0].Close);
+        }
+
         [TestCaseSource(nameof(NextSessionTradingDayCases))]
         public void CreatesNewSessionBarWithCorrectNextTradingDay(DateTime startDate, DateTime expectedDate)
         {
@@ -173,7 +200,11 @@ namespace QuantConnect.Tests.Indicators
 
         private static Session GetSession(TickType tickType, int initialSize)
         {
-            var symbol = Symbols.SPY;
+            return GetSession(Symbols.SPY, tickType, initialSize);
+        }
+
+        private static Session GetSession(Symbol symbol, TickType tickType, int initialSize)
+        {
             var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
             var exchangeHours = marketHoursDatabase.GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
             return new Session(tickType, exchangeHours, symbol, initialSize);


### PR DESCRIPTION
What: Allow `Session.Update` to ingest already-daily bar data directly.

Why: Manual Forex session warm-up with daily quote bars skipped completed daily samples because the session path only forwarded data through the intraday consolidator.

How: Detect daily-or-larger `IBaseDataBar` inputs, convert them directly into `SessionBar` instances, and keep the existing consolidator path for lower-resolution data.

Edge cases handled: Works for `QuoteBar` and other bar inputs; preserves intraday consolidation behavior; daily bars use the source date and symbol when added to the session.

Tests added/updated: Added `SessionTests.DailyQuoteBarsPopulateSessionDirectly`. Build validation completed for `Common/QuantConnect.csproj` and `Tests/QuantConnect.Tests.csproj`; focused local test execution was blocked by Windows Application Control on the test assembly.