### PR TITLE
Add Empty property to MemoizingEnumerable

### DIFF
--- a/Common/Util/MemoizingEnumerable.cs
+++ b/Common/Util/MemoizingEnumerable.cs
@@ -56,6 +56,26 @@ namespace QuantConnect.Util
         }
 
         /// <summary>
+        /// Gets whether the enumerable is empty. This will force enumeration of the first item if it has not already been enumerated.
+        /// </summary>
+        public bool Empty
+        {
+            get
+            {
+                if (!Enabled)
+                {
+                    throw new InvalidOperationException("Empty is not supported when memoization is disabled");
+                }
+                if (_buffer == null || _buffer.Count == 0)
+                {
+                    using var enumerator = GetEnumerator();
+                    return !enumerator.MoveNext();
+                }
+                return _buffer.Count == 0;
+            }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MemoizingEnumerable{T}"/> class
         /// </summary>
         /// <param name="enumerable">The source enumerable to be memoized</param>

--- a/Tests/Common/Util/MemoizingEnumerableTests.cs
+++ b/Tests/Common/Util/MemoizingEnumerableTests.cs
@@ -60,5 +60,56 @@ namespace QuantConnect.Tests.Common.Util
             Assert.AreEqual(5, memoized.Count);
             Assert.AreEqual(memoized.Count, memoized.ToList().Count);
         }
+
+        [Test]
+        public void EmptyIsFalseForNonEmptyEnumerable()
+        {
+            var list = new List<int> {1, 2, 3, 4, 5};
+            var memoized = new MemoizingEnumerable<int>(list);
+            Assert.IsFalse(memoized.Empty);
+            // still enumerates fully after checking Empty
+            CollectionAssert.AreEqual(list, memoized);
+        }
+
+        [Test]
+        public void EmptyIsTrueForEmptyEnumerable()
+        {
+            var memoized = new MemoizingEnumerable<int>(Enumerable.Empty<int>());
+            Assert.IsTrue(memoized.Empty);
+        }
+
+        [Test]
+        public void EmptyDoesNotForceFullEnumeration()
+        {
+            var enumerated = 0;
+            var enumerable = Enumerable.Range(0, 10).Select(x => { enumerated++; return x; });
+            var memoized = new MemoizingEnumerable<int>(enumerable);
+            Assert.IsFalse(memoized.Empty);
+            // only the first item should have been enumerated
+            Assert.AreEqual(1, enumerated);
+        }
+
+        [Test]
+        public void EnumerationAfterEmptyKeepsIntegrity()
+        {
+            var i = 0;
+            // lazy source where each element is produced exactly once
+            var enumerable = Enumerable.Range(0, 5).Select(x => i++);
+            var memoized = new MemoizingEnumerable<int>(enumerable);
+
+            // accessing Empty consumes the first item from the source
+            Assert.IsFalse(memoized.Empty);
+
+            // enumerating should still yield the full sequence without duplicating the first item
+            CollectionAssert.AreEqual(new[] { 0, 1, 2, 3, 4 }, memoized.ToList());
+        }
+
+        [Test]
+        public void EmptyThrowsWhenDisabled()
+        {
+            var list = new List<int> {1, 2, 3, 4, 5};
+            var memoized = new MemoizingEnumerable<int>(list) { Enabled = false };
+            Assert.Throws<InvalidOperationException>(() => { var _ = memoized.Empty; });
+        }
     }
 }


### PR DESCRIPTION
#### Description
Adds a boolean `Empty` property to `MemoizingEnumerable<T>` that reports whether the enumerable yields any items.

- Mirrors the existing `Count` property: throws `InvalidOperationException` when memoization is disabled.
- Forces enumeration of only the **first** item (not the whole collection), preserving lazy evaluation and memoization.
- Enumerating the instance after accessing `Empty` keeps enumerable integrity — the first item is served from the buffer and is not duplicated or dropped.

#### Related Issue
N/A — small self-contained addition.

#### Motivation and Context
Consumers frequently need to know whether a memoized enumerable has any elements without triggering a full enumeration (as `Count` does) and without breaking the single-pass guarantee of the underlying source. The new `Empty` property provides a cheap, safe way to do this by consuming at most one item into the memoization buffer.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Added unit tests in `Tests/Common/Util/MemoizingEnumerableTests.cs` covering:
- `Empty` is `false` for a non-empty enumerable (and the instance still enumerates fully afterwards).
- `Empty` is `true` for an empty enumerable.
- `Empty` does not force full enumeration (only the first item is consumed).
- Enumeration after accessing `Empty` keeps integrity (no duplicated/dropped first item) using a lazy single-pass source.
- `Empty` throws `InvalidOperationException` when memoization is disabled.

Ran locally against the built test assembly:
`dotnet test ./Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName~MemoizingEnumerableTests"` → 9 passed, 0 failed.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
