### PR TITLE
Convert daily resolution market orders to MarketOnClose/MarketOnOpen

### DIFF
--- a/Algorithm.CSharp/AllShortableSymbolsCoarseSelectionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AllShortableSymbolsCoarseSelectionRegressionAlgorithm.cs
@@ -282,7 +282,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Lowest Capacity Asset", "NB R735QTJ8XC9X"},
             {"Portfolio Turnover", "3.62%"},
             {"Drawdown Recovery", "0"},
-            {"OrderListHash", "0ea806c53bfa2bdca2504ba7155ef130"}
+            {"OrderListHash", "ce85d312f2e4e97c605d13dda0aab8fd"}
         };
     }
 }

--- a/Algorithm.CSharp/DailyResolutionMarketOrderConversionRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/DailyResolutionMarketOrderConversionRegressionAlgorithm.cs
@@ -1,0 +1,216 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting that a market order placed through an intraday scheduled event on an asset
+    /// subscribed only at daily resolution is automatically converted, so it fills at a real daily open/close instead
+    /// of the stale previous close (no fresh intraday price is available for a daily resolution subscription):
+    ///     - While the market is open (before the MarketOnClose submission buffer): converted to MarketOnClose,
+    ///       filling at today's close.
+    ///     - Within the MarketOnClose submission buffer near the close: converted to MarketOnOpen, filling at the
+    ///       next open.
+    /// At the same time, a market order on a minute resolution asset placed at the same intraday time is NOT converted:
+    /// it stays a regular market order and fills immediately, since fresh intraday data is available.
+    /// </summary>
+    public class DailyResolutionMarketOrderConversionRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _daily;
+        private Symbol _minute;
+
+        private OrderTicket _marketOnCloseTicket;
+        private OrderTicket _marketOnOpenTicket;
+        private OrderTicket _minuteTicket;
+
+        private static readonly DateTime _tradingDay = new(2013, 10, 8);
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 07);
+            SetEndDate(2013, 10, 09);
+            SetCash(100000);
+
+            // Daily resolution: market orders have no fresh intraday price, so they get converted.
+            _daily = AddEquity("SPY", Resolution.Daily).Symbol;
+            // Minute resolution: fresh intraday data is available, so market orders are left untouched.
+            _minute = AddEquity("IBM", Resolution.Minute).Symbol;
+
+            // Right after the open (09:31): even one minute into the session only the previous daily close is
+            // available for the daily asset, so its order must still be converted to MarketOnClose. The minute order,
+            // which has fresh intraday data, must NOT be converted.
+            Schedule.On(DateRules.On(_tradingDay.Year, _tradingDay.Month, _tradingDay.Day), TimeRules.At(9, 31), () =>
+            {
+                if (!Securities[_daily].HasData || !Securities[_minute].HasData)
+                {
+                    throw new RegressionTestException($"Expected both securities to have data on {Time}");
+                }
+
+                // Minute asset: not converted, fills immediately on fresh intraday data
+                _minuteTicket = MarketOrder(_minute, 10);
+                if (_minuteTicket.OrderType != OrderType.Market)
+                {
+                    throw new RegressionTestException(
+                        $"Expected the minute resolution order to remain a Market order but was {_minuteTicket.OrderType}. Time: {Time}");
+                }
+                if (_minuteTicket.Status != OrderStatus.Filled)
+                {
+                    throw new RegressionTestException($"Expected the minute resolution order to fill immediately on {Time}");
+                }
+
+                // Daily asset: converted to MarketOnClose
+                _marketOnCloseTicket = MarketOrder(_daily, 10);
+                if (_marketOnCloseTicket.OrderType != OrderType.MarketOnClose)
+                {
+                    throw new RegressionTestException(
+                        $"Expected the daily market order to be converted to MarketOnClose but was {_marketOnCloseTicket.OrderType}. Time: {Time}");
+                }
+                if (_marketOnCloseTicket.Status.IsFill())
+                {
+                    throw new RegressionTestException($"The MarketOnClose order was not expected to fill at submission time {Time}");
+                }
+            });
+
+            // Within the MarketOnClose submission buffer near the close: the daily order falls back to MarketOnOpen.
+            Schedule.On(DateRules.On(_tradingDay.Year, _tradingDay.Month, _tradingDay.Day), TimeRules.At(15, 55), () =>
+            {
+                _marketOnOpenTicket = MarketOrder(_daily, 10);
+                if (_marketOnOpenTicket.OrderType != OrderType.MarketOnOpen)
+                {
+                    throw new RegressionTestException(
+                        $"Expected the daily market order near the close to be converted to MarketOnOpen but was {_marketOnOpenTicket.OrderType}. Time: {Time}");
+                }
+                if (_marketOnOpenTicket.Status.IsFill())
+                {
+                    throw new RegressionTestException($"The MarketOnOpen order was not expected to fill at submission time {Time}");
+                }
+            });
+        }
+
+        public override void OnOrderEvent(OrderEvent orderEvent)
+        {
+            if (orderEvent.Status != OrderStatus.Filled)
+            {
+                return;
+            }
+
+            var fillLocalTime = orderEvent.UtcTime.ConvertFromUtc(Securities[orderEvent.Symbol].Exchange.TimeZone);
+
+            if (_marketOnCloseTicket != null && orderEvent.OrderId == _marketOnCloseTicket.OrderId)
+            {
+                // MarketOnClose must fill at the close of the submission day, not on the stale previous close
+                var expectedClose = Securities[_daily].Exchange.Hours.GetNextMarketClose(_tradingDay, false);
+                if (fillLocalTime != expectedClose)
+                {
+                    throw new RegressionTestException(
+                        $"Expected the MarketOnClose order to fill at {expectedClose} but filled at {fillLocalTime}");
+                }
+            }
+            else if (_marketOnOpenTicket != null && orderEvent.OrderId == _marketOnOpenTicket.OrderId)
+            {
+                // MarketOnOpen must fill on a later session (the next open), not on the submission day
+                if (fillLocalTime.Date <= _tradingDay.Date)
+                {
+                    throw new RegressionTestException(
+                        $"Expected the MarketOnOpen order to fill on a later session than {_tradingDay:yyyy-MM-dd} but filled at {fillLocalTime}");
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_minuteTicket == null || _minuteTicket.Status != OrderStatus.Filled)
+            {
+                throw new RegressionTestException("The minute resolution market order was expected to be filled");
+            }
+
+            if (_marketOnCloseTicket == null || _marketOnCloseTicket.Status != OrderStatus.Filled)
+            {
+                throw new RegressionTestException("The converted MarketOnClose order was expected to be filled");
+            }
+
+            if (_marketOnOpenTicket == null || _marketOnOpenTicket.Status != OrderStatus.Filled)
+            {
+                throw new RegressionTestException("The converted MarketOnOpen order was expected to be filled");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 3150;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "3"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "-1.206%"},
+            {"Drawdown", "0.000%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "99991.14"},
+            {"Net Profit", "-0.009%"},
+            {"Sharpe Ratio", "-3.861"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0.008"},
+            {"Beta", "0.035"},
+            {"Annual Standard Deviation", "0.005"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "5.642"},
+            {"Tracking Error", "0.131"},
+            {"Treynor Ratio", "-0.526"},
+            {"Total Fees", "$3.00"},
+            {"Estimated Strategy Capacity", "$42000000.00"},
+            {"Lowest Capacity Asset", "IBM R735QTJ8XC9X"},
+            {"Portfolio Turnover", "1.41%"},
+            {"Drawdown Recovery", "0"},
+            {"OrderListHash", "ebf45813288201552f706cd072fe9ad8"}
+        };
+    }
+}

--- a/Algorithm.CSharp/IndexOptionCallITMExpiryDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallITMExpiryDailyRegressionAlgorithm.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 197;
+        public override long DataPoints => 196;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/IndexOptionCallITMExpiryDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallITMExpiryDailyRegressionAlgorithm.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 196;
+        public override long DataPoints => 197;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -77,7 +77,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Lowest Capacity Asset", "SPX XL80P3GHIA9A|SPX 31"},
             {"Portfolio Turnover", "1.90%"},
             {"Drawdown Recovery", "9"},
-            {"OrderListHash", "b02af3819f796241269614e0ebf49964"}
+            {"OrderListHash", "b2fd77dc3263ae6b61f9940fc2370235"}
         };
     }
 }

--- a/Algorithm.CSharp/IndexOptionCallOTMExpiryDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallOTMExpiryDailyRegressionAlgorithm.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 187;
+        public override long DataPoints => 186;
 
         /// <summary>
         /// Data Points count of the algorithm history

--- a/Algorithm.CSharp/IndexOptionCallOTMExpiryDailyRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionCallOTMExpiryDailyRegressionAlgorithm.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of all timeslices of algorithm
         /// </summary>
-        public override long DataPoints => 186;
+        public override long DataPoints => 187;
 
         /// <summary>
         /// Data Points count of the algorithm history
@@ -77,7 +77,7 @@ namespace QuantConnect.Algorithm.CSharp
             {"Lowest Capacity Asset", "SPX XL80P59H9OI6|SPX 31"},
             {"Portfolio Turnover", "0.00%"},
             {"Drawdown Recovery", "0"},
-            {"OrderListHash", "0a8db8bba3b2198ba4675fc909426c35"}
+            {"OrderListHash", "c9b46cdc095c129d82c87864aba89cad"}
         };
     }
 }

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -261,8 +261,8 @@ namespace QuantConnect.Algorithm
                 // it has no fresh intraday price to fill against (it would otherwise fill at the stale previous
                 // close). It is filled at today's close (MarketOnClose), or at the next open (MarketOnOpen) if we are
                 // already within the MarketOnClose submission buffer.
-                // This is only done in backtesting. In live trading an open-market market order fills at the real
-                // current price, so we leave it as a regular market order. Markets that never close (e.g. crypto,
+                // This is only done in backtesting. In live trading an open-market market order fills at the current
+                // market price, so we leave it as a regular market order. Markets that never close (e.g. crypto,
                 // forex) have no open/close to convert to, so they are left as a regular market order too.
                 if (!LiveMode && !security.Exchange.Hours.IsMarketAlwaysOpen && IsDailyResolutionOnly(security.Symbol))
                 {
@@ -272,7 +272,7 @@ namespace QuantConnect.Algorithm
 
                     if (!_isDailyResolutionMarketOrderConversionWarningSent && convertedTicket.SubmitRequest.Response.IsSuccess)
                     {
-                        Debug("Warning: market orders on daily resolution data sent during market hours are automatically converted into MarketOnClose orders (or MarketOnOpen near the close) to avoid filling at the stale previous close. Note: in live trading this conversion is not applied, as the order fills at the real current price.");
+                        Debug("Warning: market orders on daily resolution data sent during market hours are automatically converted into MarketOnClose orders (or MarketOnOpen near the close) to avoid filling at the stale previous close. Note: in live trading this conversion is not applied, as the order fills at the current market price.");
                         _isDailyResolutionMarketOrderConversionWarningSent = true;
                     }
                     return convertedTicket;

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -245,14 +245,13 @@ namespace QuantConnect.Algorithm
             if (security.Type != SecurityType.Future && security.Type != SecurityType.FutureOption)
             {
                 // When the market is closed the order is converted to fill at the next open (MarketOnOpen),
-                // regardless of resolution. IsDailyResolutionOnly is only needed here for the one-time warning,
-                // so it is short-circuited away once the warning has been sent.
+                // regardless of resolution.
                 if (!security.Exchange.ExchangeOpen)
                 {
                     var mooTicket = MarketOnOpenOrder(security.Symbol, quantity, asynchronous, tag, orderProperties);
-                    if (!_isMarketOnOpenOrderWarningSent && mooTicket.SubmitRequest.Response.IsSuccess && IsDailyResolutionOnly(security.Symbol))
+                    if (!_isMarketOnOpenOrderWarningSent && mooTicket.SubmitRequest.Response.IsSuccess)
                     {
-                        Debug("Warning: market orders sent using daily data, or after market hours, are automatically converted into MarketOnOpen orders to fill at the next market open.");
+                        Debug("Warning: market orders submitted while the market is closed are automatically converted into MarketOnOpen orders to fill at the next market open.");
                         _isMarketOnOpenOrderWarningSent = true;
                     }
                     return mooTicket;
@@ -263,8 +262,9 @@ namespace QuantConnect.Algorithm
                 // close). It is filled at today's close (MarketOnClose), or at the next open (MarketOnOpen) if we are
                 // already within the MarketOnClose submission buffer.
                 // This is only done in backtesting. In live trading an open-market market order fills at the real
-                // current price, so we leave it as a regular market order.
-                if (!LiveMode && IsDailyResolutionOnly(security.Symbol))
+                // current price, so we leave it as a regular market order. Markets that never close (e.g. crypto,
+                // forex) have no open/close to convert to, so they are left as a regular market order too.
+                if (!LiveMode && !security.Exchange.Hours.IsMarketAlwaysOpen && IsDailyResolutionOnly(security.Symbol))
                 {
                     var convertedTicket = IsWithinMarketOnCloseSubmissionBuffer(security)
                         ? MarketOnOpenOrder(security.Symbol, quantity, asynchronous, tag, orderProperties)

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -31,6 +31,7 @@ namespace QuantConnect.Algorithm
     {
         private int _maxOrders = 10000;
         private bool _isMarketOnOpenOrderWarningSent;
+        private bool _isDailyResolutionMarketOrderConversionWarningSent;
         private bool _isMarketOnOpenOrderRestrictedForFuturesWarningSent;
         private bool _isGtdTfiForMooAndMocOrdersValidationWarningSent;
         private bool _isOptionsOrderOnStockSplitWarningSent;
@@ -240,21 +241,42 @@ namespace QuantConnect.Algorithm
         {
             var security = GetSecurityForOrder(symbol);
 
-            // check the exchange is open before sending a market order, if it's not open then convert it into a market on open order.
             // For futures and FOPs, market orders can be submitted on extended hours, so we let them through.
-            if ((security.Type != SecurityType.Future && security.Type != SecurityType.FutureOption) && !security.Exchange.ExchangeOpen)
+            if (security.Type != SecurityType.Future && security.Type != SecurityType.FutureOption)
             {
-                var mooTicket = MarketOnOpenOrder(security.Symbol, quantity, asynchronous, tag, orderProperties);
-                if (!_isMarketOnOpenOrderWarningSent)
+                // When the market is closed the order is converted to fill at the next open (MarketOnOpen),
+                // regardless of resolution. IsDailyResolutionOnly is only needed here for the one-time warning,
+                // so it is short-circuited away once the warning has been sent.
+                if (!security.Exchange.ExchangeOpen)
                 {
-                    var anyNonDailySubscriptions = security.Subscriptions.Any(x => x.Resolution != Resolution.Daily);
-                    if (mooTicket.SubmitRequest.Response.IsSuccess && !anyNonDailySubscriptions)
+                    var mooTicket = MarketOnOpenOrder(security.Symbol, quantity, asynchronous, tag, orderProperties);
+                    if (!_isMarketOnOpenOrderWarningSent && mooTicket.SubmitRequest.Response.IsSuccess && IsDailyResolutionOnly(security.Symbol))
                     {
-                        Debug("Warning: all market orders sent using daily data, or market orders sent after hours are automatically converted into MarketOnOpen orders.");
+                        Debug("Warning: market orders sent using daily data, or after market hours, are automatically converted into MarketOnOpen orders to fill at the next market open.");
                         _isMarketOnOpenOrderWarningSent = true;
                     }
+                    return mooTicket;
                 }
-                return mooTicket;
+
+                // The market is open: only a security subscribed solely to daily resolution needs conversion, since
+                // it has no fresh intraday price to fill against (it would otherwise fill at the stale previous
+                // close). It is filled at today's close (MarketOnClose), or at the next open (MarketOnOpen) if we are
+                // already within the MarketOnClose submission buffer.
+                // This is only done in backtesting. In live trading an open-market market order fills at the real
+                // current price, so we leave it as a regular market order.
+                if (!LiveMode && IsDailyResolutionOnly(security.Symbol))
+                {
+                    var convertedTicket = IsWithinMarketOnCloseSubmissionBuffer(security)
+                        ? MarketOnOpenOrder(security.Symbol, quantity, asynchronous, tag, orderProperties)
+                        : MarketOnCloseOrder(security.Symbol, quantity, asynchronous, tag, orderProperties);
+
+                    if (!_isDailyResolutionMarketOrderConversionWarningSent && convertedTicket.SubmitRequest.Response.IsSuccess)
+                    {
+                        Debug("Warning: market orders on daily resolution data sent during market hours are automatically converted into MarketOnClose orders (or MarketOnOpen near the close) to avoid filling at the stale previous close. Note: in live trading this conversion is not applied, as the order fills at the real current price.");
+                        _isDailyResolutionMarketOrderConversionWarningSent = true;
+                    }
+                    return convertedTicket;
+                }
             }
 
             var request = CreateSubmitOrderRequest(OrderType.Market, security, quantity, tag, orderProperties ?? DefaultOrderProperties?.Clone(), asynchronous);
@@ -371,6 +393,37 @@ namespace QuantConnect.Algorithm
             var request = CreateSubmitOrderRequest(OrderType.MarketOnClose, security, quantity, tag, properties, asynchronous);
 
             return SubmitOrderRequest(request);
+        }
+
+        /// <summary>
+        /// Determines whether the given symbol is subscribed only at daily resolution, i.e. there is no intraday
+        /// (sub-daily) data to fill a market order against. Internal subscriptions are excluded. The current,
+        /// non-stale subscriptions are fetched from the subscription manager rather than from the security.
+        /// </summary>
+        private bool IsDailyResolutionOnly(Symbol symbol)
+        {
+            var configs = SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(symbol);
+            return configs.Count > 0 && configs.All(x => x.Resolution == Resolution.Daily);
+        }
+
+        /// <summary>
+        /// Determines whether a <see cref="OrderType.MarketOnClose"/> order for the given security would be rejected
+        /// for being submitted too close to the market close (within <see cref="Orders.MarketOnCloseOrder.SubmissionTimeBuffer"/>).
+        /// Mirrors the validation enforced in <see cref="PreOrderChecksImpl"/>.
+        /// </summary>
+        private bool IsWithinMarketOnCloseSubmissionBuffer(Security security)
+        {
+            if (security.Exchange.Hours.IsMarketAlwaysOpen)
+            {
+                return false;
+            }
+
+            var nextMarketClose = security.Exchange.Hours.GetNextMarketClose(security.LocalTime, false);
+            var latestSubmissionTimeUtc = nextMarketClose
+                .ConvertToUtc(security.Exchange.TimeZone)
+                .Subtract(Orders.MarketOnCloseOrder.SubmissionTimeBuffer);
+
+            return UtcTime > latestSubmissionTimeUtc;
         }
 
         /// <summary>
@@ -1149,7 +1202,13 @@ namespace QuantConnect.Algorithm
 
                 if (security.Exchange.Hours.IsOpen(security.LocalTime, false))
                 {
-                    return OrderResponse.Error(request, OrderResponseErrorCode.MarketOnOpenNotAllowedDuringRegularHours, $"Cannot submit a {nameof(OrderType.MarketOnOpen)} order while the market is open.");
+                    // A security subscribed only to daily resolution has no intraday data to fill against, so
+                    // MarketOnOpen/MarketOnClose are its execution proxies; allow MOO during regular hours for those
+                    // (e.g. when a daily market order is converted near the close, past the MarketOnClose buffer).
+                    if (!IsDailyResolutionOnly(security.Symbol))
+                    {
+                        return OrderResponse.Error(request, OrderResponseErrorCode.MarketOnOpenNotAllowedDuringRegularHours, $"Cannot submit a {nameof(OrderType.MarketOnOpen)} order while the market is open.");
+                    }
                 }
             }
             else if (request.OrderType == OrderType.MarketOnClose)
@@ -1159,17 +1218,12 @@ namespace QuantConnect.Algorithm
                     throw new InvalidOperationException($"Market never closes for this symbol {security.Symbol}, can no submit a {nameof(OrderType.MarketOnClose)} order.");
                 }
 
-                var nextMarketClose = security.Exchange.Hours.GetNextMarketClose(security.LocalTime, false);
-
-                // Enforce MarketOnClose submission buffer
-                var latestSubmissionTimeUtc = nextMarketClose
-                    .ConvertToUtc(security.Exchange.TimeZone)
-                    .Subtract(Orders.MarketOnCloseOrder.SubmissionTimeBuffer);
-                if (UtcTime > latestSubmissionTimeUtc)
+                // Enforce MarketOnClose submission buffer.
+                // Default buffer is 15.5 minutes because with minute data a user will receive the 3:44->3:45 bar at 3:45,
+                // if the latest time is 3:45 it is already too late to submit one of these orders
+                if (IsWithinMarketOnCloseSubmissionBuffer(security))
                 {
                     // Tell user the required buffer on these orders, also inform them it can be changed for special cases.
-                    // Default buffer is 15.5 minutes because with minute data a user will receive the 3:44->3:45 bar at 3:45,
-                    // if the latest time is 3:45 it is already too late to submit one of these orders
                     return OrderResponse.Error(request, OrderResponseErrorCode.MarketOnCloseOrderTooLate,
                         $"MarketOnClose orders must be placed within {Orders.MarketOnCloseOrder.SubmissionTimeBuffer} before market close." +
                         " Override this TimeSpan buffer by setting Orders.MarketOnCloseOrder.SubmissionTimeBuffer in QCAlgorithm.Initialize()."

--- a/Tests/Engine/Results/BacktestingResultHandlerTests.cs
+++ b/Tests/Engine/Results/BacktestingResultHandlerTests.cs
@@ -446,10 +446,10 @@ namespace QuantConnect.Tests.Engine.Results
             {
                 0,                      // First sample at start 10/7 12AM, zero because no change has occurred yet
                 0,                      // 10/7 - 10/8 <- We get first data at 12AM on 10/8
-                -0.01112113,            // 10/8 - 10/9 <- We buy at with OnMarketOpen order
-                -3.291606E-05,          // 10/9 - 10/10
-                0.01100997,             // 10/10 - 10/11
-                0.005968033             // 10/11 12AM - 10/11 8PM
+                -0.01112113,            // 10/8 - 10/9 <- We buy with a MarketOnOpen order (submitted while the market is closed)
+                0.0005122819,           // 10/9 - 10/10 <- RemoveSecurity liquidation now converts (was filling at the stale previous close)
+                0.009923037000000001,   // 10/10 - 10/11
+                0.007853915             // 10/11 12AM - 10/11 8PM
             };
 
             Assert.AreEqual(expectedPerformance, performance.Values.ToList());
@@ -463,9 +463,9 @@ namespace QuantConnect.Tests.Engine.Results
             {
                 0,                          // First sample at start 10/7 12AM, seen as missing since percent change won't exists for that day
                 0,                          // 10/7 - 10/8 <- We get first data at 12AM on 10/8
-                -0.011121126999999979,      // 10/8 - 10/9 <- We buy at with OnMarketOpen order
-                -3.29160637250732E-05,      // 10/9 - 10/10
-                0.011009966611364035,       // 10/10 - 10/11
+                -0.011121126999999979,      // 10/8 - 10/9 <- We buy with a MarketOnOpen order (submitted while the market is closed)
+                0.0005122821549045775,      // 10/9 - 10/10 <- RemoveSecurity liquidation now converts (was filling at the stale previous close)
+                0.009923037498293092,       // 10/10 - 10/11
             };
 
             Assert.AreEqual(expectedEquityPerformance, equityPerformance.ValuesAll.ToList());


### PR DESCRIPTION
## Description

A market order placed intraday — for example through a scheduled event — on an asset subscribed **only at daily resolution** has no fresh intraday price to fill against, so it was filling at the **stale previous daily close**. This is a common footgun when mixing daily resolution assets with minute resolution assets or intraday scheduled events.

`QCAlgorithm.MarketOrder` now converts these orders so they fill at a real daily open/close instead of the stale previous close:

| Situation | Behavior |
|---|---|
| Market **closed** (any resolution) | → `MarketOnOpen` *(unchanged)* |
| Market **open**, daily-only subscription, before MOC buffer | → `MarketOnClose` (today's close) |
| Market **open**, daily-only subscription, inside the MOC submission buffer near the close | → `MarketOnOpen` (next open) |
| Market **open**, asset has intraday data | plain `Market` *(unchanged)* |

Notes:
- Even right after the open (e.g. 09:31) only the previous daily close is available, so the order is still converted.
- The conversion is applied in **backtesting only**. In live trading an open-market market order fills at the real current price, so it is left as a regular market order.
- Two distinct one-time warning messages inform the user about each conversion case.

## Related Issue

Daily/Hour resolution market orders (and orders placed from intraday scheduled events) filling at a stale previous close.

## Motivation and Context

Filling at a stale previous close silently mis-prices fills for daily resolution strategies, especially when combined with intraday scheduling or mixed-resolution universes. Routing these to `MarketOnClose`/`MarketOnOpen` produces a realistic daily open/close fill.

## Requires Documentation Change

No public API change. New behavior is described via the algorithm warnings.

## How Has This Been Tested?

Added `DailyResolutionMarketOrderConversionRegressionAlgorithm` (daily SPY + minute IBM) asserting:
- 09:31 (right after open): daily order → `MarketOnClose`; minute order is **not** converted and fills immediately.
- 15:55 (inside the MOC buffer near close): daily order → `MarketOnOpen`, filling next session.
- Per-order fill-time and all-filled assertions.

Ran locally end-to-end (3 orders, both conversion warnings observed, all assertions pass).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Regression statistics updated

The conversion changes the fills of a few existing daily-resolution algorithms that place market orders intraday. All are legitimate improvements (orders no longer fill at the stale previous close), the in-algorithm assertions still pass, and only the affected fills/statistics changed:

- **IndexOptionCallITMExpiryDailyRegressionAlgorithm** / **IndexOptionCallOTMExpiryDailyRegressionAlgorithm** — the SPX index option entry is bought via `MarketOrder` one minute after the open. On daily resolution this previously filled at the stale previous close; it now converts to `MarketOnClose` and fills at the daily close. Same economics (`End Equity` unchanged), one extra data point, new `OrderListHash`.
- **AllShortableSymbolsCoarseSelectionRegressionAlgorithm** (C# and Python) — places `MarketOrder`s on daily-resolution coarse-selected symbols. An intraday order's type changes (Market → converted); `End Equity` and all other statistics are identical, only the `OrderListHash` changed.
- **ResolutionSwitchingAlgorithmSamplesNotMisalignedAbsolute** (`Tests/Engine/Results/BacktestingResultHandlerTests.cs`) — a sampling change-detector. The algorithm's `RemoveSecurity` liquidation fires at 15:50 while the market is open; on daily resolution it previously filled at the stale previous close and now converts, shifting the equity/performance samples (benchmark samples unchanged). Expected sample values were updated accordingly.

Markets that never close (crypto/forex) and futures are excluded from the conversion, and the conversion is not applied in live trading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

