### PR TITLE
Make remote custom-data downloads robust to transient empty/failed responses

### DIFF
--- a/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReader.cs
@@ -199,7 +199,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
 
                 if (attempt < maxAttempts)
                 {
-                    Thread.Sleep(1000);
+                    Thread.Sleep(2000 + 1000 * attempt);
                 }
             }
 

--- a/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReader.cs
+++ b/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReader.cs
@@ -17,7 +17,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using QuantConnect.Interfaces;
+using QuantConnect.Logging;
 using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Transport
@@ -92,16 +94,19 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
                 {
                     if (!File.Exists(LocalFileName))
                     {
-                        bytes = _downloader.DownloadBytes(source, headers, null, null);
+                        bytes = DownloadBytesWithRetry(source, headers);
                     }
                 }
             }
             else
             {
-                bytes = _downloader.DownloadBytes(source, headers, null, null);
+                bytes = DownloadBytesWithRetry(source, headers);
             }
 
-            if (bytes != null)
+            // Only persist a non-empty download. The remote source can intermittently answer with an empty body
+            // (e.g. a transient HTTP 200 with no content); writing/caching that empty response would make the
+            // whole subscription silently yield no data, and with caching enabled the empty file would be reused.
+            if (bytes != null && bytes.Length > 0)
             {
                 File.WriteAllBytes(LocalFileName, bytes);
 
@@ -158,6 +163,47 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Transport
         public static void SetDownloadProvider(IDownloadProvider downloader)
         {
             _downloader = downloader;
+        }
+
+        /// <summary>
+        /// Downloads the given source, retrying a few times on a transient failure. The remote endpoint can
+        /// intermittently throw or answer with an empty body; a bounded retry lets a single hiccup recover
+        /// instead of failing the whole subscription with no data.
+        /// </summary>
+        private static byte[] DownloadBytesWithRetry(string source, IEnumerable<KeyValuePair<string, string>> headers)
+        {
+            const int maxAttempts = 3;
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
+                {
+                    var bytes = _downloader.DownloadBytes(source, headers, null, null);
+                    if (bytes != null && bytes.Length > 0)
+                    {
+                        return bytes;
+                    }
+
+                    // a successful but empty response is transient for these sources; retry before giving up
+                    Log.Trace($"RemoteFileSubscriptionStreamReader.DownloadBytesWithRetry(): empty response for {source} " +
+                        $"(attempt {attempt}/{maxAttempts})");
+                }
+                catch (Exception exception)
+                {
+                    if (attempt == maxAttempts)
+                    {
+                        throw;
+                    }
+                    Log.Trace($"RemoteFileSubscriptionStreamReader.DownloadBytesWithRetry(): failed to download {source} " +
+                        $"(attempt {attempt}/{maxAttempts}): {exception.Message}");
+                }
+
+                if (attempt < maxAttempts)
+                {
+                    Thread.Sleep(1000);
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/Tests/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReaderTests.cs
+++ b/Tests/Engine/DataFeeds/Transport/RemoteFileSubscriptionStreamReaderTests.cs
@@ -14,11 +14,14 @@
  *
 */
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Net;
+using System.Text;
 using NUnit.Framework;
+using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Lean.Engine.DataFeeds.Transport;
 using QuantConnect.Util;
@@ -178,6 +181,65 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Transport
                     null),
                 "Api.Download(): Failed to download data from quantconnect.com. Please verify the source for missing http:// or https://"
             );
+        }
+
+        [Test]
+        public void RetriesTransientEmptyDownload()
+        {
+            // the remote endpoint answers empty twice before returning the data; the reader should retry and recover
+            var provider = new TransientEmptyDownloadProvider(emptyResponses: 2, payload: "20131007 00:00,1,2,0,1,100");
+            RemoteFileSubscriptionStreamReader.SetDownloadProvider(provider);
+
+            using var cacheProvider = new SingleEntryDataCacheProvider(TestGlobals.DataProvider, isDataEphemeral: true);
+            using var remoteReader = new RemoteFileSubscriptionStreamReader(
+                cacheProvider,
+                "https://cdn.quantconnect.com/uploads/transient-empty.csv",
+                Globals.Cache,
+                null);
+
+            Assert.IsFalse(remoteReader.EndOfStream, "reader should have data after retrying past the empty responses");
+            Assert.AreEqual("20131007 00:00,1,2,0,1,100", remoteReader.ReadLine());
+            Assert.AreEqual(3, provider.DownloadCount);
+        }
+
+        [Test]
+        public void EmptyDownloadIsNotCached()
+        {
+            var provider = new TransientEmptyDownloadProvider(emptyResponses: int.MaxValue, payload: string.Empty);
+            RemoteFileSubscriptionStreamReader.SetDownloadProvider(provider);
+
+            var url = "https://cdn.quantconnect.com/uploads/always-empty.csv";
+            using var cacheProvider = new ZipDataCacheProvider(TestGlobals.DataProvider, isDataEphemeral: false);
+            using var remoteReader = new RemoteFileSubscriptionStreamReader(cacheProvider, url, Globals.Cache, null);
+
+            Assert.IsTrue(remoteReader.EndOfStream, "an empty download should yield no data");
+            // the empty response must not have been persisted to the cache
+            Assert.IsFalse(File.Exists(Path.Combine(Globals.Cache, url.ToMD5() + ".csv")),
+                "an empty download must not be cached");
+        }
+
+        private class TransientEmptyDownloadProvider : IDownloadProvider
+        {
+            private readonly int _emptyResponses;
+            private readonly byte[] _payload;
+            public int DownloadCount { get; private set; }
+
+            public TransientEmptyDownloadProvider(int emptyResponses, string payload)
+            {
+                _emptyResponses = emptyResponses;
+                _payload = Encoding.UTF8.GetBytes(payload);
+            }
+
+            public byte[] DownloadBytes(string address, IEnumerable<KeyValuePair<string, string>> headers, string userName, string password)
+            {
+                DownloadCount++;
+                return DownloadCount <= _emptyResponses ? Array.Empty<byte>() : _payload;
+            }
+
+            public string Download(string address, IEnumerable<KeyValuePair<string, string>> headers, string userName, string password)
+            {
+                return Encoding.UTF8.GetString(DownloadBytes(address, headers, userName, password));
+            }
         }
 
         private class TestDownloadProvider : QuantConnect.Api.Api


### PR DESCRIPTION
## What this does
`RemoteFileSubscriptionStreamReader` treated a **successful-but-empty** download (`byte[0]`, e.g. a transient HTTP 200 with no body) as valid: it passed the `bytes != null` check and was written/cached as an empty file, so the subscription silently yielded no data (and the empty file was reused with caching on). This:
- retries the download a few times on a transient failure (empty response or exception), and
- only persists/caches a **non-empty** result.

## Scope (honest)
This recovers **transient** empties. It does **not** fix a *sustained* endpoint outage — if the remote source returns empty for the whole run, there's no data to get and the subscription still yields nothing. So this reduces, but does not eliminate, flakiness for regression algorithms that depend on a live remote source (e.g. `CustomDataPropertiesRegressionAlgorithm` fetching a Quandl/Nasdaq proxy URL). Fully de-flaking those needs the test data served locally/deterministically rather than from a live endpoint — a separate change.

## Tests
`RetriesTransientEmptyDownload`, `EmptyDownloadIsNotCached` pass; Engine + Tests build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)