### PR TITLE
Fix RollingWindow element order corruption on resize

### DIFF
--- a/Algorithm.CSharp/MarketImpactSlippageModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MarketImpactSlippageModelRegressionAlgorithm.cs
@@ -99,11 +99,11 @@ namespace QuantConnect.Algorithm.CSharp
             {"Drawdown", "4.200%"},
             {"Expectancy", "-1"},
             {"Start Equity", "10000000"},
-            {"End Equity", "9649796.02"},
+            {"End Equity", "9649801.20"},
             {"Net Profit", "-3.502%"},
             {"Sharpe Ratio", "-2.93"},
             {"Sortino Ratio", "-2.869"},
-            {"Probabilistic Sharpe Ratio", "7.351%"},
+            {"Probabilistic Sharpe Ratio", "7.352%"},
             {"Loss Rate", "100%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
@@ -119,7 +119,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Lowest Capacity Asset", "AAPL R735QTJ8XC9X"},
             {"Portfolio Turnover", "21.04%"},
             {"Drawdown Recovery", "0"},
-            {"OrderListHash", "bee21851fd1ac425df8e01169d0db355"}
+            {"OrderListHash", "fc0626f660981cb698f6a9a5d5d1389a"}
         };
     }
 }

--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -368,11 +368,27 @@ namespace QuantConnect.Indicators
             {
                 _listLock.EnterWriteLock();
 
-                _list.EnsureCapacity(size);
+                if (_tail != 0)
+                {
+                    // The _list is out of order due to circular overwrites
+                    // Restore oldest to newest order and reset _tail before resizing
+                    var count = _list.Count;
+                    var reordered = new List<T>(count);
+                    for (var i = count - 1; i >= 0; i--)
+                    {
+                        reordered.Add(_list[GetListIndex(i, count, _tail)]);
+                    }
+                    _list.Clear();
+                    _list.AddRange(reordered);
+                    _tail = 0;
+                }
+
                 if (size < _list.Count)
                 {
                     _list.RemoveRange(0, _list.Count - size);
                 }
+
+                _list.EnsureCapacity(size);
                 _size = size;
             }
             finally

--- a/Common/Indicators/RollingWindow.cs
+++ b/Common/Indicators/RollingWindow.cs
@@ -368,23 +368,19 @@ namespace QuantConnect.Indicators
             {
                 _listLock.EnterWriteLock();
 
-                if (_tail != 0)
-                {
-                    // The _list is out of order due to circular overwrites
-                    // Restore oldest to newest order and reset _tail before resizing
-                    var count = _list.Count;
-                    var reordered = new List<T>(count);
-                    for (var i = count - 1; i >= 0; i--)
-                    {
-                        reordered.Add(_list[GetListIndex(i, count, _tail)]);
-                    }
-                    _list.Clear();
-                    _list.AddRange(reordered);
-                    _tail = 0;
-                }
-
                 if (size < _list.Count)
                 {
+                    if (_tail != 0)
+                    {
+                        // The _list is out of order due to circular overwrites
+                        // Restore oldest to newest order and reset _tail before resizing
+                        var count = _list.Count;
+                        _list.Reverse(0, _tail);
+                        _list.Reverse(_tail, count - _tail);
+                        _list.Reverse(0, count);
+                        _tail = 0;
+                    }
+
                     _list.RemoveRange(0, _list.Count - size);
                 }
 

--- a/Common/Orders/Slippage/MarketImpactSlippageModel.cs
+++ b/Common/Orders/Slippage/MarketImpactSlippageModel.cs
@@ -238,13 +238,13 @@ namespace QuantConnect.Orders.Slippage
             _prices.Add(bar.Close);
             _volumes.Add(bar.Volume);
 
-            if (_prices.Samples < 2)
+            if (_prices.Count < 2)
             {
                 return;
             }
 
-            var rocp = new double[_prices.Samples - 1];
-            for (var i = 0; i < _prices.Samples - 1; i++)
+            var rocp = new double[_prices.Count - 1];
+            for (var i = 0; i < _prices.Count - 1; i++)
             {
                 if (_prices[i + 1] == 0) continue;
 

--- a/Tests/Indicators/RollingWindowTests.cs
+++ b/Tests/Indicators/RollingWindowTests.cs
@@ -602,5 +602,55 @@ def rolling_window_with_custom_data_type():
                 Assert.AreEqual(expectedValue, value);
             }
         }
+
+        [TestCase(2, 3, 5, new[] { 3, 2 })]
+        [TestCase(5, 7, 3, new[] { 7, 6, 5 })]
+        [TestCase(3, 6, 2, new[] { 6, 5 })]
+        [TestCase(3, 6, 5, new[] { 6, 5, 4 })]
+        public void ResizeFromOverwrittenWindowPreservesNewestElements(int initialSize, int totalAdds, int newSize, int[] expected)
+        {
+            var window = new RollingWindow<int>(initialSize);
+            for (var i = 1; i <= totalAdds; i++)
+            {
+                window.Add(i);
+            }
+
+            window.Size = newSize;
+
+            for (var i = 0; i < expected.Length; i++)
+            {
+                Assert.AreEqual(expected[i], window[i]);
+            }
+        }
+
+        [Test]
+        public void MultipleResizesOnOverwrittenWindowPreserveElementOrder()
+        {
+            var window = new RollingWindow<int>(5);
+            for (var i = 1; i <= 7; i++)
+            {
+                window.Add(i);
+            }
+
+            window.Size = 3;
+            Assert.AreEqual(7, window[0]);
+            Assert.AreEqual(6, window[1]);
+            Assert.AreEqual(5, window[2]);
+
+            window.Size = 10;
+            Assert.AreEqual(7, window[0]);
+            Assert.AreEqual(6, window[1]);
+            Assert.AreEqual(5, window[2]);
+
+            for (var i = 8; i <= 17; i++)
+            {
+                window.Add(i);
+            }
+
+            Assert.AreEqual(17, window[0]);
+            Assert.AreEqual(16, window[1]);
+            Assert.AreEqual(15, window[2]);
+            Assert.AreEqual(8, window[9]);
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
When resizing a full RollingWindow, the internal write position was not accounted for, causing index calculations to return elements in the wrong order. Fix reorders the internal list to match the new layout before resizing.

#### Related Issue
Closes #9355 

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
