### PR TITLE
Remove KRX futures opening call auction from tradable hours

### DIFF
--- a/Data/market-hours/market-hours-database.json
+++ b/Data/market-hours/market-hours-database.json
@@ -123355,11 +123355,6 @@
       "sunday": [],
       "monday": [
         {
-          "start": "08:30:00",
-          "end": "08:45:00",
-          "state": "premarket"
-        },
-        {
           "start": "08:45:00",
           "end": "15:45:00",
           "state": "market"
@@ -123374,11 +123369,6 @@
         {
           "start": "00:00:00",
           "end": "06:00:00",
-          "state": "premarket"
-        },
-        {
-          "start": "08:30:00",
-          "end": "08:45:00",
           "state": "premarket"
         },
         {
@@ -123399,11 +123389,6 @@
           "state": "premarket"
         },
         {
-          "start": "08:30:00",
-          "end": "08:45:00",
-          "state": "premarket"
-        },
-        {
           "start": "08:45:00",
           "end": "15:45:00",
           "state": "market"
@@ -123421,11 +123406,6 @@
           "state": "premarket"
         },
         {
-          "start": "08:30:00",
-          "end": "08:45:00",
-          "state": "premarket"
-        },
-        {
           "start": "08:45:00",
           "end": "15:45:00",
           "state": "market"
@@ -123440,11 +123420,6 @@
         {
           "start": "00:00:00",
           "end": "06:00:00",
-          "state": "premarket"
-        },
-        {
-          "start": "08:30:00",
-          "end": "08:45:00",
           "state": "premarket"
         },
         {
@@ -123932,11 +123907,6 @@
       "sunday": [],
       "monday": [
         {
-          "start": "08:30:00",
-          "end": "08:45:00",
-          "state": "premarket"
-        },
-        {
           "start": "08:45:00",
           "end": "15:45:00",
           "state": "market"
@@ -123951,11 +123921,6 @@
         {
           "start": "00:00:00",
           "end": "06:00:00",
-          "state": "premarket"
-        },
-        {
-          "start": "08:30:00",
-          "end": "08:45:00",
           "state": "premarket"
         },
         {
@@ -123976,11 +123941,6 @@
           "state": "premarket"
         },
         {
-          "start": "08:30:00",
-          "end": "08:45:00",
-          "state": "premarket"
-        },
-        {
           "start": "08:45:00",
           "end": "15:45:00",
           "state": "market"
@@ -123998,11 +123958,6 @@
           "state": "premarket"
         },
         {
-          "start": "08:30:00",
-          "end": "08:45:00",
-          "state": "premarket"
-        },
-        {
           "start": "08:45:00",
           "end": "15:45:00",
           "state": "market"
@@ -124017,11 +123972,6 @@
         {
           "start": "00:00:00",
           "end": "06:00:00",
-          "state": "premarket"
-        },
-        {
-          "start": "08:30:00",
-          "end": "08:45:00",
           "state": "premarket"
         },
         {


### PR DESCRIPTION
## Description

Removes the KRX derivatives **opening call auction (08:30–08:45 KST)** from the tradable market hours of `Future-krx-[*]` and `Future-krx-KM`.

The window had been modeled as a `premarket` segment. In Lean, `premarket`/`postmarket` segments are **tradable** whenever a subscription enables extended market hours (`LocalMarketHours.IsOpen` returns `extendedMarketHours || state == Market`). But the KRX opening auction is order-collection only — no continuous trading occurs during it; all matching happens in a single cross at 08:45. Modeling it as `premarket` therefore let orders fill continuously across a window where the real market only crosses once.

Removing the segment makes the earliest possible fill the **08:45 opening cross**, which is the start of the `market` segment (08:45–15:45) and matches the KRX regular-session start.

## Verified against KRX specs

| Phase | KRX spec | After this change |
|---|---|---|
| Pre-open call auction | 08:30–08:45 (auction only) | not tradable ✅ |
| Continuous (day) | 08:45–15:35 | `market` 08:45–15:45 |
| Closing call auction | 15:35–15:45 (cross at 15:45) | tail of `market` (captures close print) |
| Night session | 18:00–06:00 next day (continuous) | `postmarket`+`premarket`, **kept** |

The night session is genuine continuous trading and is intentionally left unchanged. The closing auction remains inside `market` (ending 15:45) so the closing-cross print is still fillable — matching the convention used for other markets (e.g. US equity `market` runs to 16:00).

Sources: [KRX Derivatives Trading Hours](https://global.krx.co.kr/contents/GLB/06/0603/0603010300/GLB0603010300.jsp), [Guide to Night Session in KRX Derivatives Market](https://global.krx.co.kr/contents/GLB/02/0201/0201041003/Guide_to_Night_Session_in_KRX_Derivatives_Market.pdf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
