### PR TITLE
Fix chart trimming breaking live trading statistics

### DIFF
--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -986,7 +986,7 @@ namespace QuantConnect.Lean.Engine.Results
         /// <summary>
         /// Will generate the statistics results and update the provided runtime statistics
         /// </summary>
-        protected StatisticsResults GenerateStatisticsResults(Dictionary<string, Chart> charts,
+        protected virtual StatisticsResults GenerateStatisticsResults(Dictionary<string, Chart> charts,
             SortedDictionary<DateTime, decimal> profitLoss = null, CapacityEstimate estimatedStrategyCapacity = null)
         {
             var statisticsResults = new StatisticsResults();

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -336,21 +336,7 @@ namespace QuantConnect.Lean.Engine.Results
                     if (utcNow > _nextChartTrimming)
                     {
                         Log.Debug("LiveTradingResultHandler.Update(): Trimming charts");
-                        var timeLimitUtc = utcNow.AddDays(-2);
-                        lock (ChartLock)
-                        {
-                            foreach (var chart in Charts)
-                            {
-                                foreach (var series in chart.Value.Series)
-                                {
-                                    // trim data that's older than 2 days
-                                    series.Value.Values =
-                                        (from v in series.Value.Values
-                                         where v.Time > timeLimitUtc
-                                         select v).ToList();
-                                }
-                            }
-                        }
+                        TrimCharts(utcNow);
                         _nextChartTrimming = DateTime.UtcNow.AddMinutes(10);
                         Log.Debug("LiveTradingResultHandler.Update(): Finished trimming charts");
                     }
@@ -380,6 +366,30 @@ namespace QuantConnect.Lean.Engine.Results
         {
             // Update the status json file every X
             _nextStatusUpdate = DateTime.UtcNow.AddMinutes(10);
+        }
+
+        /// <summary>
+        /// Removes chart series points older than their retention window: 10 days for performance charts, 2 days for all others.
+        /// </summary>
+        protected virtual void TrimCharts(DateTime utcNow)
+        {
+            lock (ChartLock)
+            {
+                foreach (var chart in Charts)
+                {
+                    var timeLimitUtc = AlgorithmPerformanceCharts.Contains(chart.Key)
+                        ? utcNow.AddDays(-10)
+                        : utcNow.AddDays(-2);
+
+                    foreach (var series in chart.Value.Series)
+                    {
+                        series.Value.Values =
+                            (from v in series.Value.Values
+                             where v.Time > timeLimitUtc
+                             select v).ToList();
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -79,6 +79,8 @@ namespace QuantConnect.Lean.Engine.Results
         private bool _userExchangeIsOpen;
         private DateTime _lastChartSampleLogicCheck;
         private readonly Dictionary<string, SecurityExchangeHours> _exchangeHours;
+        protected readonly SortedDictionary<DateTime, decimal> _dailyEquityClose = new();
+        protected readonly object _dailyEquityCloseLock = new();
 
 
         /// <summary>
@@ -371,22 +373,78 @@ namespace QuantConnect.Lean.Engine.Results
         /// <summary>
         /// Removes chart series points older than their retention window: 10 days for performance charts, 2 days for all others.
         /// </summary>
+        public override void Sample(DateTime time)
+        {
+            base.Sample(time);
+            if (!Algorithm.IsWarmingUp)
+            {
+                lock (_dailyEquityCloseLock)
+                {
+                    _dailyEquityClose[time.Date] = GetPortfolioValue();
+                }
+            }
+        }
+
+        protected override StatisticsResults GenerateStatisticsResults(Dictionary<string, Chart> charts,
+            SortedDictionary<DateTime, decimal> profitLoss = null, CapacityEstimate estimatedStrategyCapacity = null)
+        {
+            List<KeyValuePair<DateTime, decimal>> historicalCloses;
+            lock (_dailyEquityCloseLock)
+            {
+                historicalCloses = _dailyEquityClose.ToList();
+            }
+
+            if (historicalCloses.Count > 0 &&
+                charts.TryGetValue(StrategyEquityKey, out var strategyEquity) &&
+                strategyEquity.Series.TryGetValue(EquityKey, out var equitySeries))
+            {
+                var existingDates = new HashSet<DateTime>(equitySeries.Values.Select(v => v.Time.Date));
+                var toInject = historicalCloses
+                    .Where(kvp => !existingDates.Contains(kvp.Key))
+                    .Select(kvp => (ISeriesPoint)new Candlestick(kvp.Key, kvp.Value, kvp.Value, kvp.Value, kvp.Value))
+                    .ToList();
+
+                if (toInject.Count > 0)
+                {
+                    var mergedEquity = (CandlestickSeries)equitySeries.Clone();
+                    mergedEquity.Values.InsertRange(0, toInject);
+
+                    var mergedChart = new Chart(StrategyEquityKey);
+                    foreach (var kvp in strategyEquity.Series)
+                    {
+                        mergedChart.Series[kvp.Key] = kvp.Key == EquityKey ? mergedEquity : kvp.Value;
+                    }
+
+                    charts = new Dictionary<string, Chart>(charts) { [StrategyEquityKey] = mergedChart };
+                }
+            }
+
+            return base.GenerateStatisticsResults(charts, profitLoss, estimatedStrategyCapacity);
+        }
+
+        /// <summary>
+        /// Removes chart series points older than their retention window: 2 years for daily statistics series
+        /// (Return, Benchmark), 2 days for all others.
+        /// </summary>
         protected virtual void TrimCharts(DateTime utcNow)
         {
+            var defaultLimit = utcNow.AddDays(-2);
+            var dailyStatsLimit = utcNow.AddDays(-730);
+
             lock (ChartLock)
             {
                 foreach (var chart in Charts)
                 {
-                    var timeLimitUtc = AlgorithmPerformanceCharts.Contains(chart.Key)
-                        ? utcNow.AddDays(-10)
-                        : utcNow.AddDays(-2);
-
                     foreach (var series in chart.Value.Series)
                     {
-                        series.Value.Values =
-                            (from v in series.Value.Values
-                             where v.Time > timeLimitUtc
-                             select v).ToList();
+                        var isDailyStatsSeries =
+                            (chart.Key == StrategyEquityKey && series.Key == ReturnKey) ||
+                            (chart.Key == BenchmarkKey && series.Key == BenchmarkKey);
+
+                        var timeLimitUtc = isDailyStatsSeries ? dailyStatsLimit : defaultLimit;
+                        series.Value.Values = series.Value.Values
+                            .Where(v => v.Time > timeLimitUtc)
+                            .ToList();
                     }
                 }
             }

--- a/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
+++ b/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
@@ -149,7 +149,7 @@ namespace QuantConnect.Tests.Engine.Results
             using var messagging = new QuantConnect.Messaging.Messaging();
             var referenceDate = new DateTime(2020, 11, 25);
             var resultHandler = new LiveTradingResultHandler();
-            resultHandler.Initialize(new (new LiveNodePacket(), messagging, api, new BacktestingTransactionHandler(), null));
+            resultHandler.Initialize(new(new LiveNodePacket(), messagging, api, new BacktestingTransactionHandler(), null));
 
             try
             {
@@ -188,6 +188,62 @@ namespace QuantConnect.Tests.Engine.Results
             {
                 resultHandler.Exit();
             }
+        }
+
+        [Test]
+        public void TrimChartsUsesLongerWindowForPerformanceCharts()
+        {
+            var handler = new TestableLiveTradingResultHandler();
+            var utcNow = new DateTime(2020, 11, 25, 12, 0, 0, DateTimeKind.Utc);
+
+            var benchmarkChart = new Chart(BaseResultsHandler.BenchmarkKey);
+            benchmarkChart.Series.Add(BaseResultsHandler.BenchmarkKey, new Series(BaseResultsHandler.BenchmarkKey));
+            handler.Charts[BaseResultsHandler.BenchmarkKey] = benchmarkChart;
+
+            // Add a custom user chart to verify it still uses the 2 day window 
+            var customChart = new Chart("MyCustomChart");
+            customChart.Series.Add("MyMetric", new Series("MyMetric"));
+            handler.Charts["MyCustomChart"] = customChart;
+
+            var returnSeries = handler.Charts[BaseResultsHandler.StrategyEquityKey].Series[BaseResultsHandler.ReturnKey];
+            var equitySeries = handler.Charts[BaseResultsHandler.StrategyEquityKey].Series[BaseResultsHandler.EquityKey];
+            var benchmarkSeries = benchmarkChart.Series[BaseResultsHandler.BenchmarkKey];
+            var customSeries = customChart.Series["MyMetric"];
+
+            // performance charts: 15 daily samples covering well beyond both trim windows
+            for (var i = 15; i >= 1; i--)
+            {
+                var t = utcNow.AddDays(-i);
+                returnSeries.Values.Add(new ChartPoint(t, i));
+                benchmarkSeries.Values.Add(new ChartPoint(t, i));
+                equitySeries.Values.Add(new Candlestick(t, 100, 110, 90, 105));
+            }
+
+            // custom chart: 5 samples to verify it uses the 2-day window
+            for (var i = 5; i >= 1; i--)
+            {
+                customSeries.Values.Add(new ChartPoint(utcNow.AddDays(-i), i));
+            }
+
+            handler.PublicTrimCharts(utcNow);
+
+            // performance charts keep 10 day window
+            var performanceChartsCutoff = utcNow.AddDays(-10);
+            Assert.IsTrue(returnSeries.Values.All(v => v.Time > performanceChartsCutoff));
+            Assert.IsTrue(benchmarkSeries.Values.All(v => v.Time > performanceChartsCutoff));
+            Assert.IsTrue(equitySeries.Values.All(v => v.Time > performanceChartsCutoff));
+            Assert.AreEqual(9, returnSeries.Values.Count);
+            Assert.AreEqual(9, benchmarkSeries.Values.Count);
+
+            // other charts keep 2 day window
+            var otherChartsCutoff = utcNow.AddDays(-2);
+            Assert.IsTrue(customSeries.Values.All(v => v.Time > otherChartsCutoff));
+            Assert.AreEqual(1, customSeries.Values.Count);
+        }
+
+        private class TestableLiveTradingResultHandler : LiveTradingResultHandler
+        {
+            public void PublicTrimCharts(DateTime utcNow) => TrimCharts(utcNow);
         }
 
         private class TestDataFeed : IDataFeed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Performance charts sampled once per day were trimmed to 2 days, leaving StatisticsBuilder with too few points to compute PSR and other risk metrics, so extending the retention window to 10 days for those charts fixes the issue.

#### Related Issue
Closes #9477 

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
