### PR TITLE
Fix CBOE index market hours lookup

### DIFF
--- a/Common/Securities/MarketHoursDatabase.cs
+++ b/Common/Securities/MarketHoursDatabase.cs
@@ -256,6 +256,10 @@ namespace QuantConnect.Securities
             return Entries.TryGetValue(symbolKey, out entry)
                 // now check with null symbol key
                 || Entries.TryGetValue(symbolKey.CreateCommonKey(), out entry)
+                // CBOE index market hours use the USA index entries in the data folder.
+                || securityType == SecurityType.Index
+                    && market == Market.CBOE
+                    && TryGetEntry(Market.USA, symbol, securityType, out entry)
                 // if FOP check for future
                 || securityType == SecurityType.FutureOption && TryGetEntry(market,
                     FuturesOptionsSymbolMappings.MapFromOption(symbol), SecurityType.Future, out entry)

--- a/Tests/Common/Securities/MarketHoursDatabaseTests.cs
+++ b/Tests/Common/Securities/MarketHoursDatabaseTests.cs
@@ -460,6 +460,20 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(returnedEntry, entry);
         }
 
+        [TestCase("VIX3M")]
+        [TestCase("TEST")]
+        public void RetrievesCboeIndexExchangeHours(string ticker)
+        {
+            var database = MarketHoursDatabase.FromDataFolder();
+            var symbol = Symbol.Create(ticker, SecurityType.Index, Market.CBOE);
+            var usaSymbol = Symbol.Create(ticker, SecurityType.Index, Market.USA);
+            var expected = database.GetExchangeHours(Market.USA, usaSymbol, SecurityType.Index);
+
+            var result = database.GetExchangeHours(Market.CBOE, symbol, SecurityType.Index);
+
+            Assert.AreSame(expected, result);
+        }
+
         [Test]
         public void VerifyMarketHoursDataIntegrityForAllSymbols()
         {


### PR DESCRIPTION
#### Description
This fixes CBOE index market-hours lookup by falling back to the existing USA index market-hours entries when an index symbol is requested with `Market.CBOE`.

LEAN already maps CBOE index tickers such as `VIX3M` to `Market.CBOE`, but the market-hours database stores the index hours under the USA index entries. As a result, adding CBOE indexes for live trading could fail to find exchange hours even though the appropriate hours data exists.

#### Changes
- Add a CBOE index fallback in `MarketHoursDatabase.TryGetEntryImpl` to resolve `Market.CBOE` index requests through `Market.USA` index entries.
- Add regression coverage for `VIX3M` and a generic CBOE index ticker to verify both specific and wildcard USA index entries are reused.

#### Validation
- `dotnet build Tests/QuantConnect.Tests.csproj -v:q` passes.
- Filtered test execution was attempted, but the local test host aborted due to missing local data directory `Data/equity/sgx/map_files`, followed by a Python GIL finalizer exception before the selected test could report.

Closes #5752