### PR TITLE
Minor backtest analysis fixes

### DIFF
--- a/Engine/Results/Analysis/Analyses/OrderFillsDuringExtendedMarketHoursAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/OrderFillsDuringExtendedMarketHoursAnalysis.cs
@@ -53,11 +53,23 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
 
             foreach (var orderEvent in orderEvents)
             {
-                if (orderEvent.Status != OrderStatus.Filled || algorithm.IsMarketOpen(orderEvent.Symbol))
+                if (orderEvent.Status != OrderStatus.Filled || !algorithm.Securities.TryGetValue(orderEvent.Symbol, out var security))
                 {
                     continue;
                 }
 
+                var localFillTime = orderEvent.UtcTime.ConvertFromUtc(security.Exchange.TimeZone);
+                var exchangeHours = security.Exchange.Hours;
+                var lastDataPoint = security.GetLastData();
+                var isDailyResolution = lastDataPoint != null && (lastDataPoint.EndTime - lastDataPoint.Time) > Time.OneHour;
+                if (exchangeHours.IsOpen(localFillTime, extendedMarketHours: false)
+                    // consider at the close as open
+                    || exchangeHours.IsOpen(localFillTime.AddTicks(-1), extendedMarketHours: false)
+                    // daily midnight data
+                    || isDailyResolution && !algorithm.Settings.DailyPreciseEndTime && exchangeHours.IsDateOpen(localFillTime.AddDays(-1), extendedMarketHours: false))
+                {
+                    continue;
+                }
                 result.Add(orderEvent);
             }
 

--- a/Engine/Results/Analysis/Analyses/OrderResponseErrorsAnalyses/ExceedsShortableQuantityOrderResponseErrorAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/OrderResponseErrorsAnalyses/ExceedsShortableQuantityOrderResponseErrorAnalysis.cs
@@ -57,7 +57,6 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
         {
             var result = orderEvents
                 .Where(e => e.Message != null && MessageText.All(t => e.Message.Contains(t, StringComparison.InvariantCultureIgnoreCase)))
-                //.Select(OrdersReader.ParseOrderEvent)
                 .ToList();
 
             var potentialSolutions = result.Count > 0 ? Solutions(language) : [];

--- a/Engine/Results/Analysis/Analyses/StaleOrderFillsAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/StaleOrderFillsAnalysis.cs
@@ -50,7 +50,6 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
         {
             var result = orderEvents
                 .Where(e => e.Message != null && e.Message.Contains("Warning: fill at stale price", StringComparison.InvariantCultureIgnoreCase))
-                //.Select(OrdersReader.ParseOrderEvent)
                 .ToList();
 
             var potentialSolutions = result.Count > 0 ? Solutions(language) : [];

--- a/Engine/Results/Analysis/ResultsAnalyzer.cs
+++ b/Engine/Results/Analysis/ResultsAnalyzer.cs
@@ -146,7 +146,7 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
             // ── 1. backtest equity from "Strategy Equity" chart ──────────────────
             BaseSeries equitySeries;
             if (result.Charts.TryGetValue("Strategy Equity", out var chart) &&
-                chart.Series.TryGetValue("Equity", out var series))
+                chart.Series.TryGetValue("Equity", out var series) && series.Values.Count > 0)
             {
                 equitySeries = series;
             }


### PR DESCRIPTION
- Fix OrderFillsDuringExtendedMarketHoursAnalysis which was always using algorithm end time to evaluate fill
- Fix exception when no equities were sampled