### PR TITLE
Proactively refresh OAuth tokens on a background timer

### DIFF
--- a/Brokerages/Authentication/LeanOAuthTokenHandler.cs
+++ b/Brokerages/Authentication/LeanOAuthTokenHandler.cs
@@ -15,6 +15,7 @@
 
 using System;
 using QuantConnect.Api;
+using QuantConnect.Util;
 using System.Threading;
 
 namespace QuantConnect.Brokerages.Authentication
@@ -96,6 +97,34 @@ namespace QuantConnect.Brokerages.Authentication
         public TimeSpan OffsetBeforeExpiration { get; set; } = TimeSpan.FromMinutes(2);
 
         /// <summary>
+        /// Timer that proactively refreshes the cached token before it expires, independent of request traffic.
+        /// </summary>
+        private readonly Timer _refreshTimer;
+
+        /// <summary>
+        /// Signals shutdown to the background refresh so any in-flight retry wait is aborted.
+        /// </summary>
+        private readonly CancellationTokenSource _refreshCancellationTokenSource = new();
+
+        /// <summary>
+        /// Indicates the handler has been disposed and the background refresh should stop.
+        /// </summary>
+        private volatile bool _disposed;
+
+        /// <summary>
+        /// The delay until the next proactive refresh: the token lifetime less the safety offset, i.e. the moment
+        /// the cached token becomes eligible for refresh. Falls back to <see cref="RetryInterval"/> if misconfigured.
+        /// </summary>
+        private TimeSpan RefreshPeriod
+        {
+            get
+            {
+                var period = _tokenLifetime - OffsetBeforeExpiration;
+                return period > TimeSpan.Zero ? period : RetryInterval;
+            }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="LeanOAuthTokenHandler"/> class.
         /// </summary>
         /// <param name="apiClient">The API client used to communicate with the Lean platform.</param>
@@ -109,6 +138,8 @@ namespace QuantConnect.Brokerages.Authentication
             _apiClient = apiClient;
             _jsonBodyRequest = request.ToJson();
             _tokenLifetime = tokenLifetime;
+
+            _refreshTimer = new Timer(BackgroundRefresh, null, RefreshPeriod, Timeout.InfiniteTimeSpan);
         }
 
         /// <summary>
@@ -165,6 +196,79 @@ namespace QuantConnect.Brokerages.Authentication
                 // Unreachable — the loop always returns or throws
                 throw new InvalidOperationException($"LeanOAuthTokenHandler.{nameof(GetAccessToken)}: Unexpected state in token retry loop.");
             }
+        }
+
+        /// <summary>
+        /// Background timer callback that refreshes the access token and re-arms the timer.
+        /// </summary>
+        /// <param name="state">Unused timer state.</param>
+        private void BackgroundRefresh(object state)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            try
+            {
+                // The cache window has elapsed, so this forces a real refresh against the Lean platform.
+                GetAccessToken(_refreshCancellationTokenSource.Token);
+            }
+            catch (Exception ex)
+            {
+                // Terminal failures already raised AuthenticationFailed inside GetAccessToken; log and keep the timer alive.
+                Logging.Log.Error($"LeanOAuthTokenHandler.{nameof(BackgroundRefresh)}: {ex.Message}");
+            }
+            finally
+            {
+                ScheduleNextRefresh();
+            }
+        }
+
+        /// <summary>
+        /// Arms the refresh timer to fire when the cached token next becomes eligible for refresh.
+        /// </summary>
+        private void ScheduleNextRefresh()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            TimeSpan delay;
+            lock (_lock)
+            {
+                // Fire when the current cached token is due to be refreshed. If a request-driven refresh
+                // already pushed the expiry out, we wake up later; if we have no valid token, retry soon.
+                var remaining = _tokenExpiresAt - DateTime.UtcNow;
+                delay = remaining > TimeSpan.Zero ? remaining : RetryInterval;
+            }
+
+            try
+            {
+                _refreshTimer.Change(delay, Timeout.InfiniteTimeSpan);
+            }
+            catch (ObjectDisposedException)
+            {
+                // The handler was disposed concurrently; nothing more to schedule.
+            }
+        }
+
+        /// <summary>
+        /// Stops the background refresh and releases resources.
+        /// </summary>
+        /// <param name="disposing">True when called from <see cref="IDisposable.Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _disposed = true;
+                _refreshCancellationTokenSource.Cancel();
+                _refreshTimer.DisposeSafely();
+                _refreshCancellationTokenSource.DisposeSafely();
+            }
+
+            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
LeanOAuthTokenHandler only fetched tokens lazily, via GetAccessToken on outgoing HTTP requests (the delegating handler) or WebSocket re-login. An idle algorithm with a stable WebSocket and no REST traffic therefore never refreshed and stopped phoning home to live/auth0/refresh.

Add a self-rearming background Timer that fires when the cached token becomes eligible for refresh (tokenLifetime - OffsetBeforeExpiration), forcing a real refresh regardless of request activity and keeping the platform token store current. Disposed with the handler.


<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [ ] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
