### PR TITLE
Liquidate ignores unknown symbols

### DIFF
--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -35,6 +35,7 @@ namespace QuantConnect.Algorithm
         private bool _isMarketOnOpenOrderRestrictedForFuturesWarningSent;
         private bool _isGtdTfiForMooAndMocOrdersValidationWarningSent;
         private bool _isOptionsOrderOnStockSplitWarningSent;
+        private bool _liquidateSymbolNotFoundWarningSent;
 
         /// <summary>
         /// Transaction Manager - Process transaction fills and order management.
@@ -1268,7 +1269,7 @@ namespace QuantConnect.Algorithm
         private Security GetSecurityForOrder(Symbol symbol)
         {
             var isCanonical = symbol.IsCanonical();
-            if (Securities.TryGetValue(symbol, out var security) && 
+            if (Securities.TryGetValue(symbol, out var security) &&
                 // Let canonical and delisted securities through instead of throwing. An invalid ticket will be returned later on when trying to submit the order.
                 (isCanonical || security.IsTradable || security.IsDelisted))
             {
@@ -1326,8 +1327,7 @@ namespace QuantConnect.Algorithm
             IEnumerable<Symbol> toLiquidate;
             if (symbol != null)
             {
-                toLiquidate = Securities.ContainsKey(symbol)
-                    ? new[] { symbol } : Enumerable.Empty<Symbol>();
+                toLiquidate = new[] { symbol };
             }
             else
             {
@@ -1357,6 +1357,17 @@ namespace QuantConnect.Algorithm
             tag ??= "Liquidated";
             foreach (var symbolToLiquidate in symbols)
             {
+                // skip symbols that have not been added to the algorithm instead of throwing
+                if (!Securities.ContainsKey(symbolToLiquidate))
+                {
+                    if (!_liquidateSymbolNotFoundWarningSent)
+                    {
+                        _liquidateSymbolNotFoundWarningSent = true;
+                        Debug($"Warning: Liquidate() ignored symbol '{symbolToLiquidate}' because it has not been added to the algorithm. Add the security before liquidating it.");
+                    }
+                    continue;
+                }
+
                 // get open orders
                 var orders = Transactions.GetOpenOrders(symbolToLiquidate);
 

--- a/Algorithm/QCAlgorithm.Trading.cs
+++ b/Algorithm/QCAlgorithm.Trading.cs
@@ -1363,7 +1363,7 @@ namespace QuantConnect.Algorithm
                     if (!_liquidateSymbolNotFoundWarningSent)
                     {
                         _liquidateSymbolNotFoundWarningSent = true;
-                        Debug($"Warning: Liquidate() ignored symbol '{symbolToLiquidate}' because it has not been added to the algorithm. Add the security before liquidating it.");
+                        Debug($"Warning: liquidate ignored symbol '{symbolToLiquidate}' because it has not been added to the algorithm. Add the security before liquidating it.");
                     }
                     continue;
                 }

--- a/Tests/Algorithm/AlgorithmTradingTests.cs
+++ b/Tests/Algorithm/AlgorithmTradingTests.cs
@@ -1556,6 +1556,41 @@ namespace QuantConnect.Tests.Algorithm
             Assert.IsTrue(limitOrderCanceled);
         }
 
+        [TestCase(Language.CSharp, true)]
+        [TestCase(Language.CSharp, false)]
+        [TestCase(Language.Python, true)]
+        [TestCase(Language.Python, false)]
+        public void LiquidateIgnoresSymbolsNotAddedToTheAlgorithm(Language language, bool singleSymbol)
+        {
+            var algo = GetAlgorithm(out _, 1, 0);
+
+            // AAPL was never added to the algorithm
+            List<OrderTicket> liquidatedTickets = null;
+            if (language == Language.CSharp)
+            {
+                if (singleSymbol)
+                {
+                    Assert.DoesNotThrow(() => liquidatedTickets = algo.Liquidate(Symbols.AAPL));
+                }
+                else
+                {
+                    Assert.DoesNotThrow(() => liquidatedTickets = algo.Liquidate(new List<Symbol>() { Symbols.AAPL }));
+                }
+            }
+            else
+            {
+                using (Py.GIL())
+                {
+                    var symbols = singleSymbol
+                        ? Symbols.AAPL.ToPython()
+                        : (new List<Symbol>() { Symbols.AAPL }).ToPython();
+                    Assert.DoesNotThrow(() => liquidatedTickets = algo.Liquidate(symbols));
+                }
+            }
+
+            Assert.IsEmpty(liquidatedTickets);
+        }
+
         [Test]
         public void MarketOrdersAreSupportedForFuturesOnExtendedMarketHours()
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
If you pass a symbol that isn't in the algorithm, Liquidate just warns once and skips it instead of blowing up.

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
