### PR TITLE
Add TerminalLink brokerage model

### DIFF
--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -195,8 +195,10 @@ namespace QuantConnect.Brokerages
             switch (brokerage)
             {
                 case BrokerageName.Default:
-                case BrokerageName.TerminalLink:
                     return new DefaultBrokerageModel(accountType);
+
+                case BrokerageName.TerminalLink:
+                    return new TerminalLinkBrokerageModel(accountType);
 
                 case BrokerageName.Alpaca:
                     return new AlpacaBrokerageModel();

--- a/Common/Brokerages/TerminalLinkBrokerageModel.cs
+++ b/Common/Brokerages/TerminalLinkBrokerageModel.cs
@@ -1,0 +1,87 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Brokerages
+{
+    /// <summary>
+    /// Provides Bloomberg EMSX (TerminalLink) specific properties.
+    /// </summary>
+    public class TerminalLinkBrokerageModel : DefaultBrokerageModel
+    {
+        private readonly HashSet<SecurityType> _supportedSecurityTypes = new()
+        {
+            SecurityType.Equity,
+            SecurityType.Option,
+            SecurityType.Future,
+        };
+
+        private readonly HashSet<OrderType> _supportedOrderTypes = new()
+        {
+            OrderType.Market,
+            OrderType.MarketOnOpen,
+            OrderType.MarketOnClose,
+            OrderType.Limit,
+            OrderType.StopMarket,
+            OrderType.StopLimit,
+        };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TerminalLinkBrokerageModel"/> class.
+        /// </summary>
+        /// <param name="accountType">Cash or Margin</param>
+        public TerminalLinkBrokerageModel(AccountType accountType = AccountType.Margin) : base(accountType)
+        {
+        }
+
+        /// <summary>
+        /// Returns true if the brokerage could accept this order.
+        /// </summary>
+        /// <param name="security">The security of the order</param>
+        /// <param name="order">The order to be processed</param>
+        /// <param name="message">If this function returns false, a brokerage message detailing why the order may not be submitted</param>
+        public override bool CanSubmitOrder(Security security, Order order, out BrokerageMessageEvent message)
+        {
+            if (!_supportedSecurityTypes.Contains(security.Type))
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    Messages.DefaultBrokerageModel.UnsupportedSecurityType(this, security));
+                return false;
+            }
+
+            if (!_supportedOrderTypes.Contains(order.Type))
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    Messages.DefaultBrokerageModel.UnsupportedOrderType(this, order, _supportedOrderTypes));
+                return false;
+            }
+
+            return base.CanSubmitOrder(security, order, out message);
+        }
+
+        /// <summary>
+        /// Bloomberg EMSX supports cancel/replace (35=G) on order quantity, price, stop price,
+        /// order type and time in force.
+        /// </summary>
+        public override bool CanUpdateOrder(Security security, Order order, UpdateOrderRequest request, out BrokerageMessageEvent message)
+        {
+            message = null;
+            return true;
+        }
+    }
+}

--- a/Tests/Common/Brokerages/TerminalLinkBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/TerminalLinkBrokerageModelTests.cs
@@ -1,0 +1,118 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Brokerages;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+using QuantConnect.Tests.Engine.DataFeeds;
+
+namespace QuantConnect.Tests.Common.Brokerages
+{
+    [TestFixture, Parallelizable(ParallelScope.All)]
+    public class TerminalLinkBrokerageModelTests
+    {
+        private readonly TerminalLinkBrokerageModel _brokerageModel = new();
+
+        [TestCase("SPY", SecurityType.Equity)]
+        [TestCase("SPY", SecurityType.Option)]
+        [TestCase("ES", SecurityType.Future)]
+        public void CanSubmitOrder_ForSupportedSecurityTypes(string ticker, SecurityType securityType)
+        {
+            var algo = new AlgorithmStub();
+            var security = algo.AddSecurity(securityType, ticker);
+            var order = new MarketOrder(security.Symbol, 1, new DateTime(2024, 1, 2));
+
+            Assert.IsTrue(_brokerageModel.CanSubmitOrder(security, order, out var message), message?.Message);
+            Assert.IsNull(message);
+        }
+
+        // Index is data-only on TerminalLink; Forex/Crypto/Cfd and option chains other than
+        // equity options (IndexOption/FutureOption) are not supported for trading.
+        [TestCase("EURUSD", SecurityType.Forex)]
+        [TestCase("BTCUSD", SecurityType.Crypto)]
+        [TestCase("DE10YBEUR", SecurityType.Cfd)]
+        [TestCase("SPX", SecurityType.Index)]
+        public void CannotSubmitOrder_ForUnsupportedSecurityTypes(string ticker, SecurityType securityType)
+        {
+            var algo = new AlgorithmStub();
+            var security = algo.AddSecurity(securityType, ticker);
+            var order = new MarketOrder(security.Symbol, 1, new DateTime(2024, 1, 2));
+
+            Assert.IsFalse(_brokerageModel.CanSubmitOrder(security, order, out var message));
+            Assert.AreEqual(BrokerageMessageType.Warning, message.Type);
+            Assert.AreEqual("NotSupported", message.Code);
+        }
+
+        [TestCase(OrderType.Market)]
+        [TestCase(OrderType.MarketOnOpen)]
+        [TestCase(OrderType.MarketOnClose)]
+        [TestCase(OrderType.Limit)]
+        [TestCase(OrderType.StopMarket)]
+        [TestCase(OrderType.StopLimit)]
+        public void CanSubmitOrder_ForSupportedOrderTypes(OrderType orderType)
+        {
+            var algo = new AlgorithmStub();
+            var security = algo.AddSecurity(SecurityType.Equity, "SPY");
+            var order = CreateOrder(orderType, security.Symbol, 1);
+
+            Assert.IsTrue(_brokerageModel.CanSubmitOrder(security, order, out var message), message?.Message);
+            Assert.IsNull(message);
+        }
+
+        [TestCase(OrderType.LimitIfTouched)]
+        [TestCase(OrderType.TrailingStop)]
+        public void CannotSubmitOrder_ForUnsupportedOrderTypes(OrderType orderType)
+        {
+            var algo = new AlgorithmStub();
+            var security = algo.AddSecurity(SecurityType.Equity, "SPY");
+            var order = CreateOrder(orderType, security.Symbol, 1);
+
+            Assert.IsFalse(_brokerageModel.CanSubmitOrder(security, order, out var message));
+            Assert.AreEqual(BrokerageMessageType.Warning, message.Type);
+            Assert.AreEqual("NotSupported", message.Code);
+        }
+
+        [Test]
+        public void CanUpdateOrder_IsAlwaysAllowed()
+        {
+            var algo = new AlgorithmStub();
+            var security = algo.AddSecurity(SecurityType.Equity, "SPY");
+            var order = new MarketOrder(security.Symbol, 1, new DateTime(2024, 1, 2));
+            var request = new UpdateOrderRequest(new DateTime(2024, 1, 2), order.Id, new UpdateOrderFields());
+
+            Assert.IsTrue(_brokerageModel.CanUpdateOrder(security, order, request, out var message));
+            Assert.IsNull(message);
+        }
+
+        private static Order CreateOrder(OrderType orderType, Symbol symbol, decimal quantity)
+        {
+            var time = new DateTime(2024, 1, 2);
+            return orderType switch
+            {
+                OrderType.Market => new MarketOrder(symbol, quantity, time),
+                OrderType.MarketOnOpen => new MarketOnOpenOrder(symbol, quantity, time),
+                OrderType.MarketOnClose => new MarketOnCloseOrder(symbol, quantity, time),
+                OrderType.Limit => new LimitOrder(symbol, quantity, 100m, time),
+                OrderType.StopMarket => new StopMarketOrder(symbol, quantity, 100m, time),
+                OrderType.StopLimit => new StopLimitOrder(symbol, quantity, 100m, 100m, time),
+                OrderType.LimitIfTouched => new LimitIfTouchedOrder(symbol, quantity, 100m, 100m, time),
+                OrderType.TrailingStop => new TrailingStopOrder(symbol, quantity, 100m, 0.1m, true, time),
+                _ => throw new NotImplementedException($"Unhandled order type: {orderType}")
+            };
+        }
+    }
+}


### PR DESCRIPTION
#### Description
Adds `TerminalLinkBrokerageModel` (inheriting from `DefaultBrokerageModel`) and wires `BrokerageName.TerminalLink` to use it instead of the plain default.

The model enforces what the Bloomberg EMSX (TerminalLink) brokerage can actually route:
- **Security types:** Equity, Option (equity options only), Future
- **Order types:** Market, MarketOnOpen, MarketOnClose, Limit, StopMarket, StopLimit
- `CanUpdateOrder` returns true (EMSX supports cancel/replace)

#### Related Issue
N/A

#### Motivation and Context
TerminalLink currently resolves to `DefaultBrokerageModel`, which accepts any security type and order type. As a result the engine silently lets an algorithm submit orders the EMSX brokerage cannot handle (e.g. unsupported security types such as Forex/Crypto/CFD/Index, or unsupported order types such as LimitIfTouched/TrailingStop). These only fail later at the brokerage/symbol-mapping layer. This model rejects them up front via `CanSubmitOrder` with a clear `NotSupported` warning.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Added `TerminalLinkBrokerageModelTests` covering supported/unsupported security types, supported/unsupported order types, and order update. Validated the supported set against the `Lean.Brokerages.TerminalLink` implementation (symbol mapper and order conversion).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`