### PR TITLE
feature: support index options on Bloomberg FIX brokerage model

### DIFF
--- a/Common/Brokerages/BloombergFixBrokerageModel.cs
+++ b/Common/Brokerages/BloombergFixBrokerageModel.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Brokerages
         {
             SecurityType.Equity,
             SecurityType.Option,
+            SecurityType.IndexOption,
             SecurityType.Future,
         };
 
@@ -72,13 +73,6 @@ namespace QuantConnect.Brokerages
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
                     Messages.DefaultBrokerageModel.UnsupportedOrderType(this, order, _supportedOrderTypes));
-                return false;
-            }
-
-            if (order.AbsoluteQuantity % 1 != 0)
-            {
-                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
-                    $"Order Quantity must be Integer, but provided {order.AbsoluteQuantity}.");
                 return false;
             }
 


### PR DESCRIPTION
#### Description
Adds `IndexOption` to the security types accepted by the Bloomberg FIX brokerage model, and removes the integer order-quantity check from `CanSubmitOrder`.

#### Related PR(s)
N/A

#### Related Issue
N/A

#### Motivation and Context
Index option orders (e.g. SPX/SPXW) were rejected because `IndexOption` was missing from the supported security types, so they could not be routed through Bloomberg FIX. The model also rejected any order with a fractional quantity:

    "Order Quantity must be Integer, but provided {order.AbsoluteQuantity}."

This check is removed because the Lean engine already rounds order quantity to the security lot size before the order reaches the brokerage model, so the check was no longer needed.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Ran the Bloomberg FIX integration tests in the Lean.Brokerages.Fix.Bloomberg repo. The `OrderParameters` test source now includes an SPXW index option limit order, and the full order lifecycle tests pass for it: `LongFromZero`, `CloseFromLong`, `ShortFromZero`, `CloseFromShort`, `ShortFromLong`, `LongFromShort`, and `CancelOrders`.

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`