### PR TITLE
Respect caller-provided User-Agent in Api.DownloadBytes

### DIFF
--- a/Api/Api.cs
+++ b/Api/Api.cs
@@ -1043,15 +1043,19 @@ namespace QuantConnect.Api
             {
                 client.Value.DefaultRequestHeaders.Clear();
 
-                // Add a user agent header in case the requested URI contains a query.
-                client.Value.DefaultRequestHeaders.TryAddWithoutValidation("user-agent", "QCAlgorithm.Download(): User Agent Header");
-
                 if (headers != null)
                 {
                     foreach (var header in headers)
                     {
                         client.Value.DefaultRequestHeaders.TryAddWithoutValidation(header.Key, header.Value);
                     }
+                }
+
+                // Add a user agent header in case the requested URI contains a query, unless the caller already provided one.
+                // DefaultRequestHeaders.Contains matches header names case-insensitively per the HTTP spec.
+                if (!client.Value.DefaultRequestHeaders.Contains("User-Agent"))
+                {
+                    client.Value.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "QCAlgorithm.Download(): User Agent Header");
                 }
 
                 if (!userName.IsNullOrEmpty() || !password.IsNullOrEmpty())


### PR DESCRIPTION
#### Description
`Api.DownloadBytes` always set a default `User-Agent` header (`"QCAlgorithm.Download(): User Agent Header"`) before applying caller-supplied headers. Because `HttpRequestHeaders` deduplicates case-insensitively but `TryAddWithoutValidation` does not replace an existing header, a caller that passed their own `User-Agent` (in any casing) ended up sending the default value instead of the one they specified.

The default is now applied only when the caller has not already supplied a `User-Agent`. The check uses `DefaultRequestHeaders.Contains("User-Agent")`, which matches header names case-insensitively per the HTTP spec, so `user-agent`, `User-Agent`, and `USER-AGENT` are all detected.

#### Related Issue
N/A — small fix surfaced while reviewing `Api.DownloadBytes`.

#### Motivation and Context
Algorithms calling `QCAlgorithm.Download(...)` with a custom `User-Agent` (e.g., to comply with a third-party API's UA policy) were silently overridden by the framework default, causing requests to be rejected or rate-limited by the remote endpoint.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Inspected `HttpRequestHeaders.Contains` semantics (case-insensitive header-name match).
- Verified manually that:
  - When `headers` is `null` or has no UA, the default UA is added.
  - When `headers` contains a `User-Agent` (any casing), the default is skipped and the caller's value is sent.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!-- Behavior is exercised through existing `Api.DownloadBytes` paths; the change is a small conditional around an HTTP-client header. -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`