### PR TITLE
Use risk-free rate in probabilistic Sharpe ratio

### DIFF
--- a/Common/Statistics/PortfolioStatistics.cs
+++ b/Common/Statistics/PortfolioStatistics.cs
@@ -309,7 +309,7 @@ namespace QuantConnect.Statistics
 
             // deannualize a 1 sharpe ratio
             var benchmarkSharpeRatio = 1.0d / Math.Sqrt(tradingDaysPerYear);
-            ProbabilisticSharpeRatio = Statistics.ProbabilisticSharpeRatio(listPerformance, benchmarkSharpeRatio).SafeDecimalCast();
+            ProbabilisticSharpeRatio = Statistics.ProbabilisticSharpeRatio(listPerformance, benchmarkSharpeRatio, (double)riskFreeRate / tradingDaysPerYear).SafeDecimalCast();
 
             ValueAtRisk99 = GetValueAtRisk(listPerformance, tradingDaysPerYear, 0.99d);
             ValueAtRisk95 = GetValueAtRisk(listPerformance, tradingDaysPerYear, 0.95d);

--- a/Common/Statistics/Statistics.cs
+++ b/Common/Statistics/Statistics.cs
@@ -195,11 +195,13 @@ namespace QuantConnect.Statistics
         /// </summary>
         /// <param name="listPerformance">The list of algorithm performance values</param>
         /// <param name="benchmarkSharpeRatio">The benchmark sharpe ratio to use</param>
+        /// <param name="riskFreeRate">The risk free rate for each performance sample</param>
         /// <returns>Probabilistic Sharpe Ratio</returns>
         public static double ProbabilisticSharpeRatio(List<double> listPerformance,
-             double benchmarkSharpeRatio)
+             double benchmarkSharpeRatio,
+             double riskFreeRate = 0)
         {
-            var observedSharpeRatio = ObservedSharpeRatio(listPerformance);
+            var observedSharpeRatio = ObservedSharpeRatio(listPerformance, riskFreeRate);
 
             var skewness = listPerformance.Skewness();
             var kurtosis = listPerformance.Kurtosis();
@@ -224,10 +226,11 @@ namespace QuantConnect.Statistics
         /// Calculates the observed sharpe ratio
         /// </summary>
         /// <param name="listPerformance">The performance samples to use</param>
+        /// <param name="riskFreeRate">The risk free rate for each performance sample</param>
         /// <returns>The observed sharpe ratio</returns>
-        public static double ObservedSharpeRatio(List<double> listPerformance)
+        public static double ObservedSharpeRatio(List<double> listPerformance, double riskFreeRate = 0)
         {
-            var performanceAverage = listPerformance.Average();
+            var performanceAverage = listPerformance.Average() - riskFreeRate;
             var standardDeviation = listPerformance.StandardDeviation();
             // we don't annualize it
             return standardDeviation.IsNaNOrZero() ? 0 : performanceAverage / standardDeviation;

--- a/Tests/Common/Statistics/ProbabilisticSharpeRatioTests.cs
+++ b/Tests/Common/Statistics/ProbabilisticSharpeRatioTests.cs
@@ -77,5 +77,22 @@ namespace QuantConnect.Tests.Common.Statistics
 
             Assert.AreEqual(0d, result, 0.001);
         }
+
+        [Test]
+        public void UsesRiskFreeRateForObservedSharpeRatio()
+        {
+            var performance = new List<double>
+            {
+                0.00018, 0.00021, 0.00017, 0.00020, 0.00019,
+                0.00022, 0.00018, 0.00021, 0.00017, 0.00020
+            };
+
+            var benchmarkSharpeRatio = 1.0d / System.Math.Sqrt(252);
+            var grossResult = QuantConnect.Statistics.Statistics.ProbabilisticSharpeRatio(performance, benchmarkSharpeRatio);
+            var excessReturnResult = QuantConnect.Statistics.Statistics.ProbabilisticSharpeRatio(performance, benchmarkSharpeRatio, 0.00025);
+
+            Assert.Greater(grossResult, 0.99d);
+            Assert.Less(excessReturnResult, 0.01d);
+        }
     }
 }


### PR DESCRIPTION
#### Description

Fixes #9533.

`PortfolioStatistics` reports SharpeRatio on excess returns by subtracting the risk-free rate, but ProbabilisticSharpeRatio was still using the gross-return observed Sharpe ratio. That can make a low-volatility cash-like series report a strongly negative Sharpe ratio and a near-100% PSR at the same time.

This PR keeps the existing PSR/ObservedSharpeRatio APIs backward compatible by adding an optional per-sample `riskFreeRate = 0` parameter, then has `PortfolioStatistics` pass the annual risk-free rate deannualized by `tradingDaysPerYear`. The PSR is then inference about the same excess-return Sharpe ratio basis as the reported SharpeRatio.

#### Related Issue

#9533

#### Motivation and Context

The reported Sharpe ratio and PSR should be on the same return basis. Otherwise high-rate, low-volatility assets can show contradictory statistics.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

- `git diff --check`
- Formula sanity check outside Lean: the new regression sample has gross observed Sharpe around 10.9, giving PSR approximately 1.0, but after subtracting a per-sample risk-free rate of 0.00025 the observed Sharpe is around -3.23 and PSR is approximately 1.6e-12.

I could not run `dotnet test` locally because this machine does not have `dotnet`, `csc`, `mcs`, or `msbuild` installed.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New test

#### Checklist

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed where runnable locally.