### PR TITLE
Fix flaky TriggersWeeklyScheduledEventsEachWeekLive test

### DIFF
--- a/Tests/Common/Scheduling/ScheduleManagerTests.cs
+++ b/Tests/Common/Scheduling/ScheduleManagerTests.cs
@@ -222,6 +222,14 @@ namespace QuantConnect.Tests.Common.Scheduling
             public ManualTimeProvider ManualTimeProvider = new ManualTimeProvider();
 
             protected override ITimeProvider TimeProvider => ManualTimeProvider;
+
+            // Time is fully driven by the ManualTimeProvider in tests, so there's no need to pace the
+            // scan loop to real wall-clock time. Sleeping here (Thread.Sleep granularity is ~15ms on
+            // Windows) would make the loop take longer than the test's timeout for long simulated ranges,
+            // causing the last scheduled events to be missed intermittently.
+            protected override void WaitTillNextSecond(DateTime time)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
﻿## Description

Fixes the intermittently failing `ScheduleManagerTests.TriggersWeeklyScheduledEventsEachWeekLive` unit test (random failures observed on `master` in CI).

### Root cause

The test is flaky due to **real-time pacing in the test harness**, not a product bug:

- `LiveTradingRealTimeHandler.Run()` paces its scan loop with `WaitTillNextSecond()`. On Windows this does `Thread.Sleep(1)`, which sleeps ~15ms because of the default OS timer granularity.
- The test drives simulated time by advancing the `ManualTimeProvider` 60 minutes per loop iteration, from `2024-02-10` to month >= 4 — roughly 1200 iterations.
- `~1200 x ~15ms` is around 18s, which can exceed the test's `finished.Wait(TimeSpan.FromSeconds(15))`. When the wait times out, `handler.Exit()` cancels the scan thread before the last weekly event (`2024-03-25 19:00`) fires, so the final expected trigger time is missing intermittently:

```
Expected ... 7 elements, actual ... 6 elements
Values differ at index [6]
Missing:  < 2024-03-25 19:00:00 >
```

### Fix

Time is fully driven by the `ManualTimeProvider` in tests, so the per-second real-time pacing serves no purpose there and only adds wall-clock latency. The 60-minute stepping is deterministic regardless of sleeping (each iteration snapshots the time and the advance event fires exactly once). Override `WaitTillNextSecond` to a no-op in `TestableLiveTradingRealTimeHandler`, so the loop runs at full speed.

No production code is changed.

### Verification

Ran the test 5x consecutively after the fix — passes every time in ~4-6s instead of racing the 15s timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
