### PR TITLE
Add Python version of IndicatorVolatilityModelAlgorithm

### DIFF
--- a/Algorithm.CSharp/IndicatorVolatilityModelAlgorithm.cs
+++ b/Algorithm.CSharp/IndicatorVolatilityModelAlgorithm.cs
@@ -128,7 +128,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// This is used by the regression test system to indicate which languages this algorithm is written in.
         /// </summary>
-        public List<Language> Languages { get; } = new() { Language.CSharp };
+        public List<Language> Languages { get; } = new() { Language.CSharp, Language.Python };
 
         /// <summary>
         /// Data Points count of all timeslices of algorithm

--- a/Algorithm.Python/IndicatorVolatilityModelAlgorithm.py
+++ b/Algorithm.Python/IndicatorVolatilityModelAlgorithm.py
@@ -1,0 +1,85 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Algorithm illustrating the usage of the IndicatorVolatilityModel and
+### how to handle splits and dividends to avoid price discontinuities
+### </summary>
+class IndicatorVolatilityModelAlgorithm(QCAlgorithm):
+
+    _indicator_periods = 7
+
+    _data_normalization_mode = DataNormalizationMode.RAW
+
+    def initialize(self):
+        self.set_start_date(2014, 1, 1)
+        self.set_end_date(2014, 12, 31)
+        self.set_cash(100000)
+
+        equity = self.add_equity("AAPL", Resolution.DAILY, data_normalization_mode=self._data_normalization_mode)
+        self._aapl = equity.symbol
+
+        std = StandardDeviation(self._indicator_periods)
+        mean = SimpleMovingAverage(self._indicator_periods)
+        self._indicator = IndicatorExtensions.over(std, mean)
+
+        def update_indicator(security, data, indicator):
+            if data.price > 0:
+                std.update(data.time, data.price)
+                mean.update(data.time, data.price)
+
+        self._volatility_model = IndicatorVolatilityModel(self._indicator, update_indicator)
+        equity.set_volatility_model(self._volatility_model)
+
+        self._splits_and_dividends_count = 0
+        self._volatility_checked = False
+
+    def on_data(self, slice):
+        if slice.splits.contains_key(self._aapl) or slice.dividends.contains_key(self._aapl):
+            self._splits_and_dividends_count += 1
+
+            # On a split or dividend event, we need to reset and warm the indicator up as Lean does to BaseVolatilityModel's
+            # to avoid big jumps in volatility due to price discontinuities
+            self._indicator.reset()
+            equity = self.securities[self._aapl]
+            VolatilityModelExtensions.warm_up(
+                self._volatility_model,
+                self,
+                equity,
+                equity.resolution,
+                self._indicator_periods,
+                self._data_normalization_mode
+            )
+
+    def on_end_of_day(self, symbol):
+        if symbol != self._aapl or not self._indicator.is_ready:
+            return
+
+        self._volatility_checked = True
+
+        # This is expected only in this case, 0.05 is not a magical number of any kind.
+        # Just making sure we don't get big jumps on volatility
+        volatility = self.securities[self._aapl].volatility_model.volatility
+        if volatility <= 0 or volatility > 0.05:
+            raise RegressionTestException(
+                "Expected volatility to stay less than 0.05 (not big jumps due to price discontinuities on splits and dividends), "
+                f"but got {volatility}")
+
+    def on_end_of_algorithm(self):
+        if self._splits_and_dividends_count == 0:
+            raise RegressionTestException("Expected to get at least one split or dividend event")
+
+        if not self._volatility_checked:
+            raise RegressionTestException("Expected to check volatility at least once")


### PR DESCRIPTION
#### Description
Adds `Algorithm.Python/IndicatorVolatilityModelAlgorithm.py`, a Python port of the existing C# regression algorithm demonstrating `IndicatorVolatilityModel` usage — including how to reset and warm the indicator back up on splits and dividends so volatility doesn't jump on price discontinuities. Also updates the C# definition's `Languages` to `{ CSharp, Python }` so the regression suite runs both variants against the same expected statistics.

#### Related Issue
Closes #6375

#### Motivation and Context
#6375 asks for an example of `IndicatorVolatilityModel`. The C# example algorithm and unit tests were added in #7058; this completes the issue with the Python counterpart, matching the convention that example/regression algorithms ship in both languages.

#### Requires Documentation Change
No — this adds the example the documentation can reference.

#### How Has This Been Tested?
Ran the regression tests inside the `quantconnect/lean:foundation` container (same image as the Regression Tests CI workflow):

```
dotnet test Tests/bin/Release/QuantConnect.Tests.dll --filter "FullyQualifiedName~IndicatorVolatilityModelAlgorithm"
```

Result: 2/2 passed (`CSharp/IndicatorVolatilityModelAlgorithm`, `Python/IndicatorVolatilityModelAlgorithm`); the Python variant produces statistics identical to the C# `ExpectedStatistics`.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7LGdW3eC9za8WMrtssHGr