### PR TITLE
Allow option filter functions to return None/null

### DIFF
--- a/Algorithm.CSharp/OptionFilterReturnsNullRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionFilterReturnsNullRegressionAlgorithm.cs
@@ -1,0 +1,153 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting that the option filter function is allowed to return null (None in Python):
+    /// the filter methods modify the universe in place, so returning it is only necessary for chaining.
+    /// </summary>
+    public class OptionFilterReturnsNullRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private const string UnderlyingTicker = "GOOG";
+        private Symbol _optionSymbol;
+        private bool _optionChainReceived;
+
+        public override void Initialize()
+        {
+            SetStartDate(2015, 12, 24);
+            SetEndDate(2015, 12, 24);
+            SetCash(100000);
+
+            var equity = AddEquity(UnderlyingTicker);
+            var option = AddOption(UnderlyingTicker);
+            _optionSymbol = option.Symbol;
+
+            // set our strike/expiry filter for this option chain without returning the universe:
+            // it is modified in place by the filter methods, returning it is only necessary for chaining
+            option.SetFilter(universe =>
+            {
+                universe.StandardsOnly().Strikes(-2, +2).Expiration(0, 180);
+                return null;
+            });
+
+            // use the underlying equity as the benchmark
+            SetBenchmark(equity.Symbol);
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (!Portfolio.Invested && IsMarketOpen(_optionSymbol))
+            {
+                OptionChain chain;
+                if (slice.OptionChains.TryGetValue(_optionSymbol, out chain) && chain.Any())
+                {
+                    _optionChainReceived = true;
+
+                    // we find at the money (ATM) put contract with farthest expiration
+                    var atmContract = chain
+                        .OrderByDescending(x => x.Expiry)
+                        .ThenBy(x => Math.Abs(chain.Underlying.Price - x.Strike))
+                        .ThenByDescending(x => x.Right)
+                        .FirstOrDefault();
+
+                    if (atmContract != null)
+                    {
+                        // if found, trade it
+                        MarketOrder(atmContract.Symbol, 1);
+                        MarketOnCloseOrder(atmContract.Symbol, -1);
+                    }
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_optionChainReceived)
+            {
+                throw new RegressionTestException("The option filter did not select any contracts");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 15012;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "2"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "99718"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$2.00"},
+            {"Estimated Strategy Capacity", "$1300000.00"},
+            {"Lowest Capacity Asset", "GOOCV 30AKMEIPOX2DI|GOOCV VP83T1ZUHROL"},
+            {"Portfolio Turnover", "10.71%"},
+            {"Drawdown Recovery", "0"},
+            {"OrderListHash", "19ba1220073493495880581b38df2da9"}
+        };
+    }
+}

--- a/Algorithm.Python/OptionFilterReturnsNullRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionFilterReturnsNullRegressionAlgorithm.py
@@ -1,0 +1,67 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression algorithm asserting that the option filter function is allowed to return None (null in C#):
+### the filter methods modify the universe in place, so returning it is only necessary for chaining.
+### </summary>
+class OptionFilterReturnsNullRegressionAlgorithm(QCAlgorithm):
+    underlying_ticker = "GOOG"
+
+    def initialize(self):
+        self.set_start_date(2015, 12, 24)
+        self.set_end_date(2015, 12, 24)
+        self.set_cash(100000)
+
+        equity = self.add_equity(self.underlying_ticker)
+        option = self.add_option(self.underlying_ticker)
+        self.option_symbol = option.symbol
+        self._option_chain_received = False
+
+        # set our strike/expiry filter for this option chain without returning the universe:
+        # it is modified in place by the filter methods, returning it is only necessary for chaining
+        option.set_filter(self._option_filter)
+
+        # use the underlying equity as the benchmark
+        self.set_benchmark(equity.symbol)
+
+    def _option_filter(self, universe: OptionFilterUniverse) -> None:
+        universe.standards_only().strikes(-2, +2).expiration(0, 180)
+
+    def on_data(self, slice):
+        if self.portfolio.invested or not self.is_market_open(self.option_symbol):
+            return
+
+        chain = slice.option_chains.get(self.option_symbol)
+        if not chain:
+            return
+
+        self._option_chain_received = True
+
+        # we find at the money (ATM) put contract with farthest expiration
+        contracts = sorted(sorted(sorted(chain, \
+            key = lambda x: abs(chain.underlying.price - x.strike)), \
+            key = lambda x: x.expiry, reverse=True), \
+            key = lambda x: x.right, reverse=True)
+
+        # if found, trade it
+        if len(contracts) == 0: return
+        symbol = contracts[0].symbol
+        self.market_order(symbol, 1)
+        self.market_on_close_order(symbol, -1)
+
+    def on_end_of_algorithm(self):
+        if not self._option_chain_received:
+            raise Exception("The option filter did not select any contracts")

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -600,6 +600,13 @@ namespace QuantConnect.Securities.Option
                     OptionFilterUniverse filter;
                     List<Symbol> list;
 
+                    //A None result is allowed: filter methods modify the universe in place,
+                    //returning it is only necessary for chaining
+                    if (result == null || result.IsNone())
+                    {
+                        return optionUniverse.ApplyTypesFilter();
+                    }
+
                     if ((result).TryConvert(out filter))
                     {
                         optionUniverse = filter;

--- a/Common/Securities/Option/Option.cs
+++ b/Common/Securities/Option/Option.cs
@@ -574,7 +574,9 @@ namespace QuantConnect.Securities.Option
             ContractFilter = new FuncSecurityDerivativeFilter<OptionUniverse>(universe =>
             {
                 var optionUniverse = universe as OptionFilterUniverse;
-                var result = universeFunc(optionUniverse);
+                //A null result is allowed: filter methods modify the universe in place,
+                //returning it is only necessary for chaining
+                var result = universeFunc(optionUniverse) ?? optionUniverse;
                 return result.ApplyTypesFilter();
             });
             ContractFilter.Asynchronous = false;

--- a/Tests/Python/PythonOptionTests.cs
+++ b/Tests/Python/PythonOptionTests.cs
@@ -15,9 +15,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using Python.Runtime;
 using QuantConnect.Algorithm;
+using QuantConnect.Data.Market;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.Securities;
 using QuantConnect.Statistics;
 using QuantConnect.Tests.Engine.DataFeeds;
 
@@ -70,6 +74,44 @@ namespace QuantConnect.Tests.Python
                 var filterFunction = module.GetAttr("filter");
                 Assert.DoesNotThrow(() => spyOption.SetFilter(filterFunction));
             }
+        }
+
+        [Test]
+        public void PythonFilterFunctionReturnsNone()
+        {
+            var algorithm = new QCAlgorithm();
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
+            var spyOption = algorithm.AddOption("SPY");
+
+            using (Py.GIL())
+            {
+                //Filter function that modifies the universe in place and returns None:
+                //the return value is only necessary for chaining
+                var module = PyModule.FromString(Guid.NewGuid().ToString(),
+                    "def filter(universe):\n" +
+                    "   universe.strikes(-20, 20).expiration(0, 10)\n"
+                );
+
+                var filterFunction = module.GetAttr("filter");
+                spyOption.SetFilter(filterFunction);
+            }
+
+            var underlying = new Tick { Value = 10m, Time = new DateTime(2016, 12, 29) };
+            var symbols = new[]
+            {
+                // within the 0-10 days expiration window
+                Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, OptionRight.Call, 10, new DateTime(2017, 01, 04)),
+                Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, OptionRight.Put, 10, new DateTime(2017, 01, 06)),
+                // beyond the 0-10 days expiration window
+                Symbol.CreateOption("SPY", Market.USA, OptionStyle.American, OptionRight.Call, 10, new DateTime(2017, 01, 20)),
+            };
+
+            var data = symbols.Select(x => new OptionUniverse() { Symbol = x }).ToList();
+            var filtered = spyOption.ContractFilter.Filter(new OptionFilterUniverse(spyOption, data, underlying)).ToList();
+
+            Assert.AreEqual(2, filtered.Count);
+            Assert.AreEqual(symbols[0], filtered[0].Symbol);
+            Assert.AreEqual(symbols[1], filtered[1].Symbol);
         }
 
         [Test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Allows option filter functions to return `None` (Python) / `null` (C#) from `Option.SetFilter()`. The `OptionFilterUniverse` is modified in place by the filter methods (`Strikes()`, `Expiration()`, etc.), so returning the universe is only necessary for chaining. A filter like the following would previously kill the algorithm with a `NullReferenceException` during universe selection because it implicitly returns `None`:

```python
def _option_filter(self, universe: OptionFilterUniverse) -> None:
    universe.strikes(-20, 20).expiration(0, 0)   # no return -> None
```

When the filter function returns `None`/`null`, the universe instance that was passed to the function is now used as is. This also covers index options, since `IndexOption` shares `Option`'s filter setup.

#### Related Issue
N/A

#### Motivation and Context
Mutating the universe without returning it is a natural way to write a filter function, especially in Python where a function without a `return` statement implicitly returns `None`. Instead of crashing the algorithm with an unhelpful `NullReferenceException`, the already-filtered universe is used.

#### Requires Documentation Change
It could be documented that returning the universe from option filter functions is optional and only necessary for chaining.

#### How Has This Been Tested?
- New unit test `PythonOptionTests.PythonFilterFunctionReturnsNone` reproduces the bug (fails with `NullReferenceException` without the fix) by invoking the contract filter with a Python filter function that returns `None`, and asserts the in-place filters are applied.
- New regression algorithm `OptionFilterReturnsNullRegressionAlgorithm` (C# and Python) illustrates a filter function that modifies the universe in place and returns `null`/`None`, asserting contracts are selected and traded.
- Existing `PythonOptionTests` and option filter tests pass.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
