### PR TITLE
Fix SessionConsolidator skipping bars when updated manually

### DIFF
--- a/Common/Data/Consolidators/SessionConsolidator.cs
+++ b/Common/Data/Consolidators/SessionConsolidator.cs
@@ -83,21 +83,10 @@ namespace Common.Data.Consolidators
                 workingBar.Time = data.Time.Date;
             }
 
+            _initialized = true;
+
             // Update the working session bar
             workingBar.Update(data, Consolidated);
-        }
-
-        /// <summary>
-        /// Updates the session with new market data and initializes the consolidator if needed
-        /// </summary>
-        /// <param name="data">The new data to update the session with</param>
-        public override void Update(BaseData data)
-        {
-            if (!_initialized)
-            {
-                _initialized = true;
-            }
-            base.Update(data);
         }
 
         /// <summary>

--- a/Common/Data/Consolidators/SessionConsolidator.cs
+++ b/Common/Data/Consolidators/SessionConsolidator.cs
@@ -90,7 +90,11 @@ namespace Common.Data.Consolidators
         {
             if (!_initialized)
             {
-                _workingBar.Time = data.Time.Date;
+                // Set the working bar time only if it hasn't been set yet
+                if (_workingBar.Time == DateTime.MaxValue)
+                {
+                    _workingBar.Time = data.Time.Date;
+                }
                 _initialized = true;
             }
             base.Update(data);

--- a/Common/Data/Consolidators/SessionConsolidator.cs
+++ b/Common/Data/Consolidators/SessionConsolidator.cs
@@ -65,6 +65,15 @@ namespace Common.Data.Consolidators
         /// <param name="data">The new data</param>
         protected override void AggregateBar(ref SessionBar workingBar, BaseData data)
         {
+            if (!_initialized)
+            {
+                if (workingBar.Time == DateTime.MaxValue || data.Time.Date > workingBar.Time.Date)
+                {
+                    workingBar.Time = data.Time.Date;
+                }
+                _initialized = true;
+            }
+
             // Handle open interest
             if (data.DataType == MarketDataType.Tick && data is Tick oiTick && oiTick.TickType == TickType.OpenInterest)
             {
@@ -77,13 +86,6 @@ namespace Common.Data.Consolidators
             {
                 return;
             }
-
-            if (workingBar.Time == DateTime.MaxValue || data.Time.Date > workingBar.Time.Date)
-            {
-                workingBar.Time = data.Time.Date;
-            }
-
-            _initialized = true;
 
             // Update the working session bar
             workingBar.Update(data, Consolidated);

--- a/Common/Data/Consolidators/SessionConsolidator.cs
+++ b/Common/Data/Consolidators/SessionConsolidator.cs
@@ -78,8 +78,7 @@ namespace Common.Data.Consolidators
                 return;
             }
 
-            // Correct the timestamp if data skipped the predicted next trading day
-            if (workingBar.Time != DateTime.MaxValue && data.Time.Date > workingBar.Time.Date)
+            if (workingBar.Time == DateTime.MaxValue || data.Time.Date > workingBar.Time.Date)
             {
                 workingBar.Time = data.Time.Date;
             }
@@ -96,11 +95,6 @@ namespace Common.Data.Consolidators
         {
             if (!_initialized)
             {
-                // Set the working bar time only if it hasn't been set yet
-                if (_workingBar.Time == DateTime.MaxValue)
-                {
-                    _workingBar.Time = data.Time.Date;
-                }
                 _initialized = true;
             }
             base.Update(data);

--- a/Common/Data/Consolidators/SessionConsolidator.cs
+++ b/Common/Data/Consolidators/SessionConsolidator.cs
@@ -78,6 +78,12 @@ namespace Common.Data.Consolidators
                 return;
             }
 
+            // Correct the timestamp if data skipped the predicted next trading day
+            if (workingBar.Time != DateTime.MaxValue && data.Time.Date > workingBar.Time.Date)
+            {
+                workingBar.Time = data.Time.Date;
+            }
+
             // Update the working session bar
             workingBar.Update(data, Consolidated);
         }

--- a/Tests/Indicators/SessionTests.cs
+++ b/Tests/Indicators/SessionTests.cs
@@ -193,6 +193,27 @@ namespace QuantConnect.Tests.Indicators
             Assert.AreEqual(barCount, session.Samples);
         }
 
+        [Test]
+        public void GapDayDataPreservesCorrectTimestampAndContent()
+        {
+            var symbol = Symbols.SPY;
+            var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+            var session = new Session(TickType.Trade, exchangeHours, symbol, 5);
+
+            var sep2 = new DateTime(2025, 9, 2, 9, 30, 0);
+            var sep4 = new DateTime(2025, 9, 4, 9, 30, 0);
+            var sep5 = new DateTime(2025, 9, 5, 9, 30, 0);
+
+            session.Update(new TradeBar(sep2, symbol, 100, 110, 90, 105, 1000, Time.OneDay));
+            session.Update(new TradeBar(sep4, symbol, 200, 210, 190, 205, 2000, Time.OneDay));
+            session.Update(new TradeBar(sep5, symbol, 300, 310, 290, 305, 3000, Time.OneDay));
+
+            Assert.AreEqual(sep4.Date, session[1].Time);
+            Assert.AreEqual(200, session[1].Open);
+            Assert.AreEqual(sep2.Date, session[2].Time);
+            Assert.AreEqual(100, session[2].Open);
+        }
+
         private static Session GetSession(TickType tickType, int initialSize)
         {
             var symbol = Symbols.SPY;

--- a/Tests/Indicators/SessionTests.cs
+++ b/Tests/Indicators/SessionTests.cs
@@ -171,6 +171,28 @@ namespace QuantConnect.Tests.Indicators
             yield return new TestCaseData(new DateTime(2025, 8, 29, 10, 0, 0), new DateTime(2025, 9, 2));
         }
 
+        [Test]
+        public void ManualDailyBarUpdateProducesOneConsolidationPerBar()
+        {
+            var symbol = Symbols.SPY;
+            var barCount = 20;
+            var exchangeHours = MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType);
+            var session = new Session(TickType.Trade, exchangeHours, symbol, barCount + 1);
+
+            var barDate = new DateTime(2025, 9, 2, 9, 30, 0);
+            for (var i = 0; i < barCount; i++)
+            {
+                session.Update(new TradeBar(barDate, symbol, 100 + i, 101 + i, 99 + i, 100 + i, 1000, Time.OneDay));
+                barDate = barDate.AddDays(1);
+                while (!exchangeHours.IsDateOpen(barDate.Date, false))
+                {
+                    barDate = barDate.AddDays(1);
+                }
+            }
+
+            Assert.AreEqual(barCount, session.Samples);
+        }
+
         private static Session GetSession(TickType tickType, int initialSize)
         {
             var symbol = Symbols.SPY;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Fixed a bug in SessionConsolidator where feeding daily bars manually via `Update()` was only producing half the expected consolidations. Root cause was that after each consolidation the working bar time was being overridden, losing track of the correct next trading day.

#### Related Issue
Closes #9353

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
