### PR TITLE
Fix #9447: Convert IEnumerable to List before passing to Python universe selector

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -3079,7 +3079,11 @@ namespace QuantConnect
             {
                 return (dataPoints) => dataPoints.Select(x => x.Symbol);
             }
-            return selector.ConvertSelectionSymbolDelegate();
+            // Convert IEnumerable to List before passing to the Python selector so that
+            // Python users can use list semantics such as indexing (e.g. fundamentals[0])
+            // and len() (e.g. len(fundamentals)) without errors. See GH issue #9447.
+            Func<IEnumerable<T>, object> listSelector = data => selector(data.ToList());
+            return listSelector.ConvertSelectionSymbolDelegate();
         }
 
         /// <summary>

--- a/Tests/Common/Util/ExtensionsTests.cs
+++ b/Tests/Common/Util/ExtensionsTests.cs
@@ -1955,6 +1955,49 @@ def select_symbol(fundamental):
             }
         }
 
+        [Test]
+        public void UniverseSelectionDelegatePassesListToPythonSelector()
+        {
+            // Regression test for GH issue #9447:
+            // The Python universe selector should receive a List, not an IEnumerable,
+            // so that users can use list semantics: fundamentals[0] and len(fundamentals).
+            using (Py.GIL())
+            {
+                var module = PyModule.FromString(
+                    "UniverseSelectionDelegatePassesListToPythonSelector",
+                    @"
+def select_symbols(fundamentals):
+    # These two operations crash if fundamentals is an IEnumerable (iterator):
+    count = len(fundamentals)       # raises TypeError on iterator
+    first = fundamentals[0]         # raises TypeError on iterator
+    return [x.Symbol for x in fundamentals]
+"
+                );
+                var selectSymbolPythonMethod = module.GetAttr("select_symbols");
+                Assert.IsTrue(selectSymbolPythonMethod.TryAs(out Func<IEnumerable<Fundamental>, object> selectSymbols));
+                Assert.IsNotNull(selectSymbols);
+
+                var selectSymbolsDelegate = selectSymbols.ConvertToUniverseSelectionSymbolDelegate();
+
+                var reference = new DateTime(2024, 2, 1);
+                // Pass as IEnumerable (simulating what C# engine provides) — not a list
+                IEnumerable<Fundamental> fundamentals = new List<Fundamental>
+                {
+                    new Fundamental(reference, Symbols.SPY),
+                    new Fundamental(reference, Symbols.AAPL),
+                    new Fundamental(reference, Symbols.IBM),
+                }.Select(x => x); // .Select() returns IEnumerable, not List
+
+                List<Symbol> symbols = null;
+                // This must NOT throw — previously crashed because Python received an
+                // IEnumerable that doesn't support len() or indexing.
+                Assert.DoesNotThrow(() => symbols = selectSymbolsDelegate(fundamentals).ToList());
+                Assert.IsNotNull(symbols);
+                CollectionAssert.IsNotEmpty(symbols);
+                Assert.AreEqual(3, symbols.Count);
+            }
+        }
+
         [TestCaseSource(nameof(DivideCases))]
         public void SafeDivisionWorksAsExpectedWithEdgeCases(decimal numerator, decimal denominator)
         {


### PR DESCRIPTION
## Summary
Fixes #9447
The universe selection parameter passed to Python selector functions was an `IEnumerable<T>` (a lazy C# iterator). When crossing the C#→Python boundary, Python receives this as a generator object — which does **not** support list semantics. This causes `TypeError` on the two most common operations users perform:
```python
def _fundamental_filter(self, fundamentals: List[Fundamental]) -> List[Symbol]:
    count = len(fundamentals)   # ❌ TypeError: object of type 'generator' has no len()
    first = fundamentals[0]     # ❌ TypeError: 'generator' object is not subscriptable
```
Bug Reproduction
I reproduced the exact behavior by simulating what LEAN's C# engine passes to Python — an IEnumerable (generator) instead of a List:


Output shows:
```
Type received: <class 'generator'>
FAIL: len(fundamentals) → TypeError: object of type 'generator' has no len()
FAIL: fundamentals[0] → TypeError: 'generator' object is not subscriptable
Second iteration returns empty — iterator is exhausted after first pass
After fix (list() conversion): all 4 operations pass ✅
```
Root Cause
In Common/Extensions.cs, the method ConvertToUniverseSelectionSymbolDelegate<T> passed the raw IEnumerable<T> directly to the Python selector:

csharp
```
// Before (bug): IEnumerable passed as-is to Python
return selector.ConvertSelectionSymbolDelegate();
Since IEnumerable<T> in C# is a lazy iterator, Python receives it as a generator — not a list.
```

Fix
Wrap the selector call with .ToList() before invoking Python, converting the lazy iterator to a materialized list:

csharp
// After (fix): convert to List so Python gets list semantics
```
Func<IEnumerable<T>, object> listSelector = data => selector(data.ToList());
return listSelector.ConvertSelectionSymbolDelegate();
File changed: Common/Extensions.cs — ConvertToUniverseSelectionSymbolDelegate<T> method
```

This matches the Potential Solution suggested in the issue: converting IEnumerable to List is friendlier to users than requiring them to manually call list(fundamentals) themselves.

Test Added
Added regression test UniverseSelectionDelegatePassesListToPythonSelector in Tests/Common/Util/ExtensionsTests.cs.

The test:

Creates a Python selector that calls len(fundamentals) and fundamentals[0]
Passes an IEnumerable<Fundamental> (via .Select(x => x) to ensure it is NOT a list)
Asserts the delegate executes without throwing a TypeError
Asserts the correct symbols are returned
Checklist
 I have completely filled out this template
 I have confirmed that this issue exists on the current master branch
 I have confirmed that this is not a duplicate issue
 Linked issue: #9447
 Unit test added: UniverseSelectionDelegatePassesListToPythonSelector
 
<img width="931" height="909" alt="image" src="https://github.com/user-attachments/assets/e25c894a-ca02-485a-b7a7-a802cad1ad5d" />
