### PR TITLE
Use underlying tradable days for linked custom data bar count history

### DIFF
--- a/Common/Data/HistoryRequestFactory.cs
+++ b/Common/Data/HistoryRequestFactory.cs
@@ -166,6 +166,19 @@ namespace QuantConnect.Data
             Type dataType,
             bool? extendedMarketHours = null)
         {
+            // Custom data linked to an underlying security, like some alternative datasets,
+            // only has data points for days the underlying security trades. Since the custom data market
+            // is always open, we count back the requested periods using the underlying exchange hours,
+            // else we would count calendar days and get fewer data points than requested
+            if (exchange.IsMarketAlwaysOpen && symbol.SecurityType == SecurityType.Base && symbol.HasUnderlying)
+            {
+                var underlyingExchange = _algorithm.GetExchangeHours(symbol.Underlying);
+                if (!underlyingExchange.IsMarketAlwaysOpen)
+                {
+                    exchange = underlyingExchange;
+                }
+            }
+
             var isExtendedMarketHours = false;
             // hour and daily resolution does no have extended market hours data. Same for chain universes
             if (resolution < Resolution.Hour && LeanData.SupportsExtendedMarketHours(dataType))

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -4058,6 +4058,22 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Helper method to get the exchange hours for the given symbol, from the security if available,
+        /// since the user can override them, else from the market hours database
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance to search for the security</param>
+        /// <param name="symbol">The symbol to get the exchange hours for</param>
+        /// <returns>The exchange hours of the symbol</returns>
+        public static SecurityExchangeHours GetExchangeHours(this IAlgorithm algorithm, Symbol symbol)
+        {
+            if (algorithm.Securities.TryGetValue(symbol, out var security))
+            {
+                return security.Exchange.Hours;
+            }
+            return MarketHoursDatabase.FromDataFolder().GetExchangeHours(symbol.ID.Market, symbol, symbol.ID.SecurityType);
+        }
+
+        /// <summary>
         /// Helper method to set an algorithm runtime exception in a normalized fashion
         /// </summary>
         public static void SetRuntimeError(this IAlgorithm algorithm, Exception exception, string context)

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -3235,6 +3235,45 @@ tradeBar = TradeBar
             Assert.AreEqual(marketOpen, requestStart);
         }
 
+        // This reproduces https://github.com/QuantConnect/Lean/issues/9598
+        [Test]
+        public void GetsBarCountHistoryRequestStartTimeForLinkedCustomDataUsingUnderlyingTradableDays()
+        {
+            var end = new DateTime(2014, 6, 9);
+            var algorithm = GetAlgorithm(end);
+            var aapl = algorithm.AddEquity("AAPL");
+            var customSecurity = algorithm.AddData<CustomData>(aapl.Symbol);
+            var config = algorithm.SubscriptionManager.SubscriptionDataConfigService
+                .GetSubscriptionDataConfigs(customSecurity.Symbol)
+                .Single();
+            Assert.IsTrue(customSecurity.Exchange.Hours.IsMarketAlwaysOpen);
+
+            var historyRequestFactory = new HistoryRequestFactory(algorithm);
+            var requestStart = historyRequestFactory.GetStartTimeAlgoTz(customSecurity.Symbol, 10, Resolution.Daily,
+                customSecurity.Exchange.Hours, config.DataTimeZone, config.Type);
+
+            // Even though the custom data market is always open, the start time is computed counting back
+            // 10 tradable days of the underlying equity, skipping weekends and the Memorial Day holiday (2014-05-26),
+            // instead of 10 calendar days which would be 2014-05-30
+            Assert.AreEqual(new DateTime(2014, 5, 23), requestStart);
+        }
+
+        // This reproduces https://github.com/QuantConnect/Lean/issues/9598
+        [Test]
+        public void LinkedCustomDataBarCountHistoryAccountsForUnderlyingTradableDays()
+        {
+            var end = new DateTime(2013, 10, 14);
+            var algorithm = GetAlgorithm(end);
+            var spy = algorithm.AddEquity("SPY").Symbol;
+            var customSymbol = algorithm.AddData<CustomData>(spy).Symbol;
+
+            var history = algorithm.History<CustomData>(customSymbol, 10, Resolution.Daily).ToList();
+
+            // The custom data only has data points for days the underlying trades,
+            // so counting back calendar days would return fewer points than requested
+            Assert.AreEqual(10, history.Count);
+        }
+
         // This reproduces https://github.com/QuantConnect/Lean/issues/7504
         [TestCase(Language.CSharp)]
         [TestCase(Language.Python)]
@@ -4347,8 +4386,7 @@ def get_history(algorithm, symbol):
         {
             public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
             {
-                var source = Path.Combine(Globals.DataFolder, "equity", "usa", config.Resolution.ToString().ToLower(),
-                    Symbols.SPY.Value.ToLowerInvariant(), LeanData.GenerateZipFileName(Symbols.SPY, date, config.Resolution, config.TickType));
+                var source = LeanData.GenerateZipFilePath(Globals.DataFolder, Symbols.SPY, date, config.Resolution, config.TickType);
                 return new SubscriptionDataSource(source, SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
             }
             public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)


### PR DESCRIPTION
#### Description

Bar count history requests for custom data linked to an underlying security, e.g. `BrainSentimentIndicator7Day` on an equity, returned fewer data points than requested. Since the custom data market is always open, the request start time was computed by counting back calendar days, but the data only exists for days the underlying security trades, so weekends and holidays in the lookback window reduced the number of points returned.

`HistoryRequestFactory.GetStartTimeAlgoTz` now counts back the requested periods using the underlying exchange hours when the symbol is custom data with an underlying and its market is always open. Behavior is unchanged when the custom data type has specific market hours defined or the underlying market is also always open. Since the fix is in the factory, all bar count paths benefit: both `History` overloads from the issue, indicator warm up and algorithm warm up.

Also adds an `IAlgorithm.GetExchangeHours` extension that gets the exchange hours from the security if available, since the user can override them, else from the market hours database.

#### Related Issue

Closes #9598

#### Motivation and Context

Requesting N daily bars of linked custom data should return N data points.

#### Requires Documentation Change

No

#### How Has This Been Tested?

- New unit test asserting the bar count request start time for linked custom data counts back the underlying tradable days, skipping weekends and holidays
- New end to end test asserting a 10 daily bar history request for linked custom data returns exactly 10 data points (returned 6 before the fix)
- Full `AlgorithmHistoryTests` (334 tests) and warm up tests (105 tests) pass

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)