### PR TITLE
Fix random TriggersWeeklyScheduledEventsEachWeekLive failures

### DIFF
--- a/Tests/Common/Scheduling/ScheduleManagerTests.cs
+++ b/Tests/Common/Scheduling/ScheduleManagerTests.cs
@@ -145,7 +145,12 @@ namespace QuantConnect.Tests.Common.Scheduling
             // Start
             handler.SetTime(time);
 
-            finished.Wait(TimeSpan.FromSeconds(15));
+            // The time advance is driven by the live real-time handler firing the scheduled events above, so the
+            // fast-forward from February to April is bounded by wall-clock. Give it a generous budget and assert it
+            // actually reached the end, instead of asserting on a partially advanced timeline (which under load
+            // dropped the final week's scheduled event and produced a misleading count mismatch).
+            Assert.IsTrue(finished.Wait(TimeSpan.FromSeconds(120)),
+                "Timed out waiting for the scheduled time advance to reach April");
 
             handler.Exit();
 


### PR DESCRIPTION
## Problem
The test fast-forwards simulated time from February to April by having the live real-time handler fire a scheduled `Every(60min)` event that advances a `ManualTimeProvider` each step. Because the advance is driven by the real-time handler, completing it is bounded by **wall-clock** time. The test waited only 15s and then asserted on the collected event times **regardless of whether the fast-forward had finished**.

Under load the 15s wait timed out around late March, so the final week's scheduled event (`2024-03-25 19:00`) had not fired yet, and the assertion failed with 6 vs 7 events:

```
Expected ... with 7 elements, actual ... with 6 elements
Missing:  < 2024-03-25 19:00:00 >
```

## Fix
Give the advance a generous budget and assert it actually reached the end, instead of asserting on a partially-advanced timeline:

```csharp
Assert.IsTrue(finished.Wait(TimeSpan.FromSeconds(120)),
    "Timed out waiting for the scheduled time advance to reach April");
```

Once the timeline reaches April every expected event (all of which precede April) has necessarily fired, so the collection assert is deterministic. A genuine hang now fails with a clear message rather than a misleading count mismatch. Normal runtime is unchanged (~6-8s); the larger budget is only a ceiling.

## Verification
Ran the test repeatedly: passed every time (~6-8s each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)