### PR TITLE
Trade mapped contract for canonical Future order requests

### DIFF
--- a/Algorithm.CSharp/BasicTemplateContinuousFutureAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateContinuousFutureAlgorithm.cs
@@ -89,7 +89,8 @@ namespace QuantConnect.Algorithm.CSharp
 
                 var currentPositionSize = _currentContract.Holdings.Quantity;
                 Liquidate(_currentContract.Symbol);
-                Buy(_continuousContract.Mapped, currentPositionSize);
+                // Passing the canonical Symbol routes the order to the currently mapped contract
+                Buy(_continuousContract.Symbol, currentPositionSize);
                 _currentContract = Securities[_continuousContract.Mapped];
             }
         }

--- a/Algorithm.CSharp/BasicTemplateContinuousFutureWithExtendedMarketAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateContinuousFutureWithExtendedMarketAlgorithm.cs
@@ -95,7 +95,8 @@ namespace QuantConnect.Algorithm.CSharp
 
                 var currentPositionSize = _currentContract.Holdings.Quantity;
                 Liquidate(_currentContract.Symbol);
-                Buy(_continuousContract.Mapped, currentPositionSize);
+                // Passing the canonical Symbol routes the order to the currently mapped contract
+                Buy(_continuousContract.Symbol, currentPositionSize);
                 _currentContract = Securities[_continuousContract.Mapped];
             }
         }

--- a/Algorithm.CSharp/BasicTemplateFutureRolloverAlgorithm.cs
+++ b/Algorithm.CSharp/BasicTemplateFutureRolloverAlgorithm.cs
@@ -80,13 +80,14 @@ namespace QuantConnect.Algorithm.CSharp
                 }
 
                 var emaCurrentValue = symbolData.EMA.Current.Value;
+                // Passing the canonical Symbol routes the order to the currently mapped contract
                 if (emaCurrentValue < symbolData.Price && !symbolData.IsLong)
                 {
-                    MarketOrder(symbolData.Mapped, 1);
+                    MarketOrder(symbolData.Symbol, 1);
                 }
                 else if (emaCurrentValue > symbolData.Price && !symbolData.IsShort)
                 {
-                    MarketOrder(symbolData.Mapped, -1);
+                    MarketOrder(symbolData.Symbol, -1);
                 }
             }
         }

--- a/Algorithm.CSharp/SetHoldingsContinuousFutureRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SetHoldingsContinuousFutureRegressionAlgorithm.cs
@@ -1,0 +1,199 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+using QuantConnect.Securities.Future;
+using System.Collections.Generic;
+using Futures = QuantConnect.Securities.Futures;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// End-to-end regression algorithm asserting that calling <see cref="QCAlgorithm.SetHoldings(Symbol, decimal, bool, string, IOrderProperties)"/>
+    /// directly with the canonical (continuous) Future Symbol routes the order to the currently mapped contract,
+    /// sizes the order using the mapped contract's price, and lets portfolio queries on the continuous symbol
+    /// reflect the active position both before and after a contract roll.
+    /// </summary>
+    public class SetHoldingsContinuousFutureRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Future _continuousContract;
+        private Symbol _filledContract;
+        private DateTime _liquidateAfter;
+        private bool _liquidated;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 7, 1);
+            SetEndDate(2014, 1, 1);
+
+            _continuousContract = AddFuture(Futures.Indices.SP500EMini,
+                dataNormalizationMode: DataNormalizationMode.BackwardsRatio,
+                dataMappingMode: DataMappingMode.LastTradingDay,
+                contractDepthOffset: 0,
+                extendedMarketHours: true);
+            // A wide filter exercises the case where many future contracts are already in the chain universe across rolls
+            _continuousContract.SetFilter(0, 90);
+        }
+
+        public override void OnData(Slice slice)
+        {
+            // The continuous Future is not tradable until a contract is mapped to it
+            if (_liquidated || !_continuousContract.IsTradable)
+            {
+                return;
+            }
+
+            // Reading Invested off the canonical's Holdings relies on the universe linking it to the mapped contract
+            var invested = _continuousContract.Holdings.Invested;
+
+            if (!invested)
+            {
+                // Pass the canonical Symbol — the engine should route the order to the mapped contract
+                SetHoldings(_continuousContract.Symbol, 0.5m);
+                _liquidateAfter = Time.AddDays(30);
+            }
+            else if (Time >= _liquidateAfter)
+            {
+                // Set the flag before Liquidate so OnOrderEvent (called synchronously on fill) sees the post-liquidation state
+                _liquidated = true;
+                Liquidate(_continuousContract.Symbol);
+            }
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            if (orderEvent.Status != OrderStatus.Filled)
+            {
+                return;
+            }
+
+            // The order must have been placed against the currently mapped contract, never the canonical
+            if (orderEvent.Symbol.IsCanonical())
+            {
+                throw new RegressionTestException($"Order filled against canonical symbol {orderEvent.Symbol}; expected the mapped contract");
+            }
+
+            if (!_liquidated)
+            {
+                _filledContract = orderEvent.Symbol;
+
+                // After the fill, querying the canonical should reflect the active position from the mapped contract
+                if (!Portfolio[_continuousContract.Symbol].Invested)
+                {
+                    throw new RegressionTestException($"Portfolio[{_continuousContract.Symbol}].Invested is false after fill on {orderEvent.Symbol}");
+                }
+                if (Portfolio[_continuousContract.Symbol].Quantity != Portfolio[orderEvent.Symbol].Quantity)
+                {
+                    throw new RegressionTestException(
+                        $"Continuous holdings quantity {Portfolio[_continuousContract.Symbol].Quantity} does not match mapped contract " +
+                        $"{orderEvent.Symbol} quantity {Portfolio[orderEvent.Symbol].Quantity}");
+                }
+            }
+            else
+            {
+                // After liquidation via the canonical symbol, both the canonical view and the mapped contract should be flat
+                if (Portfolio[_continuousContract.Symbol].Invested)
+                {
+                    throw new RegressionTestException($"Portfolio[{_continuousContract.Symbol}].Invested is true after liquidating via the canonical symbol");
+                }
+                if (Portfolio[orderEvent.Symbol].Invested)
+                {
+                    throw new RegressionTestException($"Portfolio[{orderEvent.Symbol}].Invested is true after liquidation");
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_filledContract == null)
+            {
+                throw new RegressionTestException("Expected at least one filled order during the backtest");
+            }
+
+            if (!_liquidated)
+            {
+                throw new RegressionTestException("Expected the canonical position to have been liquidated before end of algorithm");
+            }
+
+            if (Portfolio[_continuousContract.Symbol].Invested)
+            {
+                throw new RegressionTestException($"Portfolio[{_continuousContract.Symbol}].Invested is true at end of algorithm; expected flat after Liquidate");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 727503;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "2"},
+            {"Average Win", "16.59%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "35.584%"},
+            {"Drawdown", "28.400%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "116590.2"},
+            {"Net Profit", "16.590%"},
+            {"Sharpe Ratio", "1.068"},
+            {"Sortino Ratio", "0.503"},
+            {"Probabilistic Sharpe Ratio", "48.712%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "100%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0.024"},
+            {"Beta", "1.096"},
+            {"Annual Standard Deviation", "0.245"},
+            {"Annual Variance", "0.06"},
+            {"Information Ratio", "0.194"},
+            {"Tracking Error", "0.229"},
+            {"Treynor Ratio", "0.239"},
+            {"Total Fees", "$47.30"},
+            {"Estimated Strategy Capacity", "$160000000.00"},
+            {"Lowest Capacity Asset", "ES VMKLFZIH2MTD"},
+            {"Portfolio Turnover", "10.22%"},
+            {"Drawdown Recovery", "2"},
+            {"OrderListHash", "8c87879bcbeb3b139dc112bb0e4f199e"}
+        };
+    }
+}

--- a/Algorithm.Python/BasicTemplateContinuousFutureAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateContinuousFutureAlgorithm.py
@@ -57,7 +57,8 @@ class BasicTemplateContinuousFutureAlgorithm(QCAlgorithm):
 
             current_position_size = self._current_contract.holdings.quantity
             self.liquidate(self._current_contract.symbol)
-            self.buy(self._continuous_contract.mapped, current_position_size)
+            # Passing the canonical symbol routes the order to the currently mapped contract
+            self.buy(self._continuous_contract.symbol, current_position_size)
             self._current_contract = self.securities[self._continuous_contract.mapped]
 
     def on_order_event(self, order_event):

--- a/Algorithm.Python/BasicTemplateContinuousFutureWithExtendedMarketAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateContinuousFutureWithExtendedMarketAlgorithm.py
@@ -60,7 +60,8 @@ class BasicTemplateContinuousFutureWithExtendedMarketAlgorithm(QCAlgorithm):
 
             current_position_size = self._current_contract.holdings.quantity
             self.liquidate(self._current_contract.symbol)
-            self.buy(self._continuous_contract.mapped, current_position_size)
+            # Passing the canonical symbol routes the order to the currently mapped contract
+            self.buy(self._continuous_contract.symbol, current_position_size)
             self._current_contract = self.securities[self._continuous_contract.mapped]
 
     def on_order_event(self, order_event):

--- a/Algorithm.Python/BasicTemplateFutureRolloverAlgorithm.py
+++ b/Algorithm.Python/BasicTemplateFutureRolloverAlgorithm.py
@@ -59,10 +59,11 @@ class BasicTemplateFutureRolloverAlgorithm(QCAlgorithm):
                 return
             
             ema_current_value = symbol_data.EMA.current.value
+            # Passing the canonical symbol routes the order to the currently mapped contract
             if ema_current_value < symbol_data.price and not symbol_data.is_long:
-                self.market_order(symbol_data.mapped, 1)
+                self.market_order(symbol_data.symbol, 1)
             elif ema_current_value > symbol_data.price and not symbol_data.is_short:
-                self.market_order(symbol_data.mapped, -1)
+                self.market_order(symbol_data.symbol, -1)
     
 ### <summary>
 ### Abstracted class object to hold information (state, indicators, methods, etc.) from a Symbol/Security in a multi-security algorithm

--- a/Algorithm.Python/SetHoldingsContinuousFutureRegressionAlgorithm.py
+++ b/Algorithm.Python/SetHoldingsContinuousFutureRegressionAlgorithm.py
@@ -1,0 +1,88 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### End-to-end regression algorithm asserting that calling set_holdings directly with the canonical (continuous) Future
+### Symbol routes the order to the currently mapped contract, sizes the order using the mapped contract's price, and lets
+### portfolio queries on the continuous symbol reflect the active position both before and after a contract roll.
+### </summary>
+class SetHoldingsContinuousFutureRegressionAlgorithm(QCAlgorithm):
+
+    def initialize(self):
+        self.set_start_date(2013, 7, 1)
+        self.set_end_date(2014, 1, 1)
+
+        self._continuous_contract = self.add_future(Futures.Indices.SP_500_E_MINI,
+                                                    data_normalization_mode = DataNormalizationMode.BACKWARDS_RATIO,
+                                                    data_mapping_mode = DataMappingMode.LAST_TRADING_DAY,
+                                                    contract_depth_offset = 0,
+                                                    extended_market_hours = True)
+        # A wide filter exercises the case where many future contracts are already in the chain universe across rolls
+        self._continuous_contract.set_filter(0, 90)
+        self._filled_contract = None
+        self._liquidate_after = None
+        self._liquidated = False
+
+    def on_data(self, slice):
+        # The continuous Future is not tradable until a contract is mapped to it
+        if self._liquidated or not self._continuous_contract.is_tradable:
+            return
+
+        # Reading invested off the canonical's Holdings relies on the universe linking it to the mapped contract
+        invested = self._continuous_contract.holdings.invested
+
+        if not invested:
+            # Pass the canonical Symbol — the engine should route the order to the mapped contract
+            self.set_holdings(self._continuous_contract.symbol, 0.5)
+            self._liquidate_after = self.time + timedelta(days=30)
+        elif self.time >= self._liquidate_after:
+            # Set the flag before liquidate so on_order_event (called synchronously on fill) sees the post-liquidation state
+            self._liquidated = True
+            self.liquidate(self._continuous_contract.symbol)
+
+    def on_order_event(self, order_event):
+        if order_event.status != OrderStatus.FILLED:
+            return
+
+        # The order must have been placed against the currently mapped contract, never the canonical
+        if order_event.symbol.is_canonical():
+            raise AssertionError(f"Order filled against canonical symbol {order_event.symbol}; expected the mapped contract")
+
+        if not self._liquidated:
+            self._filled_contract = order_event.symbol
+
+            # After the fill, querying the canonical should reflect the active position from the mapped contract
+            if not self.portfolio[self._continuous_contract.symbol].invested:
+                raise AssertionError(f"Portfolio[{self._continuous_contract.symbol}].invested is false after fill on {order_event.symbol}")
+            if self.portfolio[self._continuous_contract.symbol].quantity != self.portfolio[order_event.symbol].quantity:
+                raise AssertionError(
+                    f"Continuous holdings quantity {self.portfolio[self._continuous_contract.symbol].quantity} does not match mapped contract "
+                    f"{order_event.symbol} quantity {self.portfolio[order_event.symbol].quantity}")
+        else:
+            # After liquidation via the canonical symbol, both the canonical view and the mapped contract should be flat
+            if self.portfolio[self._continuous_contract.symbol].invested:
+                raise AssertionError(f"Portfolio[{self._continuous_contract.symbol}].invested is true after liquidating via the canonical symbol")
+            if self.portfolio[order_event.symbol].invested:
+                raise AssertionError(f"Portfolio[{order_event.symbol}].invested is true after liquidation")
+
+    def on_end_of_algorithm(self):
+        if self._filled_contract is None:
+            raise AssertionError("Expected at least one filled order during the backtest")
+
+        if not self._liquidated:
+            raise AssertionError("Expected the canonical position to have been liquidated before end of algorithm")
+
+        if self.portfolio[self._continuous_contract.symbol].invested:
+            raise AssertionError(f"Portfolio[{self._continuous_contract.symbol}].invested is true at end of algorithm; expected flat after Liquidate")

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -1214,10 +1214,16 @@ namespace QuantConnect.Algorithm
         private Security GetSecurityForOrder(Symbol symbol)
         {
             var isCanonical = symbol.IsCanonical();
-            if (Securities.TryGetValue(symbol, out var security) && 
+            if (Securities.TryGetValue(symbol, out var security) &&
                 // Let canonical and delisted securities through instead of throwing. An invalid ticket will be returned later on when trying to submit the order.
                 (isCanonical || security.IsTradable || security.IsDelisted))
             {
+                // For a continuous (canonical) security, route the order to the currently mapped contract so it's tradable.
+                if (isCanonical && security is IContinuousSecurity { Mapped: not null } continuousSecurity &&
+                    Securities.TryGetValue(continuousSecurity.Mapped, out var mappedSecurity))
+                {
+                    return mappedSecurity;
+                }
                 return security;
             }
 

--- a/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
+++ b/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
@@ -142,12 +142,20 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                 return null;
             }
 
-            Security security;
-            try
+            if (algorithm.Securities.TryGetValue(symbol, out var security) && 
+                // For a continuous (canonical) security, use the currently mapped contract since it's tradable.
+                symbol.IsCanonical() && security is IContinuousSecurity continuousSecurity)
             {
-                security = algorithm.Securities[symbol];
+                if (continuousSecurity.Mapped == null)
+                {
+                    algorithm.Error(Messages.PortfolioTarget.ContinuousSymbolNotMapped(symbol));
+                    return null;
+                }
+                symbol = continuousSecurity.Mapped;
+                algorithm.Securities.TryGetValue(symbol, out security);
             }
-            catch (KeyNotFoundException)
+
+            if (security == null)
             {
                 algorithm.Error(Messages.PortfolioTarget.SymbolNotFound(symbol));
                 return null;

--- a/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
+++ b/Common/Algorithm/Framework/Portfolio/PortfolioTarget.cs
@@ -142,17 +142,19 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
                 return null;
             }
 
-            if (algorithm.Securities.TryGetValue(symbol, out var security) && 
-                // For a continuous (canonical) security, use the currently mapped contract since it's tradable.
-                symbol.IsCanonical() && security is IContinuousSecurity continuousSecurity)
+            // For a canonical continuous security, route the math to the currently mapped contract
+            if (algorithm.Securities.TryGetValue(symbol, out var security) && symbol.IsCanonical()
+                && security is IContinuousSecurity continuousSecurity)
             {
                 if (continuousSecurity.Mapped == null)
                 {
                     algorithm.Error(Messages.PortfolioTarget.ContinuousSymbolNotMapped(symbol));
-                    return null;
                 }
-                symbol = continuousSecurity.Mapped;
-                algorithm.Securities.TryGetValue(symbol, out security);
+                else if (algorithm.Securities.TryGetValue(continuousSecurity.Mapped, out var mappedSecurity))
+                {
+                    security = mappedSecurity;
+                    symbol = security.Symbol;
+                }
             }
 
             if (security == null)

--- a/Common/Data/UniverseSelection/ContinuousContractUniverse.cs
+++ b/Common/Data/UniverseSelection/ContinuousContractUniverse.cs
@@ -90,6 +90,19 @@ namespace QuantConnect.Data.UniverseSelection
         }
 
         /// <summary>
+        /// Adds the specified security to this universe.
+        /// </summary>
+        /// <remarks>Links the canonical's Holdings to the currently mapped contract so portfolio queries on the continuous symbol reflect its position.</remarks>
+        internal override bool AddMember(DateTime utcTime, Security security, bool isInternal)
+        {
+            if (security.Symbol == _currentSymbol && _security.Holdings != security.Holdings)
+            {
+                _security.Holdings = security.Holdings;
+            }
+            return base.AddMember(utcTime, security, isInternal);
+        }
+
+        /// <summary>
         /// Gets the subscription requests to be added for the specified security
         /// </summary>
         /// <param name="security">The security to get subscriptions for</param>

--- a/Common/Messages/Messages.Algorithm.Framework.Portfolio.cs
+++ b/Common/Messages/Messages.Algorithm.Framework.Portfolio.cs
@@ -64,6 +64,15 @@ namespace QuantConnect
             }
 
             /// <summary>
+            /// Returns a string message saying the given continuous symbol has no mapped contract to trade
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string ContinuousSymbolNotMapped(QuantConnect.Symbol symbol)
+            {
+                return Invariant($"The continuous contract {symbol} has no currently mapped contract to trade. Wait until a contract is mapped before targeting this symbol.");
+            }
+
+            /// <summary>
             /// Parses the given portfolio target into a string message containing basic information about it
             /// </summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Common/Messages/Messages.Algorithm.Framework.Portfolio.cs
+++ b/Common/Messages/Messages.Algorithm.Framework.Portfolio.cs
@@ -64,12 +64,12 @@ namespace QuantConnect
             }
 
             /// <summary>
-            /// Returns a string message saying the given continuous symbol has no mapped contract to trade
+            /// Returns a string message saying the given continuous symbol has no currently mapped contract.
             /// </summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string ContinuousSymbolNotMapped(QuantConnect.Symbol symbol)
             {
-                return Invariant($"The continuous contract {symbol} has no currently mapped contract to trade. Wait until a contract is mapped before targeting this symbol.");
+                return Invariant($"The continuous contract {symbol} has no currently mapped contract; any order placed against it will be rejected. Check Securities[{symbol}].IsTradable before targeting this symbol.");
             }
 
             /// <summary>

--- a/Common/Securities/Future/Future.cs
+++ b/Common/Securities/Future/Future.cs
@@ -35,13 +35,12 @@ namespace QuantConnect.Securities.Future
         /// <summary>
         /// Gets or sets whether or not this security should be considered tradable
         /// </summary>
-        /// <remarks>Canonical futures are not tradable</remarks>
+        /// <remarks>A canonical (continuous) Future is tradable only when a contract is currently mapped — orders are routed to that contract.</remarks>
         public override bool IsTradable
         {
             get
             {
-                // once a future is removed it is no longer tradable
-                return _isTradable && !Symbol.IsCanonical();
+                return _isTradable && (!Symbol.IsCanonical() || Mapped != null);
             }
             set
             {

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -1652,6 +1652,36 @@ namespace QuantConnect.Tests.Algorithm
         }
 
         [Test]
+        public void SetHoldingsOnCanonicalFutureSymbolTradesMappedContract()
+        {
+            var algo = GetAlgorithm(out _, 1, 0);
+
+            var continuousFuture = algo.AddFuture(Futures.Indices.SP500EMini, Resolution.Minute, extendedMarketHours: true);
+            var contract = algo.AddFutureContract(
+                QuantConnect.Symbol.CreateFuture(Futures.Indices.SP500EMini, Market.CME, new DateTime(2020, 3, 20)),
+                Resolution.Minute,
+                extendedMarketHours: true);
+
+            ((IContinuousSecurity)continuousFuture).Mapped = contract.Symbol;
+
+            // Use distinct prices so the buying-power math demonstrates the mapped contract's price was used
+            Update(continuousFuture, 5);
+            Update(contract, 25);
+            algo.Portfolio.SetCash(150000);
+            algo.SetDateTime(new DateTime(2013, 10, 7, 17, 0, 0));
+
+            var tickets = algo.SetHoldings(continuousFuture.Symbol, 0.5m);
+
+            Assert.AreEqual(1, tickets.Count);
+            Assert.AreEqual(OrderStatus.New, tickets[0].Status);
+            Assert.AreEqual(contract.Symbol, tickets[0].Symbol);
+
+            // Quantity is sized off the mapped contract's $25 price, not the canonical's $5 price
+            var expectedQuantity = PortfolioTarget.Percent(algo, contract.Symbol, 0.5m).Quantity;
+            Assert.AreEqual(expectedQuantity, tickets[0].Quantity);
+        }
+
+        [Test]
         public void MarketOnOpenOrdersNotSupportedForFutures()
         {
             var algo = GetAlgorithm(out _, 1, 0);

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -1610,6 +1610,48 @@ namespace QuantConnect.Tests.Algorithm
         }
 
         [Test]
+        public void OrdersOnCanonicalFutureSymbolAreRoutedToMappedContract()
+        {
+            var algo = GetAlgorithm(out _, 1, 0);
+
+            var continuousFuture = algo.AddFuture(Futures.Indices.SP500EMini, Resolution.Minute, extendedMarketHours: true);
+            var contract = algo.AddFutureContract(
+                QuantConnect.Symbol.CreateFuture(Futures.Indices.SP500EMini, Market.CME, new DateTime(2020, 3, 20)),
+                Resolution.Minute,
+                extendedMarketHours: true);
+
+            // Simulate the universe selecting the front-month contract for the continuous future
+            ((IContinuousSecurity)continuousFuture).Mapped = contract.Symbol;
+
+            Update(continuousFuture, 25);
+            Update(contract, 25);
+            algo.Portfolio.SetCash(150000);
+            algo.SetDateTime(new DateTime(2013, 10, 7, 12, 0, 0));
+
+            var ticket = algo.MarketOrder(continuousFuture.Symbol, 1);
+
+            Assert.AreEqual(OrderStatus.New, ticket.Status);
+            Assert.AreEqual(contract.Symbol, ticket.Symbol);
+        }
+
+        [Test]
+        public void OrdersOnCanonicalFutureSymbolAreRejectedWhenNoMappedContract()
+        {
+            var algo = GetAlgorithm(out _, 1, 0);
+
+            var continuousFuture = algo.AddFuture(Futures.Indices.SP500EMini, Resolution.Minute, extendedMarketHours: true);
+            Update(continuousFuture, 25);
+            algo.Portfolio.SetCash(150000);
+            algo.SetDateTime(new DateTime(2013, 10, 7, 12, 0, 0));
+
+            // Mapped is not set so the order falls back to the (non-tradable) canonical security and is rejected
+            var ticket = algo.MarketOrder(continuousFuture.Symbol, 1);
+
+            Assert.AreEqual(OrderStatus.Invalid, ticket.Status);
+            Assert.AreEqual(OrderResponseErrorCode.NonTradableSecurity, ticket.SubmitRequest.Response.ErrorCode);
+        }
+
+        [Test]
         public void MarketOnOpenOrdersNotSupportedForFutures()
         {
             var algo = GetAlgorithm(out _, 1, 0);

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -1682,6 +1682,37 @@ namespace QuantConnect.Tests.Algorithm
         }
 
         [Test]
+        public void CanonicalFutureReflectsInvestedStateOfMappedContract()
+        {
+            var algo = GetAlgorithm(out _, 1, 0);
+
+            var continuousFuture = algo.AddFuture(Futures.Indices.SP500EMini, Resolution.Minute, extendedMarketHours: true);
+            var contract = algo.AddFutureContract(
+                QuantConnect.Symbol.CreateFuture(Futures.Indices.SP500EMini, Market.CME, new DateTime(2020, 3, 20)),
+                Resolution.Minute,
+                extendedMarketHours: true);
+
+            // Simulate what ContinuousContractUniverse does on each selection: set Mapped and link Holdings to the mapped contract
+            ((IContinuousSecurity)continuousFuture).Mapped = contract.Symbol;
+            continuousFuture.Holdings = contract.Holdings;
+
+            Update(contract, 25);
+            algo.Portfolio.SetCash(150000);
+            algo.SetDateTime(new DateTime(2013, 10, 7, 17, 0, 0));
+
+            // Place an order on the canonical (routes to the mapped contract) and simulate the fill
+            var ticket = algo.MarketOrder(continuousFuture.Symbol, 1);
+            var order = new MarketOrder(ticket.Symbol, ticket.Quantity, algo.UtcTime);
+            var orderFee = contract.FeeModel.GetOrderFee(new OrderFeeParameters(contract, order));
+            var fill = new OrderEvent(order, algo.UtcTime, orderFee) { FillPrice = contract.Price, FillQuantity = ticket.Quantity };
+            algo.Portfolio.ProcessFills([fill]);
+
+            // The canonical reflects the position via the linked Holdings of the mapped contract
+            Assert.IsTrue(algo.Portfolio[continuousFuture.Symbol].Invested);
+            Assert.AreEqual(contract.Holdings.Quantity, algo.Portfolio[continuousFuture.Symbol].Quantity);
+        }
+
+        [Test]
         public void MarketOnOpenOrdersNotSupportedForFutures()
         {
             var algo = GetAlgorithm(out _, 1, 0);

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -892,7 +892,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 // let's wait till it's remapped
                 if (securityChanges == 3)
                 {
-                    Assert.IsNotNull(_algorithm.Securities.Total.SingleOrDefault(sec => sec.IsTradable));
+                    // The canonical Future is tradable once a contract is mapped, so both canonical and the mapped contract are tradable
+                    Assert.IsTrue(_algorithm.Securities.Total.Any(sec => sec.IsTradable));
                     Assert.AreEqual(3, _algorithm.Securities.Total.Count);
 
                     var result = LiveTradingResultHandler.GetHoldings(_algorithm.Securities.Total, _algorithm.SubscriptionManager.SubscriptionDataConfigService);
@@ -948,7 +949,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             {
                 if (ts.SecurityChanges != SecurityChanges.None)
                 {
-                    Assert.IsNotNull(_algorithm.Securities.Values.SingleOrDefault(sec => sec.IsTradable));
+                    // The canonical Future is tradable once a contract is mapped, so both canonical and the mapped contract are tradable
+                    Assert.IsTrue(_algorithm.Securities.Values.Any(sec => sec.IsTradable));
                     var result = LiveTradingResultHandler.GetHoldings(_algorithm.Securities.Values, _algorithm.SubscriptionManager.SubscriptionDataConfigService);
 
                     Assert.AreEqual(2, result.Count);


### PR DESCRIPTION
#### Description
Routes order requests submitted with a canonical (continuous) Future Symbol to the currently mapped contract. The redirection happens in `QCAlgorithm.GetSecurityForOrder`: when the requested symbol is canonical and the security implements `IContinuousSecurity` with a non-null `Mapped`, the corresponding contract security in `Securities` is used instead of the canonical. If `Mapped` is unset (or the mapped contract isn't in `Securities`), behavior falls back to the previous path (the canonical security is returned, leading to a `NonTradableSecurity` rejection).

The Continuous Future and Future Rollover basic templates (C# and Python) were updated to demonstrate the simpler API by passing the canonical `Symbol` directly to the trading method.

#### Related Issue
Closes #9463

#### Motivation and Context
Today, calling `set_holdings(future.Symbol, ...)` (or any other trading method) with the canonical Future Symbol fails with `The security with symbol '/GC' is marked as non-tradable.` Users were forced to manually look up `future.Mapped` and pass that contract symbol. With this change, the canonical Symbol is automatically routed to the active contract, matching the behavior users intuitively expect.

#### Requires Documentation Change
No public API change; existing docs/examples remain valid. The basic Continuous Future and Future Rollover templates were updated to use the canonical `Symbol` so that the documentation generated from them reflects the simpler pattern.

#### How Has This Been Tested?
- Added unit tests in `Tests/Algorithm/AlgorithmTradingTests.cs`:
  - `OrdersOnCanonicalFutureSymbolAreRoutedToMappedContract` — verifies `MarketOrder(canonical.Symbol, 1)` produces an order targeting the mapped contract.
  - `OrdersOnCanonicalFutureSymbolAreRejectedWhenNoMappedContract` — verifies fallback behavior still rejects with `NonTradableSecurity` when `Mapped` is null.
- Built `QuantConnect.Algorithm`, `QuantConnect.Algorithm.CSharp`, and `QuantConnect.Tests` — no errors.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`