### PR TITLE
feature: add public order properties

### DIFF
--- a/Common/Brokerages/PublicBrokerageModel.cs
+++ b/Common/Brokerages/PublicBrokerageModel.cs
@@ -104,6 +104,13 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
+            if (order.Properties is PublicOrderProperties publicOrderProperties)
+            {
+                // A cash account has no margin buying power, so margin is always off there.
+                // On a margin account, keep an explicit choice and otherwise use margin by default.
+                publicOrderProperties.UseMargin = AccountType != AccountType.Cash && (publicOrderProperties.UseMargin ?? true);
+            }
+
             // Public.com handles crossing a zero position natively, so the order is not split or rejected here.
             return base.CanSubmitOrder(security, order, out message);
         }

--- a/Common/Brokerages/PublicBrokerageModel.cs
+++ b/Common/Brokerages/PublicBrokerageModel.cs
@@ -96,6 +96,14 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
+            // Public.com only accepts Limit orders in the extended (outside regular trading hours) session.
+            if (order.Properties is PublicOrderProperties { OutsideRegularTradingHours: true } && order.Type != OrderType.Limit)
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    Messages.PublicBrokerageModel.ExtendedMarketOrderMustBeLimit(order));
+                return false;
+            }
+
             // Public.com handles crossing a zero position natively, so the order is not split or rejected here.
             return base.CanSubmitOrder(security, order, out message);
         }

--- a/Common/Messages/Messages.Brokerages.cs
+++ b/Common/Messages/Messages.Brokerages.cs
@@ -629,6 +629,21 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Provides user-facing messages for the <see cref="Brokerages.PublicBrokerageModel"/> class and its consumers or related classes
+        /// </summary>
+        public static class PublicBrokerageModel
+        {
+            /// <summary>
+            /// Returns a message explaining that orders for the extended market must be Limit orders with Day time-in-force.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string ExtendedMarketOrderMustBeLimit(Orders.Order order)
+            {
+                return Invariant($"Orders for extended market must be of type '{nameof(OrderType.Limit)}' and with 'DAY' time-in-force, but {order.Type} was specified.");
+            }
+        }
+
+        /// <summary>
         /// Provides user-facing messages for the <see cref="Brokerages.RBIBrokerageModel"/> class and its consumers or related classes
         /// </summary>
         public static class RBIBrokerageModel

--- a/Common/Orders/PublicOrderProperties.cs
+++ b/Common/Orders/PublicOrderProperties.cs
@@ -31,9 +31,10 @@ namespace QuantConnect.Orders
         public bool OutsideRegularTradingHours { get; set; }
 
         /// <summary>
-        /// If set to <c>true</c>, the order uses margin buying power when the account allows it;
-        /// if <c>false</c>, the order uses cash-only buying power.
+        /// Controls the buying power used by the order.
+        /// <c>true</c> uses margin buying power when the account allows it; <c>false</c> uses cash-only buying power.
+        /// When left <c>null</c>, the brokerage model fills it in from the account type before the order is sent.
         /// </summary>
-        public bool UseMargin { get; set; }
+        public bool? UseMargin { get; set; }
     }
 }

--- a/Common/Orders/PublicOrderProperties.cs
+++ b/Common/Orders/PublicOrderProperties.cs
@@ -1,0 +1,39 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+namespace QuantConnect.Orders
+{
+    /// <summary>
+    /// Represents the properties of an order in Public.com.
+    /// </summary>
+    public class PublicOrderProperties : OrderProperties
+    {
+        /// <summary>
+        /// If set to <c>true</c>, allows the order to trigger or fill outside of regular trading hours
+        /// (the extended session).
+        /// </summary>
+        /// <remarks>
+        /// Applicable to day time-in-force equity orders only.
+        /// </remarks>
+        public bool OutsideRegularTradingHours { get; set; }
+
+        /// <summary>
+        /// If set to <c>true</c>, the order uses margin buying power when the account allows it;
+        /// if <c>false</c>, the order uses cash-only buying power.
+        /// </summary>
+        public bool UseMargin { get; set; }
+    }
+}

--- a/Tests/Common/Brokerages/PublicBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/PublicBrokerageModelTests.cs
@@ -119,6 +119,28 @@ namespace QuantConnect.Tests.Common.Brokerages
             Assert.That(message, Is.Null);
         }
 
+        // A margin account keeps an explicit UseMargin choice and otherwise uses margin by default;
+        // a cash account has no margin buying power, so UseMargin is always forced off there.
+        [TestCase(AccountType.Margin, null, true)]
+        [TestCase(AccountType.Margin, true, true)]
+        [TestCase(AccountType.Margin, false, false)]
+        [TestCase(AccountType.Cash, null, false)]
+        [TestCase(AccountType.Cash, true, false)]
+        [TestCase(AccountType.Cash, false, false)]
+        public void CanSubmitOrderResolvesUseMarginFromAccountType(AccountType accountType, bool? requestedUseMargin, bool expectedUseMargin)
+        {
+            var brokerageModel = new PublicBrokerageModel(accountType);
+            var security = GetSecurityForType(SecurityType.Equity);
+            var properties = new PublicOrderProperties { UseMargin = requestedUseMargin };
+            var order = new LimitOrder(security.Symbol, 1m, 100m, DateTime.UtcNow, properties: properties);
+
+            var canSubmit = brokerageModel.CanSubmitOrder(security, order, out var message);
+
+            Assert.That(canSubmit, Is.True);
+            Assert.That(message, Is.Null);
+            Assert.That(properties.UseMargin, Is.EqualTo(expectedUseMargin));
+        }
+
         [Test]
         public void CanUpdateOrderSingleOrderReturnsTrue()
         {


### PR DESCRIPTION
#### Description

Adds `PublicOrderProperties` so an algorithm can opt into Public.com extended-hours trading and choose margin or cash-only buying power per order. The `Lean.Brokerages.Public` plugin reads these and maps `OutsideRegularTradingHours` to the request's `equityMarketSession` field and `UseMargin` to its `useMargin` field.

```csharp
DefaultOrderProperties = new PublicOrderProperties
{
    OutsideRegularTradingHours = true, // route equity orders to the EXTENDED session
    UseMargin = false                  // use cash-only buying power
};
```

#### Related PR(s)

N/A

#### Related Issue

N/A

#### Motivation and Context

Public.com supports an extended trading session and a per-order choice between margin and cash-only buying power. Lean had no order-properties type to express either, so these options could not be set from an algorithm.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Manually placed equity orders through the `Lean.Brokerages.Public` plugin and confirmed the place-order request carried `equityMarketSession` (`CORE`/`EXTENDED`) and `useMargin` as set on the properties.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
