### PR TITLE
Set security cache open interest from chain universe data

### DIFF
--- a/Algorithm.CSharp/FutureUniverseOpenInterestRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/FutureUniverseOpenInterestRegressionAlgorithm.cs
@@ -1,0 +1,51 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Linq;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting that the future security cache open interest is set from the chain universe data open interest
+    /// </summary>
+    public class FutureUniverseOpenInterestRegressionAlgorithm : OptionUniverseOpenInterestRegressionAlgorithm
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 8);
+            SetEndDate(2013, 10, 8);
+            SetCash(100000);
+
+            var future = AddFuture(Futures.Indices.SP500EMini, Resolution.Minute);
+            future.SetFilter(universe => universe.Contracts(contracts => contracts.Where(x => x.OpenInterest != 0)));
+        }
+
+        /// <summary>
+        /// Gets the chain universe data point stored in the given security cache if any
+        /// </summary>
+        protected override BaseChainUniverseData GetChainUniverseData(Security security)
+        {
+            return security.Cache.GetData<FutureUniverse>();
+        }
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public override long DataPoints => 8494;
+    }
+}

--- a/Algorithm.CSharp/IndexOptionUniverseOpenInterestRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/IndexOptionUniverseOpenInterestRegressionAlgorithm.cs
@@ -1,0 +1,77 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting that the index option security cache open interest is set from the chain universe data open interest
+    /// </summary>
+    public class IndexOptionUniverseOpenInterestRegressionAlgorithm : OptionUniverseOpenInterestRegressionAlgorithm
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2021, 1, 4);
+            SetEndDate(2021, 1, 5);
+            SetCash(100000);
+
+            var option = AddIndexOption("SPX");
+            option.SetFilter(universe => universe.Contracts(contracts => contracts.Where(x => x.OpenInterest != 0).Take(10)));
+        }
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public override long DataPoints => 14433;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public override Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "-17.826"},
+            {"Tracking Error", "0.077"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"Drawdown Recovery", "0"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/OptionUniverseOpenInterestRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionUniverseOpenInterestRegressionAlgorithm.cs
@@ -1,0 +1,177 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting that the security cache open interest is set from the chain universe data open interest
+    /// </summary>
+    public class OptionUniverseOpenInterestRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        /// <summary>
+        /// The number of times the open interest was successfully asserted against the chain universe data
+        /// </summary>
+        protected int AssertionCount { get; private set; }
+
+        public override void Initialize()
+        {
+            SetStartDate(2015, 12, 24);
+            SetEndDate(2015, 12, 24);
+            SetCash(100000);
+
+            AddEquity("GOOG");
+            var option = AddOption("GOOG");
+            option.SetFilter(universe => universe.Contracts(contracts => contracts.Where(x => x.OpenInterest != 0).Take(10)));
+        }
+
+        /// <summary>
+        /// Gets the chain universe data point stored in the given security cache if any
+        /// </summary>
+        protected virtual BaseChainUniverseData GetChainUniverseData(Security security)
+        {
+            return security.Cache.GetData<OptionUniverse>();
+        }
+
+        public override void OnSecuritiesChanged(SecurityChanges changes)
+        {
+            // The securities are added in the same time slice as the chain universe data that selected them,
+            // which the algorithm manager stores in the security cache before any user code is called,
+            // so the cache open interest must already be set here
+            foreach (var security in changes.AddedSecurities)
+            {
+                AssertOpenInterest(security, checkOpenInterestTick: false);
+            }
+        }
+
+        public override void OnData(Slice slice)
+        {
+            foreach (var security in Securities.Values)
+            {
+                AssertOpenInterest(security, checkOpenInterestTick: true);
+            }
+        }
+
+        private void AssertOpenInterest(Security security, bool checkOpenInterestTick)
+        {
+            var securityType = security.Symbol.SecurityType;
+            if (security.Symbol.IsCanonical() || !securityType.IsOption() && securityType != SecurityType.Future)
+            {
+                return;
+            }
+
+            var chainUniverseData = GetChainUniverseData(security);
+            if (chainUniverseData == null || chainUniverseData.OpenInterest == 0)
+            {
+                return;
+            }
+
+            // If a more recent open interest tick was received from the data feed, the cache will reflect it instead
+            if (checkOpenInterestTick)
+            {
+                var lastOpenInterestTick = security.Cache.GetData<OpenInterest>();
+                if (lastOpenInterestTick != null && lastOpenInterestTick.EndTime > chainUniverseData.EndTime)
+                {
+                    return;
+                }
+            }
+
+            var expectedOpenInterest = (long)chainUniverseData.OpenInterest;
+            if (security.Cache.OpenInterest != expectedOpenInterest)
+            {
+                throw new RegressionTestException($"Unexpected open interest value for {security.Symbol}. " +
+                    $"Expected {expectedOpenInterest} from the chain universe data but found {security.Cache.OpenInterest}");
+            }
+            AssertionCount++;
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (AssertionCount == 0)
+            {
+                throw new RegressionTestException("The security cache open interest was never set from the chain universe data.");
+            }
+            Log($"Open interest was asserted {AssertionCount} times against the chain universe data");
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public virtual bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public virtual List<Language> Languages { get; } = new() { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public virtual long DataPoints => 8886;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public virtual int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public virtual AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public virtual Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"Drawdown Recovery", "0"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Common/Securities/Future/FutureCache.cs
+++ b/Common/Securities/Future/FutureCache.cs
@@ -1,11 +1,11 @@
 /*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,6 +13,8 @@
  * limitations under the License.
 */
 
+using System;
+using System.Collections.Generic;
 using QuantConnect.Data;
 
 namespace QuantConnect.Securities.Future
@@ -20,7 +22,6 @@ namespace QuantConnect.Securities.Future
     /// <summary>
     /// Future specific caching support
     /// </summary>
-    /// <remarks>Class is virtually empty and scheduled to be made obsolete. Potentially could be used for user data storage.</remarks>
     /// <seealso cref="SecurityCache"/>
     public class FutureCache : SecurityCache
     {
@@ -39,6 +40,17 @@ namespace QuantConnect.Securities.Future
             base.ProcessDataPoint(data, cacheByType);
 
             SettlementPrice = Price;
+        }
+
+        /// <summary>
+        /// Stores the specified data list in the cache, updating the open interest from any chain universe data
+        /// </summary>
+        /// <param name="data">The collection of data to store in this cache</param>
+        /// <param name="dataType">The data type</param>
+        public override void StoreData(IReadOnlyList<BaseData> data, Type dataType)
+        {
+            UpdateOpenInterest(data[data.Count - 1]);
+            base.StoreData(data, dataType);
         }
     }
 }

--- a/Common/Securities/Future/FutureCache.cs
+++ b/Common/Securities/Future/FutureCache.cs
@@ -49,7 +49,7 @@ namespace QuantConnect.Securities.Future
         /// <param name="dataType">The data type</param>
         public override void StoreData(IReadOnlyList<BaseData> data, Type dataType)
         {
-            UpdateOpenInterest(data[data.Count - 1]);
+            UpdateOpenInterest(data);
             base.StoreData(data, dataType);
         }
     }

--- a/Common/Securities/FutureOption/FutureOptionCache.cs
+++ b/Common/Securities/FutureOption/FutureOptionCache.cs
@@ -13,27 +13,13 @@
  * limitations under the License.
 */
 
-using System;
-using System.Collections.Generic;
-using QuantConnect.Data;
-
-namespace QuantConnect.Securities.Option
+namespace QuantConnect.Securities.FutureOption
 {
     /// <summary>
-    /// Option specific caching support
+    /// Future option specific caching support
     /// </summary>
     /// <seealso cref="SecurityCache"/>
-    public class OptionCache : SecurityCache
+    public class FutureOptionCache : Option.OptionCache
     {
-        /// <summary>
-        /// Stores the specified data list in the cache, updating the open interest from any chain universe data
-        /// </summary>
-        /// <param name="data">The collection of data to store in this cache</param>
-        /// <param name="dataType">The data type</param>
-        public override void StoreData(IReadOnlyList<BaseData> data, Type dataType)
-        {
-            UpdateOpenInterest(data[data.Count - 1]);
-            base.StoreData(data, dataType);
-        }
     }
 }

--- a/Common/Securities/IndexOption/IndexOptionCache.cs
+++ b/Common/Securities/IndexOption/IndexOptionCache.cs
@@ -13,27 +13,13 @@
  * limitations under the License.
 */
 
-using System;
-using System.Collections.Generic;
-using QuantConnect.Data;
-
-namespace QuantConnect.Securities.Option
+namespace QuantConnect.Securities.IndexOption
 {
     /// <summary>
-    /// Option specific caching support
+    /// Index option specific caching support
     /// </summary>
     /// <seealso cref="SecurityCache"/>
-    public class OptionCache : SecurityCache
+    public class IndexOptionCache : Option.OptionCache
     {
-        /// <summary>
-        /// Stores the specified data list in the cache, updating the open interest from any chain universe data
-        /// </summary>
-        /// <param name="data">The collection of data to store in this cache</param>
-        /// <param name="dataType">The data type</param>
-        public override void StoreData(IReadOnlyList<BaseData> data, Type dataType)
-        {
-            UpdateOpenInterest(data[data.Count - 1]);
-            base.StoreData(data, dataType);
-        }
     }
 }

--- a/Common/Securities/Option/OptionCache.cs
+++ b/Common/Securities/Option/OptionCache.cs
@@ -32,7 +32,7 @@ namespace QuantConnect.Securities.Option
         /// <param name="dataType">The data type</param>
         public override void StoreData(IReadOnlyList<BaseData> data, Type dataType)
         {
-            UpdateOpenInterest(data[data.Count - 1]);
+            UpdateOpenInterest(data);
             base.StoreData(data, dataType);
         }
     }

--- a/Common/Securities/SecurityCache.cs
+++ b/Common/Securities/SecurityCache.cs
@@ -335,6 +335,18 @@ namespace QuantConnect.Securities
         }
 
         /// <summary>
+        /// Helper method to update the open interest cache property from the last data point of a stored data list
+        /// </summary>
+        /// <param name="data">The data list being stored</param>
+        protected void UpdateOpenInterest(IReadOnlyList<BaseData> data)
+        {
+            if (data.Count != 0)
+            {
+                UpdateOpenInterest(data[data.Count - 1]);
+            }
+        }
+
+        /// <summary>
         /// Get last data packet received for this security if any else null
         /// </summary>
         /// <returns>BaseData type of the security</returns>

--- a/Common/Securities/SecurityCache.cs
+++ b/Common/Securities/SecurityCache.cs
@@ -298,7 +298,7 @@ namespace QuantConnect.Securities
         /// </summary>
         /// <param name="data">The collection of data to store in this cache</param>
         /// <param name="dataType">The data type</param>
-        public void StoreData(IReadOnlyList<BaseData> data, Type dataType)
+        public virtual void StoreData(IReadOnlyList<BaseData> data, Type dataType)
         {
             if (dataType == typeof(Tick))
             {
@@ -318,6 +318,19 @@ namespace QuantConnect.Securities
             {
                 _dataByType ??= new();
                 _dataByType[dataType] = data;
+            }
+        }
+
+        /// <summary>
+        /// Helper method to update the open interest cache property from a chain universe data point,
+        /// which carries the contracts daily open interest
+        /// </summary>
+        /// <param name="data">The data point being stored</param>
+        protected void UpdateOpenInterest(BaseData data)
+        {
+            if (data is BaseChainUniverseData chainUniverseData)
+            {
+                OpenInterest = (long)chainUniverseData.OpenInterest;
             }
         }
 

--- a/Common/Securities/SecurityCacheProvider.cs
+++ b/Common/Securities/SecurityCacheProvider.cs
@@ -21,6 +21,8 @@ using QuantConnect.Securities.Index;
 using QuantConnect.Securities.Option;
 using QuantConnect.Securities.Future;
 using QuantConnect.Securities.Equity;
+using QuantConnect.Securities.IndexOption;
+using QuantConnect.Securities.FutureOption;
 
 namespace QuantConnect.Securities
 {
@@ -63,6 +65,12 @@ namespace QuantConnect.Securities
                     break;
                 case SecurityType.Option:
                     securityCache = new OptionCache();
+                    break;
+                case SecurityType.IndexOption:
+                    securityCache = new IndexOptionCache();
+                    break;
+                case SecurityType.FutureOption:
+                    securityCache = new FutureOptionCache();
                     break;
                 case SecurityType.Forex:
                     securityCache = new ForexCache();


### PR DESCRIPTION
#### Description
Sets the security cache `OpenInterest` property from chain universe data points (`OptionUniverse`, `FutureUniverse`). The algorithm manager already pushes universe data into the security caches through `SecurityCache.StoreData()`, but only stored it by type without updating any cache properties.

Implementation:
- `SecurityCache.StoreData(IReadOnlyList<BaseData>, Type)` is now virtual, and a new protected `UpdateOpenInterest(BaseData)` helper detects `BaseChainUniverseData` and sets the `OpenInterest` cache property (0 is treated as a valid value).
- `OptionCache` and `FutureCache` override `StoreData` calling the helper.
- New `IndexOptionCache` and `FutureOptionCache` (deriving from `OptionCache`) are now mapped in `SecurityCacheProvider`; these security types previously fell through to the base `SecurityCache`.

Note: future option chain universe files currently have empty `open_interest` columns in the test data, so the future option case is covered by the shared `OptionCache` implementation but not by a dedicated regression algorithm.

#### Motivation and Context
Daily open interest is available in the chain universe files but was not being surfaced through `Security.OpenInterest`, which only updated from open interest ticks. With this change the cache reflects the universe values as soon as selection runs, for options, index options, future options and futures.

#### Requires Documentation Change
None.

#### How Has This Been Tested?
- New regression algorithms asserting the cache open interest matches the chain universe data at selection time (`OnSecuritiesChanged`) and on data updates: `OptionUniverseOpenInterestRegressionAlgorithm` (GOOG equity options), `IndexOptionUniverseOpenInterestRegressionAlgorithm` (SPX index options), `FutureUniverseOpenInterestRegressionAlgorithm` (ES futures). All three fail without the `SecurityCache` change and pass with it.
- Existing related regression algorithms verified unchanged: `OptionUniverseFilterGreeksRegressionAlgorithm`, `FutureUniverseHistoryRegressionAlgorithm`, `OpenInterestFuturesRegressionAlgorithm` (same statistics, order hashes and data point counts).
- `SecurityCacheTests` and `SecurityCacheProviderTests` pass.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
