### PR TITLE
Add EMSX locate properties to TerminalLinkOrderProperties

### DIFF
--- a/Common/Orders/TerminalLinkOrderProperties.cs
+++ b/Common/Orders/TerminalLinkOrderProperties.cs
@@ -75,6 +75,20 @@ namespace QuantConnect.Orders
         public string Broker { get; set; }
 
         /// <summary>
+        /// The EMSX locate broker code identifying the counterparty the shares are being borrowed
+        /// from for a short sale (EMSX_LOCATE_BROKER, e.g. "BMTB"). Maps to the LocBrkr field on
+        /// the EMSX trading ticket. Setting this (or <see cref="LocateId"/>) on a short equity sale
+        /// causes the brokerage to emit EMSX_LOCATE_REQ = "Y" alongside.
+        /// </summary>
+        public string LocateBroker { get; set; }
+
+        /// <summary>
+        /// The EMSX locate confirmation/ticket id returned by the lending broker (EMSX_LOCATE_ID).
+        /// Maps to the LocId field on the EMSX trading ticket.
+        /// </summary>
+        public string LocateId { get; set; }
+
+        /// <summary>
         /// The EMSX order strategy details.
         /// Strategy parameters must be appended in the correct order as expected by EMSX.
         /// </summary>

--- a/Tests/Common/Orders/TerminalLinkOrderPropertiesTests.cs
+++ b/Tests/Common/Orders/TerminalLinkOrderPropertiesTests.cs
@@ -65,5 +65,40 @@ def getOrderProperties() -> TerminalLinkOrderProperties:
                 Assert.IsNull(orderProperties.Strategy.Fields[3].Value);
             }
         }
+
+        [Test]
+        public void LocateFieldsDefaultToEmpty()
+        {
+            // Locate fields are only meaningful for Reg SHO short equity sales; for any other
+            // order they must be unset so the brokerage doesn't emit EMSX_LOCATE_* on the request.
+            var properties = new TerminalLinkOrderProperties();
+            Assert.IsNull(properties.LocateBroker);
+            Assert.IsNull(properties.LocateId);
+        }
+
+        [Test]
+        public void SetsLocateFieldsFromPython()
+        {
+            using (Py.GIL())
+            {
+                var module = PyModule.FromString("locateFieldsModule",
+                    @"
+from AlgorithmImports import *
+
+def getOrderProperties() -> TerminalLinkOrderProperties:
+    properties = TerminalLinkOrderProperties()
+    properties.LocateBroker = ""BMTB""
+    properties.LocateId = ""LOC-123""
+    return properties
+");
+
+                dynamic getOrderProperties = module.GetAttr("getOrderProperties");
+                var properties = (TerminalLinkOrderProperties)getOrderProperties();
+
+                Assert.IsNotNull(properties);
+                Assert.AreEqual("BMTB", properties.LocateBroker);
+                Assert.AreEqual("LOC-123", properties.LocateId);
+            }
+        }
     }
 }


### PR DESCRIPTION
#### Description
Adds two new properties to `TerminalLinkOrderProperties` so algorithms can attach Reg SHO locate information to short equity sales routed through Bloomberg EMSX:

- `LocateBroker` (`string`) — counterparty broker code the shares are borrowed from (e.g. `"BMTB"`), emitted as `EMSX_LOCATE_BROKER`
- `LocateId` (`string`) — locate confirmation/ticket id returned by the lender, emitted as `EMSX_LOCATE_ID`

These correspond to the `LocBrkr` / `LocId` fields on the EMSX trading ticket. The TerminalLink brokerage emits `EMSX_LOCATE_REQ = "Y"` automatically whenever either identifier is set on a short equity sale, so no separate "required" flag is exposed here — presence of an identifier is the signal.

#### Related Issue
N/A — surfaced via a TerminalLink customer report. Companion brokerage-side PR: QuantConnect/Lean.Brokerages.TerminalLink#116.

#### Motivation and Context
The TerminalLink brokerage currently emits `EMSX_SIDE = "SHRT"` for short equity sales (since #115) but has no way to identify the lender. Prime brokers reject short sales without a locate attached, so the brokerage needs algorithm-supplied locate fields to route these orders successfully.

#### Requires Documentation Change
No. These follow the same shape as existing properties on the class (`Broker`, `Account`, `HandlingInstruction`, etc.) and will be picked up by the standard XML doc generation.

#### How Has This Been Tested?
Added two unit tests in `Tests/Common/Orders/TerminalLinkOrderPropertiesTests.cs`:
- `LocateFieldsDefaultToEmpty` — verifies both properties default to `null`
- `SetsLocateFieldsFromPython` — verifies the properties round-trip from a Python algorithm via PythonNet

Both pass alongside the existing `SeamlesslySetsStrategyInPython` test (3/3 in the test fixture).

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>` — no associated issue; branch is `feature-terminallink-locate-fields`

🤖 Generated with [Claude Code](https://claude.com/claude-code)