### PR TITLE
Run CI on self-hosted runners

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: self-hosted
     container:
         image: quantconnect/lean:foundation
+        options: --cpus 12 --memory 12g
         env:
           QC_JOB_USER_ID: ${{ secrets.QC_JOB_USER_ID }}
           QC_API_ACCESS_TOKEN: ${{ secrets.QC_API_ACCESS_TOKEN }}

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Liberate disk space
+        if: ${{ runner.environment == 'github-hosted' }}
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: self-hosted

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
     # Only run on push events (not on pull_request) for security reasons in order to be able to use secrets
     if: ${{ github.event_name == 'push' }}
     steps:

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -10,43 +10,22 @@ on:
 jobs:
   build:
     runs-on: self-hosted
+    container:
+        image: quantconnect/lean:foundation
+        env:
+          QC_JOB_USER_ID: ${{ secrets.QC_JOB_USER_ID }}
+          QC_API_ACCESS_TOKEN: ${{ secrets.QC_API_ACCESS_TOKEN }}
+          QC_JOB_ORGANIZATION_ID: ${{ secrets.QC_JOB_ORGANIZATION_ID }}
     # Only run on push events (not on pull_request) for security reasons in order to be able to use secrets
     if: ${{ github.event_name == 'push' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
-      - name: Liberate disk space
-        if: ${{ runner.environment == 'github-hosted' }}
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-
-      - name: Define docker helper
-        run: |
-          echo 'runInContainer() { docker exec test-container "$@"; }' > $HOME/ci_functions.sh
-          echo "BASH_ENV=$HOME/ci_functions.sh" >> $GITHUB_ENV
-
-      - name: Start container
-        run: |
-          docker run -d \
-            --workdir /__w/Lean/Lean \
-            -v /home/runner/work:/__w \
-            -e GITHUB_REF="${{ github.ref }}" \
-            -e QC_JOB_USER_ID="${{ secrets.QC_JOB_USER_ID }}" \
-            -e QC_API_ACCESS_TOKEN="${{ secrets.QC_API_ACCESS_TOKEN }}" \
-            -e QC_JOB_ORGANIZATION_ID="${{ secrets.QC_JOB_ORGANIZATION_ID }}" \
-            --name test-container \
-            quantconnect/lean:foundation \
-            tail -f /dev/null
 
       - name: Run API Tests
         run: |
           # Build
-          runInContainer dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln
-          
+          dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln
+
           # Run Projects tests
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --blame-hang-timeout 7minutes --blame-crash --logger "console;verbosity=detailed" --filter "FullyQualifiedName=QuantConnect.Tests.API.ProjectTests|FullyQualifiedName=QuantConnect.Tests.API.ObjectStoreTests" -- TestRunParameters.Parameter\(name=\"log-handler\", value=\"ConsoleErrorLogHandler\"\)
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --blame-hang-timeout 7minutes --blame-crash --logger "console;verbosity=detailed" --filter "FullyQualifiedName=QuantConnect.Tests.API.ProjectTests|FullyQualifiedName=QuantConnect.Tests.API.ObjectStoreTests" -- TestRunParameters.Parameter\(name=\"log-handler\", value=\"ConsoleErrorLogHandler\"\)

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: [self-hosted, benchmark]
     container:
         image: quantconnect/lean:foundation
         volumes:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: [self-hosted, benchmark]
     container:
         image: quantconnect/lean:foundation
+        options: --cpus 12 --memory 12g
         volumes:
           - /nas:/Data:ro
     steps:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -13,7 +13,7 @@ jobs:
     container:
         image: quantconnect/lean:foundation
         volumes:
-          - /nas:/Data
+          - /nas:/Data:ro
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: [self-hosted, benchmark]

--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -10,61 +10,40 @@ on:
 jobs:
   build:
     runs-on: self-hosted
+    container:
+        image: quantconnect/lean:foundation
+        env:
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          QC_GIT_TOKEN: ${{ secrets.QC_GIT_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Ensures we fetch all history
 
-      - name: Liberate disk space
-        if: ${{ runner.environment == 'github-hosted' }}
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-
-      - name: Define docker helper
-        run: |
-          echo -e 'runInContainer() { docker exec test-container "$@"; }\n' > "$HOME/ci_functions.sh"
-          echo "BASH_ENV=$HOME/ci_functions.sh" >> $GITHUB_ENV
-
-      - name: Start container
-        run: |
-          docker run -d \
-            --workdir /__w/Lean/Lean \
-            -v /home/runner/work:/__w \
-            -e GITHUB_REF="${{ github.ref }}" \
-            -e PYPI_API_TOKEN="${{ secrets.PYPI_API_TOKEN }}" \
-            -e QC_GIT_TOKEN="${{ secrets.QC_GIT_TOKEN }}" \
-            --name test-container \
-            quantconnect/lean:foundation \
-            tail -f /dev/null
-
       - name: Run build and tests
         run: |
           # Add exception
-          runInContainer git config --global --add safe.directory /__w/Lean/Lean
-          
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+
           # Get Last Commit of the Current Tag
-          TAG_COMMIT=$(runInContainer git rev-parse HEAD) && echo "CURRENT BRANCH LAST COMMIT $TAG_COMMIT"
-          
+          TAG_COMMIT=$(git rev-parse HEAD) && echo "CURRENT BRANCH LAST COMMIT $TAG_COMMIT"
+
           # Get Last Commit of the master
-          MASTER_COMMIT=$(runInContainer git rev-parse origin/master) && echo "MASTER BRANCH LAST COMMIT $MASTER_COMMIT"
-          
+          MASTER_COMMIT=$(git rev-parse origin/master) && echo "MASTER BRANCH LAST COMMIT $MASTER_COMMIT"
+
           # Build
-          runInContainer dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln
-          
+          dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln
+
           # Run Tests
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --blame-hang-timeout 300seconds --blame-crash --filter "TestCategory!=TravisExclude&TestCategory!=ResearchRegressionTests" -- TestRunParameters.Parameter\(name=\"log-handler\", value=\"ConsoleErrorLogHandler\"\)
-          
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --blame-hang-timeout 300seconds --blame-crash --filter "TestCategory!=TravisExclude&TestCategory!=ResearchRegressionTests" -- TestRunParameters.Parameter\(name=\"log-handler\", value=\"ConsoleErrorLogHandler\"\)
+
           # Generate & Publish python stubs
           echo "GITHUB_REF ${{ github.ref }}"
           if [[ "${{ github.ref }}" = refs/tags/* && "$TAG_COMMIT" = "$MASTER_COMMIT" ]]; then
             echo "Generating stubs"
-            runInContainer chmod +x ci_build_stubs.sh
-            runInContainer bash -c 'export ADDITIONAL_STUBS_REPOS=$(python find_datasource_repos.py) && ./ci_build_stubs.sh -t -g -p'
-          else 
+            chmod +x ci_build_stubs.sh
+            export ADDITIONAL_STUBS_REPOS=$(python find_datasource_repos.py) && ./ci_build_stubs.sh -t -g -p
+          else
             echo "Skipping stub generation"
           fi

--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: self-hosted

--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: self-hosted
     container:
         image: quantconnect/lean:foundation
+        options: --cpus 12 --memory 12g
         env:
           PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
           QC_GIT_TOKEN: ${{ secrets.QC_GIT_TOKEN }}

--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -44,10 +44,17 @@ jobs:
 
           # Generate & Publish python stubs
           echo "GITHUB_REF ${{ github.ref }}"
-          if [[ "${{ github.ref }}" = refs/tags/* && "$TAG_COMMIT" = "$MASTER_COMMIT" ]]; then
-            echo "Generating stubs"
-            chmod +x ci_build_stubs.sh
-            export ADDITIONAL_STUBS_REPOS=$(python find_datasource_repos.py) && ./ci_build_stubs.sh -t -g -p
-          else
-            echo "Skipping stub generation"
-          fi
+          case "${{ github.ref }}" in
+            refs/tags/*)
+              if [ "$TAG_COMMIT" = "$MASTER_COMMIT" ]; then
+                echo "Generating stubs"
+                chmod +x ci_build_stubs.sh
+                export ADDITIONAL_STUBS_REPOS=$(python find_datasource_repos.py) && ./ci_build_stubs.sh -t -g -p
+              else
+                echo "Skipping stub generation"
+              fi
+              ;;
+            *)
+              echo "Skipping stub generation"
+              ;;
+          esac

--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -17,6 +17,7 @@ jobs:
           fetch-depth: 0  # Ensures we fetch all history
 
       - name: Liberate disk space
+        if: ${{ runner.environment == 'github-hosted' }}
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true

--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/rebase-org-branches.yml
+++ b/.github/workflows/rebase-org-branches.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: self-hosted
+    container:
+        image: quantconnect/lean:foundation
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/rebase-org-branches.yml
+++ b/.github/workflows/rebase-org-branches.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: self-hosted
     container:
         image: quantconnect/lean:foundation
+        options: --cpus 12 --memory 12g
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/rebase-org-branches.yml
+++ b/.github/workflows/rebase-org-branches.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: self-hosted
     container:
         image: quantconnect/lean:foundation
+        options: --cpus 12 --memory 12g
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -10,39 +10,18 @@ on:
 jobs:
   build:
     runs-on: self-hosted
+    container:
+        image: quantconnect/lean:foundation
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
-      - name: Liberate disk space
-        if: ${{ runner.environment == 'github-hosted' }}
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-
-      - name: Define docker helper
-        run: |
-          echo 'runInContainer() { docker exec test-container "$@"; }' > $HOME/ci_functions.sh
-          echo "BASH_ENV=$HOME/ci_functions.sh" >> $GITHUB_ENV
-
-      - name: Start container
-        run: |
-          docker run -d \
-            --workdir /__w/Lean/Lean \
-            -v /home/runner/work:/__w \
-            --name test-container \
-            quantconnect/lean:foundation \
-            tail -f /dev/null
 
       - name: Build
-        run: runInContainer dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln
+        run: dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln
 
       - name: Run Tests
         run: |
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll \
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll \
             --filter TestCategory=RegressionTests \
             -- TestRunParameters.Parameter\(name=\"log-handler\", value=\"ConsoleErrorLogHandler\"\) \
             TestRunParameters.Parameter\(name=\"reduced-disk-size\", value=\"true\"\)

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Liberate disk space
+        if: ${{ runner.environment == 'github-hosted' }}
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: self-hosted

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/report-generator.yml
+++ b/.github/workflows/report-generator.yml
@@ -10,40 +10,19 @@ on:
 jobs:
   build:
     runs-on: self-hosted
+    container:
+        image: quantconnect/lean:foundation
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
-      - name: Liberate disk space
-        if: ${{ runner.environment == 'github-hosted' }}
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-
-      - name: Define docker helper
-        run: |
-          echo 'runInContainer() { docker exec test-container "$@"; }' > $HOME/ci_functions.sh
-          echo "BASH_ENV=$HOME/ci_functions.sh" >> $GITHUB_ENV
-
-      - name: Start container
-        run: |
-          docker run -d \
-            --workdir /__w/Lean/Lean \
-            -v /home/runner/work:/__w \
-            --name test-container \
-            quantconnect/lean:foundation \
-            tail -f /dev/null
 
       - name: Build and Run Report Generator Tests
         run: |
           # Build
-          runInContainer dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln
-          
+          dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln
+
           # Run Backtest
-          runInContainer bash -c "cd ./Launcher/bin/Release && dotnet QuantConnect.Lean.Launcher.dll"
-          
+          (cd ./Launcher/bin/Release && dotnet QuantConnect.Lean.Launcher.dll)
+
           # Run Report
-          runInContainer bash -c "cd ./Report/bin/Release && dotnet ./QuantConnect.Report.dll --backtest-data-source-file ../../../Launcher/bin/Release/BasicTemplateFrameworkAlgorithm.json --close-automatically true"
+          (cd ./Report/bin/Release && dotnet ./QuantConnect.Report.dll --backtest-data-source-file ../../../Launcher/bin/Release/BasicTemplateFrameworkAlgorithm.json --close-automatically true)

--- a/.github/workflows/report-generator.yml
+++ b/.github/workflows/report-generator.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: self-hosted
     container:
         image: quantconnect/lean:foundation
+        options: --cpus 12 --memory 12g
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/report-generator.yml
+++ b/.github/workflows/report-generator.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Liberate disk space
+        if: ${{ runner.environment == 'github-hosted' }}
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true

--- a/.github/workflows/report-generator.yml
+++ b/.github/workflows/report-generator.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: self-hosted

--- a/.github/workflows/report-generator.yml
+++ b/.github/workflows/report-generator.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/research-regression-tests.yml
+++ b/.github/workflows/research-regression-tests.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: self-hosted
     container:
         image: quantconnect/lean:foundation
+        options: --cpus 12 --memory 12g
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/research-regression-tests.yml
+++ b/.github/workflows/research-regression-tests.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Liberate disk space
+        if: ${{ runner.environment == 'github-hosted' }}
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true

--- a/.github/workflows/research-regression-tests.yml
+++ b/.github/workflows/research-regression-tests.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: self-hosted

--- a/.github/workflows/research-regression-tests.yml
+++ b/.github/workflows/research-regression-tests.yml
@@ -10,59 +10,34 @@ on:
 jobs:
   build:
     runs-on: self-hosted
+    container:
+        image: quantconnect/lean:foundation
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
-      - name: Liberate disk space
-        if: ${{ runner.environment == 'github-hosted' }}
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
 
-      - name: Define docker helper
-        run: |
-          echo 'runInContainer() { docker exec test-container "$@"; }' > $HOME/ci_functions.sh
-          echo "BASH_ENV=$HOME/ci_functions.sh" >> $GITHUB_ENV
-
-      - name: Start container
-        run: |
-          docker run -d \
-            --workdir /__w/Lean/Lean \
-            -v /home/runner/work:/__w \
-            --name test-container \
-            quantconnect/lean:foundation \
-            tail -f /dev/null
-          
       - name: Install Dependencies and Setup Kernel
         run: |
-          runInContainer bash -c "
-            # Install dependencies
-            pip3 install papermill==2.4.0 clr-loader==0.2.9
-            
-            # Install kernel
-            dotnet tool install -g --no-cache --version 1.0.661703 \
-              --add-source 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json' \
-              Microsoft.dotnet-interactive
-              
-            # Add dotnet tools to Path and activate kernel
-            export PATH=\"/root/.dotnet/tools:\$PATH\"
-            dotnet interactive jupyter install
-          "
+          # Install dependencies
+          pip3 install papermill==2.4.0 clr-loader==0.2.9
+
+          # Install kernel
+          dotnet tool install -g --no-cache --version 1.0.661703 \
+            --add-source 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json' \
+            Microsoft.dotnet-interactive
+
+          # Add dotnet tools to Path and activate kernel
+          export PATH="/root/.dotnet/tools:$PATH"
+          dotnet interactive jupyter install
 
       - name: Build and Run Research Tests
         run: |
-          runInContainer bash -c "
-            # Build
-            export PATH=\"/root/.dotnet/tools:\$PATH\"
-            dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln
-            
-            # Run Tests
-            dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll \
-              --filter TestCategory=ResearchRegressionTests \
-              -- \"TestRunParameters.Parameter(name=\\\"log-handler\\\", value=\\\"ConsoleErrorLogHandler\\\")\" \
-              \"TestRunParameters.Parameter(name=\\\"reduced-disk-size\\\", value=\\\"true\\\")\"
-          "
+          # Build
+          export PATH="/root/.dotnet/tools:$PATH"
+          dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln
+
+          # Run Tests
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll \
+            --filter TestCategory=ResearchRegressionTests \
+            -- "TestRunParameters.Parameter(name=\"log-handler\", value=\"ConsoleErrorLogHandler\")" \
+            "TestRunParameters.Parameter(name=\"reduced-disk-size\", value=\"true\")"

--- a/.github/workflows/research-regression-tests.yml
+++ b/.github/workflows/research-regression-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/research-regression-tests.yml
+++ b/.github/workflows/research-regression-tests.yml
@@ -31,13 +31,13 @@ jobs:
             Microsoft.dotnet-interactive
 
           # Add dotnet tools to Path and activate kernel
-          export PATH="/root/.dotnet/tools:$PATH"
+          export PATH="$HOME/.dotnet/tools:$PATH"
           dotnet interactive jupyter install
 
       - name: Build and Run Research Tests
         run: |
           # Build
-          export PATH="/root/.dotnet/tools:$PATH"
+          export PATH="$HOME/.dotnet/tools:$PATH"
           dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln
 
           # Run Tests

--- a/.github/workflows/syntax-tests.yml
+++ b/.github/workflows/syntax-tests.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: self-hosted
     container:
         image: quantconnect/lean:foundation
+        options: --cpus 12 --memory 12g
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/syntax-tests.yml
+++ b/.github/workflows/syntax-tests.yml
@@ -10,34 +10,13 @@ on:
 jobs:
   build:
     runs-on: self-hosted
+    container:
+        image: quantconnect/lean:foundation
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Liberate disk space
-        if: ${{ runner.environment == 'github-hosted' }}
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-
-      - name: Define docker helper
-        run: |
-          echo 'runInContainer() { docker exec test-container "$@"; }' > $HOME/ci_functions.sh
-          echo "BASH_ENV=$HOME/ci_functions.sh" >> $GITHUB_ENV
-
-      - name: Start container
-        run: |
-          docker run -d \
-            --workdir /__w/Lean/Lean \
-            -v /home/runner/work:/__w \
-            --name test-container \
-            quantconnect/lean:foundation \
-            tail -f /dev/null
-
       - name: Run Syntax Test
         run: |
-          runInContainer bash -c "pip install --no-cache-dir quantconnect-stubs types-requests==2.32.* types-pytz==2025.2.0.* mypy==1.20.2"
-          runInContainer python run_syntax_check.py
+          pip install --no-cache-dir quantconnect-stubs types-requests==2.32.* types-pytz==2025.2.0.* mypy==1.20.2
+          python run_syntax_check.py

--- a/.github/workflows/syntax-tests.yml
+++ b/.github/workflows/syntax-tests.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: self-hosted

--- a/.github/workflows/syntax-tests.yml
+++ b/.github/workflows/syntax-tests.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Liberate disk space
+        if: ${{ runner.environment == 'github-hosted' }}
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true

--- a/.github/workflows/syntax-tests.yml
+++ b/.github/workflows/syntax-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/virtual-environments.yml
+++ b/.github/workflows/virtual-environments.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: self-hosted
     container:
         image: quantconnect/lean:foundation
+        options: --cpus 12 --memory 12g
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/virtual-environments.yml
+++ b/.github/workflows/virtual-environments.yml
@@ -10,90 +10,69 @@ on:
 jobs:
   build:
     runs-on: self-hosted
+    container:
+        image: quantconnect/lean:foundation
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
-      - name: Liberate disk space
-        if: ${{ runner.environment == 'github-hosted' }}
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-
-      - name: Define docker helper
-        run: |
-          echo 'runInContainer() { docker exec test-container "$@"; }' > $HOME/ci_functions.sh
-          echo "BASH_ENV=$HOME/ci_functions.sh" >> $GITHUB_ENV
-
-      - name: Start container
-        run: |
-          docker run -d \
-            --workdir /__w/Lean/Lean \
-            -v /home/runner/work:/__w \
-            --name test-container \
-            quantconnect/lean:foundation \
-            tail -f /dev/null
 
       - name: Run Python Virtual Environments Tests
         run: |
           # Build
-          runInContainer dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln
-          
+          dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Lean.sln
+
           # Python Virtual Environment System Packages
-          runInContainer bash -c "python -m venv /lean-testenv --system-site-packages && . /lean-testenv/bin/activate && pip install --no-cache-dir lean==1.0.221 && deactivate"
-          
+          python -m venv /lean-testenv --system-site-packages && . /lean-testenv/bin/activate && pip install --no-cache-dir lean==1.0.221 && deactivate
+
           # Run Virtual Environment Test System Packages
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonVirtualEnvironmentTests.AssertVirtualEnvironment"
-          
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonVirtualEnvironmentTests.AssertVirtualEnvironment"
+
           # Python Virtual Environment
-          runInContainer bash -c "rm -rf /lean-testenv && python -m venv /lean-testenv && . /lean-testenv/bin/activate && pip install --no-cache-dir lean==1.0.221 && deactivate"
-          
+          rm -rf /lean-testenv && python -m venv /lean-testenv && . /lean-testenv/bin/activate && pip install --no-cache-dir lean==1.0.221 && deactivate
+
           # Run Virtual Environment Test
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonVirtualEnvironmentTests.AssertVirtualEnvironment"
-          
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonVirtualEnvironmentTests.AssertVirtualEnvironment"
+
           # Run Python Package Tests
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests" --blame-hang-timeout 120seconds --blame-crash
-          
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests" --blame-hang-timeout 120seconds --blame-crash
+
           # Run StableBaselines Python Package Test
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.StableBaselinesTest" --blame-hang-timeout 120seconds --blame-crash
-          
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.StableBaselinesTest" --blame-hang-timeout 120seconds --blame-crash
+
           # Run AxPlatform Python Package Test
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.AxPlatformTest" --blame-hang-timeout 120seconds --blame-crash
-          
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.AxPlatformTest" --blame-hang-timeout 120seconds --blame-crash
+
           # Run TensorlyTest Python Package Test
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.TensorlyTest" --blame-hang-timeout 120seconds --blame-crash
-          
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.TensorlyTest" --blame-hang-timeout 120seconds --blame-crash
+
           # Run NeuralTangents, Ignite Python Package Test
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.IgniteTest" --blame-hang-timeout 120seconds --blame-crash
-          
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.IgniteTest" --blame-hang-timeout 120seconds --blame-crash
+
           # Run TensorflowTest
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.TensorflowTest" --blame-hang-timeout 120seconds --blame-crash
-          
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.TensorflowTest" --blame-hang-timeout 120seconds --blame-crash
+
           # Run TensorflowProbability
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.TensorflowProbabilityTest" --blame-hang-timeout 120seconds --blame-crash
-          
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.TensorflowProbabilityTest" --blame-hang-timeout 120seconds --blame-crash
+
           # Run Hvplot Python Package Test
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.RiskparityportfolioTest" --blame-hang-timeout 120seconds --blame-crash
-          
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.RiskparityportfolioTest" --blame-hang-timeout 120seconds --blame-crash
+
           # Run Transformers
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.Transformers" --blame-hang-timeout 120seconds --blame-crash
-          
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.XTransformers" --blame-hang-timeout 120seconds --blame-crash
-          
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.Transformers" --blame-hang-timeout 120seconds --blame-crash
+
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.XTransformers" --blame-hang-timeout 120seconds --blame-crash
+
           # Run Shap
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.KerasTest|PyvinecopulibTest" --blame-hang-timeout 120seconds --blame-crash
-          
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.StatsForecast|Mlforecast" --blame-hang-timeout 120seconds --blame-crash
-          
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.MlxtendTest|Thinc" --blame-hang-timeout 120seconds --blame-crash
-          
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.ModuleVersionTestExplicit" --blame-hang-timeout 120seconds --blame-crash
-          
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.Neuralforecast" --blame-hang-timeout 120seconds --blame-crash
-          
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.Tsfel" --blame-hang-timeout 120seconds --blame-crash
-          
-          runInContainer dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.ScikitOptimizeTest" --blame-hang-timeout 120seconds --blame-crash
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.KerasTest|PyvinecopulibTest" --blame-hang-timeout 120seconds --blame-crash
+
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.StatsForecast|Mlforecast" --blame-hang-timeout 120seconds --blame-crash
+
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.MlxtendTest|Thinc" --blame-hang-timeout 120seconds --blame-crash
+
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.ModuleVersionTestExplicit" --blame-hang-timeout 120seconds --blame-crash
+
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.Neuralforecast" --blame-hang-timeout 120seconds --blame-crash
+
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.Tsfel" --blame-hang-timeout 120seconds --blame-crash
+
+          dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName=QuantConnect.Tests.Python.PythonPackagesTests.ScikitOptimizeTest" --blame-hang-timeout 120seconds --blame-crash

--- a/.github/workflows/virtual-environments.yml
+++ b/.github/workflows/virtual-environments.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Liberate disk space
+        if: ${{ runner.environment == 'github-hosted' }}
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true

--- a/.github/workflows/virtual-environments.yml
+++ b/.github/workflows/virtual-environments.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: self-hosted

--- a/.github/workflows/virtual-environments.yml
+++ b/.github/workflows/virtual-environments.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description

Switches all GitHub Actions workflows from the GitHub-hosted `ubuntu-24.04` runners to self-hosted runners.

- All workflows now use `runs-on: self-hosted`.
- The **Benchmarks** workflow targets a runner with the dedicated `benchmark` label (`runs-on: [self-hosted, benchmark]`) so benchmarking only runs on that machine, keeping benchmark results consistent and isolated.

Workflows updated:
- `gh-actions.yml` (Build & Test Lean)
- `api-tests.yml`
- `regression-tests.yml`
- `research-regression-tests.yml`
- `report-generator.yml`
- `syntax-tests.yml`
- `virtual-environments.yml`
- `rebase-org-branches.yml`
- `benchmarks.yml` → `[self-hosted, benchmark]`

## Related Issue

N/A

## Motivation and Context

Move CI off GitHub-hosted runners onto self-hosted infrastructure, with benchmarks pinned to a dedicated labeled runner.

## How Has This Been Tested?

Workflow YAML changes only; will be validated by the runners picking up the jobs.

## Types of changes

- [x] Refactor / CI (changes to build/CI configuration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)