### PR TITLE
Reduce TimeSliceFactory update allocations

### DIFF
--- a/Engine/DataFeeds/TimeSliceFactory.cs
+++ b/Engine/DataFeeds/TimeSliceFactory.cs
@@ -172,8 +172,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     custom.Add(new UpdateData<ISecurityPrice>(packet.Security, packet.Configuration.Type, list, packet.Configuration.IsInternalFeed));
                 }
 
+                var canShareUpdateData = !packet.Configuration.IsInternalFeed
+                    && !symbol.SecurityType.IsOption()
+                    && symbol.SecurityType != SecurityType.Future;
                 var securityUpdate = new List<BaseData>(list.Count);
-                var consolidatorUpdate = new List<BaseData>(list.Count);
+                var consolidatorUpdate = canShareUpdateData
+                    ? securityUpdate
+                    : new List<BaseData>(list.Count);
                 var containsFillForwardData = false;
                 for (var i = 0; i < list.Count; i++)
                 {
@@ -316,7 +321,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         // do not add it if it is a Suspicious tick
                         if (tick != null && tick.Suspicious) continue;
 
-                        securityUpdate.Add(baseData);
+                        if (!canShareUpdateData)
+                        {
+                            securityUpdate.Add(baseData);
+                        }
 
                         // option underlying security update
                         if (!packet.Configuration.IsInternalFeed)
@@ -376,11 +384,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     }
                 }
 
-                if (securityUpdate.Count > 0)
+                if (canShareUpdateData && securityUpdate.Count > 0)
+                {
+                    var updateData = securityUpdate.AsReadOnly();
+                    security.Add(new UpdateData<ISecurityPrice>(packet.Security, packet.Configuration.Type, updateData, false, containsFillForwardData));
+                    consolidator.Add(new UpdateData<SubscriptionDataConfig>(packet.Configuration, packet.Configuration.Type, updateData, false, containsFillForwardData));
+                }
+                else if (securityUpdate.Count > 0)
                 {
                     security.Add(new UpdateData<ISecurityPrice>(packet.Security, packet.Configuration.Type, securityUpdate, packet.Configuration.IsInternalFeed, containsFillForwardData));
                 }
-                if (consolidatorUpdate.Count > 0)
+                if (!canShareUpdateData && consolidatorUpdate.Count > 0)
                 {
                     consolidator.Add(new UpdateData<SubscriptionDataConfig>(packet.Configuration, packet.Configuration.Type, consolidatorUpdate, packet.Configuration.IsInternalFeed, containsFillForwardData));
                 }

--- a/Tests/Engine/DataFeeds/TimeSliceTests.cs
+++ b/Tests/Engine/DataFeeds/TimeSliceTests.cs
@@ -217,6 +217,69 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Assert.AreEqual(281, data[1].Value);
         }
 
+        [Test]
+        public void ExternalEquityUpdatesShareReadOnlyData()
+        {
+            var config = new SubscriptionDataConfig(
+                typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.Utc, TimeZones.Utc, true, false, false);
+            var timeSlice = CreateTimeSlice(config, new TradeBar { Symbol = Symbols.SPY, Time = DateTime.UtcNow, Value = 100 });
+
+            Assert.AreEqual(1, timeSlice.SecuritiesUpdateData.Count);
+            Assert.AreEqual(1, timeSlice.ConsolidatorUpdateData.Count);
+
+            var securityData = timeSlice.SecuritiesUpdateData[0].Data;
+            var consolidatorData = timeSlice.ConsolidatorUpdateData[0].Data;
+            Assert.AreSame(securityData, consolidatorData);
+            Assert.Throws<NotSupportedException>(() => ((IList<BaseData>)securityData).Add(new TradeBar()));
+        }
+
+        [TestCase(SecurityType.Option)]
+        [TestCase(SecurityType.Future)]
+        public void DerivativeUpdatesUseDistinctData(SecurityType securityType)
+        {
+            var symbol = securityType == SecurityType.Option
+                ? Symbols.SPY_C_192_Feb19_2016
+                : Symbols.Fut_SPY_Mar19_2016;
+            var config = new SubscriptionDataConfig(
+                typeof(TradeBar), symbol, Resolution.Minute, TimeZones.Utc, TimeZones.Utc, true, false, false);
+            var timeSlice = CreateTimeSlice(config, new TradeBar { Symbol = symbol, Time = DateTime.UtcNow, Value = 100 });
+
+            var securityUpdate = timeSlice.SecuritiesUpdateData.Single(update => update.Target.Symbol == symbol);
+            var consolidatorUpdate = timeSlice.ConsolidatorUpdateData.Single(update => update.Target.Symbol == symbol);
+            Assert.AreNotSame(securityUpdate.Data, consolidatorUpdate.Data);
+        }
+
+        [Test]
+        public void InternalFeedOnlyCreatesSecurityUpdateData()
+        {
+            var config = new SubscriptionDataConfig(
+                typeof(TradeBar), Symbols.SPY, Resolution.Minute, TimeZones.Utc, TimeZones.Utc, true, false, true);
+            var timeSlice = CreateTimeSlice(config, new TradeBar { Symbol = Symbols.SPY, Time = DateTime.UtcNow, Value = 100 });
+
+            Assert.AreEqual(1, timeSlice.SecuritiesUpdateData.Count);
+            Assert.AreEqual(0, timeSlice.ConsolidatorUpdateData.Count);
+            Assert.IsTrue(timeSlice.SecuritiesUpdateData[0].IsInternalConfig);
+        }
+
+        private TimeSlice CreateTimeSlice(SubscriptionDataConfig config, BaseData data)
+        {
+            var security = GetSecurity(config);
+            var packets = new List<DataFeedPacket>();
+            if (security is Option option)
+            {
+                var underlying = new TradeBar { Symbol = option.Underlying.Symbol, Time = data.Time, Value = 100 };
+                packets.Add(new DataFeedPacket(option.Underlying, option.Underlying.SubscriptionDataConfig,
+                    new List<BaseData> { underlying }));
+            }
+            packets.Add(new DataFeedPacket(security, config, new List<BaseData> { data }));
+
+            return _timeSliceFactory.Create(
+                data.Time,
+                packets,
+                SecurityChangesTests.CreateNonInternal(Enumerable.Empty<Security>(), Enumerable.Empty<Security>()),
+                new Dictionary<Universe, BaseDataCollection>());
+        }
+
         private IEnumerable<Slice> GetSlices(Symbol symbol, int initialVolume)
         {
             var dataType = symbol.SecurityType.IsOption() ? typeof(OptionUniverse) : typeof(FutureUniverse);


### PR DESCRIPTION
## Summary

- reuse one read-only filtered data collection for external non-derivative security and consolidator updates
- preserve the separate option, future, and internal-feed update paths
- add focused tests for shared data, derivative isolation, and internal feeds

## Performance

The allocation evaluator measures `TimeSliceFactory.Create` with the same representative packet workload before and after this change:

| Version | Allocated bytes/Create |
| --- | ---: |
| `master` | 31,256 |
| This PR | 27,416 |
| Reduction | 3,840 (12.285641%) |

This is a deterministic allocation metric rather than a CPU timing claim. The candidate repeated at `27,416 bytes/Create` in both measured runs.

[Public autoresearch record](https://dashboard.weco.ai/share/x3kitZBpqalZR5XuB0ylN3yeD6YIREVb)

This optimization was developed through an autoresearch process tracked with Weco.

## Validation

- 9 focused `TimeSliceTests` cases passed in the sealed source-and-test evaluation lane
- exact output snapshots preserved ordering, counts, subscriptions, chains, update targets, deferred input behavior, and empty-collection behavior
- evaluator negative controls rejected out-of-scope edits, reordered or dropped data, and metric instrumentation

This is a partial improvement for #7554; it does not attempt the issue's broader lazy-collection refactor.
