### PR TITLE
Add scheduled walk-forward optimization support

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -58,6 +58,9 @@ using QuantConnect.Commands;
 using Newtonsoft.Json;
 using QuantConnect.Securities.Index;
 using QuantConnect.Api;
+using QuantConnect.Optimizer;
+using QuantConnect.Optimizer.Objectives;
+using QuantConnect.Optimizer.Parameters;
 using Common.Util;
 
 namespace QuantConnect.Algorithm
@@ -165,6 +168,7 @@ namespace QuantConnect.Algorithm
         private readonly HistoryRequestFactory _historyRequestFactory;
 
         private IApi _api;
+        private IWalkForwardOptimizationProvider _walkForwardOptimizationProvider = NullWalkForwardOptimizationProvider.Instance;
 
         /// <summary>
         /// QCAlgorithm Base Class Constructor - Initialize the underlying QCAlgorithm components.
@@ -3137,6 +3141,107 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Schedules a walk-forward optimization using the specified date and time rules.
+        /// </summary>
+        /// <param name="dateRule">Specifies what dates the optimization should run</param>
+        /// <param name="timeRule">Specifies the times on those dates the optimization should run</param>
+        /// <param name="target">The optimization target used to select the winning parameter set</param>
+        /// <param name="parameters">The optimization parameters to evaluate</param>
+        /// <param name="constraints">The optional constraints to apply to optimization results</param>
+        [DocumentationAttribute(ParameterAndOptimization)]
+        [DocumentationAttribute(ScheduledEvents)]
+        public ScheduledEvent Optimize(
+            IDateRule dateRule,
+            ITimeRule timeRule,
+            Target target,
+            HashSet<OptimizationParameter> parameters,
+            IReadOnlyList<Constraint> constraints = null)
+        {
+            if (target == null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
+
+            return ScheduleWalkForwardOptimization(dateRule, timeRule, triggerTime =>
+                new WalkForwardOptimizationRequest(this, triggerTime, target, parameters, constraints));
+        }
+
+        /// <summary>
+        /// Schedules a walk-forward optimization using the specified date and time rules.
+        /// </summary>
+        /// <param name="dateRule">Specifies what dates the optimization should run</param>
+        /// <param name="timeRule">Specifies the times on those dates the optimization should run</param>
+        /// <param name="targetSelector">Selects the winning parameter set from optimization backtests</param>
+        /// <param name="parameters">The optimization parameters to evaluate</param>
+        /// <param name="constraints">The optional constraints to apply to optimization results</param>
+        [DocumentationAttribute(ParameterAndOptimization)]
+        [DocumentationAttribute(ScheduledEvents)]
+        public ScheduledEvent Optimize(
+            IDateRule dateRule,
+            ITimeRule timeRule,
+            Func<IReadOnlyList<OptimizationBacktest>, ParameterSet> targetSelector,
+            HashSet<OptimizationParameter> parameters,
+            IReadOnlyList<Constraint> constraints = null)
+        {
+            if (targetSelector == null)
+            {
+                throw new ArgumentNullException(nameof(targetSelector));
+            }
+
+            return ScheduleWalkForwardOptimization(dateRule, timeRule, triggerTime =>
+                new WalkForwardOptimizationRequest(this, triggerTime, targetSelector, parameters, constraints));
+        }
+
+        private ScheduledEvent ScheduleWalkForwardOptimization(
+            IDateRule dateRule,
+            ITimeRule timeRule,
+            Func<DateTime, WalkForwardOptimizationRequest> requestFactory)
+        {
+            if (dateRule == null)
+            {
+                throw new ArgumentNullException(nameof(dateRule));
+            }
+            if (timeRule == null)
+            {
+                throw new ArgumentNullException(nameof(timeRule));
+            }
+            if (requestFactory == null)
+            {
+                throw new ArgumentNullException(nameof(requestFactory));
+            }
+
+            var name = $"Optimization: {dateRule.Name}: {timeRule.Name}";
+            return Schedule.On(name, dateRule, timeRule, (eventName, triggerTime) =>
+            {
+                RunWalkForwardOptimization(requestFactory(triggerTime));
+            });
+        }
+
+        private void RunWalkForwardOptimization(WalkForwardOptimizationRequest request)
+        {
+            if (AlgorithmMode == AlgorithmMode.Optimization)
+            {
+                Debug("Skipping walk-forward optimization because this algorithm is already running as an optimization child.");
+                return;
+            }
+
+            var result = _walkForwardOptimizationProvider.Optimize(request);
+            var parameterSet = result?.ParameterSet;
+            if (parameterSet == null && request.TargetSelector != null)
+            {
+                parameterSet = request.TargetSelector(result?.Backtests ?? Array.Empty<OptimizationBacktest>());
+            }
+
+            if (parameterSet?.Value == null)
+            {
+                Debug("Walk-forward optimization completed without a selected parameter set.");
+                return;
+            }
+
+            SetParameters(parameterSet.Value.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+        }
+
+        /// <summary>
         /// Event invocator for the <see cref="InsightsGenerated"/> event
         /// </summary>
         /// <param name="insights">The collection of insights generaed at the current time step</param>
@@ -3173,6 +3278,16 @@ namespace QuantConnect.Algorithm
         public void SetApi(IApi api)
         {
             _api = api;
+        }
+
+        /// <summary>
+        /// Sets the walk-forward optimization provider.
+        /// </summary>
+        /// <param name="provider">The provider used to run walk-forward optimizations</param>
+        [DocumentationAttribute(ParameterAndOptimization)]
+        public void SetWalkForwardOptimizationProvider(IWalkForwardOptimizationProvider provider)
+        {
+            _walkForwardOptimizationProvider = provider ?? throw new ArgumentNullException(nameof(provider));
         }
 
         /// <summary>

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -1130,6 +1130,12 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         public void SetHistoryProvider(IHistoryProvider historyProvider) => _baseAlgorithm.SetHistoryProvider(historyProvider);
 
         /// <summary>
+        /// Sets the walk-forward optimization provider.
+        /// </summary>
+        /// <param name="provider">Walk-forward optimization provider</param>
+        public void SetWalkForwardOptimizationProvider(IWalkForwardOptimizationProvider provider) => _baseAlgorithm.SetWalkForwardOptimizationProvider(provider);
+
+        /// <summary>
         /// Set live mode state of the algorithm run: Public setter for the algorithm property LiveMode.
         /// </summary>
         /// <param name="live">Bool live mode flag</param>

--- a/Api/ApiWalkForwardOptimizationProvider.cs
+++ b/Api/ApiWalkForwardOptimizationProvider.cs
@@ -1,0 +1,121 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using QuantConnect.Interfaces;
+using QuantConnect.Optimizer;
+using QuantConnect.Util;
+
+namespace QuantConnect.Api
+{
+    /// <summary>
+    /// Runs scheduled walk-forward optimization using the QuantConnect cloud API optimization endpoints.
+    /// </summary>
+    public class ApiWalkForwardOptimizationProvider : IWalkForwardOptimizationProvider
+    {
+        private readonly IApi _api;
+
+        /// <summary>
+        /// Creates a new instance using the configured API client.
+        /// </summary>
+        public ApiWalkForwardOptimizationProvider()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance using the specified API client.
+        /// </summary>
+        /// <param name="api">The API client</param>
+        public ApiWalkForwardOptimizationProvider(IApi api)
+        {
+            _api = api;
+        }
+
+        /// <summary>
+        /// Runs a cloud optimization for the specified walk-forward request.
+        /// </summary>
+        /// <param name="request">The walk-forward optimization request</param>
+        /// <returns>The walk-forward optimization result</returns>
+        public WalkForwardOptimizationResult Optimize(WalkForwardOptimizationRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            if (request.Algorithm.ProjectId <= 0)
+            {
+                throw new InvalidOperationException("Walk-forward cloud optimization requires a configured project id.");
+            }
+
+            var settings = WalkForwardOptimizationCloudSettings.Read(request);
+            var optimization = CreateAndWaitForOptimization(request, settings);
+            var backtests = optimization.Backtests?.Values.ToList() ?? new List<OptimizationBacktest>();
+            var parameterSet = request.TargetSelector == null
+                ? WalkForwardOptimizationBacktestSelector.SelectParameterSet(settings.Target, backtests)
+                : null;
+
+            return new WalkForwardOptimizationResult(parameterSet, backtests);
+        }
+
+        /// <summary>
+        /// Gets the API client used to submit and poll cloud optimizations.
+        /// </summary>
+        protected virtual IApi ApiClient => _api ?? Composer.Instance.GetPart<IApi>();
+
+        private Optimization CreateAndWaitForOptimization(WalkForwardOptimizationRequest request, WalkForwardOptimizationCloudSettings settings)
+        {
+            var summary = ApiClient.CreateOptimization(
+                request.Algorithm.ProjectId,
+                settings.Name,
+                settings.Target.Target,
+                settings.TargetTo,
+                settings.Target.TargetValue,
+                settings.Strategy,
+                settings.CompileId,
+                request.Parameters,
+                request.Constraints,
+                settings.EstimatedCost,
+                settings.NodeType,
+                settings.ParallelNodes);
+
+            if (string.IsNullOrWhiteSpace(summary?.OptimizationId))
+            {
+                throw new InvalidOperationException("Walk-forward cloud optimization did not return an optimization id.");
+            }
+
+            var timeoutUtc = DateTime.UtcNow.AddMinutes(settings.TimeoutMinutes);
+            while (true)
+            {
+                var optimization = ApiClient.ReadOptimization(summary.OptimizationId);
+                if (optimization?.Status == OptimizationStatus.Completed)
+                {
+                    return optimization;
+                }
+                if (optimization?.Status == OptimizationStatus.Aborted)
+                {
+                    throw new InvalidOperationException($"Walk-forward cloud optimization '{summary.OptimizationId}' was aborted.");
+                }
+                if (settings.TimeoutMinutes >= 0 && DateTime.UtcNow >= timeoutUtc)
+                {
+                    throw new TimeoutException($"Walk-forward cloud optimization '{summary.OptimizationId}' timed out after {settings.TimeoutMinutes} minutes.");
+                }
+                if (settings.PollIntervalSeconds > 0)
+                {
+                    Thread.Sleep(TimeSpan.FromSeconds(settings.PollIntervalSeconds));
+                }
+            }
+        }
+    }
+}

--- a/Api/WalkForwardOptimizationBacktestSelector.cs
+++ b/Api/WalkForwardOptimizationBacktestSelector.cs
@@ -1,0 +1,118 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using QuantConnect.Optimizer.Objectives;
+using QuantConnect.Optimizer.Parameters;
+
+namespace QuantConnect.Api
+{
+    /// <summary>
+    /// Selects the best parameter set from cloud optimization backtests.
+    /// </summary>
+    internal static class WalkForwardOptimizationBacktestSelector
+    {
+        /// <summary>
+        /// Selects the best parameter set according to the specified target.
+        /// </summary>
+        public static ParameterSet SelectParameterSet(Target target, IReadOnlyList<OptimizationBacktest> backtests)
+        {
+            OptimizationBacktest bestBacktest = null;
+            decimal bestValue = 0;
+
+            foreach (var backtest in backtests.Where(backtest => backtest?.ParameterSet != null))
+            {
+                if (!TryGetTargetValue(backtest.Statistics, target.Target, out var targetValue))
+                {
+                    continue;
+                }
+                if (bestBacktest == null || target.Extremum.Better(bestValue, targetValue))
+                {
+                    bestBacktest = backtest;
+                    bestValue = targetValue;
+                }
+            }
+
+            return bestBacktest?.ParameterSet;
+        }
+
+        private static bool TryGetTargetValue(IDictionary<string, string> statistics, string targetPath, out decimal targetValue)
+        {
+            targetValue = 0;
+            if (statistics == null)
+            {
+                return false;
+            }
+
+            foreach (var targetKey in GetCandidateStatisticKeys(targetPath))
+            {
+                var statistic = statistics.FirstOrDefault(kvp => string.Equals(kvp.Key, targetKey, StringComparison.OrdinalIgnoreCase));
+                if (statistic.Key != null && TryParseStatistic(statistic.Value, out targetValue))
+                {
+                    return true;
+                }
+
+                statistic = statistics.FirstOrDefault(kvp => string.Equals(RemoveWhitespace(kvp.Key), RemoveWhitespace(targetKey), StringComparison.OrdinalIgnoreCase));
+                if (statistic.Key != null && TryParseStatistic(statistic.Value, out targetValue))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static IEnumerable<string> GetCandidateStatisticKeys(string targetPath)
+        {
+            yield return targetPath;
+
+            var path = targetPath.Replace("[", string.Empty, StringComparison.Ordinal)
+                .Replace("]", string.Empty, StringComparison.Ordinal)
+                .Replace("'", string.Empty, StringComparison.Ordinal)
+                .Split(".");
+            var lastPart = path.LastOrDefault();
+            if (!string.IsNullOrWhiteSpace(lastPart))
+            {
+                yield return lastPart;
+                yield return Regex.Replace(lastPart, "([a-z])([A-Z])", "$1 $2");
+            }
+        }
+
+        private static bool TryParseStatistic(string value, out decimal parsed)
+        {
+            value = value?.Trim();
+            var percentage = value?.EndsWith('%') == true;
+            if (percentage)
+            {
+                value = value.TrimEnd('%');
+            }
+            var success = decimal.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out parsed);
+            if (success && percentage)
+            {
+                parsed /= 100;
+            }
+            return success;
+        }
+
+        private static string RemoveWhitespace(string value)
+        {
+            return value == null ? string.Empty : Regex.Replace(value, @"\s+", string.Empty);
+        }
+    }
+}

--- a/Api/WalkForwardOptimizationCloudSettings.cs
+++ b/Api/WalkForwardOptimizationCloudSettings.cs
@@ -1,0 +1,112 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using QuantConnect.Configuration;
+using QuantConnect.Optimizer;
+using QuantConnect.Optimizer.Objectives;
+using QuantConnect.Statistics;
+using QuantConnect.Util;
+
+namespace QuantConnect.Api
+{
+    /// <summary>
+    /// Configuration used to run walk-forward cloud optimizations.
+    /// </summary>
+    internal sealed class WalkForwardOptimizationCloudSettings
+    {
+        private const string DefaultOptimizationStrategy = "QuantConnect.Optimizer.Strategies.GridSearchOptimizationStrategy";
+
+        /// <summary>
+        /// Optimization name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Optimization target.
+        /// </summary>
+        public Target Target { get; set; }
+
+        /// <summary>
+        /// Optimization direction used by the API.
+        /// </summary>
+        public string TargetTo { get; set; }
+
+        /// <summary>
+        /// Optimization strategy type name.
+        /// </summary>
+        public string Strategy { get; set; }
+
+        /// <summary>
+        /// Compile id to optimize.
+        /// </summary>
+        public string CompileId { get; set; }
+
+        /// <summary>
+        /// User-confirmed estimated cost.
+        /// </summary>
+        public decimal EstimatedCost { get; set; }
+
+        /// <summary>
+        /// Cloud optimization node type.
+        /// </summary>
+        public string NodeType { get; set; }
+
+        /// <summary>
+        /// Number of parallel nodes.
+        /// </summary>
+        public int ParallelNodes { get; set; }
+
+        /// <summary>
+        /// Poll interval in seconds.
+        /// </summary>
+        public int PollIntervalSeconds { get; set; }
+
+        /// <summary>
+        /// Timeout in minutes.
+        /// </summary>
+        public int TimeoutMinutes { get; set; }
+
+        /// <summary>
+        /// Reads and validates cloud optimization settings for a request.
+        /// </summary>
+        public static WalkForwardOptimizationCloudSettings Read(WalkForwardOptimizationRequest request)
+        {
+            return new WalkForwardOptimizationCloudSettings
+            {
+                Name = Config.Get("walk-forward-optimization-name", $"Walk Forward Optimization {request.TriggerTimeUtc:O}"),
+                Target = request.Target ?? new Target(Config.Get("walk-forward-optimization-selector-target", PerformanceMetrics.NetProfit), new Maximization(), null),
+                TargetTo = request.Target?.Extremum is Minimization ? "min" : "max",
+                Strategy = Config.Get("walk-forward-optimization-strategy", DefaultOptimizationStrategy),
+                CompileId = GetRequiredConfig("walk-forward-optimization-compile-id"),
+                EstimatedCost = GetRequiredConfig("walk-forward-optimization-estimated-cost").ToDecimal(),
+                NodeType = GetRequiredConfig("walk-forward-optimization-node-type"),
+                ParallelNodes = GetRequiredConfig("walk-forward-optimization-parallel-nodes").ToInt32(),
+                PollIntervalSeconds = Math.Max(0, Config.GetInt("walk-forward-optimization-api-poll-interval-seconds", 10)),
+                TimeoutMinutes = Config.GetInt("walk-forward-optimization-api-timeout-minutes", 60)
+            };
+        }
+
+        private static string GetRequiredConfig(string key)
+        {
+            var value = Config.Get(key);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException($"{key} must be configured before running walk-forward cloud optimization.");
+            }
+            return value;
+        }
+    }
+}

--- a/Common/AlgorithmImports.py
+++ b/Common/AlgorithmImports.py
@@ -41,6 +41,7 @@ from QuantConnect.Python import *
 from QuantConnect.Storage import *
 from QuantConnect.Research import *
 from QuantConnect.Commands import *
+from QuantConnect.Optimizer import *
 from QuantConnect.Algorithm import *
 from QuantConnect.Statistics import *
 from QuantConnect.Parameters import *
@@ -54,6 +55,7 @@ from QuantConnect.DataSource import *
 from QuantConnect.Orders.Fees import *
 from QuantConnect.Data.Custom import *
 from QuantConnect.Data.Market import *
+from QuantConnect.Optimizer.Objectives import *
 from QuantConnect.Lean.Engine import *
 from QuantConnect.Orders.Fills import *
 from QuantConnect.Configuration import *
@@ -70,6 +72,7 @@ from QuantConnect.Securities.Future import *
 from QuantConnect.Data.Consolidators import *
 from QuantConnect.Orders.TimeInForces import *
 from QuantConnect.Algorithm.Framework import *
+from QuantConnect.Optimizer.Parameters import *
 from QuantConnect.Algorithm.Selection import *
 from QuantConnect.Securities.Positions import *
 from QuantConnect.Orders.OptionExercise import *

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -901,6 +901,12 @@ namespace QuantConnect.Interfaces
         void SetApi(IApi api);
 
         /// <summary>
+        /// Sets the walk-forward optimization provider.
+        /// </summary>
+        /// <param name="provider">The provider used to run walk-forward optimizations</param>
+        void SetWalkForwardOptimizationProvider(IWalkForwardOptimizationProvider provider);
+
+        /// <summary>
         /// Sets the object store
         /// </summary>
         /// <param name="objectStore">The object store</param>

--- a/Common/Interfaces/IWalkForwardOptimizationProvider.cs
+++ b/Common/Interfaces/IWalkForwardOptimizationProvider.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System.ComponentModel.Composition;
 using QuantConnect.Optimizer;
 
 namespace QuantConnect.Interfaces
@@ -20,6 +21,7 @@ namespace QuantConnect.Interfaces
     /// <summary>
     /// Provides walk-forward optimization results for a running algorithm.
     /// </summary>
+    [InheritedExport(typeof(IWalkForwardOptimizationProvider))]
     public interface IWalkForwardOptimizationProvider
     {
         /// <summary>

--- a/Common/Interfaces/IWalkForwardOptimizationProvider.cs
+++ b/Common/Interfaces/IWalkForwardOptimizationProvider.cs
@@ -1,0 +1,32 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Optimizer;
+
+namespace QuantConnect.Interfaces
+{
+    /// <summary>
+    /// Provides walk-forward optimization results for a running algorithm.
+    /// </summary>
+    public interface IWalkForwardOptimizationProvider
+    {
+        /// <summary>
+        /// Runs an optimization for the specified request.
+        /// </summary>
+        /// <param name="request">The walk-forward optimization request</param>
+        /// <returns>The optimization result</returns>
+        WalkForwardOptimizationResult Optimize(WalkForwardOptimizationRequest request);
+    }
+}

--- a/Common/Optimizer/NullWalkForwardOptimizationProvider.cs
+++ b/Common/Optimizer/NullWalkForwardOptimizationProvider.cs
@@ -27,7 +27,10 @@ namespace QuantConnect.Optimizer
         /// </summary>
         public static NullWalkForwardOptimizationProvider Instance { get; } = new NullWalkForwardOptimizationProvider();
 
-        private NullWalkForwardOptimizationProvider()
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        public NullWalkForwardOptimizationProvider()
         {
         }
 

--- a/Common/Optimizer/NullWalkForwardOptimizationProvider.cs
+++ b/Common/Optimizer/NullWalkForwardOptimizationProvider.cs
@@ -1,0 +1,42 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Optimizer
+{
+    /// <summary>
+    /// Default walk-forward optimization provider used when no runtime provider is configured.
+    /// </summary>
+    public sealed class NullWalkForwardOptimizationProvider : IWalkForwardOptimizationProvider
+    {
+        /// <summary>
+        /// Gets the singleton instance.
+        /// </summary>
+        public static NullWalkForwardOptimizationProvider Instance { get; } = new NullWalkForwardOptimizationProvider();
+
+        private NullWalkForwardOptimizationProvider()
+        {
+        }
+
+        /// <summary>
+        /// Returns an empty result.
+        /// </summary>
+        public WalkForwardOptimizationResult Optimize(WalkForwardOptimizationRequest request)
+        {
+            return WalkForwardOptimizationResult.Empty;
+        }
+    }
+}

--- a/Common/Optimizer/WalkForwardOptimizationRequest.cs
+++ b/Common/Optimizer/WalkForwardOptimizationRequest.cs
@@ -1,0 +1,102 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Api;
+using QuantConnect.Interfaces;
+using QuantConnect.Optimizer.Objectives;
+using QuantConnect.Optimizer.Parameters;
+
+namespace QuantConnect.Optimizer
+{
+    /// <summary>
+    /// Defines a scheduled walk-forward optimization request.
+    /// </summary>
+    public class WalkForwardOptimizationRequest
+    {
+        /// <summary>
+        /// The parent algorithm requesting the optimization.
+        /// </summary>
+        public IAlgorithm Algorithm { get; }
+
+        /// <summary>
+        /// The UTC time that triggered the scheduled optimization.
+        /// </summary>
+        public DateTime TriggerTimeUtc { get; }
+
+        /// <summary>
+        /// The optimization target used by provider-selected optimizations.
+        /// </summary>
+        public Target Target { get; }
+
+        /// <summary>
+        /// The optional selector used to choose a winning parameter set from optimization backtests.
+        /// </summary>
+        public Func<IReadOnlyList<OptimizationBacktest>, ParameterSet> TargetSelector { get; }
+
+        /// <summary>
+        /// The optimization parameters to evaluate.
+        /// </summary>
+        public HashSet<OptimizationParameter> Parameters { get; }
+
+        /// <summary>
+        /// The constraints to apply to optimization results.
+        /// </summary>
+        public IReadOnlyList<Constraint> Constraints { get; }
+
+        /// <summary>
+        /// Creates a new instance for provider-selected target optimization.
+        /// </summary>
+        public WalkForwardOptimizationRequest(
+            IAlgorithm algorithm,
+            DateTime triggerTimeUtc,
+            Target target,
+            HashSet<OptimizationParameter> parameters,
+            IReadOnlyList<Constraint> constraints = null)
+            : this(algorithm, triggerTimeUtc, target, null, parameters, constraints)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance for selector-based optimization.
+        /// </summary>
+        public WalkForwardOptimizationRequest(
+            IAlgorithm algorithm,
+            DateTime triggerTimeUtc,
+            Func<IReadOnlyList<OptimizationBacktest>, ParameterSet> targetSelector,
+            HashSet<OptimizationParameter> parameters,
+            IReadOnlyList<Constraint> constraints = null)
+            : this(algorithm, triggerTimeUtc, null, targetSelector, parameters, constraints)
+        {
+        }
+
+        private WalkForwardOptimizationRequest(
+            IAlgorithm algorithm,
+            DateTime triggerTimeUtc,
+            Target target,
+            Func<IReadOnlyList<OptimizationBacktest>, ParameterSet> targetSelector,
+            HashSet<OptimizationParameter> parameters,
+            IReadOnlyList<Constraint> constraints)
+        {
+            Algorithm = algorithm ?? throw new ArgumentNullException(nameof(algorithm));
+            TriggerTimeUtc = triggerTimeUtc;
+            Target = target;
+            TargetSelector = targetSelector;
+            Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+            Constraints = constraints ?? Array.Empty<Constraint>();
+        }
+    }
+}

--- a/Common/Optimizer/WalkForwardOptimizationResult.cs
+++ b/Common/Optimizer/WalkForwardOptimizationResult.cs
@@ -1,0 +1,70 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Api;
+using QuantConnect.Optimizer.Parameters;
+
+namespace QuantConnect.Optimizer
+{
+    /// <summary>
+    /// Defines the result of a walk-forward optimization request.
+    /// </summary>
+    public class WalkForwardOptimizationResult
+    {
+        /// <summary>
+        /// Empty result used when no optimization was run.
+        /// </summary>
+        public static WalkForwardOptimizationResult Empty { get; } = new WalkForwardOptimizationResult(
+            null,
+            Array.Empty<OptimizationBacktest>());
+
+        /// <summary>
+        /// The selected parameter set.
+        /// </summary>
+        public ParameterSet ParameterSet { get; }
+
+        /// <summary>
+        /// The optimization backtests produced by the provider.
+        /// </summary>
+        public IReadOnlyList<OptimizationBacktest> Backtests { get; }
+
+        /// <summary>
+        /// Creates a new result with the selected parameter set.
+        /// </summary>
+        public WalkForwardOptimizationResult(ParameterSet parameterSet)
+            : this(parameterSet, Array.Empty<OptimizationBacktest>())
+        {
+        }
+
+        /// <summary>
+        /// Creates a new result with candidate backtests for selector-based optimization.
+        /// </summary>
+        public WalkForwardOptimizationResult(IReadOnlyList<OptimizationBacktest> backtests)
+            : this(null, backtests)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new result with a selected parameter set and candidate backtests.
+        /// </summary>
+        public WalkForwardOptimizationResult(ParameterSet parameterSet, IReadOnlyList<OptimizationBacktest> backtests)
+        {
+            ParameterSet = parameterSet;
+            Backtests = backtests ?? Array.Empty<OptimizationBacktest>();
+        }
+    }
+}

--- a/Engine/Server/LocalLeanManager.cs
+++ b/Engine/Server/LocalLeanManager.cs
@@ -16,7 +16,9 @@
 using QuantConnect.Util;
 using QuantConnect.Packets;
 using QuantConnect.Commands;
+using QuantConnect.Configuration;
 using QuantConnect.Interfaces;
+using QuantConnect.Optimizer;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Lean.Engine.DataFeeds.Transport;
 
@@ -67,6 +69,9 @@ namespace QuantConnect.Lean.Engine.Server
         {
             Algorithm = algorithm;
             algorithm.SetApi(SystemHandlers.Api);
+            algorithm.SetWalkForwardOptimizationProvider(
+                Composer.Instance.GetExportedValueByTypeName<IWalkForwardOptimizationProvider>(
+                    Config.Get("walk-forward-optimization-provider", nameof(NullWalkForwardOptimizationProvider))));
             RemoteFileSubscriptionStreamReader.SetDownloadProvider((Api.Api)SystemHandlers.Api);
         }
 

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -343,6 +343,9 @@
     "ema-slow": 20
   },
 
+  // provider used by QCAlgorithm.Optimize scheduled walk-forward optimization
+  "walk-forward-optimization-provider": "NullWalkForwardOptimizationProvider",
+
   // specify supported languages when running regression tests
   "regression-test-languages": [ "CSharp", "Python" ],
 

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -344,7 +344,7 @@
   },
 
   // provider used by QCAlgorithm.Optimize scheduled walk-forward optimization
-  "walk-forward-optimization-provider": "NullWalkForwardOptimizationProvider",
+  "walk-forward-optimization-provider": "LocalWalkForwardOptimizationProvider",
 
   // specify supported languages when running regression tests
   "regression-test-languages": [ "CSharp", "Python" ],

--- a/Optimizer.Launcher/LocalWalkForwardOptimizationProvider.cs
+++ b/Optimizer.Launcher/LocalWalkForwardOptimizationProvider.cs
@@ -1,0 +1,133 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Threading;
+using Newtonsoft.Json;
+using QuantConnect.Configuration;
+using QuantConnect.Interfaces;
+using QuantConnect.Optimizer.Objectives;
+using QuantConnect.Optimizer.Strategies;
+using QuantConnect.Statistics;
+using QuantConnect.Util;
+
+namespace QuantConnect.Optimizer.Launcher
+{
+    /// <summary>
+    /// Runs scheduled walk-forward optimization using the local LEAN optimizer launcher.
+    /// </summary>
+    public class LocalWalkForwardOptimizationProvider : IWalkForwardOptimizationProvider
+    {
+        /// <summary>
+        /// Runs a local optimization for the specified walk-forward request.
+        /// </summary>
+        /// <param name="request">The walk-forward optimization request</param>
+        /// <returns>The walk-forward optimization result</returns>
+        public WalkForwardOptimizationResult Optimize(WalkForwardOptimizationRequest request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            using var endedEvent = new ManualResetEvent(false);
+            using var optimizer = CreateOptimizer(CreatePacket(request));
+
+            OptimizationResult result = null;
+            optimizer.Ended += (sender, optimizationResult) =>
+            {
+                result = optimizationResult;
+                endedEvent.Set();
+            };
+
+            optimizer.Start();
+
+            var timeoutMinutes = Config.GetInt("walk-forward-optimization-timeout-minutes");
+            if (timeoutMinutes > 0)
+            {
+                if (!endedEvent.WaitOne(TimeSpan.FromMinutes(timeoutMinutes)))
+                {
+                    throw new TimeoutException($"Walk-forward optimization timed out after {timeoutMinutes} minutes.");
+                }
+            }
+            else
+            {
+                endedEvent.WaitOne();
+            }
+
+            var backtests = result?.Backtests ?? optimizer.CompletedOptimizationBacktests;
+            var parameterSet = request.TargetSelector == null ? result?.ParameterSet : null;
+            return new WalkForwardOptimizationResult(parameterSet, backtests);
+        }
+
+        /// <summary>
+        /// Creates the optimizer instance for the optimization packet.
+        /// </summary>
+        /// <param name="packet">The optimization packet</param>
+        /// <returns>The optimizer instance</returns>
+        protected virtual LeanOptimizer CreateOptimizer(OptimizationNodePacket packet)
+        {
+            var optimizerType = Config.Get(
+                "walk-forward-optimization-launcher",
+                Config.Get("optimization-launcher", nameof(ConsoleLeanOptimizer)));
+
+            return (LeanOptimizer)Activator.CreateInstance(Composer.Instance
+                .GetExportedTypes<LeanOptimizer>()
+                .Single(type => type.Name == optimizerType || type.FullName == optimizerType), packet);
+        }
+
+        private static OptimizationNodePacket CreatePacket(WalkForwardOptimizationRequest request)
+        {
+            return new OptimizationNodePacket
+            {
+                Name = Config.Get("walk-forward-optimization-name", $"Walk Forward Optimization {request.TriggerTimeUtc:O}"),
+                Created = request.TriggerTimeUtc,
+                ProjectId = request.Algorithm.ProjectId,
+                OptimizationId = Config.Get("walk-forward-optimization-id", Guid.NewGuid().ToString()),
+                OptimizationStrategy = Config.Get(
+                    "walk-forward-optimization-strategy",
+                    Config.Get("optimization-strategy", typeof(GridSearchOptimizationStrategy).FullName)),
+                OptimizationStrategySettings = GetStrategySettings(),
+                Criterion = request.Target ?? GetSelectorTarget(),
+                Constraints = request.Constraints,
+                OptimizationParameters = request.Parameters,
+                MaximumConcurrentBacktests = Config.GetInt(
+                    "walk-forward-optimization-maximum-concurrent-backtests",
+                    Config.GetInt("maximum-concurrent-backtests", Math.Max(1, Environment.ProcessorCount / 2))),
+                Channel = Config.Get("data-channel")
+            };
+        }
+
+        private static OptimizationStrategySettings GetStrategySettings()
+        {
+            var settings = Config.Get(
+                "walk-forward-optimization-strategy-settings",
+                Config.Get("optimization-strategy-settings",
+                    "{\"$type\":\"QuantConnect.Optimizer.Strategies.StepBaseOptimizationStrategySettings, QuantConnect.Optimizer\"}"));
+            return (OptimizationStrategySettings)JsonConvert.DeserializeObject(
+                settings,
+                new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All });
+        }
+
+        private static Target GetSelectorTarget()
+        {
+            return new Target(
+                Config.Get("walk-forward-optimization-selector-target", PerformanceMetrics.NetProfit),
+                new Maximization(),
+                null);
+        }
+    }
+}

--- a/Optimizer/LeanOptimizer.cs
+++ b/Optimizer/LeanOptimizer.cs
@@ -14,8 +14,11 @@
 */
 
 using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System.Threading;
 using QuantConnect.Util;
+using QuantConnect.Api;
 using QuantConnect.Logging;
 using QuantConnect.Configuration;
 using System.Collections.Concurrent;
@@ -44,11 +47,26 @@ namespace QuantConnect.Optimizer
 
         // Per-backtest metrics extracted in NewResult so we don't retain the full backtest JSON.
         private readonly List<OptimizationBacktestMetrics> _completedBacktests = new();
+        private readonly List<OptimizationBacktest> _completedOptimizationBacktests = new();
 
         /// <summary>
         /// The total completed backtests count
         /// </summary>
         protected int CompletedBacktests => _failedBacktest + _completedBacktest;
+
+        /// <summary>
+        /// The lightweight backtest summaries completed by this optimization.
+        /// </summary>
+        public IReadOnlyList<OptimizationBacktest> CompletedOptimizationBacktests
+        {
+            get
+            {
+                lock (_completedOptimizationBacktests)
+                {
+                    return new List<OptimizationBacktest>(_completedOptimizationBacktests);
+                }
+            }
+        }
 
         /// <summary>
         /// Lock to update optimization status
@@ -199,6 +217,10 @@ namespace QuantConnect.Optimizer
                     {
                         backtestsSnapshot = new List<OptimizationBacktestMetrics>(_completedBacktests);
                     }
+                    lock (_completedOptimizationBacktests)
+                    {
+                        result.Backtests = new List<OptimizationBacktest>(_completedOptimizationBacktests);
+                    }
                     var parameters = new OptimizationAnalysisRunParameters(
                         backtestsSnapshot,
                         NodePacket.OptimizationParameters);
@@ -281,6 +303,15 @@ namespace QuantConnect.Optimizer
                     lock (_completedBacktests)
                     {
                         _completedBacktests.Add(metrics);
+                    }
+                }
+
+                var optimizationBacktest = CreateOptimizationBacktest(backtestId, parameterSet, jsonBacktestResult);
+                if (optimizationBacktest != null)
+                {
+                    lock (_completedOptimizationBacktests)
+                    {
+                        _completedOptimizationBacktests.Add(optimizationBacktest);
                     }
                 }
 
@@ -479,6 +510,30 @@ namespace QuantConnect.Optimizer
                 {
                     Log.Error($"LeanOptimizer.LaunchLeanForParameterSet({GetLogDetails()}): Error encountered while placing optimization message into the queue: {ex.Message}");
                 }
+            }
+        }
+
+        private static OptimizationBacktest CreateOptimizationBacktest(string backtestId, ParameterSet parameterSet, string jsonBacktestResult)
+        {
+            if (string.IsNullOrEmpty(jsonBacktestResult))
+            {
+                return null;
+            }
+
+            try
+            {
+                var result = JObject.Parse(jsonBacktestResult);
+                var statistics = result["Statistics"] ?? result["statistics"];
+                return new OptimizationBacktest(parameterSet, backtestId, "OptimizationBacktest")
+                {
+                    Progress = 1,
+                    Statistics = statistics?.ToObject<Dictionary<string, string>>()
+                };
+            }
+            catch (JsonException ex)
+            {
+                Log.Error(ex, $"LeanOptimizer.CreateOptimizationBacktest(): failed to parse backtest result for '{backtestId}'");
+                return null;
             }
         }
     }

--- a/Optimizer/OptimizationResult.cs
+++ b/Optimizer/OptimizationResult.cs
@@ -13,6 +13,9 @@
  * limitations under the License.
 */
 
+using System;
+using System.Collections.Generic;
+using QuantConnect.Api;
 using QuantConnect.Optimizer.Parameters;
 
 namespace QuantConnect.Optimizer
@@ -48,9 +51,14 @@ namespace QuantConnect.Optimizer
         public ParameterSet ParameterSet { get; }
 
         /// <summary>
-        /// Aggregate diagnostic for the whole optimization; populated only on the final result fired via <see cref="LeanOptimizer.Ended"/>.
+        /// Aggregate analysis for the whole optimization; populated only on the final result fired via <see cref="LeanOptimizer.Ended"/>.
         /// </summary>
         public OptimizationAnalysis Analysis { get; set; }
+
+        /// <summary>
+        /// Lightweight backtest summaries produced during the optimization.
+        /// </summary>
+        public IReadOnlyList<OptimizationBacktest> Backtests { get; set; } = Array.Empty<OptimizationBacktest>();
 
         /// <summary>
         /// Create an instance of <see cref="OptimizationResult"/>

--- a/Tests/Algorithm/AlgorithmWalkForwardOptimizationTests.cs
+++ b/Tests/Algorithm/AlgorithmWalkForwardOptimizationTests.cs
@@ -1,0 +1,175 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using QuantConnect.Api;
+using QuantConnect.Algorithm;
+using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine;
+using QuantConnect.Lean.Engine.RealTime;
+using QuantConnect.Optimizer;
+using QuantConnect.Optimizer.Objectives;
+using QuantConnect.Optimizer.Parameters;
+using QuantConnect.Packets;
+using QuantConnect.Util.RateLimit;
+
+namespace QuantConnect.Tests.Algorithm
+{
+    [TestFixture]
+    public class AlgorithmWalkForwardOptimizationTests
+    {
+        [Test]
+        public void ScheduledOptimizationAppliesWinningParameterSet()
+        {
+            var algorithm = CreateAlgorithm(out var realTimeHandler);
+            var provider = new FakeWalkForwardOptimizationProvider
+            {
+                Result = new WalkForwardOptimizationResult(new ParameterSet(1, new Dictionary<string, string>
+                {
+                    { "ema-fast", "20" },
+                    { "ema-slow", "200" }
+                }))
+            };
+            algorithm.SetWalkForwardOptimizationProvider(provider);
+            algorithm.SetParameters(new Dictionary<string, string>
+            {
+                { "ema-fast", "10" },
+                { "ema-slow", "100" }
+            });
+
+            algorithm.Optimize(
+                algorithm.DateRules.Today,
+                algorithm.TimeRules.Now,
+                new Target("Profit", new Maximization(), null),
+                new HashSet<OptimizationParameter>
+                {
+                    new OptimizationStepParameter("ema-fast", 10, 20, 10),
+                    new OptimizationStepParameter("ema-slow", 100, 200, 100)
+                });
+
+            realTimeHandler.SetTime(algorithm.UtcTime);
+
+            Assert.AreEqual("20", algorithm.GetParameter("ema-fast"));
+            Assert.AreEqual("200", algorithm.GetParameter("ema-slow"));
+            Assert.AreEqual(1, provider.Requests.Count);
+            Assert.AreEqual(algorithm, provider.Requests[0].Algorithm);
+            Assert.AreEqual(2, provider.Requests[0].Parameters.Count);
+            Assert.IsNotNull(provider.Requests[0].Target);
+        }
+
+        [Test]
+        public void SelectorOptimizationAppliesSelectedBacktestParameterSet()
+        {
+            var algorithm = CreateAlgorithm(out var realTimeHandler);
+            var expectedParameterSet = new ParameterSet(2, new Dictionary<string, string>
+            {
+                { "lookback", "40" }
+            });
+            var provider = new FakeWalkForwardOptimizationProvider
+            {
+                Result = new WalkForwardOptimizationResult(new[]
+                {
+                    new OptimizationBacktest(new ParameterSet(1, new Dictionary<string, string>
+                    {
+                        { "lookback", "20" }
+                    }), "backtest-1", "candidate-1"),
+                    new OptimizationBacktest(expectedParameterSet, "backtest-2", "candidate-2")
+                })
+            };
+            algorithm.SetWalkForwardOptimizationProvider(provider);
+            algorithm.SetParameters(new Dictionary<string, string>
+            {
+                { "lookback", "20" }
+            });
+
+            algorithm.Optimize(
+                algorithm.DateRules.Today,
+                algorithm.TimeRules.Now,
+                backtests => expectedParameterSet,
+                new HashSet<OptimizationParameter>
+                {
+                    new OptimizationStepParameter("lookback", 20, 40, 20)
+                });
+
+            realTimeHandler.SetTime(algorithm.UtcTime);
+
+            Assert.AreEqual("40", algorithm.GetParameter("lookback"));
+            Assert.AreEqual(1, provider.Requests.Count);
+            Assert.IsNull(provider.Requests[0].Target);
+            Assert.IsNotNull(provider.Requests[0].TargetSelector);
+        }
+
+        [Test]
+        public void OptimizationChildAlgorithmDoesNotStartNestedOptimization()
+        {
+            var algorithm = CreateAlgorithm(out var realTimeHandler);
+            var provider = new FakeWalkForwardOptimizationProvider
+            {
+                Result = new WalkForwardOptimizationResult(new ParameterSet(1, new Dictionary<string, string>
+                {
+                    { "ema-fast", "20" }
+                }))
+            };
+            algorithm.SetWalkForwardOptimizationProvider(provider);
+            algorithm.SetParameters(new Dictionary<string, string>
+            {
+                { "ema-fast", "10" }
+            });
+            typeof(QCAlgorithm)
+                .GetField("_algorithmMode", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(algorithm, AlgorithmMode.Optimization);
+
+            algorithm.Optimize(
+                algorithm.DateRules.Today,
+                algorithm.TimeRules.Now,
+                new Target("Profit", new Maximization(), null),
+                new HashSet<OptimizationParameter>
+                {
+                    new OptimizationStepParameter("ema-fast", 10, 20, 10)
+                });
+
+            realTimeHandler.SetTime(algorithm.UtcTime);
+
+            Assert.AreEqual("10", algorithm.GetParameter("ema-fast"));
+            Assert.AreEqual(0, provider.Requests.Count);
+        }
+
+        private static QCAlgorithm CreateAlgorithm(out BacktestingRealTimeHandler realTimeHandler)
+        {
+            var algorithm = new QCAlgorithm();
+            realTimeHandler = new BacktestingRealTimeHandler();
+            var timeLimitManager = new AlgorithmTimeLimitManager(TokenBucket.Null, TimeSpan.MaxValue);
+            realTimeHandler.Setup(algorithm, new AlgorithmNodePacket(PacketType.BacktestNode), null, null, timeLimitManager);
+            algorithm.Schedule.SetEventSchedule(realTimeHandler);
+            algorithm.SetDateTime(new DateTime(2024, 1, 1));
+            return algorithm;
+        }
+
+        private sealed class FakeWalkForwardOptimizationProvider : IWalkForwardOptimizationProvider
+        {
+            public List<WalkForwardOptimizationRequest> Requests { get; } = new List<WalkForwardOptimizationRequest>();
+            public WalkForwardOptimizationResult Result { get; set; } = WalkForwardOptimizationResult.Empty;
+
+            public WalkForwardOptimizationResult Optimize(WalkForwardOptimizationRequest request)
+            {
+                Requests.Add(request);
+                return Result;
+            }
+        }
+    }
+}

--- a/Tests/Api/ApiWalkForwardOptimizationProviderSelectionTests.cs
+++ b/Tests/Api/ApiWalkForwardOptimizationProviderSelectionTests.cs
@@ -1,0 +1,121 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using NUnit.Framework;
+using QuantConnect.Interfaces;
+using QuantConnect.Optimizer;
+using QuantConnect.Optimizer.Objectives;
+using QuantConnect.Optimizer.Parameters;
+using QuantConnect.Optimizer.Strategies;
+using QuantConnect.Statistics;
+using ApiOptimization = QuantConnect.Api.Optimization;
+using ApiOptimizationNodes = QuantConnect.Api.OptimizationNodes;
+using ApiOptimizationSummary = QuantConnect.Api.OptimizationSummary;
+using ApiWalkForwardOptimizationProvider = QuantConnect.Api.ApiWalkForwardOptimizationProvider;
+
+namespace QuantConnect.Tests.API
+{
+    [TestFixture]
+    [NonParallelizable]
+    public class ApiWalkForwardOptimizationProviderSelectionTests : ApiWalkForwardOptimizationProviderTestBase
+    {
+        [Test]
+        public void CreatesCloudOptimizationAndReturnsWinningParameterSet()
+        {
+            var request = CreateTargetRequest();
+            var api = CreateApiForCompletedOptimization(request, "['Statistics'].['Net Profit']", "max", CreateCompletedOptimization());
+            var provider = new ApiWalkForwardOptimizationProvider(api.Object);
+
+            var result = provider.Optimize(request);
+
+            Assert.AreEqual("20", result.ParameterSet.Value["ema-fast"]);
+            Assert.AreEqual(2, result.Backtests.Count);
+            api.Verify(apiClient => apiClient.ReadOptimization("optimization-1"), Times.Exactly(2));
+        }
+
+        [Test]
+        public void MinimizationTargetsSelectLowestBacktestStatistic()
+        {
+            var request = CreateTargetRequest(new Target(PerformanceMetrics.Drawdown, new Minimization(), null));
+            var api = CreateApiForCompletedOptimization(
+                request,
+                "['Statistics'].['Drawdown']",
+                "min",
+                CreateCompletedOptimization(PerformanceMetrics.Drawdown, 10, 5),
+                includeRunningRead: false);
+            var provider = new ApiWalkForwardOptimizationProvider(api.Object);
+
+            var result = provider.Optimize(request);
+
+            Assert.AreEqual("20", result.ParameterSet.Value["ema-fast"]);
+        }
+
+        [Test]
+        public void SelectorRequestsReturnBacktestsWithoutPreselectedParameterSet()
+        {
+            var request = CreateSelectorRequest();
+            var api = CreateApiForCompletedOptimization(request, "['Statistics'].['Net Profit']", "max", CreateCompletedOptimization(), false);
+            var provider = new ApiWalkForwardOptimizationProvider(api.Object);
+
+            var result = provider.Optimize(request);
+
+            Assert.IsNull(result.ParameterSet);
+            Assert.AreEqual(2, result.Backtests.Count);
+            Assert.AreEqual("20", request.TargetSelector(result.Backtests).Value["ema-fast"]);
+        }
+
+        private static Mock<IApi> CreateApiForCompletedOptimization(
+            WalkForwardOptimizationRequest request,
+            string target,
+            string targetTo,
+            ApiOptimization completedOptimization,
+            bool includeRunningRead = true)
+        {
+            var api = new Mock<IApi>(MockBehavior.Strict);
+            api.Setup(apiClient => apiClient.CreateOptimization(
+                    request.Algorithm.ProjectId,
+                    It.Is<string>(name => name.StartsWith("Walk Forward Optimization", StringComparison.Ordinal)),
+                    target,
+                    targetTo,
+                    null,
+                    typeof(GridSearchOptimizationStrategy).FullName,
+                    CompileId,
+                    request.Parameters,
+                    request.Constraints,
+                    0.25m,
+                    ApiOptimizationNodes.O2_8,
+                    2))
+                .Returns(new ApiOptimizationSummary { OptimizationId = "optimization-1" });
+
+            if (includeRunningRead)
+            {
+                api.SetupSequence(apiClient => apiClient.ReadOptimization("optimization-1"))
+                    .Returns(new ApiOptimization { Status = OptimizationStatus.Running })
+                    .Returns(completedOptimization);
+            }
+            else
+            {
+                api.Setup(apiClient => apiClient.ReadOptimization("optimization-1"))
+                    .Returns(completedOptimization);
+            }
+
+            return api;
+        }
+    }
+}

--- a/Tests/Api/ApiWalkForwardOptimizationProviderTestBase.cs
+++ b/Tests/Api/ApiWalkForwardOptimizationProviderTestBase.cs
@@ -1,0 +1,123 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Configuration;
+using QuantConnect.Optimizer;
+using QuantConnect.Optimizer.Objectives;
+using QuantConnect.Optimizer.Parameters;
+using QuantConnect.Optimizer.Strategies;
+using QuantConnect.Statistics;
+using QuantConnect.Util;
+using ApiOptimization = QuantConnect.Api.Optimization;
+using ApiOptimizationBacktest = QuantConnect.Api.OptimizationBacktest;
+
+namespace QuantConnect.Tests.API
+{
+    public abstract class ApiWalkForwardOptimizationProviderTestBase
+    {
+        protected const string CompileId = "compile-1";
+
+        [SetUp]
+        public void SetUp()
+        {
+            Config.Set("walk-forward-optimization-compile-id", CompileId);
+            Config.Set("walk-forward-optimization-estimated-cost", "0.25");
+            Config.Set("walk-forward-optimization-node-type", QuantConnect.Api.OptimizationNodes.O2_8);
+            Config.Set("walk-forward-optimization-parallel-nodes", "2");
+            Config.Set("walk-forward-optimization-api-poll-interval-seconds", "0");
+            Config.Set("walk-forward-optimization-api-timeout-minutes", "1");
+            Config.Set("walk-forward-optimization-strategy", typeof(GridSearchOptimizationStrategy).FullName);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            SetUp();
+        }
+
+        protected static WalkForwardOptimizationRequest CreateTargetRequest(Target target = null)
+        {
+            return new WalkForwardOptimizationRequest(
+                CreateAlgorithm(),
+                new DateTime(2026, 1, 1),
+                target ?? new Target(PerformanceMetrics.NetProfit, new Maximization(), null),
+                CreateParameters());
+        }
+
+        protected static WalkForwardOptimizationRequest CreateSelectorRequest()
+        {
+            return new WalkForwardOptimizationRequest(
+                CreateAlgorithm(),
+                new DateTime(2026, 1, 1),
+                backtests => backtests
+                    .OrderByDescending(backtest => backtest.Statistics[PerformanceMetrics.NetProfit].ToDecimal())
+                    .First()
+                    .ParameterSet,
+                CreateParameters());
+        }
+
+        protected static HashSet<OptimizationParameter> CreateParameters()
+        {
+            return new HashSet<OptimizationParameter>
+            {
+                new OptimizationStepParameter("ema-fast", 10, 20, 10)
+            };
+        }
+
+        protected static ApiOptimization CreateCompletedOptimization(
+            string statistic = PerformanceMetrics.NetProfit,
+            decimal firstValue = 10,
+            decimal secondValue = 20)
+        {
+            return new ApiOptimization
+            {
+                Status = OptimizationStatus.Completed,
+                Backtests = new Dictionary<string, ApiOptimizationBacktest>
+                {
+                    { "backtest-1", CreateBacktest(1, "10", statistic, firstValue) },
+                    { "backtest-2", CreateBacktest(2, "20", statistic, secondValue) }
+                }
+            };
+        }
+
+        private static QCAlgorithm CreateAlgorithm()
+        {
+            return new QCAlgorithm { ProjectId = 123 };
+        }
+
+        private static ApiOptimizationBacktest CreateBacktest(
+            int id,
+            string parameterValue,
+            string statistic,
+            decimal statisticValue)
+        {
+            return new ApiOptimizationBacktest(
+                new ParameterSet(id, new Dictionary<string, string> { { "ema-fast", parameterValue } }),
+                $"backtest-{id}",
+                $"candidate-{id}")
+            {
+                Statistics = new Dictionary<string, string>
+                {
+                    { statistic, statisticValue.ToStringInvariant() }
+                }
+            };
+        }
+    }
+}

--- a/Tests/Api/ApiWalkForwardOptimizationProviderTests.cs
+++ b/Tests/Api/ApiWalkForwardOptimizationProviderTests.cs
@@ -1,0 +1,104 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using Moq;
+using NUnit.Framework;
+using QuantConnect.Configuration;
+using QuantConnect.Interfaces;
+using QuantConnect.Optimizer;
+using QuantConnect.Optimizer.Objectives;
+using QuantConnect.Optimizer.Parameters;
+using ApiOptimization = QuantConnect.Api.Optimization;
+using ApiOptimizationSummary = QuantConnect.Api.OptimizationSummary;
+using ApiWalkForwardOptimizationProvider = QuantConnect.Api.ApiWalkForwardOptimizationProvider;
+
+namespace QuantConnect.Tests.API
+{
+    [TestFixture]
+    [NonParallelizable]
+    public class ApiWalkForwardOptimizationProviderTests : ApiWalkForwardOptimizationProviderTestBase
+    {
+        [Test]
+        public void RequiresExplicitCloudResourceConfiguration()
+        {
+            Config.Set("walk-forward-optimization-compile-id", string.Empty);
+            var api = new Mock<IApi>(MockBehavior.Strict);
+            var provider = new ApiWalkForwardOptimizationProvider(api.Object);
+
+            Assert.Throws<InvalidOperationException>(() => provider.Optimize(CreateTargetRequest()));
+
+            api.Verify(
+                apiClient => apiClient.CreateOptimization(
+                    It.IsAny<int>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<decimal?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<HashSet<OptimizationParameter>>(),
+                    It.IsAny<IReadOnlyList<Constraint>>(),
+                    It.IsAny<decimal>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int>()),
+                Times.Never);
+        }
+
+        [Test]
+        public void ThrowsWhenCloudOptimizationIsAborted()
+        {
+            var api = CreateApiForSingleRead(new ApiOptimization { Status = OptimizationStatus.Aborted });
+            var provider = new ApiWalkForwardOptimizationProvider(api.Object);
+
+            Assert.Throws<InvalidOperationException>(() => provider.Optimize(CreateTargetRequest()));
+        }
+
+        [Test]
+        public void ThrowsWhenCloudOptimizationTimesOut()
+        {
+            Config.Set("walk-forward-optimization-api-timeout-minutes", "0");
+            var api = CreateApiForSingleRead(new ApiOptimization { Status = OptimizationStatus.Running });
+            var provider = new ApiWalkForwardOptimizationProvider(api.Object);
+
+            Assert.Throws<TimeoutException>(() => provider.Optimize(CreateTargetRequest()));
+            api.Verify(apiClient => apiClient.ReadOptimization("optimization-1"), Times.Once);
+        }
+
+        private static Mock<IApi> CreateApiForSingleRead(ApiOptimization optimization)
+        {
+            var api = new Mock<IApi>(MockBehavior.Strict);
+            api.Setup(apiClient => apiClient.CreateOptimization(
+                    It.IsAny<int>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<decimal?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<HashSet<OptimizationParameter>>(),
+                    It.IsAny<IReadOnlyList<Constraint>>(),
+                    It.IsAny<decimal>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int>()))
+                .Returns(new ApiOptimizationSummary { OptimizationId = "optimization-1" });
+            api.Setup(apiClient => apiClient.ReadOptimization("optimization-1"))
+                .Returns(optimization);
+
+            return api;
+        }
+    }
+}

--- a/Tests/Engine/WalkForwardOptimizationProviderRoutingTests.cs
+++ b/Tests/Engine/WalkForwardOptimizationProviderRoutingTests.cs
@@ -1,0 +1,75 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Reflection;
+using Moq;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Configuration;
+using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine;
+using QuantConnect.Lean.Engine.Server;
+using QuantConnect.Optimizer;
+using QuantConnect.Packets;
+using QuantConnect.Util;
+
+namespace QuantConnect.Tests.Engine
+{
+    [TestFixture]
+    public class WalkForwardOptimizationProviderRoutingTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            Config.Set("walk-forward-optimization-provider", nameof(TestWalkForwardOptimizationProvider));
+            Composer.Instance.Reset();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Config.Set("walk-forward-optimization-provider", nameof(NullWalkForwardOptimizationProvider));
+            Composer.Instance.Reset();
+        }
+
+        [Test]
+        public void LocalLeanManagerInjectsConfiguredWalkForwardOptimizationProvider()
+        {
+            var manager = new LocalLeanManager();
+            var systemHandlers = new LeanEngineSystemHandlers(
+                Mock.Of<IJobQueueHandler>(),
+                new QuantConnect.Api.Api(),
+                Mock.Of<IMessagingHandler>(),
+                Mock.Of<ILeanManager>());
+            manager.Initialize(systemHandlers, null, new BacktestNodePacket(), null);
+            var algorithm = new QCAlgorithm();
+
+            manager.SetAlgorithm(algorithm);
+
+            var provider = typeof(QCAlgorithm)
+                .GetField("_walkForwardOptimizationProvider", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(algorithm);
+            Assert.IsInstanceOf<TestWalkForwardOptimizationProvider>(provider);
+        }
+    }
+
+    public sealed class TestWalkForwardOptimizationProvider : IWalkForwardOptimizationProvider
+    {
+        public WalkForwardOptimizationResult Optimize(WalkForwardOptimizationRequest request)
+        {
+            return WalkForwardOptimizationResult.Empty;
+        }
+    }
+}

--- a/Tests/Engine/WalkForwardOptimizationProviderRoutingTests.cs
+++ b/Tests/Engine/WalkForwardOptimizationProviderRoutingTests.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Moq;
 using NUnit.Framework;
@@ -45,12 +46,14 @@ namespace QuantConnect.Tests.Engine
         }
 
         [Test]
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "LeanEngineSystemHandlers owns and disposes the API instance.")]
         public void LocalLeanManagerInjectsConfiguredWalkForwardOptimizationProvider()
         {
-            var manager = new LocalLeanManager();
-            var systemHandlers = new LeanEngineSystemHandlers(
+            using var manager = new LocalLeanManager();
+            var api = new QuantConnect.Api.Api();
+            using var systemHandlers = new LeanEngineSystemHandlers(
                 Mock.Of<IJobQueueHandler>(),
-                new QuantConnect.Api.Api(),
+                api,
                 Mock.Of<IMessagingHandler>(),
                 Mock.Of<ILeanManager>());
             manager.Initialize(systemHandlers, null, new BacktestNodePacket(), null);

--- a/Tests/Optimizer/LocalWalkForwardOptimizationProviderTests.cs
+++ b/Tests/Optimizer/LocalWalkForwardOptimizationProviderTests.cs
@@ -1,0 +1,181 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using QuantConnect.Algorithm;
+using QuantConnect.Api;
+using QuantConnect.Optimizer;
+using QuantConnect.Optimizer.Launcher;
+using QuantConnect.Optimizer.Objectives;
+using QuantConnect.Optimizer.Parameters;
+using QuantConnect.Statistics;
+using QuantConnect.Util;
+
+namespace QuantConnect.Tests.Optimizer
+{
+    [TestFixture]
+    public class LocalWalkForwardOptimizationProviderTests
+    {
+        [Test]
+        public void RunsOptimizerAndReturnsWinningParameterSet()
+        {
+            var provider = new TestLocalWalkForwardOptimizationProvider();
+            var parameters = new HashSet<OptimizationParameter>
+            {
+                new OptimizationStepParameter("ema-fast", 10, 20, 10)
+            };
+            var target = new Target("Profit", new Maximization(), null);
+
+            var result = provider.Optimize(new WalkForwardOptimizationRequest(
+                new QCAlgorithm(),
+                new DateTime(2026, 1, 1),
+                target,
+                parameters));
+
+            Assert.AreEqual("20", result.ParameterSet.Value["ema-fast"]);
+            Assert.AreSame(target, provider.Packet.Criterion);
+            Assert.AreSame(parameters, provider.Packet.OptimizationParameters);
+            Assert.AreEqual(2, result.Backtests.Count);
+        }
+
+        [Test]
+        public void SelectorRequestsReturnBacktestsWithoutPreselectedParameterSet()
+        {
+            var provider = new TestLocalWalkForwardOptimizationProvider();
+            var parameters = new HashSet<OptimizationParameter>
+            {
+                new OptimizationStepParameter("ema-fast", 10, 20, 10)
+            };
+
+            var result = provider.Optimize(new WalkForwardOptimizationRequest(
+                new QCAlgorithm(),
+                new DateTime(2026, 1, 1),
+                backtests => backtests
+                    .OrderByDescending(backtest => backtest.Statistics[PerformanceMetrics.NetProfit].ToDecimal())
+                    .First()
+                    .ParameterSet,
+                parameters));
+
+            Assert.IsNull(result.ParameterSet);
+            Assert.AreEqual(2, result.Backtests.Count);
+            Assert.AreEqual("20", result.Backtests
+                .OrderByDescending(backtest => backtest.Statistics[PerformanceMetrics.NetProfit].ToDecimal())
+                .First()
+                .ParameterSet
+                .Value["ema-fast"]);
+            Assert.AreEqual(
+                "Statistics." + PerformanceMetrics.NetProfit,
+                provider.Packet.Criterion.Target
+                    .Replace("['", string.Empty, StringComparison.Ordinal)
+                    .Replace("']", string.Empty, StringComparison.Ordinal));
+        }
+
+        [Test]
+        public void SelectorRequestsReturnBacktestsWhenDefaultTargetDoesNotSelectSolution()
+        {
+            var provider = new TestLocalWalkForwardOptimizationProvider(includeNetProfit: false);
+            var parameters = new HashSet<OptimizationParameter>
+            {
+                new OptimizationStepParameter("ema-fast", 10, 20, 10)
+            };
+
+            var result = provider.Optimize(new WalkForwardOptimizationRequest(
+                new QCAlgorithm(),
+                new DateTime(2026, 1, 1),
+                backtests => backtests
+                    .OrderByDescending(backtest => backtest.Statistics["Profit"].ToDecimal())
+                    .First()
+                    .ParameterSet,
+                parameters));
+
+            Assert.IsNull(result.ParameterSet);
+            Assert.AreEqual(2, result.Backtests.Count);
+            Assert.AreEqual("20", result.Backtests
+                .OrderByDescending(backtest => backtest.Statistics["Profit"].ToDecimal())
+                .First()
+                .ParameterSet
+                .Value["ema-fast"]);
+        }
+
+        private sealed class TestLocalWalkForwardOptimizationProvider : LocalWalkForwardOptimizationProvider
+        {
+            private readonly bool _includeNetProfit;
+
+            public TestLocalWalkForwardOptimizationProvider(bool includeNetProfit = true)
+            {
+                _includeNetProfit = includeNetProfit;
+            }
+
+            public OptimizationNodePacket Packet { get; private set; }
+
+            protected override LeanOptimizer CreateOptimizer(OptimizationNodePacket packet)
+            {
+                Packet = packet;
+                return new ImmediateLeanOptimizer(packet, _includeNetProfit);
+            }
+        }
+
+        private sealed class ImmediateLeanOptimizer : LeanOptimizer
+        {
+            private readonly bool _includeNetProfit;
+
+            public ImmediateLeanOptimizer(OptimizationNodePacket nodePacket, bool includeNetProfit)
+                : base(nodePacket)
+            {
+                _includeNetProfit = includeNetProfit;
+            }
+
+            protected override string RunLean(ParameterSet parameterSet, string backtestName)
+            {
+                var backtestId = parameterSet.Id.ToStringInvariant();
+                Task.Delay(10).ContinueWith(_ =>
+                {
+                    var netProfit = parameterSet.Value["ema-fast"].ToDecimal();
+                    NewResult(CreateBacktestJson(netProfit, _includeNetProfit), backtestId);
+                }, TaskScheduler.Default);
+                return backtestId;
+            }
+
+            protected override void AbortLean(string backtestId)
+            {
+            }
+
+            protected override void SendUpdate()
+            {
+            }
+
+            private static string CreateBacktestJson(decimal netProfit, bool includeNetProfit)
+            {
+                var statistics = new Dictionary<string, string>
+                {
+                    { "Profit", netProfit.ToStringInvariant() }
+                };
+                if (includeNetProfit)
+                {
+                    statistics[PerformanceMetrics.NetProfit] = netProfit.ToStringInvariant();
+                }
+
+                return Newtonsoft.Json.JsonConvert.SerializeObject(new
+                {
+                    Statistics = statistics
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Description
Adds scheduled walk-forward optimization support for algorithms:

- `QCAlgorithm.Optimize(...)` overloads that schedule walk-forward optimization similarly to `Train(...)`.
- A provider abstraction for local and cloud-backed walk-forward optimization execution.
- Local optimizer and QuantConnect API-backed providers.
- Result plumbing for selected parameter sets and backtest summaries, with safeguards against nested child optimizations.

#### Related Issue
Addresses #7031

#### Motivation and Context
Issue #7031 requests walk-forward optimization support in LEAN. This PR adds a core API contract and provider routing so algorithms can trigger optimization over time and apply chosen parameters without hard-coding a single execution backend.

#### Requires Documentation Change
Yes. If accepted, documentation should describe the new `Optimize(...)` API and the `walk-forward-optimization-*` configuration keys for local and cloud execution.

#### How Has This Been Tested?
Local environment: macOS, .NET SDK in this checkout.

- `dotnet build Tests/QuantConnect.Tests.csproj /p:Configuration=Debug /v:quiet`
- Focused walk-forward optimization tests: 13 passed
- Optimizer regression tests: 186 passed
- `git diff --check origin/master...HEAD`

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. I ran the build, focused WFO tests, and optimizer regression coverage listed above; I did not run the entire repository test suite locally.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

Disclosure: I used AI-assisted coding tools while preparing this PR. I reviewed the changes myself, tested them, and take responsibility for the implementation and any follow-up revisions needed.
