### PR TITLE
Retain live statistics samples through chart trimming

### DIFF
--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -986,7 +986,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <summary>
         /// Will generate the statistics results and update the provided runtime statistics
         /// </summary>
-        protected StatisticsResults GenerateStatisticsResults(Dictionary<string, Chart> charts,
+        protected virtual StatisticsResults GenerateStatisticsResults(Dictionary<string, Chart> charts,
             SortedDictionary<DateTime, decimal> profitLoss = null, CapacityEstimate estimatedStrategyCapacity = null)
         {
             var statisticsResults = new StatisticsResults();

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -79,6 +79,16 @@ namespace QuantConnect.Lean.Engine.Results
         private bool _userExchangeIsOpen;
         private DateTime _lastChartSampleLogicCheck;
         private readonly Dictionary<string, SecurityExchangeHours> _exchangeHours;
+        private readonly object _statisticsRetentionLock = new();
+        private readonly Dictionary<string, Dictionary<string, RetainedStatisticsSeries>> _statisticsSeriesRetention = new();
+
+        private static readonly IReadOnlyList<Tuple<string, string>> StatisticsSeries = new[]
+        {
+            Tuple.Create(StrategyEquityKey, EquityKey),
+            Tuple.Create(StrategyEquityKey, ReturnKey),
+            Tuple.Create(BenchmarkKey, BenchmarkKey),
+            Tuple.Create(PortfolioTurnoverKey, PortfolioTurnoverKey)
+        };
 
 
         /// <summary>
@@ -93,6 +103,18 @@ namespace QuantConnect.Lean.Engine.Results
             _samplePortfolioPeriod = _storeInsightPeriod = TimeSpan.FromMinutes(10);
             _streamedChartLimit = Config.GetInt("streamed-chart-limit", 12);
             _streamedChartGroupSize = Config.GetInt("streamed-chart-group-size", 3);
+        }
+
+        /// <summary>
+        /// Samples portfolio equity, benchmark, and daily performance
+        /// Called by scheduled event every night at midnight algorithm time
+        /// </summary>
+        /// <param name="time">Current UTC time in the AlgorithmManager loop</param>
+        public override void Sample(DateTime time)
+        {
+            base.Sample(time);
+
+            RetainStatisticsSamples();
         }
 
         /// <summary>
@@ -643,6 +665,106 @@ namespace QuantConnect.Lean.Engine.Results
                 //Add our value:
                 series.Values.Add(value);
             }
+        }
+
+        /// <summary>
+        /// Will generate the statistics results and update the provided runtime statistics
+        /// </summary>
+        protected override StatisticsResults GenerateStatisticsResults(Dictionary<string, Chart> charts,
+            SortedDictionary<DateTime, decimal> profitLoss = null, CapacityEstimate estimatedStrategyCapacity = null)
+        {
+            MergeRetainedStatisticsSamples(charts);
+
+            return base.GenerateStatisticsResults(charts, profitLoss, estimatedStrategyCapacity);
+        }
+
+        private void RetainStatisticsSamples()
+        {
+            lock (ChartLock)
+            {
+                foreach (var retainedSeries in StatisticsSeries)
+                {
+                    if (Charts.TryGetValue(retainedSeries.Item1, out var chart) &&
+                        chart.Series.TryGetValue(retainedSeries.Item2, out var series) &&
+                        series.Values.Count > 0)
+                    {
+                        RetainStatisticsSample(retainedSeries.Item1, retainedSeries.Item2, series);
+                    }
+                }
+            }
+        }
+
+        private void RetainStatisticsSample(string chartName, string seriesName, BaseSeries series)
+        {
+            var value = series.Values.Last();
+
+            lock (_statisticsRetentionLock)
+            {
+                if (!_statisticsSeriesRetention.TryGetValue(chartName, out var chartRetention))
+                {
+                    chartRetention = new Dictionary<string, RetainedStatisticsSeries>();
+                    _statisticsSeriesRetention[chartName] = chartRetention;
+                }
+
+                if (!chartRetention.TryGetValue(seriesName, out var seriesRetention))
+                {
+                    seriesRetention = new RetainedStatisticsSeries(series.Clone(empty: true));
+                    chartRetention[seriesName] = seriesRetention;
+                }
+
+                var values = seriesRetention.Values;
+                if (values.Count > 0 && values[values.Count - 1].Time == value.Time)
+                {
+                    values[values.Count - 1] = value.Clone();
+                }
+                else
+                {
+                    values.Add(value.Clone());
+                }
+            }
+        }
+
+        private void MergeRetainedStatisticsSamples(Dictionary<string, Chart> charts)
+        {
+            lock (_statisticsRetentionLock)
+            {
+                foreach (var chartRetention in _statisticsSeriesRetention)
+                {
+                    if (!charts.TryGetValue(chartRetention.Key, out var chart))
+                    {
+                        chart = new Chart(chartRetention.Key);
+                        charts[chartRetention.Key] = chart;
+                    }
+
+                    foreach (var seriesRetention in chartRetention.Value)
+                    {
+                        if (!chart.Series.TryGetValue(seriesRetention.Key, out var series))
+                        {
+                            series = seriesRetention.Value.Template.Clone(empty: true);
+                            chart.Series[seriesRetention.Key] = series;
+                        }
+
+                        series.Values = series.Values
+                            .Concat(seriesRetention.Value.Values.Select(x => x.Clone()))
+                            .GroupBy(x => x.Time)
+                            .Select(x => x.Last())
+                            .OrderBy(x => x.Time)
+                            .ToList();
+                    }
+                }
+            }
+        }
+
+        private class RetainedStatisticsSeries
+        {
+            public RetainedStatisticsSeries(BaseSeries template)
+            {
+                Template = template;
+            }
+
+            public BaseSeries Template { get; }
+
+            public List<ISeriesPoint> Values { get; } = new();
         }
 
         /// <summary>

--- a/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
+++ b/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Packets;
@@ -190,6 +191,43 @@ namespace QuantConnect.Tests.Engine.Results
             }
         }
 
+        [Test]
+        public void RetainsDailyStatisticsSamplesAfterChartTrimming()
+        {
+            var resultHandler = new TestableLiveTradingResultHandler();
+            var algorithm = new AlgorithmStub(createDataManager: false);
+            algorithm.SetStartDate(2026, 04, 30);
+            algorithm.SetFinishedWarmingUp();
+            algorithm.PostInitialize();
+            resultHandler.SetAlgorithm(algorithm, 100000);
+
+            for (var i = 0; i < 5; i++)
+            {
+                algorithm.Portfolio.CashBook["USD"].AddAmount(1000);
+                algorithm.Portfolio.InvalidateTotalPortfolioValue();
+                resultHandler.Sample(new DateTime(2026, 05, 01 + i, 0, 0, 0, DateTimeKind.Utc));
+            }
+
+            var charts = new Dictionary<string, Chart>
+            {
+                [BaseResultsHandler.StrategyEquityKey] = resultHandler.Charts[BaseResultsHandler.StrategyEquityKey].Clone(),
+                [BaseResultsHandler.BenchmarkKey] = resultHandler.Charts[BaseResultsHandler.BenchmarkKey].Clone()
+            };
+
+            foreach (var series in charts.Values.SelectMany(chart => chart.Series.Values))
+            {
+                series.Values = series.Values.TakeLast(2).ToList();
+            }
+
+            resultHandler.CallGenerateStatisticsResults(charts);
+
+            Assert.AreEqual(5, charts[BaseResultsHandler.StrategyEquityKey].Series[BaseResultsHandler.EquityKey].Values.Count);
+            Assert.AreEqual(5, charts[BaseResultsHandler.StrategyEquityKey].Series[BaseResultsHandler.ReturnKey].Values.Count);
+            Assert.AreEqual(5, charts[BaseResultsHandler.BenchmarkKey].Series[BaseResultsHandler.BenchmarkKey].Values.Count);
+            Assert.IsTrue(charts.ContainsKey(BaseResultsHandler.PortfolioTurnoverKey));
+            Assert.AreEqual(5, charts[BaseResultsHandler.PortfolioTurnoverKey].Series[BaseResultsHandler.PortfolioTurnoverKey].Values.Count);
+        }
+
         private class TestDataFeed : IDataFeed
         {
             public bool IsActive { get; }
@@ -216,6 +254,14 @@ namespace QuantConnect.Tests.Engine.Results
             }
             public void Exit()
             {
+            }
+        }
+
+        private class TestableLiveTradingResultHandler : LiveTradingResultHandler
+        {
+            public void CallGenerateStatisticsResults(Dictionary<string, Chart> charts)
+            {
+                GenerateStatisticsResults(charts);
             }
         }
     }


### PR DESCRIPTION
#### Description
Fixes #9477.

Live chart trimming keeps streamed/displayed charts bounded to the recent window, but statistics were generated from those same trimmed series. After a few days, daily `Return` and `Benchmark` samples could be trimmed down to too few points, causing PSR and related live-mode risk metrics to collapse to defaults.

This change keeps a small live-only retention buffer for the daily statistics inputs and merges those retained samples into the chart clones used for statistics generation. The visible/live chart trimming path remains unchanged.

#### Changes
- Made `BaseResultsHandler.GenerateStatisticsResults(Dictionary<string, Chart>, ...)` virtual so live results can prepare statistics inputs before delegating.
- Retain daily live samples for:
  - `Strategy Equity / Equity`
  - `Strategy Equity / Return`
  - `Benchmark / Benchmark`
  - `Portfolio Turnover / Portfolio Turnover`
- Merge retained samples into the cloned charts used for statistics, deduplicating by timestamp.
- Added coverage that simulates chart trimming and verifies statistics samples are restored before generation.

#### Testing
- `git diff --check`
- Attempted: `dotnet test Tests\QuantConnect.Tests.csproj --filter RetainsDailyStatisticsSamplesAfterChartTrimming --no-restore --logger "console;verbosity=minimal"`
- Attempted: `dotnet build Tests\QuantConnect.Tests.csproj --no-restore -v:minimal /m:1 /nr:false`
- Result: both local .NET commands hung during startup/build without compiler or fixture output and were terminated after timeout.
