### PR TITLE
feature: add bloomberg fix brokerage model

### DIFF
--- a/Common/Brokerages/BloombergFixBrokerageModel.cs
+++ b/Common/Brokerages/BloombergFixBrokerageModel.cs
@@ -1,0 +1,97 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Brokerages
+{
+    /// <summary>
+    /// Provides Bloomberg FixNet HUB specific properties.
+    /// </summary>
+    public class BloombergFixBrokerageModel : DefaultBrokerageModel
+    {
+        private readonly HashSet<SecurityType> _supportedSecurityTypes = new()
+        {
+            SecurityType.Equity,
+            SecurityType.Option,
+            SecurityType.Future,
+        };
+
+        private readonly HashSet<OrderType> _supportedOrderTypes = new()
+        {
+            OrderType.Market,
+            OrderType.Limit,
+            OrderType.StopMarket,
+            OrderType.StopLimit,
+        };
+
+        /// <summary>
+        /// Constructor for Bloomberg FIX brokerage model.
+        /// </summary>
+        /// <param name="accountType">Cash or Margin</param>
+        public BloombergFixBrokerageModel(AccountType accountType = AccountType.Margin) : base(accountType)
+        {
+            if (accountType == AccountType.Cash)
+            {
+                throw new NotSupportedException($"Bloomberg FIX brokerage can only be used with a {AccountType.Margin} account type");
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the brokerage could accept this order.
+        /// </summary>
+        /// <param name="security">The security of the order</param>
+        /// <param name="order">The order to be processed</param>
+        /// <param name="message">If this function returns false, a brokerage message detailing why the order may not be submitted</param>
+        public override bool CanSubmitOrder(Security security, Order order, out BrokerageMessageEvent message)
+        {
+            if (!_supportedSecurityTypes.Contains(security.Type))
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    Messages.DefaultBrokerageModel.UnsupportedSecurityType(this, security));
+                return false;
+            }
+
+            if (!_supportedOrderTypes.Contains(order.Type))
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    Messages.DefaultBrokerageModel.UnsupportedOrderType(this, order, _supportedOrderTypes));
+                return false;
+            }
+
+            if (order.AbsoluteQuantity % 1 != 0)
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    $"Order Quantity must be Integer, but provided {order.AbsoluteQuantity}.");
+                return false;
+            }
+
+            return base.CanSubmitOrder(security, order, out message);
+        }
+
+        /// <summary>
+        /// Bloomberg FixNet HUB supports cancel/replace (35=G) on order quantity, price, stop price,
+        /// order type and time in force.
+        /// </summary>
+        public override bool CanUpdateOrder(Security security, Order order, UpdateOrderRequest request, out BrokerageMessageEvent message)
+        {
+            message = null;
+            return true;
+        }
+    }
+}

--- a/Common/Brokerages/BloombergFixBrokerageModel.cs
+++ b/Common/Brokerages/BloombergFixBrokerageModel.cs
@@ -35,6 +35,7 @@ namespace QuantConnect.Brokerages
         private readonly HashSet<OrderType> _supportedOrderTypes = new()
         {
             OrderType.Market,
+            OrderType.MarketOnOpen,
             OrderType.Limit,
             OrderType.StopMarket,
             OrderType.StopLimit,


### PR DESCRIPTION
#### Description
Add a `BloombergFixBrokerageModel` for the Bloomberg FixNet HUB FIX brokerage. The model lists the security types and order types Bloomberg's FixNet HUB accepts, and forces a margin account.

#### Related PR(s)
N/A

#### Related Issue
N/A

#### Motivation and Context
The Bloomberg FIX brokerage plugin needs a brokerage model so Lean can reject orders that Bloomberg will not accept before they reach the FIX session. This model declares the supported security types (Equity, Option, Future) and order types (Market, Limit, StopMarket, StopLimit), and requires a margin account.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- `BloombergFixBrokerageFactory.GetBrokerageModel()` returns this model and tests pass in the Bloomberg FIX brokerage plugin repo.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`