### PR TITLE
Add IndexOption support to TerminalLinkBrokerageModel

### DIFF
--- a/Common/Brokerages/TerminalLinkBrokerageModel.cs
+++ b/Common/Brokerages/TerminalLinkBrokerageModel.cs
@@ -28,6 +28,7 @@ namespace QuantConnect.Brokerages
         {
             SecurityType.Equity,
             SecurityType.Option,
+            SecurityType.IndexOption,
             SecurityType.Future,
         };
 

--- a/Tests/Common/Brokerages/TerminalLinkBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/TerminalLinkBrokerageModelTests.cs
@@ -29,6 +29,7 @@ namespace QuantConnect.Tests.Common.Brokerages
 
         [TestCase("SPY", SecurityType.Equity)]
         [TestCase("SPY", SecurityType.Option)]
+        [TestCase("SPX", SecurityType.IndexOption)]
         [TestCase("ES", SecurityType.Future)]
         public void CanSubmitOrder_ForSupportedSecurityTypes(string ticker, SecurityType securityType)
         {
@@ -40,8 +41,8 @@ namespace QuantConnect.Tests.Common.Brokerages
             Assert.IsNull(message);
         }
 
-        // Index is data-only on TerminalLink; Forex/Crypto/Cfd and option chains other than
-        // equity options (IndexOption/FutureOption) are not supported for trading.
+        // Index is data-only on TerminalLink; Forex/Crypto/Cfd and FutureOption
+        // are not supported for trading.
         [TestCase("EURUSD", SecurityType.Forex)]
         [TestCase("BTCUSD", SecurityType.Crypto)]
         [TestCase("DE10YBEUR", SecurityType.Cfd)]


### PR DESCRIPTION
## Description

Adds `SecurityType.IndexOption` to the supported security types of `TerminalLinkBrokerageModel`, so index option orders (e.g. SPX/SPXW contracts) are no longer rejected by the brokerage model.

Companion to QuantConnect/Lean.Brokerages.TerminalLink#131, which maps `IndexOption` contracts to the Bloomberg `Index` yellow key on the EMSX order-routing and market-data paths.

Unit tests updated: `IndexOption` moved to the supported-security-type cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)