### PR TITLE
Fix IResultHandler.RuntimeError not stopping the algorithm

### DIFF
--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -16,6 +16,7 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using QuantConnect;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Indicators;
@@ -953,8 +954,7 @@ namespace QuantConnect.Lean.Engine.Results
             State["StackTrace"] = stack;
             if (Algorithm != null && Algorithm.RunTimeError == null && !string.IsNullOrEmpty(error))
             {
-                Algorithm.SetRunTimeError(new Exception(error));
-                Algorithm.SetStatus(AlgorithmStatus.RuntimeError);
+                Algorithm.SetRuntimeError(new Exception(error), nameof(IResultHandler.RuntimeError));
             }
         }
 

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -951,6 +951,11 @@ namespace QuantConnect.Lean.Engine.Results
         {
             State["RuntimeError"] = error;
             State["StackTrace"] = stack;
+            if (Algorithm != null && Algorithm.RunTimeError == null && !string.IsNullOrEmpty(error))
+            {
+                Algorithm.SetRunTimeError(new Exception(error));
+                Algorithm.SetStatus(AlgorithmStatus.RuntimeError);
+            }
         }
 
         /// <summary>

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -39,6 +39,7 @@ using QuantConnect.Packets;
 using QuantConnect.Scheduling;
 using QuantConnect.Securities;
 using QuantConnect.Statistics;
+using QuantConnect.Util;
 using Log = QuantConnect.Logging.Log;
 
 namespace QuantConnect.Tests.Engine
@@ -386,6 +387,36 @@ namespace QuantConnect.Tests.Engine
             {
                 ++Loops;
                 SetStatus(AlgorithmStatus);
+            }
+        }
+
+        [Test]
+        public void RuntimeErrorFromResultHandlerStopsAlgorithm()
+        {
+            ResultHandlerRuntimeErrorTest.Loops = 0;
+            var parameter = new RegressionTests.AlgorithmStatisticsTestParameters(
+                "QuantConnect.Tests.Engine.AlgorithmManagerTests+ResultHandlerRuntimeErrorTest",
+                new Dictionary<string, string>(),
+                Language.CSharp,
+                AlgorithmStatus.RuntimeError);
+
+            AlgorithmRunner.RunLocalBacktest(parameter.Algorithm,
+                parameter.Statistics,
+                parameter.Language,
+                parameter.ExpectedFinalStatus,
+                algorithmLocation: "QuantConnect.Tests.dll");
+
+            Assert.AreEqual(1, ResultHandlerRuntimeErrorTest.Loops);
+        }
+
+        public class ResultHandlerRuntimeErrorTest : BasicTemplateDailyAlgorithm
+        {
+            public static int Loops { get; set; }
+
+            public override void OnData(Slice data)
+            {
+                ++Loops;
+                Composer.Instance.GetPart<IResultHandler>()?.RuntimeError("Brokerage triggered a fatal error");
             }
         }
     }

--- a/Tests/Engine/Results/BaseResultsHandlerTests.cs
+++ b/Tests/Engine/Results/BaseResultsHandlerTests.cs
@@ -199,6 +199,14 @@ namespace QuantConnect.Tests.Engine.Results
                 ResultsDestinationFolder = folder;
             }
             public string GetResultsDestinationFolder => ResultsDestinationFolder;
+
+            public void SetAlgorithmDirect(IAlgorithm algorithm)
+            {
+                Algorithm = algorithm;
+            }
+
+            public void CallSetAlgorithmState(string error, string stack) => SetAlgorithmState(error, stack);
+
             protected override void Run()
             {
                 throw new NotImplementedException();
@@ -222,6 +230,33 @@ namespace QuantConnect.Tests.Engine.Results
             protected override void AddToLogStore(string message)
             {
             }
+        }
+
+        [Test]
+        public void RuntimeErrorSetsAlgorithmRunTimeErrorAndStatus()
+        {
+            var handler = new BaseResultsHandlerTestable(AlgorithmId);
+            var algorithm = new QCAlgorithm();
+            handler.SetAlgorithmDirect(algorithm);
+
+            handler.CallSetAlgorithmState("Something went wrong", "stack trace here");
+
+            Assert.IsNotNull(algorithm.RunTimeError);
+            Assert.AreEqual("Something went wrong", algorithm.RunTimeError.Message);
+            Assert.AreEqual(AlgorithmStatus.RuntimeError, algorithm.Status);
+        }
+
+        [Test]
+        public void RuntimeErrorDoesNotOverwriteExistingRunTimeError()
+        {
+            var handler = new BaseResultsHandlerTestable(AlgorithmId);
+            var algorithm = new QCAlgorithm();
+            handler.SetAlgorithmDirect(algorithm);
+
+            handler.CallSetAlgorithmState("First error", "");
+            handler.CallSetAlgorithmState("Second error", "");
+
+            Assert.AreEqual("First error", algorithm.RunTimeError.Message);
         }
 
         private struct SampleParams


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
SetAlgorithmState now sets `Algorithm.RunTimeError` and status so the `AlgorithmManager` detects the error and stops execution when `IResultHandler.RuntimeError()` is called from a brokerage or data source

#### Related Issue
Closes #9273

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
