### PR TITLE
refactor: make unsubscribe virtual

### DIFF
--- a/Common/Data/DataQueueHandlerSubscriptionManager.cs
+++ b/Common/Data/DataQueueHandlerSubscriptionManager.cs
@@ -64,7 +64,7 @@ namespace QuantConnect.Data
         /// Decrement number of subscribers for current <see cref="TickType"/>
         /// </summary>
         /// <param name="dataConfig">defines the subscription configuration data.</param> 
-        public void Unsubscribe(SubscriptionDataConfig dataConfig)
+        public virtual void Unsubscribe(SubscriptionDataConfig dataConfig)
         {
             try
             {


### PR DESCRIPTION
#### Description
Make `DataQueueHandlerSubscriptionManager.Unsubscribe(SubscriptionDataConfig)` `virtual` so subclasses can override the unsubscribe flow when the default per-config decrement doesn't fit the brokerage's channel/subscription model.

#### Related PR(s)
N/A

#### Related Issue
N/A

#### Motivation and Context
The base implementation handles the common path, but some brokerage subscription managers need to customize how an `Unsubscribe` is dispatched (e.g., to coordinate with channel-level fan-out or to suppress the underlying broker call when other configs still rely on the same channel). The sibling `Subscribe` method is already virtual; making `Unsubscribe` virtual restores symmetry and unblocks the override.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Existing `DataQueueHandlerSubscriptionManager` tests pass — the change is purely a visibility relaxation and does not alter the base behavior.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!-- N/A — visibility-only change; existing tests remain valid -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
