### PR TITLE
docs: setup steps say dotnet 9, but projects target net10.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ NOTE: Visual Studio for Mac [has been discontinued](https://learn.microsoft.com/
 
 - Install [Visual Studio Code for Mac](https://code.visualstudio.com/download)
 - Install the [C# Dev Kit extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit)
-- Install [dotnet 9 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/9.0):
+- Install [dotnet 10 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0):
 - To build the solution, either:
   - choose **Run Task** > **build** from the Panel task dropdown, or
   - from the command line run
@@ -159,7 +159,7 @@ NOTE: Visual Studio for Mac [has been discontinued](https://learn.microsoft.com/
 
 ### Linux (Debian, Ubuntu)
 
-- Install [dotnet 9](https://docs.microsoft.com/en-us/dotnet/core/install/linux):
+- Install [dotnet 10](https://docs.microsoft.com/en-us/dotnet/core/install/linux):
 - Compile Lean Solution:
 ```
 dotnet build QuantConnect.Lean.sln


### PR DESCRIPTION
## What this fixes

The setup instructions ask contributors to install **dotnet 9**, but the projects target **.NET 10**, so a fresh setup following the README fails to build.

- `readme.md` line 144 (macOS): `Install [dotnet 9 SDK](.../download/dotnet/9.0)`
- `readme.md` line 162 (Linux): `Install [dotnet 9]`

Meanwhile:

```
$ grep -rhoE '<TargetFramework>[^<]+</TargetFramework>' --include=*.csproj | sort -u
<TargetFramework>net10.0</TargetFramework>   # all 23 projects
```

and `DockerfileLeanFoundation` installs `dotnet-sdk-10.0`. This updates the two README steps (and the download link) to dotnet 10 so they match.

Docs-only change.

---

*Disclosure: I used an AI tool to help spot this; I verified the target framework and the Dockerfile against the repo myself and take responsibility for it.*
