### PR TITLE
Seed runtime-added currency conversion rates immediately

### DIFF
--- a/Algorithm.CSharp/RuntimeCurrencyConversionSeedingRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/RuntimeCurrencyConversionSeedingRegressionAlgorithm.cs
@@ -1,0 +1,174 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Brokerages;
+using QuantConnect.Data;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting that a currency added at runtime (here BTCEUR, from a scheduled event) has its
+    /// conversion rate seeded right away, so using it immediately no longer throws because the rate is still 0.
+    /// </summary>
+    public class RuntimeCurrencyConversionSeedingRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _ltcusd;
+        private bool _addedAtRuntime;
+        private bool _assertedSeeded;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2018, 4, 5);
+            SetEndDate(2018, 4, 5);
+            SetBrokerageModel(BrokerageName.GDAX, AccountType.Cash);
+            SetCash(100000);
+
+            // Account currency asset that funds the loop
+            _ltcusd = AddCrypto("LTCUSD", Resolution.Minute).Symbol;
+
+            // Add a non-account-currency asset at runtime, mirroring users that add assets from a scheduled event
+            Schedule.On(DateRules.EveryDay(), TimeRules.At(10, 0), () =>
+            {
+                if (_addedAtRuntime)
+                {
+                    return;
+                }
+                _addedAtRuntime = true;
+                AddCrypto("BTCEUR", Resolution.Minute);
+            });
+        }
+
+        /// <summary>
+        /// Runs right after the runtime-added security is wired up, the earliest point it can be used
+        /// </summary>
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            if (!changes.AddedSecurities.Any(security => security.Symbol.Value == "BTCEUR"))
+            {
+                return;
+            }
+            _assertedSeeded = true;
+
+            // With the fix these are already seeded here. Without it they would still be 0 and the conversion below would throw.
+            var eur = Portfolio.CashBook["EUR"];
+            var btc = Portfolio.CashBook["BTC"];
+            if (eur.ConversionRate == 0 || btc.ConversionRate == 0)
+            {
+                throw new RegressionTestException(
+                    $"Runtime-added currency conversion rates were not seeded (EUR={eur.ConversionRate}, BTC={btc.ConversionRate})");
+            }
+
+            if (Portfolio.CashBook.ConvertToAccountCurrency(100m, "EUR") <= 0)
+            {
+                throw new RegressionTestException("Expected a positive EUR -> account currency conversion");
+            }
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
+        {
+            if (!_addedAtRuntime || Portfolio.Invested)
+            {
+                return;
+            }
+
+            if (Securities[_ltcusd].Price != 0)
+            {
+                SetHoldings(_ltcusd, 0.5);
+            }
+        }
+
+        /// <summary>
+        /// Makes sure the seeding path was actually exercised so the test can't silently pass
+        /// </summary>
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_assertedSeeded)
+            {
+                throw new RegressionTestException("BTCEUR was never added at runtime, the seeding path was not exercised");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 6005;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 591;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000.00"},
+            {"End Equity", "99064.52"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$149.18"},
+            {"Estimated Strategy Capacity", "$160000.00"},
+            {"Lowest Capacity Asset", "LTCUSD 2XR"},
+            {"Portfolio Turnover", "50.20%"},
+            {"Drawdown Recovery", "0"},
+            {"OrderListHash", "69d27a394cffbd938ec23fbb451f37ae"}
+        };
+    }
+}

--- a/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
@@ -199,7 +199,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 0;
+        public int AlgorithmHistoryDataPoints => 50;
 
         /// <summary>
         /// Final status of the algorithm

--- a/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ScheduledUniverseSelectionModelRegressionAlgorithm.cs
@@ -199,7 +199,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 50;
+        public int AlgorithmHistoryDataPoints => 10;
 
         /// <summary>
         /// Final status of the algorithm

--- a/Common/AlgorithmUtils.cs
+++ b/Common/AlgorithmUtils.cs
@@ -15,6 +15,7 @@
 
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -44,6 +45,40 @@ namespace QuantConnect
                         security.SetMarketPrice(datum);
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Seeds an initial conversion rate for the cashbook currencies that don't have one yet, so they are
+        /// non-zero right away instead of waiting for the first conversion pair bar to arrive
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
+        /// <param name="currenciesToUpdateWhiteList">
+        /// If passed, only the currencies in the CashBook contained in this list will be updated.
+        /// By default, if not passed (null), all currencies in the cashbook without a properly set up currency conversion will be updated.
+        /// </param>
+        public static void SeedCurrencyConversionRates(IAlgorithm algorithm, IReadOnlyCollection<string> currenciesToUpdateWhiteList = null)
+        {
+            Func<Cash, bool> cashToUpdateFilter = currenciesToUpdateWhiteList == null
+                ? (x) => x.CurrencyConversion != null && x.ConversionRate == 0
+                : (x) => currenciesToUpdateWhiteList.Contains(x.Symbol);
+            var cashToUpdate = algorithm.Portfolio.CashBook.Values.Where(cashToUpdateFilter).ToList();
+
+            if (cashToUpdate.Count == 0)
+            {
+                return;
+            }
+
+            var securitiesToUpdate = cashToUpdate
+                .SelectMany(x => x.CurrencyConversion.ConversionRateSecurities)
+                .Distinct()
+                .ToList();
+
+            SeedSecurities(securitiesToUpdate, algorithm);
+
+            foreach (var cash in cashToUpdate)
+            {
+                cash.Update();
             }
         }
     }

--- a/Engine/DataFeeds/CurrencySubscriptionDataConfigManager.cs
+++ b/Engine/DataFeeds/CurrencySubscriptionDataConfigManager.cs
@@ -131,7 +131,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <summary>
         /// Checks the current <see cref="SubscriptionDataConfig"/> and adds new necessary currency pair feeds to provide real time conversion data
         /// </summary>
-        public void EnsureCurrencySubscriptionDataConfigs(SecurityChanges securityChanges, IBrokerageModel brokerageModel)
+        /// <returns>True if new currency conversion feeds were introduced, false otherwise. Lets callers skip
+        /// follow up work like seeding the new conversion rates when nothing was added</returns>
+        public bool EnsureCurrencySubscriptionDataConfigs(SecurityChanges securityChanges, IBrokerageModel brokerageModel)
         {
             _ensureCurrencyDataFeeds = false;
             // remove any 'to be added' if the security has already been added
@@ -150,6 +152,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 _toBeAddedCurrencySubscriptionDataConfigs.Add(config);
             }
             _pendingSubscriptionDataConfigs = _toBeAddedCurrencySubscriptionDataConfigs.Any();
+
+            return newConfigs.Count > 0;
         }
     }
 }

--- a/Engine/DataFeeds/CurrencySubscriptionDataConfigManager.cs
+++ b/Engine/DataFeeds/CurrencySubscriptionDataConfigManager.cs
@@ -131,10 +131,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <summary>
         /// Checks the current <see cref="SubscriptionDataConfig"/> and adds new necessary currency pair feeds to provide real time conversion data
         /// </summary>
-        /// <returns>True if new currency conversion feeds were introduced, false otherwise. Lets callers skip
-        /// follow up work like seeding the new conversion rates when nothing was added</returns>
+        /// <returns>True if a new currency was introduced, either as a new internal conversion feed or as a new cash
+        /// entry added to the cashbook. Lets callers skip follow up work like seeding the new conversion rates when
+        /// nothing was added</returns>
         public bool EnsureCurrencySubscriptionDataConfigs(SecurityChanges securityChanges, IBrokerageModel brokerageModel)
         {
+            // a new cash added to the cashbook also needs its conversion rate seeded, even when its conversion
+            // security is an already subscribed one and no new internal feed is introduced below
+            var newCashAdded = _ensureCurrencyDataFeeds;
             _ensureCurrencyDataFeeds = false;
             // remove any 'to be added' if the security has already been added
             _toBeAddedCurrencySubscriptionDataConfigs.RemoveWhere(
@@ -153,7 +157,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
             _pendingSubscriptionDataConfigs = _toBeAddedCurrencySubscriptionDataConfigs.Any();
 
-            return newConfigs.Count > 0;
+            return newConfigs.Count > 0 || newCashAdded;
         }
     }
 }

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -424,10 +424,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// known price. The setup handler passes false because it performs its own (optionally white-listed) seeding</param>
         public void EnsureCurrencyDataFeeds(SecurityChanges securityChanges, bool seedNewCurrencies = true)
         {
-            var newCurrencyFeedsAdded = _currencySubscriptionDataConfigManager.EnsureCurrencySubscriptionDataConfigs(securityChanges, _algorithm.BrokerageModel);
+            var newCurrenciesAdded = _currencySubscriptionDataConfigManager.EnsureCurrencySubscriptionDataConfigs(securityChanges, _algorithm.BrokerageModel);
 
-            // Only scan the cashbook and seed when a new conversion feed was actually introduced
-            if (!seedNewCurrencies || !newCurrencyFeedsAdded)
+            // Only scan the cashbook and seed when a new currency was actually introduced, either as a new
+            // internal conversion feed or as a new cash entry whose conversion security is an already added one
+            if (!seedNewCurrencies || !newCurrenciesAdded)
             {
                 return;
             }
@@ -435,28 +436,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             // Seed the new conversion rates with their last known price so they are non-zero right away, instead of
             // waiting for the first conversion pair bar to arrive. Otherwise a conversion needed in that gap would
             // throw. This is the same thing BaseSetupHandler does during setup, but for cashes added at runtime.
-            var cashToUpdate = _algorithm.Portfolio.CashBook.Values
-                .Where(cash => cash.CurrencyConversion != null && cash.ConversionRate == 0)
-                .ToList();
-
-            if (cashToUpdate.Count == 0)
-            {
-                return;
-            }
-
-            var securitiesToUpdate = cashToUpdate
-                .SelectMany(cash => cash.CurrencyConversion.ConversionRateSecurities)
-                .Distinct()
-                .ToList();
-
             try
             {
-                AlgorithmUtils.SeedSecurities(securitiesToUpdate, _algorithm);
-
-                foreach (var cash in cashToUpdate)
-                {
-                    cash.Update();
-                }
+                AlgorithmUtils.SeedCurrencyConversionRates(_algorithm);
             }
             catch (Exception err)
             {

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -128,7 +128,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                     // if the input is already fundamental data we just need to filter it and pass it through
                     var hasFundamentalData = universeData.Data.Count > 0 && universeData.Data[0] is Fundamental;
-                    if(hasFundamentalData)
+                    if (hasFundamentalData)
                     {
                         // Remove selected symbols that does not have fine fundamental data
                         var anyDoesNotHaveFundamentalData = false;
@@ -137,7 +137,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         // which do not use coarse data as underlying, in which case it could happen that we try to load fine fundamental data that is missing, but no problem,
                         // 'FineFundamentalSubscriptionEnumeratorFactory' won't emit it
                         var set = selectSymbolsResult.ToHashSet();
-                        fineCollection.Data.AddRange(universeData.Data.OfType<Fundamental>().Where(fundamental => {
+                        fineCollection.Data.AddRange(universeData.Data.OfType<Fundamental>().Where(fundamental =>
+                        {
                             // we remove to we distict by symbol
                             if (set.Remove(fundamental.Symbol))
                             {
@@ -360,7 +361,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         resolution = supportedResolutions.OrderByDescending(x => x).First();
                     }
 
-                    var subscriptionList = new List<Tuple<Type, TickType>>() {subscriptionType};
+                    var subscriptionList = new List<Tuple<Type, TickType>>() { subscriptionType };
                     var dataConfig = _algorithm.SubscriptionManager.SubscriptionDataConfigService.Add(
                         securityBenchmark.Security.Symbol,
                         resolution,
@@ -419,28 +420,21 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// Checks the current subscriptions and adds necessary currency pair feeds to provide real time conversion data
         /// </summary>
         /// <param name="securityChanges">The security changes to consume</param>
-        /// <param name="seedNewCurrencies">
-        /// When true (the default, used by the runtime universe selection path), any newly introduced currency
-        /// conversion securities are immediately seeded with their last known price so the conversion rate is
-        /// non-zero right away. <see cref="BaseSetupHandler.SetupCurrencyConversions"/> passes false because it
-        /// performs its own (optionally white-listed) seeding right after calling this method during setup.
-        /// </param>
+        /// <param name="seedNewCurrencies">Whether to seed the conversion rate of newly added currencies with their last
+        /// known price. The setup handler passes false because it performs its own (optionally white-listed) seeding</param>
         public void EnsureCurrencyDataFeeds(SecurityChanges securityChanges, bool seedNewCurrencies = true)
         {
-            _currencySubscriptionDataConfigManager.EnsureCurrencySubscriptionDataConfigs(securityChanges, _algorithm.BrokerageModel);
+            var newCurrencyFeedsAdded = _currencySubscriptionDataConfigManager.EnsureCurrencySubscriptionDataConfigs(securityChanges, _algorithm.BrokerageModel);
 
-            if (!seedNewCurrencies)
+            // Only scan the cashbook and seed when a new conversion feed was actually introduced
+            if (!seedNewCurrencies || !newCurrencyFeedsAdded)
             {
                 return;
             }
 
-            // Seed any newly introduced currency conversion securities so they have a non-zero conversion rate
-            // immediately, instead of waiting for the first bar of the conversion pair to arrive. Otherwise any
-            // conversion requested in that gap (e.g. a scheduled order before the day's first conversion bar) would
-            // throw 'The conversion rate for <currency> is not available'. This mirrors what
-            // BaseSetupHandler.SetupCurrencyConversions does during setup, but for cashes added/required at runtime.
-            // We only target cashes that still have a zero conversion rate, so already seeded currencies aren't
-            // re-seeded. SeedSecurities degrades gracefully (no history/data leaves the rate at 0, same as today).
+            // Seed the new conversion rates with their last known price so they are non-zero right away, instead of
+            // waiting for the first conversion pair bar to arrive. Otherwise a conversion needed in that gap would
+            // throw. This is the same thing BaseSetupHandler does during setup, but for cashes added at runtime.
             var cashToUpdate = _algorithm.Portfolio.CashBook.Values
                 .Where(cash => cash.CurrencyConversion != null && cash.ConversionRate == 0)
                 .ToList();
@@ -455,9 +449,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 .Distinct()
                 .ToList();
 
-            // Best-effort pre-seeding: it must never break the algorithm. If the last-known-price lookup can't run
-            // (e.g. no history provider, no data, or a conversion security missing properties), we degrade gracefully
-            // and leave the rate at 0 - exactly the pre-fix behavior - so the first conversion-pair bar still updates it.
             try
             {
                 AlgorithmUtils.SeedSecurities(securitiesToUpdate, _algorithm);
@@ -469,8 +460,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
             catch (Exception err)
             {
-                Log.Error($"UniverseSelection.EnsureCurrencyDataFeeds(): failed to seed runtime currency conversion rate(s), " +
-                    $"they will be set once the first conversion-pair bar arrives. {err.Message}");
+                // Seeding must never break the algorithm, the rate will be set on the first conversion pair bar
+                Log.Error($"UniverseSelection.EnsureCurrencyDataFeeds(): failed to seed runtime currency conversion rate(s): {err.Message}");
             }
         }
 

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -418,9 +418,49 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         /// <summary>
         /// Checks the current subscriptions and adds necessary currency pair feeds to provide real time conversion data
         /// </summary>
-        public void EnsureCurrencyDataFeeds(SecurityChanges securityChanges)
+        /// <param name="securityChanges">The security changes to consume</param>
+        /// <param name="seedNewCurrencies">
+        /// When true (the default, used by the runtime universe selection path), any newly introduced currency
+        /// conversion securities are immediately seeded with their last known price so the conversion rate is
+        /// non-zero right away. <see cref="BaseSetupHandler.SetupCurrencyConversions"/> passes false because it
+        /// performs its own (optionally white-listed) seeding right after calling this method during setup.
+        /// </param>
+        public void EnsureCurrencyDataFeeds(SecurityChanges securityChanges, bool seedNewCurrencies = true)
         {
             _currencySubscriptionDataConfigManager.EnsureCurrencySubscriptionDataConfigs(securityChanges, _algorithm.BrokerageModel);
+
+            if (!seedNewCurrencies)
+            {
+                return;
+            }
+
+            // Seed any newly introduced currency conversion securities so they have a non-zero conversion rate
+            // immediately, instead of waiting for the first bar of the conversion pair to arrive. Otherwise any
+            // conversion requested in that gap (e.g. a scheduled order before the day's first conversion bar) would
+            // throw 'The conversion rate for <currency> is not available'. This mirrors what
+            // BaseSetupHandler.SetupCurrencyConversions does during setup, but for cashes added/required at runtime.
+            // We only target cashes that still have a zero conversion rate, so already seeded currencies aren't
+            // re-seeded. SeedSecurities degrades gracefully (no history/data leaves the rate at 0, same as today).
+            var cashToUpdate = _algorithm.Portfolio.CashBook.Values
+                .Where(cash => cash.CurrencyConversion != null && cash.ConversionRate == 0)
+                .ToList();
+
+            if (cashToUpdate.Count == 0)
+            {
+                return;
+            }
+
+            var securitiesToUpdate = cashToUpdate
+                .SelectMany(cash => cash.CurrencyConversion.ConversionRateSecurities)
+                .Distinct()
+                .ToList();
+
+            AlgorithmUtils.SeedSecurities(securitiesToUpdate, _algorithm);
+
+            foreach (var cash in cashToUpdate)
+            {
+                cash.Update();
+            }
         }
 
         /// <summary>

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -455,11 +455,22 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 .Distinct()
                 .ToList();
 
-            AlgorithmUtils.SeedSecurities(securitiesToUpdate, _algorithm);
-
-            foreach (var cash in cashToUpdate)
+            // Best-effort pre-seeding: it must never break the algorithm. If the last-known-price lookup can't run
+            // (e.g. no history provider, no data, or a conversion security missing properties), we degrade gracefully
+            // and leave the rate at 0 - exactly the pre-fix behavior - so the first conversion-pair bar still updates it.
+            try
             {
-                cash.Update();
+                AlgorithmUtils.SeedSecurities(securitiesToUpdate, _algorithm);
+
+                foreach (var cash in cashToUpdate)
+                {
+                    cash.Update();
+                }
+            }
+            catch (Exception err)
+            {
+                Log.Error($"UniverseSelection.EnsureCurrencyDataFeeds(): failed to seed runtime currency conversion rate(s), " +
+                    $"they will be set once the first conversion-pair bar arrives. {err.Message}");
             }
         }
 

--- a/Engine/Setup/BaseSetupHandler.cs
+++ b/Engine/Setup/BaseSetupHandler.cs
@@ -84,8 +84,10 @@ namespace QuantConnect.Lean.Engine.Setup
             IReadOnlyCollection<string> currenciesToUpdateWhiteList = null)
         {
             // this is needed to have non-zero currency conversion rates during warmup
-            // will also set the Cash.ConversionRateSecurity
-            universeSelection.EnsureCurrencyDataFeeds(SecurityChanges.None);
+            // will also set the Cash.ConversionRateSecurity.
+            // We disable the runtime auto-seeding here because this method does its own (optionally white-listed)
+            // seeding right below; letting EnsureCurrencyDataFeeds seed as well would ignore the white list.
+            universeSelection.EnsureCurrencyDataFeeds(SecurityChanges.None, seedNewCurrencies: false);
 
             // now set conversion rates
             Func<Cash, bool> cashToUpdateFilter = currenciesToUpdateWhiteList == null

--- a/Engine/Setup/BaseSetupHandler.cs
+++ b/Engine/Setup/BaseSetupHandler.cs
@@ -90,22 +90,7 @@ namespace QuantConnect.Lean.Engine.Setup
             universeSelection.EnsureCurrencyDataFeeds(SecurityChanges.None, seedNewCurrencies: false);
 
             // now set conversion rates
-            Func<Cash, bool> cashToUpdateFilter = currenciesToUpdateWhiteList == null
-                ? (x) => x.CurrencyConversion != null && x.ConversionRate == 0
-                : (x) => currenciesToUpdateWhiteList.Contains(x.Symbol);
-            var cashToUpdate = algorithm.Portfolio.CashBook.Values.Where(cashToUpdateFilter).ToList();
-
-            var securitiesToUpdate = cashToUpdate
-                .SelectMany(x => x.CurrencyConversion.ConversionRateSecurities)
-                .Distinct()
-                .ToList();
-
-            AlgorithmUtils.SeedSecurities(securitiesToUpdate, algorithm);
-
-            foreach (var cash in cashToUpdate)
-            {
-                cash.Update();
-            }
+            AlgorithmUtils.SeedCurrencyConversionRates(algorithm, currenciesToUpdateWhiteList);
 
             Log.Trace($"BaseSetupHandler.SetupCurrencyConversions():{Environment.NewLine}" +
                 $"Account Type: {algorithm.BrokerageModel.AccountType}{Environment.NewLine}{Environment.NewLine}{algorithm.Portfolio.CashBook}");

--- a/Engine/Setup/BaseSetupHandler.cs
+++ b/Engine/Setup/BaseSetupHandler.cs
@@ -85,8 +85,8 @@ namespace QuantConnect.Lean.Engine.Setup
         {
             // this is needed to have non-zero currency conversion rates during warmup
             // will also set the Cash.ConversionRateSecurity.
-            // We disable the runtime auto-seeding here because this method does its own (optionally white-listed)
-            // seeding right below; letting EnsureCurrencyDataFeeds seed as well would ignore the white list.
+            // We don't let it seed the conversion rates here because we do that right below,
+            // where we can also limit the seeding to a specific white list of currencies
             universeSelection.EnsureCurrencyDataFeeds(SecurityChanges.None, seedNewCurrencies: false);
 
             // now set conversion rates

--- a/Tests/Engine/Setup/BaseSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BaseSetupHandlerTests.cs
@@ -16,6 +16,7 @@
 
 using NUnit.Framework;
 using QuantConnect.Data;
+using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Util;
 using QuantConnect.Data.Auxiliary;
 using QuantConnect.Lean.Engine.Setup;
@@ -109,6 +110,60 @@ namespace QuantConnect.Tests.Engine.Setup
             // The remaining currencies should not have conversion rate set
             Assert.AreEqual(0, algorithm.Portfolio.CashBook["EUR"].ConversionRate);
             Assert.AreEqual(0, algorithm.Portfolio.CashBook["USDT"].ConversionRate);
+        }
+
+        [Test]
+        public void RuntimeCurrencyConversionRateIsSeeded()
+        {
+            // Regression test for the runtime currency-conversion seeding gap: when a currency that requires a
+            // conversion feed is introduced after setup (e.g. a SetCash mid-algorithm, or a universe adding a
+            // security whose quote currency isn't yet in the cashbook), the runtime path
+            // (UniverseSelection.EnsureCurrencyDataFeeds) used to only create the conversion subscription without
+            // seeding its price. The rate therefore stayed 0 until the first bar of the pair arrived, and any
+            // conversion in that window threw 'The conversion rate for <currency> is not available'.
+            // After the fix, the runtime path seeds the new conversion security just like BaseSetupHandler does
+            // during setup, so the rate is non-zero immediately.
+
+            var historyProvider = new SubscriptionDataReaderHistoryProvider();
+
+            var algorithm = new BrokerageSetupHandlerTests.TestAlgorithm { UniverseSettings = { Resolution = Resolution.Minute } };
+
+            historyProvider.Initialize(new HistoryProviderInitializeParameters(
+                null,
+                null,
+                TestGlobals.DataProvider,
+                TestGlobals.DataCacheProvider,
+                TestGlobals.MapFileProvider,
+                TestGlobals.FactorFileProvider,
+                null,
+                false,
+                new DataPermissionManager(),
+                algorithm.ObjectStore,
+                algorithm.Settings));
+            algorithm.SetHistoryProvider(historyProvider);
+
+            algorithm.SetStartDate(2015, 1, 24);
+            algorithm.SetCash("USD", 0);
+
+            // Run setup so the engine is in the post-setup (runtime) state.
+            BaseSetupHandler.SetupCurrencyConversions(algorithm, algorithm.DataManager.UniverseSelection);
+
+            // Now introduce a new currency at runtime, after setup has already run. This mirrors a SetCash mid-run
+            // or a universe adding a security with a new quote currency. Before the fix the conversion rate would
+            // remain 0 here until the first BTCUSD bar arrived.
+            algorithm.SetCash("BTC", 10);
+
+            // The runtime path that wires up the conversion feed during universe selection.
+            algorithm.DataManager.UniverseSelection.EnsureCurrencyDataFeeds(SecurityChanges.None);
+
+            // The new currency should have its conversion security and a non-zero rate already, without waiting for
+            // a live bar - so a conversion requested right now would no longer throw.
+            Assert.IsNotNull(algorithm.Portfolio.CashBook["BTC"].CurrencyConversion);
+            Assert.AreNotEqual(0, algorithm.Portfolio.CashBook["BTC"].ConversionRate);
+            Assert.IsTrue(algorithm.Portfolio.CashBook["BTC"].ValueInAccountCurrency > 0);
+
+            // Sanity: converting the runtime currency does not throw.
+            Assert.DoesNotThrow(() => algorithm.Portfolio.CashBook.ConvertToAccountCurrency(10, "BTC"));
         }
     }
 }

--- a/Tests/Engine/Setup/BaseSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BaseSetupHandlerTests.cs
@@ -115,14 +115,10 @@ namespace QuantConnect.Tests.Engine.Setup
         [Test]
         public void RuntimeCurrencyConversionRateIsSeeded()
         {
-            // Regression test for the runtime currency-conversion seeding gap: when a currency that requires a
-            // conversion feed is introduced after setup (e.g. a SetCash mid-algorithm, or a universe adding a
-            // security whose quote currency isn't yet in the cashbook), the runtime path
-            // (UniverseSelection.EnsureCurrencyDataFeeds) used to only create the conversion subscription without
-            // seeding its price. The rate therefore stayed 0 until the first bar of the pair arrived, and any
-            // conversion in that window threw 'The conversion rate for <currency> is not available'.
-            // After the fix, the runtime path seeds the new conversion security just like BaseSetupHandler does
-            // during setup, so the rate is non-zero immediately.
+            // When a currency requiring a conversion feed is introduced at runtime (a universe adding a security
+            // whose quote currency isn't in the cashbook yet), the runtime path used to wire up the conversion
+            // subscription without seeding its price, leaving the rate at 0 until the first pair bar. After the fix
+            // it seeds the new conversion security right away, just like BaseSetupHandler does during setup.
 
             var historyProvider = new SubscriptionDataReaderHistoryProvider();
 
@@ -145,24 +141,17 @@ namespace QuantConnect.Tests.Engine.Setup
             algorithm.SetStartDate(2015, 1, 24);
             algorithm.SetCash("USD", 0);
 
-            // Run setup so the engine is in the post-setup (runtime) state.
+            // Run setup so the engine is in the post-setup (runtime) state
             BaseSetupHandler.SetupCurrencyConversions(algorithm, algorithm.DataManager.UniverseSelection);
 
-            // Now introduce a new currency at runtime, after setup has already run. This mirrors a SetCash mid-run
-            // or a universe adding a security with a new quote currency. Before the fix the conversion rate would
-            // remain 0 here until the first BTCUSD bar arrived.
+            // Introduce a new currency at runtime and drive the runtime path that wires up its conversion feed
             algorithm.SetCash("BTC", 10);
-
-            // The runtime path that wires up the conversion feed during universe selection.
             algorithm.DataManager.UniverseSelection.EnsureCurrencyDataFeeds(SecurityChanges.None);
 
-            // The new currency should have its conversion security and a non-zero rate already, without waiting for
-            // a live bar - so a conversion requested right now would no longer throw.
+            // The new currency should already have a non-zero rate, without waiting for a live bar
             Assert.IsNotNull(algorithm.Portfolio.CashBook["BTC"].CurrencyConversion);
             Assert.AreNotEqual(0, algorithm.Portfolio.CashBook["BTC"].ConversionRate);
             Assert.IsTrue(algorithm.Portfolio.CashBook["BTC"].ValueInAccountCurrency > 0);
-
-            // Sanity: converting the runtime currency does not throw.
             Assert.DoesNotThrow(() => algorithm.Portfolio.CashBook.ConvertToAccountCurrency(10, "BTC"));
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
If a currency is added while the algorithm is running (for example a scheduled event adds a security whose quote currency isn't in the cashbook yet), the runtime path created the conversion feed but never set its rate. The rate stayed at 0 until the first bar of the pair arrived, so any conversion before that, like a scheduled SetHoldings, would throw "The conversion rate for X is not available".

The warmup setup path already seeds these rates, but the runtime path didn't. This change makes the runtime path seed them the same way, only when a new feed is actually added, and it falls back safely when there is no data so live trading isn't affected.

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit and regression tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
