### PR TITLE
Remove Symbol/str mypy suppression from syntax check script

### DIFF
--- a/run_syntax_check.py
+++ b/run_syntax_check.py
@@ -72,7 +72,6 @@ def should_ignore(line: str, prev_line_ignored: bool) -> bool:
         'Too many arguments for "update" of "IndicatorBase"',
         'Signature of "update" incompatible with supertype "IndicatorBase"',
         'Signature of "update" incompatible with supertype "QuantConnect.Indicators.IndicatorBase"',
-        'has incompatible type "Symbol"; expected "str"',
         # This methods take an indicator and consolidator which might be instances of custom
         # indicator/consolidator Python classes that don't inherit from PythonIndicator or IDataConsolidator
         'No overload variant of "register_indicator" of "QCAlgorithm" matches argument types',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
The `has incompatible type "Symbol"; expected "str"` mypy error was being suppressed as a workaround. The root cause has been fixed in the stubs generator, so the suppression is no longer needed.

#### Related Issue
See Related [#97](https://github.com/QuantConnect/quantconnect-stubs-generator/pull/97)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
