### PR TITLE
Fix MaximumSharpeRatioPortfolioOptimizer to maximize the Sharpe ratio

### DIFF
--- a/Algorithm.Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizer.cs
+++ b/Algorithm.Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizer.cs
@@ -14,6 +14,7 @@
 */
 
 using System.Collections.Generic;
+using System.Linq;
 using Accord.Math;
 using Accord.Math.Optimization;
 using Accord.Statistics;
@@ -45,40 +46,35 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
         }
 
         /// <summary>
-        /// Sum of all weight is one: 1^T w = 1 / Σw = 1
-        /// </summary>
-        /// <param name="size">number of variables</param>
-        /// <returns>linear constraint object</returns>
-        protected LinearConstraint GetBudgetConstraint(int size)
-        {
-            return new LinearConstraint(size)
-            {
-                CombinedAs = Vector.Create(size, 1.0),
-                ShouldBe = ConstraintType.EqualTo,
-                Value = 1.0
-            };
-        }
-
-        /// <summary>
         /// Boundary constraints on weights: lw ≤ w ≤ up
         /// </summary>
+        /// <remarks>
+        /// Expressed in the substituted variable y = κw (κ = 1ᵀy &gt; 0), the per-weight bounds
+        /// become linear: yᵢ − up·(1ᵀy) ≤ 0 and yᵢ − lw·(1ᵀy) ≥ 0.
+        /// </remarks>
         /// <param name="size">number of variables</param>
         /// <returns>enumeration of linear constraint objects</returns>
         protected IEnumerable<LinearConstraint> GetBoundaryConditions(int size)
         {
             for (int i = 0; i < size; i++)
             {
-                yield return new LinearConstraint(1)
+                // yᵢ − up·(1ᵀy) ≤ 0
+                var upper = Vector.Create(size, -_upper);
+                upper[i] += 1.0;
+                yield return new LinearConstraint(size)
                 {
-                    VariablesAtIndices = new int[] { i },
-                    ShouldBe = ConstraintType.GreaterThanOrEqualTo,
-                    Value = _lower
-                };
-                yield return new LinearConstraint(1)
-                {
-                    VariablesAtIndices = new int[] { i },
+                    CombinedAs = upper,
                     ShouldBe = ConstraintType.LesserThanOrEqualTo,
-                    Value = _upper
+                    Value = 0.0
+                };
+                // yᵢ − lw·(1ᵀy) ≥ 0
+                var lower = Vector.Create(size, -_lower);
+                lower[i] += 1.0;
+                yield return new LinearConstraint(size)
+                {
+                    CombinedAs = lower,
+                    ShouldBe = ConstraintType.GreaterThanOrEqualTo,
+                    Value = 0.0
                 };
             }
         }
@@ -96,36 +92,49 @@ namespace QuantConnect.Algorithm.Framework.Portfolio
             var returns = (expectedReturns ?? historicalReturns.Mean(0)).Subtract(_riskFreeRate);
 
             var size = covariance.GetLength(0);
-            var x0 = Vector.Create(size, 1.0 / size);
-            var k = returns.Dot(x0);
+            var equalWeights = Vector.Create(size, 1.0 / size);
 
+            // The Charnes-Cooper substitution needs a portfolio with positive expected excess
+            // return to exist, otherwise the Sharpe ratio cannot be maximized.
+            var feasible = _lower >= 0 ? returns.Any(x => x > 0) : returns.Any(x => x != 0);
+            if (!feasible)
+            {
+                return equalWeights;
+            }
+
+            // Charnes-Cooper substitution y = κw (κ = 1ᵀy): maximizing the Sharpe ratio
+            // (µ − r_f)ᵀw / √(wᵀΣw) becomes minimizing wᵀΣw subject to (µ − r_f)ᵀy = 1,
+            // recovering the weights afterwards as w = y / (1ᵀy).
+            // https://quant.stackexchange.com/questions/18521/sharpe-maximization-under-quadratic-constraints
             var constraints = new List<LinearConstraint>
             {
-                // Sharpe Maximization under Quadratic Constraints
-                // https://quant.stackexchange.com/questions/18521/sharpe-maximization-under-quadratic-constraints
-                // (µ − r_f)^T w = k
+                // (µ − r_f)ᵀy = 1
                 new LinearConstraint(size)
                 {
                     CombinedAs = returns,
                     ShouldBe = ConstraintType.EqualTo,
-                    Value = k
+                    Value = 1.0
                 }
             };
-
-            // Σw = 1
-            constraints.Add(GetBudgetConstraint(size));
 
             // lw ≤ w ≤ up
             constraints.AddRange(GetBoundaryConditions(size));
 
-            // Setup solver
+            // Setup solver: minimize yᵀΣy
             var optfunc = new QuadraticObjectiveFunction(covariance, Vector.Create(size, 0.0));
             var solver = new GoldfarbIdnani(optfunc, constraints);
 
             // Solve problem
-            var success = solver.Minimize(Vector.Copy(x0));
-            var sharpeRatio = returns.Dot(solver.Solution) / solver.Value;
-            return success ? solver.Solution : x0;
+            var success = solver.Minimize(Vector.Copy(equalWeights));
+            if (!success)
+            {
+                return equalWeights;
+            }
+
+            // Recover the portfolio weights: w = y / (1ᵀy)
+            var y = solver.Solution;
+            var sum = y.Sum();
+            return sum > 0 ? y.Divide(sum) : equalWeights;
         }
     }
 }

--- a/Algorithm.Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizer.py
+++ b/Algorithm.Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizer.py
@@ -55,24 +55,23 @@ class MaximumSharpeRatioPortfolioOptimizer:
 
         size = covariance.columns.size   # K x 1
         x0 = np.array(size * [1. / size])
-        k = expected_returns.dot(x0)
 
-        # Sharpe Maximization under Quadratic Constraints
+        # SLSQP maximizes the Sharpe ratio (µ − r_f)^T w / √(w^T Σ w) directly, so the fractional
+        # objective is optimized in place without any substitution. The budget constraint Σw = 1 and
+        # the per-weight bounds lw ≤ w ≤ up are applied as-is. The previous implementation instead
+        # fixed (µ − r_f)^T w to the equal-weight return, which collapsed the optimizer to minimum
+        # variance. The C# implementation uses the Charnes-Cooper QP substitution because its solver
+        # only handles quadratic objectives.
         # https://quant.stackexchange.com/questions/18521/sharpe-maximization-under-quadratic-constraints
-        # (µ − r_f)^T w = k
         constraints = [
-            {'type': 'eq', 'fun': lambda weights: expected_returns.dot(weights) - k}]
+            # Σw = 1
+            {'type': 'eq', 'fun': lambda weights: self.get_budget_constraint(weights)}]
 
-        # Σw = 1
-        constraints.append(
-            {'type': 'eq', 'fun': lambda weights: self.get_budget_constraint(weights)})
-
-        opt = minimize(lambda weights: self.portfolio_variance(weights, covariance),   # Objective function
+        opt = minimize(lambda weights: -expected_returns.dot(weights) / np.sqrt(self.portfolio_variance(weights, covariance)),   # Objective function: −Sharpe ratio
                        x0,                                                        # Initial guess
                        bounds = self.get_boundary_conditions(size),               # Bounds for variables: lw ≤ w ≤ up
                        constraints = constraints,                                 # Constraints definition
                        method='SLSQP')        # Optimization method:  Sequential Least SQuares Programming
-        sharpe_ratio = expected_returns.dot(opt['x']) / opt.fun
 
         return opt['x'] if opt['success'] else x0
 

--- a/Tests/Algorithm/Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizerTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizerTests.cs
@@ -152,5 +152,73 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 Assert.LessOrEqual(rounded, upper);
             };
         }
+
+        // Cases with a positive-definite covariance, where the maximum Sharpe ratio
+        // portfolio is well defined (case 1 has a zero-variance asset and case 4 an
+        // indefinite covariance, so they are excluded here).
+        [TestCase(0)]
+        [TestCase(2)]
+        [TestCase(5)]
+        [TestCase(7)]
+        public void OptimizedWeightsMaximizeSharpeRatio(int testCaseNumber)
+        {
+            // Independent of the hardcoded ExpectedResults: the returned portfolio must
+            // achieve a Sharpe ratio no lower than equal weights or any other feasible
+            // portfolio drawn from the constraint set.
+            var testOptimizer = new MaximumSharpeRatioPortfolioOptimizer();
+            var expectedReturns = ExpectedReturns[testCaseNumber];
+            var covariance = Covariances[testCaseNumber];
+
+            var result = testOptimizer.Optimize(HistoricalReturns[testCaseNumber], expectedReturns, covariance);
+            var optimalSharpe = SharpeRatio(result, expectedReturns, covariance);
+
+            var size = result.Length;
+            var equalWeights = Enumerable.Repeat(1.0 / size, size).ToArray();
+            Assert.GreaterOrEqual(optimalSharpe, SharpeRatio(equalWeights, expectedReturns, covariance));
+
+            var random = new Random(0);
+            for (var i = 0; i < 10000; i++)
+            {
+                var candidate = RandomFeasibleWeights(random, size, lower: -1.0, upper: 1.0);
+                Assert.GreaterOrEqual(optimalSharpe + 1e-6, SharpeRatio(candidate, expectedReturns, covariance));
+            }
+        }
+
+        private static double SharpeRatio(double[] weights, double[] expectedReturns, double[,] covariance)
+        {
+            var size = weights.Length;
+            var portfolioReturn = 0.0;
+            var portfolioVariance = 0.0;
+            for (var i = 0; i < size; i++)
+            {
+                portfolioReturn += weights[i] * expectedReturns[i];
+                for (var j = 0; j < size; j++)
+                {
+                    portfolioVariance += weights[i] * covariance[i, j] * weights[j];
+                }
+            }
+            return portfolioReturn / Math.Sqrt(portfolioVariance);
+        }
+
+        private static double[] RandomFeasibleWeights(Random random, int size, double lower, double upper)
+        {
+            // Draw weights uniformly from the box and keep only those summing to one.
+            while (true)
+            {
+                var weights = new double[size];
+                var sum = 0.0;
+                for (var i = 0; i < size - 1; i++)
+                {
+                    weights[i] = lower + random.NextDouble() * (upper - lower);
+                    sum += weights[i];
+                }
+                var last = 1.0 - sum;
+                if (last >= lower && last <= upper)
+                {
+                    weights[size - 1] = last;
+                    return weights;
+                }
+            }
+        }
     }
 }

--- a/Tests/Algorithm/Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizerTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizerTests.cs
@@ -13,6 +13,8 @@
  * limitations under the License.
 */
 
+using Accord.Math;
+using Accord.Statistics;
 using NUnit.Framework;
 using QuantConnect.Algorithm.Framework.Portfolio;
 using System;
@@ -153,23 +155,28 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             };
         }
 
-        // Cases with a positive-definite covariance, where the maximum Sharpe ratio
-        // portfolio is well defined (case 1 has a zero-variance asset and case 4 an
-        // indefinite covariance, so they are excluded here).
+        // Every case whose maximum Sharpe ratio portfolio is well defined. Case 1 has a
+        // zero-variance asset (the ratio is unbounded) and case 4 an indefinite covariance
+        // (it falls back to equal weights), so neither has a finite interior optimum and
+        // both are excluded.
         [TestCase(0)]
         [TestCase(2)]
+        [TestCase(3)]
         [TestCase(5)]
+        [TestCase(6)]
         [TestCase(7)]
         public void OptimizedWeightsMaximizeSharpeRatio(int testCaseNumber)
         {
             // Independent of the hardcoded ExpectedResults: the returned portfolio must
             // achieve a Sharpe ratio no lower than equal weights or any other feasible
-            // portfolio drawn from the constraint set.
+            // portfolio drawn from the constraint set. The mean and covariance are
+            // reconstructed exactly as the optimizer does so the check uses the same inputs.
             var testOptimizer = new MaximumSharpeRatioPortfolioOptimizer();
-            var expectedReturns = ExpectedReturns[testCaseNumber];
-            var covariance = Covariances[testCaseNumber];
+            var historicalReturns = HistoricalReturns[testCaseNumber];
+            var expectedReturns = ExpectedReturns[testCaseNumber] ?? historicalReturns.Mean(0);
+            var covariance = Covariances[testCaseNumber] ?? historicalReturns.Covariance();
 
-            var result = testOptimizer.Optimize(HistoricalReturns[testCaseNumber], expectedReturns, covariance);
+            var result = testOptimizer.Optimize(historicalReturns, ExpectedReturns[testCaseNumber], Covariances[testCaseNumber]);
             var optimalSharpe = SharpeRatio(result, expectedReturns, covariance);
 
             var size = result.Length;

--- a/Tests/Algorithm/Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizerTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizerTests.cs
@@ -65,14 +65,14 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
 
             ExpectedResults = new List<double[]>
             {
-                new double[] { -0.562396, 0.608942, 0.953453 },
-                new double[] { 0.686025, -0.269589, 0.583023 },
-                new double[] { 0.26394, -0.043374, 0.779434 },
-                new double[] { -0.223905, 0.401036, 1, 0.065329, -0.24246 },
-                new double[] { 0.5, 0.5 },
                 new double[] { -0.5, 0.5, 1 },
-                new double[] { -0.242647, 1, 0.242647 },
-                new double[] { -1, 0.922902, 0.364512, 0.712585 },
+                new double[] { 0, 0, 1 },
+                new double[] { -0.404692, 0.404692, 1 },
+                new double[] { -0.418338, 0.023261, 1, 0.040668, 0.35441 },
+                new double[] { 0.5, 0.5 },
+                new double[] { -0.670213, 0.670213, 1 },
+                new double[] { -1, 1, 1 },
+                new double[] { -1, 0.315476, 0.684524, 1 },
             };
         }
 
@@ -98,7 +98,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         public void OptimizeWeightingsSpecifyingLowerBoundAndRiskFreeRate(int testCaseNumber)
         {
             var testOptimizer = new MaximumSharpeRatioPortfolioOptimizer(lower: 0, riskFreeRate: 0.04);
-            var expectedResult = new double[] { 0, 0.44898, 0.55102 };
+            var expectedResult = new double[] { 0, 0, 1 };
 
             var result = testOptimizer.Optimize(HistoricalReturns[testCaseNumber]);
 
@@ -106,13 +106,14 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
         }
 
         [Test]
-        public void SingleSecurityPortfolioReturnsNaN()
+        public void SingleSecurityPortfolioReturnsFullWeight()
         {
             var testOptimizer = new MaximumSharpeRatioPortfolioOptimizer();
             var historicalReturns = new double[,] { { -0.1 } };
             var expectedReturns = new double[] { -0.1 };
 
-            var expectedResult = new double[] { double.NaN };
+            // With a single security the budget constraint Σw = 1 leaves it fully invested
+            var expectedResult = new double[] { 1 };
 
             var result = testOptimizer.Optimize(historicalReturns, expectedReturns);
 

--- a/Tests/Algorithm/Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizerTests.cs
+++ b/Tests/Algorithm/Framework/Portfolio/MaximumSharpeRatioPortfolioOptimizerTests.cs
@@ -183,6 +183,10 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
             var equalWeights = Enumerable.Repeat(1.0 / size, size).ToArray();
             Assert.GreaterOrEqual(optimalSharpe, SharpeRatio(equalWeights, expectedReturns, covariance));
 
+            // The Sharpe ratio cannot exceed the unconstrained tangency portfolio, a hard
+            // analytic ceiling (Cauchy-Schwarz) that no feasible portfolio can beat.
+            Assert.LessOrEqual(optimalSharpe, TangencySharpe(expectedReturns, covariance) + 1e-6);
+
             var random = new Random(0);
             for (var i = 0; i < 10000; i++)
             {
@@ -205,6 +209,23 @@ namespace QuantConnect.Tests.Algorithm.Framework.Portfolio
                 }
             }
             return portfolioReturn / Math.Sqrt(portfolioVariance);
+        }
+
+        private static double TangencySharpe(double[] expectedReturns, double[,] covariance)
+        {
+            // The unconstrained maximum Sharpe ratio is sqrt(mu' inv(S) mu), the largest
+            // value any portfolio can reach regardless of the budget or weight bounds.
+            var inverse = covariance.Inverse();
+            var size = expectedReturns.Length;
+            var quadraticForm = 0.0;
+            for (var i = 0; i < size; i++)
+            {
+                for (var j = 0; j < size; j++)
+                {
+                    quadraticForm += expectedReturns[i] * inverse[i, j] * expectedReturns[j];
+                }
+            }
+            return Math.Sqrt(quadraticForm);
         }
 
         private static double[] RandomFeasibleWeights(Random random, int size, double lower, double upper)


### PR DESCRIPTION
## Description

Fix `MaximumSharpeRatioPortfolioOptimizer` so it maximizes the Sharpe ratio. Python optimizes `(mu - rf)'w / sqrt(w'Sw)` directly with SLSQP. C# uses a bounds-aware Charnes-Cooper QP (`y = kw`, minimize `y'Sy` s.t. `(mu - rf)'y = 1`, recover `w = y / (1'y)`), with the per-weight bounds written as linear constraints in `y` so it stays a convex QP. Both honor the `[lower, upper]` range and reach the same optimum. Unit test expectations are updated to the corrected weights, and a new property based test asserts the optimality directly so they are not just hardcoded numbers.

## Related Issue

Closes #9322

## Motivation and Context

The optimizer constrained the portfolio return to the equal-weight return (`(mu - rf)'w = k`) and minimized variance, so it behaved like a minimum-variance model and returned near-flat weights regardless of the inputs instead of the maximum Sharpe ratio portfolio.

## Requires Documentation Change

N/A

## How Has This Been Tested?

[Notebook test](https://www.quantconnect.cloud/backtest/8fc77999de31bfecd3233297586cdf56/?theme=darkly):
- Get history for a set of assets.                                                      
- Feed that DataFrame into the old optimizer and the new optimizer to get weights.      
- Using the DataFrame and the weights from each model, calculate the trailing Sharpe    
  ratio each model produces.                                                            
- Compare them and show the new implemention gives better Sharpe ratio. 
<img width="261" height="418" alt="image" src="https://github.com/user-attachments/assets/c93775b3-0d5f-452f-9d98-84db60041f9f" />

[Notebook tangency ceiling (√(µᵀΣ⁻¹µ))](https://www.quantconnect.cloud/backtest/52feed932f64ad8fa5beeaf2201f254b/?theme=darkly):
Proves that the Outputted sharpe ratio by the optimizer is non-degenerate. by bouding it between the equal weight and the Markowitz optimum (tangency ceiling; highest possible without including the risk free rate)

Python:
[Broken optimizer](https://www.quantconnect.cloud/backtest/095e7c39225f12f38818b8a62ca39ea1/?theme=darkly)
[Fixed optimizer](https://www.quantconnect.cloud/backtest/6a3e80d2ff962bacff86079c91e87f1f/?theme=darkly)
<img width="422" height="323" alt="image" src="https://github.com/user-attachments/assets/df2c2fda-23a0-403f-8dc4-b8f295c363d7" />
<img width="413" height="308" alt="image" src="https://github.com/user-attachments/assets/c105042c-ceb1-43f0-a8b6-92b9ead48e46" />

Updated `MaximumSharpeRatioPortfolioOptimizerTests` with the corrected weights and added `OptimizedWeightsMaximizeSharpeRatio`, a property based test that asserts the returned portfolio has a Sharpe ratio no lower than equal weights or 10,000 random feasible portfolios, so the expectations are validated by the optimality property rather than only by fixed numbers.

The corrected weights were also independently confirmed to be the global Sharpe maximum two ways that do not use the C# QP: multi-start SLSQP on the raw fractional objective and a brute-force search over the feasible set. Every changed value matches the global optimum and beats the previous (min-variance-collapsed) output on the actual Sharpe ratio.

No regression algorithm consumes this optimizer (the Black-Litterman models and tests pass `UnconstrainedMeanVariancePortfolioOptimizer` explicitly), so the impact is limited to this optimizer and its unit tests.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

## Checklist:

- [X] My code follows the code style of this project.
- [X] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] My branch follows the naming convention bug-<issue#>-<description> or feature-<issue#>-<description>
