### PR TITLE
Add configurable futures roll date

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -1054,7 +1054,7 @@ namespace QuantConnect.Algorithm
                         request.DataType, request.Symbol, request.Resolution, request.ExchangeHours,
                         request.DataTimeZone, request.FillForwardResolution, request.IncludeExtendedMarketHours,
                         request.IsCustomData, request.DataNormalizationMode, request.TickType, request.DataMappingMode,
-                        request.ContractDepthOffset);
+                        request.ContractDepthOffset, request.DataMappingModeDaysOffset, request.ContractMonthCycle);
 
                     if (!sentMessage)
                     {
@@ -1291,6 +1291,8 @@ namespace QuantConnect.Algorithm
                 var dataNormalizationMode = userConfigIfAny?.DataNormalizationMode ?? UniverseSettings.GetUniverseNormalizationModeOrDefault(symbol.SecurityType);
                 var dataMappingMode = userConfigIfAny?.DataMappingMode ?? UniverseSettings.GetUniverseMappingModeOrDefault(symbol.SecurityType, symbol.ID.Market);
                 var contractDepthOffset = userConfigIfAny?.ContractDepthOffset ?? (uint)Math.Abs(UniverseSettings.ContractDepthOffset);
+                var dataMappingModeDaysOffset = userConfigIfAny?.DataMappingModeDaysOffset ?? UniverseSettings.DataMappingModeDaysOffset;
+                var contractMonthCycle = userConfigIfAny?.ContractMonthCycle ?? UniverseSettings.ContractMonthCycle;
 
                 // If type was specified and not a lean data type and also not abstract, we create a new subscription
                 if (type != null && !LeanData.IsCommonLeanDataType(type) && !type.IsAbstract)
@@ -1322,7 +1324,9 @@ namespace QuantConnect.Algorithm
                         true,
                         dataNormalizationMode,
                         dataMappingMode,
-                        contractDepthOffset)};
+                        contractDepthOffset,
+                        dataMappingModeDaysOffset: dataMappingModeDaysOffset,
+                        contractMonthCycle: contractMonthCycle)};
                 }
 
                 var res = GetResolution(symbol, resolution, type);
@@ -1352,7 +1356,9 @@ namespace QuantConnect.Algorithm
                             true,
                             dataNormalizationMode,
                             dataMappingMode,
-                            contractDepthOffset);
+                            contractDepthOffset,
+                            dataMappingModeDaysOffset: dataMappingModeDaysOffset,
+                            contractMonthCycle: contractMonthCycle);
                     })
                     // lets make sure to respect the order of the data types, if used on a history request will affect outcome when using pushthrough for example
                     .OrderByDescending(config => GetTickTypeOrder(config.SecurityType, config.TickType));

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1987,10 +1987,13 @@ namespace QuantConnect.Algorithm
         /// <param name="dataNormalizationMode">The price scaling mode to use for the security</param>
         /// <param name="contractDepthOffset">The continuous contract desired offset from the current front month.
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
+        /// <param name="dataMappingModeDaysOffset">The continuous contract mapping offset in tradeable days</param>
+        /// <param name="contractMonthCycle">Optional contract expiration months to use when walking continuous future contract depth</param>
         /// <returns>The new Security that was added to the algorithm</returns>
         [DocumentationAttribute(AddingData)]
         public Security AddSecurity(Symbol symbol, Resolution? resolution = null, bool? fillForward = null, decimal leverage = Security.NullLeverage, bool? extendedMarketHours = null,
-            DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0)
+            DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0,
+            int dataMappingModeDaysOffset = 0, int[] contractMonthCycle = null)
         {
             // allow users to specify negative numbers, we get the abs of it
             var contractOffset = (uint)Math.Abs(contractDepthOffset);
@@ -2030,7 +2033,9 @@ namespace QuantConnect.Algorithm
                     extendedMarketHours.Value,
                     isFilteredSubscription,
                     dataNormalizationMode: dataNormalizationMode.Value,
-                    contractDepthOffset: (uint)contractDepthOffset);
+                    contractDepthOffset: (uint)contractDepthOffset,
+                    dataMappingModeDaysOffset: dataMappingModeDaysOffset,
+                    contractMonthCycle: contractMonthCycle);
             }
             else
             {
@@ -2039,7 +2044,9 @@ namespace QuantConnect.Algorithm
                    securityFillForward,
                    extendedMarketHours.Value,
                    isFilteredSubscription,
-                   contractDepthOffset: (uint)contractDepthOffset);
+                   contractDepthOffset: (uint)contractDepthOffset,
+                   dataMappingModeDaysOffset: dataMappingModeDaysOffset,
+                   contractMonthCycle: contractMonthCycle);
             }
 
             var security = Securities.CreateSecurity(symbol, configs, leverage);
@@ -2076,6 +2083,8 @@ namespace QuantConnect.Algorithm
                             DataMappingMode = dataMappingMode ?? UniverseSettings.GetUniverseMappingModeOrDefault(symbol.SecurityType, symbol.ID.Market),
                             DataNormalizationMode = dataNormalizationMode ?? UniverseSettings.GetUniverseNormalizationModeOrDefault(symbol.SecurityType),
                             ContractDepthOffset = (int)contractOffset,
+                            DataMappingModeDaysOffset = dataMappingModeDaysOffset,
+                            ContractMonthCycle = contractMonthCycle,
                             SubscriptionDataTypes = dataTypes,
                             Asynchronous = UniverseSettings.Asynchronous
                         };
@@ -2213,11 +2222,14 @@ namespace QuantConnect.Algorithm
         /// <param name="dataNormalizationMode">The price scaling mode to use for the continuous future contract</param>
         /// <param name="contractDepthOffset">The continuous future contract desired offset from the current front month.
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
+        /// <param name="dataMappingModeDaysOffset">The continuous contract mapping offset in tradeable days</param>
+        /// <param name="contractMonthCycle">Optional contract expiration months to use when walking continuous future contract depth</param>
         /// <returns>The new <see cref="Future"/> security</returns>
         [DocumentationAttribute(AddingData)]
         public Future AddFuture(string ticker, Resolution? resolution = null, string market = null,
             bool? fillForward = null, decimal leverage = Security.NullLeverage, bool? extendedMarketHours = null,
-            DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0)
+            DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0,
+            int dataMappingModeDaysOffset = 0, int[] contractMonthCycle = null)
         {
             market = GetMarket(market, ticker, SecurityType.Future);
 
@@ -2231,7 +2243,8 @@ namespace QuantConnect.Algorithm
             }
 
             return (Future)AddSecurity(canonicalSymbol, resolution, fillForward, leverage, extendedMarketHours, dataMappingMode: dataMappingMode,
-                dataNormalizationMode: dataNormalizationMode, contractDepthOffset: contractDepthOffset);
+                dataNormalizationMode: dataNormalizationMode, contractDepthOffset: contractDepthOffset, dataMappingModeDaysOffset: dataMappingModeDaysOffset,
+                contractMonthCycle: contractMonthCycle);
         }
 
         /// <summary>

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -610,10 +610,14 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// <param name="dataNormalizationMode">The price scaling mode to use for the security</param>
         /// <param name="contractDepthOffset">The continuous contract desired offset from the current front month.
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
+        /// <param name="dataMappingModeDaysOffset">The continuous contract mapping offset in tradeable days</param>
+        /// <param name="contractMonthCycle">Optional contract expiration months to use when walking continuous future contract depth</param>
         /// <returns>The new Security that was added to the algorithm</returns>
         public Security AddSecurity(Symbol symbol, Resolution? resolution = null, bool? fillForward = null, decimal leverage = Security.NullLeverage, bool? extendedMarketHours = null,
-            DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0)
-            => _baseAlgorithm.AddSecurity(symbol, resolution, fillForward, leverage, extendedMarketHours, dataMappingMode, dataNormalizationMode, contractDepthOffset);
+            DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0,
+            int dataMappingModeDaysOffset = 0, int[] contractMonthCycle = null)
+            => _baseAlgorithm.AddSecurity(symbol, resolution, fillForward, leverage, extendedMarketHours, dataMappingMode, dataNormalizationMode,
+                contractDepthOffset, dataMappingModeDaysOffset, contractMonthCycle);
 
         /// <summary>
         /// Creates and adds a new single <see cref="Future"/> contract to the algorithm

--- a/Common/Data/Auxiliary/MapFile.cs
+++ b/Common/Data/Auxiliary/MapFile.cs
@@ -105,6 +105,11 @@ namespace QuantConnect.Data.Auxiliary
         /// <returns>Symbol on this date.</returns>
         public string GetMappedSymbol(DateTime searchDate, string defaultReturnValue = "", DataMappingMode? dataMappingMode = null)
         {
+            if (dataMappingMode == DataMappingMode.TradingDaysBeforeExpiry)
+            {
+                dataMappingMode = DataMappingMode.LastTradingDay;
+            }
+
             var mappedSymbol = defaultReturnValue;
             //Iterate backwards to find the most recent factor:
             for (var i = 0; i < _data.Count; i++)

--- a/Common/Data/Auxiliary/MappingContractFactorProvider.cs
+++ b/Common/Data/Auxiliary/MappingContractFactorProvider.cs
@@ -43,6 +43,13 @@ namespace QuantConnect.Data.Auxiliary
                 return 0;
             }
 
+            if (dataMappingMode == DataMappingMode.TradingDaysBeforeExpiry)
+            {
+                throw new NotSupportedException(
+                    $"{DataMappingMode.TradingDaysBeforeExpiry} does not support {dataNormalizationMode} normalization because continuous future factor files do not contain factors for shifted roll dates. " +
+                    $"Use {DataNormalizationMode.Raw} normalization or choose a factor-file-backed mapping mode.");
+            }
+
             var factor = 1m;
             if (dataNormalizationMode is DataNormalizationMode.BackwardsPanamaCanal or DataNormalizationMode.ForwardPanamaCanal)
             {

--- a/Common/Data/HistoryRequest.cs
+++ b/Common/Data/HistoryRequest.cs
@@ -98,6 +98,16 @@ namespace QuantConnect.Data
         public uint ContractDepthOffset { get; set; }
 
         /// <summary>
+        /// The continuous contract mapping offset in tradeable days
+        /// </summary>
+        public int DataMappingModeDaysOffset { get; set; }
+
+        /// <summary>
+        /// Optional contract expiration months to use when walking continuous future contract depth
+        /// </summary>
+        public IReadOnlyList<int> ContractMonthCycle { get; set; }
+
+        /// <summary>
         /// Gets the tradable days specified by this request, in the security's data time zone
         /// </summary>
         public override IEnumerable<DateTime> TradableDaysInDataTimeZone => Time.EachTradeableDayInTimeZone(ExchangeHours,
@@ -137,7 +147,9 @@ namespace QuantConnect.Data
             DataNormalizationMode dataNormalizationMode,
             TickType tickType,
             DataMappingMode dataMappingMode = DataMappingMode.OpenInterest,
-            uint contractDepthOffset = 0)
+            uint contractDepthOffset = 0,
+            int dataMappingModeDaysOffset = 0,
+            IReadOnlyList<int> contractMonthCycle = null)
             : base(startTimeUtc, endTimeUtc, exchangeHours, tickType, isCustomData, dataType)
         {
             Symbol = symbol;
@@ -149,6 +161,8 @@ namespace QuantConnect.Data
             TickType = tickType;
             DataMappingMode = dataMappingMode;
             ContractDepthOffset = contractDepthOffset;
+            DataMappingModeDaysOffset = dataMappingModeDaysOffset;
+            ContractMonthCycle = contractMonthCycle;
         }
 
         /// <summary>
@@ -161,7 +175,8 @@ namespace QuantConnect.Data
         public HistoryRequest(SubscriptionDataConfig config, SecurityExchangeHours hours, DateTime startTimeUtc, DateTime endTimeUtc)
             : this(startTimeUtc, endTimeUtc, config.Type, config.Symbol, config.Resolution,
                 hours, config.DataTimeZone, config.FillDataForward ? config.Resolution : (Resolution?)null,
-                config.ExtendedMarketHours, config.IsCustomData, config.DataNormalizationMode, config.TickType, config.DataMappingMode, config.ContractDepthOffset)
+                config.ExtendedMarketHours, config.IsCustomData, config.DataNormalizationMode, config.TickType, config.DataMappingMode,
+                config.ContractDepthOffset, config.DataMappingModeDaysOffset, config.ContractMonthCycle)
         {
         }
 
@@ -173,7 +188,8 @@ namespace QuantConnect.Data
         /// <param name="newEndTimeUtc">The end time for this request</param>
         public HistoryRequest(HistoryRequest request, Symbol newSymbol, DateTime newStartTimeUtc, DateTime newEndTimeUtc)
             : this (newStartTimeUtc, newEndTimeUtc, request.DataType, newSymbol, request.Resolution, request.ExchangeHours, request.DataTimeZone, request.FillForwardResolution,
-                  request.IncludeExtendedMarketHours, request.IsCustomData, request.DataNormalizationMode, request.TickType, request.DataMappingMode, request.ContractDepthOffset)
+                  request.IncludeExtendedMarketHours, request.IsCustomData, request.DataNormalizationMode, request.TickType, request.DataMappingMode,
+                  request.ContractDepthOffset, request.DataMappingModeDaysOffset, request.ContractMonthCycle)
         { }
     }
 }

--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Linq;
 using NodaTime;
 using QuantConnect.Util;
 using QuantConnect.Securities;
@@ -109,6 +110,17 @@ namespace QuantConnect.Data
         public uint ContractDepthOffset { get; }
 
         /// <summary>
+        /// The continuous contract mapping offset in tradeable days.
+        /// For example, 30 will map 30 tradeable days before the mapped contract's normal mapping date
+        /// </summary>
+        public int DataMappingModeDaysOffset { get; }
+
+        /// <summary>
+        /// Optional contract expiration months to use when walking continuous future contract depth
+        /// </summary>
+        public IReadOnlyList<int> ContractMonthCycle { get; }
+
+        /// <summary>
         /// Price Scaling Factor:
         /// </summary>
         public decimal PriceScaleFactor { get; set; }
@@ -143,7 +155,7 @@ namespace QuantConnect.Data
                     return;
                 }
                 var oldSymbol = Symbol;
-                Symbol = Symbol.UpdateMappedSymbol(value, ContractDepthOffset);
+                Symbol = Symbol.UpdateMappedSymbol(value, ContractDepthOffset, ContractMonthCycle);
 
                 if (MappedSymbol != oldMappedValue)
                 {
@@ -197,6 +209,10 @@ namespace QuantConnect.Data
         /// <param name="dataMappingMode">The contract mapping mode to use for the security</param>
         /// <param name="contractDepthOffset">The continuous contract desired offset from the current front month.
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
+        /// <param name="mappedConfig">True if this is created as a mapped config. This is useful for continuous contract at live trading
+        /// where we subscribe to the mapped symbol but want to preserve uniqueness</param>
+        /// <param name="dataMappingModeDaysOffset">The continuous contract mapping offset in tradeable days</param>
+        /// <param name="contractMonthCycle">Optional contract expiration months to use when walking continuous future contract depth</param>
         public SubscriptionDataConfig(Type objectType,
             Symbol symbol,
             Resolution resolution,
@@ -211,7 +227,9 @@ namespace QuantConnect.Data
             DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted,
             DataMappingMode dataMappingMode = DataMappingMode.OpenInterest,
             uint contractDepthOffset = 0,
-            bool mappedConfig = false)
+            bool mappedConfig = false,
+            int dataMappingModeDaysOffset = 0,
+            IReadOnlyList<int> contractMonthCycle = null)
         {
             if (objectType == null) throw new ArgumentNullException(nameof(objectType));
             if (symbol == null) throw new ArgumentNullException(nameof(symbol));
@@ -229,6 +247,8 @@ namespace QuantConnect.Data
             DataTimeZone = dataTimeZone;
             _mappedConfig = mappedConfig;
             DataMappingMode = dataMappingMode;
+            DataMappingModeDaysOffset = dataMappingModeDaysOffset;
+            ContractMonthCycle = contractMonthCycle?.ToArray();
             ExchangeTimeZone = exchangeTimeZone;
             ContractDepthOffset = contractDepthOffset;
             IsFilteredSubscription = isFilteredSubscription;
@@ -265,6 +285,8 @@ namespace QuantConnect.Data
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
         /// <param name="mappedConfig">True if this is created as a mapped config. This is useful for continuous contract at live trading
         /// where we subscribe to the mapped symbol but want to preserve uniqueness</param>
+        /// <param name="dataMappingModeDaysOffset">The continuous contract mapping offset in tradeable days</param>
+        /// <param name="contractMonthCycle">Optional contract expiration months to use when walking continuous future contract depth</param>
         public SubscriptionDataConfig(SubscriptionDataConfig config,
             Type objectType = null,
             Symbol symbol = null,
@@ -280,7 +302,9 @@ namespace QuantConnect.Data
             DataNormalizationMode? dataNormalizationMode = null,
             DataMappingMode? dataMappingMode = null,
             uint? contractDepthOffset = null,
-            bool? mappedConfig = null)
+            bool? mappedConfig = null,
+            int? dataMappingModeDaysOffset = null,
+            IReadOnlyList<int> contractMonthCycle = null)
             : this(
             objectType ?? config.Type,
             symbol ?? config.Symbol,
@@ -296,7 +320,9 @@ namespace QuantConnect.Data
             dataNormalizationMode ?? config.DataNormalizationMode,
             dataMappingMode ?? config.DataMappingMode,
             contractDepthOffset ?? config.ContractDepthOffset,
-            mappedConfig ?? false
+            mappedConfig ?? false,
+            dataMappingModeDaysOffset ?? config.DataMappingModeDaysOffset,
+            contractMonthCycle ?? config.ContractMonthCycle
             )
         {
             PriceScaleFactor = config.PriceScaleFactor;
@@ -326,6 +352,8 @@ namespace QuantConnect.Data
                 && DataMappingMode == other.DataMappingMode
                 && ExchangeTimeZone.Equals(other.ExchangeTimeZone)
                 && ContractDepthOffset == other.ContractDepthOffset
+                && DataMappingModeDaysOffset == other.DataMappingModeDaysOffset
+                && ContractMonthCyclesAreEqual(ContractMonthCycle, other.ContractMonthCycle)
                 && IsFilteredSubscription == other.IsFilteredSubscription
                 && _mappedConfig == other._mappedConfig;
         }
@@ -364,6 +392,14 @@ namespace QuantConnect.Data
                 hashCode = (hashCode*397) ^ IsInternalFeed.GetHashCode();
                 hashCode = (hashCode*397) ^ IsCustomData.GetHashCode();
                 hashCode = (hashCode*397) ^ DataMappingMode.GetHashCode();
+                hashCode = (hashCode*397) ^ DataMappingModeDaysOffset.GetHashCode();
+                if (ContractMonthCycle != null)
+                {
+                    foreach (var month in ContractMonthCycle)
+                    {
+                        hashCode = (hashCode*397) ^ month.GetHashCode();
+                    }
+                }
                 hashCode = (hashCode*397) ^ DataTimeZone.Id.GetHashCode();// timezone hash is expensive, use id instead
                 hashCode = (hashCode*397) ^ ExchangeTimeZone.Id.GetHashCode();// timezone hash is expensive, use id instead
                 hashCode = (hashCode*397) ^ ContractDepthOffset.GetHashCode();
@@ -409,6 +445,19 @@ namespace QuantConnect.Data
         public string ToString(string symbol)
         {
             return Invariant($"{symbol},#{ContractDepthOffset},{MappedSymbol},{Resolution},{Type.Name},{TickType},{DataNormalizationMode},{DataMappingMode}{(IsInternalFeed ? ",Internal" : string.Empty)}");
+        }
+
+        private static bool ContractMonthCyclesAreEqual(IReadOnlyList<int> left, IReadOnlyList<int> right)
+        {
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+            if (left == null || right == null)
+            {
+                return false;
+            }
+            return left.SequenceEqual(right);
         }
 
         /// <summary>

--- a/Common/Data/UniverseSelection/ContinuousContractUniverse.cs
+++ b/Common/Data/UniverseSelection/ContinuousContractUniverse.cs
@@ -52,7 +52,9 @@ namespace QuantConnect.Data.UniverseSelection
             UniverseSettings = universeSettings;
             _mapFileProvider = Composer.Instance.GetPart<IMapFileProvider>();
 
-            _config = new SubscriptionDataConfig(Configuration, dataMappingMode: UniverseSettings.DataMappingMode, symbol: _security.Symbol.Canonical);
+            _config = new SubscriptionDataConfig(Configuration, dataMappingMode: UniverseSettings.DataMappingMode, symbol: _security.Symbol.Canonical,
+                dataMappingModeDaysOffset: UniverseSettings.DataMappingModeDaysOffset,
+                contractMonthCycle: UniverseSettings.ContractMonthCycle);
         }
 
         /// <summary>
@@ -66,7 +68,8 @@ namespace QuantConnect.Data.UniverseSelection
             yield return _security.Symbol.Canonical;
 
             var mapFile = _mapFileProvider.ResolveMapFile(_config);
-            var mappedSymbol = mapFile.GetMappedSymbol(utcTime.ConvertFromUtc(_security.Exchange.TimeZone), dataMappingMode: _config.DataMappingMode);
+            var localTime = utcTime.ConvertFromUtc(_security.Exchange.TimeZone);
+            var mappedSymbol = mapFile.GetMappedSymbol(GetMappingSearchDate(localTime), dataMappingMode: _config.DataMappingMode);
             if (!string.IsNullOrEmpty(mappedSymbol) && mappedSymbol != _mappedSymbol)
             {
                 if (_currentSymbol != null)
@@ -77,7 +80,7 @@ namespace QuantConnect.Data.UniverseSelection
                 _mappedSymbol = mappedSymbol;
 
                 _currentSymbol = _security.Symbol.Canonical
-                    .UpdateMappedSymbol(mappedSymbol, Configuration.ContractDepthOffset)
+                    .UpdateMappedSymbol(mappedSymbol, Configuration.ContractDepthOffset, _config.ContractMonthCycle)
                     .Underlying;
             }
 
@@ -144,10 +147,22 @@ namespace QuantConnect.Data.UniverseSelection
                     subscriptionDataTypes: new List<Tuple<Type, TickType>> { pair },
                     dataMappingMode: universeSettings.DataMappingMode,
                     contractDepthOffset: (uint)Math.Abs(universeSettings.ContractDepthOffset),
+                    dataMappingModeDaysOffset: universeSettings.DataMappingModeDaysOffset,
+                    contractMonthCycle: universeSettings.ContractMonthCycle,
                     // open interest is internal and the underlying mapped contracts of the continuous canonical
                     isInternalFeed: !symbol.IsCanonical() || pair.Item2 == TickType.OpenInterest));
             }
             return configs;
+        }
+
+        private DateTime GetMappingSearchDate(DateTime localTime)
+        {
+            if (_config.DataMappingMode != DataMappingMode.TradingDaysBeforeExpiry || _config.DataMappingModeDaysOffset == 0)
+            {
+                return localTime;
+            }
+
+            return Time.AddTradeableDays(_security.Exchange.Hours, localTime, _config.DataMappingModeDaysOffset, Configuration.ExtendedMarketHours);
         }
 
         /// <summary>

--- a/Common/Data/UniverseSelection/UniverseSettings.cs
+++ b/Common/Data/UniverseSelection/UniverseSettings.cs
@@ -16,6 +16,7 @@
 using System;
 using QuantConnect.Scheduling;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace QuantConnect.Data.UniverseSelection
 {
@@ -77,6 +78,17 @@ namespace QuantConnect.Data.UniverseSelection
         public int ContractDepthOffset { get; set; }
 
         /// <summary>
+        /// The continuous contract mapping offset in tradeable days.
+        /// For example, 30 will map 30 tradeable days before the mapped contract's normal mapping date
+        /// </summary>
+        public int DataMappingModeDaysOffset { get; set; }
+
+        /// <summary>
+        /// Optional contract expiration months to use when walking continuous future contract depth
+        /// </summary>
+        public IReadOnlyList<int> ContractMonthCycle { get; set; }
+
+        /// <summary>
         /// Allows a universe to specify which data types to add for a selected symbol
         /// </summary>
         public List<Tuple<Type, TickType>> SubscriptionDataTypes { get; set; }
@@ -101,13 +113,16 @@ namespace QuantConnect.Data.UniverseSelection
         /// <param name="asynchronous">True if universe selection can run asynchronous</param>
         /// <param name="selectionDateRule">If provided, will be used to determine universe selection schedule</param>
         public UniverseSettings(Resolution resolution, decimal leverage, bool fillForward, bool extendedMarketHours, TimeSpan minimumTimeInUniverse, DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted,
-            DataMappingMode dataMappingMode = DataMappingMode.OpenInterest, int contractDepthOffset = 0, bool? asynchronous = null, IDateRule selectionDateRule = null)
+            DataMappingMode dataMappingMode = DataMappingMode.OpenInterest, int contractDepthOffset = 0, bool? asynchronous = null, IDateRule selectionDateRule = null,
+            int dataMappingModeDaysOffset = 0, IReadOnlyList<int> contractMonthCycle = null)
         {
             Resolution = resolution;
             Leverage = leverage;
             FillForward = fillForward;
             DataMappingMode = dataMappingMode;
             ContractDepthOffset = contractDepthOffset;
+            DataMappingModeDaysOffset = dataMappingModeDaysOffset;
+            ContractMonthCycle = contractMonthCycle?.ToArray();
             ExtendedMarketHours = extendedMarketHours;
             MinimumTimeInUniverse = minimumTimeInUniverse;
             DataNormalizationMode = dataNormalizationMode;
@@ -129,6 +144,8 @@ namespace QuantConnect.Data.UniverseSelection
             FillForward = universeSettings.FillForward;
             DataMappingMode = universeSettings.DataMappingMode;
             ContractDepthOffset = universeSettings.ContractDepthOffset;
+            DataMappingModeDaysOffset = universeSettings.DataMappingModeDaysOffset;
+            ContractMonthCycle = universeSettings.ContractMonthCycle?.ToArray();
             ExtendedMarketHours = universeSettings.ExtendedMarketHours;
             MinimumTimeInUniverse = universeSettings.MinimumTimeInUniverse;
             DataNormalizationMode = universeSettings.DataNormalizationMode;

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -2699,6 +2699,9 @@ namespace QuantConnect
                 case "3":
                 case "openinterestannual":
                     return DataMappingMode.OpenInterestAnnual;
+                case "4":
+                case "tradingdaysbeforeexpiry":
+                    return DataMappingMode.TradingDaysBeforeExpiry;
                 default:
                     throw new ArgumentException(Messages.Extensions.UnknownDataMappingMode(dataMappingMode));
             }
@@ -3587,13 +3590,32 @@ namespace QuantConnect
         /// <returns>A new future expiration symbol instance</returns>
         public static Symbol AdjustSymbolByOffset(this Symbol symbol, uint offset)
         {
+            return symbol.AdjustSymbolByOffset(offset, null);
+        }
+
+        /// <summary>
+        /// Helper method that will return a back month, with future expiration, future contract based on the given offset and contract month cycle
+        /// </summary>
+        /// <param name="symbol">The none canonical future symbol</param>
+        /// <param name="offset">The quantity of contracts to move into the future expiration chain</param>
+        /// <param name="contractMonthCycle">Optional contract expiration months to include in the offset walk</param>
+        /// <returns>A new future expiration symbol instance</returns>
+        public static Symbol AdjustSymbolByOffset(this Symbol symbol, uint offset, IReadOnlyCollection<int> contractMonthCycle)
+        {
             if (symbol.SecurityType != SecurityType.Future || symbol.IsCanonical())
             {
                 throw new InvalidOperationException(Messages.Extensions.ErrorAdjustingSymbolByOffset);
             }
 
+            var contractMonths = contractMonthCycle?.ToHashSet();
             var expiration = symbol.ID.Date;
-            for (var i = 0; i < offset; i++)
+            var remainingOffset = offset;
+            if (contractMonths != null && !contractMonths.Contains(expiration.Month))
+            {
+                remainingOffset++;
+            }
+
+            for (var i = 0; i < remainingOffset; i++)
             {
                 var expiryFunction = FuturesExpiryFunctions.FuturesExpiryFunction(symbol);
                 DateTime newExpiration;
@@ -3603,7 +3625,7 @@ namespace QuantConnect
                 {
                     monthOffset++;
                     newExpiration = expiryFunction(expiration.AddMonths(monthOffset)).Date;
-                } while (newExpiration <= expiration);
+                } while (newExpiration <= expiration || contractMonths != null && !contractMonths.Contains(newExpiration.Month));
 
                 expiration = newExpiration;
                 symbol = Symbol.CreateFuture(symbol.ID.Symbol, symbol.ID.Market, newExpiration);
@@ -4152,7 +4174,8 @@ namespace QuantConnect
             var dataNormalizationMode = settings.GetUniverseNormalizationModeOrDefault(symbol.SecurityType);
 
             future = (Future)algorithm.AddSecurity(symbol.Canonical, settings.Resolution, settings.FillForward, settings.Leverage, settings.ExtendedMarketHours,
-                settings.DataMappingMode, dataNormalizationMode, settings.ContractDepthOffset);
+                settings.DataMappingMode, dataNormalizationMode, settings.ContractDepthOffset, settings.DataMappingModeDaysOffset,
+                settings.ContractMonthCycle?.ToArray());
 
             // let's yield back both the future chain and the continuous future universe
             return algorithm.UniverseManager.Values.Where(universe => universe.Configuration.Symbol == symbol.Canonical || ContinuousContractUniverse.CreateSymbol(symbol.Canonical) == universe.Configuration.Symbol);
@@ -4286,7 +4309,9 @@ namespace QuantConnect
                 isFilteredSubscription,
                 request.DataNormalizationMode,
                 request.DataMappingMode,
-                request.ContractDepthOffset
+                request.ContractDepthOffset,
+                dataMappingModeDaysOffset: request.DataMappingModeDaysOffset,
+                contractMonthCycle: request.ContractMonthCycle
             );
         }
 

--- a/Common/Global.cs
+++ b/Common/Global.cs
@@ -984,6 +984,10 @@ namespace QuantConnect
         /// The contract maps when any of the back month contracts of the next year have a higher volume that the current front month (3)
         /// </summary>
         OpenInterestAnnual,
+        /// <summary>
+        /// The contract maps a configured number of trading days before the front month contract expires (4)
+        /// </summary>
+        TradingDaysBeforeExpiry
     }
 
     /// <summary>

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -725,9 +725,12 @@ namespace QuantConnect.Interfaces
         /// <param name="dataNormalizationMode">The price scaling mode to use for the security</param>
         /// <param name="contractDepthOffset">The continuous contract desired offset from the current front month.
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
+        /// <param name="dataMappingModeDaysOffset">The continuous contract mapping offset in tradeable days</param>
+        /// <param name="contractMonthCycle">Optional contract expiration months to use when walking continuous future contract depth</param>
         /// <returns>The new Security that was added to the algorithm</returns>
         Security AddSecurity(Symbol symbol, Resolution? resolution = null, bool? fillForward = null, decimal leverage = Security.NullLeverage, bool? extendedMarketHours = null,
-            DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0);
+            DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0,
+            int dataMappingModeDaysOffset = 0, int[] contractMonthCycle = null);
 
         /// <summary>
         /// Creates and adds a new single <see cref="Future"/> contract to the algorithm

--- a/Common/Interfaces/ISubscriptionDataConfigService.cs
+++ b/Common/Interfaces/ISubscriptionDataConfigService.cs
@@ -42,7 +42,9 @@ namespace QuantConnect.Interfaces
             bool isCustomData = false,
             DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted,
             DataMappingMode dataMappingMode = DataMappingMode.OpenInterest,
-            uint contractDepthOffset = 0
+            uint contractDepthOffset = 0,
+            int dataMappingModeDaysOffset = 0,
+            IReadOnlyList<int> contractMonthCycle = null
             );
 
         /// <summary>
@@ -61,7 +63,9 @@ namespace QuantConnect.Interfaces
             List<Tuple<Type, TickType>> subscriptionDataTypes = null,
             DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted,
             DataMappingMode dataMappingMode = DataMappingMode.OpenInterest,
-            uint contractDepthOffset = 0
+            uint contractDepthOffset = 0,
+            int dataMappingModeDaysOffset = 0,
+            IReadOnlyList<int> contractMonthCycle = null
             );
 
         /// <summary>

--- a/Common/Symbol.cs
+++ b/Common/Symbol.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using ProtoBuf;
 using Python.Runtime;
 using Newtonsoft.Json;
@@ -482,6 +483,16 @@ namespace QuantConnect
         /// </summary>
         public Symbol UpdateMappedSymbol(string mappedSymbol, uint contractDepthOffset = 0)
         {
+            return UpdateMappedSymbol(mappedSymbol, contractDepthOffset, null);
+        }
+
+        /// <summary>
+        /// Creates new symbol with updated mapped symbol and optional future contract month cycle.
+        /// Symbol Mapping: When symbols change over time (e.g. CHASE-> JPM) need to update the symbol requested.
+        /// Method returns newly created symbol
+        /// </summary>
+        public Symbol UpdateMappedSymbol(string mappedSymbol, uint contractDepthOffset, IReadOnlyCollection<int> contractMonthCycle)
+        {
             // Throw for any option SecurityType that is not for equities, we don't support mapping for them (FOPs and Index Options)
             if (ID.SecurityType.IsOption() && SecurityType != SecurityType.Option)
             {
@@ -497,7 +508,7 @@ namespace QuantConnect
                 }
                 var id = SecurityIdentifier.Parse(mappedSymbol);
                 var underlying = new Symbol(id, mappedSymbol);
-                underlying = underlying.AdjustSymbolByOffset(contractDepthOffset);
+                underlying = underlying.AdjustSymbolByOffset(contractDepthOffset, contractMonthCycle);
 
                 // we map the underlying
                 return new Symbol(ID, underlying.Value, underlying);
@@ -513,7 +524,7 @@ namespace QuantConnect
             // This will ensure that we map all of the underlying Symbol(s) that also require mapping updates.
             if (HasUnderlying)
             {
-                underlyingSymbol = Underlying.UpdateMappedSymbol(mappedSymbol, contractDepthOffset);
+                underlyingSymbol = Underlying.UpdateMappedSymbol(mappedSymbol, contractDepthOffset, contractMonthCycle);
             }
 
             // If this Symbol is not a custom data type, and the security type does not support mapping,

--- a/Common/Time.cs
+++ b/Common/Time.cs
@@ -556,6 +556,37 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Adds the requested number of tradeable days to the supplied local date using the given exchange hours
+        /// </summary>
+        public static DateTime AddTradeableDays(SecurityExchangeHours exchange, DateTime from, int tradeableDays, bool extendedMarketHours = false)
+        {
+            if (tradeableDays < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tradeableDays), "The tradeable day offset must be greater than or equal to zero.");
+            }
+
+            if (tradeableDays == 0)
+            {
+                return from.Date;
+            }
+
+            var count = 0;
+            for (var day = from.Date.AddDays(1); ; day = day.AddDays(1))
+            {
+                if (!exchange.IsDateOpen(day, extendedMarketHours))
+                {
+                    continue;
+                }
+
+                count++;
+                if (count == tradeableDays)
+                {
+                    return day;
+                }
+            }
+        }
+
+        /// <summary>
         /// Define an enumerable date range of tradeable dates but expressed in a different time zone.
         /// </summary>
         /// <remarks>

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -305,6 +305,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 throw new InvalidOperationException($"{DataNormalizationMode.ScaledRaw} normalization mode only intended for history requests.");
             }
 
+            if (request.Configuration.DataMappingMode == DataMappingMode.TradingDaysBeforeExpiry &&
+                request.Configuration.DataNormalizationMode != DataNormalizationMode.Raw)
+            {
+                throw new NotSupportedException(
+                    $"{DataMappingMode.TradingDaysBeforeExpiry} does not support {request.Configuration.DataNormalizationMode} normalization because continuous future factor files do not contain factors for shifted roll dates. " +
+                    $"Use {DataNormalizationMode.Raw} normalization or choose a factor-file-backed mapping mode.");
+            }
+
             // before adding the configuration to the data feed let's assert it's valid
             _dataPermissionManager.AssertConfiguration(request.Configuration, request.StartTimeLocal, request.EndTimeLocal);
 

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -546,12 +546,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             bool isCustomData = false,
             DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted,
             DataMappingMode dataMappingMode = DataMappingMode.OpenInterest,
-            uint contractDepthOffset = 0
+            uint contractDepthOffset = 0,
+            int dataMappingModeDaysOffset = 0,
+            IReadOnlyList<int> contractMonthCycle = null
             )
         {
             return Add(symbol, resolution, fillForward, extendedMarketHours, isFilteredSubscription, isInternalFeed, isCustomData,
                 new List<Tuple<Type, TickType>> { new Tuple<Type, TickType>(dataType, LeanData.GetCommonTickTypeForCommonDataTypes(dataType, symbol.SecurityType)) },
-                dataNormalizationMode, dataMappingMode, contractDepthOffset)
+                dataNormalizationMode, dataMappingMode, contractDepthOffset, dataMappingModeDaysOffset, contractMonthCycle)
                 .First();
         }
 
@@ -571,7 +573,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             List<Tuple<Type, TickType>> subscriptionDataTypes = null,
             DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted,
             DataMappingMode dataMappingMode = DataMappingMode.OpenInterest,
-            uint contractDepthOffset = 0
+            uint contractDepthOffset = 0,
+            int dataMappingModeDaysOffset = 0,
+            IReadOnlyList<int> contractMonthCycle = null
             )
         {
             var dataTypes = subscriptionDataTypes;
@@ -685,7 +689,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                               tickType: tickType,
                               dataNormalizationMode: dataNormalizationMode,
                               dataMappingMode: dataMappingMode,
-                              contractDepthOffset: contractDepthOffset)).ToList();
+                              contractDepthOffset: contractDepthOffset,
+                              dataMappingModeDaysOffset: dataMappingModeDaysOffset,
+                              contractMonthCycle: contractMonthCycle)).ToList();
 
             for (int i = 0; i < result.Count; i++)
             {

--- a/Engine/DataFeeds/Enumerators/MappingEventProvider.cs
+++ b/Engine/DataFeeds/Enumerators/MappingEventProvider.cs
@@ -20,6 +20,7 @@ using QuantConnect.Interfaces;
 using QuantConnect.Data.Market;
 using System.Collections.Generic;
 using QuantConnect.Data.Auxiliary;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
 {
@@ -40,6 +41,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// </summary>
         protected MapFile MapFile { get; private set; }
 
+        private SecurityExchangeHours _exchangeHours;
+
         /// <summary>
         /// Initializes this instance
         /// </summary>
@@ -55,12 +58,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         {
             _mapFileProvider = mapFileProvider;
             Config = config;
+            _exchangeHours = MarketHoursDatabase.FromDataFolder().GetEntry(Config.Market, Config.Symbol, Config.SecurityType).ExchangeHours;
             InitializeMapFile();
 
-            if (MapFile.HasData(startTime.Date))
+            var mappingSearchDate = GetMappingSearchDate(startTime.Date);
+            if (MapFile.HasData(mappingSearchDate))
             {
                 // initialize mapped symbol using request start date
-                Config.MappedSymbol = MapFile.GetMappedSymbol(startTime.Date, Config.MappedSymbol, Config.DataMappingMode);
+                Config.MappedSymbol = MapFile.GetMappedSymbol(mappingSearchDate, Config.MappedSymbol, Config.DataMappingMode);
             }
         }
 
@@ -71,11 +76,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         /// <returns>New mapping event if any</returns>
         public virtual IEnumerable<BaseData> GetEvents(NewTradableDateEventArgs eventArgs)
         {
+            var mappingSearchDate = GetMappingSearchDate(eventArgs.Date);
             if (Config.Symbol == eventArgs.Symbol
-                && MapFile.HasData(eventArgs.Date))
+                && MapFile.HasData(mappingSearchDate))
             {
                 var old = Config.MappedSymbol;
-                var newSymbol = MapFile.GetMappedSymbol(eventArgs.Date, Config.MappedSymbol, Config.DataMappingMode);
+                var newSymbol = MapFile.GetMappedSymbol(mappingSearchDate, Config.MappedSymbol, Config.DataMappingMode);
                 Config.MappedSymbol = newSymbol;
 
                 // check to see if the symbol was remapped
@@ -97,6 +103,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         protected void InitializeMapFile()
         {
             MapFile = _mapFileProvider.ResolveMapFile(Config);
+        }
+
+        private DateTime GetMappingSearchDate(DateTime date)
+        {
+            if (Config.DataMappingMode != DataMappingMode.TradingDaysBeforeExpiry || Config.DataMappingModeDaysOffset == 0)
+            {
+                return date;
+            }
+
+            return Time.AddTradeableDays(_exchangeHours, date, Config.DataMappingModeDaysOffset, Config.ExtendedMarketHours);
         }
     }
 }

--- a/Tests/Common/Data/Auxiliary/FactorFileTests.cs
+++ b/Tests/Common/Data/Auxiliary/FactorFileTests.cs
@@ -396,6 +396,25 @@ namespace QuantConnect.Tests.Common.Data.Auxiliary
         }
 
         [Test]
+        [TestCase(DataNormalizationMode.BackwardsRatio)]
+        [TestCase(DataNormalizationMode.BackwardsPanamaCanal)]
+        [TestCase(DataNormalizationMode.ForwardPanamaCanal)]
+        public void RejectsTradingDaysBeforeExpiryForAdjustedFutureFactorFiles(DataNormalizationMode dataNormalizationMode)
+        {
+            var lines = new[]
+            {
+                "{\"Date\":\"2010-01-28T00:00:00\",\"BackwardsRatioScale\":[1.1575],\"BackwardsPanamaCanalScale\":[7.06],\"ForwardPanamaCanalScale\":[0.0],\"DataMappingMode\":0}"
+            };
+
+            var factorFile = PriceScalingExtensions.SafeRead("cl", lines, SecurityType.Future) as MappingContractFactorProvider;
+
+            Assert.Throws<NotSupportedException>(() => factorFile.GetPriceFactor(
+                new DateTime(2010, 01, 28),
+                dataNormalizationMode,
+                DataMappingMode.TradingDaysBeforeExpiry));
+        }
+
+        [Test]
         public void ResolvesCorrectMostRecentFactorChangeDate()
         {
             var lines = new[]

--- a/Tests/Common/Data/Auxiliary/MapFileTests.cs
+++ b/Tests/Common/Data/Auxiliary/MapFileTests.cs
@@ -21,6 +21,7 @@ using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Data.Auxiliary;
+using QuantConnect.Securities;
 
 namespace QuantConnect.Tests.Common.Data.Auxiliary
 {
@@ -86,6 +87,24 @@ namespace QuantConnect.Tests.Common.Data.Auxiliary
             });
 
             Assert.AreEqual(new DateTime(2014, 03, 27), mapFile.FirstDate);
+        }
+
+        [Test]
+        public void TradingDaysBeforeExpiryUsesLastTradingDayRows()
+        {
+            var april = Symbol.CreateFuture(Futures.Metals.Gold, QuantConnect.Market.COMEX, new DateTime(2026, 4, 28));
+            var june = Symbol.CreateFuture(Futures.Metals.Gold, QuantConnect.Market.COMEX, new DateTime(2026, 6, 26));
+            var mapFile = new MapFile("gc", new List<MapFileRow>
+            {
+                new MapFileRow(new DateTime(2026, 4, 28), april.ID.ToString(), "COMEX", QuantConnect.Market.COMEX, SecurityType.Future, DataMappingMode.LastTradingDay),
+                new MapFileRow(new DateTime(2026, 6, 26), june.ID.ToString(), "COMEX", QuantConnect.Market.COMEX, SecurityType.Future, DataMappingMode.LastTradingDay)
+            });
+
+            var result = mapFile.GetMappedSymbol(
+                new DateTime(2026, 4, 28),
+                dataMappingMode: DataMappingMode.TradingDaysBeforeExpiry);
+
+            Assert.AreEqual(april.ID.ToString().ToUpperInvariant(), result);
         }
 
         [Test]

--- a/Tests/Common/SymbolTests.cs
+++ b/Tests/Common/SymbolTests.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using NUnit.Framework;
 using QuantConnect.Data;
 using System.Collections.Generic;
+using QuantConnect.Securities;
 using QuantConnect.Securities.Option;
 
 namespace QuantConnect.Tests.Common
@@ -107,6 +108,27 @@ namespace QuantConnect.Tests.Common
             Assert.AreEqual(0m, sid.StrikePrice);
             Assert.AreEqual(default(OptionRight), sid.OptionRight);
             Assert.AreEqual(default(OptionStyle), sid.OptionStyle);
+        }
+
+        [Test]
+        public void AdjustFutureSymbolByOffsetRespectsContractMonthCycle()
+        {
+            var symbol = Symbol.CreateFuture(Futures.Metals.Gold, Market.COMEX, new DateTime(2026, 4, 28));
+
+            var adjusted = symbol.AdjustSymbolByOffset(1, new[] { 2, 4, 6, 8, 12 });
+
+            Assert.AreEqual(new DateTime(2026, 6, 26), adjusted.ID.Date);
+        }
+
+        [Test]
+        public void AdjustFutureSymbolByOffsetSkipsCurrentContractOutsideContractMonthCycle()
+        {
+            var symbol = Symbol.CreateFuture(Futures.Metals.Gold, Market.COMEX, new DateTime(2026, 10, 28));
+
+            var adjusted = symbol.AdjustSymbolByOffset(0, new[] { 2, 4, 6, 8, 12 });
+
+            Assert.AreEqual(2026, adjusted.ID.Date.Year);
+            Assert.AreEqual(12, adjusted.ID.Date.Month);
         }
 
         [Test]

--- a/Tests/Common/TimeTests.cs
+++ b/Tests/Common/TimeTests.cs
@@ -221,6 +221,18 @@ namespace QuantConnect.Tests.Common
         }
 
         [Test]
+        public void AddTradeableDaysSkipsClosedDates()
+        {
+            var exchange = CreateUsEquitySecurityExchangeHours();
+            var start = new DateTime(2018, 8, 31);
+            var expected = new DateTime(2018, 9, 4);
+
+            var actual = Time.AddTradeableDays(exchange, start, 1);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
         public void MultipliesTimeSpans()
         {
             var interval = TimeSpan.FromSeconds(1);

--- a/Tests/Engine/DataFeeds/DataManagerTests.cs
+++ b/Tests/Engine/DataFeeds/DataManagerTests.cs
@@ -275,9 +275,72 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Assert.That(exception.Message, Does.Contain(nameof(DataNormalizationMode.ScaledRaw)));
         }
 
+        [TestCase(DataNormalizationMode.BackwardsRatio)]
+        [TestCase(DataNormalizationMode.BackwardsPanamaCanal)]
+        [TestCase(DataNormalizationMode.ForwardPanamaCanal)]
+        public void TradingDaysBeforeExpiryAdjustedNormalizationFailsBeforeCreatingSubscription(DataNormalizationMode dataNormalizationMode)
+        {
+            var dataPermissionManager = new DataPermissionManager();
+            var dataFeed = new TestDataFeed();
+            var dataManager = new DataManager(dataFeed,
+                new UniverseSelection(_algorithm,
+                    _securityService,
+                    dataPermissionManager,
+                    TestGlobals.DataProvider),
+                _algorithm,
+                _algorithm.TimeKeeper,
+                MarketHoursDatabase.AlwaysOpen,
+                false,
+                new RegisteredSecurityDataTypesProvider(),
+                dataPermissionManager);
+
+            var symbol = Symbol.CreateFuture(Futures.Indices.SP500EMini, Market.CME, new DateTime(2015, 12, 18));
+            var config = new SubscriptionDataConfig(typeof(TradeBar),
+                symbol,
+                Resolution.Daily,
+                TimeZones.NewYork,
+                TimeZones.NewYork,
+                true,
+                false,
+                false,
+                dataNormalizationMode: dataNormalizationMode,
+                dataMappingMode: DataMappingMode.TradingDaysBeforeExpiry,
+                dataMappingModeDaysOffset: 2);
+
+            using var universe = new TestUniverse(
+                config,
+                new UniverseSettings(Resolution.Daily, 1, false, false, TimeSpan.FromDays(365)));
+            var security = new QuantConnect.Securities.Future.Future(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                config,
+                new Cash(Currencies.USD, 1, 1),
+                SymbolProperties.GetDefault(Currencies.USD),
+                new IdentityCurrencyConverter(Currencies.USD),
+                new RegisteredSecurityDataTypesProvider());
+
+            var subscriptionRequest = new SubscriptionRequest(
+                false,
+                universe,
+                security,
+                config,
+                new DateTime(2014, 10, 10),
+                new DateTime(2015, 10, 10));
+
+            var exception = Assert.Throws<NotSupportedException>(() =>
+            {
+                dataManager.AddSubscription(subscriptionRequest);
+            });
+
+            Assert.That(exception.Message, Does.Contain(nameof(DataMappingMode.TradingDaysBeforeExpiry)));
+            Assert.That(exception.Message, Does.Contain(dataNormalizationMode.ToString()));
+            Assert.AreEqual(0, dataFeed.CreateSubscriptionCallCount);
+        }
+
         private class TestDataFeed : IDataFeed
         {
             public Subscription Subscription { get; set; }
+
+            public int CreateSubscriptionCallCount { get; private set; }
 
             public bool IsActive { get; }
 
@@ -290,6 +353,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             public Subscription CreateSubscription(SubscriptionRequest request)
             {
+                CreateSubscriptionCallCount++;
                 return Subscription;
             }
 


### PR DESCRIPTION
## Summary

- Adds `DataMappingMode.TradingDaysBeforeExpiry` for continuous futures that need to roll before the normal last-trading-day mapping date.
- Threads a tradeable-day roll offset and optional contract month cycle through continuous future subscriptions, universe settings, history requests, mapping events, and the Python wrapper.
- Reuses existing `LastTradingDay` map-file rows for the new mapping mode and applies the optional contract month cycle when walking continuous future contract depth.

## Motivation

Fixes #9440.

The issue describes two related continuous futures needs:

- rolling a configurable number of trading days before the normal last-trading-day roll;
- restricting held futures contracts to selected contract months, for example skipping weak open-interest months.

## Testing

- `dotnet build Tests/QuantConnect.Tests.csproj --no-restore -clp:ErrorsOnly --verbosity quiet`

Added focused tests for:

- `TradingDaysBeforeExpiry` reusing `LastTradingDay` map-file rows;
- contract-depth walking with a selected contract month cycle;
- skipping a current mapped contract when its month is outside the selected cycle;
- adding tradeable days across closed exchange dates.

I was able to build the test project locally. Direct local NUnit execution in my Linux container aborted during global Python/test-host initialization before the selected tests ran, so CI should be the authoritative full test run.
