### PR TITLE
Fix PandasColumn equality with non-string values

### DIFF
--- a/Common/PandasMapper.py
+++ b/Common/PandasMapper.py
@@ -37,7 +37,10 @@ class PandasColumn(str):
 
     def __eq__(self, other):
         # We need this since Lean created data frames might contain Symbol objects in the indexes
-        return super().__eq__(other) and type(other) is not Symbol
+        if type(other) is Symbol:
+            return False
+        # For non-strings str.__eq__ returns NotImplemented, which Python resolves to False
+        return super().__eq__(other)
 
     def __hash__(self):
         return super().__hash__()

--- a/Tests/Python/PandasIndexingTests.cs
+++ b/Tests/Python/PandasIndexingTests.cs
@@ -85,5 +85,17 @@ namespace QuantConnect.Tests.Python
                 Assert.IsTrue(exception.Contains("No key found for either mapped or original key.", StringComparison.InvariantCulture), exception);
             }
         }
+
+        [Test]
+        public void ColumnEqualsOnlyMatchingString()
+        {
+            using (Py.GIL())
+            {
+                PyObject result = _pandasDataFrameTests.test_column_equals_only_matching_string();
+                var test = result.As<bool>();
+
+                Assert.IsTrue(test);
+            }
+        }
     }
 }

--- a/Tests/Python/PandasTests/PandasIndexingTests.py
+++ b/Tests/Python/PandasTests/PandasIndexingTests.py
@@ -14,6 +14,7 @@
 from AlgorithmImports import *
 from QuantConnect.Tests import *
 from QuantConnect.Tests.Python import *
+from PandasMapper import PandasColumn
 
 # TODO: Rename to PandasResearchTests and keep this class for QB related tests; rename py module to PandasTests
 class PandasIndexingTests():
@@ -68,3 +69,8 @@ class PandasDataFrameTests():
             return True
         except:
             return False
+
+    def test_column_equals_only_matching_string(self):
+        # A column label should only equal a matching string, never None/ints/floats
+        column = PandasColumn("shares")
+        return (not (column == None)) and (not (column == 0)) and (not (column == 123)) and (column == "shares")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
PandasColumn labels wrongly returned True when compared to None, ints or floats instead of False. Now they only compare equal to matching strings.

#### Related Issue
Closes #9507 

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
