### PR TITLE
Use option quotes for target margin pricing

### DIFF
--- a/Common/Securities/Option/OptionMarginModel.cs
+++ b/Common/Securities/Option/OptionMarginModel.cs
@@ -107,13 +107,29 @@ namespace QuantConnect.Securities.Option
         {
             var security = parameters.Security;
             var quantity = parameters.Quantity;
+            var price = GetInitialMarginPrice(security, quantity);
             var value = security.QuoteCurrency.ConversionRate
                         * security.SymbolProperties.ContractMultiplier
-                        * security.Price
+                        * price
                         * quantity;
 
             // Initial margin requirement for long options is only the premium that is paid upfront
             return new OptionInitialMargin(parameters.Quantity >= 0 ? 0 : value * GetMarginRequirement(security, quantity, value), value);
+        }
+
+        private static decimal GetInitialMarginPrice(Security security, decimal quantity)
+        {
+            if (quantity > 0 && security.AskPrice != 0m)
+            {
+                return security.AskPrice;
+            }
+
+            if (quantity < 0 && security.BidPrice != 0m)
+            {
+                return security.BidPrice;
+            }
+
+            return security.Price;
         }
 
         /// <summary>

--- a/Tests/Common/Securities/OptionMarginBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionMarginBuyingPowerModelTests.cs
@@ -79,6 +79,59 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
+        public void LongOptionInitialMarginUsesAskPriceIfAvailable()
+        {
+            const decimal bidPrice = 1.5m;
+            const decimal askPrice = 2.5m;
+            const decimal lastPrice = 2m;
+            const decimal underlyingPrice = 200m;
+            const decimal quantity = 10m;
+
+            var equity = CreateEquity();
+            equity.SetMarketPrice(new Tick { Value = underlyingPrice });
+
+            var optionCall = CreateOption(equity, OptionRight.Call, 192m);
+            optionCall.SetMarketPrice(new Tick
+            {
+                Value = lastPrice,
+                BidPrice = bidPrice,
+                AskPrice = askPrice,
+                TickType = TickType.Quote
+            });
+
+            var buyingPowerModel = new OptionMarginModel();
+            var expectedPremium = askPrice * optionCall.SymbolProperties.ContractMultiplier * quantity;
+
+            Assert.AreEqual(expectedPremium, buyingPowerModel.GetInitialMarginRequirement(optionCall, quantity));
+        }
+
+        [Test]
+        public void ShortOptionInitialMarginUsesBidPriceIfAvailable()
+        {
+            const decimal bidPrice = 1.5m;
+            const decimal askPrice = 2.5m;
+            const decimal lastPrice = 2m;
+            const decimal underlyingPrice = 200m;
+            const decimal quantity = -10m;
+
+            var equity = CreateEquity();
+            equity.SetMarketPrice(new Tick { Value = underlyingPrice });
+
+            var optionCall = CreateOption(equity, OptionRight.Call, 192m);
+            optionCall.SetMarketPrice(new Tick
+            {
+                Value = lastPrice,
+                BidPrice = bidPrice,
+                AskPrice = askPrice,
+                TickType = TickType.Quote
+            });
+
+            var buyingPowerModel = new OptionMarginModel();
+
+            Assert.AreEqual(-41500, (double)buyingPowerModel.GetInitialMarginRequirement(optionCall, quantity), delta: 0.01);
+        }
+
+        [Test]
         public void TestShortCallsITM()
         {
             const decimal price = 14m;


### PR DESCRIPTION
#### Description

This updates option initial margin pricing to use available executable quote prices when calculating the premium/margin value for a target option quantity:

- positive option quantities use the ask price when available
- negative option quantities use the bid price when available
- existing last/mark price behavior remains the fallback when quote prices are unavailable

This keeps the change local to the option margin model and avoids changing the generic buying power model behavior for other security types.

#### Related Issue

Closes #6360

#### Motivation and Context

`PortfolioTarget.Percent` depends on the security buying power model's initial margin requirement when calculating target quantities. For options, the existing initial margin path priced the quantity with `security.Price`. When quote data is available, that can size long option targets from a mid/last price instead of the ask, causing the filled position weight to exceed the requested target percentage by roughly the bid/ask spread.

Using the ask for increases and bid for reductions makes option target sizing line up with the executable side of the quote while retaining the previous fallback behavior when quote data has not been populated.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Tested in the QuantConnect foundation container on local Linux arm64:

- `dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln` passed.
- `dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --blame-hang-timeout 300seconds --blame-crash --filter "FullyQualifiedName~QuantConnect.Tests.Common.Securities.OptionMarginBuyingPowerModelTests" -- "TestRunParameters.Parameter(name=\"log-handler\", value=\"ConsoleErrorLogHandler\")"` passed: 41 passed, 0 failed.
- A full local arm64 foundation-container run of `QuantConnect.Tests.dll` with the repository CI filter completed with 35,966 passed, 26 skipped, and 2 failures.

The two local full-suite failures were checked against unchanged upstream `master` at the same base commit and reproduced there as well in the same arm64 foundation-container environment:

- `CompressionTests.ZipBytesReturnsByteArrayWithCorrectLength` fails on upstream `master` with expected `906121`, actual `905693`.
- `LiveTradingDataFeedTests.HandlesAllTypes` has local timeout behavior on upstream `master` as well.

So the option-margin change and its focused test coverage pass locally, while the full local arm64 suite has baseline failures that are not introduced by this branch. I am leaving the checklist item for all existing tests unchecked rather than claiming that local full-suite result passed.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. See testing note above: focused tests pass; two local arm64 full-suite failures reproduce on unchanged upstream `master`.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
