### PR TITLE
Fix TerminalLink brokerage model order update and MarketOnClose support

### DIFF
--- a/Common/Brokerages/TerminalLinkBrokerageModel.cs
+++ b/Common/Brokerages/TerminalLinkBrokerageModel.cs
@@ -35,7 +35,6 @@ namespace QuantConnect.Brokerages
         {
             OrderType.Market,
             OrderType.MarketOnOpen,
-            OrderType.MarketOnClose,
             OrderType.Limit,
             OrderType.StopMarket,
             OrderType.StopLimit,
@@ -75,13 +74,13 @@ namespace QuantConnect.Brokerages
         }
 
         /// <summary>
-        /// Bloomberg EMSX supports cancel/replace (35=G) on order quantity, price, stop price,
-        /// order type and time in force.
+        /// TerminalLink does not allow modifying live orders; the EMSX brokerage rejects updates.
         /// </summary>
         public override bool CanUpdateOrder(Security security, Order order, UpdateOrderRequest request, out BrokerageMessageEvent message)
         {
-            message = null;
-            return true;
+            message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                Messages.DefaultBrokerageModel.OrderUpdateNotSupported);
+            return false;
         }
     }
 }

--- a/Tests/Common/Brokerages/TerminalLinkBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/TerminalLinkBrokerageModelTests.cs
@@ -59,7 +59,6 @@ namespace QuantConnect.Tests.Common.Brokerages
 
         [TestCase(OrderType.Market)]
         [TestCase(OrderType.MarketOnOpen)]
-        [TestCase(OrderType.MarketOnClose)]
         [TestCase(OrderType.Limit)]
         [TestCase(OrderType.StopMarket)]
         [TestCase(OrderType.StopLimit)]
@@ -73,6 +72,7 @@ namespace QuantConnect.Tests.Common.Brokerages
             Assert.IsNull(message);
         }
 
+        [TestCase(OrderType.MarketOnClose)]
         [TestCase(OrderType.LimitIfTouched)]
         [TestCase(OrderType.TrailingStop)]
         public void CannotSubmitOrder_ForUnsupportedOrderTypes(OrderType orderType)
@@ -87,15 +87,16 @@ namespace QuantConnect.Tests.Common.Brokerages
         }
 
         [Test]
-        public void CanUpdateOrder_IsAlwaysAllowed()
+        public void CannotUpdateOrder()
         {
             var algo = new AlgorithmStub();
             var security = algo.AddSecurity(SecurityType.Equity, "SPY");
             var order = new MarketOrder(security.Symbol, 1, new DateTime(2024, 1, 2));
             var request = new UpdateOrderRequest(new DateTime(2024, 1, 2), order.Id, new UpdateOrderFields());
 
-            Assert.IsTrue(_brokerageModel.CanUpdateOrder(security, order, request, out var message));
-            Assert.IsNull(message);
+            Assert.IsFalse(_brokerageModel.CanUpdateOrder(security, order, request, out var message));
+            Assert.AreEqual(BrokerageMessageType.Warning, message.Type);
+            Assert.AreEqual("NotSupported", message.Code);
         }
 
         private static Order CreateOrder(OrderType orderType, Symbol symbol, decimal quantity)


### PR DESCRIPTION
#### Description
Follow-up to #9546 to correct two restrictions in `TerminalLinkBrokerageModel`:
- **Order updates:** `CanUpdateOrder` now returns `false` (was `true`). The TerminalLink (Bloomberg EMSX) brokerage disables order modification entirely.
- **MarketOnClose:** removed from the supported order types.

#### Related Issue
Follow-up to #9546.

#### Motivation and Context
#9546 added `TerminalLinkBrokerageModel` but allowed order updates and Market-on-Close orders, neither of which the brokerage actually supports:
- `TerminalLinkBrokerage.UpdateOrder` is hard-disabled and always returns `false` (logs "Modification of order is not allowed"), so the model advertising update support would let the engine attempt modifications the brokerage rejects.
- Market-on-Close is not a supported order type for the integration.

Rejecting both up front in `CanSubmitOrder`/`CanUpdateOrder` gives the algorithm a clear `NotSupported` warning instead of a silent downstream failure.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Updated `TerminalLinkBrokerageModelTests`: MarketOnClose moved to the unsupported-order-types case, and the order-update test now asserts the request is rejected with a `NotSupported` warning.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`