### PR TITLE
Fix open interest future universe history lookup

### DIFF
--- a/Algorithm.Framework/Selection/OpenInterestFutureUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/OpenInterestFutureUniverseSelectionModel.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NodaTime;
 using Python.Runtime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
@@ -31,6 +30,8 @@ namespace QuantConnect.Algorithm.Framework.Selection
     /// </summary>
     public class OpenInterestFutureUniverseSelectionModel : FutureUniverseSelectionModel
     {
+        private static readonly TimeSpan OpenInterestHistoryLookback = TimeSpan.FromDays(7);
+
         private readonly int? _chainContractsLookupLimit;
         private readonly IAlgorithm _algorithm;
         private readonly int? _resultsLimit;
@@ -116,11 +117,10 @@ namespace QuantConnect.Algorithm.Framework.Selection
         {
             var current = _algorithm.UtcTime;
             var exchangeHours = marketHours.ExchangeHours;
-            var endTime = Instant.FromDateTimeUtc(_algorithm.UtcTime).InZone(exchangeHours.TimeZone).ToDateTimeUnspecified();
-            var previousDay = Time.GetStartTimeForTradeBars(exchangeHours, endTime, Time.OneDay, 1, true, marketHours.DataTimeZone);
+            var startTime = current - OpenInterestHistoryLookback;
             var requests = symbols.Select(
                     symbol => new HistoryRequest(
-                        previousDay,
+                        startTime,
                         current,
                         typeof(Tick),
                         symbol,
@@ -139,7 +139,7 @@ namespace QuantConnect.Algorithm.Framework.Selection
                 .Where(s => s.HasData && s.Ticks.Keys.Count > 0)
                 .SelectMany(s => s.Ticks.Select(x => new Tuple<Symbol, Tick>(x.Key, x.Value.LastOrDefault())))
                 .GroupBy(x => x.Item1)
-                .ToDictionary(x => x.Key, x => x.OrderByDescending(i => i.Item2.Time).LastOrDefault().Item2.Value);
+                .ToDictionary(x => x.Key, x => x.OrderByDescending(i => i.Item2.Time).FirstOrDefault().Item2.Value);
         }
 
         /// <summary>

--- a/Tests/Algorithm/Framework/Selection/OpenInterestFutureUniverseSelectionModelTests.cs
+++ b/Tests/Algorithm/Framework/Selection/OpenInterestFutureUniverseSelectionModelTests.cs
@@ -35,7 +35,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Selection
         private static readonly Symbol March = Symbol.CreateFuture(Futures.Metals.Gold, Market.COMEX, new DateTime(2020, 03, 01));
         private static readonly Symbol April = Symbol.CreateFuture(Futures.Metals.Gold, Market.COMEX, new DateTime(2020, 04, 01));
         private static readonly DateTime TestDate = new DateTime(2020, 05, 11, 0, 0, 0, DateTimeKind.Utc);
-        private static readonly DateTime ExpectedPreviousDate = new DateTime(2020, 05, 09, 20, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTime ExpectedPreviousDate = TestDate.AddDays(-7);
         private static readonly IReadOnlyDictionary<Symbol, decimal> OpenInterestData = new Dictionary<Symbol, decimal>
         {
             [Jan] = 3,
@@ -140,19 +140,68 @@ namespace QuantConnect.Tests.Algorithm.Framework.Selection
             Assert.AreEqual(items.Keys, results);
         }
 
-        private static Slice CreateReplySlice(Symbol symbol, decimal openInterest)
+        [Test]
+        public void Selects_Most_Recent_Open_Interest()
         {
-            var ticks = new Ticks {{symbol, new List<Tick> {new OpenInterest(TestDate, symbol, openInterest)}}};
-            return new Slice(TestDate, null, null, null, ticks, null, null, null, null, null, null, null, TestDate, true);
+            SetupSubject(OpenInterestData.Count, OpenInterestData.Count);
+            _mockHistoryProvider.Setup(x => x.GetHistory(It.IsAny<IEnumerable<HistoryRequest>>(), It.IsAny<DateTimeZone>()))
+                .Returns<IEnumerable<HistoryRequest>, DateTimeZone>((rq, tz) =>
+                    rq.SelectMany(r => new[]
+                    {
+                        CreateReplySlice(r.Symbol, 1, TestDate.AddDays(-5)),
+                        CreateReplySlice(r.Symbol, OpenInterestData[r.Symbol], TestDate.AddDays(-1))
+                    }).ToArray());
+
+            var data = OpenInterestData.Keys.ToDictionary(x => x, x => MarketHours);
+            var results = _underTest.FilterByOpenInterest(data).ToList();
+
+            Assert.AreEqual(4, results.Count);
+            Assert.AreEqual(Feb, results[0]);
+            Assert.AreEqual(Jan, results[1]);
+            Assert.AreEqual(March, results[2]);
+            Assert.AreEqual(April, results[3]);
         }
 
-        private void SetupSubject(int? testChainContractLookupLimit, int? testResultsLimit)
+        [Test]
+        public void Requests_Open_Interest_Across_Non_Trading_Days()
+        {
+            var mondayMidnight = new DateTime(2023, 02, 27, 0, 0, 0, DateTimeKind.Utc);
+            SetupSubject(OpenInterestData.Count, OpenInterestData.Count, mondayMidnight);
+
+            _mockHistoryProvider.Setup(x => x.GetHistory(It.IsAny<IEnumerable<HistoryRequest>>(), It.IsAny<DateTimeZone>()))
+                .Returns<IEnumerable<HistoryRequest>, DateTimeZone>((requests, tz) =>
+                {
+                    foreach (var request in requests)
+                    {
+                        Assert.AreEqual(mondayMidnight.AddDays(-7), request.StartTimeUtc);
+                        Assert.AreEqual(mondayMidnight, request.EndTimeUtc);
+                    }
+
+                    return requests.Select(r => CreateReplySlice(r.Symbol, OpenInterestData[r.Symbol], mondayMidnight.AddDays(-3))).ToArray();
+                })
+                .Verifiable();
+
+            var data = OpenInterestData.Keys.ToDictionary(x => x, x => MarketHours);
+            var results = _underTest.FilterByOpenInterest(data).ToList();
+
+            _mockHistoryProvider.Verify();
+            Assert.AreEqual(4, results.Count);
+        }
+
+        private static Slice CreateReplySlice(Symbol symbol, decimal openInterest, DateTime? time = null)
+        {
+            var sliceTime = time ?? TestDate;
+            var ticks = new Ticks {{symbol, new List<Tick> {new OpenInterest(sliceTime, symbol, openInterest)}}};
+            return new Slice(sliceTime, null, null, null, ticks, null, null, null, null, null, null, null, sliceTime, true);
+        }
+
+        private void SetupSubject(int? testChainContractLookupLimit, int? testResultsLimit, DateTime? utcTime = null)
         {
             _mockHistoryProvider = new Mock<IHistoryProvider>();
 
             var mockAlgorithm = new Mock<IAlgorithm>();
             mockAlgorithm.SetupGet(x => x.HistoryProvider).Returns(_mockHistoryProvider.Object);
-            mockAlgorithm.SetupGet(x => x.UtcTime).Returns(TestDate);
+            mockAlgorithm.SetupGet(x => x.UtcTime).Returns(utcTime ?? TestDate);
             _underTest = new OpenInterestFutureUniverseSelectionModel(mockAlgorithm.Object, _ => OpenInterestData.Keys, testChainContractLookupLimit, testResultsLimit);
         }
     }


### PR DESCRIPTION
#### Description
Fixes #7708.

The open interest universe model now requests a seven-day tick history window instead of a previous single trading-day window. This lets it recover the latest available open-interest tick when the selection time lands around weekends/non-trading days, including the February 27, 2023 case described in the issue.

#### Root cause
The previous request window could start on a non-trading day boundary after timezone rounding, causing the history provider to return no open-interest data even when recent data existed.

#### Changes
- Widened the open-interest history lookup to seven days.
- Select the most recent open-interest tick per contract from the returned history.
- Added tests for using the latest tick and requesting across non-trading days.

#### Testing
- Attempted: `dotnet test Tests\QuantConnect.Tests.csproj --filter OpenInterestFutureUniverseSelectionModelTests --no-restore`
- Result: local command hung during test startup/build and timed out twice (2 minutes, then 10 minutes) without fixture output.
