### PR TITLE
Keep pythonnet overloads hint in NoMethodMatchPythonExceptionInterpreter message

### DIFF
--- a/Common/Exceptions/NoMethodMatchPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/NoMethodMatchPythonExceptionInterpreter.cs
@@ -53,6 +53,12 @@ namespace QuantConnect.Exceptions
             var methodName = GetMethodName(pe.Message);
             var message = Messages.NoMethodMatchPythonExceptionInterpreter.AttemptedToAccessMethodThatDoesNotExist(methodName);
 
+            var overloadsHint = GetOverloadsHint(pe.Message);
+            if (!string.IsNullOrEmpty(overloadsHint))
+            {
+                message += $" {overloadsHint}";
+            }
+
             message += PythonUtil.PythonExceptionStackParser(pe.StackTrace);
 
             return new MissingMethodException(message, pe);
@@ -80,6 +86,22 @@ namespace QuantConnect.Exceptions
                 : exceptionMessage.Substring(methodNameStart);
 
             return methodName.Trim();
+        }
+
+        /// <summary>
+        /// Extracts the candidate-signatures hint pythonnet appends to the binding-failure
+        /// message ("The expected signature is:" or "The following overloads are available:"
+        /// followed by the signatures), so the interpreted message can keep it.
+        /// </summary>
+        private static string GetOverloadsHint(string exceptionMessage)
+        {
+            var hintIndex = exceptionMessage.IndexOfInvariant("The expected signature is:");
+            if (hintIndex == -1)
+            {
+                hintIndex = exceptionMessage.IndexOfInvariant("The following overloads are available:");
+            }
+
+            return hintIndex == -1 ? null : exceptionMessage.Substring(hintIndex).Trim();
         }
     }
 }

--- a/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
@@ -120,6 +120,45 @@ namespace QuantConnect.Tests.Common.Exceptions
             Assert.That(exception.Message, Does.Not.Contain(">)"));
         }
 
+        [Test]
+        public void VerifyMessageKeepsTheOverloadsHint()
+        {
+            // pythonnet appends the candidate signatures to the binding-failure message.
+            // set_cash('SPY') has multiple candidate overloads.
+            var pythonException = (PythonException)CreateExceptionFromType(typeof(PythonException));
+            StringAssert.Contains("The following overloads are available:", pythonException.Message);
+
+            var interpreter = new NoMethodMatchPythonExceptionInterpreter();
+            var exception = interpreter.Interpret(pythonException, NullExceptionInterpreter.Instance);
+
+            // The interpreted message must keep the overloads hint so the user can see
+            // what the method expects, not just that no overload matched.
+            Assert.That(exception.Message, Does.Contain("The following overloads are available:"));
+            Assert.That(exception.Message, Does.Contain("set_cash("));
+        }
+
+        [Test]
+        public void VerifyMessageKeepsTheExpectedSignatureHint()
+        {
+            PythonException pythonException;
+            using (Py.GIL())
+            {
+                var module = Py.Import("Test_PythonExceptionInterpreter");
+                dynamic algorithm = module.GetAttr("Test_PythonExceptionInterpreter").Invoke();
+                pythonException = Assert.Throws<PythonException>(() => algorithm.no_method_match_rsi());
+            }
+
+            // rsi's candidate overloads collapse into a single snake-case signature,
+            // so pythonnet words the hint as "The expected signature is:"
+            StringAssert.Contains("The expected signature is:", pythonException.Message);
+
+            var interpreter = new NoMethodMatchPythonExceptionInterpreter();
+            var exception = interpreter.Interpret(pythonException, NullExceptionInterpreter.Instance);
+
+            Assert.That(exception.Message, Does.Contain("The expected signature is:"));
+            Assert.That(exception.Message, Does.Contain("rsi("));
+        }
+
         private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _pythonException : (Exception)Activator.CreateInstance(type);
     }
 }


### PR DESCRIPTION
#### Description

Since pythonnet 2.0.57, the "No method matches given arguments" TypeError message includes the candidate signatures so the caller can see what the method expects:

```
No method matches given arguments for rsi: (<class 'QuantConnect.Symbol'>, <class 'int'>, <class 'QuantConnect.Resolution'>). The expected signature is:
  rsi(Symbol symbol, Int32 period, MovingAverageType moving_average_type = Wilders, Resolution? resolution = None, Func[IBaseData, Decimal] selector = None)
```

`NoMethodMatchPythonExceptionInterpreter` replaced the original message with a friendly one built from the parsed method name, discarding that hint. The hint section ("The expected signature is:" / "The following overloads are available:" plus the signatures) is now extracted from the original message and appended to the interpreted one:

> Trying to dynamically access a method that does not exist throws a TypeError exception. To prevent the exception, ensure each parameter type matches those required by the rsi method. Please checkout the API documentation. The expected signature is:
>   rsi(Symbol symbol, Int32 period, MovingAverageType moving_average_type = Wilders, Resolution? resolution = None, Func[IBaseData, Decimal] selector = None)

#### Related Issue

N/A — follow-up to #9573; the hint was reported missing from interpreted messages of Python algorithms failing overload resolution (e.g. `self.limit_order(symbol, contracts, entry, "tag")`, where the hint reveals the tag must be passed as a keyword since the `asynchronous` parameter was introduced).

#### Motivation and Context

The signatures hint is the part of the message that tells users *which* parameter didn't match and how to fix the call; dropping it left only the method name.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Added two tests to `NoMethodMatchPythonExceptionInterpreterTests`, one per hint wording:
- `VerifyMessageKeepsTheOverloadsHint` — `set_cash('SPY')` (multiple candidates, "The following overloads are available:").
- `VerifyMessageKeepsTheExpectedSignatureHint` — `rsi(symbol, 15, Resolution.DAILY)` (candidates collapse to a single signature, "The expected signature is:").

Both fail before the fix and pass after. Full `NoMethodMatchPythonExceptionInterpreterTests` fixture passes (15/15) and the whole `Tests.Common.Exceptions` suite passes (103/103).

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)