### PR TITLE
Fix trade statistics for option assignment underlying fills

### DIFF
--- a/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
@@ -81,19 +81,33 @@ namespace QuantConnect.Algorithm.CSharp
             }
         }
 
+        private Security GetSecurity(Symbol symbol)
+        {
+            if (symbol == Stock.Symbol)
+            {
+                return Stock;
+            }
+            if (symbol == CallOptionSymbol)
+            {
+                return CallOption;
+            }
+            if (symbol == PutOptionSymbol)
+            {
+                return PutOption;
+            }
+            throw new RegressionTestException($"Unexpected symbol: {symbol}");
+        }
+
         public override void OnEndOfAlgorithm()
         {
-            foreach (var trade in TradeBuilder.ClosedTrades.Where(trade => trade.Symbols.Contains(Stock.Symbol)))
+            foreach (var trade in TradeBuilder.ClosedTrades)
             {
                 var direction = trade.Direction == TradeDirection.Long ? 1m : -1m;
-                var expectedProfitLoss = Math.Round(
-                    (trade.ExitPrice - trade.EntryPrice) * trade.Quantity * direction * Stock.SymbolProperties.ContractMultiplier,
-                    2);
+                var expectedProfitLoss = Math.Round((trade.ExitPrice - trade.EntryPrice) * trade.Quantity * direction * GetSecurity(trade.Symbols.Single()).SymbolProperties.ContractMultiplier, 2);
 
                 if (trade.ProfitLoss != expectedProfitLoss)
                 {
-                    throw new RegressionTestException(
-                        $"Expected underlying trade profit/loss to be {expectedProfitLoss}. Actual: {trade.ProfitLoss}");
+                    throw new RegressionTestException($"Expected underlying trade profit/loss to be {expectedProfitLoss}. Actual: {trade.ProfitLoss}");
                 }
             }
         }

--- a/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionAssignmentRegressionAlgorithm.cs
@@ -14,11 +14,13 @@
  *
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Data;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
+using QuantConnect.Statistics;
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -75,6 +77,23 @@ namespace QuantConnect.Algorithm.CSharp
                 if (Time < CallOptionSymbol.ID.Date)
                 {
                     MarketOrder(CallOptionSymbol, -1);
+                }
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            foreach (var trade in TradeBuilder.ClosedTrades.Where(trade => trade.Symbols.Contains(Stock.Symbol)))
+            {
+                var direction = trade.Direction == TradeDirection.Long ? 1m : -1m;
+                var expectedProfitLoss = Math.Round(
+                    (trade.ExitPrice - trade.EntryPrice) * trade.Quantity * direction * Stock.SymbolProperties.ContractMultiplier,
+                    2);
+
+                if (trade.ProfitLoss != expectedProfitLoss)
+                {
+                    throw new RegressionTestException(
+                        $"Expected underlying trade profit/loss to be {expectedProfitLoss}. Actual: {trade.ProfitLoss}");
                 }
             }
         }

--- a/Algorithm.Python/OptionAssignmentRegressionAlgorithm.py
+++ b/Algorithm.Python/OptionAssignmentRegressionAlgorithm.py
@@ -47,3 +47,22 @@ class OptionAssignmentRegressionAlgorithm(QCAlgorithm):
 
             if self.time < self.call_option_symbol.id.date:
                 self.market_order(self.call_option_symbol, -1)
+
+    def get_security(self, symbol):
+        if symbol == self.stock.symbol:
+            return self.stock
+        if symbol == self.call_option_symbol:
+            return self.call_option
+        if symbol == self.put_option_symbol:
+            return self.put_option
+        raise RegressionTestException(f"Unexpected symbol: {symbol}")
+
+    def on_end_of_algorithm(self):
+        for trade in self.trade_builder.closed_trades:
+            symbol, = trade.symbols
+            direction = 1 if trade.direction == TradeDirection.LONG else -1
+            multiplier = self.get_security(symbol).symbol_properties.contract_multiplier
+            expected_profit_loss = round((trade.exit_price - trade.entry_price) * trade.quantity * direction * multiplier, 2)
+
+            if trade.profit_loss != expected_profit_loss:
+                raise RegressionTestException(f"Expected underlying trade profit/loss to be {expected_profit_loss}. Actual: {trade.profit_loss}")

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1186,7 +1186,10 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                         return;
                     }
 
-                    orders.Add(new OpenOrderState(order, ticket, security ?? _algorithm.Securities[order.Symbol]));
+                    // we take the order event symbol security to make sure to match the actual traded asset:
+                    // for order exercises, the underlying security events are traded under the same option order id,
+                    // but the order event symbol is the underlying security, not the option contract.
+                    orders.Add(new OpenOrderState(order, ticket, security != null && security.Symbol == orderEvent.Symbol ? security : _algorithm.Securities[orderEvent.Symbol]));
                     orderEvent.Ticket = ticket;
                 }
 
@@ -1313,7 +1316,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
                     if (orderEvent.Status == OrderStatus.Filled || orderEvent.Status == OrderStatus.PartiallyFilled)
                     {
-                        var security = _algorithm.Securities[orderEvent.Symbol];
+                        var security = orders[i].Security;
 
                         var multiplier = security.SymbolProperties.ContractMultiplier;
                         var securityConversionRate = security.QuoteCurrency.ConversionRate;

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -1313,7 +1313,7 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
 
                     if (orderEvent.Status == OrderStatus.Filled || orderEvent.Status == OrderStatus.PartiallyFilled)
                     {
-                        var security = orders[i].Security;
+                        var security = _algorithm.Securities[orderEvent.Symbol];
 
                         var multiplier = security.SymbolProperties.ContractMultiplier;
                         var securityConversionRate = security.QuoteCurrency.ConversionRate;


### PR DESCRIPTION
## Description

Physical option settlement emits an option fill and an underlying fill with the same option exercise order ID. `BrokerageTransactionHandler` previously used the parent order's security when sending both events to `TradeBuilder`, so an underlying fill that closed a trade used the option contract multiplier and quote-currency conversion rate.

For a standard US equity option, the existing `OptionAssignmentRegressionAlgorithm` reproduced an expected underlying loss of $20,000 as $2,000,000. The underlying fill quantity already contains the contract unit of trade, so applying the option multiplier again inflated closed-trade P&L, MAE, MFE, and end-trade drawdown.

This change resolves the security from `orderEvent.Symbol`, matching portfolio fill processing. Normal fills are unchanged because their order and event symbols are identical.

The existing option-assignment regression now verifies every closed underlying trade uses the underlying security's multiplier.

## Tests

- `OptionAssignmentRegressionAlgorithm` (fails before the fix, passes after)
- `OptionAssignmentStatisticsRegressionAlgorithm`
- `OptionExerciseAssignRegressionAlgorithm`