### PR TITLE
improve(messages): make currency conversion-rate error actionable

### DIFF
--- a/Common/Messages/Messages.Securities.cs
+++ b/Common/Messages/Messages.Securities.cs
@@ -279,12 +279,12 @@ namespace QuantConnect
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string ConversionRateNotFound(string currency)
             {
-                return Invariant($"The conversion rate for {currency} is not available. " +
+                return $"The conversion rate for {currency} is not available. " +
                     $"This usually means there is no data to convert {currency} into the account currency. " +
                     "To fix this, make sure a conversion path to the account currency exists, for example by " +
                     $"subscribing to a security/pair that links {currency} to the account currency (e.g. via AddForex/AddCrypto/AddCfd), " +
                     "or by providing the conversion pair when calling SetCash. " +
-                    "See https://www.quantconnect.com/docs/v2/writing-algorithms/portfolio/cashbook for more information.");
+                    "See https://www.quantconnect.com/docs/v2/writing-algorithms/portfolio/cashbook for more information.";
             }
 
             /// <summary>

--- a/Common/Messages/Messages.Securities.cs
+++ b/Common/Messages/Messages.Securities.cs
@@ -279,7 +279,12 @@ namespace QuantConnect
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string ConversionRateNotFound(string currency)
             {
-                return Invariant($"The conversion rate for {currency} is not available.");
+                return Invariant($"The conversion rate for {currency} is not available. " +
+                    $"This usually means there is no data to convert {currency} into the account currency. " +
+                    "To fix this, make sure a conversion path to the account currency exists, for example by " +
+                    $"subscribing to a security/pair that links {currency} to the account currency (e.g. via AddForex/AddCrypto/AddCfd), " +
+                    "or by providing the conversion pair when calling SetCash. " +
+                    "See https://www.quantconnect.com/docs/v2/writing-algorithms/portfolio/cashbook for more information.");
             }
 
             /// <summary>


### PR DESCRIPTION
### Description

A very common runtime error in backtests is:

> Runtime Error: The conversion rate for `<CURRENCY>` is not available.

It is thrown (in `CashBook.Convert`) whenever an algorithm needs a currency conversion — e.g. during `SetHoldings`/`set_holdings` or when computing the account-currency value of holdings — but there is no conversion path/data for that currency to the account currency.

The current message states *what* failed but not *how to fix it*, which leaves users stuck.

### Change

This extends `Messages.CashBook.ConversionRateNotFound` to explain the likely cause and the resolution, while still naming the missing currency:

- Cause: there is no data to convert the currency into the account currency.
- Fix: ensure a conversion path exists — subscribe to a security/pair linking the currency to the account currency (e.g. `AddForex`/`AddCrypto`/`AddCfd`), or provide the conversion pair when calling `SetCash`.
- Links to the cashbook docs.

Minimal, single-message change; no behavior change. No tests assert the exact old string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)