### PR TITLE
Fix order deserialization overflow for values at the edge of the decimal range

### DIFF
--- a/Common/Orders/OrderJsonConverter.cs
+++ b/Common/Orders/OrderJsonConverter.cs
@@ -118,9 +118,9 @@ namespace QuantConnect.Orders
             var orderSubmissionData = jObject["OrderSubmissionData"] ?? jObject["orderSubmissionData"];
             if (orderSubmissionData != null && orderSubmissionData.Type != JTokenType.Null)
             {
-                var bidPrice = orderSubmissionData["BidPrice"]?.Value<decimal>() ?? orderSubmissionData["bidPrice"].Value<decimal>();
-                var askPrice = orderSubmissionData["AskPrice"]?.Value<decimal>() ?? orderSubmissionData["askPrice"].Value<decimal>();
-                var lastPrice = orderSubmissionData["LastPrice"]?.Value<decimal>() ?? orderSubmissionData["lastPrice"].Value<decimal>();
+                var bidPrice = SafeDecimalValue(orderSubmissionData["BidPrice"] ?? orderSubmissionData["bidPrice"]);
+                var askPrice = SafeDecimalValue(orderSubmissionData["AskPrice"] ?? orderSubmissionData["askPrice"]);
+                var lastPrice = SafeDecimalValue(orderSubmissionData["LastPrice"] ?? orderSubmissionData["lastPrice"]);
                 order.OrderSubmissionData = new OrderSubmissionData(bidPrice, askPrice, lastPrice);
             }
 
@@ -157,11 +157,11 @@ namespace QuantConnect.Orders
                 order.Tag = string.Empty;
             }
 
-            order.Quantity = jObject["Quantity"]?.Value<decimal>() ?? jObject["quantity"].Value<decimal>();
+            order.Quantity = SafeDecimalValue(jObject["Quantity"] ?? jObject["quantity"]);
             var orderPrice = jObject["Price"] ?? jObject["price"];
             if (orderPrice != null && orderPrice.Type != JTokenType.Null)
             {
-                order.Price = orderPrice.Value<decimal>();
+                order.Price = SafeDecimalValue(orderPrice);
             }
             else
             {
@@ -256,29 +256,29 @@ namespace QuantConnect.Orders
                     break;
 
                 case OrderType.Limit:
-                    order = new LimitOrder { LimitPrice = jObject["LimitPrice"]?.Value<decimal>() ?? jObject["limitPrice"]?.Value<decimal>() ?? default(decimal) };
+                    order = new LimitOrder { LimitPrice = SafeDecimalValueOrDefault(jObject["LimitPrice"] ?? jObject["limitPrice"]) };
                     break;
 
                 case OrderType.StopMarket:
                     order = new StopMarketOrder
                     {
-                        StopPrice = jObject["stopPrice"]?.Value<decimal>() ?? jObject["StopPrice"]?.Value<decimal>() ?? default(decimal)
+                        StopPrice = SafeDecimalValueOrDefault(jObject["stopPrice"] ?? jObject["StopPrice"])
                     };
                     break;
 
                 case OrderType.StopLimit:
                     order = new StopLimitOrder
                     {
-                        LimitPrice = jObject["LimitPrice"]?.Value<decimal>() ?? jObject["limitPrice"]?.Value<decimal>() ?? default(decimal),
-                        StopPrice = jObject["stopPrice"]?.Value<decimal>() ?? jObject["StopPrice"]?.Value<decimal>() ?? default(decimal)
+                        LimitPrice = SafeDecimalValueOrDefault(jObject["LimitPrice"] ?? jObject["limitPrice"]),
+                        StopPrice = SafeDecimalValueOrDefault(jObject["stopPrice"] ?? jObject["StopPrice"])
                     };
                     break;
 
                 case OrderType.TrailingStop:
                     order = new TrailingStopOrder
                     {
-                        StopPrice = jObject["StopPrice"]?.Value<decimal>() ?? jObject["stopPrice"]?.Value<decimal>() ?? default(decimal),
-                        TrailingAmount = jObject["TrailingAmount"]?.Value<decimal>() ?? jObject["trailingAmount"]?.Value<decimal>() ??  default(decimal),
+                        StopPrice = SafeDecimalValueOrDefault(jObject["StopPrice"] ?? jObject["stopPrice"]),
+                        TrailingAmount = SafeDecimalValueOrDefault(jObject["TrailingAmount"] ?? jObject["trailingAmount"]),
                         TrailingAsPercentage = jObject["TrailingAsPercentage"]?.Value<bool>() ?? jObject["trailingAsPercentage"]?.Value<bool>() ?? default(bool)
                     };
                     break;
@@ -286,8 +286,8 @@ namespace QuantConnect.Orders
                 case OrderType.LimitIfTouched:
                     order = new LimitIfTouchedOrder
                     {
-                        LimitPrice = jObject["LimitPrice"]?.Value<decimal>() ?? jObject["limitPrice"]?.Value<decimal>() ?? default(decimal),
-                        TriggerPrice = jObject["TriggerPrice"]?.Value<decimal>() ?? jObject["triggerPrice"]?.Value<decimal>() ?? default(decimal)
+                        LimitPrice = SafeDecimalValueOrDefault(jObject["LimitPrice"] ?? jObject["limitPrice"]),
+                        TriggerPrice = SafeDecimalValueOrDefault(jObject["TriggerPrice"] ?? jObject["triggerPrice"])
                     };
                     break;
 
@@ -315,7 +315,7 @@ namespace QuantConnect.Orders
                     order = new ComboLegLimitOrder
                     {
                         GroupOrderManager = DeserializeGroupOrderManager(jObject),
-                        LimitPrice = jObject["LimitPrice"]?.Value<decimal>() ?? jObject["limitPrice"]?.Value<decimal>() ?? default(decimal)
+                        LimitPrice = SafeDecimalValueOrDefault(jObject["LimitPrice"] ?? jObject["limitPrice"])
                     };
                     break;
 
@@ -372,8 +372,8 @@ namespace QuantConnect.Orders
             var result = new GroupOrderManager(
                 groupOrderManagerJObject["Id"]?.Value<int>() ?? groupOrderManagerJObject["id"].Value<int>(),
                 groupOrderManagerJObject["Count"]?.Value<int>() ?? groupOrderManagerJObject["count"].Value<int>(),
-                groupOrderManagerJObject["Quantity"]?.Value<decimal>() ?? groupOrderManagerJObject["quantity"].Value<decimal>(),
-                groupOrderManagerJObject["LimitPrice"]?.Value<decimal>() ?? groupOrderManagerJObject["limitPrice"].Value<decimal>()
+                SafeDecimalValue(groupOrderManagerJObject["Quantity"] ?? groupOrderManagerJObject["quantity"]),
+                SafeDecimalValue(groupOrderManagerJObject["LimitPrice"] ?? groupOrderManagerJObject["limitPrice"])
             );
 
             foreach (var orderId in (groupOrderManagerJObject["OrderIds"]?.Values<int>() ?? groupOrderManagerJObject["orderIds"].Values<int>()))
@@ -382,6 +382,29 @@ namespace QuantConnect.Orders
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Gets the decimal value of the given token, clamping it to the decimal range when the token holds
+        /// a double too large or too small to be represented as a decimal. Values at the edge of the range,
+        /// like a quantity clamped to <see cref="decimal.MaxValue"/> by <see cref="Extensions.SafeDecimalCast"/>,
+        /// are parsed back from JSON as doubles that round past the decimal range
+        /// </summary>
+        private static decimal SafeDecimalValue(JToken token)
+        {
+            if (token is JValue { Value: double value })
+            {
+                return value.SafeDecimalCast();
+            }
+            return token.Value<decimal>();
+        }
+
+        /// <summary>
+        /// Gets the decimal value of the given token, or zero if the token is null
+        /// </summary>
+        private static decimal SafeDecimalValueOrDefault(JToken token)
+        {
+            return token == null ? default : SafeDecimalValue(token);
         }
     }
 }

--- a/Tests/Common/Orders/OrderJsonConverterTests.cs
+++ b/Tests/Common/Orders/OrderJsonConverterTests.cs
@@ -760,6 +760,103 @@ namespace QuantConnect.Tests.Common.Orders
             Assert.IsTrue(order.TimeInForce is DayTimeInForce);
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void RoundTripsQuantityAtTheEdgeOfTheDecimalRange(bool positive)
+        {
+            // quantities out of the decimal range are clamped to decimal.MaxValue/MinValue at order creation,
+            // e.g. by the QCAlgorithm double quantity order methods, and must survive the JSON round trip
+            var quantity = positive ? decimal.MaxValue : decimal.MinValue;
+            var expected = new MarketOrder(Symbols.SPY, quantity, new DateTime(2015, 11, 23, 17, 15, 37), "now")
+            {
+                Id = 12345,
+                ContingentId = 123456,
+                BrokerId = new List<string> { "727", "54970" }
+            };
+
+            var actual = TestOrderType(expected);
+
+            Assert.AreEqual(quantity, actual.Quantity);
+        }
+
+        [Test]
+        public void RoundTripsOrderPricesAtTheEdgeOfTheDecimalRange()
+        {
+            var time = new DateTime(2015, 11, 23, 17, 15, 37);
+
+            var stopLimit = TestOrderType(new StopLimitOrder(Symbols.SPY, 100, decimal.MaxValue, decimal.MinValue, time));
+            Assert.AreEqual(decimal.MaxValue, stopLimit.StopPrice);
+            Assert.AreEqual(decimal.MinValue, stopLimit.LimitPrice);
+
+            var trailingStop = TestOrderType(new TrailingStopOrder(Symbols.SPY, 100, decimal.MaxValue, decimal.MaxValue, false, time));
+            Assert.AreEqual(decimal.MaxValue, trailingStop.StopPrice);
+            Assert.AreEqual(decimal.MaxValue, trailingStop.TrailingAmount);
+
+            var limitIfTouched = TestOrderType(new LimitIfTouchedOrder(Symbols.SPY, 100, decimal.MaxValue, decimal.MinValue, time));
+            Assert.AreEqual(decimal.MaxValue, limitIfTouched.TriggerPrice);
+            Assert.AreEqual(decimal.MinValue, limitIfTouched.LimitPrice);
+
+            var marketOrder = TestOrderType(new MarketOrder(Symbols.SPY, 100, time)
+            {
+                OrderSubmissionData = new OrderSubmissionData(decimal.MinValue, decimal.MaxValue, decimal.MaxValue)
+            });
+            Assert.AreEqual(decimal.MinValue, marketOrder.OrderSubmissionData.BidPrice);
+            Assert.AreEqual(decimal.MaxValue, marketOrder.OrderSubmissionData.AskPrice);
+            Assert.AreEqual(decimal.MaxValue, marketOrder.OrderSubmissionData.LastPrice);
+        }
+
+        [TestCase("79228162514264337593543950335.0")] // decimal.MaxValue as serialized to JSON
+        [TestCase("7.9228162514264338E+28")]
+        [TestCase("1E+300")]
+        public void DeserializesQuantityAndPriceTooLargeForDecimal(string value)
+        {
+            foreach (var (jsonValue, expected) in new[] { (value, decimal.MaxValue), ("-" + value, decimal.MinValue) })
+            {
+                var json = $@"{{'Type':0,
+'Id':1,
+'ContingentId':0,
+'BrokerId':['1'],
+'Symbol':{{'Value':'SPY','Permtick':'SPY'}},
+'Price':{jsonValue},
+'Time':'2010-03-04T14:31:00Z',
+'Quantity':{jsonValue},
+'Status':3,
+'TimeInForce':0,
+'Tag':'',
+'SecurityType':1,
+'Direction':0}}";
+
+                var order = DeserializeOrder<MarketOrder>(json);
+
+                Assert.AreEqual(expected, order.Quantity);
+                Assert.AreEqual(expected, order.Price);
+            }
+        }
+
+        [Test]
+        public void DeserializesGroupOrderManagerQuantityTooLargeForDecimal()
+        {
+            const string json = @"{'Type':8,
+'Id':1,
+'ContingentId':0,
+'BrokerId':['1'],
+'Symbol':{'Value':'SPY','Permtick':'SPY'},
+'Price':100.086914328,
+'Time':'2010-03-04T14:31:00Z',
+'Quantity':100.0,
+'Status':3,
+'TimeInForce':0,
+'Tag':'',
+'SecurityType':1,
+'Direction':0,
+'GroupOrderManager':{'Id':1,'Count':2,'Quantity':1E+300,'LimitPrice':-1E+300,'OrderIds':[1,2]}}";
+
+            var order = (ComboMarketOrder)DeserializeOrder<ComboMarketOrder>(json);
+
+            Assert.AreEqual(decimal.MaxValue, order.GroupOrderManager.Quantity);
+            Assert.AreEqual(decimal.MinValue, order.GroupOrderManager.LimitPrice);
+        }
+
         private static T TestOrderType<T>(T expected)
             where T : Order
         {


### PR DESCRIPTION
#### Description
`OrderJsonConverter` threw a `System.OverflowException` (\"Value was either too large or too small for a Decimal\") when deserializing orders whose quantity or prices sit at the edge of the decimal range.

Quantities/prices out of the decimal range are clamped to `decimal.MaxValue`/`decimal.MinValue` at order creation — e.g. the `QCAlgorithm` double-quantity order methods go through `Extensions.SafeDecimalCast`, so a runaway `double` quantity in user code (Python floats bind to these overloads) produces an order with `Quantity = decimal.MaxValue`. That order serializes fine, but on deserialization `JObject` parses the number back as a `double` that rounds *past* the decimal range (`decimal.MaxValue` is 2⁹⁶ − 1; the nearest double is exactly 2⁹⁶), so `Value<decimal>()` overflowed and the stored result file could never be read back.

The fix reads decimal fields through a helper that applies the same `SafeDecimalCast` clamping used at order creation when the token holds a double, mirroring what `DecimalJsonConverter` already does. Applied to `Quantity`, `Price`, `OrderSubmissionData` prices, stop/limit/trigger prices, trailing amount and `GroupOrderManager` quantity/limit price.

#### Related Issue
N/A — hit in production reading stored backtest results.

#### Motivation and Context
Stored backtest/live results containing such an order could never be deserialized again, permanently breaking result APIs for that backtest.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
New unit tests round-trip orders with `decimal.MaxValue`/`MinValue` quantity, order-type prices and order submission prices, plus direct deserialization of JSON with out-of-range literals (`79228162514264337593543950335.0`, `7.9228162514264338E+28`, `1E+300`) for quantity, price and group order manager fields. All 7 new test cases fail without the fix; full `OrderJsonConverterTests` fixture passes with it (56/56).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)