### PR TITLE
fix: update binance-fwebsocket-url to /private/ws

### DIFF
--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -149,7 +149,7 @@
   "binance-orders-websocket-url": "wss://ws-api.binance.com:9443/ws-api/v3",
   // USDT futures
   "binance-fapi-url": "https://fapi.binance.com",
-  "binance-fwebsocket-url": "wss://fstream.binance.com/ws",
+  "binance-fwebsocket-url": "wss://fstream.binance.com/private/ws",
   // Coin futures
   "binance-dapi-url": "https://dapi.binance.com",
   "binance-dwebsocket-url": "wss://dstream.binance.com/ws",


### PR DESCRIPTION
#### Description
Update USDT futures user-data websocket URL from `wss://fstream.binance.com/ws` to `wss://fstream.binance.com/private/ws`.

#### Related Issue
N/A

#### Motivation and Context
Binance split the futures websocket endpoints into per-stream-type paths (`/public/ws`, `/market/ws`, `/private/ws`). The legacy `/ws` path is no longer the canonical entry point for user-data (private) streams on `fstream.binance.com`, so the config must point at `/private/ws` to keep the user-data subscription stable.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Connected to `wss://fstream.binance.com/private/ws` from the launcher with valid USDT futures credentials and confirmed the user-data stream subscribes and receives account/order events as before.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- config-only change; no behavioral code path added -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`