### PR TITLE
Cache cross-zero unsupported-order-type set in brokerage models

### DIFF
--- a/Common/Brokerages/TastytradeBrokerageModel.cs
+++ b/Common/Brokerages/TastytradeBrokerageModel.cs
@@ -55,7 +55,7 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// The set of <see cref="OrderType"/> values that cannot be used for cross-zero execution.
         /// </summary>
-        private static IReadOnlySet<OrderType> NotSupportedCrossZeroOrderTypes => new HashSet<OrderType>()
+        private static readonly IReadOnlySet<OrderType> NotSupportedCrossZeroOrderTypes = new HashSet<OrderType>()
         {
             OrderType.ComboLimit
         };

--- a/Common/Brokerages/TradeStationBrokerageModel.cs
+++ b/Common/Brokerages/TradeStationBrokerageModel.cs
@@ -75,7 +75,7 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// The set of <see cref="OrderType"/> values that cannot be used for cross-zero execution.
         /// </summary>
-        private static IReadOnlySet<OrderType> NotSupportedCrossZeroOrderTypes => new HashSet<OrderType>()
+        private static readonly IReadOnlySet<OrderType> NotSupportedCrossZeroOrderTypes = new HashSet<OrderType>()
         {
             OrderType.ComboMarket,
             OrderType.ComboLimit,


### PR DESCRIPTION
## Summary
`TastytradeBrokerageModel` and `TradeStationBrokerageModel` declared `NotSupportedCrossZeroOrderTypes` as an **expression-bodied property** (`=> new HashSet<OrderType>(){...}`), so a new constant set was allocated on **every** `CanSubmitOrder` call (each is used in `BrokerageExtensions.ValidateCrossZeroOrder` per order). Changed to a `static readonly` field, built once.

This matches the pattern already used in the same module — `BrokerageExtensions.DefaultNotSupportedCrossZeroOrderTypes` is a `static readonly` field.

## Correctness
The set contents are identical (fixed `OrderType` values), so cross-zero order validation behavior is unchanged — this only removes the per-call allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)