### PR TITLE
Skip object store folder creation when no storage access

### DIFF
--- a/Engine/Storage/LocalObjectStore.cs
+++ b/Engine/Storage/LocalObjectStore.cs
@@ -141,15 +141,25 @@ namespace QuantConnect.Lean.Engine.Storage
         /// <param name="algorithmMode">The algorithm mode</param>
         public virtual void Initialize(int userId, int projectId, string userToken, Controls controls, AlgorithmMode algorithmMode)
         {
-            AlgorithmStorageRoot = StorageRoot();
-
-            // create the root path if it does not exist
-            var directoryInfo = FileHandler.CreateDirectory(AlgorithmStorageRoot);
-            // full name will return a normalized path which is later easier to compare
-            AlgorithmStorageRoot = directoryInfo.FullName;
-
             Controls = controls;
             _algorithmMode = algorithmMode;
+
+            AlgorithmStorageRoot = StorageRoot();
+
+            // if the user has no storage access at all there's no point in creating the folder, which might even fail due to missing permissions
+            var storageAccess = Controls.StorageAccess;
+            if (storageAccess == null || storageAccess.Read || storageAccess.Write || storageAccess.Delete)
+            {
+                // create the root path if it does not exist
+                var directoryInfo = FileHandler.CreateDirectory(AlgorithmStorageRoot);
+                // full name will return a normalized path which is later easier to compare
+                AlgorithmStorageRoot = directoryInfo.FullName;
+            }
+            else
+            {
+                // no storage access so we don't create the folder, but still normalize the path so it's consistent for later comparisons
+                AlgorithmStorageRoot = Path.GetFullPath(AlgorithmStorageRoot);
+            }
 
             // if <= 0 we disable periodic persistence and make it synchronous
             if (Controls.PersistenceIntervalSeconds > 0)
@@ -157,7 +167,7 @@ namespace QuantConnect.Lean.Engine.Storage
                 _persistenceTimer = new Timer(_ => Persist(), null, Controls.PersistenceIntervalSeconds * 1000, Timeout.Infinite);
             }
 
-            Log.Trace($"LocalObjectStore.Initialize(): Storage Root: {directoryInfo.FullName}. StorageFileCount {controls.StorageFileCount}. StorageLimit {BytesToMb(controls.StorageLimit)}MB. StoragePermissions {Controls.StorageAccess}");
+            Log.Trace($"LocalObjectStore.Initialize(): Storage Root: {AlgorithmStorageRoot}. StorageFileCount {controls.StorageFileCount}. StorageLimit {BytesToMb(controls.StorageLimit)}MB. StoragePermissions {Controls.StorageAccess}");
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

`LocalObjectStore.Initialize` created the storage root directory unconditionally, and did so *before* `Controls` were even assigned. On environments where the process lacks permission to the target path (e.g. a read-only `/Storage` mount), this threw an `UnauthorizedAccessException` during engine startup even for jobs that have no storage access at all:

```
System.UnauthorizedAccessException: Access to the path '/Storage' is denied.
 ---> System.IO.IOException: Permission denied
   at System.IO.Directory.CreateDirectory(String path)
   at QuantConnect.Lean.Engine.Storage.LocalObjectStore.Initialize(...)
```

## Changes

- Assign `Controls` and `_algorithmMode` before resolving the storage root.
- Only create the root directory when `StorageAccess` is `null` (backwards-compatible default) or grants at least one of read/write/delete. This matches the permission checks that already guard every disk-touching operation (`ContainsKey`/`ReadBytes`/`SaveBytes`/`Delete`/enumeration), so when all permissions are false nothing ever reaches the folder.
- When access is fully denied, `AlgorithmStorageRoot` is still normalized via `Path.GetFullPath` (no filesystem write) so later path comparisons remain consistent with the `FullName`-normalized form used elsewhere.

## Related Issue

N/A