### PR TITLE
Add arithmetic operators to numeric MultiPeriodField classes

### DIFF
--- a/Common/Data/Fundamental/MultiPeriodField.cs
+++ b/Common/Data/Fundamental/MultiPeriodField.cs
@@ -191,6 +191,33 @@ namespace QuantConnect.Data.Fundamental
         {
             return (decimal)instance.Value;
         }
+
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        /// <summary>
+        /// Adds the default values of two fields
+        /// </summary>
+        public static decimal operator +(MultiPeriodField left, MultiPeriodField right) => (decimal)left.Value + (decimal)right.Value;
+
+        /// <summary>
+        /// Subtracts the right field's default value from the left field's default value
+        /// </summary>
+        public static decimal operator -(MultiPeriodField left, MultiPeriodField right) => (decimal)left.Value - (decimal)right.Value;
+
+        /// <summary>
+        /// Multiplies the default values of two fields
+        /// </summary>
+        public static decimal operator *(MultiPeriodField left, MultiPeriodField right) => (decimal)left.Value * (decimal)right.Value;
+
+        /// <summary>
+        /// Divides the left field's default value by the right field's default value
+        /// </summary>
+        public static decimal operator /(MultiPeriodField left, MultiPeriodField right) => (decimal)left.Value / (decimal)right.Value;
+
+        /// <summary>
+        /// Computes the remainder of dividing the left field's default value by the right field's default value
+        /// </summary>
+        public static decimal operator %(MultiPeriodField left, MultiPeriodField right) => (decimal)left.Value % (decimal)right.Value;
+#pragma warning restore CA2225 // Operator overloads have named alternates
     }
 
     /// <summary>
@@ -221,5 +248,32 @@ namespace QuantConnect.Data.Fundamental
         {
             return (decimal)instance.Value;
         }
+
+#pragma warning disable CA2225 // Operator overloads have named alternates
+        /// <summary>
+        /// Adds the default values of two fields
+        /// </summary>
+        public static decimal operator +(MultiPeriodFieldLong left, MultiPeriodFieldLong right) => (decimal)left.Value + right.Value;
+
+        /// <summary>
+        /// Subtracts the right field's default value from the left field's default value
+        /// </summary>
+        public static decimal operator -(MultiPeriodFieldLong left, MultiPeriodFieldLong right) => (decimal)left.Value - right.Value;
+
+        /// <summary>
+        /// Multiplies the default values of two fields
+        /// </summary>
+        public static decimal operator *(MultiPeriodFieldLong left, MultiPeriodFieldLong right) => (decimal)left.Value * right.Value;
+
+        /// <summary>
+        /// Divides the left field's default value by the right field's default value
+        /// </summary>
+        public static decimal operator /(MultiPeriodFieldLong left, MultiPeriodFieldLong right) => (decimal)left.Value / right.Value;
+
+        /// <summary>
+        /// Computes the remainder of dividing the left field's default value by the right field's default value
+        /// </summary>
+        public static decimal operator %(MultiPeriodFieldLong left, MultiPeriodFieldLong right) => (decimal)left.Value % right.Value;
+#pragma warning restore CA2225 // Operator overloads have named alternates
     }
 }

--- a/Common/Data/Fundamental/MultiPeriodField.cs
+++ b/Common/Data/Fundamental/MultiPeriodField.cs
@@ -217,6 +217,56 @@ namespace QuantConnect.Data.Fundamental
         /// Computes the remainder of dividing the left field's default value by the right field's default value
         /// </summary>
         public static decimal operator %(MultiPeriodField left, MultiPeriodField right) => (decimal)left.Value % (decimal)right.Value;
+
+        /// <summary>
+        /// Adds the default values of a double and a long backed field
+        /// </summary>
+        public static decimal operator +(MultiPeriodField left, MultiPeriodFieldLong right) => (decimal)left.Value + right.Value;
+
+        /// <summary>
+        /// Adds the default values of a long and a double backed field
+        /// </summary>
+        public static decimal operator +(MultiPeriodFieldLong left, MultiPeriodField right) => left.Value + (decimal)right.Value;
+
+        /// <summary>
+        /// Subtracts the right field's default value from the left field's default value
+        /// </summary>
+        public static decimal operator -(MultiPeriodField left, MultiPeriodFieldLong right) => (decimal)left.Value - right.Value;
+
+        /// <summary>
+        /// Subtracts the right field's default value from the left field's default value
+        /// </summary>
+        public static decimal operator -(MultiPeriodFieldLong left, MultiPeriodField right) => left.Value - (decimal)right.Value;
+
+        /// <summary>
+        /// Multiplies the default values of a double and a long backed field
+        /// </summary>
+        public static decimal operator *(MultiPeriodField left, MultiPeriodFieldLong right) => (decimal)left.Value * right.Value;
+
+        /// <summary>
+        /// Multiplies the default values of a long and a double backed field
+        /// </summary>
+        public static decimal operator *(MultiPeriodFieldLong left, MultiPeriodField right) => left.Value * (decimal)right.Value;
+
+        /// <summary>
+        /// Divides the left field's default value by the right field's default value
+        /// </summary>
+        public static decimal operator /(MultiPeriodField left, MultiPeriodFieldLong right) => (decimal)left.Value / right.Value;
+
+        /// <summary>
+        /// Divides the left field's default value by the right field's default value
+        /// </summary>
+        public static decimal operator /(MultiPeriodFieldLong left, MultiPeriodField right) => left.Value / (decimal)right.Value;
+
+        /// <summary>
+        /// Computes the remainder of dividing the left field's default value by the right field's default value
+        /// </summary>
+        public static decimal operator %(MultiPeriodField left, MultiPeriodFieldLong right) => (decimal)left.Value % right.Value;
+
+        /// <summary>
+        /// Computes the remainder of dividing the left field's default value by the right field's default value
+        /// </summary>
+        public static decimal operator %(MultiPeriodFieldLong left, MultiPeriodField right) => left.Value % (decimal)right.Value;
 #pragma warning restore CA2225 // Operator overloads have named alternates
     }
 

--- a/Tests/Common/Data/Fundamental/MultiPeriodFieldTests.cs
+++ b/Tests/Common/Data/Fundamental/MultiPeriodFieldTests.cs
@@ -140,6 +140,29 @@ namespace QuantConnect.Tests.Common.Data.Fundamental
         }
 
         [Test]
+        public void ArithmeticOperatorsBetweenDoubleAndLongFields()
+        {
+            var doubleField = new TestMultiPeriodField();
+            doubleField.OneYear = 10;
+            var longField = new TestMultiPeriodFieldLong();
+            longField.OneYear = 4;
+
+            // double on the left, long on the right
+            Assert.AreEqual(14m, doubleField + longField);
+            Assert.AreEqual(6m, doubleField - longField);
+            Assert.AreEqual(40m, doubleField * longField);
+            Assert.AreEqual(2.5m, doubleField / longField);
+            Assert.AreEqual(2m, doubleField % longField);
+
+            // long on the left, double on the right
+            Assert.AreEqual(14m, longField + doubleField);
+            Assert.AreEqual(-6m, longField - doubleField);
+            Assert.AreEqual(40m, longField * doubleField);
+            Assert.AreEqual(0.4m, longField / doubleField);
+            Assert.AreEqual(4m, longField % doubleField);
+        }
+
+        [Test]
         public void ArithmeticOperatorsWithScalar()
         {
             var field = new TestMultiPeriodField();

--- a/Tests/Common/Data/Fundamental/MultiPeriodFieldTests.cs
+++ b/Tests/Common/Data/Fundamental/MultiPeriodFieldTests.cs
@@ -109,6 +109,63 @@ namespace QuantConnect.Tests.Common.Data.Fundamental
             Assert.AreEqual("", field.ToString());
         }
 
+        [Test]
+        public void ArithmeticOperatorsBetweenDoubleFields()
+        {
+            var left = new TestMultiPeriodField();
+            left.OneYear = 10;
+            var right = new TestMultiPeriodField();
+            right.OneYear = 4;
+
+            Assert.AreEqual(14m, left + right);
+            Assert.AreEqual(6m, left - right);
+            Assert.AreEqual(40m, left * right);
+            Assert.AreEqual(2.5m, left / right);
+            Assert.AreEqual(2m, left % right);
+        }
+
+        [Test]
+        public void ArithmeticOperatorsBetweenLongFields()
+        {
+            var left = new TestMultiPeriodFieldLong();
+            left.OneYear = 10;
+            var right = new TestMultiPeriodFieldLong();
+            right.OneYear = 4;
+
+            Assert.AreEqual(14m, left + right);
+            Assert.AreEqual(6m, left - right);
+            Assert.AreEqual(40m, left * right);
+            Assert.AreEqual(2.5m, left / right);
+            Assert.AreEqual(2m, left % right);
+        }
+
+        [Test]
+        public void ArithmeticOperatorsWithScalar()
+        {
+            var field = new TestMultiPeriodField();
+            field.OneYear = 10;
+
+            // field implicitly converts to decimal, the built-in decimal operators apply
+            Assert.AreEqual(13m, field + 3m);
+            Assert.AreEqual(7m, field - 3m);
+            Assert.AreEqual(30m, field * 3m);
+            Assert.AreEqual(5m, field / 2m);
+            Assert.AreEqual(1m, field % 3m);
+        }
+
+        [Test]
+        public void ArithmeticOperatorsUseDefaultPeriodValue()
+        {
+            // No default period value available, falls back to first available period (3M = 1)
+            var left = new TestMultiPeriodField();
+            left.ThreeMonths = 1;
+            var right = new TestMultiPeriodField();
+            right.ThreeMonths = 1;
+
+            Assert.IsFalse(left.HasValue);
+            Assert.AreEqual(2m, left + right);
+        }
+
         private class TestMultiPeriodField : MultiPeriodField
         {
             protected override string DefaultPeriod => "OneYear";
@@ -154,6 +211,53 @@ namespace QuantConnect.Tests.Common.Data.Fundamental
                 foreach (var kvp in new[] { new Tuple<string, double>("1Y", OneYear), new Tuple<string, double>("3M", ThreeMonths), new Tuple<string, double>("3Y", ThreeYears), new Tuple<string, double>("5Y", FiveYears) })
                 {
                     if (!BaseFundamentalDataProvider.IsNone(typeof(double), kvp.Item2))
+                    {
+                        result[kvp.Item1] = kvp.Item2;
+                    }
+                }
+                return result;
+            }
+        }
+
+        private class TestMultiPeriodFieldLong : MultiPeriodFieldLong
+        {
+            protected override string DefaultPeriod => "OneYear";
+
+            public long ThreeMonths { get; set; } = NoValue;
+            public long OneYear { get; set; } = NoValue;
+            public override bool HasValue => !BaseFundamentalDataProvider.IsNone(typeof(long), OneYear);
+            public override long Value
+            {
+                get
+                {
+                    var defaultValue = OneYear;
+                    if (!BaseFundamentalDataProvider.IsNone(typeof(long), defaultValue))
+                    {
+                        return defaultValue;
+                    }
+                    return base.Value;
+                }
+            }
+
+            public override long GetPeriodValue(string period)
+            {
+                switch (period)
+                {
+                    case QuantConnect.Data.Fundamental.Period.ThreeMonths:
+                        return ThreeMonths;
+                    case QuantConnect.Data.Fundamental.Period.OneYear:
+                        return OneYear;
+                    default:
+                        return NoValue;
+                }
+            }
+
+            public override IReadOnlyDictionary<string, long> GetPeriodValues()
+            {
+                var result = new Dictionary<string, long>();
+                foreach (var kvp in new[] { new Tuple<string, long>("1Y", OneYear), new Tuple<string, long>("3M", ThreeMonths) })
+                {
+                    if (!BaseFundamentalDataProvider.IsNone(typeof(long), kvp.Item2))
                     {
                         result[kvp.Item1] = kvp.Item2;
                     }


### PR DESCRIPTION
#### Description
Adds the arithmetic operators `+`, `-`, `*`, `/` and `%` to the numeric `MultiPeriodField` base classes so fundamental fields can be combined arithmetically (e.g. `fine.EarningReports.BasicEPS + fine.EarningReports.DilutedEPS`).

The operators are defined once on each numeric base class — `MultiPeriodField` (double-backed) and `MultiPeriodFieldLong` (long-backed) — so every concrete generated fundamental field inherits them. They are intentionally **not** added to the generic `MultiPeriodField<T>` base, since that base is also used by non-numeric variants such as `MultiPeriodField<string>` (`AuditorReportStatus`) and `MultiPeriodField<DateTime>` (`BalanceSheetFileDate`).

Cross-type arithmetic between a double-backed and a long-backed field (in either order) is also supported via explicit mixed-type operator overloads, since the two numeric base classes are distinct closed generic types with no shared numeric base.

Each operator acts on the field's default-period `Value` and returns `decimal`, consistent with the existing implicit `decimal` conversion. Returning `decimal` also resolves a latent ambiguity (each operand otherwise has both an implicit `double` and an implicit `decimal` conversion). Scalar arithmetic (e.g. `field * 2m`) is handled for free through the existing implicit `decimal` conversion plus the built-in `decimal` operators.

#### Related Issue
N/A — small self-contained enhancement.

#### Motivation and Context
Fundamental `MultiPeriodField` values frequently need to be combined (sums, ratios, differences) when building factors or selection logic. Previously this required explicitly reading `.Value` (or casting) on each field before doing the math; these operators make the common case read naturally.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Added unit tests in `MultiPeriodFieldTests` covering `+`, `-`, `*`, `/` and `%` for:
- field-to-field arithmetic on the `double`-backed `MultiPeriodField`
- field-to-field arithmetic on the `long`-backed `MultiPeriodFieldLong`
- cross-type arithmetic between `double`-backed and `long`-backed fields (both orderings)
- field-to-scalar arithmetic
- default-period fallback behavior

All tests pass (`dotnet test` filtered to `MultiPeriodFieldTests`). The operators were additionally verified against the real generated `BasicEPS` field to confirm they resolve correctly on concrete subclasses.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
