### PR TITLE
Fix GetPreviousMarketOpen: 7-day search limit insufficient

### DIFF
--- a/Common/Securities/SecurityExchangeHours.cs
+++ b/Common/Securities/SecurityExchangeHours.cs
@@ -278,7 +278,7 @@ namespace QuantConnect.Securities
             }
 
             // let's loop for a week
-            for (int i = 0; i < 7; i++)
+            for (int i = 0; i < 9; i++)
             {
                 DateTime? potentialResult = null;
                 foreach (var segment in marketHours.Segments.Reverse())


### PR DESCRIPTION
- Increase loop iteration count from 7 to 9

Closes https://github.com/QuantConnect/Lean/issues/9592