### PR TITLE
Improve ApiConnection request error logging and connection handling

### DIFF
--- a/Api/ApiConnection.cs
+++ b/Api/ApiConnection.cs
@@ -24,6 +24,9 @@ using System.Collections.Generic;
 using QuantConnect.Util;
 using System.IO;
 using System.Threading;
+using System.Diagnostics;
+using System.Net.Sockets;
+using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.Api
 {
@@ -99,7 +102,17 @@ namespace QuantConnect.Api
                 _httpClient.DisposeSafely();
             }
 
-            _httpClient = new HttpClient() { BaseAddress = new Uri($"{baseUrl.TrimEnd('/')}/") };
+            var baseAddress = new Uri($"{baseUrl.TrimEnd('/')}/");
+#pragma warning disable CA2000 // Dispose objects before losing scope: the client takes ownership of the handler
+            var handler = new SocketsHttpHandler
+            {
+                // fail fast when a connection can't be established instead of consuming the whole request timeout
+                ConnectTimeout = TimeSpan.FromMinutes(1),
+                // recycle pooled connections so DNS/load balancer changes and stale NAT state are picked up
+                PooledConnectionLifetime = TimeSpan.FromMinutes(5)
+            };
+            _httpClient = new HttpClient(handler, disposeHandler: true) { BaseAddress = baseAddress };
+#pragma warning restore CA2000
             Client = new RestClient(baseUrl);
 
             if (defaultHeaders != null)
@@ -228,6 +241,8 @@ namespace QuantConnect.Api
             // Default to 100 seconds (since we disabled the default client timeout)
             timeout ??= TimeSpan.FromSeconds(100);
 
+            using var cancellationTokenSource = new CancellationTokenSource(timeout.Value);
+            var stopwatch = Stopwatch.StartNew();
             try
             {
                 if (request.RequestUri.OriginalString.StartsWith('/'))
@@ -238,7 +253,6 @@ namespace QuantConnect.Api
                 SetAuthenticator(request);
 
                 // Execute the authenticated REST API Call
-                using var cancellationTokenSource = new CancellationTokenSource(timeout.Value);
                 response = await _httpClient.SendAsync(request, cancellationTokenSource.Token).ConfigureAwait(false);
                 responseContentStream = await response.Content.ReadAsStreamAsync(cancellationTokenSource.Token).ConfigureAwait(false);
 
@@ -260,7 +274,7 @@ namespace QuantConnect.Api
             }
             catch (Exception err)
             {
-                Log.Error($"ApiConnection.TryRequest({request.RequestUri}): Error: {err.Message}, Response content: {GetRawResponseContent(responseContentStream)}");
+                Log.Error($"ApiConnection.TryRequest({request.RequestUri}): {DescribeError(err, cancellationTokenSource.IsCancellationRequested, stopwatch.ElapsedMilliseconds, timeout.Value)}, Response content: {GetRawResponseContent(responseContentStream)}");
                 return new Tuple<bool, T>(false, null);
             }
             finally
@@ -270,6 +284,52 @@ namespace QuantConnect.Api
             }
 
             return new Tuple<bool, T>(true, result);
+        }
+
+        /// <summary>
+        /// Builds a diagnostic description of a failed request: distinguishes a timeout from an external
+        /// cancellation, includes how long the request ran, the exception cause chain with socket/http error
+        /// codes and the thread pool state, to help tell network failures apart from process-level issues
+        /// </summary>
+        private static string DescribeError(Exception exception, bool timeoutElapsed, long elapsedMilliseconds, TimeSpan timeout)
+        {
+            try
+            {
+                var builder = new StringBuilder("Error: ");
+                if (exception is OperationCanceledException)
+                {
+                    builder.Append(timeoutElapsed
+                        ? Invariant($"request timed out, no response received (timeout {timeout.TotalSeconds}s)")
+                        : "request was canceled before the timeout elapsed");
+                }
+                else
+                {
+                    for (var inner = exception; inner != null; inner = inner.InnerException)
+                    {
+                        if (inner != exception)
+                        {
+                            builder.Append(" -> ");
+                        }
+                        builder.Append(inner.GetType().Name);
+                        if (inner is HttpRequestException httpException)
+                        {
+                            builder.Append(Invariant($"[{httpException.HttpRequestError}]"));
+                        }
+                        else if (inner is SocketException socketException)
+                        {
+                            builder.Append(Invariant($"[{socketException.SocketErrorCode}]"));
+                        }
+                        builder.Append(": ").Append(inner.Message);
+                    }
+                }
+                builder.Append(Invariant($" after {elapsedMilliseconds}ms. ThreadPool: {ThreadPool.ThreadCount} threads, {ThreadPool.PendingWorkItemCount} pending work items"));
+                return builder.ToString();
+            }
+            catch (Exception)
+            {
+                // we are already handling a request failure, describing it should never throw
+                return $"Error: {exception?.Message}";
+            }
         }
 
         private static string GetRawResponseContent(Stream stream)


### PR DESCRIPTION
#### Description

Live deployments hitting API connectivity issues currently log every failure as `Error: A task was canceled., Response content:` regardless of the underlying cause, which makes incidents (timeouts vs DNS failures vs connection refusals vs thread pool starvation) impossible to tell apart from the logs.

**Error logging** (`TryRequestAsync<T>(HttpRequestMessage)`): failures now log through a new `DescribeError` helper that reports:
- whether the request timed out (its cancellation token fired) vs was canceled externally
- how long the request ran vs the configured timeout, so instant failures are distinguishable from full-window hangs
- the exception cause chain including `HttpRequestException.HttpRequestError` (`NameResolutionError`/`ConnectionError`/`SecureConnectionError`) and `SocketException.SocketErrorCode`
- thread pool state (`ThreadCount`, `PendingWorkItemCount`) to tell network failures apart from process-level starvation (the sync `TryRequest` path is sync-over-async, so a starved pool times out every request even with a healthy network)

Example output, before vs after:
```
Error: A task was canceled., Response content:
Error: request timed out, no response received (timeout 100s) after 100013ms. ThreadPool: 132 threads, 4817 pending work items, Response content:
Error: HttpRequestException[NameResolutionError]: Resource temporarily unavailable -> SocketException[TryAgain]: ... after 8021ms. ThreadPool: 14 threads, 0 pending work items, Response content:
```

`DescribeError` is wrapped in try/catch and falls back to the previous message format, so the error path can never throw while logging.

**Connection handling** (`SetClient`): the `HttpClient` is now built over a `SocketsHttpHandler` with:
- `ConnectTimeout = 1 minute` (default is infinite): connection establishment failures surface quickly and distinctly instead of consuming the whole request timeout
- `PooledConnectionLifetime = 5 minutes` (default is infinite): pooled connections are recycled so DNS/load balancer changes and silently dead NAT flows self-heal instead of persisting for the process lifetime

Motivated by a live deployment that lost API connectivity for 15+ minutes while a sibling container on the same host could reach the API fine; the existing logs could not narrow down the cause.

#### Checklist
- [x] my code follows the coding style of this project
- [x] my change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [x] all new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)