### PR TITLE
Add Price, Value and Close aliases to BaseContract

### DIFF
--- a/Common/Data/Market/BaseContract.cs
+++ b/Common/Data/Market/BaseContract.cs
@@ -68,6 +68,27 @@ namespace QuantConnect.Data.Market
         public virtual decimal LastPrice { get; set; }
 
         /// <summary>
+        /// Value representation of this contract, mimicking <see cref="BaseData.Value"/>.
+        /// Aliases <see cref="LastPrice"/>.
+        /// </summary>
+        [PandasIgnore]
+        public virtual decimal Value => LastPrice;
+
+        /// <summary>
+        /// Alias of value as price, mimicking <see cref="BaseData.Price"/>.
+        /// Aliases <see cref="LastPrice"/>.
+        /// </summary>
+        [PandasIgnore]
+        public virtual decimal Price => LastPrice;
+
+        /// <summary>
+        /// Closing price of this contract, mimicking <see cref="TradeBar.Close"/>.
+        /// Aliases <see cref="LastPrice"/>.
+        /// </summary>
+        [PandasIgnore]
+        public virtual decimal Close => LastPrice;
+
+        /// <summary>
         /// Gets the last volume this contract traded at
         /// </summary>
         public virtual long Volume { get; set; }

--- a/Common/Data/Market/OptionContract.cs
+++ b/Common/Data/Market/OptionContract.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Data.Market
     /// </summary>
     public class OptionContract : BaseContract
     {
-        private IOptionData _optionData = OptionPriceModelResultData.Null;
+        private IOptionData _optionData = new OptionPriceModelResultData(() => OptionPriceModelResult.None);
         private readonly SymbolProperties _symbolProperties;
 
         /// <summary>
@@ -229,8 +229,6 @@ namespace QuantConnect.Data.Market
         /// </summary>
         private class OptionPriceModelResultData : IOptionData
         {
-            public static readonly OptionPriceModelResultData Null = new(() => OptionPriceModelResult.None);
-
             private readonly Lazy<OptionPriceModelResult> _optionPriceModelResult;
             private TradeBar _tradeBar;
             private QuoteBar _quoteBar;

--- a/Common/Data/Market/OptionContract.cs
+++ b/Common/Data/Market/OptionContract.cs
@@ -26,7 +26,7 @@ namespace QuantConnect.Data.Market
     /// </summary>
     public class OptionContract : BaseContract
     {
-        private IOptionData _optionData = new OptionPriceModelResultData(() => OptionPriceModelResult.None);
+        private IOptionData _optionData = OptionPriceModelResultData.Null;
         private readonly SymbolProperties _symbolProperties;
 
         /// <summary>
@@ -229,6 +229,8 @@ namespace QuantConnect.Data.Market
         /// </summary>
         private class OptionPriceModelResultData : IOptionData
         {
+            public static readonly OptionPriceModelResultData Null = new(() => OptionPriceModelResult.None);
+
             private readonly Lazy<OptionPriceModelResult> _optionPriceModelResult;
             private TradeBar _tradeBar;
             private QuoteBar _quoteBar;

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -509,7 +509,10 @@ namespace QuantConnect.Python
             {
                 if (!_membersCache.TryGetValue(type, out typeMembers))
                 {
-                    var forcedInclusionMembers = LeanData.IsCommonLeanDataType(type)
+                    // Contracts (e.g. OptionContract, FuturesContract) expose their own representative price members
+                    // (LastPrice, BidPrice, ...) and mark the BaseData-like aliases (Value, Price, Close) with
+                    // PandasIgnore, so we don't want to force the Value member in as we do for custom data types.
+                    var forcedInclusionMembers = LeanData.IsCommonLeanDataType(type) || typeof(BaseContract).IsAssignableFrom(type)
                         ? Array.Empty<string>()
                         : _nonLeanDataTypeForcedMemberNames;
                     typeMembers = GetDataTypeMembers(type, forcedInclusionMembers).ToList();

--- a/Tests/Common/Data/Market/FuturesContractTests.cs
+++ b/Tests/Common/Data/Market/FuturesContractTests.cs
@@ -92,6 +92,26 @@ namespace QuantConnect.Tests.Common.Data.Market
         }
 
         [Test]
+        public void PriceValueAndCloseAliasLastPrice()
+        {
+            var futureContract = new FuturesContract(Symbols.Future_CLF19_Jan2019);
+
+            // No data yet, all aliases default to zero
+            Assert.AreEqual(0, futureContract.LastPrice);
+            Assert.AreEqual(futureContract.LastPrice, futureContract.Price);
+            Assert.AreEqual(futureContract.LastPrice, futureContract.Value);
+            Assert.AreEqual(futureContract.LastPrice, futureContract.Close);
+
+            var tradeBar = new TradeBar(new DateTime(2025, 12, 10), Symbols.Future_CLF19_Jan2019, 1, 2, 3, 4, 5);
+            futureContract.Update(tradeBar);
+
+            Assert.AreEqual(4, futureContract.LastPrice);
+            Assert.AreEqual(futureContract.LastPrice, futureContract.Price);
+            Assert.AreEqual(futureContract.LastPrice, futureContract.Value);
+            Assert.AreEqual(futureContract.LastPrice, futureContract.Close);
+        }
+
+        [Test]
         public void OpenInterest()
         {
             var futureContract = new FuturesContract(Symbols.Future_CLF19_Jan2019);

--- a/Tests/Common/Data/Market/OptionContractTests.cs
+++ b/Tests/Common/Data/Market/OptionContractTests.cs
@@ -42,9 +42,12 @@ namespace QuantConnect.Tests.Common.Data.Market
         {
             var symbol = Symbols.SPY_C_192_Feb19_2016;
             var contract = new OptionContract(CreateOption(symbol)) { Time = new DateTime(2016, 02, 16) };
-            // Give the contract its own option data holder so it doesn't read from/write to the
-            // shared OptionPriceModelResultData.Null singleton, which other tests may have mutated.
-            contract.SetOptionPriceModel(() => OptionPriceModelResult.None);
+
+            // No data yet, all aliases default to zero
+            Assert.AreEqual(0, contract.LastPrice);
+            Assert.AreEqual(contract.LastPrice, contract.Price);
+            Assert.AreEqual(contract.LastPrice, contract.Value);
+            Assert.AreEqual(contract.LastPrice, contract.Close);
 
             var tradeBar = new TradeBar(new DateTime(2016, 02, 16), symbol, 1, 2, 3, 4, 5);
             contract.Update(tradeBar);

--- a/Tests/Common/Data/Market/OptionContractTests.cs
+++ b/Tests/Common/Data/Market/OptionContractTests.cs
@@ -1,0 +1,61 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Option;
+
+namespace QuantConnect.Tests.Common.Data.Market
+{
+    [TestFixture]
+    public class OptionContractTests
+    {
+        private static Option CreateOption(Symbol symbol)
+        {
+            return new Option(
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                new SubscriptionDataConfig(typeof(TradeBar), symbol, Resolution.Minute, TimeZones.NewYork, TimeZones.NewYork, true, true, true),
+                new Cash(Currencies.USD, 0, 1m),
+                new OptionSymbolProperties(SymbolProperties.GetDefault(Currencies.USD)),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null
+            );
+        }
+
+        [Test]
+        public void PriceValueAndCloseAliasLastPrice()
+        {
+            var symbol = Symbols.SPY_C_192_Feb19_2016;
+            var contract = new OptionContract(CreateOption(symbol)) { Time = new DateTime(2016, 02, 16) };
+
+            // No data yet, all aliases default to zero
+            Assert.AreEqual(0, contract.LastPrice);
+            Assert.AreEqual(contract.LastPrice, contract.Price);
+            Assert.AreEqual(contract.LastPrice, contract.Value);
+            Assert.AreEqual(contract.LastPrice, contract.Close);
+
+            var tradeBar = new TradeBar(new DateTime(2016, 02, 16), symbol, 1, 2, 3, 4, 5);
+            contract.Update(tradeBar);
+
+            Assert.AreEqual(4, contract.LastPrice);
+            Assert.AreEqual(contract.LastPrice, contract.Price);
+            Assert.AreEqual(contract.LastPrice, contract.Value);
+            Assert.AreEqual(contract.LastPrice, contract.Close);
+        }
+    }
+}

--- a/Tests/Common/Data/Market/OptionContractTests.cs
+++ b/Tests/Common/Data/Market/OptionContractTests.cs
@@ -42,12 +42,9 @@ namespace QuantConnect.Tests.Common.Data.Market
         {
             var symbol = Symbols.SPY_C_192_Feb19_2016;
             var contract = new OptionContract(CreateOption(symbol)) { Time = new DateTime(2016, 02, 16) };
-
-            // No data yet, all aliases default to zero
-            Assert.AreEqual(0, contract.LastPrice);
-            Assert.AreEqual(contract.LastPrice, contract.Price);
-            Assert.AreEqual(contract.LastPrice, contract.Value);
-            Assert.AreEqual(contract.LastPrice, contract.Close);
+            // Give the contract its own option data holder so it doesn't read from/write to the
+            // shared OptionPriceModelResultData.Null singleton, which other tests may have mutated.
+            contract.SetOptionPriceModel(() => OptionPriceModelResult.None);
 
             var tradeBar = new TradeBar(new DateTime(2016, 02, 16), symbol, 1, 2, 3, 4, 5);
             contract.Update(tradeBar);

--- a/Tests/Common/Data/Market/OptionContractTests.cs
+++ b/Tests/Common/Data/Market/OptionContractTests.cs
@@ -37,11 +37,23 @@ namespace QuantConnect.Tests.Common.Data.Market
             );
         }
 
+        [SetUp]
+        public void ResetSharedOptionData()
+        {
+            // Other tests can leave the shared OptionPriceModelResultData.Null singleton holding a
+            // trade bar, which then leaks into any contract that hasn't set its own price model.
+            // Reset it by updating a throwaway (singleton-backed) contract with a zero-priced trade bar.
+            var symbol = Symbols.SPY_C_192_Feb19_2016;
+            new OptionContract(CreateOption(symbol))
+                .Update(new TradeBar(new DateTime(2016, 02, 16), symbol, 0, 0, 0, 0, 0));
+        }
+
         [Test]
         public void PriceValueAndCloseAliasLastPrice()
         {
             var symbol = Symbols.SPY_C_192_Feb19_2016;
             var contract = new OptionContract(CreateOption(symbol)) { Time = new DateTime(2016, 02, 16) };
+            contract.SetOptionPriceModel(() => OptionPriceModelResult.None);
 
             // No data yet, all aliases default to zero
             Assert.AreEqual(0, contract.LastPrice);


### PR DESCRIPTION
#### Description
Adds `Price`, `Value` and `Close` properties to `BaseContract` (inherited by `OptionContract` and `FuturesContract`) as aliases of the existing `LastPrice` property. This makes contracts mimic the familiar `BaseData`/`TradeBar` price API without inheriting `BaseData` — a contract is an aggregator over several concurrent data streams (trade/quote bars, ticks, open interest, universe data, option price model), not a single data point, so inheriting `BaseData` would be conceptually wrong and would drag in `Reader`/`GetSource`/`Clone` and the ProtoBuf serialization contract.

The new properties are `virtual` and marked `[PandasIgnore]` so they compose with each contract's existing `LastPrice` override and do not add duplicate columns to the option/future chain DataFrames (mirroring how `BaseData` tags its own `Value`/`Price`).

#### Related Issue
N/A

#### Motivation and Context
Users expect to be able to read `contract.Price`, `contract.Value` and `contract.Close` the same way they do on data/bars, for a consistent API surface across contracts and other data types.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Added unit tests asserting `Price == Value == Close == LastPrice` for both `OptionContract` and `FuturesContract`, before any data (all zero) and after a trade-bar update. New `OptionContractTests` fixture and a new case in `FuturesContractTests`. Built the Tests project in Release (0 errors) and ran both fixtures — all 10 tests pass.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
