### PR TITLE
Fix CryptoFuture.IsCryptoCoinFuture() misclassifying USD-quoted linea…

### DIFF
--- a/Common/Securities/CryptoFuture/CryptoFuture.cs
+++ b/Common/Securities/CryptoFuture/CryptoFuture.cs
@@ -60,7 +60,7 @@ namespace QuantConnect.Securities.CryptoFuture
                 cache,
                 new SecurityPortfolioModel(),
                 new ImmediateFillModel(),
-                IsCryptoCoinFuture(quoteCurrency.Symbol) ? new BinanceCoinFuturesFeeModel() : new BinanceFuturesFeeModel(),
+                IsCryptoCoinFuture(symbol.ID.Market, quoteCurrency.Symbol) ? new BinanceCoinFuturesFeeModel() : new BinanceFuturesFeeModel(),
                 NullSlippageModel.Instance,
                 new ImmediateSettlementModel(),
                 Securities.VolatilityModel.Null,
@@ -83,16 +83,26 @@ namespace QuantConnect.Securities.CryptoFuture
         /// <returns>True if the security is a crypto coin future</returns>
         public bool IsCryptoCoinFuture()
         {
-            return IsCryptoCoinFuture(QuoteCurrency.Symbol);
+            return IsCryptoCoinFuture(Symbol.ID.Market, QuoteCurrency.Symbol);
         }
 
         /// <summary>
         /// Checks whether the security is a crypto coin future
         /// </summary>
+        /// <param name="market">The security market</param>
         /// <param name="quoteCurrency">The security quote currency</param>
         /// <returns>True if the security is a crypto coin future</returns>
-        private static bool IsCryptoCoinFuture(string quoteCurrency)
+        private static bool IsCryptoCoinFuture(string market, string quoteCurrency)
         {
+            // Binance coin-margined futures are nominally quoted in USD (e.g. BTCUSD_PERP) but settle in the base
+            // currency, so on Binance any quote currency other than one of its known USD-pegged stablecoins implies
+            // a coin-margined contract. Other venues, notably EU MiCA-compliant exchanges, quote linear (USD-margined)
+            // futures directly in fiat USD, so outside of Binance the quote currency alone can't be used this way.
+            if (market != Market.Binance)
+            {
+                return false;
+            }
+
             return quoteCurrency != "USDT" && quoteCurrency != "BUSD" && quoteCurrency != "USDC";
         }
 

--- a/Tests/Common/Securities/CryptoFuture/CryptoFutureMarginModelTests.cs
+++ b/Tests/Common/Securities/CryptoFuture/CryptoFutureMarginModelTests.cs
@@ -207,6 +207,42 @@ namespace QuantConnect.Tests.Common.Securities.CryptoFuture
             Assert.AreEqual(0, buyingPower.Value);
         }
 
+        [Test]
+        public void BinanceUsdQuotedFutureIsCoinMargined()
+        {
+            var symbol = Symbol.Create("BTCUSD", SecurityType.CryptoFuture, Market.Binance);
+            var cryptoFuture = new QuantConnect.Securities.CryptoFuture.CryptoFuture(
+                symbol,
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                new Cash("USD", 0, 1m),
+                new Cash("BTC", 0, 1m),
+                SymbolProperties.GetDefault("USD"),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache());
+
+            Assert.IsTrue(cryptoFuture.IsCryptoCoinFuture());
+        }
+
+        [Test]
+        public void NonBinanceUsdQuotedFutureIsNotCoinMargined()
+        {
+            // EU MiCA-compliant exchanges (e.g. Kraken Futures, OKX EU) quote linear, USD-margined
+            // futures directly in fiat USD rather than a stablecoin.
+            var symbol = Symbol.Create("BTCUSD", SecurityType.CryptoFuture, Market.Kraken);
+            var cryptoFuture = new QuantConnect.Securities.CryptoFuture.CryptoFuture(
+                symbol,
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                new Cash("USD", 0, 1m),
+                new Cash("BTC", 0, 1m),
+                SymbolProperties.GetDefault("USD"),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache());
+
+            Assert.IsFalse(cryptoFuture.IsCryptoCoinFuture());
+        }
+
         private static QCAlgorithm GetAlgorithm()
         {
             // Initialize algorithm


### PR DESCRIPTION
Fixes #9574

`IsCryptoCoinFuture()` used a quote-currency whitelist (USDT/BUSD/USDC) to distinguish linear from coin-margined futures. This broke any exchange quoting linear perpetuals in fiat USD instead of a stablecoin — the case for EU MiCA-compliant exchanges (Kraken Futures, OKX EU), which are barred from using stablecoins for derivative settlement.

Since `CryptoFutureHolding.GetQuantityValue()` and `CryptoFutureMarginModel.GetCollateralCash()` both derive their behavior from this shared classification, the misclassification cascaded into wrong holdings value, collateral attribution, and total portfolio value for USD-quoted linear futures.

`IsCryptoCoinFuture` now also considers market: Binance keeps its existing quote-currency heuristic (Binance's coin-margined contracts are also nominally quoted in USD, e.g. BTCUSD_PERP), while other markets are treated as linear/USD-margined, since Lean currently has no coin-margined contracts outside Binance.

Added tests confirming Binance's BTCUSD coin-margined classification is unchanged, and that a Kraken-market BTCUSD future is now correctly treated as linear.
