### PR TITLE
Fix maximum Sharpe ratio optimizer objective

### DIFF
--- a/Algorithm.Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizer.cs
+++ b/Algorithm.Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizer.cs
@@ -14,6 +14,7 @@
 */
 
 using System.Collections.Generic;
+using System.Linq;
 using Accord.Math;
 using Accord.Math.Optimization;
 using Accord.Statistics;
@@ -97,35 +98,82 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
 
             var size = covariance.GetLength(0);
             var x0 = Vector.Create(size, 1.0 / size);
-            var k = returns.Dot(x0);
+            var variableCount = size + 1;
+            var kappaIndex = size;
 
             var constraints = new List<LinearConstraint>
             {
-                // Sharpe Maximization under Quadratic Constraints
+                // Sharpe maximization under quadratic constraints via Charnes-Cooper:
+                // y = w * kappa, kappa > 0, (µ - r_f)^T y = 1.
                 // https://quant.stackexchange.com/questions/18521/sharpe-maximization-under-quadratic-constraints
-                // (µ − r_f)^T w = k
-                new LinearConstraint(size)
+                new LinearConstraint(variableCount)
                 {
-                    CombinedAs = returns,
+                    CombinedAs = returns.Concat(new[] { 0.0 }).ToArray(),
                     ShouldBe = ConstraintType.EqualTo,
-                    Value = k
+                    Value = 1.0
+                },
+                // Σy = kappa
+                new LinearConstraint(variableCount)
+                {
+                    CombinedAs = Enumerable.Range(0, variableCount)
+                        .Select(i => i == kappaIndex ? -1.0 : 1.0)
+                        .ToArray(),
+                    ShouldBe = ConstraintType.EqualTo,
+                    Value = 0.0
                 }
             };
 
-            // Σw = 1
-            constraints.Add(GetBudgetConstraint(size));
+            for (var i = 0; i < size; i++)
+            {
+                // y_i >= lower * kappa
+                constraints.Add(new LinearConstraint(variableCount)
+                {
+                    CombinedAs = Enumerable.Range(0, variableCount)
+                        .Select(j => j == i ? 1.0 : j == kappaIndex ? -_lower : 0.0)
+                        .ToArray(),
+                    ShouldBe = ConstraintType.GreaterThanOrEqualTo,
+                    Value = 0.0
+                });
+                // y_i <= upper * kappa
+                constraints.Add(new LinearConstraint(variableCount)
+                {
+                    CombinedAs = Enumerable.Range(0, variableCount)
+                        .Select(j => j == i ? 1.0 : j == kappaIndex ? -_upper : 0.0)
+                        .ToArray(),
+                    ShouldBe = ConstraintType.LesserThanOrEqualTo,
+                    Value = 0.0
+                });
+            }
 
-            // lw ≤ w ≤ up
-            constraints.AddRange(GetBoundaryConditions(size));
+            constraints.Add(new LinearConstraint(1)
+            {
+                VariablesAtIndices = new[] { kappaIndex },
+                ShouldBe = ConstraintType.GreaterThanOrEqualTo,
+                Value = 0.0
+            });
 
             // Setup solver
-            var optfunc = new QuadraticObjectiveFunction(covariance, Vector.Create(size, 0.0));
+            var objective = new double[variableCount, variableCount];
+            for (var row = 0; row < size; row++)
+            {
+                for (var column = 0; column < size; column++)
+                {
+                    objective[row, column] = covariance[row, column];
+                }
+            }
+            var optfunc = new QuadraticObjectiveFunction(objective, Vector.Create(variableCount, 0.0));
             var solver = new GoldfarbIdnani(optfunc, constraints);
 
             // Solve problem
-            var success = solver.Minimize(Vector.Copy(x0));
-            var sharpeRatio = returns.Dot(solver.Solution) / solver.Value;
-            return success ? solver.Solution : x0;
+            var y0 = x0.Concat(new[] { 1.0 }).ToArray();
+            var success = solver.Minimize(Vector.Copy(y0));
+            if (!success || solver.Solution[kappaIndex].IsNaNOrInfinity() || solver.Solution[kappaIndex] <= 0)
+            {
+                return x0;
+            }
+
+            var solution = solver.Solution.Take(size).ToArray().Divide(solver.Solution[kappaIndex]);
+            return solution.Any(x => x.IsNaNOrInfinity()) ? x0 : solution;
         }
     }
 }

--- a/Algorithm.Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizer.py
+++ b/Algorithm.Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizer.py
@@ -55,26 +55,23 @@ class MaximumSharpeRatioPortfolioOptimizer:
 
         size = covariance.columns.size   # K x 1
         x0 = np.array(size * [1. / size])
-        k = expected_returns.dot(x0)
-
-        # Sharpe Maximization under Quadratic Constraints
-        # https://quant.stackexchange.com/questions/18521/sharpe-maximization-under-quadratic-constraints
-        # (µ − r_f)^T w = k
-        constraints = [
-            {'type': 'eq', 'fun': lambda weights: expected_returns.dot(weights) - k}]
 
         # Σw = 1
-        constraints.append(
-            {'type': 'eq', 'fun': lambda weights: self.get_budget_constraint(weights)})
+        constraints = [
+            {'type': 'eq', 'fun': lambda weights: self.get_budget_constraint(weights)}]
 
-        opt = minimize(lambda weights: self.portfolio_variance(weights, covariance),   # Objective function
+        opt = minimize(lambda weights: self.negative_sharpe_ratio(weights, expected_returns, covariance),
                        x0,                                                        # Initial guess
                        bounds = self.get_boundary_conditions(size),               # Bounds for variables: lw ≤ w ≤ up
                        constraints = constraints,                                 # Constraints definition
                        method='SLSQP')        # Optimization method:  Sequential Least SQuares Programming
-        sharpe_ratio = expected_returns.dot(opt['x']) / opt.fun
 
         return opt['x'] if opt['success'] else x0
+
+    def negative_sharpe_ratio(self, weights, expected_returns, covariance):
+        '''Computes the negative Sharpe ratio for minimization.'''
+        variance = self.portfolio_variance(weights, covariance)
+        return -expected_returns.dot(weights) / np.sqrt(variance)
 
     def portfolio_variance(self, weights, covariance):
         '''Computes the portfolio variance

--- a/Tests/Algorithm/Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizerTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizerTests.cs
@@ -18,6 +18,7 @@ using QuantConnect.Algorithm.Framework.Portfolio;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Accord.Statistics;
 
 namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 {
@@ -91,14 +92,22 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         [TestCase(7)]
         public override void OptimizeWeightings(int testCaseNumber)
         {
-            base.OptimizeWeightings(testCaseNumber);
+            var testOptimizer = CreateOptimizer();
+            var historicalReturns = HistoricalReturns[testCaseNumber];
+            var expectedReturns = ExpectedReturns[testCaseNumber] ?? historicalReturns.Mean(0);
+            var covariance = Covariances[testCaseNumber] ?? historicalReturns.Covariance();
+            var result = testOptimizer.Optimize(historicalReturns, ExpectedReturns[testCaseNumber], Covariances[testCaseNumber]);
+
+            AssertWeightConstraintsAreSatisfied(result);
+            Assert.GreaterOrEqual(SharpeRatio(result, expectedReturns, covariance),
+                SharpeRatio(EqualWeights(result.Length), expectedReturns, covariance) - 1e-6);
         }
 
         [TestCase(0)]
         public void OptimizeWeightingsSpecifyingLowerBoundAndRiskFreeRate(int testCaseNumber)
         {
             var testOptimizer = new MaximumSharpeRatioPortfolioOptimizer(lower: 0, riskFreeRate: 0.04);
-            var expectedResult = new double[] { 0, 0.44898, 0.55102 };
+            var expectedResult = new double[] { 0, 0, 1 };
 
             var result = testOptimizer.Optimize(HistoricalReturns[testCaseNumber]);
 
@@ -106,13 +115,33 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         }
 
         [Test]
-        public void SingleSecurityPortfolioReturnsNaN()
+        public void MaximizesSharpeRatioInsteadOfMatchingEqualWeightReturn()
+        {
+            var testOptimizer = new MaximumSharpeRatioPortfolioOptimizer(lower: 0, upper: 1);
+            var historicalReturns = new double[,] { { 0, 0, 0 }, { 0, 0, 0 } };
+            var expectedReturns = new double[] { 0.05, 0.09, 0.18 };
+            var covariance = new double[,]
+            {
+                { 0.0100, 0.0010, 0.0010 },
+                { 0.0010, 0.0225, 0.0010 },
+                { 0.0010, 0.0010, 0.0625 }
+            };
+
+            var result = testOptimizer.Optimize(historicalReturns, expectedReturns, covariance);
+            var equalWeightSharpeRatio = SharpeRatio(EqualWeights(result.Length), expectedReturns, covariance);
+
+            AssertWeightConstraintsAreSatisfied(result, 0, 1);
+            Assert.Greater(SharpeRatio(result, expectedReturns, covariance), equalWeightSharpeRatio + 0.01);
+        }
+
+        [Test]
+        public void SingleSecurityPortfolioReturnsFullWeight()
         {
             var testOptimizer = new MaximumSharpeRatioPortfolioOptimizer();
             var historicalReturns = new double[,] { { -0.1 } };
             var expectedReturns = new double[] { -0.1 };
 
-            var expectedResult = new double[] { double.NaN };
+            var expectedResult = new double[] { 1 };
 
             var result = testOptimizer.Optimize(historicalReturns, expectedReturns);
 
@@ -150,6 +179,38 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 Assert.GreaterOrEqual(rounded, lower);
                 Assert.LessOrEqual(rounded, upper);
             };
+        }
+
+        private static void AssertWeightConstraintsAreSatisfied(double[] result, double lower = -1, double upper = 1)
+        {
+            Assert.AreEqual(1, Math.Round(result.Sum(), 6));
+            foreach (var x in result)
+            {
+                var rounded = Math.Round(x, 6);
+                Assert.GreaterOrEqual(rounded, lower);
+                Assert.LessOrEqual(rounded, upper);
+            }
+        }
+
+        private static double[] EqualWeights(int size)
+        {
+            return Enumerable.Repeat(1d / size, size).ToArray();
+        }
+
+        private static double SharpeRatio(double[] weights, double[] expectedReturns, double[,] covariance)
+        {
+            var portfolioReturn = 0d;
+            var variance = 0d;
+            for (var i = 0; i < weights.Length; i++)
+            {
+                portfolioReturn += weights[i] * expectedReturns[i];
+                for (var j = 0; j < weights.Length; j++)
+                {
+                    variance += weights[i] * covariance[i, j] * weights[j];
+                }
+            }
+
+            return portfolioReturn / Math.Sqrt(variance);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix the C# maximum Sharpe ratio optimizer to solve the Charnes-Cooper transformed Sharpe maximization problem instead of minimizing variance at the equal-weight portfolio return.
- Fix the Python optimizer to minimize the negative Sharpe ratio directly under the existing budget and weight-bound constraints.
- Add a regression test that verifies the optimizer improves Sharpe versus equal weights on a case where the old fixed-return minimum-variance objective stayed near the wrong solution.

Fixes #9322.

## Tests
- `git diff --check`
- `PYTHONPYCACHEPREFIX=/private/tmp/lean-pycache /opt/homebrew/bin/python3.11 -m py_compile Algorithm.Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizer.py`
- Python harness importing `MaximumSharpeRatioPortfolioOptimizer.py` with a mocked `AlgorithmImports`, verifying weights sum to 1, respect [0, 1], and improve Sharpe from 1.0069068408440842 to 1.0220736842416358.

I could not run the C# NUnit suite locally because this machine does not have `dotnet`, `msbuild`, `csc`, or `mcs` installed.
