### PR TITLE
Enable warm-up for RelativeDailyVolume

### DIFF
--- a/Indicators/RelativeDailyVolume.cs
+++ b/Indicators/RelativeDailyVolume.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Indicators
     /// 
     /// Current volume from open to current time of day / Average over the past x days from open to current time of day
     /// </summary>
-    public class RelativeDailyVolume : TradeBarIndicator
+    public class RelativeDailyVolume : TradeBarIndicator, IIndicatorWarmUpPeriodProvider
     {
         private readonly SortedDictionary<TimeSpan, SimpleMovingAverage> _relativeData;
         private readonly Dictionary<DateTime, decimal> _currentData;
@@ -38,6 +38,11 @@ namespace QuantConnect.Indicators
         /// Gets a flag indicating when the indicator is ready and fully initialized
         /// </summary>
         public override bool IsReady => _days >= _period;
+
+        /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public int WarmUpPeriod { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the RelativeDailyVolume class using the specified period
@@ -59,6 +64,7 @@ namespace QuantConnect.Indicators
             _relativeData = new SortedDictionary<TimeSpan, SimpleMovingAverage>();
             _currentData = new Dictionary<DateTime, decimal>();
             _period = period;
+            WarmUpPeriod = period + 1;
             _previousDay = -1; // No calendar day can be -1, thus default is not a calendar day
             _days = -1; // Will increment by one after first TradeBar, then will increment by one every new day
         }

--- a/Tests/Indicators/RelativeDailyVolumeTests.cs
+++ b/Tests/Indicators/RelativeDailyVolumeTests.cs
@@ -113,6 +113,19 @@ namespace QuantConnect.Tests.Indicators
             Assert.IsFalse(rdv8.IsReady);
         }
 
+        [Test]
+        public void ProvidesConfigurableWarmUpPeriod()
+        {
+            var rdv = new RelativeDailyVolume(2);
+            var warmUpPeriodProvider = (IIndicatorWarmUpPeriodProvider)rdv;
+
+            Assert.AreEqual(3, warmUpPeriodProvider.WarmUpPeriod);
+
+            rdv.WarmUpPeriod = 1000;
+
+            Assert.AreEqual(1000, warmUpPeriodProvider.WarmUpPeriod);
+        }
+
         /// <summary>
         /// The final value of this indicator is zero because it uses the Volume of the bars it receives.
         /// Since RenkoBar's don't always have Volume, the final current value is zero. Therefore we


### PR DESCRIPTION
What: Add warm-up period support to `RelativeDailyVolume`.

Why: RDV did not expose `IIndicatorWarmUpPeriodProvider`, so consumers could not warm it up consistently through the standard indicator warm-up path.

How: Implemented `IIndicatorWarmUpPeriodProvider`, added configurable `WarmUpPeriod`, and defaulted it to `period + 1` to account for the first day initialization sample.

Edge cases handled: User overrides of `WarmUpPeriod` are preserved; the existing readiness behavior remains based on completed daily samples.

Tests added/updated: Added `RelativeDailyVolumeTests.ProvidesConfigurableWarmUpPeriod`. Build validation completed for `Indicators/QuantConnect.Indicators.csproj` and `Tests/QuantConnect.Tests.csproj`; focused local test execution was blocked by the existing pythonnet GIL finalizer crash.