### PR TITLE
Use close price outside market hours

### DIFF
--- a/Common/Securities/SecurityHolding.cs
+++ b/Common/Securities/SecurityHolding.cs
@@ -494,8 +494,12 @@ namespace QuantConnect.Securities
                 feesInAccountCurrency = _currencyConverter.ConvertToAccountCurrency(liquidationFees).Amount;
             }
 
-            // if we are long, we would need to sell against the bid
-            var price = IsLong ? _security.BidPrice : _security.AskPrice;
+            // if we are long, we would need to sell against the bid. Outside of
+            // regular market hours, use the last price because these positions
+            // cannot be closed against stale bid/ask quotes.
+            var price = _security.IsMarketOpen(false)
+                ? (IsLong ? _security.BidPrice : _security.AskPrice)
+                : _security.Price;
             if (price == 0)
             {
                 // Bid/Ask prices can both be equal to 0. This usually happens when we request our holdings from

--- a/Tests/Common/Securities/SecurityHoldingTests.cs
+++ b/Tests/Common/Securities/SecurityHoldingTests.cs
@@ -53,6 +53,38 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
+        public void TotalCloseProfitUsesPriceOutsideRegularMarketHours()
+        {
+            var security = GetSecurity<QuantConnect.Securities.Equity.Equity>(Symbols.SPY, Resolution.Minute, false);
+            var holding = new SecurityHolding(security, new IdentityCurrencyConverter(Currencies.USD));
+
+            holding.SetHoldings(90m, 100m);
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, 100m, 80m, 120m));
+
+            SetSecurityLocalTime(security, new DateTime(2023, 6, 26, 12, 0, 0));
+            Assert.AreEqual(-1000m, holding.TotalCloseProfit(includeFees: false));
+
+            SetSecurityLocalTime(security, new DateTime(2023, 6, 26, 20, 0, 0));
+            Assert.AreEqual(1000m, holding.TotalCloseProfit(includeFees: false));
+        }
+
+        [Test]
+        public void TotalCloseProfitUsesPriceForShortsOutsideRegularMarketHours()
+        {
+            var security = GetSecurity<QuantConnect.Securities.Equity.Equity>(Symbols.SPY, Resolution.Minute, false);
+            var holding = new SecurityHolding(security, new IdentityCurrencyConverter(Currencies.USD));
+
+            holding.SetHoldings(110m, -100m);
+            security.SetMarketPrice(new Tick(DateTime.Now, security.Symbol, 100m, 80m, 120m));
+
+            SetSecurityLocalTime(security, new DateTime(2023, 6, 26, 12, 0, 0));
+            Assert.AreEqual(-1000m, holding.TotalCloseProfit(includeFees: false));
+
+            SetSecurityLocalTime(security, new DateTime(2023, 6, 26, 20, 0, 0));
+            Assert.AreEqual(1000m, holding.TotalCloseProfit(includeFees: false));
+        }
+
+        [Test]
         public void Raises_QuantityChanged_WhenSetHoldingsCalled()
         {
             var arguments = new List<SecurityHoldingQuantityChangedEventArgs>();
@@ -82,7 +114,7 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(firstPrice, second.PreviousAveragePrice);
         }
 
-        private Security GetSecurity<T>(Symbol symbol, Resolution resolution)
+        private Security GetSecurity<T>(Symbol symbol, Resolution resolution, bool isMarketAlwaysOpen = true)
         {
             var subscriptionDataConfig = new SubscriptionDataConfig(
                 typeof(T),
@@ -94,8 +126,12 @@ namespace QuantConnect.Tests.Common.Securities
                 true,
                 false);
 
+            var exchangeHours = isMarketAlwaysOpen
+                ? SecurityExchangeHours.AlwaysOpen(TimeZones.Utc)
+                : MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+
             var security = new Security(
-                SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
+                exchangeHours,
                 subscriptionDataConfig,
                 new Cash(Currencies.USD, 0, 1m),
                 SymbolProperties.GetDefault(Currencies.USD),
@@ -110,6 +146,13 @@ namespace QuantConnect.Tests.Common.Securities
             security.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(subscriptionDataConfig.DataTimeZone));
 
             return security;
+        }
+
+        private static void SetSecurityLocalTime(Security security, DateTime localTime)
+        {
+            security.SetLocalTimeKeeper(new LocalTimeKeeper(
+                localTime.ConvertToUtc(security.Exchange.TimeZone),
+                security.Exchange.TimeZone));
         }
     }
 }


### PR DESCRIPTION
What: Use the security last price for close-profit estimates outside regular market hours.

Why: Stale bid/ask quotes can distort `SecurityHolding.TotalCloseProfit()` when the security cannot be closed during regular market hours.

How: Select bid/ask pricing only while regular market hours are open; otherwise use `Security.Price` before falling back through the existing zero-price handling.

Edge cases handled: Long and short holdings are covered; open-market behavior still uses bid for longs and ask for shorts; closed-market behavior avoids stale quote spreads.

Tests added/updated: Added long and short `SecurityHoldingTests` coverage for open and closed regular market hours. Build validation completed for `Tests/QuantConnect.Tests.csproj`; focused local discovery did not find the new tests in this environment and the Release build attempt timed out.