### PR TITLE
Fix FisherTransform.IsReady to check the Minimum indicator

### DIFF
--- a/Indicators/FisherTransform.cs
+++ b/Indicators/FisherTransform.cs
@@ -69,7 +69,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Gets a flag indicating when this indicator is ready and fully initialized
         /// </summary>
-        public override bool IsReady => _medianMax.IsReady && _medianMax.IsReady;
+        public override bool IsReady => _medianMax.IsReady && _medianMin.IsReady;
 
         /// <summary>
         /// Required period, in data points, for the indicator to be ready and fully initialized.


### PR DESCRIPTION
## Summary
`FisherTransform.IsReady` was defined as:
```csharp
public override bool IsReady => _medianMax.IsReady && _medianMax.IsReady;
```
The second term repeats `_medianMax`, so the `Minimum` indicator (`_medianMin`) readiness was never checked. This fixes it to:
```csharp
public override bool IsReady => _medianMax.IsReady && _medianMin.IsReady;
```

## Why it matters
`_medianMin` and `_medianMax` are both `period`-length rolling indicators warmed in lockstep, so in normal use they become ready on the same bar and the bug is usually masked. But `IsReady` no longer reflects the actual state of both sub-indicators, which is incorrect and brittle (e.g. if warm-up paths ever diverge). Both are now checked.

## Tests
Indicators builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)