### PR TITLE
Default to all market hours when no symbol is provided to time rules

### DIFF
--- a/Common/Scheduling/BaseScheduleRules.cs
+++ b/Common/Scheduling/BaseScheduleRules.cs
@@ -17,6 +17,7 @@
 using NodaTime;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
+using System.Collections.Generic;
 
 namespace QuantConnect.Scheduling
 {
@@ -68,6 +69,34 @@ namespace QuantConnect.Scheduling
                 return MarketHoursDatabase.GetEntry(symbol.ID.Market, symbol, symbol.SecurityType).ExchangeHours;
             }
             return security.Exchange.Hours;
+        }
+
+        /// <summary>
+        /// Helper method to fetch the exchange hours of the securities currently in <see cref="Securities"/>
+        /// whose markets are not always open. If no such securities are present, falls back to US equities (SPY).
+        /// </summary>
+        protected IEnumerable<SecurityExchangeHours> GetMarketOpenCloseExchangeHours()
+        {
+            // Pre-seed with SPY's exchange hours: this guarantees a fallback when no eligible
+            // security is subscribed and implicitly covers every US equity, which shares the
+            // same exchange hours — so we can skip US equities below to save the lookup.
+            var hours = new HashSet<SecurityExchangeHours>
+            {
+                MarketHoursDatabase.GetEntry(Market.USA, "SPY", SecurityType.Equity).ExchangeHours
+            };
+            foreach (var (symbol, security) in Securities)
+            {
+                if (security.Type == SecurityType.Equity && symbol.ID.Market == Market.USA)
+                {
+                    continue;
+                }
+                var exchangeHours = security.Exchange.Hours;
+                if (!exchangeHours.IsMarketAlwaysOpen)
+                {
+                    hours.Add(exchangeHours);
+                }
+            }
+            return hours;
         }
 
         protected Symbol GetSymbol(string ticker)

--- a/Common/Scheduling/TimeRules.cs
+++ b/Common/Scheduling/TimeRules.cs
@@ -156,6 +156,19 @@ namespace QuantConnect.Scheduling
         }
 
         /// <summary>
+        /// Specifies an event should fire at market open +- <paramref name="minutesBeforeOpen"/>.
+        /// Picks, per date, the earliest market open across the algorithm's securities, ignoring always-open
+        /// exchanges. Defaults to US equities (SPY) when no eligible security is subscribed.
+        /// </summary>
+        /// <param name="minutesBeforeOpen">The minutes before market open that the event should fire</param>
+        /// <param name="extendedMarketOpen">True to use extended market open, false to use regular market open</param>
+        /// <returns>A time rule that fires the specified number of minutes before the earliest market open</returns>
+        public ITimeRule BeforeMarketOpen(double minutesBeforeOpen = 0, bool extendedMarketOpen = false)
+        {
+            return AfterMarketOpen(minutesBeforeOpen * (-1), extendedMarketOpen);
+        }
+
+        /// <summary>
         /// Specifies an event should fire at market open +- <paramref name="minutesBeforeOpen"/>
         /// </summary>
         /// <param name="symbol">The symbol whose market open we want an event for</param>
@@ -174,6 +187,54 @@ namespace QuantConnect.Scheduling
         public ITimeRule BeforeMarketOpen(Symbol symbol, double minutesBeforeOpen = 0, bool extendedMarketOpen = false)
         {
             return AfterMarketOpen(symbol, minutesBeforeOpen * (-1), extendedMarketOpen);
+        }
+
+        /// <summary>
+        /// Specifies an event should fire at market open +- <paramref name="minutesAfterOpen"/>.
+        /// Picks, per date, the earliest market open across the algorithm's securities, ignoring always-open
+        /// exchanges. Defaults to US equities (SPY) when no eligible security is subscribed.
+        /// </summary>
+        /// <param name="minutesAfterOpen">The minutes after market open that the event should fire</param>
+        /// <param name="extendedMarketOpen">True to use extended market open, false to use regular market open</param>
+        /// <returns>A time rule that fires the specified number of minutes after the earliest market open</returns>
+        public ITimeRule AfterMarketOpen(double minutesAfterOpen = 0, bool extendedMarketOpen = false)
+        {
+            var type = extendedMarketOpen ? "ExtendedMarketOpen" : "MarketOpen";
+            var afterOrBefore = minutesAfterOpen > 0 ? "after" : "before";
+            var name = Invariant($"{Math.Abs(minutesAfterOpen):0.##} min {afterOrBefore} {type}");
+            var timeAfterOpen = TimeSpan.FromMinutes(minutesAfterOpen);
+
+            return new FuncTimeRule(name, dates => EarliestMarketOpenTimes(dates, extendedMarketOpen, timeAfterOpen));
+        }
+
+        private IEnumerable<DateTime> EarliestMarketOpenTimes(IEnumerable<DateTime> dates, bool extendedMarketOpen, TimeSpan timeAfterOpen)
+        {
+            var exchangeHoursList = GetMarketOpenCloseExchangeHours();
+            foreach (var date in dates)
+            {
+                var earliestUtc = default(DateTime);
+                foreach (var exchangeHours in exchangeHoursList)
+                {
+                    if (!exchangeHours.IsDateOpen(date, extendedMarketOpen))
+                    {
+                        continue;
+                    }
+                    var marketOpen = exchangeHours.GetFirstDailyMarketOpen((date + Time.OneDay).AddTicks(-1), extendedMarketOpen);
+                    if (marketOpen.Date != date.Date)
+                    {
+                        continue;
+                    }
+                    var utc = (marketOpen + timeAfterOpen).ConvertToUtc(exchangeHours.TimeZone);
+                    if (earliestUtc == default || utc < earliestUtc)
+                    {
+                        earliestUtc = utc;
+                    }
+                }
+                if (earliestUtc != default)
+                {
+                    yield return earliestUtc;
+                }
+            }
         }
 
         /// <summary>
@@ -213,6 +274,19 @@ namespace QuantConnect.Scheduling
         }
 
         /// <summary>
+        /// Specifies an event should fire at the market close +- <paramref name="minutesAfterClose"/>.
+        /// Picks, per date, the latest market close across the algorithm's securities, ignoring always-open
+        /// exchanges. Defaults to US equities (SPY) when no eligible security is subscribed.
+        /// </summary>
+        /// <param name="minutesAfterClose">The time after market close that the event should fire</param>
+        /// <param name="extendedMarketClose">True to use extended market close, false to use regular market close</param>
+        /// <returns>A time rule that fires the specified number of minutes after the latest market close</returns>
+        public ITimeRule AfterMarketClose(double minutesAfterClose = 0, bool extendedMarketClose = false)
+        {
+            return BeforeMarketClose(minutesAfterClose * (-1), extendedMarketClose);
+        }
+
+        /// <summary>
         /// Specifies an event should fire at the market close +- <paramref name="minutesAfterClose"/>
         /// </summary>
         /// <param name="symbol">The symbol whose market close we want an event for</param>
@@ -231,6 +305,50 @@ namespace QuantConnect.Scheduling
         public ITimeRule AfterMarketClose(Symbol symbol, double minutesAfterClose = 0, bool extendedMarketClose = false)
         {
             return BeforeMarketClose(symbol, minutesAfterClose * (-1), extendedMarketClose);
+        }
+
+        /// <summary>
+        /// Specifies an event should fire at the market close +- <paramref name="minutesBeforeClose"/>.
+        /// Picks, per date, the latest market close across the algorithm's securities, ignoring always-open
+        /// exchanges. Defaults to US equities (SPY) when no eligible security is subscribed.
+        /// </summary>
+        /// <param name="minutesBeforeClose">The time before market close that the event should fire</param>
+        /// <param name="extendedMarketClose">True to use extended market close, false to use regular market close</param>
+        /// <returns>A time rule that fires the specified number of minutes before the latest market close</returns>
+        public ITimeRule BeforeMarketClose(double minutesBeforeClose = 0, bool extendedMarketClose = false)
+        {
+            var type = extendedMarketClose ? "ExtendedMarketClose" : "MarketClose";
+            var afterOrBefore = minutesBeforeClose > 0 ? "before" : "after";
+            var name = Invariant($"{Math.Abs(minutesBeforeClose):0.##} min {afterOrBefore} {type}");
+            var timeBeforeClose = TimeSpan.FromMinutes(minutesBeforeClose);
+
+            return new FuncTimeRule(name, dates => LatestMarketCloseTimes(dates, extendedMarketClose, timeBeforeClose));
+        }
+
+        private IEnumerable<DateTime> LatestMarketCloseTimes(IEnumerable<DateTime> dates, bool extendedMarketClose, TimeSpan timeBeforeClose)
+        {
+            var exchangeHoursList = GetMarketOpenCloseExchangeHours();
+            foreach (var date in dates)
+            {
+                var latestUtc = default(DateTime);
+                foreach (var exchangeHours in exchangeHoursList)
+                {
+                    if (!exchangeHours.IsDateOpen(date, extendedMarketClose))
+                    {
+                        continue;
+                    }
+                    var marketClose = exchangeHours.GetLastDailyMarketClose(date, extendedMarketClose);
+                    var utc = (marketClose - timeBeforeClose).ConvertToUtc(exchangeHours.TimeZone);
+                    if (utc > latestUtc)
+                    {
+                        latestUtc = utc;
+                    }
+                }
+                if (latestUtc != default)
+                {
+                    yield return latestUtc;
+                }
+            }
         }
 
         /// <summary>

--- a/Tests/Common/Scheduling/TimeRulesTests.cs
+++ b/Tests/Common/Scheduling/TimeRulesTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using NodaTime;
 using NUnit.Framework;
 using Python.Runtime;
@@ -380,6 +381,237 @@ namespace QuantConnect.Tests.Common.Scheduling
             Assert.AreEqual(1, count);
         }
 
+        [Test]
+        public void NoSymbolMarketOpenDefaultsToSpyWhenNoSecurities()
+        {
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            var rule = rules.AfterMarketOpen(30);
+            var times = rule.CreateUtcEventTimes([new DateTime(2000, 01, 03)]);
+
+            int count = 0;
+            foreach (var time in times)
+            {
+                count++;
+                Assert.AreEqual(TimeSpan.FromHours(9.5 + 5 + .5), time.TimeOfDay);
+            }
+            Assert.AreEqual(1, count);
+        }
+
+        [Test]
+        public void NoSymbolMarketCloseDefaultsToSpyWhenNoSecurities()
+        {
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            var rule = rules.BeforeMarketClose(30);
+            var times = rule.CreateUtcEventTimes([new DateTime(2000, 01, 03)]);
+
+            int count = 0;
+            foreach (var time in times)
+            {
+                count++;
+                Assert.AreEqual(TimeSpan.FromHours(16 + 5 - .5), time.TimeOfDay);
+            }
+            Assert.AreEqual(1, count);
+        }
+
+        [Test]
+        public void NoSymbolMarketOpenIgnoresAlwaysOpenAndUsesSpy()
+        {
+            // Only an always-open (24/7) security is subscribed: it should be skipped and SPY used as fallback.
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            AddAlwaysOpenSecurity(rules);
+
+            var rule = rules.AfterMarketOpen();
+            var times = rule.CreateUtcEventTimes([new DateTime(2000, 01, 03)]);
+
+            int count = 0;
+            foreach (var time in times)
+            {
+                count++;
+                Assert.AreEqual(TimeSpan.FromHours(9.5 + 5), time.TimeOfDay);
+            }
+            Assert.AreEqual(1, count);
+        }
+
+        [Test]
+        public void NoSymbolMarketOpenWithEquityAndExtendedFuturePicksFuture()
+        {
+            // SPY extended opens at 4:00 NY = 9:00 UTC; ES Future extended opens at 0:00 NY = 5:00 UTC. ES wins.
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            AddSecurity(rules, Symbols.SPY);
+            AddSecurity(rules, Symbols.ES_Future_Chain, extendedMarketHours: true);
+
+            var rule = rules.AfterMarketOpen(0, extendedMarketOpen: true);
+            var times = rule.CreateUtcEventTimes([new DateTime(2022, 01, 03)]).ToList();
+
+            Assert.AreEqual(1, times.Count);
+            Assert.AreEqual(new DateTime(2022, 01, 03, 5, 0, 0), times[0]);
+        }
+
+        [Test]
+        public void NoSymbolMarketCloseWithEquityAndExtendedFuturePicksFuture()
+        {
+            // SPY extended closes at 20:00 NY = 01:00 UTC next day; ES Future extended closes at 24:00 NY = 5:00 UTC next day. ES wins.
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            AddSecurity(rules, Symbols.SPY);
+            AddSecurity(rules, Symbols.ES_Future_Chain, extendedMarketHours: true);
+
+            var rule = rules.BeforeMarketClose(0, extendedMarketClose: true);
+            var times = rule.CreateUtcEventTimes([new DateTime(2022, 01, 03)]).ToList();
+
+            Assert.AreEqual(1, times.Count);
+            Assert.AreEqual(new DateTime(2022, 01, 04, 5, 0, 0), times[0]);
+        }
+
+        [Test]
+        public void NoSymbolMarketOpenWithEquityAndForexPicksForex()
+        {
+            // EURUSD (Oanda) on Mon Jan 3, 2022 first daily open is 0:00 NY = 5:00 UTC; SPY regular opens 9:30 NY = 14:30 UTC. Forex wins.
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            AddSecurity(rules, Symbols.SPY);
+            AddSecurity(rules, Symbols.EURUSD);
+
+            var rule = rules.AfterMarketOpen();
+            var times = rule.CreateUtcEventTimes([new DateTime(2022, 01, 03)]).ToList();
+
+            Assert.AreEqual(1, times.Count);
+            Assert.AreEqual(new DateTime(2022, 01, 03, 5, 0, 0), times[0]);
+        }
+
+        [Test]
+        public void NoSymbolMarketCloseWithEquityAndForexPicksForex()
+        {
+            // EURUSD last daily close on Mon Jan 3, 2022 is 24:00 NY = 5:00 UTC next day; SPY regular closes 16:00 NY = 21:00 UTC. Forex wins.
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            AddSecurity(rules, Symbols.SPY);
+            AddSecurity(rules, Symbols.EURUSD);
+
+            var rule = rules.BeforeMarketClose();
+            var times = rule.CreateUtcEventTimes([new DateTime(2022, 01, 03)]).ToList();
+
+            Assert.AreEqual(1, times.Count);
+            Assert.AreEqual(new DateTime(2022, 01, 04, 5, 0, 0), times[0]);
+        }
+
+        [Test]
+        public void NoSymbolMarketOpenWithEquityAndCfdPicksCfd()
+        {
+            // XAUUSD (Oanda CFD) Mon first daily open is 0:00 NY = 5:00 UTC; SPY regular opens 14:30 UTC. CFD wins.
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            AddSecurity(rules, Symbols.SPY);
+            AddSecurity(rules, Symbols.XAUUSD);
+
+            var rule = rules.AfterMarketOpen();
+            var times = rule.CreateUtcEventTimes([new DateTime(2022, 01, 03)]).ToList();
+
+            Assert.AreEqual(1, times.Count);
+            Assert.AreEqual(new DateTime(2022, 01, 03, 5, 0, 0), times[0]);
+        }
+
+        [Test]
+        public void NoSymbolMarketCloseWithEquityAndCfdPicksCfd()
+        {
+            // XAUUSD last daily close on Mon is 24:00 NY = 5:00 UTC next day; SPY regular closes 21:00 UTC. CFD wins.
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            AddSecurity(rules, Symbols.SPY);
+            AddSecurity(rules, Symbols.XAUUSD);
+
+            var rule = rules.BeforeMarketClose();
+            var times = rule.CreateUtcEventTimes([new DateTime(2022, 01, 03)]).ToList();
+
+            Assert.AreEqual(1, times.Count);
+            Assert.AreEqual(new DateTime(2022, 01, 04, 5, 0, 0), times[0]);
+        }
+
+        [Test]
+        public void NoSymbolMarketOpenWithEquityAndRegularFutureMatchesEquity()
+        {
+            // SPY and ES regular sessions both open at 9:30 NY = 14:30 UTC on Mon Jan 3, 2022.
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            AddSecurity(rules, Symbols.SPY);
+            AddSecurity(rules, Symbols.ES_Future_Chain);
+
+            var rule = rules.AfterMarketOpen();
+            var times = rule.CreateUtcEventTimes([new DateTime(2022, 01, 03)]).ToList();
+
+            Assert.AreEqual(1, times.Count);
+            Assert.AreEqual(new DateTime(2022, 01, 03, 14, 30, 0), times[0]);
+        }
+
+        [Test]
+        public void NoSymbolMarketCloseWithEquityAndRegularFuturePicksFuture()
+        {
+            // SPY regular closes 16:00 NY = 21:00 UTC; ES regular closes 17:00 NY = 22:00 UTC. ES wins.
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            AddSecurity(rules, Symbols.SPY);
+            AddSecurity(rules, Symbols.ES_Future_Chain);
+
+            var rule = rules.BeforeMarketClose();
+            var times = rule.CreateUtcEventTimes([new DateTime(2022, 01, 03)]).ToList();
+
+            Assert.AreEqual(1, times.Count);
+            Assert.AreEqual(new DateTime(2022, 01, 03, 22, 0, 0), times[0]);
+        }
+
+        [Test]
+        public void NoSymbolMarketOpenWithEquityAndEquityOptionMatches()
+        {
+            // SPY equity and SPY options share regular hours: 9:30 NY = 14:30 UTC.
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            AddSecurity(rules, Symbols.SPY);
+            AddSecurity(rules, Symbols.SPY_Option_Chain);
+
+            var rule = rules.AfterMarketOpen();
+            var times = rule.CreateUtcEventTimes([new DateTime(2022, 01, 03)]).ToList();
+
+            Assert.AreEqual(1, times.Count);
+            Assert.AreEqual(new DateTime(2022, 01, 03, 14, 30, 0), times[0]);
+        }
+
+        [Test]
+        public void NoSymbolMarketCloseWithEquityAndEquityOptionMatches()
+        {
+            // SPY equity and SPY options share regular close: 16:00 NY = 21:00 UTC.
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            AddSecurity(rules, Symbols.SPY);
+            AddSecurity(rules, Symbols.SPY_Option_Chain);
+
+            var rule = rules.BeforeMarketClose();
+            var times = rule.CreateUtcEventTimes([new DateTime(2022, 01, 03)]).ToList();
+
+            Assert.AreEqual(1, times.Count);
+            Assert.AreEqual(new DateTime(2022, 01, 03, 21, 0, 0), times[0]);
+        }
+
+        [Test]
+        public void NoSymbolMarketOpenWithEquityAndIndexOptionMatches()
+        {
+            // SPX index option regular opens 8:30 CT = 14:30 UTC, same as SPY equity 14:30 UTC.
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            AddSecurity(rules, Symbols.SPY);
+            AddSecurity(rules, Symbol.CreateCanonicalOption(Symbols.SPX));
+
+            var rule = rules.AfterMarketOpen();
+            var times = rule.CreateUtcEventTimes([new DateTime(2022, 01, 03)]).ToList();
+
+            Assert.AreEqual(1, times.Count);
+            Assert.AreEqual(new DateTime(2022, 01, 03, 14, 30, 0), times[0]);
+        }
+
+        [Test]
+        public void NoSymbolMarketCloseWithEquityAndIndexOptionPicksIndexOption()
+        {
+            // SPY regular closes 16:00 NY = 21:00 UTC; SPX index option closes 15:15 CT = 21:15 UTC. SPX wins.
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            AddSecurity(rules, Symbols.SPY);
+            AddSecurity(rules, Symbol.CreateCanonicalOption(Symbols.SPX));
+
+            var rule = rules.BeforeMarketClose();
+            var times = rule.CreateUtcEventTimes([new DateTime(2022, 01, 03)]).ToList();
+
+            Assert.AreEqual(1, times.Count);
+            Assert.AreEqual(new DateTime(2022, 01, 03, 21, 15, 0), times[0]);
+        }
+
         [TestCase(0)]
         [TestCase(-1)]
         public void EveryValidatesTimeSpan(int timeSpanMinutes)
@@ -470,6 +702,42 @@ wrongCustomTimeRule = ""hello""
                 dynamic pythonCustomTimeRule = pythonModule.GetAttr("wrongCustomTimeRule");
                 Assert.Throws<ArgumentException>(() => new FuncTimeRule("PythonFuncTimeRule", pythonCustomTimeRule));
             }
+        }
+
+        private static TimeRules GetEmptyTimeRules(DateTimeZone dateTimeZone)
+        {
+            var timeKeeper = new TimeKeeper(_utcNow, new List<DateTimeZone>());
+            var manager = new SecurityManager(timeKeeper);
+            var mhdb = MarketHoursDatabase.FromDataFolder();
+            return new TimeRules(null, manager, dateTimeZone, mhdb);
+        }
+
+        private static SecurityManager GetSecurityManager(TimeRules rules)
+        {
+            var prop = typeof(BaseScheduleRules).GetProperty("Securities", BindingFlags.NonPublic | BindingFlags.Instance);
+            return (SecurityManager)prop.GetValue(rules);
+        }
+
+        private static void AddSecurity(TimeRules rules, Symbol symbol, bool extendedMarketHours = false)
+        {
+            var manager = GetSecurityManager(rules);
+            var mhdb = MarketHoursDatabase.FromDataFolder();
+            var entry = mhdb.GetEntry(symbol.ID.Market, symbol, symbol.SecurityType);
+            var config = new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Daily,
+                entry.DataTimeZone, entry.ExchangeHours.TimeZone, true, extendedMarketHours, false);
+            manager.Add(symbol, new Security(
+                entry.ExchangeHours,
+                config,
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()));
+        }
+
+        private static void AddAlwaysOpenSecurity(TimeRules rules)
+        {
+            AddSecurity(rules, Symbols.BTCUSD);
         }
 
         private static TimeRules GetTimeRules(DateTimeZone dateTimeZone)

--- a/Tests/Common/Scheduling/TimeRulesTests.cs
+++ b/Tests/Common/Scheduling/TimeRulesTests.cs
@@ -598,6 +598,26 @@ namespace QuantConnect.Tests.Common.Scheduling
         }
 
         [Test]
+        public void GetMarketOpenCloseExchangeHoursDedupesOptionContracts()
+        {
+            var rules = GetEmptyTimeRules(TimeZones.Utc);
+            var expiry = new DateTime(2024, 01, 19);
+            for (var strike = 100; strike < 110; strike++)
+            {
+                var contract = Symbol.CreateOption(Symbols.SPY, Market.USA, OptionStyle.American,
+                    OptionRight.Call, strike, expiry);
+                AddSecurity(rules, contract);
+            }
+
+            var method = typeof(BaseScheduleRules).GetMethod("GetMarketOpenCloseExchangeHours",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var hours = ((IEnumerable<SecurityExchangeHours>)method.Invoke(rules, null)).ToList();
+
+            // Expected 2: SPY equity hours (pre-seeded fallback) + SPY option hours (10 contracts deduped to one).
+            Assert.AreEqual(2, hours.Count);
+        }
+
+        [Test]
         public void NoSymbolMarketCloseWithEquityAndIndexOptionPicksIndexOption()
         {
             // SPY regular closes 16:00 NY = 21:00 UTC; SPX index option closes 15:15 CT = 21:15 UTC. SPX wins.


### PR DESCRIPTION
#### Description
Adds no-symbol overloads of `AfterMarketOpen`, `BeforeMarketOpen`, `AfterMarketClose` and `BeforeMarketClose` on `TimeRules`. Per-date, the helpers pick the earliest market open / latest market close across the algorithm's subscribed exchanges, ignoring always-open ones (e.g. Crypto). When no eligible security is subscribed they default to US equities (SPY).

A small helper `BaseScheduleRules.GetMarketOpenCloseExchangeHours()` builds the (deduped) set of `SecurityExchangeHours` to consider. The set is pre-seeded with SPY's exchange hours so the fallback is always present and US equities are skipped during the walk (they share the SPY entry).

#### Related Issue
Closes #9461

#### Motivation and Context
Agents (and users) frequently write `time_rules.after_market_open(minutes=30)` without a symbol, which currently throws because every overload requires one. The fix lets those calls succeed by inferring sensible market hours from the algorithm's subscriptions.

#### Requires Documentation Change
The Scheduled Events documentation should mention that the no-symbol form is now available and document its open/close selection rule (earliest open / latest close, ignoring always-open exchanges, SPY fallback).

#### How Has This Been Tested?
Added 15 new unit tests in `Tests/Common/Scheduling/TimeRulesTests.cs` covering:
- Empty `Securities` → SPY fallback (open and close)
- Always-open-only subscription → SPY fallback
- US equity vs extended-hours future → future wins both open and close
- US equity vs Forex (EURUSD) → forex wins both open and close
- US equity vs CFD (XAUUSD) → CFD wins both open and close
- US equity vs regular-hours future → tied open, future wins close
- US equity vs equity option (SPY options) → tied open and close
- US equity vs index option (SPX) → tied open, SPX option wins close

All 43 `TimeRulesTests` pass (28 pre-existing + 15 new).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`