### PR TITLE
Respect outside regular hours in fill models

### DIFF
--- a/Common/Orders/Fills/EquityFillModel.cs
+++ b/Common/Orders/Fills/EquityFillModel.cs
@@ -59,7 +59,7 @@ namespace QuantConnect.Orders.Fills
             if (order.Status == OrderStatus.Canceled) return fill;
 
             // Fill only if open or extended
-            if (!IsExchangeOpen(asset,
+            if (!IsExchangeOpen(asset, order,
                 Parameters.ConfigProvider
                     .GetSubscriptionDataConfigs(asset.Symbol)
                     .IsExtendedMarketHours()))
@@ -130,7 +130,7 @@ namespace QuantConnect.Orders.Fills
             if (order.Status == OrderStatus.Canceled) return fill;
 
             // Make sure the exchange is open/normal market hours before filling
-            if (!IsExchangeOpen(asset, false)) return fill;
+            if (!IsExchangeOpen(asset, order, false)) return fill;
 
             // Calculate the model slippage: e.g. 0.01c
             var slip = asset.SlippageModel.GetSlippageApproximation(asset, order);
@@ -187,7 +187,7 @@ namespace QuantConnect.Orders.Fills
             if (order.Status == OrderStatus.Canceled) return fill;
 
             // Make sure the exchange is open/normal market hours before filling
-            if (!IsExchangeOpen(asset, false)) return fill;
+            if (!IsExchangeOpen(asset, order, false)) return fill;
 
             // Get the trade bar that closes after the order time
             var tradeBar = GetBestEffortTradeBar(asset, order.Time);
@@ -266,7 +266,7 @@ namespace QuantConnect.Orders.Fills
 
             // make sure the exchange is open before filling -- allow pre/post market fills to occur
             if (!IsExchangeOpen(
-                asset,
+                asset, order,
                 Parameters.ConfigProvider
                     .GetSubscriptionDataConfigs(asset.Symbol)
                     .IsExtendedMarketHours()))
@@ -371,7 +371,7 @@ namespace QuantConnect.Orders.Fills
             if (order.Status == OrderStatus.Canceled) return fill;
 
             // make sure the exchange is open before filling -- allow pre/post market fills to occur
-            if (!IsExchangeOpen(asset,
+            if (!IsExchangeOpen(asset, order,
                 Parameters.ConfigProvider
                     .GetSubscriptionDataConfigs(asset.Symbol)
                     .IsExtendedMarketHours()))

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -286,7 +286,7 @@ namespace QuantConnect.Orders.Fills
             if (order.Status == OrderStatus.Canceled) return fill;
 
             // make sure the exchange is open/normal market hours before filling
-            if (!IsExchangeOpen(asset, false)) return fill;
+            if (!IsExchangeOpen(asset, order, false)) return fill;
 
             var orderDirection = order.Direction;
             var prices = GetPricesCheckingPythonWrapper(asset, orderDirection);
@@ -339,7 +339,7 @@ namespace QuantConnect.Orders.Fills
             if (order.Status == OrderStatus.Canceled) return fill;
 
             // make sure the exchange is open/normal market hours before filling
-            if (!IsExchangeOpen(asset, false)) return fill;
+            if (!IsExchangeOpen(asset, order, false)) return fill;
 
             //Get the range of prices in the last bar:
             var prices = GetPricesCheckingPythonWrapper(asset, order.Direction);
@@ -398,7 +398,7 @@ namespace QuantConnect.Orders.Fills
             if (order.Status == OrderStatus.Canceled) return fill;
 
             // Make sure the exchange is open/normal market hours before filling
-            if (!IsExchangeOpen(asset, false)) return fill;
+            if (!IsExchangeOpen(asset, order, false)) return fill;
 
             // Get the range of prices in the last bar:
             var prices = GetPricesCheckingPythonWrapper(asset, order.Direction);
@@ -478,7 +478,7 @@ namespace QuantConnect.Orders.Fills
             if (order.Status == OrderStatus.Canceled) return fill;
 
             // make sure the exchange is open before filling -- allow pre/post market fills to occur
-            if (!IsExchangeOpen(asset))
+            if (!IsExchangeOpen(asset, order))
             {
                 return fill;
             }
@@ -568,7 +568,7 @@ namespace QuantConnect.Orders.Fills
             if (order.Status == OrderStatus.Canceled) return fill;
 
             // Fill only if open or extended
-            if (!IsExchangeOpen(asset))
+            if (!IsExchangeOpen(asset, order))
             {
                 return fill;
             }
@@ -670,7 +670,7 @@ namespace QuantConnect.Orders.Fills
             if (order.Status == OrderStatus.Canceled) return fill;
 
             // make sure the exchange is open before filling -- allow pre/post market fills to occur
-            if (!IsExchangeOpen(asset))
+            if (!IsExchangeOpen(asset, order))
             {
                 return fill;
             }
@@ -1095,6 +1095,11 @@ namespace QuantConnect.Orders.Fills
                 }
 
                 var barSpan = currentBar.EndTime - currentBar.Time;
+                if (barSpan < Time.OneHour)
+                {
+                    return false;
+                }
+
                 var isOnCurrentBar = barSpan > Time.OneHour
                     // for fill purposes we consider the market open for daily bars if we are in the same day
                     ? asset.LocalTime.Date == currentBar.EndTime.Date
@@ -1105,6 +1110,51 @@ namespace QuantConnect.Orders.Fills
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Determines if the exchange is open for the specified order using the current time of the asset
+        /// </summary>
+        protected virtual bool IsExchangeOpen(Security asset, Order order, bool isExtendedMarketHours)
+        {
+            if (TryGetOutsideRegularTradingHours(order, out var outsideRegularTradingHours))
+            {
+                isExtendedMarketHours = outsideRegularTradingHours;
+            }
+
+            return IsExchangeOpen(asset, isExtendedMarketHours);
+        }
+
+        private bool IsExchangeOpen(Security asset, Order order)
+        {
+            if (TryGetOutsideRegularTradingHours(order, out var outsideRegularTradingHours))
+            {
+                return IsExchangeOpen(asset, outsideRegularTradingHours);
+            }
+
+            return IsExchangeOpen(asset);
+        }
+
+        private static bool TryGetOutsideRegularTradingHours(Order order, out bool outsideRegularTradingHours)
+        {
+            switch (order.Properties)
+            {
+                case AlpacaOrderProperties properties:
+                    outsideRegularTradingHours = properties.OutsideRegularTradingHours;
+                    return true;
+                case InteractiveBrokersOrderProperties properties:
+                    outsideRegularTradingHours = properties.OutsideRegularTradingHours;
+                    return true;
+                case TradierOrderProperties properties:
+                    outsideRegularTradingHours = properties.OutsideRegularTradingHours;
+                    return true;
+                case TradeStationOrderProperties properties:
+                    outsideRegularTradingHours = properties.OutsideRegularTradingHours;
+                    return true;
+                default:
+                    outsideRegularTradingHours = false;
+                    return false;
+            }
         }
 
         private class ComboLimitOrderLegParameters

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -1095,11 +1095,6 @@ namespace QuantConnect.Orders.Fills
                 }
 
                 var barSpan = currentBar.EndTime - currentBar.Time;
-                if (barSpan < Time.OneHour)
-                {
-                    return false;
-                }
-
                 var isOnCurrentBar = barSpan > Time.OneHour
                     // for fill purposes we consider the market open for daily bars if we are in the same day
                     ? asset.LocalTime.Date == currentBar.EndTime.Date
@@ -1119,7 +1114,9 @@ namespace QuantConnect.Orders.Fills
         {
             if (TryGetOutsideRegularTradingHours(order, out var outsideRegularTradingHours))
             {
-                isExtendedMarketHours = outsideRegularTradingHours;
+                return outsideRegularTradingHours
+                    ? IsExchangeOpen(asset, true)
+                    : asset.Exchange.Hours.IsOpen(asset.LocalTime, false);
             }
 
             return IsExchangeOpen(asset, isExtendedMarketHours);
@@ -1129,7 +1126,9 @@ namespace QuantConnect.Orders.Fills
         {
             if (TryGetOutsideRegularTradingHours(order, out var outsideRegularTradingHours))
             {
-                return IsExchangeOpen(asset, outsideRegularTradingHours);
+                return outsideRegularTradingHours
+                    ? IsExchangeOpen(asset, true)
+                    : asset.Exchange.Hours.IsOpen(asset.LocalTime, false);
             }
 
             return IsExchangeOpen(asset);

--- a/Tests/Common/Orders/Fills/EquityFillModelTests.StopMarketFill.cs
+++ b/Tests/Common/Orders/Fills/EquityFillModelTests.StopMarketFill.cs
@@ -236,25 +236,28 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             Assert.AreEqual(OrderStatus.None, fill.Status);
         }
 
-        [TestCase(false, OrderStatus.None, 0)]
-        [TestCase(true, OrderStatus.Filled, 10)]
-        public void StopMarketOrderRespectsOutsideRegularTradingHours(bool outsideRegularTradingHours, OrderStatus expectedStatus, decimal expectedQuantity)
+        [TestCase(true, OrderStatus.None, 0)]
+        [TestCase(false, OrderStatus.Filled, 10)]
+        public void StopMarketOrderRespectsOutsideRegularTradingHours(bool submitOutsideRegularHoursRestriction, OrderStatus expectedStatus, decimal expectedQuantity)
         {
             var time = new DateTime(2026, 5, 5, 9, 29, 0);
             var timeKeeper = new TimeKeeper(time.ConvertToUtc(TimeZones.NewYork), TimeZones.NewYork);
             var fillModel = new EquityFillModel();
             var configTradeBar = CreateTradeBarConfig(Symbols.SPY, extendedHours: true);
             var equity = CreateEquity(configTradeBar);
+            var orderProperties = submitOutsideRegularHoursRestriction
+                ? new TradeStationOrderProperties
+                {
+                    TimeInForce = TimeInForce.Day,
+                    OutsideRegularTradingHours = false
+                }
+                : null;
             var order = new StopMarketOrder(
                 Symbols.SPY,
                 10,
                 1m,
                 time.ConvertToUtc(TimeZones.NewYork),
-                properties: new TradeStationOrderProperties
-                {
-                    TimeInForce = TimeInForce.Day,
-                    OutsideRegularTradingHours = outsideRegularTradingHours
-                });
+                properties: orderProperties);
 
             equity.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             equity.SetMarketPrice(new TradeBar(time, Symbols.SPY, 100m, 101m, 99m, 100m, 100, Time.OneMinute));

--- a/Tests/Common/Orders/Fills/EquityFillModelTests.StopMarketFill.cs
+++ b/Tests/Common/Orders/Fills/EquityFillModelTests.StopMarketFill.cs
@@ -236,6 +236,40 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             Assert.AreEqual(OrderStatus.None, fill.Status);
         }
 
+        [TestCase(false, OrderStatus.None, 0)]
+        [TestCase(true, OrderStatus.Filled, 10)]
+        public void StopMarketOrderRespectsOutsideRegularTradingHours(bool outsideRegularTradingHours, OrderStatus expectedStatus, decimal expectedQuantity)
+        {
+            var time = new DateTime(2026, 5, 5, 9, 29, 0);
+            var timeKeeper = new TimeKeeper(time.ConvertToUtc(TimeZones.NewYork), TimeZones.NewYork);
+            var fillModel = new EquityFillModel();
+            var configTradeBar = CreateTradeBarConfig(Symbols.SPY, extendedHours: true);
+            var equity = CreateEquity(configTradeBar);
+            var order = new StopMarketOrder(
+                Symbols.SPY,
+                10,
+                1m,
+                time.ConvertToUtc(TimeZones.NewYork),
+                properties: new TradeStationOrderProperties
+                {
+                    TimeInForce = TimeInForce.Day,
+                    OutsideRegularTradingHours = outsideRegularTradingHours
+                });
+
+            equity.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+            equity.SetMarketPrice(new TradeBar(time, Symbols.SPY, 100m, 101m, 99m, 100m, 100, Time.OneMinute));
+
+            var fill = fillModel.Fill(new FillModelParameters(
+                equity,
+                order,
+                new MockSubscriptionDataConfigProvider(configTradeBar),
+                Time.OneHour,
+                null)).Single();
+
+            Assert.AreEqual(expectedStatus, fill.Status);
+            Assert.AreEqual(expectedQuantity, fill.FillQuantity);
+        }
+
         [TestCase(100, 290.50)]
         [TestCase(-100, 291.50)]
         public void StopMarketOrderFillsAtOpenWithUnfavourableGap(decimal orderQuantity, decimal stopPrice)

--- a/Tests/Common/Orders/Fills/EquityFillModelTests.StopMarketFill.cs
+++ b/Tests/Common/Orders/Fills/EquityFillModelTests.StopMarketFill.cs
@@ -236,28 +236,23 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             Assert.AreEqual(OrderStatus.None, fill.Status);
         }
 
-        [TestCase(true, OrderStatus.None, 0)]
-        [TestCase(false, OrderStatus.Filled, 10)]
-        public void StopMarketOrderRespectsOutsideRegularTradingHours(bool submitOutsideRegularHoursRestriction, OrderStatus expectedStatus, decimal expectedQuantity)
+        public void StopMarketOrderRespectsOutsideRegularTradingHours()
         {
             var time = new DateTime(2026, 5, 5, 9, 29, 0);
             var timeKeeper = new TimeKeeper(time.ConvertToUtc(TimeZones.NewYork), TimeZones.NewYork);
             var fillModel = new EquityFillModel();
             var configTradeBar = CreateTradeBarConfig(Symbols.SPY, extendedHours: true);
             var equity = CreateEquity(configTradeBar);
-            var orderProperties = submitOutsideRegularHoursRestriction
-                ? new TradeStationOrderProperties
-                {
-                    TimeInForce = TimeInForce.Day,
-                    OutsideRegularTradingHours = false
-                }
-                : null;
             var order = new StopMarketOrder(
                 Symbols.SPY,
                 10,
                 1m,
                 time.ConvertToUtc(TimeZones.NewYork),
-                properties: orderProperties);
+                properties: new TradeStationOrderProperties
+                {
+                    TimeInForce = TimeInForce.Day,
+                    OutsideRegularTradingHours = false
+                });
 
             equity.SetLocalTimeKeeper(timeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
             equity.SetMarketPrice(new TradeBar(time, Symbols.SPY, 100m, 101m, 99m, 100m, 100, Time.OneMinute));
@@ -269,8 +264,8 @@ namespace QuantConnect.Tests.Common.Orders.Fills
                 Time.OneHour,
                 null)).Single();
 
-            Assert.AreEqual(expectedStatus, fill.Status);
-            Assert.AreEqual(expectedQuantity, fill.FillQuantity);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+            Assert.AreEqual(0, fill.FillQuantity);
         }
 
         [TestCase(100, 290.50)]


### PR DESCRIPTION
#### Description
Updates fill eligibility to respect order-level outside regular trading hours settings when the order properties expose that setting. This prevents extended-hours subscriptions from filling orders that explicitly disallow outside regular trading hours.

The shared exchange-open helper now applies the order property override before checking market hours, and short bars no longer use the large-bar boundary fallback when the exchange is closed at the order time.

#### Related Issue
Fixes #9476

#### Motivation and Context
A stop market order submitted during pre-market data could fill when the subscription had extended market hours enabled, even if the order property set `OutsideRegularTradingHours = false`.

#### Requires Documentation Change
No

#### How Has This Been Tested?
- `dotnet build Tests\QuantConnect.Tests.csproj --no-restore -v minimal /p:RunAnalyzers=false`
- Added a regression test covering both allowed and disallowed outside-regular-hours stop market fills.

#### Types of Changes
- Bug fix
- Tests