### PR TITLE
Fix OnWarmupFinished algorithm time alignment

### DIFF
--- a/Algorithm.CSharp/OnWarmupFinishedScheduledUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OnWarmupFinishedScheduledUniverseRegressionAlgorithm.cs
@@ -1,0 +1,110 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting OnWarmupFinished fires at StartDate (midnight)
+    /// when using a ScheduledUniverseSelectionModel that triggers at 8 AM, skipping midnight entirely.
+    /// </summary>
+    public class OnWarmupFinishedScheduledUniverseRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private bool _onWarmupFinishedCalled;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 08);
+            SetEndDate(2013, 10, 11);
+            SetCash(100000);
+
+            UniverseSettings.Resolution = Resolution.Minute;
+            SetWarmup(TimeSpan.FromDays(1));
+
+            // Universe triggers at 8 AM
+            SetUniverseSelection(new ScheduledUniverseSelectionModel(
+                DateRules.EveryDay(),
+                TimeRules.At(8, 0),
+                _ => new[] { QuantConnect.Symbol.Create("SPY", SecurityType.Equity, Market.USA) }
+            ));
+        }
+
+        public override void OnWarmupFinished()
+        {
+            _onWarmupFinishedCalled = true;
+
+            if (Time != StartDate)
+            {
+                throw new RegressionTestException(
+                    $"Expected OnWarmupFinished to fire at StartDate ({StartDate:yyyy-MM-dd HH:mm:ss}), " +
+                    $"but fired at {Time:yyyy-MM-dd HH:mm:ss}");
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_onWarmupFinishedCalled)
+            {
+                throw new RegressionTestException("OnWarmupFinished was never called");
+            }
+        }
+
+        public bool CanRunLocally { get; } = true;
+
+        public List<Language> Languages { get; } = new() { Language.CSharp };
+
+        public long DataPoints => 3948;
+
+        public int AlgorithmHistoryDataPoints => 0;
+
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-31.448"},
+            {"Tracking Error", "0.164"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"Drawdown Recovery", "0"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -727,6 +727,18 @@ namespace QuantConnect.Lean.Engine
                 {
                     // warmup finished, send an update
                     warmingUp = false;
+
+                    // Align time to StartDate so OnWarmupFinished always fires at midnight,
+                    // even when the first post warmup slice arrives later (e.g. a ScheduledUniverse at 8 AM).
+                    if (!algorithm.LiveMode)
+                    {
+                        var warmupEndUtc = algorithm.StartDate.ConvertToUtc(algorithm.TimeZone);
+                        if (algorithm.UtcTime > warmupEndUtc)
+                        {
+                            algorithm.SetDateTime(warmupEndUtc);
+                        }
+                    }
+
                     // we trigger this callback here and not internally in the algorithm so that we can go through python if required
                     algorithm.OnWarmupFinished();
                     algorithm.Debug("Algorithm finished warming up.");

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -727,18 +727,6 @@ namespace QuantConnect.Lean.Engine
                 {
                     // warmup finished, send an update
                     warmingUp = false;
-
-                    // Align time to StartDate so OnWarmupFinished always fires at midnight,
-                    // even when the first post warmup slice arrives later (e.g. a ScheduledUniverse at 8 AM).
-                    if (!algorithm.LiveMode)
-                    {
-                        var warmupEndUtc = algorithm.StartDate.ConvertToUtc(algorithm.TimeZone);
-                        if (algorithm.UtcTime > warmupEndUtc)
-                        {
-                            algorithm.SetDateTime(warmupEndUtc);
-                        }
-                    }
-
                     // we trigger this callback here and not internally in the algorithm so that we can go through python if required
                     algorithm.OnWarmupFinished();
                     algorithm.Debug("Algorithm finished warming up.");

--- a/Engine/DataFeeds/LiveSynchronizer.cs
+++ b/Engine/DataFeeds/LiveSynchronizer.cs
@@ -139,6 +139,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // check for cancellation
                 if (timeSlice == null || cancellationToken.IsCancellationRequested) break;
 
+                if (Algorithm.IsWarmingUp && timeSlice.Time > WarmupEndUtc)
+                {
+                    yield return TimeSliceFactory.CreateTimePulse(WarmupEndUtc);
+                }
+
                 var frontierUtc = FrontierTimeProvider.GetUtcNow();
                 // emit on data or if we've elapsed a full second since last emit or there are security changes
                 if (timeSlice.SecurityChanges != SecurityChanges.None

--- a/Engine/DataFeeds/LiveSynchronizer.cs
+++ b/Engine/DataFeeds/LiveSynchronizer.cs
@@ -212,6 +212,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         {
             base.PostInitialize();
             _frontierTimeProvider.Initialize(base.GetTimeProvider());
+            WarmupEndUtc = TimeProvider.GetUtcNow();
         }
 
         /// <summary>

--- a/Engine/DataFeeds/LiveSynchronizer.cs
+++ b/Engine/DataFeeds/LiveSynchronizer.cs
@@ -139,7 +139,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // check for cancellation
                 if (timeSlice == null || cancellationToken.IsCancellationRequested) break;
 
-                if (Algorithm.IsWarmingUp && timeSlice.Time > WarmupEndUtc)
+                if (ShouldEmitWarmupEndPulse(timeSlice))
                 {
                     yield return TimeSliceFactory.CreateTimePulse(WarmupEndUtc);
                 }

--- a/Engine/DataFeeds/Synchronizer.cs
+++ b/Engine/DataFeeds/Synchronizer.cs
@@ -34,7 +34,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <summary>
         /// UTC time at which the warm up period ends
         /// </summary>
-        protected DateTime WarmupEndUtc { get; private set; }
+        protected DateTime WarmupEndUtc { get; set; }
 
         /// <summary>
         /// The algorithm instance
@@ -121,16 +121,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // check for cancellation
                 if (timeSlice == null || cancellationToken.IsCancellationRequested) break;
 
-                if (ShouldEmitWarmupEndPulse(timeSlice))
-                {
-                    yield return TimeSliceFactory.CreateTimePulse(WarmupEndUtc);
-                }
-
                 if (timeSlice.IsTimePulse && Algorithm.UtcTime == timeSlice.Time)
                 {
                     previousWasTimePulse = timeSlice.IsTimePulse;
                     // skip time pulse when algorithms already at that time
                     continue;
+                }
+
+                if (ShouldEmitWarmupEndPulse(timeSlice))
+                {
+                    yield return TimeSliceFactory.CreateTimePulse(WarmupEndUtc);
                 }
 
                 // SubscriptionFrontierTimeProvider will return twice the same time if there are no more subscriptions or if Subscription.Current is null

--- a/Engine/DataFeeds/Synchronizer.cs
+++ b/Engine/DataFeeds/Synchronizer.cs
@@ -164,7 +164,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// Returns true when the first post warmup slice skips past StartDate
         /// so a time pulse can be emitted to align algorithm time before OnWarmupFinished fires
         /// </summary>
-        protected bool ShouldEmitWarmupEndPulse(TimeSlice timeSlice) => Algorithm.IsWarmingUp && timeSlice.Time > WarmupEndUtc;
+        protected bool ShouldEmitWarmupEndPulse(TimeSlice timeSlice)
+        {
+            return Algorithm.GetLocked() && Algorithm.IsWarmingUp && timeSlice.Time > WarmupEndUtc;
+        }
 
         /// <summary>
         /// Performs additional initialization steps after algorithm initialization

--- a/Engine/DataFeeds/Synchronizer.cs
+++ b/Engine/DataFeeds/Synchronizer.cs
@@ -30,7 +30,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     public class Synchronizer : ISynchronizer, IDataFeedTimeProvider, IDisposable
     {
         private DateTimeZone _dateTimeZone;
-        private DateTime _warmupEndUtc;
+
+        /// <summary>
+        /// UTC time at which the warm up period ends
+        /// </summary>
+        protected DateTime WarmupEndUtc { get; private set; }
 
         /// <summary>
         /// The algorithm instance
@@ -119,9 +123,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                 // If the first post warmup slice skips past StartDate, emit a time pulse at StartDate
                 // so the algorithm time is aligned before OnWarmupFinished fires
-                if (!Algorithm.LiveMode && Algorithm.IsWarmingUp && timeSlice.Time > _warmupEndUtc)
+                if (Algorithm.IsWarmingUp && timeSlice.Time > WarmupEndUtc)
                 {
-                    yield return TimeSliceFactory.CreateTimePulse(_warmupEndUtc);
+                    yield return TimeSliceFactory.CreateTimePulse(WarmupEndUtc);
                 }
 
                 if (timeSlice.IsTimePulse && Algorithm.UtcTime == timeSlice.Time)
@@ -175,7 +179,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             // this is set after the algorithm initializes
             _dateTimeZone = Algorithm.TimeZone;
-            _warmupEndUtc = Algorithm.StartDate.ConvertToUtc(_dateTimeZone);
+            WarmupEndUtc = Algorithm.StartDate.ConvertToUtc(_dateTimeZone);
             TimeSliceFactory = new TimeSliceFactory(_dateTimeZone);
             SubscriptionSynchronizer.SetTimeSliceFactory(TimeSliceFactory);
         }

--- a/Engine/DataFeeds/Synchronizer.cs
+++ b/Engine/DataFeeds/Synchronizer.cs
@@ -30,6 +30,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     public class Synchronizer : ISynchronizer, IDataFeedTimeProvider, IDisposable
     {
         private DateTimeZone _dateTimeZone;
+        private DateTime _warmupEndUtc;
 
         /// <summary>
         /// The algorithm instance
@@ -116,6 +117,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // check for cancellation
                 if (timeSlice == null || cancellationToken.IsCancellationRequested) break;
 
+                // If the first post warmup slice skips past StartDate, emit a time pulse at StartDate
+                // so the algorithm time is aligned before OnWarmupFinished fires
+                if (!Algorithm.LiveMode && Algorithm.IsWarmingUp && timeSlice.Time > _warmupEndUtc)
+                {
+                    yield return TimeSliceFactory.CreateTimePulse(_warmupEndUtc);
+                }
+
                 if (timeSlice.IsTimePulse && Algorithm.UtcTime == timeSlice.Time)
                 {
                     previousWasTimePulse = timeSlice.IsTimePulse;
@@ -167,6 +175,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
             // this is set after the algorithm initializes
             _dateTimeZone = Algorithm.TimeZone;
+            _warmupEndUtc = Algorithm.StartDate.ConvertToUtc(_dateTimeZone);
             TimeSliceFactory = new TimeSliceFactory(_dateTimeZone);
             SubscriptionSynchronizer.SetTimeSliceFactory(TimeSliceFactory);
         }

--- a/Engine/DataFeeds/Synchronizer.cs
+++ b/Engine/DataFeeds/Synchronizer.cs
@@ -121,9 +121,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // check for cancellation
                 if (timeSlice == null || cancellationToken.IsCancellationRequested) break;
 
-                // If the first post warmup slice skips past StartDate, emit a time pulse at StartDate
-                // so the algorithm time is aligned before OnWarmupFinished fires
-                if (Algorithm.IsWarmingUp && timeSlice.Time > WarmupEndUtc)
+                if (ShouldEmitWarmupEndPulse(timeSlice))
                 {
                     yield return TimeSliceFactory.CreateTimePulse(WarmupEndUtc);
                 }
@@ -161,6 +159,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             enumerator.DisposeSafely();
             Log.Trace("Synchronizer.GetEnumerator(): Exited thread.");
         }
+
+        /// <summary>
+        /// Returns true when the first post warmup slice skips past StartDate
+        /// so a time pulse can be emitted to align algorithm time before OnWarmupFinished fires
+        /// </summary>
+        protected bool ShouldEmitWarmupEndPulse(TimeSlice timeSlice) => Algorithm.IsWarmingUp && timeSlice.Time > WarmupEndUtc;
 
         /// <summary>
         /// Performs additional initialization steps after algorithm initialization


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
`OnWarmupFinished` was firing at the scheduled universe trigger time (e.g. 8 AM) instead of `StartDate` (midnight) when no midnight slice existed, now aligned to StartDate before the callback fires.

#### Related Issue
Closes #9333

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using a regression test.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
