### PR TITLE
feature: map exchange string to primary exchange on level one ticks

### DIFF
--- a/Brokerages/LevelOneOrderBook/LevelOneMarketData.cs
+++ b/Brokerages/LevelOneOrderBook/LevelOneMarketData.cs
@@ -111,7 +111,9 @@ namespace QuantConnect.Brokerages.LevelOneOrderBook
         /// <param name="bidSize">The size available at the best bid.</param>
         /// <param name="askPrice">The best ask price.</param>
         /// <param name="askSize">The size available at the best ask.</param>
-        public void UpdateQuote(DateTime? quoteDateTimeUtc, decimal? bidPrice, decimal? bidSize, decimal? askPrice, decimal? askSize)
+        /// <param name="saleCondition">The sale condition string.</param>
+        /// <param name="exchange">The exchange identifier.</param>
+        public void UpdateQuote(DateTime? quoteDateTimeUtc, decimal? bidPrice, decimal? bidSize, decimal? askPrice, decimal? askSize, string saleCondition, string exchange)
         {
             if (!IsValidTimestamp(quoteDateTimeUtc))
             {
@@ -141,10 +143,24 @@ namespace QuantConnect.Brokerages.LevelOneOrderBook
 
             if (isBidUpdated || isAskUpdated)
             {
-                var lastQuoteTick = new Tick(quoteDateTimeUtc.Value.ConvertFromUtc(SymbolDateTimeZone), Symbol, BestBidSize, BestBidPrice, BestAskSize, BestAskPrice);
+                var lastQuoteTick = new Tick(quoteDateTimeUtc.Value.ConvertFromUtc(SymbolDateTimeZone), Symbol, saleCondition, exchange.GetPrimaryExchange(Symbol.SecurityType), BestBidSize, BestBidPrice, BestAskSize, BestAskPrice);
 
                 BaseDataReceived?.Invoke(this, new(lastQuoteTick));
             }
+        }
+
+        /// <summary>
+        /// Updates the best bid and ask prices and sizes.
+        /// Constructs and publishes a quote <see cref="Tick"/> to the <see cref="IDataAggregator"/>.
+        /// </summary>
+        /// <param name="quoteDateTimeUtc">The UTC timestamp when the quote was received.</param>
+        /// <param name="bidPrice">The best bid price.</param>
+        /// <param name="bidSize">The size available at the best bid.</param>
+        /// <param name="askPrice">The best ask price.</param>
+        /// <param name="askSize">The size available at the best ask.</param>
+        public void UpdateQuote(DateTime? quoteDateTimeUtc, decimal? bidPrice, decimal? bidSize, decimal? askPrice, decimal? askSize)
+        {
+            UpdateQuote(quoteDateTimeUtc, bidPrice, bidSize, askPrice, askSize, string.Empty, string.Empty);
         }
 
         /// <summary>
@@ -175,7 +191,7 @@ namespace QuantConnect.Brokerages.LevelOneOrderBook
                 tradeDateTimeUtc.Value.ConvertFromUtc(SymbolDateTimeZone),
                 Symbol,
                 saleCondition,
-                exchange,
+                exchange.GetPrimaryExchange(Symbol.SecurityType),
                 LastTradeSize,
                 LastTradePrice);
 

--- a/Tests/Brokerages/LevelOneOrderBook/LevelOneMarketDataTests.cs
+++ b/Tests/Brokerages/LevelOneOrderBook/LevelOneMarketDataTests.cs
@@ -15,6 +15,7 @@
 
 using System;
 using NUnit.Framework;
+using QuantConnect.Data.Market;
 using QuantConnect.Brokerages.LevelOneOrderBook;
 
 namespace QuantConnect.Tests.Brokerages.LevelOneOrderBook
@@ -174,6 +175,40 @@ namespace QuantConnect.Tests.Brokerages.LevelOneOrderBook
                 Assert.AreEqual(bidSize, levelOneMarketData.BestAskSize, "Bid size should be overwritten with 0.");
                 Assert.AreEqual(askSize, levelOneMarketData.BestBidSize, "Ask size should be overwritten with 0.");
             }
+        }
+
+        [TestCase("T", "NASDAQ")]
+        [TestCase("Z", "BATS")]
+        [TestCase("N", "NYSE")]
+        [TestCase("P", "ARCA")]
+        [TestCase("", "")]
+        [TestCase(null, "")]
+        public void LevelOneMarketDataShouldMapExchangeStringOnPublishedTicks(string exchange, string expectedExchange)
+        {
+            var levelOneMarketData = new LevelOneMarketData(_aapl);
+            var quoteTick = default(Tick);
+            var tradeTick = default(Tick);
+
+            levelOneMarketData.BaseDataReceived += (_, e) =>
+            {
+                var tick = (Tick)e.BaseData;
+                if (tick.TickType == TickType.Quote)
+                {
+                    quoteTick = tick;
+                }
+                else if (tick.TickType == TickType.Trade)
+                {
+                    tradeTick = tick;
+                }
+            };
+
+            levelOneMarketData.UpdateQuote(_mockDateTime, 1, 1, 1, 1, saleCondition: string.Empty, exchange: exchange);
+            levelOneMarketData.UpdateLastTrade(_mockDateTime, 1, 1, exchange: exchange);
+
+            Assert.IsNotNull(quoteTick, "Expected BaseDataReceived to publish a quote tick.");
+            Assert.IsNotNull(tradeTick, "Expected BaseDataReceived to publish a trade tick.");
+            Assert.AreEqual(expectedExchange, quoteTick.Exchange, "Quote tick exchange mismatch.");
+            Assert.AreEqual(expectedExchange, tradeTick.Exchange, "Trade tick exchange mismatch.");
         }
 
         [TestCase(true, 0, 2)]


### PR DESCRIPTION
#### Description
Adds `saleCondition` and `exchange` parameters to `LevelOneMarketData.UpdateQuote` and normalizes the exchange string through `GetPrimaryExchange` on both `UpdateQuote` and `UpdateLastTrade`. Resulting ticks now carry the canonical primary exchange name (e.g. `"T"` → `"NASDAQ"`, `"Z"` → `"BATS"`) instead of the raw broker-provided code.

#### Related Issue
N/A

#### Motivation and Context
Brokerage providers send exchange identifiers as short codes (`T`, `Z`, `N`, `P`, ...). Without normalization, downstream consumers see the raw code and have to map it themselves. Centralizing the mapping at tick-construction time gives a consistent `Tick.Exchange` value across the engine and matches the behavior already used by `UpdateLastTrade`'s sibling code paths.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Added a combined NUnit test in `Tests/Brokerages/LevelOneOrderBook/LevelOneMarketDataTests.cs`:

- `LevelOneMarketDataShouldMapExchangeStringOnPublishedTicks` subscribes to `BaseDataReceived` and asserts the resulting `Tick.Exchange` for both the quote tick (`UpdateQuote`) and the trade tick (`UpdateLastTrade`).
- Covered cases: `"T"` → `"NASDAQ"`, `"Z"` → `"BATS"`, `"N"` → `"NYSE"`, `"P"` → `"ARCA"`, `""` → `""`, `null` → `""`.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`