### PR TITLE
Add Count property to derivative security filter universes

### DIFF
--- a/Common/Securities/ContractSecurityFilterUniverse.cs
+++ b/Common/Securities/ContractSecurityFilterUniverse.cs
@@ -68,6 +68,11 @@ namespace QuantConnect.Securities
         public DateTime LocalTime { get; private set; }
 
         /// <summary>
+        /// The number of contracts in the universe
+        /// </summary>
+        public int Count => _data.Count;
+
+        /// <summary>
         /// All data in this filter
         /// Marked internal for use by extensions
         /// </summary>

--- a/Common/Securities/EmptyContractFilter.cs
+++ b/Common/Securities/EmptyContractFilter.cs
@@ -46,6 +46,8 @@ namespace QuantConnect.Securities
         {
             public DateTime LocalTime => default;
 
+            public int Count => 0;
+
             public IEnumerator<T> GetEnumerator()
             {
                 return Enumerable.Empty<T>().GetEnumerator();

--- a/Common/Securities/IDerivativeSecurityFilterUniverse.cs
+++ b/Common/Securities/IDerivativeSecurityFilterUniverse.cs
@@ -24,5 +24,9 @@ namespace QuantConnect.Securities
     public interface IDerivativeSecurityFilterUniverse<T> : IEnumerable<T>
         where T : IChainUniverseData
     {
+        /// <summary>
+        /// The number of contracts in the universe
+        /// </summary>
+        int Count { get; }
     }
 }

--- a/Tests/Common/Securities/FutureFilterTests.cs
+++ b/Tests/Common/Securities/FutureFilterTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using Python.Runtime;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Securities;
@@ -60,6 +61,87 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(symbols[5], filtered[2]);
             Assert.AreEqual(symbols[6], filtered[3]);
             Assert.AreEqual(symbols[7], filtered[4]);
+        }
+
+        [Test]
+        public void CountReturnsTheNumberOfContractsInTheUniverse()
+        {
+            var time = new DateTime(2016, 02, 26);
+            var symbols = new[]
+            {
+                Symbol.CreateFuture("SPY", Market.CME, time.AddDays(3)),
+                Symbol.CreateFuture("SPY", Market.CME, time.AddDays(5)),
+                Symbol.CreateFuture("SPY", Market.CME, time.AddDays(10)),
+            };
+            var data = symbols.Select(x => new FutureUniverse() { Symbol = x }).ToList();
+            var universe = new FutureFilterUniverse(data, time);
+
+            Assert.AreEqual(symbols.Length, universe.Count);
+
+            // Filter and check the count reflects the filtered contracts
+            universe.Expiration(TimeSpan.FromDays(3), TimeSpan.FromDays(7));
+            Assert.AreEqual(2, universe.Count);
+        }
+
+        [Test]
+        public void CountIsUpdatedAsFiltersReduceTheUniverse()
+        {
+            var time = new DateTime(2016, 02, 26);
+            var symbols = Enumerable.Range(0, 10)
+                .Select(i => Symbol.CreateFuture("SPY", Market.CME, time.AddDays(i)))
+                .ToArray();
+            var data = symbols.Select(x => new FutureUniverse() { Symbol = x }).ToList();
+            var universe = new FutureFilterUniverse(data, time);
+
+            Assert.AreEqual(symbols.Length, universe.Count);
+
+            // Contracts expiring within 3 to 7 days
+            universe.Expiration(TimeSpan.FromDays(3), TimeSpan.FromDays(7));
+            Assert.AreEqual(5, universe.Count);
+
+            // Out of those, only the earliest expiring contract
+            universe.FrontMonth();
+            Assert.AreEqual(1, universe.Count);
+        }
+
+        [Test]
+        public void PythonLenReturnsTheNumberOfContractsInTheUniverse()
+        {
+            var time = new DateTime(2016, 02, 26);
+            var symbols = new[]
+            {
+                Symbol.CreateFuture("SPY", Market.CME, time.AddDays(0)), // 0
+                Symbol.CreateFuture("SPY", Market.CME, time.AddDays(1)), // 1
+                Symbol.CreateFuture("SPY", Market.CME, time.AddDays(2)), // 2
+                Symbol.CreateFuture("SPY", Market.CME, time.AddDays(3)), // 3
+                Symbol.CreateFuture("SPY", Market.CME, time.AddDays(4)), // 4
+                Symbol.CreateFuture("SPY", Market.CME, time.AddDays(5)), // 5
+                Symbol.CreateFuture("SPY", Market.CME, time.AddDays(6)), // 6
+                Symbol.CreateFuture("SPY", Market.CME, time.AddDays(7)), // 7
+                Symbol.CreateFuture("SPY", Market.CME, time.AddDays(8)), // 8
+                Symbol.CreateFuture("SPY", Market.CME, time.AddDays(9)), // 9
+            };
+            var data = symbols.Select(x => new FutureUniverse() { Symbol = x }).ToList();
+            var universe = new FutureFilterUniverse(data, time);
+
+            using (Py.GIL())
+            {
+                using var module = PyModule.FromString("testModule",
+                    @"
+def get_length(universe):
+    return len(universe)");
+                using var getLength = module.GetAttr("get_length");
+                using var pyUniverse = universe.ToPython();
+
+                // The whole universe
+                using var length = getLength.Invoke(pyUniverse);
+                Assert.AreEqual(symbols.Length, length.As<int>());
+
+                // Filter and check the length reflects the filtered contracts
+                universe.Expiration(TimeSpan.FromDays(3), TimeSpan.FromDays(7));
+                using var filteredLength = getLength.Invoke(pyUniverse);
+                Assert.AreEqual(5, filteredLength.As<int>());
+            }
         }
 
         [TestCase(false, 6)]

--- a/Tests/Common/Securities/Options/OptionFilterUniverseTests.cs
+++ b/Tests/Common/Securities/Options/OptionFilterUniverseTests.cs
@@ -14,6 +14,7 @@
 */
 
 using NUnit.Framework;
+using Python.Runtime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
@@ -227,6 +228,92 @@ namespace QuantConnect.Tests.Common.Securities.Options
                 Assert.Throws<InvalidOperationException>(() => universe.Rho(0m, 1m));
                 Assert.Throws<InvalidOperationException>(() => universe.R(0m, 1m));
             });
+        }
+
+        [Test]
+        public void CountReturnsTheNumberOfContractsInTheUniverse()
+        {
+            var minIV = 0.10m;
+            var maxIV = 0.12m;
+            var expectedContracts = 11;
+
+            // Set up
+            var universe = new OptionFilterUniverse(GetOption(), _testOptionsData, _underlying);
+            universe.Refresh(_testOptionsData, _underlying, _underlying.EndTime);
+
+            Assert.AreEqual(_testOptionsData.Count, universe.Count);
+
+            // Filter and check the count reflects the filtered contracts
+            universe.ImpliedVolatility(minIV, maxIV);
+            Assert.AreEqual(expectedContracts, universe.Count);
+        }
+
+        [Test]
+        public void CountIsUpdatedAsFiltersReduceTheUniverse()
+        {
+            // Use an underlying price that matches one of the strikes in the test data
+            // so that the strikes filter can find contracts around the ATM strike
+            var underlying = new TradeBar
+            {
+                Symbol = _underlying.Symbol,
+                Close = 5410m,
+                Time = _underlying.Time,
+                EndTime = _underlying.EndTime
+            };
+
+            // Set up
+            var universe = new OptionFilterUniverse(GetOption(), _testOptionsData, underlying);
+            universe.Refresh(_testOptionsData, underlying, underlying.EndTime);
+
+            Assert.AreEqual(_testOptionsData.Count, universe.Count);
+
+            // Contracts with strikes 5405, 5410 and 5415
+            universe.Strikes(-1, 1);
+            Assert.AreEqual(13, universe.Count);
+
+            // Out of those, contracts expiring within 60 days: 2024-07-19 and 2024-08-16
+            universe.Expiration(0, 60);
+            Assert.AreEqual(6, universe.Count);
+        }
+
+        [Test]
+        public void EmptyContractFilterUniverseCountIsZero()
+        {
+            var universe = new OptionFilterUniverse(GetOption(), _testOptionsData, _underlying);
+            var emptyUniverse = new EmptyContractFilter<OptionUniverse>().Filter(universe);
+
+            Assert.AreEqual(0, emptyUniverse.Count);
+        }
+
+        [Test]
+        public void PythonLenReturnsTheNumberOfContractsInTheUniverse()
+        {
+            var minIV = 0.10m;
+            var maxIV = 0.12m;
+            var expectedContracts = 11;
+
+            // Set up
+            var universe = new OptionFilterUniverse(GetOption(), _testOptionsData, _underlying);
+            universe.Refresh(_testOptionsData, _underlying, _underlying.EndTime);
+
+            using (Py.GIL())
+            {
+                using var module = PyModule.FromString("testModule",
+                    @"
+def get_length(universe):
+    return len(universe)");
+                using var getLength = module.GetAttr("get_length");
+                using var pyUniverse = universe.ToPython();
+
+                // The whole universe
+                using var length = getLength.Invoke(pyUniverse);
+                Assert.AreEqual(_testOptionsData.Count, length.As<int>());
+
+                // Filter and check the length reflects the filtered contracts
+                universe.ImpliedVolatility(minIV, maxIV);
+                using var filteredLength = getLength.Invoke(pyUniverse);
+                Assert.AreEqual(expectedContracts, filteredLength.As<int>());
+            }
         }
 
         private static Option GetOption(Symbol symbol = null)


### PR DESCRIPTION
#### Description
Adds an `int Count` property to `IDerivativeSecurityFilterUniverse<T>` and implements it in all implementations:

- `ContractSecurityFilterUniverse<T, TData>` (base of `OptionFilterUniverse` and `FutureFilterUniverse`) returns the number of contracts currently in the universe, reflecting any filters already applied.
- `EmptyContractFilter<T>`'s internal empty universe returns `0`.

Besides making the contract count directly accessible from C#, this enables `len()` on filter universes in Python algorithms, since Python.NET assigns `__len__` to enumerable CLR types that expose a public `Count` property:

```python
def initialize(self):
    option = self.add_option("GOOG")
    option.set_filter(self.filter)

def filter(self, universe):
    filtered = universe.strikes(-2, +2).expiration(0, 180)
    self.log(f"selected={len(filtered)}")  # previously: TypeError: object of type 'OptionFilterUniverse' has no len()
    return filtered
```

#### Related Issue
N/A

#### Motivation and Context
Calling `len()` on an `OptionFilterUniverse`/`FutureFilterUniverse` from a Python algorithm's contract filter raised `TypeError: object of type 'OptionFilterUniverse' has no len()`, forcing users to enumerate the universe just to count contracts. There was also no direct way to get the contract count from C# without LINQ's `Count()`.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- New unit tests in `OptionFilterUniverseTests` and `FutureFilterTests`:
  - `PythonLenReturnsTheNumberOfContractsInTheUniverse`: asserts `len()` works from Python and reflects applied filters. These tests reproduce the `TypeError` and fail without this change.
  - `CountReturnsTheNumberOfContractsInTheUniverse` and `CountIsUpdatedAsFiltersReduceTheUniverse`: assert `Count` returns the universe size and is updated as chained filters (`Strikes`/`Expiration`/`FrontMonth`) reduce the universe.
  - `EmptyContractFilterUniverseCountIsZero`: asserts the `EmptyContractFilter` universe reports `Count == 0`.
- Full `OptionFilterUniverseTests`, `OptionFilterTests`, `OptionStrategyFilterTests` and `FutureFilterTests` fixtures pass.
- Manually verified end-to-end by running `BasicTemplateOptionsAlgorithm.py` with a `len(filtered)` call in the option filter through the Lean launcher.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
