### PR TITLE
Fix ScheduledUniverse emitting triggers past end time

### DIFF
--- a/Algorithm.CSharp/BaseFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/BaseFrameworkRegressionAlgorithm.cs
@@ -80,7 +80,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public virtual long DataPoints => 765;
+        public virtual long DataPoints => 764;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/EmaCrossAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/EmaCrossAlphaModelFrameworkRegressionAlgorithm.cs
@@ -48,7 +48,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "38"},
             {"Average Win", "0.36%"},
             {"Average Loss", "-0.17%"},
-            {"Compounding Annual Return", "68.881%"},
+            {"Compounding Annual Return", "69.878%"},
             {"Drawdown", "0.900%"},
             {"Expectancy", "1.552"},
             {"Start Equity", "100000"},

--- a/Algorithm.CSharp/HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/HistoricalReturnsAlphaModelFrameworkRegressionAlgorithm.cs
@@ -39,7 +39,7 @@ namespace QuantConnect.Algorithm.CSharp
             }
         }
 
-        public override long DataPoints => 779;
+        public override long DataPoints => 778;
 
         public override int AlgorithmHistoryDataPoints => 4;
 
@@ -56,7 +56,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "69"},
             {"Average Win", "0.18%"},
             {"Average Loss", "-0.15%"},
-            {"Compounding Annual Return", "42.429%"},
+            {"Compounding Annual Return", "42.996%"},
             {"Drawdown", "0.900%"},
             {"Expectancy", "0.367"},
             {"Start Equity", "100000"},

--- a/Algorithm.CSharp/MacdAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/MacdAlphaModelFrameworkRegressionAlgorithm.cs
@@ -54,7 +54,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "29"},
             {"Average Win", "0.36%"},
             {"Average Loss", "-0.49%"},
-            {"Compounding Annual Return", "30.410%"},
+            {"Compounding Annual Return", "30.800%"},
             {"Drawdown", "1.800%"},
             {"Expectancy", "0.335"},
             {"Start Equity", "100000"},

--- a/Algorithm.CSharp/OnWarmupFinishedScheduledUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OnWarmupFinishedScheduledUniverseRegressionAlgorithm.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Algorithm.CSharp
 
         public List<Language> Languages { get; } = new() { Language.CSharp };
 
-        public long DataPoints => 3948;
+        public long DataPoints => 3947;
 
         public int AlgorithmHistoryDataPoints => 0;
 
@@ -96,8 +96,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "0"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-31.448"},
-            {"Tracking Error", "0.164"},
+            {"Information Ratio", "-57.739"},
+            {"Tracking Error", "0.178"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},

--- a/Algorithm.CSharp/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.cs
+++ b/Algorithm.CSharp/PearsonCorrelationPairsTradingAlphaModelFrameworkAlgorithm.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 14089;
+        public long DataPoints => 14088;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -99,7 +99,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "6"},
             {"Average Win", "0.99%"},
             {"Average Loss", "-0.84%"},
-            {"Compounding Annual Return", "24.021%"},
+            {"Compounding Annual Return", "25.943%"},
             {"Drawdown", "0.800%"},
             {"Expectancy", "0.089"},
             {"Start Equity", "100000"},

--- a/Algorithm.CSharp/RsiAlphaModelFrameworkRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RsiAlphaModelFrameworkRegressionAlgorithm.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.Algorithm.CSharp
             }
         }
 
-        public override long DataPoints => 772;
+        public override long DataPoints => 771;
 
         public override int AlgorithmHistoryDataPoints => 56;
 
@@ -58,7 +58,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "28"},
             {"Average Win", "0.14%"},
             {"Average Loss", "-0.08%"},
-            {"Compounding Annual Return", "0.234%"},
+            {"Compounding Annual Return", "0.237%"},
             {"Drawdown", "1.900%"},
             {"Expectancy", "0.186"},
             {"Start Equity", "100000"},

--- a/Algorithm.CSharp/ScheduledUniverseRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ScheduledUniverseRegressionAlgorithm.cs
@@ -88,7 +88,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 1584;
+        public long DataPoints => 1583;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -108,29 +108,29 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "1"},
             {"Average Win", "0%"},
             {"Average Loss", "0%"},
-            {"Compounding Annual Return", "-87.920%"},
-            {"Drawdown", "1.700%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
             {"Expectancy", "0"},
             {"Start Equity", "100000"},
             {"End Equity", "98824.68"},
-            {"Net Profit", "-1.175%"},
-            {"Sharpe Ratio", "-5.981"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
             {"Sortino Ratio", "0"},
             {"Probabilistic Sharpe Ratio", "0%"},
             {"Loss Rate", "0%"},
             {"Win Rate", "0%"},
             {"Profit-Loss Ratio", "0"},
-            {"Alpha", "-0.002"},
-            {"Beta", "0.996"},
-            {"Annual Standard Deviation", "0.13"},
-            {"Annual Variance", "0.017"},
-            {"Information Ratio", "2.618"},
-            {"Tracking Error", "0.001"},
-            {"Treynor Ratio", "-0.778"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
             {"Total Fees", "$3.44"},
             {"Estimated Strategy Capacity", "$56000000.00"},
             {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
-            {"Portfolio Turnover", "33.21%"},
+            {"Portfolio Turnover", "49.82%"},
             {"Drawdown Recovery", "0"},
             {"OrderListHash", "3da9fa60bf95b9ed148b95e02e0cfc9e"}
         };

--- a/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
@@ -194,7 +194,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 989;
+        public long DataPoints => 987;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -214,29 +214,29 @@ namespace QuantConnect.Algorithm.CSharp
             {"Total Orders", "59"},
             {"Average Win", "0.28%"},
             {"Average Loss", "-0.20%"},
-            {"Compounding Annual Return", "73.882%"},
+            {"Compounding Annual Return", "75.392%"},
             {"Drawdown", "1.100%"},
             {"Expectancy", "0.749"},
             {"Start Equity", "100000"},
             {"End Equity", "105049.17"},
             {"Net Profit", "5.049%"},
-            {"Sharpe Ratio", "7.048"},
-            {"Sortino Ratio", "10.495"},
-            {"Probabilistic Sharpe Ratio", "96.425%"},
+            {"Sharpe Ratio", "7.229"},
+            {"Sortino Ratio", "10.917"},
+            {"Probabilistic Sharpe Ratio", "96.421%"},
             {"Loss Rate", "27%"},
             {"Win Rate", "73%"},
             {"Profit-Loss Ratio", "1.39"},
-            {"Alpha", "0.458"},
-            {"Beta", "0.044"},
-            {"Annual Standard Deviation", "0.066"},
+            {"Alpha", "0.477"},
+            {"Beta", "0.042"},
+            {"Annual Standard Deviation", "0.067"},
             {"Annual Variance", "0.004"},
-            {"Information Ratio", "3.893"},
-            {"Tracking Error", "0.083"},
-            {"Treynor Ratio", "10.5"},
+            {"Information Ratio", "3.991"},
+            {"Tracking Error", "0.084"},
+            {"Treynor Ratio", "11.625"},
             {"Total Fees", "$35.53"},
             {"Estimated Strategy Capacity", "$2600000.00"},
             {"Lowest Capacity Asset", "EURUSD 8G"},
-            {"Portfolio Turnover", "87.56%"},
+            {"Portfolio Turnover", "90.30%"},
             {"Drawdown Recovery", "3"},
             {"OrderListHash", "9af211e68f600642a2aaa58f3bec6380"}
         };

--- a/Algorithm.CSharp/TimeRulesDefaultTimeZoneRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TimeRulesDefaultTimeZoneRegressionAlgorithm.cs
@@ -90,7 +90,7 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 throw new RegressionTestException($"Unexpected universe selection call count: {_selectionMethodCallCount}");
             }
-            if (_scheduleEventEveryCallCount != 130)
+            if (_scheduleEventEveryCallCount != 127)
             {
                 throw new RegressionTestException($"Unexpected scheduled event call count: {_scheduleEventEveryCallCount}");
             }
@@ -117,7 +117,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public long DataPoints => 187;
+        public long DataPoints => 186;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -153,8 +153,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "0"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-2.962"},
-            {"Tracking Error", "0.052"},
+            {"Information Ratio", "-3.002"},
+            {"Tracking Error", "0.054"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},

--- a/Algorithm.CSharp/TimeRulesDefaultTimeZoneRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/TimeRulesDefaultTimeZoneRegressionAlgorithm.cs
@@ -98,7 +98,7 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 throw new RegressionTestException($"Unexpected scheduled event call count: {_scheduleEventNoonCallCount}");
             }
-            if (_scheduleEventMidnightCallCount != 33)
+            if (_scheduleEventMidnightCallCount != 32)
             {
                 throw new RegressionTestException($"Unexpected scheduled event call count: {_scheduleEventMidnightCallCount}");
             }
@@ -153,8 +153,8 @@ namespace QuantConnect.Algorithm.CSharp
             {"Beta", "0"},
             {"Annual Standard Deviation", "0"},
             {"Annual Variance", "0"},
-            {"Information Ratio", "-3.002"},
-            {"Tracking Error", "0.054"},
+            {"Information Ratio", "-3.017"},
+            {"Tracking Error", "0.053"},
             {"Treynor Ratio", "0"},
             {"Total Fees", "$0.00"},
             {"Estimated Strategy Capacity", "$0"},

--- a/Common/Data/UniverseSelection/ScheduledUniverse.cs
+++ b/Common/Data/UniverseSelection/ScheduledUniverse.cs
@@ -103,7 +103,8 @@ namespace QuantConnect.Data.UniverseSelection
         }
 
         /// <summary>
-        /// Get an enumerator of UTC DateTimes that defines when this universe will be invoked
+        /// Get an enumerator of UTC DateTimes that defines when this universe will be invoked,
+        /// only including times within [startTimeUtc, endTimeUtc], both bounds inclusive.
         /// </summary>
         /// <param name="startTimeUtc">The start time of the range in UTC</param>
         /// <param name="endTimeUtc">The end time of the range in UTC</param>

--- a/Common/Data/UniverseSelection/ScheduledUniverse.cs
+++ b/Common/Data/UniverseSelection/ScheduledUniverse.cs
@@ -132,6 +132,11 @@ namespace QuantConnect.Data.UniverseSelection
             // Start yielding times
             do
             {
+                if (times.Current > endTimeUtc)
+                {
+                    times.Dispose();
+                    yield break;
+                }
                 yield return times.Current;
             }
             while (times.MoveNext());

--- a/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
+++ b/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
@@ -49,7 +49,7 @@ namespace QuantConnect.Tests.Common.Data.UniverseSelection
         public void TimeTriggeredDoesNotReturnPastTimes()
         {
             // Schedule our universe for 12PM each day
-            using var universe = new ScheduledUniverse( 
+            using var universe = new ScheduledUniverse(
                 _dateRules.EveryDay(), _timeRules.At(12, 0),
                 (time =>
                 {
@@ -84,6 +84,25 @@ namespace QuantConnect.Tests.Common.Data.UniverseSelection
         }
 
         [Test]
+        public void TimeTriggeredDoesNotReturnTimesAfterEndTime()
+        {
+            // Schedule our universe for 12PM each day
+            using var universe = new ScheduledUniverse(
+                _dateRules.EveryDay(), _timeRules.At(12, 0),
+                time => new List<Symbol>()
+            );
+
+            var start = new DateTime(2000, 1, 5, 8, 0, 0).ConvertToUtc(_timezone);
+            var end = new DateTime(2000, 1, 5, 11, 0, 0).ConvertToUtc(_timezone);
+
+            // Get our trigger times
+            var triggerTimes = universe.GetTriggerTimes(start, end, MarketHoursDatabase.AlwaysOpen).ToList();
+
+            // Assert that there are no trigger times because 12PM is after the end time of 11AM
+            Assert.IsEmpty(triggerTimes);
+        }
+
+        [Test]
         public void TriggerTimesNone()
         {
             // Test to see what happens when we expect no trigger times.
@@ -91,7 +110,7 @@ namespace QuantConnect.Tests.Common.Data.UniverseSelection
             // on a single day from 3pm-4pm, meaning we should get none.
             var timezone = TimeZones.NewYork;
             var start = new DateTime(2000, 1, 5, 15, 0, 0);
-            var end = new DateTime(2000, 1, 5, 16,0,0);
+            var end = new DateTime(2000, 1, 5, 16, 0, 0);
 
             var dateRule = _dateRules.EveryDay();
             var timeRule = _timeRules.At(12, 0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
ScheduledUniverse was yielding trigger times beyond endTimeUtc, causing backtests to run past the intended end date

#### Related Issue
Closes #9349

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
