### PR TITLE
Fix method name parsing in NoMethodMatchPythonExceptionInterpreter

### DIFF
--- a/Common/Exceptions/NoMethodMatchPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/NoMethodMatchPythonExceptionInterpreter.cs
@@ -50,13 +50,36 @@ namespace QuantConnect.Exceptions
         {
             var pe = (PythonException)exception;
 
-            var startIndex = pe.Message.LastIndexOfInvariant(" ");
-            var methodName = pe.Message.Substring(startIndex).Trim();
+            var methodName = GetMethodName(pe.Message);
             var message = Messages.NoMethodMatchPythonExceptionInterpreter.AttemptedToAccessMethodThatDoesNotExist(methodName);
 
             message += PythonUtil.PythonExceptionStackParser(pe.StackTrace);
 
             return new MissingMethodException(message, pe);
+        }
+
+        /// <summary>
+        /// Extracts the name of the method that failed to resolve from the Python exception message.
+        /// The message has the form: "No method matches given arguments for {methodName}: ({argumentTypes})",
+        /// so the method name sits between the "for " keyword and the following ":".
+        /// </summary>
+        private static string GetMethodName(string exceptionMessage)
+        {
+            const string forKeyword = "for ";
+            var forIndex = exceptionMessage.IndexOfInvariant(forKeyword);
+            if (forIndex == -1)
+            {
+                // Unexpected format, fall back to the whole message
+                return exceptionMessage.Trim();
+            }
+
+            var methodNameStart = forIndex + forKeyword.Length;
+            var colonIndex = exceptionMessage.IndexOf(':', methodNameStart);
+            var methodName = colonIndex > methodNameStart
+                ? exceptionMessage.Substring(methodNameStart, colonIndex - methodNameStart)
+                : exceptionMessage.Substring(methodNameStart);
+
+            return methodName.Trim();
         }
     }
 }

--- a/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
@@ -83,6 +83,42 @@ namespace QuantConnect.Tests.Common.Exceptions
             Assert.True(exception.Message.Contains("self.set_cash('SPY')"));
         }
 
+        [Test]
+        public void VerifyMessageContainsTheMethodName()
+        {
+            var exception = CreateExceptionFromType(typeof(PythonException));
+            var interpreter = new NoMethodMatchPythonExceptionInterpreter();
+            exception = interpreter.Interpret(exception, NullExceptionInterpreter.Instance);
+
+            // The interpreter should reference the actual method name that failed to resolve (SetCash),
+            // not a fragment of the argument type list (e.g. "'str'>)").
+            Assert.That(exception.Message, Does.Contain("SetCash"));
+            Assert.That(exception.Message, Does.Not.Contain(">)"));
+        }
+
+        [Test]
+        public void VerifyMessageContainsTheMethodNameForOverloadedMethod()
+        {
+            PythonException pythonException;
+            using (Py.GIL())
+            {
+                var module = Py.Import("Test_PythonExceptionInterpreter");
+                dynamic algorithm = module.GetAttr("Test_PythonExceptionInterpreter").Invoke();
+
+                // self.rsi(symbol, 15, Resolution.DAILY) -- the third argument should be a
+                // MovingAverageType, so no RSI overload matches the given arguments.
+                pythonException = Assert.Throws<PythonException>(() => algorithm.no_method_match_rsi());
+            }
+
+            var interpreter = new NoMethodMatchPythonExceptionInterpreter();
+            var exception = interpreter.Interpret(pythonException, NullExceptionInterpreter.Instance);
+
+            // The interpreter should reference the RSI method name, not a fragment of the
+            // argument type list (e.g. "'QuantConnect.Resolution'>)").
+            Assert.That(exception.Message, Does.Contain("RSI"));
+            Assert.That(exception.Message, Does.Not.Contain(">)"));
+        }
+
         private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _pythonException : (Exception)Activator.CreateInstance(type);
     }
 }

--- a/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
+++ b/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
@@ -23,6 +23,12 @@ class Test_PythonExceptionInterpreter(QCAlgorithm):
     def no_method_match(self):
         self.set_cash('SPY')
 
+    def no_method_match_rsi(self):
+        symbol = Symbol.create('SPY', SecurityType.EQUITY, Market.USA)
+        # The third positional argument should be a MovingAverageType, not a Resolution,
+        # so no RSI overload matches the given arguments.
+        self._indicator = self.rsi(symbol, 15, Resolution.DAILY)
+
     def unsupported_operand(self):
         x = None + "Pepe Grillo"
 


### PR DESCRIPTION
#### Description

`NoMethodMatchPythonExceptionInterpreter` builds a user-facing message that names the method that failed overload resolution. It extracted that name with `LastIndexOf(" ")`, which returns the **last** space-delimited token of the pythonnet message rather than the method name. The pythonnet message has the form:

```
No method matches given arguments for RSI: (<class 'QuantConnect.Symbol'>, <class 'int'>, <class 'QuantConnect.Resolution'>)
```

so the last token is a fragment of the argument-type list (e.g. `'QuantConnect.Resolution'>)`), producing a garbled message:

> ...ensure each parameter type matches those required by the `'QuantConnect.Resolution'>)` method. Please checkout the API documentation.

The method name is now parsed from between the `"for "` keyword and the following `":"`, yielding the correct `RSI` / `SetCash` etc.

#### Related Issue

N/A — bug found while running a Python algorithm whose `initialize` called `self.rsi(symbol, 15, Resolution.DAILY)` (the third argument should be a `MovingAverageType`).

#### Motivation and Context

The interpreted exception is meant to help users fix a bad call by telling them which method's parameters didn't match. The broken parsing instead pointed at a piece of the argument list, making the guidance confusing and useless.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Added two tests to `NoMethodMatchPythonExceptionInterpreterTests`:
- `VerifyMessageContainsTheMethodName` — using the existing `set_cash('SPY')` reproduction, asserts the interpreted message contains `SetCash` and not the `">)"` argument-list fragment.
- `VerifyMessageContainsTheMethodNameForOverloadedMethod` — reproduces the reported scenario via a new `no_method_match_rsi` method (`self.rsi(symbol, 15, Resolution.DAILY)`) and asserts the message contains `RSI` and not `">)"`.

Both tests fail before the fix and pass after. The full `NoMethodMatchPythonExceptionInterpreterTests` fixture passes (13/13).

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
