### PR TITLE
Make universe selection order deterministic

### DIFF
--- a/Algorithm.CSharp/MultipleUniverseSelectionOrderRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MultipleUniverseSelectionOrderRegressionAlgorithm.cs
@@ -1,0 +1,121 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Linq;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Fundamental;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting that multiple universe selection functions are called
+    /// in the order the universes were added to the algorithm
+    /// </summary>
+    public class MultipleUniverseSelectionOrderRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private int _selectionCallCount;
+
+        public override void Initialize()
+        {
+            SetStartDate(2014, 3, 24);
+            SetEndDate(2014, 3, 28);
+            UniverseSettings.Resolution = Resolution.Daily;
+
+            AddUniverse(SelectAssets1);
+            AddUniverse(SelectAssets2);
+            AddUniverse(SelectAssets3);
+        }
+
+        private IEnumerable<Symbol> SelectAssets1(IEnumerable<Fundamental> fundamentals)
+        {
+            ValidateSelectionOrder(1);
+            return Enumerable.Empty<Symbol>();
+        }
+
+        private IEnumerable<Symbol> SelectAssets2(IEnumerable<Fundamental> fundamentals)
+        {
+            ValidateSelectionOrder(2);
+            return Enumerable.Empty<Symbol>();
+        }
+
+        private IEnumerable<Symbol> SelectAssets3(IEnumerable<Fundamental> fundamentals)
+        {
+            ValidateSelectionOrder(3);
+            return Enumerable.Empty<Symbol>();
+        }
+
+        private void ValidateSelectionOrder(int universeIndex)
+        {
+            var expectedPositionInCycle = universeIndex - 1;
+            if (_selectionCallCount % 3 != expectedPositionInCycle)
+            {
+                throw new RegressionTestException($"Universes are not being selected in the order they were added. Expected universe {expectedPositionInCycle + 1} but got universe {universeIndex}.");
+            }
+            _selectionCallCount++;
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_selectionCallCount < 3)
+            {
+                throw new RegressionTestException($"Expected all 3 universes to be selected at least once, but got {_selectionCallCount} calls.");
+            }
+        }
+
+        public bool CanRunLocally { get; } = true;
+
+        public List<Language> Languages { get; } = new() { Language.CSharp };
+
+        public long DataPoints => -1;
+
+        public int AlgorithmHistoryDataPoints => 0;
+
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-0.404"},
+            {"Tracking Error", "0.094"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"Drawdown Recovery", "0"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm/QCAlgorithm.Universe.cs
+++ b/Algorithm/QCAlgorithm.Universe.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Collections.Specialized;
+using System.Threading;
 using NodaTime;
 using QuantConnect.Algorithm.Selection;
 using QuantConnect.Data;
@@ -33,6 +34,7 @@ namespace QuantConnect.Algorithm
         // save universe additions and apply at end of time step
         // this removes temporal dependencies from w/in initialize method
         // original motivation: adding equity/options to enforce equity raw data mode
+        private static int _universeCount;
         private readonly object _pendingUniverseAdditionsLock = new object();
         private readonly List<UserDefinedUniverseUpdate> _pendingUserDefinedUniverseSecurityChanges = new();
         private bool _pendingUniverseAdditions;
@@ -686,7 +688,7 @@ namespace QuantConnect.Algorithm
                 market ??= Market.USA;
                 if (string.IsNullOrEmpty(name))
                 {
-                    name = $"{dataType.Name}-{market}-{Guid.NewGuid()}";
+                    name = $"{dataType.Name}-{market}-{Interlocked.Increment(ref _universeCount):D10}-{Guid.NewGuid()}";
                 }
                 // same as 'AddData<>' 'T' type will be treated as custom/base data type with always open market hours
                 universeSymbol = QuantConnect.Symbol.Create(name, SecurityType.Base, market, baseDataType: dataType);

--- a/Common/Data/Fundamental/FundamentalUniverse.cs
+++ b/Common/Data/Fundamental/FundamentalUniverse.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Python.Runtime;
 using QuantConnect.Data.UniverseSelection;
 
@@ -31,6 +32,7 @@ namespace QuantConnect.Data.Fundamental
     /// </summary>
     public class FundamentalUniverse : BaseDataCollection
     {
+        private static int _universeCount;
         private static readonly Fundamental _factory = new();
 
         /// <summary>
@@ -106,7 +108,7 @@ namespace QuantConnect.Data.Fundamental
         public override Symbol UniverseSymbol(string market = null)
         {
             market ??= QuantConnect.Market.USA;
-            var ticker = $"{GetType().Name}-{market}-{Guid.NewGuid()}";
+            var ticker = $"{GetType().Name}-{market}-{Interlocked.Increment(ref _universeCount):D10}-{Guid.NewGuid()}";
             return Symbol.Create(ticker, SecurityType.Equity, market, baseDataType: GetType());
         }
 

--- a/Common/Data/UniverseSelection/BaseDataCollection.cs
+++ b/Common/Data/UniverseSelection/BaseDataCollection.cs
@@ -18,6 +18,7 @@ using System;
 using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using QuantConnect.Python;
 
 namespace QuantConnect.Data.UniverseSelection
@@ -27,6 +28,7 @@ namespace QuantConnect.Data.UniverseSelection
     /// </summary>
     public class BaseDataCollection : BaseData, IEnumerable<BaseData>
     {
+        private static int _universeCount;
         private DateTime _endTime;
 
         /// <summary>
@@ -152,7 +154,7 @@ namespace QuantConnect.Data.UniverseSelection
         public virtual Symbol UniverseSymbol(string market = null)
         {
             market ??= QuantConnect.Market.USA;
-            var ticker = $"{GetType().Name}-{market}-{Guid.NewGuid()}";
+            var ticker = $"{GetType().Name}-{market}-{Interlocked.Increment(ref _universeCount):D10}-{Guid.NewGuid()}";
             return Symbol.Create(ticker, SecurityType.Base, market, baseDataType: GetType());
         }
 

--- a/Common/Data/UniverseSelection/ETFConstituentsUniverseFactory.cs
+++ b/Common/Data/UniverseSelection/ETFConstituentsUniverseFactory.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Python.Runtime;
 
 namespace QuantConnect.Data.UniverseSelection
@@ -25,6 +26,7 @@ namespace QuantConnect.Data.UniverseSelection
     /// </summary>
     public class ETFConstituentsUniverseFactory : ConstituentsUniverse<ETFConstituentUniverse>
     {
+        private static int _universeCount;
         private const string _etfConstituentsUniverseIdentifier = "qc-universe-etf-constituents";
 
         /// <summary>
@@ -56,8 +58,7 @@ namespace QuantConnect.Data.UniverseSelection
         /// <returns>Universe Symbol with ETF set as underlying</returns>
         private static Symbol CreateConstituentUniverseETFSymbol(Symbol compositeSymbol)
         {
-            var guid = Guid.NewGuid().ToString();
-            var universeTicker = _etfConstituentsUniverseIdentifier + '-' + guid;
+            var universeTicker = $"{_etfConstituentsUniverseIdentifier}-{Interlocked.Increment(ref _universeCount):D10}-{Guid.NewGuid()}";
 
             return new Symbol(
                 SecurityIdentifier.GenerateConstituentIdentifier(

--- a/Tests/Algorithm/AlgorithmAddUniverseTests.cs
+++ b/Tests/Algorithm/AlgorithmAddUniverseTests.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using NUnit.Framework;
 using Python.Runtime;
 using QuantConnect.Algorithm;
+using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Tests.Engine.DataFeeds;
 
@@ -37,7 +38,7 @@ namespace QuantConnect.Tests.Algorithm
         {
             AssertConstituentUniverseDefinitionsSymbol(ticker, market, false, true, true);
         }
-        
+
         [TestCaseSource(nameof(ETFConstituentUniverseTestCases))]
         public void AddUniverseWithETFConstituentUniverseDefinitionSymbol(string ticker, string market)
         {
@@ -86,35 +87,35 @@ namespace QuantConnect.Tests.Algorithm
             if (isSymbol && isEtf)
             {
                 constituentUniverse = isPython
-                    ? algo.Universe.ETF(symbol, algo.UniverseSettings, (PyObject) null)
+                    ? algo.Universe.ETF(symbol, algo.UniverseSettings, (PyObject)null)
                     : algo.Universe.ETF(symbol, algo.UniverseSettings, CreateReturnAllFunc());
             }
             else if (isEtf)
             {
                 constituentUniverse = isPython
-                    ? algo.Universe.ETF(ticker, market, algo.UniverseSettings, (PyObject) null)
+                    ? algo.Universe.ETF(ticker, market, algo.UniverseSettings, (PyObject)null)
                     : algo.Universe.ETF(ticker, market, algo.UniverseSettings, CreateReturnAllFunc());
             }
             else if (isSymbol)
             {
                 constituentUniverse = isPython
-                    ? algo.Universe.Index(symbol, algo.UniverseSettings, (PyObject) null)
+                    ? algo.Universe.Index(symbol, algo.UniverseSettings, (PyObject)null)
                     : algo.Universe.Index(symbol, algo.UniverseSettings, CreateReturnAllFunc());
             }
             else
             {
                 constituentUniverse = isPython
-                    ? algo.Universe.Index(ticker, market, algo.UniverseSettings, (PyObject) null)
+                    ? algo.Universe.Index(ticker, market, algo.UniverseSettings, (PyObject)null)
                     : algo.Universe.Index(ticker, market, algo.UniverseSettings, CreateReturnAllFunc());
             }
 
             Assert.IsTrue(constituentUniverse.Configuration.Symbol.HasUnderlying);
             Assert.AreEqual(symbol, constituentUniverse.Configuration.Symbol.Underlying);
-            
+
             Assert.AreEqual(symbol.SecurityType, constituentUniverse.Configuration.Symbol.SecurityType);
             Assert.IsTrue(constituentUniverse.Configuration.Symbol.ID.Symbol.StartsWithInvariant("qc-universe-"));
         }
-        
+
         private static TestCaseData[] ETFConstituentUniverseTestCases()
         {
             return new[]
@@ -147,6 +148,35 @@ namespace QuantConnect.Tests.Algorithm
         private Func<IEnumerable<ETFConstituentUniverse>, IEnumerable<Symbol>> CreateReturnAllFunc()
         {
             return x => x.Select(y => y.Symbol);
+        }
+
+        [TestCase(typeof(BaseDataCollection))]
+        [TestCase(typeof(FundamentalUniverse))]
+        [TestCase(typeof(ETFConstituentsUniverseFactory))]
+        public void UniverseSymbolsSortInCreationOrder(Type dataType)
+        {
+            Symbol symbol1, symbol2, symbol3;
+            if (dataType == typeof(ETFConstituentsUniverseFactory))
+            {
+                var composite = Symbol.Create("SPY", SecurityType.Equity, Market.USA);
+                using var universe1 = new ETFConstituentsUniverseFactory(composite, null);
+                using var universe2 = new ETFConstituentsUniverseFactory(composite, null);
+                using var universe3 = new ETFConstituentsUniverseFactory(composite, null);
+                symbol1 = universe1.Configuration.Symbol;
+                symbol2 = universe2.Configuration.Symbol;
+                symbol3 = universe3.Configuration.Symbol;
+            }
+            else
+            {
+                var instance = (BaseDataCollection)Activator.CreateInstance(dataType);
+                symbol1 = instance.UniverseSymbol();
+                symbol2 = instance.UniverseSymbol();
+                symbol3 = instance.UniverseSymbol();
+            }
+
+            var comparer = StringComparer.OrdinalIgnoreCase;
+            Assert.That(comparer.Compare(symbol1.Value, symbol2.Value) < 0);
+            Assert.That(comparer.Compare(symbol2.Value, symbol3.Value) < 0);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Added a static counter prepended to the universe symbol ticker so lexicographic sort matches creation order, making universe selection order deterministic

#### Related Issue
Closes #9435

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit and regression tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
