### PR TITLE
fix: add EAD future-option expiry definition

### DIFF
--- a/Common/Securities/FutureOption/FuturesOptionsExpiryFunctions.cs
+++ b/Common/Securities/FutureOption/FuturesOptionsExpiryFunctions.cs
@@ -51,6 +51,7 @@ namespace QuantConnect.Securities.FutureOption
         private static readonly Symbol _chu = Symbol.CreateCanonicalOption(Symbol.Create("6S", SecurityType.Future, Market.CME));
         private static readonly Symbol _nzd = Symbol.CreateCanonicalOption(Symbol.Create("6N", SecurityType.Future, Market.CME));
         private static readonly Symbol _mxn = Symbol.CreateCanonicalOption(Symbol.Create("6M", SecurityType.Future, Market.CME));
+        private static readonly Symbol _ead = Symbol.CreateCanonicalOption(Symbol.Create("EAD", SecurityType.Future, Market.CME));
         private static readonly Symbol _le = Symbol.CreateCanonicalOption(Symbol.Create("LE", SecurityType.Future, Market.CME));
         private static readonly Symbol _he = Symbol.CreateCanonicalOption(Symbol.Create("HE", SecurityType.Future, Market.CME));
         private static readonly Symbol _lbr = Symbol.CreateCanonicalOption(Symbol.Create("LBR", SecurityType.Future, Market.CME));
@@ -99,6 +100,7 @@ namespace QuantConnect.Securities.FutureOption
             { _chu, expiryMonth => SecondFridayBeforeThirdWednesdayOfContractMonth(_chu.Underlying, expiryMonth) },
             { _nzd, expiryMonth => SecondFridayBeforeThirdWednesdayOfContractMonth(_nzd.Underlying, expiryMonth) },
             { _mxn, expiryMonth => SecondFridayBeforeThirdWednesdayOfContractMonth(_mxn.Underlying, expiryMonth) },
+            { _ead, expiryMonth => SecondFridayBeforeThirdWednesdayOfContractMonth(_ead.Underlying, expiryMonth) },
             { _le, expiryMonth => FirstFridayOfContractMonth(_le.Underlying, expiryMonth) },
             { _he, expiryMonth => TenthBusinessDayOfContractMonth(_he.Underlying, expiryMonth) },
             { _lbr, expiryMonth => LastBusinessDayInPrecedingMonthFromContractMonth(_lbr.Underlying, expiryMonth) },


### PR DESCRIPTION
#### Description

Adds an `EAD` (Euro/Australian Dollar Cross Rate) entry to `FuturesOptionsExpiryFunctions` so the FOP expires per CME spec - the second Friday prior to the third Wednesday of the contract month - instead of falling back to the underlying future's quarterly (HMUZ) expiry.

CME contract spec: https://www.cmegroup.com/markets/fx/cross-rates/euro-fx-australian-dollar.contractSpecs.options.html

#### Related PR(s)

N/A

#### Related Issue

N/A

#### Motivation and Context

#### Motivation and Context

CME lists **EAD** futures only on quarterly months (Mar/Jun/Sep/Dec), but lists EAD options on those quarters **plus** 3 serial months. Lean had no **EAD** entry in `_futuresOptionExpiryFunctions`, so the FOP expiry fell back to the future's rule, which rolls any non-quarterly month forward to the next quarter. The serial `EADN6` (Jul) and the quarterly `EADU6` (Sep) ended up with the same expiry and strike, so they became the same Lean `Symbol`.

The AlgoSeek converter then failed when both tars were processed on the same trade date:
```
AlgoSeekFuturesConverter.Convert(): Exception caught! File: /raw/futureoption/usa/20260428/EAD/EADU6.tar 
Err: AlgoSeekFuturesProcessor(): file clash detected: 
/temp-output-directory/futureoption/cme/minute/ead/202609/20260428_trade_american/20260428_ead_minute_trade_american_put_16400000_20260914.csv
```
CME spec — *Euro/Australian Dollar (EUR/AUD) Monthly Options*:
> **Listed Contracts:** Quarterly contracts (Mar, Jun, Sep, Dec) listed for 4 consecutive quarters and serial contracts listed for 3 consecutive months
>
> **Termination of Trading:** Trading terminates at 9:00 a.m. CT on the second Friday prior to the third Wednesday of the contract month.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Verified with two new `MapsCorrectly` cases in [Lean.DataSource.AlgoSeekFutures](https://github.com/QuantConnect/Lean.DataSource.AlgoSeekFutures) `AlgoSeekFuturesOptionsReaderTest`:

- `EADU6 P1640` (Sep 2026, quarterly) -> FOP expiry **2026-09-04**, underlying U6 future expires 2026-09-14.
- `EADN6 P1640` (Jul 2026, serial) -> FOP expiry **2026-07-02** (Jul 3 is observed Independence Day, shifted back one business day), underlying rolls to U6.

Both resolve to **distinct** Lean Symbols, confirming the file clash is gone.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`