### PR TITLE
Fix UniverseHistory empty results when selection returns different security type

### DIFF
--- a/Research/QuantBook.cs
+++ b/Research/QuantBook.cs
@@ -940,6 +940,7 @@ namespace QuantConnect.Research
             var history = History(universe, start, endDate);
 
             HashSet<Symbol> filteredSymbols = null;
+            SecurityType? filteredSecurityType = null;
             Func<BaseDataCollection, BaseDataCollection> processDataPoint = dataPoint =>
             {
                 var utcTime = dataPoint.EndTime.ConvertToUtc(universe.Configuration.ExchangeTimeZone);
@@ -947,14 +948,28 @@ namespace QuantConnect.Research
                 if (!ReferenceEquals(selection, Universe.Unchanged))
                 {
                     filteredSymbols = selection.ToHashSet();
+                    filteredSecurityType = filteredSymbols.FirstOrDefault()?.ID.SecurityType;
                 }
-                dataPoint.Data = dataPoint.Data.Where(x => filteredSymbols == null || filteredSymbols.Contains(x.Symbol)).ToList();
+                dataPoint.Data = FilterUniverseData(dataPoint.Data, filteredSymbols, filteredSecurityType);
                 return dataPoint;
             };
 
             Func<BaseDataCollection, DateTime> getTime = dataPoint => dataPoint.EndTime.Date;
 
             return PerformSelection<BaseDataCollection, BaseDataCollection>(history, processDataPoint, getTime, start, endDate, dateRule);
+        }
+
+        private static List<BaseData> FilterUniverseData(List<BaseData> data, HashSet<Symbol> filteredSymbols, SecurityType? filteredSecurityType)
+        {
+            return data.Where(x =>
+                filteredSymbols == null ||
+                filteredSymbols.Contains(x.Symbol) ||
+                (filteredSecurityType.HasValue && x.Symbol.SecurityType != filteredSecurityType.Value &&
+                 filteredSymbols.Any(s =>
+                     CurrencyPairUtil.TryDecomposeCurrencyPair(s, out var baseCurrency, out var quoteCurrency) &&
+                     (x.Symbol.Value.Equals(baseCurrency, StringComparison.OrdinalIgnoreCase) ||
+                      x.Symbol.Value.Equals(quoteCurrency, StringComparison.OrdinalIgnoreCase))))
+            ).ToList();
         }
 
         /// <summary>

--- a/Tests/Research/QuantBookSelectionTests.cs
+++ b/Tests/Research/QuantBookSelectionTests.cs
@@ -15,13 +15,17 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using Python.Runtime;
 using NUnit.Framework;
 using QuantConnect.Research;
 using System.Collections.Generic;
+using QuantConnect.Data;
 using QuantConnect.Data.Fundamental;
+using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Scheduling;
+using QuantConnect.Util;
 
 namespace QuantConnect.Tests.Research
 {
@@ -825,6 +829,25 @@ class Test():
         }
 
         [Test]
+        public void FilterUniverseDataFallsBackToCurrencyPairMatchingWhenSecurityTypesDiffer()
+        {
+            var eurBase = new Symbol(SecurityIdentifier.GenerateBase(typeof(Fundamental), "EUR", Market.USA), "EUR");
+            var gbpBase = new Symbol(SecurityIdentifier.GenerateBase(typeof(Fundamental), "GBP", Market.USA), "GBP");
+            var eurUsd = Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda);
+
+            // selection returns Forex — security type differs from Base data symbols
+            var filteredSymbols = new HashSet<Symbol> { eurUsd };
+            var data = new List<BaseData> { new Tick { Symbol = eurBase }, new Tick { Symbol = gbpBase } };
+
+            var filterMethod = typeof(QuantBook).GetMethod("FilterUniverseData", BindingFlags.NonPublic | BindingFlags.Static);
+            var result = (List<BaseData>)filterMethod.Invoke(null, new object[] { data, filteredSymbols, (SecurityType?)eurUsd.SecurityType });
+
+            // EUR matches EURUSD base currency, GBP matches neither
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(eurBase, result[0].Symbol);
+        }
+
+        [Test]
         public void PerformSelectionDoesNotSkipDataPointWhenPreviousDataPointIsYielded()
         {
             var historyDataPoints = new List<BaseDataCollection>()
@@ -875,7 +898,7 @@ class Test():
 .Replace("{identation}", identation, StringComparison.InvariantCulture);
         }
 
-        private class QuantBookTestClass: QuantBook
+        private class QuantBookTestClass : QuantBook
         {
             public static IEnumerable<BaseDataCollection> PerformSelection(IEnumerable<BaseDataCollection> history, DateTime start, DateTime end, IDateRule dateRule)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Fixes UniverseHistory returning no data when the user's selection function returns symbols of a different SecurityType than the universe data, by falling back to base/quote currency matching.

#### Related Issue
Closes #9351 

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
