### PR TITLE
Friendly error when option/future filter function returns null/None

### DIFF
--- a/Common/Securities/Future/Future.cs
+++ b/Common/Securities/Future/Future.cs
@@ -256,6 +256,12 @@ namespace QuantConnect.Securities.Future
             {
                 var futureUniverse = universe as FutureFilterUniverse;
                 var result = universeFunc(futureUniverse);
+                if (result == null)
+                {
+                    throw new ArgumentException("Future.SetFilter: the filter function returned null/'None'." +
+                        " Return the incoming universe with your filters applied," +
+                        " e.g. 'return universe.expiration(0, 90)'");
+                }
                 return result.ApplyTypesFilter();
             };
             ContractFilter = new FuncSecurityDerivativeFilter<FutureUniverse>(func);

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -575,6 +575,11 @@ namespace QuantConnect.Securities.Option
             {
                 var optionUniverse = universe as OptionFilterUniverse;
                 var result = universeFunc(optionUniverse);
+                if (result == null)
+                {
+                    throw new ArgumentException("Option.SetFilter: the filter function returned null." +
+                        " Return the incoming universe with your filters applied.");
+                }
                 return result.ApplyTypesFilter();
             });
             ContractFilter.Asynchronous = false;
@@ -592,6 +597,13 @@ namespace QuantConnect.Securities.Option
                 using (Py.GIL())
                 {
                     PyObject result = (universeFunc as dynamic)(optionUniverse);
+
+                    if (result == null || result.IsNone())
+                    {
+                        throw new ArgumentException("Option.SetFilter: the filter function returned 'None'." +
+                            " Return the incoming universe with your filters applied," +
+                            " e.g. 'return universe.strikes(-20, 20).expiration(0, 0)'");
+                    }
 
                     //Try to convert it to the possible outcomes and process it
                     //Must try filter first, if it is a filter and you try and convert it to
@@ -638,6 +650,11 @@ namespace QuantConnect.Securities.Option
             {
                 var optionUniverse = universe as OptionFilterUniverse;
                 var result = universeFunc(optionUniverse);
+                if (result == null)
+                {
+                    throw new ArgumentException("Option.SetFilter: the filter function returned null." +
+                        " Return the incoming universe with your filters applied.");
+                }
                 return result.ApplyTypesFilter();
             });
         }


### PR DESCRIPTION
**TLDR:** A Python option filter that forgets `return` (mutates and returns `None`) currently kills the backtest with an opaque `NullReferenceException` in the Synchronizer (`Option.cs:617`). This throws a clear `ArgumentException` telling the user to return the universe instead.

Repro (seen in production, agent-generated algo):
```python
def _option_filter(self, universe: OptionFilterUniverse) -> None:
    universe.strikes(-20, 20).expiration(0, 0)   # no return -> None
```
`SetFilter(PyObject)` converts Py `None` via `TryConvert` into a null `OptionFilterUniverse`, then `ApplyTypesFilter()` NREs:
```text
System.NullReferenceException at QuantConnect.Securities.Option.Option.<>c__DisplayClass81_0.<SetFilter>b__0(...) in Common/Securities/Option/Option.cs:line 617
```

Changes:
- `Option.SetFilter(PyObject)`: reject `None` results with an actionable message (suggests `return universe.strikes(...).expiration(...)`)
- `Option.SetFilter(Func<,>)` + `SetFilterImp`: same guard for null returns from C# lambdas
- `Future.SetFilterImp`: same guard (identical hole)

`dotnet build Common` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)