### PR TITLE
Allow SetAccountCurrency after SetCash without throwing

### DIFF
--- a/Common/Messages/Messages.Securities.cs
+++ b/Common/Messages/Messages.Securities.cs
@@ -890,13 +890,6 @@ namespace QuantConnect
                 "Cannot change AccountCurrency after adding a Security. Please move SetAccountCurrency() before AddSecurity().";
 
             /// <summary>
-            /// Returns a string message saying the AccountCurrency cannot be changed after setting cash and that the method
-            /// SetAccountCurrency() should be moved before SetCash()
-            /// </summary>
-            public static string CannotChangeAccountCurrencyAfterSettingCash =
-                "Cannot change AccountCurrency after setting cash. Please move SetAccountCurrency() before SetCash().";
-
-            /// <summary>
             /// Returns a string message saying the AccountCurrency has been changed after setting cash, reporting the
             /// remaining amount held in the previous account currency
             /// </summary>

--- a/Common/Messages/Messages.Securities.cs
+++ b/Common/Messages/Messages.Securities.cs
@@ -897,6 +897,25 @@ namespace QuantConnect
                 "Cannot change AccountCurrency after setting cash. Please move SetAccountCurrency() before SetCash().";
 
             /// <summary>
+            /// Returns a string message saying the AccountCurrency has been changed after setting cash, reporting the
+            /// remaining amount held in the previous account currency
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string AccountCurrencyChangedAfterSettingCash(Securities.Cash previousCash)
+            {
+                return Invariant($"Account currency was changed after SetCash() was called. Algorithm still holds {previousCash.Amount} {previousCash.Symbol} in the previous account currency.");
+            }
+
+            /// <summary>
+            /// Returns a string message saying the account currency starting cash has been updated from a previous amount to a new one
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string AccountCurrencyCashUpdated(string accountCurrency, decimal previousAmount, decimal newAmount)
+            {
+                return Invariant($"Account currency cash updated to {newAmount} {accountCurrency} from {previousAmount} {accountCurrency}.");
+            }
+
+            /// <summary>
             /// Returns a string message saying the AccountCurrency has already been set and that the new value for this property
             /// will be ignored
             /// </summary>

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -36,6 +36,7 @@ namespace QuantConnect.Securities
     {
         private Cash _baseCurrencyCash;
         private bool _setCashWasCalled;
+        private bool _baseCashSymbolSetExplicitly;
         private decimal _totalPortfolioValue;
         private bool _isTotalPortfolioValueValid;
         private object _totalPortfolioValueLock = new();
@@ -619,10 +620,11 @@ namespace QuantConnect.Securities
         /// as the starting cash in this currency if given.
         /// </summary>
         /// <remarks>
-        /// Should be called before adding any <see cref="Security"/>. If <see cref="SetCash(decimal)"/>
-        /// was called beforehand with a different currency, the previous cash entry is kept in the
-        /// <see cref="CashBook"/> and the base currency <see cref="Cash"/> is repointed to the new currency.
-        /// If the currency matches, <paramref name="startingCash"/> overrides the previous amount.
+        /// Should be called before adding any <see cref="Security"/>. If <see cref="SetCash(string, decimal, decimal)"/>
+        /// was called beforehand for the current account currency, that balance is kept in its own
+        /// <see cref="CashBook"/> entry and the new account currency starts at zero. Otherwise the
+        /// previously set amount carries over to the new account currency. If the currency matches,
+        /// <paramref name="startingCash"/> overrides the previous amount.
         /// </remarks>
         /// <param name="accountCurrency">The account currency cash symbol to set</param>
         /// <param name="startingCash">The account currency starting cash to set</param>
@@ -661,10 +663,11 @@ namespace QuantConnect.Securities
             // Repoint the base cash to the new account currency entry.
             _baseCurrencyCash = CashBook[accountCurrency];
 
-            if (previousCash != null && previousCash.Symbol != accountCurrency)
+            if (_baseCashSymbolSetExplicitly && previousCash != null && previousCash.Symbol != accountCurrency)
             {
-                // Keep the previous balance in its own currency entry; the new account currency
-                // starts at zero (a subsequent SetCash below will apply startingCash if provided).
+                // The user committed cash to a specific currency via SetCash(symbol, ...): keep that
+                // balance in its own entry and start the new account currency at zero. Otherwise the
+                // CashBook setter has already migrated the implicit amount to the new currency entry.
                 _baseCurrencyCash.SetAmount(0);
                 CashBook.Add(previousCash.Symbol, previousAmount.Value, previousCash.ConversionRate);
                 message += ". " + Messages.SecurityPortfolioManager.AccountCurrencyChangedAfterSettingCash(previousCash);
@@ -690,6 +693,7 @@ namespace QuantConnect.Securities
         public void SetCash(decimal cash)
         {
             _setCashWasCalled = true;
+            _baseCashSymbolSetExplicitly = false;
             _baseCurrencyCash.SetAmount(cash);
         }
 
@@ -706,6 +710,10 @@ namespace QuantConnect.Securities
             symbol = symbol.LazyToUpper();
             if (CashBook.TryGetValue(symbol, out item))
             {
+                if (symbol == _baseCurrencyCash.Symbol)
+                {
+                    _baseCashSymbolSetExplicitly = true;
+                }
                 item.SetAmount(cash);
                 item.ConversionRate = conversionRate;
             }

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -621,7 +621,7 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <remarks>
         /// Should be called before adding any <see cref="Security"/>. If <see cref="SetCash(string, decimal, decimal)"/>
-        /// was called beforehand for the current account currency, that balance is kept in its own
+        /// was called beforehand, the previous base cash balance is kept in its own
         /// <see cref="CashBook"/> entry and the new account currency starts at zero. Otherwise the
         /// previously set amount carries over to the new account currency. If the currency matches,
         /// <paramref name="startingCash"/> overrides the previous amount.
@@ -706,14 +706,10 @@ namespace QuantConnect.Securities
         public void SetCash(string symbol, decimal cash, decimal conversionRate)
         {
             _setCashWasCalled = true;
-            Cash item;
+            _baseCashSymbolSetExplicitly = true;
             symbol = symbol.LazyToUpper();
-            if (CashBook.TryGetValue(symbol, out item))
+            if (CashBook.TryGetValue(symbol, out var item))
             {
-                if (symbol == _baseCurrencyCash.Symbol)
-                {
-                    _baseCashSymbolSetExplicitly = true;
-                }
                 item.SetAmount(cash);
                 item.ConversionRate = conversionRate;
             }

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -616,10 +616,17 @@ namespace QuantConnect.Securities
 
         /// <summary>
         /// Sets the account currency cash symbol this algorithm is to manage, as well
-        /// as the starting cash in this currency if given
+        /// as the starting cash in this currency if given.
         /// </summary>
-        /// <remarks>Has to be called before calling <see cref="SetCash(decimal)"/>
-        /// or adding any <see cref="Security"/></remarks>
+        /// <remarks>
+        /// Should be called before adding any <see cref="Security"/>.
+        /// If <see cref="SetCash(decimal)"/> was called beforehand, the previous cash entry
+        /// is preserved in the <see cref="CashBook"/>: the algorithm continues to hold that
+        /// amount in the previous currency, while <see cref="_baseCurrencyCash"/> is
+        /// repointed to the new account currency. When the new account currency matches the
+        /// existing one, the optional <paramref name="startingCash"/> simply overrides the
+        /// previously set amount.
+        /// </remarks>
         /// <param name="accountCurrency">The account currency cash symbol to set</param>
         /// <param name="startingCash">The account currency starting cash to set</param>
         public void SetAccountCurrency(string accountCurrency, decimal? startingCash = null)
@@ -645,24 +652,40 @@ namespace QuantConnect.Securities
                     Messages.SecurityPortfolioManager.CannotChangeAccountCurrencyAfterAddingSecurity);
             }
 
-            if (_setCashWasCalled)
-            {
-                throw new InvalidOperationException("SecurityPortfolioManager.SetAccountCurrency(): " +
-                    Messages.SecurityPortfolioManager.CannotChangeAccountCurrencyAfterSettingCash);
-            }
-
-            Log.Trace("SecurityPortfolioManager.SetAccountCurrency(): " +
-                Messages.SecurityPortfolioManager.SettingAccountCurrency(accountCurrency));
+            // Capture the previous base cash and amount if SetCash() was called earlier so we can
+            // either report the leftover balance in the old currency or detect a same-currency override.
+            var previousCash = _setCashWasCalled ? _baseCurrencyCash : null;
+            var previousAmount = previousCash?.Amount;
+            var message = Messages.SecurityPortfolioManager.SettingAccountCurrency(accountCurrency);
 
             UnsettledCashBook.AccountCurrency = accountCurrency;
             CashBook.AccountCurrency = accountCurrency;
 
+            // Repoint the base cash to the new account currency entry.
             _baseCurrencyCash = CashBook[accountCurrency];
+
+            if (previousCash != null && previousCash.Symbol != accountCurrency)
+            {
+                // The CashBook.AccountCurrency setter migrates the previous amount onto the new
+                // currency entry and removes the old one. Undo that migration so the previous
+                // balance is kept in its own currency, and the new account currency starts at zero
+                // (a subsequent SetCash below will apply startingCash if provided).
+                _baseCurrencyCash.SetAmount(0);
+                CashBook.Add(previousCash.Symbol, previousAmount.Value, previousCash.ConversionRate);
+                message += ". " + Messages.SecurityPortfolioManager.AccountCurrencyChangedAfterSettingCash(previousCash);
+            }
 
             if (startingCash != null)
             {
-                SetCash((decimal)startingCash);
+                SetCash(startingCash.Value);
+                // When the account currency is unchanged, report the override of the prior amount.
+                if (previousCash?.Symbol == accountCurrency && previousAmount != startingCash)
+                {
+                    message = Messages.SecurityPortfolioManager.AccountCurrencyCashUpdated(accountCurrency, previousAmount.Value, startingCash.Value);
+                }
             }
+
+            Log.Trace("SecurityPortfolioManager.SetAccountCurrency(): " + message);
         }
 
         /// <summary>

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -663,10 +663,8 @@ namespace QuantConnect.Securities
 
             if (previousCash != null && previousCash.Symbol != accountCurrency)
             {
-                // The CashBook.AccountCurrency setter migrates the previous amount onto the new
-                // currency entry and removes the old one. Undo that migration so the previous
-                // balance is kept in its own currency, and the new account currency starts at zero
-                // (a subsequent SetCash below will apply startingCash if provided).
+                // Keep the previous balance in its own currency entry; the new account currency
+                // starts at zero (a subsequent SetCash below will apply startingCash if provided).
                 _baseCurrencyCash.SetAmount(0);
                 CashBook.Add(previousCash.Symbol, previousAmount.Value, previousCash.ConversionRate);
                 message += ". " + Messages.SecurityPortfolioManager.AccountCurrencyChangedAfterSettingCash(previousCash);

--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -619,13 +619,10 @@ namespace QuantConnect.Securities
         /// as the starting cash in this currency if given.
         /// </summary>
         /// <remarks>
-        /// Should be called before adding any <see cref="Security"/>.
-        /// If <see cref="SetCash(decimal)"/> was called beforehand, the previous cash entry
-        /// is preserved in the <see cref="CashBook"/>: the algorithm continues to hold that
-        /// amount in the previous currency, while <see cref="_baseCurrencyCash"/> is
-        /// repointed to the new account currency. When the new account currency matches the
-        /// existing one, the optional <paramref name="startingCash"/> simply overrides the
-        /// previously set amount.
+        /// Should be called before adding any <see cref="Security"/>. If <see cref="SetCash(decimal)"/>
+        /// was called beforehand with a different currency, the previous cash entry is kept in the
+        /// <see cref="CashBook"/> and the base currency <see cref="Cash"/> is repointed to the new currency.
+        /// If the currency matches, <paramref name="startingCash"/> overrides the previous amount.
         /// </remarks>
         /// <param name="accountCurrency">The account currency cash symbol to set</param>
         /// <param name="startingCash">The account currency starting cash to set</param>

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -2576,31 +2576,38 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.Throws<InvalidOperationException>(() => algorithm.Portfolio.SetAccountCurrency(Currencies.USD));
         }
 
-        [TestCase("SetCash(decimal cash)")]
-        [TestCase("SetCash(string symbol, ...)")]
-        public void ChangeAccountCurrencyAfterSettingCashKeepsPreviousCash(string overload)
+        [Test]
+        public void ChangeAccountCurrencyAfterImplicitSetCashRelabelsAmountToNewCurrency()
         {
             var algorithm = new QCAlgorithm();
-            if (overload == "SetCash(decimal cash)")
-            {
-                algorithm.Portfolio.SetCash(10);
-            }
-            else
-            {
-                algorithm.Portfolio.SetCash(Currencies.USD, 10, 1);
-            }
+            // SetCash(decimal) means "this many units of the (eventual) account currency",
+            // so switching the account currency re-labels the amount instead of preserving USD.
+            algorithm.Portfolio.SetCash(1);
 
-            // Switch the account currency to EUR; previous USD balance must be preserved
-            // in the CashBook and the base currency cash must be repointed to EUR.
-            Assert.DoesNotThrow(() => algorithm.Portfolio.SetAccountCurrency(Currencies.EUR));
+            Assert.DoesNotThrow(() => algorithm.Portfolio.SetAccountCurrency("BTC"));
 
-            Assert.AreEqual(Currencies.EUR, algorithm.Portfolio.CashBook.AccountCurrency);
-            Assert.AreEqual(10m, algorithm.Portfolio.CashBook[Currencies.USD].Amount);
-            Assert.AreEqual(0m, algorithm.Portfolio.CashBook[Currencies.EUR].Amount);
+            Assert.AreEqual("BTC", algorithm.Portfolio.CashBook.AccountCurrency);
+            Assert.AreEqual(1m, algorithm.Portfolio.CashBook["BTC"].Amount);
+            Assert.IsFalse(algorithm.Portfolio.CashBook.ContainsKey(Currencies.USD));
         }
 
         [Test]
-        public void ChangeAccountCurrencyAfterSettingCashAppliesStartingCashToNewCurrency()
+        public void ChangeAccountCurrencyAfterExplicitSetCashKeepsPreviousCash()
+        {
+            var algorithm = new QCAlgorithm();
+            // SetCash(symbol, ...) commits cash to a specific currency, so switching the account
+            // currency must keep that balance in its own entry and start the new one at zero.
+            algorithm.Portfolio.SetCash(Currencies.USD, 100000, 1);
+
+            Assert.DoesNotThrow(() => algorithm.Portfolio.SetAccountCurrency("BTC"));
+
+            Assert.AreEqual("BTC", algorithm.Portfolio.CashBook.AccountCurrency);
+            Assert.AreEqual(100000m, algorithm.Portfolio.CashBook[Currencies.USD].Amount);
+            Assert.AreEqual(0m, algorithm.Portfolio.CashBook["BTC"].Amount);
+        }
+
+        [Test]
+        public void ChangeAccountCurrencyAfterImplicitSetCashAppliesStartingCashToNewCurrency()
         {
             var algorithm = new QCAlgorithm();
             algorithm.Portfolio.SetCash(100000);
@@ -2608,9 +2615,20 @@ namespace QuantConnect.Tests.Common.Securities
             algorithm.Portfolio.SetAccountCurrency(Currencies.EUR, 50000);
 
             Assert.AreEqual(Currencies.EUR, algorithm.Portfolio.CashBook.AccountCurrency);
-            // Previous USD cash is retained as a residual balance in the cash book.
+            Assert.AreEqual(50000m, algorithm.Portfolio.CashBook[Currencies.EUR].Amount);
+            Assert.IsFalse(algorithm.Portfolio.CashBook.ContainsKey(Currencies.USD));
+        }
+
+        [Test]
+        public void ChangeAccountCurrencyAfterExplicitSetCashAppliesStartingCashToNewCurrency()
+        {
+            var algorithm = new QCAlgorithm();
+            algorithm.Portfolio.SetCash(Currencies.USD, 100000, 1);
+
+            algorithm.Portfolio.SetAccountCurrency(Currencies.EUR, 50000);
+
+            Assert.AreEqual(Currencies.EUR, algorithm.Portfolio.CashBook.AccountCurrency);
             Assert.AreEqual(100000m, algorithm.Portfolio.CashBook[Currencies.USD].Amount);
-            // Starting cash applies to the new account currency.
             Assert.AreEqual(50000m, algorithm.Portfolio.CashBook[Currencies.EUR].Amount);
         }
 

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -2578,7 +2578,7 @@ namespace QuantConnect.Tests.Common.Securities
 
         [TestCase("SetCash(decimal cash)")]
         [TestCase("SetCash(string symbol, ...)")]
-        public void CanNotChangeAccountCurrencyAfterSettingCash(string overload)
+        public void ChangeAccountCurrencyAfterSettingCashKeepsPreviousCash(string overload)
         {
             var algorithm = new QCAlgorithm();
             if (overload == "SetCash(decimal cash)")
@@ -2587,9 +2587,57 @@ namespace QuantConnect.Tests.Common.Securities
             }
             else
             {
-                algorithm.Portfolio.SetCash(Currencies.USD, 1, 1);
+                algorithm.Portfolio.SetCash(Currencies.USD, 10, 1);
             }
-            Assert.Throws<InvalidOperationException>(() => algorithm.Portfolio.SetAccountCurrency(Currencies.USD));
+
+            // Switch the account currency to EUR; previous USD balance must be preserved
+            // in the CashBook and the base currency cash must be repointed to EUR.
+            Assert.DoesNotThrow(() => algorithm.Portfolio.SetAccountCurrency(Currencies.EUR));
+
+            Assert.AreEqual(Currencies.EUR, algorithm.Portfolio.CashBook.AccountCurrency);
+            Assert.AreEqual(10m, algorithm.Portfolio.CashBook[Currencies.USD].Amount);
+            Assert.AreEqual(0m, algorithm.Portfolio.CashBook[Currencies.EUR].Amount);
+        }
+
+        [Test]
+        public void ChangeAccountCurrencyAfterSettingCashAppliesStartingCashToNewCurrency()
+        {
+            var algorithm = new QCAlgorithm();
+            algorithm.Portfolio.SetCash(100000);
+
+            algorithm.Portfolio.SetAccountCurrency(Currencies.EUR, 50000);
+
+            Assert.AreEqual(Currencies.EUR, algorithm.Portfolio.CashBook.AccountCurrency);
+            // Previous USD cash is retained as a residual balance in the cash book.
+            Assert.AreEqual(100000m, algorithm.Portfolio.CashBook[Currencies.USD].Amount);
+            // Starting cash applies to the new account currency.
+            Assert.AreEqual(50000m, algorithm.Portfolio.CashBook[Currencies.EUR].Amount);
+        }
+
+        [Test]
+        public void SetAccountCurrencyWithSameCurrencyOverridesStartingCash()
+        {
+            var algorithm = new QCAlgorithm();
+            algorithm.Portfolio.SetCash(100000);
+
+            // Calling SetAccountCurrency with the same currency must overwrite the previously
+            // set cash amount instead of keeping the older value.
+            algorithm.Portfolio.SetAccountCurrency(Currencies.USD, 200000);
+
+            Assert.AreEqual(Currencies.USD, algorithm.Portfolio.CashBook.AccountCurrency);
+            Assert.AreEqual(200000m, algorithm.Portfolio.CashBook[Currencies.USD].Amount);
+        }
+
+        [Test]
+        public void SetAccountCurrencyWithSameCurrencyAndNoStartingCashKeepsExistingAmount()
+        {
+            var algorithm = new QCAlgorithm();
+            algorithm.Portfolio.SetCash(100000);
+
+            algorithm.Portfolio.SetAccountCurrency(Currencies.USD);
+
+            Assert.AreEqual(Currencies.USD, algorithm.Portfolio.CashBook.AccountCurrency);
+            Assert.AreEqual(100000m, algorithm.Portfolio.CashBook[Currencies.USD].Amount);
         }
 
         [Test]


### PR DESCRIPTION
#### Description
Changes `SecurityPortfolioManager.SetAccountCurrency` so it no longer throws when called after `SetCash`. The base account currency is switched in place:

- **Different currency**: the previous `Cash` entry stays in the `CashBook` with its existing balance, the new account currency starts at zero (or `startingCash` if provided), and a trace is logged noting the residual balance held in the previous currency. This undoes the automatic amount migration performed by `CashBook.AccountCurrency`'s setter so balances stay in their original currency.
- **Same currency**: an optional `startingCash` overrides the previously set amount and a trace is logged stating the new amount and the prior amount. When `startingCash` is omitted or equals the existing amount, nothing is logged.
- **No prior `SetCash`**: behaves as before — only the existing "setting account currency to X" trace is emitted.

#### Related Issue
N/A

#### Motivation and Context
The previous behavior forced users to order `SetAccountCurrency` strictly before `SetCash`, throwing `InvalidOperationException` otherwise. Switching to a graceful in-place change with a clear log message is more forgiving and lets users override the starting amount when re-asserting the same account currency.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Replaced the obsolete `CanNotChangeAccountCurrencyAfterSettingCash` test (which expected the exception) with four new tests in `SecurityPortfolioManagerTests`:
- `ChangeAccountCurrencyAfterSettingCashKeepsPreviousCash` (covers both `SetCash` overloads) — verifies the previous balance is retained in the `CashBook` after a currency change.
- `ChangeAccountCurrencyAfterSettingCashAppliesStartingCashToNewCurrency` — verifies `startingCash` applies to the new currency while the previous balance is preserved.
- `SetAccountCurrencyWithSameCurrencyOverridesStartingCash` — verifies a same-currency call with `startingCash` overwrites the prior amount.
- `SetAccountCurrencyWithSameCurrencyAndNoStartingCashKeepsExistingAmount` — verifies a no-op same-currency call leaves the existing amount untouched.

All 8 SetAccountCurrency-related tests pass locally.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`