### PR TITLE
Throw clear error when add_data first argument is not a custom data class

### DIFF
--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -109,7 +109,7 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(AddingData)]
         public Security AddData(PyObject type, string ticker, Resolution? resolution, DateTimeZone timeZone, bool fillForward = false, decimal leverage = 1.0m)
         {
-            return AddData(type.CreateType(), ticker, resolution, timeZone, fillForward, leverage);
+            return AddData(GetCustomDataType(type), ticker, resolution, timeZone, fillForward, leverage);
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(AddingData)]
         public Security AddData(PyObject type, Symbol underlying, Resolution? resolution, DateTimeZone timeZone, bool fillForward = false, decimal leverage = 1.0m)
         {
-            return AddData(type.CreateType(), underlying, resolution, timeZone, fillForward, leverage);
+            return AddData(GetCustomDataType(type), underlying, resolution, timeZone, fillForward, leverage);
         }
 
         /// <summary>
@@ -219,7 +219,7 @@ namespace QuantConnect.Algorithm
         public Security AddData(PyObject type, string ticker, SymbolProperties properties, SecurityExchangeHours exchangeHours, Resolution? resolution = null, bool fillForward = false, decimal leverage = 1.0m)
         {
             // Get the right key for storage of base type symbols
-            var dataType = type.CreateType();
+            var dataType = GetCustomDataType(type);
             var key = SecurityIdentifier.GenerateBaseSymbol(dataType, ticker);
 
             // Add entries to our Symbol Properties DB and MarketHours DB
@@ -282,6 +282,21 @@ namespace QuantConnect.Algorithm
             var security = Securities.CreateSecurity(symbol, config, leverage, addToSymbolCache: false);
 
             return AddToUserDefinedUniverse(security, new List<SubscriptionDataConfig> { config });
+        }
+
+        /// <summary>
+        /// Resolves the custom data <see cref="Type"/> from the PyObject argument of <see cref="AddData(PyObject, string, Resolution?)"/> and overloads,
+        /// throwing a clear exception if the caller passed something other than a custom data class (e.g. a string ticker).
+        /// </summary>
+        private static Type GetCustomDataType(PyObject type)
+        {
+            if (type.TryCreateType(out var dataType))
+            {
+                return dataType;
+            }
+
+            using var _ = Py.GIL();
+            throw new ArgumentException(Messages.QCAlgorithm.AddDataInvalidPyObjectType(type.Repr()));
         }
 
         /// <summary>

--- a/Common/Messages/Messages.Algorithm.cs
+++ b/Common/Messages/Messages.Algorithm.cs
@@ -97,7 +97,7 @@ namespace QuantConnect
             public static string AddDataInvalidPyObjectType(string repr)
             {
                 return $"{AlgorithmPrefix()}.{FormatCode("AddData")}(): the first argument must be a custom data type (a Python class deriving from {FormatCode("PythonData")} or a CLR {FormatCode("BaseData")} type), but received {repr}. " +
-                    $"To subscribe to built-in asset classes use {FormatCode("AddEquity")}, {FormatCode("AddForex")}, {FormatCode("AddCfd")}, {FormatCode("AddCrypto")}, {FormatCode("AddFuture")}, {FormatCode("AddOption")} or {FormatCode("AddSecurity")} instead.";
+                    $"To subscribe to built-in asset classes use, for example, {FormatCode("AddEquity")} or {FormatCode("AddCrypto")}.";
             }
         }
 

--- a/Common/Messages/Messages.Algorithm.cs
+++ b/Common/Messages/Messages.Algorithm.cs
@@ -89,6 +89,16 @@ namespace QuantConnect
             {
                 return $"{AlgorithmPrefix()}.{FormatCode("SetWarmup")}(): This method cannot be used after algorithm initialized";
             }
+
+            /// <summary>
+            /// Returns a string message saying the first argument to AddData must be a custom data class
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string AddDataInvalidPyObjectType(string repr)
+            {
+                return $"{AlgorithmPrefix()}.{FormatCode("AddData")}(): the first argument must be a custom data type (a Python class deriving from {FormatCode("PythonData")} or a CLR {FormatCode("BaseData")} type), but received {repr}. " +
+                    $"To subscribe to built-in asset classes use {FormatCode("AddEquity")}, {FormatCode("AddForex")}, {FormatCode("AddCfd")}, {FormatCode("AddCrypto")}, {FormatCode("AddFuture")}, {FormatCode("AddOption")} or {FormatCode("AddSecurity")} instead.";
+            }
         }
 
         /// <summary>

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using Newtonsoft.Json;
 using NodaTime;
 using NUnit.Framework;
+using Python.Runtime;
 using QuantConnect.Algorithm;
 using QuantConnect.Algorithm.Framework.Selection;
 using QuantConnect.Algorithm.Selection;
@@ -635,6 +636,22 @@ namespace QuantConnect.Tests.Algorithm
                 "double",
                 Resolution.Daily,
                 DateTimeZone.Utc));
+        }
+
+        [Test]
+        public void AddDataWithStringAsTypeArgumentThrowsClearError()
+        {
+            var qcAlgorithm = new QCAlgorithm();
+            qcAlgorithm.SubscriptionManager.SetDataManager(new DataManagerStub(qcAlgorithm));
+
+            using var _ = Py.GIL();
+            using var pyTicker = "VIX".ToPython();
+
+            // Passing a string instead of a custom data class as the first argument used to silently build a
+            // dynamic assembly named after the string and later hang/fail downstream. It must now throw.
+            var ex = Assert.Throws<ArgumentException>(() => qcAlgorithm.AddData(pyTicker, "VIX", Resolution.Daily));
+            StringAssert.Contains("AddData", ex.Message);
+            StringAssert.Contains("AddEquity", ex.Message);
         }
 
         [Test]


### PR DESCRIPTION
#### Description
Calls like `self.add_data("VIX", Resolution.DAILY)` (passing a string where a custom data class is expected) used to fall into `Extensions.CreateType`, which silently built a dynamic assembly named after the string and returned a fake `Type` whose `PythonActivator.Factory` tried to `Invoke()` the str like a function. The downstream `'str' object is not callable` `PythonException` surfaced confusingly and, depending on where the engine caught it during initialization, could appear to the user as a hang.

This PR validates the `PyObject` up front in the `AddData(PyObject, ...)` entry points using the existing `TryCreateType` helper and throws an `ArgumentException` that points the user at `AddEquity` / `AddForex` / etc. when the argument is not a custom data class.

#### Related Issue
N/A — no public issue was filed for this.

#### Motivation and Context
A common user mistake (treating `add_data` like `add_equity`) produced a confusing failure mode (`'str' object is not callable` / apparent hang) instead of a clear, actionable error.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Added `AlgorithmAddDataTests.AddDataWithStringAsTypeArgumentThrowsClearError`. The test was first run against the unfixed code to confirm the original symptom (`PythonException: 'str' object is not callable` thrown from `PythonActivator.Factory` via `GetBaseDataInstance`), then re-run against the fixed code to confirm an `ArgumentException` mentioning `AddData` and `AddEquity` is now thrown. The pre-existing `PythonCustomDataTypes_AreAddedToSubscriptions_Successfully`, `PythonCustomDataTypes_AreAddedToConsolidator_Successfully`, and `AddingInvalidDataTypeThrows` tests still pass.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`