### PR TITLE
Handle AddIndexOption passing target option

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -107,6 +107,7 @@ namespace QuantConnect.Algorithm
         private bool _tagsLimitReachedLogSent;
         private bool _tagsCollectionTruncatedLogSent;
         private bool _hasShownDailyConsolidationWarning;
+        private bool _indexOptionTickerAsUnderlyingWarningSent;
         private DateTime _start;
         private DateTime _startDate;   //Default start and end dates.
         private DateTime _endDate;     //Default end to yesterday
@@ -2309,7 +2310,24 @@ namespace QuantConnect.Algorithm
 
         public IndexOption AddIndexOption(string underlying, Resolution? resolution = null, string market = null, bool fillForward = true)
         {
-            return AddIndexOption(underlying, null, resolution, market, fillForward);
+            string targetOption = null;
+            // Some non-standard index options, like the weekly SPXW, are options on an index (SPX) but have their own ticker.
+            // If one of those option tickers is provided as the underlying, e.g. AddIndexOption("SPXW"), map it to the
+            // actual underlying index and use the provided ticker as the target option. Otherwise a data-less index security
+            // would be created and used as the underlying of the option contracts, which would never get a price
+            var underlyingTicker = IndexOptionSymbol.MapToUnderlying(underlying);
+            if (!underlyingTicker.Equals(underlying, StringComparison.InvariantCultureIgnoreCase))
+            {
+                if (!_indexOptionTickerAsUnderlyingWarningSent)
+                {
+                    _indexOptionTickerAsUnderlyingWarningSent = true;
+                    Debug($"Warning: '{underlying}' is an index option ticker, using index '{underlyingTicker}' as the underlying and '{underlying}' as the target option.");
+                }
+                targetOption = underlying;
+                underlying = underlyingTicker;
+            }
+
+            return AddIndexOption(underlying, targetOption, resolution, market, fillForward);
         }
 
         /// <summary>

--- a/Tests/Algorithm/AlgorithmAddSecurityTests.cs
+++ b/Tests/Algorithm/AlgorithmAddSecurityTests.cs
@@ -258,6 +258,41 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(1, _algo.SubscriptionManager.Subscriptions.Count(x => x.Symbol == spx.Symbol));
         }
 
+        [TestCase("SPXW", "SPX")]
+        [TestCase("RUTW", "RUT")]
+        [TestCase("VIXW", "VIX")]
+        [TestCase("NDXP", "NDX")]
+        [TestCase("NQX", "NDX")]
+        [TestCase("SPX", "SPX")]
+        [TestCase("VIX", "VIX")]
+        public void AddIndexOptionMapsNonStandardOptionTickerToItsUnderlyingIndex(string ticker, string expectedUnderlyingTicker)
+        {
+            var option = _algo.AddIndexOption(ticker);
+
+            // the canonical keeps the provided option ticker
+            Assert.AreEqual($"?{ticker}", option.Symbol.Value);
+            Assert.AreEqual(ticker, option.Symbol.ID.Symbol);
+            // but the underlying is the actual index, which has data. Else the option contracts would reference
+            // a data-less underlying index security which would never get a price
+            Assert.AreEqual(SecurityType.Index, option.Symbol.Underlying.SecurityType);
+            Assert.AreEqual(expectedUnderlyingTicker, option.Symbol.Underlying.Value);
+
+            // the auto-added underlying index security is the mapped index
+            _algo.OnEndOfTimeStep();
+            Assert.IsTrue(_algo.Securities.ContainsKey(option.Symbol.Underlying));
+            Assert.AreEqual(option.Symbol.Underlying, option.Underlying.Symbol);
+            if (ticker != expectedUnderlyingTicker)
+            {
+                Assert.IsFalse(_algo.Securities.Keys.Any(x => x.SecurityType == SecurityType.Index && x.Value == ticker));
+                // a one time warning is sent about the mapping
+                Assert.AreEqual(1, _algo.DebugMessages.Count(x => x.Contains(ticker, StringComparison.InvariantCulture)));
+            }
+            else
+            {
+                Assert.IsEmpty(_algo.DebugMessages);
+            }
+        }
+
         [TestCase(Language.CSharp)]
         [TestCase(Language.Python)]
         public void AddSecurityInitializerAppendsInitializer(Language language)


### PR DESCRIPTION
- Fix AddIndexOption() creating a data-less underlying when given a non-standard index option ticker

Problem

Calling AddIndexOption("SPXW") treats "SPXW" as the underlying index ticker, creating a synthetic "SPXW" Index security which has no data source, so its price is always 0. The option contracts reference it as their underlying, which ends up throwing when holding a short position into expiration:
```
System.DivideByZeroException: Attempted to divide by zero.
   at QuantConnect.Securities.Option.DefaultOptionAssignmentModel.IsDeepInTheMoney(Option option)
   at QuantConnect.Brokerages.Backtesting.BacktestingBrokerage.ProcessAssignmentOrders()
```
The same applies to any consumer of the underlying price (greeks, margin, pricing models). The correct usage is AddIndexOption("SPX", "SPXW"), but the single-ticker form silently accepted the option ticker as an index.

Solution

In the AddIndexOption(string underlying, ...) overload, when the provided ticker is a known non-standard index option ticker, map it to its actual underlying index via IndexOptionSymbol.MapToUnderlying and use the provided ticker as the target option, sending a one-time warning to the user. So AddIndexOption("SPXW") now behaves like AddIndexOption("SPX", "SPXW"). Applies to SPXW→SPX, RUTW→RUT, VIXW→VIX, NDXP→NDX and NQX→NDX. Overloads with an explicit targetOption or Symbol are unchanged.

Adds AlgorithmAddSecurityTests.AddIndexOptionMapsNonStandardOptionTickerToItsUnderlyingIndex covering the mapped tickers and the standard SPX/VIX pass-through cases.