### PR TITLE
Update QuantConnect.pythonnet to 2.0.57

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -32,7 +32,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.56" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.57" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Fuzzy" Version="3.6.0" />
     <PackageReference Include="Accord.MachineLearning" Version="3.6.0" />

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -29,7 +29,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.56" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.57" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Math" Version="3.6.0" />
     <PackageReference Include="Accord.Statistics" Version="3.6.0" />

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -37,7 +37,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.56" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.57" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="OptionUniverseFilterGreeksShortcutsRegressionAlgorithm.py" />

--- a/Algorithm/QuantConnect.Algorithm.csproj
+++ b/Algorithm/QuantConnect.Algorithm.csproj
@@ -29,7 +29,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.56" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.57" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NodaTime" Version="3.0.5" />

--- a/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
+++ b/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
@@ -28,7 +28,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.56" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.57" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -35,7 +35,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.56" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.57" />
     <PackageReference Include="CloneExtensions" Version="1.3.0" />
     <PackageReference Include="fasterflect" Version="3.0.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -41,7 +41,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.56" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.57" />
     <PackageReference Include="fasterflect" Version="3.0.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -31,7 +31,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.56" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.57" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Report/QuantConnect.Report.csproj
+++ b/Report/QuantConnect.Report.csproj
@@ -39,7 +39,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.56" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.57" />
     <PackageReference Include="Deedle" Version="2.1.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/Research/QuantConnect.Research.csproj
+++ b/Research/QuantConnect.Research.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Plotly.NET" Version="5.1.0" />
     <PackageReference Include="Plotly.NET.CSharp" Version="0.13.0" />
     <PackageReference Include="Plotly.NET.Interactive" Version="5.0.0" />
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.56" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.57" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
@@ -90,9 +90,10 @@ namespace QuantConnect.Tests.Common.Exceptions
             var interpreter = new NoMethodMatchPythonExceptionInterpreter();
             exception = interpreter.Interpret(exception, NullExceptionInterpreter.Instance);
 
-            // The interpreter should reference the actual method name that failed to resolve (SetCash),
-            // not a fragment of the argument type list (e.g. "'str'>)").
-            Assert.That(exception.Message, Does.Contain("SetCash"));
+            // The interpreter should reference the actual method name that failed to resolve
+            // (set_cash, the snake_case name Python callers use), not a fragment of the argument
+            // type list (e.g. "'str'>)").
+            Assert.That(exception.Message, Does.Contain("set_cash"));
             Assert.That(exception.Message, Does.Not.Contain(">)"));
         }
 
@@ -113,9 +114,9 @@ namespace QuantConnect.Tests.Common.Exceptions
             var interpreter = new NoMethodMatchPythonExceptionInterpreter();
             var exception = interpreter.Interpret(pythonException, NullExceptionInterpreter.Instance);
 
-            // The interpreter should reference the RSI method name, not a fragment of the
-            // argument type list (e.g. "'QuantConnect.Resolution'>)").
-            Assert.That(exception.Message, Does.Contain("RSI"));
+            // The interpreter should reference the rsi method name (snake_case, as Python callers
+            // use it), not a fragment of the argument type list (e.g. "'QuantConnect.Resolution'>)").
+            Assert.That(exception.Message, Does.Contain("rsi"));
             Assert.That(exception.Message, Does.Not.Contain(">)"));
         }
 

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.56" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.57" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Math" Version="3.6.0" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />


### PR DESCRIPTION
#### Description
Bumps the `QuantConnect.pythonnet` package reference to `2.0.57` across all projects that consume it.

#### Related Issue
N/A — routine dependency version bump.

#### Motivation and Context
Keeps the LEAN solution on the latest QuantConnect Python.NET runtime build.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Version bump only — no source code changed. The updated package restores and builds via the standard solution build; existing CI (build + unit/regression suites) validates the runtime.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!-- N/A: dependency version bump only, no behavioral change -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
