### PR TITLE
Fix margin call handling for single-lot option strategy position groups

### DIFF
--- a/Algorithm.CSharp/SingleLotOptionStrategyMarginCallRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/SingleLotOptionStrategyMarginCallRegressionAlgorithm.cs
@@ -1,0 +1,186 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+using QuantConnect.Orders;
+using QuantConnect.Securities.Option;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting that a margin call requiring a partial reduction of a single-lot option
+    /// strategy position group fully liquidates the group instead of failing. Since a single lot cannot be
+    /// partially reduced, the margin call order quantity calculation probes a zero-quantity position group,
+    /// which used to make the option strategy margin models throw
+    /// "InvalidOperationException: Sequence contains no matching element".
+    /// </summary>
+    public class SingleLotOptionStrategyMarginCallRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private readonly DateTime _expiry = new DateTime(2021, 1, 15);
+        private Symbol _shortPut;
+        private Symbol _longPut;
+        private bool _ordered;
+        private bool _cashDropped;
+        private int _onMarginCallCount;
+
+        public override void Initialize()
+        {
+            SetStartDate(2021, 1, 4);
+            SetEndDate(2021, 1, 4);
+            SetCash(200000);
+
+            var spx = AddIndex("SPX", Resolution.Minute).Symbol;
+
+            _shortPut = AddIndexOptionContract(
+                QuantConnect.Symbol.CreateOption(spx, Market.USA, OptionStyle.European, OptionRight.Put, 4200m, _expiry),
+                Resolution.Minute).Symbol;
+            _longPut = AddIndexOptionContract(
+                QuantConnect.Symbol.CreateOption(spx, Market.USA, OptionStyle.European, OptionRight.Put, 3200m, _expiry),
+                Resolution.Minute).Symbol;
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (!_ordered)
+            {
+                if (Securities[_shortPut].HasData && Securities[_longPut].HasData)
+                {
+                    // 1 lot: sell the 4200 put, buy the 3200 put. Strike difference margin: (4200 - 3200) * 100 = $100,000
+                    var bullPutSpread = OptionStrategies.BullPutSpread(_shortPut.Canonical, 4200m, 3200m, _expiry);
+                    Buy(bullPutSpread, 1);
+                    _ordered = true;
+                }
+                return;
+            }
+
+            if (!_cashDropped && Portfolio.Invested)
+            {
+                // Simulate a drawdown: equity drops below the margin used by the spread so that the
+                // margin call model requests a partial reduction of the 1-lot position group
+                Portfolio.CashBook[Currencies.USD].SetAmount(100000);
+                _cashDropped = true;
+            }
+        }
+
+        public override void OnMarginCall(List<SubmitOrderRequest> requests)
+        {
+            _onMarginCallCount++;
+
+            if (requests.Count != 2)
+            {
+                throw new RegressionTestException($"Expected 2 margin call order requests, one per leg, but found {requests.Count}");
+            }
+
+            foreach (var request in requests)
+            {
+                var holdingsQuantity = Securities[request.Symbol].Holdings.Quantity;
+                if (request.Quantity != -holdingsQuantity)
+                {
+                    throw new RegressionTestException($@"Expected margin call order for {request.Symbol} to fully liquidate the {holdingsQuantity
+                        } holdings, but its quantity was {request.Quantity}");
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_onMarginCallCount != 1)
+            {
+                throw new RegressionTestException($"OnMarginCall was called {_onMarginCallCount} times, expected 1");
+            }
+
+            if (Portfolio.Invested)
+            {
+                throw new RegressionTestException("The margin call should have liquidated the whole position group, " +
+                    $"but are invested in: {string.Join(", ", Portfolio.Keys)}");
+            }
+
+            var orders = Transactions.GetOrders().ToList();
+            if (orders.Count != 4)
+            {
+                throw new RegressionTestException($"Expected 4 orders, the strategy entry and margin call liquidation legs, but found {orders.Count}");
+            }
+
+            if (orders.Any(order => !order.Status.IsFill()))
+            {
+                throw new RegressionTestException("All orders should be filled");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 2745;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "4"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "200000"},
+            {"End Equity", "55475"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$34000000.00"},
+            {"Lowest Capacity Asset", "SPX 31KC0UJFOS3N2|SPX 31"},
+            {"Portfolio Turnover", "159.43%"},
+            {"Drawdown Recovery", "0"},
+            {"OrderListHash", "e69ca5560c0621ec31adcc1bc1f7a932"}
+        };
+    }
+}

--- a/Common/Securities/Option/OptionStrategyPositionGroupBuyingPowerModel.cs
+++ b/Common/Securities/Option/OptionStrategyPositionGroupBuyingPowerModel.cs
@@ -49,6 +49,12 @@ namespace QuantConnect.Securities.Option
         /// <returns>The maintenance margin required for the </returns>
         public override MaintenanceMargin GetMaintenanceMargin(PositionGroupMaintenanceMarginParameters parameters)
         {
+            if (parameters.PositionGroup.Quantity == 0)
+            {
+                // a zero-quantity group, e.g. probed while iterating quantities during a margin call reduction
+                return MaintenanceMargin.Zero;
+            }
+
             if (_optionStrategy == null)
             {
                 // we could be liquidating a position
@@ -287,6 +293,12 @@ namespace QuantConnect.Securities.Option
         /// <param name="parameters">An object containing the security and quantity</param>
         public override InitialMargin GetInitialMarginRequirement(PositionGroupInitialMarginParameters parameters)
         {
+            if (parameters.PositionGroup.Quantity == 0)
+            {
+                // a zero-quantity group, e.g. probed while iterating quantities during a margin call reduction
+                return OptionInitialMargin.Zero;
+            }
+
             var result = 0m;
 
             if (_optionStrategy == null)

--- a/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
+++ b/Tests/Common/Securities/OptionStrategyPositionGroupBuyingPowerModelTests.cs
@@ -1025,6 +1025,41 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual((double)expectedMaintenanceMargin, (double)maintenanceMargin.Value, (double)(0.2m * expectedMaintenanceMargin));
         }
 
+        private static readonly TestCaseData[] ZeroQuantityPositionGroupTestCases = MaintenanceMarginTestCases
+            .Select(x => (OptionStrategyDefinition)x.Arguments[0])
+            .DistinctBy(x => x.Name)
+            .Select(x => new TestCaseData(x))
+            .ToArray();
+
+        [TestCaseSource(nameof(ZeroQuantityPositionGroupTestCases))]
+        public void GetsZeroMarginRequirementsForZeroQuantityPositionGroup(OptionStrategyDefinition optionStrategyDefinition)
+        {
+            var positionGroup = SetUpOptionStrategy(optionStrategyDefinition, 1);
+            // Zero-quantity groups are probed by PositionGroupBuyingPowerModel.GetPositionGroupOrderQuantity
+            // when iterating quantities towards a reduction target (e.g. during a margin call)
+            var zeroQuantityGroup = positionGroup.WithQuantity(0, _portfolio.Positions);
+
+            var initialMargin = zeroQuantityGroup.BuyingPowerModel.GetInitialMarginRequirement(
+                new PositionGroupInitialMarginParameters(_portfolio, zeroQuantityGroup));
+            var maintenanceMargin = zeroQuantityGroup.BuyingPowerModel.GetMaintenanceMargin(
+                new PositionGroupMaintenanceMarginParameters(_portfolio, zeroQuantityGroup));
+
+            Assert.AreEqual(0m, initialMargin.Value);
+            Assert.AreEqual(0m, maintenanceMargin.Value);
+        }
+
+        [Test]
+        public void FullyLiquidatesSingleLotGroupWhenMarginCallRequiresPartialReduction()
+        {
+            var positionGroup = SetUpOptionStrategy(OptionStrategyDefinitions.BullPutSpread, 1);
+
+            // Emulates DefaultMarginCallModel.GenerateMarginCallOrders: the margin call only needs to free
+            // part of the margin used by the group, but a single lot cannot be partially reduced,
+            // so the group should be fully liquidated instead of throwing
+            var usedMargin = positionGroup.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(_portfolio, positionGroup);
+            ComputeAndAssertQuantityForDeltaBuyingPower(positionGroup, -1, -usedMargin / 2);
+        }
+
         /// <remarks>
         /// TODO: Revisit the explicit test cases when we can take into account premium for strategies with zero margin.
         /// </remarks>


### PR DESCRIPTION
#### Description

Fixes an unhandled `InvalidOperationException: Sequence contains no matching element` that kills a backtest/live algorithm when a margin call requires a **partial** reduction of an option strategy position group the user holds **1 lot** of.

**Root cause.** When `DefaultMarginCallModel.GenerateMarginCallOrders` requests a partial reduction, `PositionGroupBuyingPowerModel.GetPositionGroupOrderQuantity` solves for the order quantity by stepping the group quantity one unit at a time toward the target and asking the buying power model for the margin at each trial quantity. For a 1-lot group, the first trial is `WithQuantity(0)` — a legitimate probe meaning "what margin remains if the group is fully closed?", whose correct answer is zero. However, `OptionStrategyPositionGroupBuyingPowerModel`'s strategy-specific margin helpers pattern-match on the legs (e.g. `positions.Single(p => p.Quantity > 0)`) and throw on a group whose legs all have zero quantity.

**Fix.** `OptionStrategyPositionGroupBuyingPowerModel.GetInitialMarginRequirement` and `GetMaintenanceMargin` now return zero margin for zero-quantity position groups, letting the quantity search correctly converge on full liquidation. Guarding once at the two public entry points covers the same `Single(...)` assumption in every strategy margin helper (call spreads, ladders, etc.).

**Why the fix lives in the model and not the quantity-search loop.** "Zero margin for an empty group" is the contract the rest of the engine already implements implicitly, and these are public API methods with multiple callers — guarding them fixes every path, not just this one. No other model needs the same change:

- `SecurityPositionGroupBuyingPowerModel` (the only other position group model) sums per-position security margins, so a zero-quantity group naturally yields zero.
- All security-level margin models already return zero at zero quantity: `BuyingPowerModel`/`SecurityMarginModel`/`PatternDayTradingMarginModel` scale margin with quantity/holdings value; `OptionMarginModel` takes the long branch (zero) for `Quantity >= 0`; `FutureMarginModel` and `CryptoFutureMarginModel` already have this exact explicit zero-quantity guard (which this PR follows as precedent); `FuturesOptionsMarginModel` delegates to the guarded `FutureMarginModel`; `ConstantBuyingPowerModel` scales with quantity; `CashBuyingPowerModel` and `NullBuyingPowerModel` have no margin requirements.

#### Related Issue

N/A — diagnosed from a cloud backtest failure. Reproducible with any two-leg strategy: hold 1 lot, drift into a margin call that targets a partial reduction.

#### Motivation and Context

Any algorithm holding a single lot of any option strategy (no buying power overrides needed) whose equity drops enough for `DefaultMarginCallModel` to request a partial reduction crashes with an unhandled runtime error instead of being liquidated. The margin call should fully liquidate the group, since a single lot cannot be partially reduced.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

- New unit test `GetsZeroMarginRequirementsForZeroQuantityPositionGroup` asserts zero initial/maintenance margin for zero-quantity groups across all option strategy definitions covered by the existing margin test cases.
- New unit test `FullyLiquidatesSingleLotGroupWhenMarginCallRequiresPartialReduction` emulates the margin call model's delta-buying-power request on a 1-lot bull put spread and asserts full liquidation instead of a throw.
- New regression algorithm `SingleLotOptionStrategyMarginCallRegressionAlgorithm` reproduces the original crash end-to-end (1-lot SPX bull put spread + equity drawdown triggering a margin call): it previously died with the `InvalidOperationException`; it now receives one `OnMarginCall` with two full-liquidation leg orders, all filled.
- Existing `OptionStrategyPositionGroupBuyingPowerModelTests` fixture passes.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
