### PR TITLE
Fix code injection (CWE-94) in PythonInitializer and argument injection (CWE-88) in ConsoleLeanOptimizer

### DIFF
--- a/Common/Python/PythonInitializer.cs
+++ b/Common/Python/PythonInitializer.cs
@@ -140,9 +140,13 @@ namespace QuantConnect.Python
                     // Insert any pending path additions
                     if (!_pendingPathAdditions.IsNullOrEmpty())
                     {
-                        var code = string.Join(";", _pendingPathAdditions
-                            .Select(s => $"sys.path.insert({insertionIndex}, '{s}')")).Replace('\\', '/');
-                        PythonEngine.Exec(code, locals: locals);
+                        // Pass each path as a Python object to avoid code injection via path strings
+                        // containing single quotes or newlines (CWE-94)
+                        foreach (var path in _pendingPathAdditions)
+                        {
+                            using var pyPath = new PyString(path.Replace('\\', '/'));
+                            sys.path.insert(insertionIndex, pyPath);
+                        }
 
                         _pendingPathAdditions.Clear();
                     }

--- a/Optimizer.Launcher/ConsoleLeanOptimizer.cs
+++ b/Optimizer.Launcher/ConsoleLeanOptimizer.cs
@@ -85,14 +85,28 @@ namespace QuantConnect.Optimizer.Launcher
             var resultDirectory = Path.Combine(_rootResultDirectory, backtestId);
             Directory.CreateDirectory(resultDirectory);
 
-            // Use ProcessStartInfo class
+            // Use ProcessStartInfo class — use ArgumentList for safe per-argument escaping (CWE-88)
             var startInfo = new ProcessStartInfo
             {
                 FileName = _leanLocation,
                 WorkingDirectory = Directory.GetParent(_leanLocation).FullName,
-                Arguments = $"--results-destination-folder \"{resultDirectory}\" --algorithm-id \"{backtestId}\" --optimization-id \"{optimizationId}\" --parameters {parameterSet} --backtest-name \"{backtestName}\" {_extraLeanArguments}",
                 WindowStyle = ProcessWindowStyle.Minimized
             };
+            startInfo.ArgumentList.Add("--results-destination-folder");
+            startInfo.ArgumentList.Add(resultDirectory);
+            startInfo.ArgumentList.Add("--algorithm-id");
+            startInfo.ArgumentList.Add(backtestId);
+            startInfo.ArgumentList.Add("--optimization-id");
+            startInfo.ArgumentList.Add(optimizationId);
+            startInfo.ArgumentList.Add("--parameters");
+            startInfo.ArgumentList.Add(parameterSet.ToString());
+            startInfo.ArgumentList.Add("--backtest-name");
+            startInfo.ArgumentList.Add(backtestName);
+            // Append any extra arguments individually — split preserving quoted tokens
+            foreach (var arg in SplitArguments(_extraLeanArguments))
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
 
             var process = new Process
             {
@@ -153,6 +167,36 @@ namespace QuantConnect.Optimizer.Launcher
                 }
                 Log.Trace(message);
             }
+        }
+
+        private static IEnumerable<string> SplitArguments(string arguments)
+        {
+            if (string.IsNullOrWhiteSpace(arguments))
+                yield break;
+
+            var current = new System.Text.StringBuilder();
+            var inQuotes = false;
+            foreach (var ch in arguments)
+            {
+                if (ch == '"')
+                {
+                    inQuotes = !inQuotes;
+                }
+                else if (ch == ' ' && !inQuotes)
+                {
+                    if (current.Length > 0)
+                    {
+                        yield return current.ToString();
+                        current.Clear();
+                    }
+                }
+                else
+                {
+                    current.Append(ch);
+                }
+            }
+            if (current.Length > 0)
+                yield return current.ToString();
         }
     }
 }


### PR DESCRIPTION
## Security Fix — Code Injection (CWE-94) + Argument Injection (CWE-88)

### Summary
- **CWE-94** — Python code injection via unsanitized path in `PythonInitializer.AddPythonPaths()`
- **CWE-88** — Argument injection via unquoted `{parameterSet}` in `ConsoleLeanOptimizer.RunLean()`

---

### VULN-001 — Python Code Injection (`Common/Python/PythonInitializer.cs:143`)

**Root cause:** Path strings were directly interpolated into a Python code string passed to `PythonEngine.Exec()`. On Linux, directory names can contain newlines and single quotes — both of which allow breaking out of the string literal and injecting arbitrary Python code.

```csharp
// Before (vulnerable)
var code = string.Join(";", _pendingPathAdditions
    .Select(s => $"sys.path.insert({{insertionIndex}}, '{{s}}')")).Replace('\\', '/');
PythonEngine.Exec(code, locals: locals);
```

**Fix:** Pass each path as a `PyString` object directly via the Python.NET API — no string interpolation needed, no injection possible.

```csharp
// After (safe)
foreach (var path in _pendingPathAdditions)
{
    using var pyPath = new PyString(path.Replace('\\', '/'));
    sys.path.insert(insertionIndex, pyPath);
}
```

---

### VULN-002 — Argument Injection (`Optimizer.Launcher/ConsoleLeanOptimizer.cs:93`)

**Root cause:** The `--parameters {parameterSet}` segment was embedded in `ProcessStartInfo.Arguments` without quoting. Since `--parameters` is registered as `CommandOptionType.MultipleValue` in the Lean argument parser, any space-separated token matching a known CLI flag is parsed as a new argument. A `StaticOptimizationParameter` value containing spaces (e.g., `1 --algorithm-location /evil.py`) injects additional arguments into every spawned backtest child process.

```csharp
// Before (vulnerable)
Arguments = $"... --parameters {parameterSet} --backtest-name \"...\"";
```

**Fix:** Use `ProcessStartInfo.ArgumentList` (.NET 5+) which handles per-argument quoting automatically.

```csharp
// After (safe)
startInfo.ArgumentList.Add("--parameters");
startInfo.ArgumentList.Add(parameterSet.ToString());
```

---

### Impact
- **CWE-94**: Arbitrary code execution in the Lean Python engine via crafted directory name in `python-additional-paths`
- **CWE-88**: Algorithm substitution in optimizer child processes — unauthorized trading, credential exfiltration, or RCE via loading a malicious algorithm file

### Affected versions
All versions `<= v2.4.0.1`

### References
- CWE-94: https://cwe.mitre.org/data/definitions/94.html
- CWE-88: https://cwe.mitre.org/data/definitions/88.html
