### PR TITLE
Improve error messages for unsupported Python objects in user-facing APIs

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -32,7 +32,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.60" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.61" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Fuzzy" Version="3.6.0" />
     <PackageReference Include="Accord.MachineLearning" Version="3.6.0" />

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -29,7 +29,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.60" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.61" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Math" Version="3.6.0" />
     <PackageReference Include="Accord.Statistics" Version="3.6.0" />

--- a/Algorithm.Framework/Selection/ScheduledUniverseSelectionModel.cs
+++ b/Algorithm.Framework/Selection/ScheduledUniverseSelectionModel.cs
@@ -90,7 +90,12 @@ namespace QuantConnect.Algorithm.Framework.Selection
         public ScheduledUniverseSelectionModel(DateTimeZone timeZone, IDateRule dateRule, ITimeRule timeRule, PyObject selector, UniverseSettings settings = null)
         {
             Func<DateTime, object> func;
-            selector.TrySafeAs(out func);
+            if (!selector.TrySafeAs(out func))
+            {
+                throw new ArgumentException(
+                    $"Unable to create a scheduled universe selector from {selector.ToDisplayString()}: it is not a function. " +
+                    "Please provide a function that takes the firing date time and returns the selected symbols.");
+            }
             _timeZone = timeZone;
             _dateRule = dateRule;
             _timeRule = timeRule;

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -37,7 +37,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.60" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.61" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="OptionUniverseFilterGreeksShortcutsRegressionAlgorithm.py" />

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -1384,7 +1384,7 @@ namespace QuantConnect.Algorithm
                 {
                     throw new ArgumentException(
                         $"Unable to set the benchmark from {benchmark.ToDisplayString()}: it is not a supported benchmark type. " +
-                        "Please use one of the available method overloads.",
+                        MethodSignatureFormatter.FormatOverloads(typeof(QCAlgorithm).GetMethods().Where(m => m.Name == nameof(SetBenchmark))),
                         exception);
                 }
             }

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -1382,13 +1382,9 @@ namespace QuantConnect.Algorithm
                 }
                 catch (InvalidCastException exception)
                 {
-                    // Skip the PyObject overload from the hint: it is the one that just rejected the value
-                    var overloads = typeof(QCAlgorithm).GetMethods()
-                        .Where(method => method.Name == nameof(SetBenchmark) &&
-                            !method.GetParameters().Any(parameter => typeof(PyObject).IsAssignableFrom(parameter.ParameterType)));
                     throw new ArgumentException(
                         $"Unable to set the benchmark from {benchmark.ToDisplayString()}: it is not a supported benchmark type. " +
-                        MethodSignatureFormatter.FormatOverloads(overloads),
+                        MethodSignatureFormatter.FormatOverloads(typeof(QCAlgorithm).GetMethods().Where(m => m.Name == nameof(SetBenchmark))),
                         exception);
                 }
             }

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -1382,9 +1382,13 @@ namespace QuantConnect.Algorithm
                 }
                 catch (InvalidCastException exception)
                 {
+                    // Skip the PyObject overload from the hint: it is the one that just rejected the value
+                    var overloads = typeof(QCAlgorithm).GetMethods()
+                        .Where(method => method.Name == nameof(SetBenchmark) &&
+                            !method.GetParameters().Any(parameter => typeof(PyObject).IsAssignableFrom(parameter.ParameterType)));
                     throw new ArgumentException(
                         $"Unable to set the benchmark from {benchmark.ToDisplayString()}: it is not a supported benchmark type. " +
-                        MethodSignatureFormatter.FormatOverloads(typeof(QCAlgorithm).GetMethods().Where(m => m.Name == nameof(SetBenchmark))),
+                        MethodSignatureFormatter.FormatOverloads(overloads),
                         exception);
                 }
             }

--- a/Algorithm/QCAlgorithm.Python.cs
+++ b/Algorithm/QCAlgorithm.Python.cs
@@ -1375,7 +1375,18 @@ namespace QuantConnect.Algorithm
                     SetBenchmark(pyBenchmark);
                     return;
                 }
-                SetBenchmark((Symbol)benchmark.AsManagedObject(typeof(Symbol)));
+
+                try
+                {
+                    SetBenchmark((Symbol)benchmark.AsManagedObject(typeof(Symbol)));
+                }
+                catch (InvalidCastException exception)
+                {
+                    throw new ArgumentException(
+                        $"Unable to set the benchmark from {benchmark.ToDisplayString()}: it is not a supported benchmark type. " +
+                        "Please use one of the available method overloads.",
+                        exception);
+                }
             }
         }
 

--- a/Algorithm/QuantConnect.Algorithm.csproj
+++ b/Algorithm/QuantConnect.Algorithm.csproj
@@ -29,7 +29,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.60" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.61" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NodaTime" Version="3.0.5" />

--- a/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
+++ b/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
@@ -28,7 +28,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.60" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.61" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/Common/Data/Consolidators/BaseDataConsolidator.cs
+++ b/Common/Data/Consolidators/BaseDataConsolidator.cs
@@ -25,7 +25,7 @@ namespace QuantConnect.Data.Consolidators
     public class BaseDataConsolidator : TradeBarConsolidatorBase<BaseData>
     {
         /// <summary>
-        /// Create a new TickConsolidator for the desired resolution
+        /// Create a new BaseDataConsolidator for the desired resolution
         /// </summary>
         /// <param name="resolution">The resolution desired</param>
         /// <returns>A consolidator that produces data on the resolution interval</returns>

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -15,7 +15,6 @@
 */
 
 using System;
-using System.Linq;
 using Python.Runtime;
 using QuantConnect.Util;
 using QuantConnect.Data.Market;
@@ -112,12 +111,9 @@ namespace QuantConnect.Data.Consolidators
             catch (InvalidCastException exception)
             {
                 var type = GetType();
-                // Skip the PyObject overloads from the hint: they are the ones that just rejected the value
-                var constructors = type.GetConstructors()
-                    .Where(constructor => !constructor.GetParameters().Any(parameter => typeof(PyObject).IsAssignableFrom(parameter.ParameterType)));
                 throw new ArgumentException(
                     $"Unable to create a consolidator period from {pyObject.ToDisplayString()}: it is not a supported period type. " +
-                    MethodSignatureFormatter.FormatOverloads(constructors, displayName: type.Name),
+                    MethodSignatureFormatter.FormatOverloads(type.GetConstructors(), displayName: type.Name),
                     exception);
             }
             _period = _periodSpecification.Period;

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -385,12 +385,13 @@ namespace QuantConnect.Data.Consolidators
                 }
                 catch (InvalidCastException exception)
                 {
+                    // Display enum values as the user typed them, e.g. Resolution.DAILY instead of Daily
+                    var value = pyObject.TryConvert(out Enum enumValue)
+                        ? $"{enumValue.GetType().Name}.{enumValue.ToString().ToSnakeCase(constant: true)}"
+                        : $"'{pyObject}' of type '{pyObject.GetPythonType().Name}'";
                     throw new ArgumentException(
-                        $"Unable to create a consolidator period from the given Python object '{pyObject}' of type '{pyObject.GetPythonType().Name}': " +
-                        $"it could not be converted to any of the supported period types. Supported types are: a timedelta ({typeof(TimeSpan)}), " +
-                        $"which sets the fixed period of the consolidated bars, and a callable ({typeof(Func<DateTime, CalendarInfo>)}) that takes " +
-                        "the current datetime and returns the CalendarInfo with the start time and period of the bar it belongs to. " +
-                        "For example, for daily consolidation use timedelta(days=1) instead of Resolution.DAILY.",
+                        $"Unable to create a consolidator period from {value}: it is not a supported period type. " +
+                        "Please use one of the available constructor overloads.",
                         exception);
                 }
             }

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Linq;
 using Python.Runtime;
 using QuantConnect.Util;
 using QuantConnect.Data.Market;
@@ -111,9 +112,12 @@ namespace QuantConnect.Data.Consolidators
             catch (InvalidCastException exception)
             {
                 var type = GetType();
+                // Skip the PyObject overloads from the hint: they are the ones that just rejected the value
+                var constructors = type.GetConstructors()
+                    .Where(constructor => !constructor.GetParameters().Any(parameter => typeof(PyObject).IsAssignableFrom(parameter.ParameterType)));
                 throw new ArgumentException(
                     $"Unable to create a consolidator period from {pyObject.ToDisplayString()}: it is not a supported period type. " +
-                    MethodSignatureFormatter.FormatOverloads(type.GetConstructors(), displayName: type.Name),
+                    MethodSignatureFormatter.FormatOverloads(constructors, displayName: type.Name),
                     exception);
             }
             _period = _periodSpecification.Period;

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -103,8 +103,20 @@ namespace QuantConnect.Data.Consolidators
         /// </summary>
         /// <param name="pyObject">Python object that defines either a function object that defines the start time of a consolidated data or a timespan</param>
         protected PeriodCountConsolidatorBase(PyObject pyObject)
-            : this(GetPeriodSpecificationFromPyObject(pyObject))
         {
+            try
+            {
+                _periodSpecification = GetPeriodSpecificationFromPyObject(pyObject);
+            }
+            catch (InvalidCastException exception)
+            {
+                var type = GetType();
+                throw new ArgumentException(
+                    $"Unable to create a consolidator period from {pyObject.ToDisplayString()}: it is not a supported period type. " +
+                    MethodSignatureFormatter.FormatOverloads(type.GetConstructors(), displayName: type.Name),
+                    exception);
+            }
+            _period = _periodSpecification.Period;
         }
 
         /// <summary>
@@ -379,17 +391,7 @@ namespace QuantConnect.Data.Consolidators
 
             using (Py.GIL())
             {
-                try
-                {
-                    return new TimeSpanPeriodSpecification(pyObject.As<TimeSpan>());
-                }
-                catch (InvalidCastException exception)
-                {
-                    throw new ArgumentException(
-                        $"Unable to create a consolidator period from {pyObject.ToDisplayString()}: it is not a supported period type. " +
-                        "Please use one of the available constructor overloads.",
-                        exception);
-                }
+                return new TimeSpanPeriodSpecification(pyObject.As<TimeSpan>());
             }
         }
 

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -379,7 +379,20 @@ namespace QuantConnect.Data.Consolidators
 
             using (Py.GIL())
             {
-                return new TimeSpanPeriodSpecification(pyObject.As<TimeSpan>());
+                try
+                {
+                    return new TimeSpanPeriodSpecification(pyObject.As<TimeSpan>());
+                }
+                catch (InvalidCastException exception)
+                {
+                    throw new ArgumentException(
+                        $"Unable to create a consolidator period from the given Python object '{pyObject}' of type '{pyObject.GetPythonType().Name}': " +
+                        $"it could not be converted to any of the supported period types. Supported types are: a timedelta ({typeof(TimeSpan)}), " +
+                        $"which sets the fixed period of the consolidated bars, and a callable ({typeof(Func<DateTime, CalendarInfo>)}) that takes " +
+                        "the current datetime and returns the CalendarInfo with the start time and period of the bar it belongs to. " +
+                        "For example, for daily consolidation use timedelta(days=1) instead of Resolution.DAILY.",
+                        exception);
+                }
             }
         }
 

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -385,12 +385,8 @@ namespace QuantConnect.Data.Consolidators
                 }
                 catch (InvalidCastException exception)
                 {
-                    // Display enum values as the user typed them, e.g. Resolution.DAILY instead of Daily
-                    var value = pyObject.TryConvert(out Enum enumValue)
-                        ? $"{enumValue.GetType().Name}.{enumValue.ToString().ToSnakeCase(constant: true)}"
-                        : $"'{pyObject}' of type '{pyObject.GetPythonType().Name}'";
                     throw new ArgumentException(
-                        $"Unable to create a consolidator period from {value}: it is not a supported period type. " +
+                        $"Unable to create a consolidator period from {pyObject.ToDisplayString()}: it is not a supported period type. " +
                         "Please use one of the available constructor overloads.",
                         exception);
                 }

--- a/Common/Data/Consolidators/QuoteBarConsolidator.cs
+++ b/Common/Data/Consolidators/QuoteBarConsolidator.cs
@@ -26,6 +26,16 @@ namespace QuantConnect.Data.Consolidators
     public class QuoteBarConsolidator : PeriodCountConsolidatorBase<QuoteBar, QuoteBar>
     {
         /// <summary>
+        /// Create a new QuoteBarConsolidator for the desired resolution
+        /// </summary>
+        /// <param name="resolution">The resolution desired</param>
+        /// <returns>A consolidator that produces data on the resolution interval</returns>
+        public static QuoteBarConsolidator FromResolution(Resolution resolution)
+        {
+            return new QuoteBarConsolidator(resolution.ToTimeSpan());
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="QuoteBarConsolidator"/> class
         /// </summary>
         /// <param name="period">The minimum span of time before emitting a consolidated bar</param>

--- a/Common/Data/DynamicData.cs
+++ b/Common/Data/DynamicData.cs
@@ -59,7 +59,7 @@ namespace QuantConnect.Data
             {
                 if (value is PyObject pyobject)
                 {
-                    Time = pyobject.As<DateTime>();
+                    Time = ConvertPropertyValue<DateTime>(pyobject, name);
                 }
                 else
                 {
@@ -70,7 +70,7 @@ namespace QuantConnect.Data
             {
                 if (value is PyObject pyobject)
                 {
-                    EndTime = pyobject.As<DateTime>();
+                    EndTime = ConvertPropertyValue<DateTime>(pyobject, name);
                 }
                 else
                 {
@@ -81,7 +81,7 @@ namespace QuantConnect.Data
             {
                 if (value is PyObject pyobject)
                 {
-                    Value = pyobject.As<decimal>();
+                    Value = ConvertPropertyValue<decimal>(pyobject, name);
                 }
                 else
                 {
@@ -98,7 +98,7 @@ namespace QuantConnect.Data
                 {
                     if (value is PyObject pyobject)
                     {
-                        Symbol = pyobject.As<Symbol>();
+                        Symbol = ConvertPropertyValue<Symbol>(pyobject, name);
                     }
                     else
                     {
@@ -195,6 +195,23 @@ namespace QuantConnect.Data
                 clone._storage.Add(kvp);
             }
             return clone;
+        }
+
+        /// <summary>
+        /// Converts the given Python value into the type expected by the reserved property with the given name
+        /// </summary>
+        private static T ConvertPropertyValue<T>(PyObject value, string name)
+        {
+            try
+            {
+                return value.As<T>();
+            }
+            catch (InvalidCastException exception)
+            {
+                throw new ArgumentException(
+                    $"Unable to set the '{name}' property from {value.ToDisplayString()}: it is not a supported {typeof(T).Name} value.",
+                    exception);
+            }
         }
     }
 }

--- a/Common/Data/UniverseSelection/ScheduledUniverse.cs
+++ b/Common/Data/UniverseSelection/ScheduledUniverse.cs
@@ -72,7 +72,12 @@ namespace QuantConnect.Data.UniverseSelection
         public ScheduledUniverse(DateTimeZone timeZone, IDateRule dateRule, ITimeRule timeRule, PyObject selector, UniverseSettings settings = null)
             : base(CreateConfiguration(timeZone, dateRule, timeRule))
         {
-            selector.TrySafeAs<Func<DateTime, object>>(out var func);
+            if (!selector.TrySafeAs<Func<DateTime, object>>(out var func))
+            {
+                throw new ArgumentException(
+                    $"Unable to create a scheduled universe selector from {selector.ToDisplayString()}: it is not a function. " +
+                    "Please provide a function that takes the firing date time and returns the selected symbols.");
+            }
             _dateRule = dateRule;
             _timeRule = timeRule;
             _selector = func.ConvertSelectionSymbolDelegate();

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -3040,6 +3040,20 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Gets a string representation of the given Python object and its type
+        /// to be used in user-facing messages, e.g. "'Daily' of type 'Resolution'"
+        /// </summary>
+        /// <param name="pyObject">The Python object to represent</param>
+        /// <returns>The string representation of the Python object</returns>
+        public static string ToDisplayString(this PyObject pyObject)
+        {
+            using (Py.GIL())
+            {
+                return $"'{pyObject}' of type '{pyObject.GetPythonType().Name}'";
+            }
+        }
+
+        /// <summary>
         /// Safely convert PyObject to ManagedObject using Py.GIL Lock
         /// If no type is given it will convert the PyObject's Python Type to a ManagedObject Type
         /// in a attempt to resolve the target type to convert to.

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -35,7 +35,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.60" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.61" />
     <PackageReference Include="CloneExtensions" Version="1.3.0" />
     <PackageReference Include="fasterflect" Version="3.0.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />

--- a/Common/Securities/Security.cs
+++ b/Common/Securities/Security.cs
@@ -992,7 +992,7 @@ namespace QuantConnect.Securities
         {
             if (Cache.Properties.TryGetValue(key, out var obj))
             {
-                value = CastDynamicPropertyValue<T>(obj);
+                value = CastDynamicPropertyValue<T>(key, obj);
                 return true;
             }
             value = default;
@@ -1007,7 +1007,7 @@ namespace QuantConnect.Securities
         /// <exception cref="KeyNotFoundException">If the property is not found</exception>
         public T Get<T>(string key)
         {
-            return CastDynamicPropertyValue<T>(Cache.Properties[key]);
+            return CastDynamicPropertyValue<T>(key, Cache.Properties[key]);
         }
 
         /// <summary>
@@ -1032,7 +1032,7 @@ namespace QuantConnect.Securities
             var result = Cache.Properties.Remove(key, out object objectValue);
             if (result)
             {
-                value = CastDynamicPropertyValue<T>(objectValue);
+                value = CastDynamicPropertyValue<T>(key, objectValue);
             }
             return result;
         }
@@ -1158,7 +1158,7 @@ namespace QuantConnect.Securities
         /// Casts a dynamic property value to the specified type.
         /// Useful for cases where the property value is a PyObject and we want to cast it to the underlying type.
         /// </summary>
-        private static T CastDynamicPropertyValue<T>(object obj)
+        private static T CastDynamicPropertyValue<T>(string key, object obj)
         {
             T value;
             var pyObj = obj as PyObject;
@@ -1166,7 +1166,16 @@ namespace QuantConnect.Securities
             {
                 using (Py.GIL())
                 {
-                    value = pyObj.As<T>();
+                    try
+                    {
+                        value = pyObj.As<T>();
+                    }
+                    catch (InvalidCastException exception)
+                    {
+                        throw new InvalidCastException(
+                            $"Unable to get the '{key}' property from {pyObj.ToDisplayString()}: it is not a supported {typeof(T).Name} value.",
+                            exception);
+                    }
                 }
             }
             else

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -41,7 +41,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.60" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.61" />
     <PackageReference Include="fasterflect" Version="3.0.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -31,7 +31,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.60" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.61" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Report/QuantConnect.Report.csproj
+++ b/Report/QuantConnect.Report.csproj
@@ -39,7 +39,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.60" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.61" />
     <PackageReference Include="Deedle" Version="2.1.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/Research/QuantConnect.Research.csproj
+++ b/Research/QuantConnect.Research.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Plotly.NET" Version="5.1.0" />
     <PackageReference Include="Plotly.NET.CSharp" Version="0.13.0" />
     <PackageReference Include="Plotly.NET.Interactive" Version="5.0.0" />
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.60" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.61" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Algorithm/AlgorithmBenchmarkTests.cs
+++ b/Tests/Algorithm/AlgorithmBenchmarkTests.cs
@@ -138,9 +138,11 @@ namespace QuantConnect.Tests.Algorithm
                 using var pyBenchmark = Resolution.Daily.ToPython();
                 var exception = Assert.Throws<ArgumentException>(() => algorithm.SetBenchmark(pyBenchmark));
 
-                Assert.That(exception.Message, Does.Contain("'Daily'"));
+                // The value rendering is case-insensitive to support both pythonnet enum str() conventions ("Daily" and "DAILY")
+                Assert.That(exception.Message, Does.Contain("Daily").IgnoreCase);
                 Assert.That(exception.Message, Does.Contain("'Resolution'"));
-                Assert.That(exception.Message, Does.Contain("method overloads"));
+                Assert.That(exception.Message, Does.Contain("The following overloads are available:"));
+                Assert.That(exception.Message, Does.Contain("set_benchmark("));
                 Assert.That(exception.InnerException, Is.TypeOf<InvalidCastException>());
             }
         }

--- a/Tests/Algorithm/AlgorithmBenchmarkTests.cs
+++ b/Tests/Algorithm/AlgorithmBenchmarkTests.cs
@@ -143,6 +143,8 @@ namespace QuantConnect.Tests.Algorithm
                 Assert.That(exception.Message, Does.Contain("'Resolution'"));
                 Assert.That(exception.Message, Does.Contain("The following overloads are available:"));
                 Assert.That(exception.Message, Does.Contain("set_benchmark("));
+                // The PyObject overload that just rejected the value is not hinted
+                Assert.That(exception.Message, Does.Not.Contain("benchmark: Any"));
                 Assert.That(exception.InnerException, Is.TypeOf<InvalidCastException>());
             }
         }

--- a/Tests/Algorithm/AlgorithmBenchmarkTests.cs
+++ b/Tests/Algorithm/AlgorithmBenchmarkTests.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using NodaTime;
 using NUnit.Framework;
+using Python.Runtime;
 using QuantConnect.Algorithm;
 using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
@@ -121,6 +122,26 @@ namespace QuantConnect.Tests.Algorithm
                 default:
                     Assert.AreEqual(0, algorithm.LogMessages.Count);
                     break;
+            }
+        }
+
+        [Test]
+        public void PythonSetBenchmarkThrowsDescriptiveErrorForUnsupportedBenchmarkType()
+        {
+            var algorithm = new QCAlgorithm();
+            var dataManager = new DataManagerStub(algorithm, new MockDataFeed());
+            algorithm.SubscriptionManager.SetDataManager(dataManager);
+
+            using (Py.GIL())
+            {
+                // Not a benchmark producing function nor a symbol
+                using var pyBenchmark = Resolution.Daily.ToPython();
+                var exception = Assert.Throws<ArgumentException>(() => algorithm.SetBenchmark(pyBenchmark));
+
+                Assert.That(exception.Message, Does.Contain("'Daily'"));
+                Assert.That(exception.Message, Does.Contain("'Resolution'"));
+                Assert.That(exception.Message, Does.Contain("method overloads"));
+                Assert.That(exception.InnerException, Is.TypeOf<InvalidCastException>());
             }
         }
 

--- a/Tests/Algorithm/Framework/Alphas/BasePairsTradingAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/BasePairsTradingAlphaModelTests.cs
@@ -44,7 +44,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
         protected override string GetExpectedModelName(IAlphaModel model)
         {
-            return $"{nameof(BasePairsTradingAlphaModel)}({_lookback},{_resolution},1)";
+            return $"{nameof(BasePairsTradingAlphaModel)}({_lookback},{GetEnumString(_resolution, model)},1)";
         }
 
         protected override IAlphaModel CreatePythonAlphaModel()

--- a/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/CommonAlphaModelTests.cs
@@ -26,6 +26,7 @@ using QuantConnect.Securities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Python.Runtime;
 using QuantConnect.Algorithm;
 using QuantConnect.Python;
 using QuantConnect.Tests.Common.Data.UniverseSelection;
@@ -261,6 +262,17 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
         /// To be override for model types that implement <see cref="INamedModel"/>
         /// </summary>
         protected abstract string GetExpectedModelName(IAlphaModel model);
+
+        /// <summary>
+        /// Gets the display string of the given enum value as rendered in the model's language:
+        /// Python models render enum values in the Python convention, e.g. Resolution.Daily as DAILY
+        /// </summary>
+        protected static string GetEnumString(Enum value, IAlphaModel model)
+        {
+            return model is AlphaModelPythonWrapper
+                ? value.ToString().ToSnakeCase(constant: true)
+                : value.ToString();
+        }
 
         /// <summary>
         /// Provides derived types a chance to initialize anything special they require

--- a/Tests/Algorithm/Framework/Alphas/ConstantAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/ConstantAlphaModelTests.cs
@@ -93,7 +93,7 @@ def test_constructor():
 
         protected override string GetExpectedModelName(IAlphaModel model)
         {
-            return Invariant($"{nameof(ConstantAlphaModel)}({_type},{_direction},{_period},{_magnitude})");
+            return Invariant($"{nameof(ConstantAlphaModel)}({GetEnumString(_type, model)},{GetEnumString(_direction, model)},{_period},{_magnitude})");
         }
     }
 }

--- a/Tests/Algorithm/Framework/Alphas/EmaCrossAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/EmaCrossAlphaModelTests.cs
@@ -53,7 +53,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
         protected override string GetExpectedModelName(IAlphaModel model)
         {
-            return $"{nameof(EmaCrossAlphaModel)}(12,26,Daily)";
+            return $"{nameof(EmaCrossAlphaModel)}(12,26,{GetEnumString(Resolution.Daily, model)})";
         }
 
         [Test]

--- a/Tests/Algorithm/Framework/Alphas/MacdAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/MacdAlphaModelTests.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Algorithm.Framework.Selection;
+using QuantConnect.Indicators;
 using QuantConnect.Tests.Common.Data.UniverseSelection;
 using QuantConnect.Util;
 
@@ -53,7 +54,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
         protected override string GetExpectedModelName(IAlphaModel model)
         {
-            return $"{nameof(MacdAlphaModel)}(12,26,9,Exponential,Daily)";
+            return $"{nameof(MacdAlphaModel)}(12,26,9,{GetEnumString(MovingAverageType.Exponential, model)},{GetEnumString(Resolution.Daily, model)})";
         }
 
         [Test]

--- a/Tests/Algorithm/Framework/Alphas/RsiAlphaModelTests.cs
+++ b/Tests/Algorithm/Framework/Alphas/RsiAlphaModelTests.cs
@@ -47,7 +47,7 @@ namespace QuantConnect.Tests.Algorithm.Framework.Alphas
 
         protected override string GetExpectedModelName(IAlphaModel model)
         {
-            return $"{nameof(RsiAlphaModel)}(14,Daily)";
+            return $"{nameof(RsiAlphaModel)}(14,{GetEnumString(Resolution.Daily, model)})";
         }
     }
 }

--- a/Tests/Common/Data/DynamicDataTests.cs
+++ b/Tests/Common/Data/DynamicDataTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using Python.Runtime;
 using QuantConnect.Data;
 
 namespace QuantConnect.Tests.Common.Data
@@ -67,6 +68,36 @@ namespace QuantConnect.Tests.Common.Data
             Assert.AreEqual(value, data.Value);
             Assert.AreEqual(value, data.Price);
             Assert.AreEqual(symbol, data.Symbol);
+        }
+
+        [Test]
+        public void SettingReservedPropertyWithUnsupportedPythonValueThrowsDescriptiveError()
+        {
+            var data = new DataType();
+            using (Py.GIL())
+            {
+                using var pyString = "not a valid value".ToPython();
+                using var pyInt = 123.ToPython();
+
+                var exception = Assert.Throws<ArgumentException>(() => data.SetProperty("time", pyString));
+                Assert.That(exception.Message, Does.Contain("'time'"));
+                Assert.That(exception.Message, Does.Contain("'str'"));
+                Assert.That(exception.Message, Does.Contain(nameof(DateTime)));
+                Assert.That(exception.InnerException, Is.TypeOf<InvalidCastException>());
+
+                exception = Assert.Throws<ArgumentException>(() => data.SetProperty("end_time", pyString));
+                Assert.That(exception.Message, Does.Contain("'end_time'"));
+                Assert.That(exception.Message, Does.Contain(nameof(DateTime)));
+
+                exception = Assert.Throws<ArgumentException>(() => data.SetProperty("value", pyString));
+                Assert.That(exception.Message, Does.Contain("'value'"));
+                Assert.That(exception.Message, Does.Contain(nameof(Decimal)));
+
+                exception = Assert.Throws<ArgumentException>(() => data.SetProperty("symbol", pyInt));
+                Assert.That(exception.Message, Does.Contain("'symbol'"));
+                Assert.That(exception.Message, Does.Contain("'int'"));
+                Assert.That(exception.Message, Does.Contain(nameof(Symbol)));
+            }
         }
 
         [Test]

--- a/Tests/Common/Data/PeriodCountConsolidatorTests.cs
+++ b/Tests/Common/Data/PeriodCountConsolidatorTests.cs
@@ -395,8 +395,8 @@ namespace QuantConnect.Tests.Common.Data
                 Assert.That(exception.Message, Does.Contain("Daily").IgnoreCase);
                 Assert.That(exception.Message, Does.Contain("Resolution"));
                 Assert.That(exception.Message, Does.Contain("The following overloads are available:"));
-                Assert.That(exception.Message, Does.Contain("QuoteBarConsolidator(TimeSpan period"));
-                Assert.That(exception.Message, Does.Contain("QuoteBarConsolidator(Int32 max_count"));
+                Assert.That(exception.Message, Does.Contain("QuoteBarConsolidator(timedelta period"));
+                Assert.That(exception.Message, Does.Contain("QuoteBarConsolidator(int max_count"));
                 Assert.That(exception.InnerException, Is.TypeOf<InvalidCastException>());
             }
         }

--- a/Tests/Common/Data/PeriodCountConsolidatorTests.cs
+++ b/Tests/Common/Data/PeriodCountConsolidatorTests.cs
@@ -390,10 +390,13 @@ namespace QuantConnect.Tests.Common.Data
                 using var pyResolution = Resolution.Daily.ToPython();
                 var exception = Assert.Throws<ArgumentException>(() => new QuoteBarConsolidator(pyResolution));
 
-                // The error must state the source value as the user typed it and point to the constructor overloads
-                Assert.That(exception.Message, Does.Contain("Daily"));
+                // The error must state the source value and its type and list the available constructor overloads.
+                // The value rendering is case-insensitive to support both pythonnet enum str() conventions ("Daily" and "DAILY")
+                Assert.That(exception.Message, Does.Contain("Daily").IgnoreCase);
                 Assert.That(exception.Message, Does.Contain("Resolution"));
-                Assert.That(exception.Message, Does.Contain("constructor overloads"));
+                Assert.That(exception.Message, Does.Contain("The following overloads are available:"));
+                Assert.That(exception.Message, Does.Contain("QuoteBarConsolidator(TimeSpan period"));
+                Assert.That(exception.Message, Does.Contain("QuoteBarConsolidator(Int32 max_count"));
                 Assert.That(exception.InnerException, Is.TypeOf<InvalidCastException>());
             }
         }

--- a/Tests/Common/Data/PeriodCountConsolidatorTests.cs
+++ b/Tests/Common/Data/PeriodCountConsolidatorTests.cs
@@ -391,10 +391,28 @@ namespace QuantConnect.Tests.Common.Data
                 var exception = Assert.Throws<ArgumentException>(() => new QuoteBarConsolidator(pyResolution));
 
                 // The error must state the source value as the user typed it and point to the constructor overloads
-                Assert.That(exception.Message, Does.Contain("Resolution.DAILY"));
+                Assert.That(exception.Message, Does.Contain("Daily"));
+                Assert.That(exception.Message, Does.Contain("Resolution"));
                 Assert.That(exception.Message, Does.Contain("constructor overloads"));
                 Assert.That(exception.InnerException, Is.TypeOf<InvalidCastException>());
             }
+        }
+
+        [Test]
+        public void QuoteBarConsolidatorFromResolutionCreatesConsolidatorWithExpectedPeriod()
+        {
+            var time = new DateTime(2015, 04, 13);
+            QuoteBar consolidated = null;
+            using var consolidator = QuoteBarConsolidator.FromResolution(Resolution.Minute);
+            consolidator.DataConsolidated += (sender, bar) => consolidated = bar;
+
+            consolidator.Update(new QuoteBar { Time = time, Period = Time.OneSecond });
+            Assert.IsNull(consolidated);
+
+            consolidator.Update(new QuoteBar { Time = time.AddMinutes(1), Period = Time.OneSecond });
+            Assert.IsNotNull(consolidated);
+            Assert.AreEqual(Time.OneMinute, consolidated.Period);
+            Assert.AreEqual(time, consolidated.Time);
         }
 
         private static void PushBarsThrough(int barCount, TimeSpan period, TradeBarConsolidator consolidator, ref DateTime time)

--- a/Tests/Common/Data/PeriodCountConsolidatorTests.cs
+++ b/Tests/Common/Data/PeriodCountConsolidatorTests.cs
@@ -395,8 +395,10 @@ namespace QuantConnect.Tests.Common.Data
                 Assert.That(exception.Message, Does.Contain("Daily").IgnoreCase);
                 Assert.That(exception.Message, Does.Contain("Resolution"));
                 Assert.That(exception.Message, Does.Contain("The following overloads are available:"));
-                Assert.That(exception.Message, Does.Contain("QuoteBarConsolidator(timedelta period"));
-                Assert.That(exception.Message, Does.Contain("QuoteBarConsolidator(int max_count"));
+                Assert.That(exception.Message, Does.Contain("QuoteBarConsolidator(period: timedelta"));
+                Assert.That(exception.Message, Does.Contain("QuoteBarConsolidator(max_count: int"));
+                // The PyObject overload that just rejected the value is not hinted
+                Assert.That(exception.Message, Does.Not.Contain("pyfuncobj"));
                 Assert.That(exception.InnerException, Is.TypeOf<InvalidCastException>());
             }
         }

--- a/Tests/Common/Data/PeriodCountConsolidatorTests.cs
+++ b/Tests/Common/Data/PeriodCountConsolidatorTests.cs
@@ -390,13 +390,9 @@ namespace QuantConnect.Tests.Common.Data
                 using var pyResolution = Resolution.Daily.ToPython();
                 var exception = Assert.Throws<ArgumentException>(() => new QuoteBarConsolidator(pyResolution));
 
-                // The error must state the source object and its type, the supported target types and the failure reason
-                Assert.That(exception.Message, Does.Contain("'Resolution'"));
-                Assert.That(exception.Message, Does.Contain($"'{pyResolution}'"));
-                Assert.That(exception.Message, Does.Contain("timedelta"));
-                Assert.That(exception.Message, Does.Contain(typeof(TimeSpan).ToString()));
-                Assert.That(exception.Message, Does.Contain(typeof(Func<DateTime, CalendarInfo>).ToString()));
-                Assert.That(exception.Message, Does.Contain("could not be converted"));
+                // The error must state the source value as the user typed it and point to the constructor overloads
+                Assert.That(exception.Message, Does.Contain("Resolution.DAILY"));
+                Assert.That(exception.Message, Does.Contain("constructor overloads"));
                 Assert.That(exception.InnerException, Is.TypeOf<InvalidCastException>());
             }
         }

--- a/Tests/Common/Data/PeriodCountConsolidatorTests.cs
+++ b/Tests/Common/Data/PeriodCountConsolidatorTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using Python.Runtime;
 using QuantConnect.Data;
 using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
@@ -377,6 +378,27 @@ namespace QuantConnect.Tests.Common.Data
             Assert.IsNotNull(consolidated);
             Assert.AreEqual(Symbols.SPY, consolidated.Symbol);
             Assert.AreEqual(expectedEndTime, consolidated.EndTime);
+        }
+
+        [Test]
+        public void PyObjectConstructorThrowsDescriptiveErrorForUnsupportedPeriodType()
+        {
+            using (Py.GIL())
+            {
+                // A Resolution enum value is neither a timedelta nor a callable returning CalendarInfo,
+                // so the consolidator cannot create a period specification from it
+                using var pyResolution = Resolution.Daily.ToPython();
+                var exception = Assert.Throws<ArgumentException>(() => new QuoteBarConsolidator(pyResolution));
+
+                // The error must state the source object and its type, the supported target types and the failure reason
+                Assert.That(exception.Message, Does.Contain("'Resolution'"));
+                Assert.That(exception.Message, Does.Contain($"'{pyResolution}'"));
+                Assert.That(exception.Message, Does.Contain("timedelta"));
+                Assert.That(exception.Message, Does.Contain(typeof(TimeSpan).ToString()));
+                Assert.That(exception.Message, Does.Contain(typeof(Func<DateTime, CalendarInfo>).ToString()));
+                Assert.That(exception.Message, Does.Contain("could not be converted"));
+                Assert.That(exception.InnerException, Is.TypeOf<InvalidCastException>());
+            }
         }
 
         private static void PushBarsThrough(int barCount, TimeSpan period, TradeBarConsolidator consolidator, ref DateTime time)

--- a/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
+++ b/Tests/Common/Data/UniverseSelection/ScheduledUniverseTests.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NodaTime;
 using NUnit.Framework;
+using Python.Runtime;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Scheduling;
 using QuantConnect.Securities;
@@ -100,6 +101,21 @@ namespace QuantConnect.Tests.Common.Data.UniverseSelection
 
             // Assert that there are no trigger times because 12PM is after the end time of 11AM
             Assert.IsEmpty(triggerTimes);
+        }
+
+        [Test]
+        public void PythonConstructorThrowsDescriptiveErrorWhenSelectorIsNotAFunction()
+        {
+            using (Py.GIL())
+            {
+                using var pySelector = "not a function".ToPython();
+                var exception = Assert.Throws<ArgumentException>(() =>
+                    new ScheduledUniverse(_dateRules.EveryDay(), _timeRules.At(12, 0), pySelector));
+
+                Assert.That(exception.Message, Does.Contain("'not a function'"));
+                Assert.That(exception.Message, Does.Contain("'str'"));
+                Assert.That(exception.Message, Does.Contain("it is not a function"));
+            }
         }
 
         [Test]

--- a/Tests/Common/Securities/SecurityTests.cs
+++ b/Tests/Common/Securities/SecurityTests.cs
@@ -461,6 +461,22 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [Test]
+        public void GettingPythonCustomPropertyWithIncompatibleTypeThrowsDescriptiveError()
+        {
+            var security = GetSecurity();
+            using (Py.GIL())
+            {
+                security.Set("StringProperty", "a string value".ToPython());
+
+                var exception = Assert.Throws<InvalidCastException>(() => security.Get<decimal>("StringProperty"));
+                Assert.That(exception.Message, Does.Contain("'StringProperty'"));
+                Assert.That(exception.Message, Does.Contain("'str'"));
+                Assert.That(exception.Message, Does.Contain(nameof(Decimal)));
+                Assert.That(exception.InnerException, Is.TypeOf<InvalidCastException>());
+            }
+        }
+
+        [Test]
         public void SetsAndGetsDynamicCustomPropertiesUsingIndexer()
         {
             var security = GetSecurity();

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.60" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.61" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Math" Version="3.6.0" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />


### PR DESCRIPTION
#### Description

Passing an unsupported Python object to several user-facing APIs surfaces pythonnet's raw conversion error, which gives the user no hint about what went wrong or how to fix it. For example:

```python
consolidator = QuoteBarConsolidator(Resolution.DAILY)
```

fails with:

```
cannot convert object to target type
```

Since none of the constructor overloads accept a `Resolution`, the call binds to the `PyObject` overload, whose handling in `PeriodCountConsolidatorBase.GetPeriodSpecificationFromPyObject` only supports a `timedelta` or a callable returning a `CalendarInfo`. The fallback `pyObject.As<TimeSpan>()` conversion throws a raw `InvalidCastException`.

This change catches these conversion failures and throws descriptive exceptions instead, stating the given value and its Python type and listing the available overloads, keeping the original exception as inner exception:

```
Unable to create a consolidator period from 'DAILY' of type 'Resolution': it is not a supported period type. The following overloads are available:
  QuoteBarConsolidator(period: timedelta, start_time: Optional[timedelta] = None)
  QuoteBarConsolidator(max_count: int)
  QuoteBarConsolidator(max_count: int, period: timedelta)
  QuoteBarConsolidator(func: Callable[[datetime], CalendarInfo])
```

The overloads are rendered as Python signatures (snake_case names, `name: type` annotations, Python types). The `PyObject` overloads — the ones that just rejected the value — are excluded from the hint.

The overload list is rendered by `MethodSignatureFormatter`, the helper exposed by QuantConnect/pythonnet#136 (the same formatting pythonnet uses for its "No method matches given arguments" hint). **This PR therefore depends on that pythonnet PR being merged and released as 2.0.61** (the reference is already bumped here) — CI will fail until the package is published.

A new `PyObject.ToDisplayString()` extension centralizes the value-and-type rendering, and the same pattern is applied to the other user-facing conversion sites that surfaced the same raw error:

- `PeriodCountConsolidatorBase(PyObject)` — all period-based consolidator constructors (`TradeBarConsolidator`, `QuoteBarConsolidator`, `TickConsolidator`, etc.)
- `QCAlgorithm.SetBenchmark(PyObject)` — non-callable, non-Symbol benchmark arguments
- `DynamicData.SetProperty` — assigning incompatible Python values to the reserved `time`/`end_time`/`value`/`symbol` properties of custom data, now naming the offending property
- `Security.Get<T>`/`TryGet<T>`/`Remove<T>` custom properties — reading a Python-stored property with an incompatible type now names the property key and target type (still `InvalidCastException`, as documented)
- `ScheduledUniverse` / `ScheduledUniverseSelectionModel` Python constructors — a non-callable selector now throws a descriptive `ArgumentException` instead of failing later with a `NullReferenceException`

Additionally, `QuoteBarConsolidator.FromResolution(Resolution)` is added, matching the existing helper in `TradeBarConsolidator`, `BaseDataConsolidator` and `OpenInterestConsolidator`, so a quote bar consolidator can be created directly from a `Resolution`.

#### Related Issue

N/A

Related PR: QuantConnect/pythonnet#136 — exposes the `MethodSignatureFormatter` helper this PR uses to render the overload lists. The `QuantConnect.pythonnet` reference is already bumped to 2.0.61 here (the version being released by QuantConnect/pythonnet#135); CI will pass once that package is published with #136 included.

#### Motivation and Context

The raw pythonnet error `cannot convert object to target type` surfaces directly to Python algorithm users during algorithm initialization and gives them no information about which argument is wrong, why, or what to use instead. This is a common stumbling block since other APIs (e.g. `self.consolidate`) do accept a `Resolution`, making it natural for users to try passing one to the consolidator constructors.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

- New unit tests covering each improved error site:
  - `PeriodCountConsolidatorTests.PyObjectConstructorThrowsDescriptiveErrorForUnsupportedPeriodType`
  - `PeriodCountConsolidatorTests.QuoteBarConsolidatorFromResolutionCreatesConsolidatorWithExpectedPeriod`
  - `AlgorithmBenchmarkTests.PythonSetBenchmarkThrowsDescriptiveErrorForUnsupportedBenchmarkType`
  - `DynamicDataTests.SettingReservedPropertyWithUnsupportedPythonValueThrowsDescriptiveError`
  - `SecurityTests.GettingPythonCustomPropertyWithIncompatibleTypeThrowsDescriptiveError`
  - `ScheduledUniverseTests.PythonConstructorThrowsDescriptiveErrorWhenSelectorIsNotAFunction`
- Ran the full `PeriodCountConsolidatorTests`, `CalendarConsolidatorsTests`, `DynamicDataTests` and `ScheduledUniverseTests` suites, which cover the supported conversion paths (Python callables, `timedelta`, valid property values), to verify no behavior change.
- Reproduced the original consolidator error end-to-end with a Python algorithm running through the Lean launcher and verified the new message is shown after the change.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
