### PR TITLE
Feature: add ReconnectBrokerage() to QCAlgorithm for self-healing data feeds

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -121,6 +121,8 @@ namespace QuantConnect.Algorithm
         private IStatisticsService _statisticsService;
         private IBrokerageModel _brokerageModel;
 
+        private Action _brokerageReconnectAction;
+
         private bool _sentBroadcastCommandsDisabled;
         private readonly HashSet<string> _oneTimeCommandErrors = new();
         private readonly Dictionary<string, Func<CallbackCommand, bool?>> _registeredCommands = new(StringComparer.InvariantCultureIgnoreCase);
@@ -1422,6 +1424,33 @@ namespace QuantConnect.Algorithm
         public void SetBrokerageMessageHandler(IBrokerageMessageHandler handler)
         {
             BrokerageMessageHandler = handler ?? throw new ArgumentNullException(nameof(handler));
+        }
+
+        /// <summary>
+        /// Sets the action used to reconnect the brokerage. Intended for internal use by the Lean engine only.
+        /// </summary>
+        /// <param name="reconnectAction">The action that performs the disconnect/connect cycle</param>
+        [DocumentationAttribute(LiveTrading)]
+        public void SetBrokerageReconnectAction(Action reconnectAction)
+        {
+            _brokerageReconnectAction = reconnectAction ?? throw new ArgumentNullException(nameof(reconnectAction));
+        }
+
+        /// <summary>
+        /// Triggers a brokerage disconnect/reconnect cycle. Use this when the algorithm detects
+        /// a data quality issue (e.g. a frozen market data feed) and needs to self-heal without
+        /// human intervention. Only meaningful in live trading; no-op in backtesting.
+        /// </summary>
+        [DocumentationAttribute(LiveTrading)]
+        public void ReconnectBrokerage()
+        {
+            if (_brokerageReconnectAction == null)
+            {
+                Debug("ReconnectBrokerage(): no reconnect action registered, ignoring.");
+                return;
+            }
+            Log("ReconnectBrokerage(): triggering brokerage reconnect.");
+            _brokerageReconnectAction();
         }
 
         /// <summary>

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -1032,6 +1032,12 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// <param name="handler">The message handler to use</param>
         public void SetBrokerageMessageHandler(IBrokerageMessageHandler handler) => _baseAlgorithm.SetBrokerageMessageHandler(handler);
 
+        /// <inheritdoc />
+        public void SetBrokerageReconnectAction(Action reconnectAction) => _baseAlgorithm.SetBrokerageReconnectAction(reconnectAction);
+
+        /// <inheritdoc />
+        public void ReconnectBrokerage() => _baseAlgorithm.ReconnectBrokerage();
+
         /// <summary>
         /// Sets the brokerage model used to resolve transaction models, settlement models,
         /// and brokerage specified ordering behaviors.

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -831,6 +831,19 @@ namespace QuantConnect.Interfaces
         void SetBrokerageMessageHandler(IBrokerageMessageHandler handler);
 
         /// <summary>
+        /// Sets the action used to reconnect the brokerage. Intended for internal use by the Lean engine only.
+        /// </summary>
+        /// <param name="reconnectAction">The action that performs the disconnect/connect cycle</param>
+        void SetBrokerageReconnectAction(Action reconnectAction);
+
+        /// <summary>
+        /// Triggers a brokerage disconnect/reconnect cycle. Use this when the algorithm detects
+        /// a data quality issue (e.g. a frozen market data feed) and needs to self-heal without
+        /// human intervention. Only meaningful in live trading; no-op in backtesting.
+        /// </summary>
+        void ReconnectBrokerage();
+
+        /// <summary>
         /// Set the historical data provider
         /// </summary>
         /// <param name="historyProvider">Historical data provider</param>

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -228,6 +228,13 @@ namespace QuantConnect.Lean.Engine
                     // initialize the default brokerage message handler
                     algorithm.BrokerageMessageHandler = factory.CreateBrokerageMessageHandler(algorithm, job, SystemHandlers.Api);
 
+                    // allow the algorithm to trigger a brokerage reconnect (e.g. when it detects a frozen data feed)
+                    algorithm.SetBrokerageReconnectAction(() =>
+                    {
+                        brokerage.Disconnect();
+                        brokerage.Connect();
+                    });
+
                     var brokerageDataQueueHandlers = Composer.Instance.GetParts<IDataQueueHandler>().OfType<IBrokerage>()
                         // In backtesting, brokerages can be used as data downloaders (BrokerageDataDownloader)
                         // and are added to the composer as IBrokerage

--- a/Tests/Algorithm/AlgorithmReconnectBrokerageTests.cs
+++ b/Tests/Algorithm/AlgorithmReconnectBrokerageTests.cs
@@ -1,0 +1,75 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Tests.Engine.DataFeeds;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    [TestFixture]
+    public class AlgorithmReconnectBrokerageTests
+    {
+        private QCAlgorithm _algo;
+
+        [SetUp]
+        public void Setup()
+        {
+            _algo = new QCAlgorithm();
+            _algo.SubscriptionManager.SetDataManager(new DataManagerStub(_algo));
+        }
+
+        [Test]
+        public void ReconnectBrokerage_InvokesRegisteredAction()
+        {
+            var reconnectCalled = false;
+            _algo.SetBrokerageReconnectAction(() => reconnectCalled = true);
+
+            _algo.ReconnectBrokerage();
+
+            Assert.IsTrue(reconnectCalled);
+        }
+
+        [Test]
+        public void ReconnectBrokerage_NoOp_WhenNoActionRegistered()
+        {
+            // should not throw when no action has been set
+            Assert.DoesNotThrow(() => _algo.ReconnectBrokerage());
+        }
+
+        [Test]
+        public void SetBrokerageReconnectAction_ThrowsOnNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => _algo.SetBrokerageReconnectAction(null));
+        }
+
+        [Test]
+        public void ReconnectBrokerage_InvokesDisconnectThenConnect()
+        {
+            var callOrder = new System.Collections.Generic.List<string>();
+            _algo.SetBrokerageReconnectAction(() =>
+            {
+                callOrder.Add("disconnect");
+                callOrder.Add("connect");
+            });
+
+            _algo.ReconnectBrokerage();
+
+            Assert.AreEqual(new[] { "disconnect", "connect" }, callOrder);
+        }
+    }
+}


### PR DESCRIPTION
  ## Summary
  - Adds `ReconnectBrokerage()` to `IAlgorithm` and `QCAlgorithm`
  - Adds `SetBrokerageReconnectAction(Action)` to allow the engine to inject the actual
  Disconnect/Connect logic
  - Wires the action in `Engine.cs` after brokerage creation
  - Implements the wrapper in `AlgorithmPythonWrapper` for Python algorithms
  - 4 unit tests covering: action invoked, no-op when unregistered, null guard, order of
  operations

  ## Motivation
  Closes #9496 — algorithms running in live trading (e.g. against IBKR) can detect a silently
  frozen data feed (bars with `Volume=0`) but previously had no way to trigger a reconnect
  short of calling `Quit()`. This API lets them self-heal without human intervention.

  ## Notes
  - Brokerage-agnostic: the `Action` delegate is injected by the engine, so `QCAlgorithm` has
  no dependency on any concrete brokerage
  - No-op in backtesting (action is never registered, logs a debug message)