### PR TITLE
Standardize report KPI precision

### DIFF
--- a/Report/ReportElements/CAGRReportElement.cs
+++ b/Report/ReportElements/CAGRReportElement.cs
@@ -60,7 +60,7 @@ namespace QuantConnect.Report.ReportElements
                 equityCurve.LastValue().SafeDecimalCast(),
                 years);
             
-            return ((decimal?)Result)?.ToString("P1") ?? "-";
+            return FormatKpiPercent((decimal?)Result);
         }
     }
 }

--- a/Report/ReportElements/InformationRatioReportElement.cs
+++ b/Report/ReportElements/InformationRatioReportElement.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Report.ReportElements
         {
             var informationRatio = _backtest?.TotalPerformance?.PortfolioStatistics?.InformationRatio;
             Result = informationRatio;
-            return informationRatio?.ToString("F1") ?? "-";
+            return FormatKpi(informationRatio);
         }
     }
 }

--- a/Report/ReportElements/MaxDrawdownReportElement.cs
+++ b/Report/ReportElements/MaxDrawdownReportElement.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.Report.ReportElements
             {
                 var backtestDrawdown = _backtest?.TotalPerformance?.PortfolioStatistics?.Drawdown;
                 Result = backtestDrawdown;
-                return backtestDrawdown?.ToString("P1") ?? "-";
+                return FormatKpiPercent(backtestDrawdown);
             }
 
             var equityCurve = new SortedDictionary<DateTime, decimal>(DrawdownCollection.NormalizeResults(_backtest, _live)
@@ -60,7 +60,7 @@ namespace QuantConnect.Report.ReportElements
             var maxDrawdown = Statistics.Statistics.CalculateDrawdownMetrics(equityCurve).Drawdown;
             Result = maxDrawdown;
 
-            return $"{maxDrawdown:P1}";
+            return FormatKpiPercent(maxDrawdown);
         }
     }
 }

--- a/Report/ReportElements/PSRReportElement.cs
+++ b/Report/ReportElements/PSRReportElement.cs
@@ -62,7 +62,7 @@ namespace QuantConnect.Report.ReportElements
                     return "-";
                 }
                 
-                return $"{psr:P0}";
+                return FormatKpiPercent(psr);
             }
 
             var equityCurvePerformance = DrawdownCollection.NormalizeResults(_backtest, _live)
@@ -86,7 +86,7 @@ namespace QuantConnect.Report.ReportElements
                 .SafeDecimalCast();
             
             Result = psr;
-            return $"{psr:P0}";
+            return FormatKpiPercent(psr);
         }
     }
 }

--- a/Report/ReportElements/ReportElement.cs
+++ b/Report/ReportElements/ReportElement.cs
@@ -13,6 +13,8 @@
  * limitations under the License.
 */
 
+using System.Globalization;
+
 namespace QuantConnect.Report.ReportElements
 {
     /// <summary>
@@ -39,6 +41,30 @@ namespace QuantConnect.Report.ReportElements
         /// Result of the render as an object for serialization to JSON
         /// </summary>
         public virtual object Result { get; protected set; }
+
+        /// <summary>
+        /// Formats a numeric KPI value with the report's standard decimal precision.
+        /// </summary>
+        protected static string FormatKpi(decimal? value)
+        {
+            return value.HasValue ? value.Value.ToString("F3", CultureInfo.InvariantCulture) : "-";
+        }
+
+        /// <summary>
+        /// Formats a numeric KPI value with the report's standard decimal precision.
+        /// </summary>
+        protected static string FormatKpi(double? value)
+        {
+            return value.HasValue ? value.Value.ToString("F3", CultureInfo.InvariantCulture) : "-";
+        }
+
+        /// <summary>
+        /// Formats a percentage KPI value with the report's standard decimal precision.
+        /// </summary>
+        protected static string FormatKpiPercent(decimal? value)
+        {
+            return value.HasValue ? value.Value.ToString("P3", CultureInfo.InvariantCulture) : "-";
+        }
 
         /// <summary>
         /// The generated output string to be injected

--- a/Report/ReportElements/SharpeRatioReportElement.cs
+++ b/Report/ReportElements/SharpeRatioReportElement.cs
@@ -72,7 +72,7 @@ namespace QuantConnect.Report.ReportElements
             if (LiveResult == null)
             {
                 Result = BacktestResultValue;
-                return BacktestResultValue?.ToString("F1") ?? "-";
+                return FormatKpi(BacktestResultValue);
             }
 
             var equityPoints = ResultsUtil.EquityPoints(LiveResult);
@@ -96,7 +96,7 @@ namespace QuantConnect.Report.ReportElements
             var annualPerformance = Statistics.Statistics.AnnualPerformance(trailingPerformance, _tradingDaysPerYear);
             var liveResultValue = Statistics.Statistics.SharpeRatio(annualPerformance, annualStandardDeviation, 0.0);
             Result = liveResultValue;
-            return liveResultValue.ToString("F2");
+            return FormatKpi(liveResultValue);
         }
 
         /// <summary>

--- a/Report/ReportElements/TradesPerDayReportElement.cs
+++ b/Report/ReportElements/TradesPerDayReportElement.cs
@@ -74,12 +74,7 @@ namespace QuantConnect.Report.ReportElements
             var tradesPerDay = orders.Count() / days;
             Result = tradesPerDay;
 
-            if (tradesPerDay > 9)
-            {
-                return $"{tradesPerDay:F0}";
-            }
-
-            return $"{tradesPerDay:F1}";
+            return FormatKpi(tradesPerDay);
         }
     }
 }

--- a/Report/ReportElements/TurnoverReportElement.cs
+++ b/Report/ReportElements/TurnoverReportElement.cs
@@ -49,7 +49,7 @@ namespace QuantConnect.Report.ReportElements
                 return "-";
             }
 
-            return $"{turnover:P0}";
+            return FormatKpiPercent(turnover);
         }
     }
 }

--- a/Tests/Report/ReportChartsTest.cs
+++ b/Tests/Report/ReportChartsTest.cs
@@ -22,6 +22,7 @@ using Python.Runtime;
 using QuantConnect.Packets;
 using QuantConnect.Report;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace QuantConnect.Tests.Report
 {
@@ -117,6 +118,31 @@ namespace QuantConnect.Tests.Report
             string html = "";
             Assert.DoesNotThrow(() => report.Compile(out html, out _));
             Assert.IsNotEmpty(html);
+        }
+
+        [Test]
+        public void KeyStatisticsRenderWithThreeDecimalPlaces()
+        {
+            var backtestResult = GetBacktestResult();
+            backtestResult.TotalPerformance.PortfolioStatistics.Drawdown = 0.01234m;
+            backtestResult.TotalPerformance.PortfolioStatistics.PortfolioTurnover = 0.12345m;
+            backtestResult.TotalPerformance.PortfolioStatistics.ProbabilisticSharpeRatio = 0.98765m;
+            backtestResult.TotalPerformance.PortfolioStatistics.SharpeRatio = 1.23456m;
+            backtestResult.TotalPerformance.PortfolioStatistics.SortinoRatio = 2.34567m;
+            backtestResult.TotalPerformance.PortfolioStatistics.InformationRatio = -0.3094m;
+
+            var report = new QuantConnect.Report.Report("Report", "Report", "v1.0.0", backtestResult, (LiveResult)null);
+            report.Compile(out var html, out var reportStatistics);
+
+            Assert.That(html, Does.Contain("<td>1.234%</td>"));
+            Assert.That(html, Does.Contain("<td>12.345%</td>"));
+            Assert.That(html, Does.Contain("<td>98.765%</td>"));
+            Assert.That(html, Does.Contain("<td>1.235</td>"));
+            Assert.That(html, Does.Contain("<td>2.346</td>"));
+            Assert.That(html, Does.Contain("<td>-0.309</td>"));
+
+            var statistics = JObject.Parse(reportStatistics);
+            Assert.AreEqual(1.23456m, statistics["sharpe"].Value<decimal>());
         }
 
         static BacktestResult GetBacktestResult()


### PR DESCRIPTION
What: Standardize report KPI display precision to three decimal places.

Why: Report key statistics used mixed formats (`P0`, `P1`, `F1`, `F2`), making rendered KPIs inconsistent.

How: Added shared KPI formatting helpers on `ReportElement` and applied them to percentage and numeric report elements while preserving raw serialized statistics.

Edge cases handled: Missing KPI values still render as `-`; percentage KPIs use invariant culture; serialized report statistics keep unrounded numeric values.

Tests added/updated: Added `ReportChartTests.KeyStatisticsRenderWithThreeDecimalPlaces`. Build validation completed for `Report/QuantConnect.Report.csproj` and `Tests/QuantConnect.Tests.csproj`; focused local test execution was blocked by the existing pythonnet GIL finalizer crash.