### PR TITLE
Allow subscriptions to declare their real bar period

### DIFF
--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -4247,7 +4247,10 @@ namespace QuantConnect.Algorithm
 
             // verify this consolidator will give reasonable results, if someone asks for second consolidation but we have minute
             // data we won't be able to do anything good, we'll call it second, but it would really just be minute!
-            if (period.HasValue && period.Value < subscription.Increment || resolution.HasValue && resolution.Value < subscription.Resolution)
+            // Both operands are compared as durations so that subscriptions declaring an explicit bar period are
+            // validated against the real period rather than the one implied by the resolution.
+            if (period.HasValue && period.Value < subscription.Increment ||
+                resolution.HasValue && resolution.Value.ToTimeSpan() < subscription.Increment)
             {
                 throw new ArgumentException($"Unable to create {symbol} consolidator because {symbol} is registered for " +
                     Invariant($"{subscription.Resolution.ToStringInvariant()} data. Consolidators require higher resolution data to produce lower resolution data.")
@@ -4268,7 +4271,8 @@ namespace QuantConnect.Algorithm
                     period = subscription.Increment;
                 }
 
-                if (period.HasValue && period.Value == subscription.Increment || resolution.HasValue && resolution.Value == subscription.Resolution)
+                if (period.HasValue && period.Value == subscription.Increment ||
+                    resolution.HasValue && resolution.Value.ToTimeSpan() == subscription.Increment)
                 {
                     consolidator = CreateIdentityConsolidator(subscription.Type);
                 }

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2008,7 +2008,7 @@ namespace QuantConnect.Algorithm
             // Short-circuit to AddOptionContract because it will add the underlying if required
             if (!isCanonical && symbol.SecurityType.IsOption())
             {
-                return AddOptionContract(symbol, resolution, securityFillForward, leverage, extendedMarketHours.Value);
+                return AddOptionContract(symbol, resolution, securityFillForward, leverage, extendedMarketHours.Value, barPeriod);
             }
 
             var securityResolution = resolution;
@@ -2298,18 +2298,20 @@ namespace QuantConnect.Algorithm
         /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
         /// <param name="leverage">The leverage to apply to the option contract</param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
+        /// <param name="barPeriod">The explicitly declared length of a single bar, when the stored data period
+        /// differs from the nominal period implied by <paramref name="resolution"/></param>
         /// <returns>Option security</returns>
         /// <exception cref="ArgumentException">Symbol is canonical (i.e. a generic Symbol returned from <see cref="AddFuture"/> or <see cref="AddOption(string, Resolution?, string, bool?, decimal)"/>)</exception>
         [DocumentationAttribute(AddingData)]
         public Option AddFutureOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true,
-            decimal leverage = Security.NullLeverage, bool extendedMarketHours = false)
+            decimal leverage = Security.NullLeverage, bool extendedMarketHours = false, TimeSpan? barPeriod = null)
         {
             if (symbol.IsCanonical())
             {
                 throw new ArgumentException("Expected non-canonical Symbol (i.e. a Symbol representing a specific Future contract");
             }
 
-            return AddOptionContract(symbol, resolution, fillForward, leverage, extendedMarketHours);
+            return AddOptionContract(symbol, resolution, fillForward, leverage, extendedMarketHours, barPeriod);
         }
 
         /// <summary>
@@ -2399,17 +2401,20 @@ namespace QuantConnect.Algorithm
         /// <param name="symbol">Symbol of the index option contract</param>
         /// <param name="resolution">Resolution of the index option contract, i.e. the granularity of the data</param>
         /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
+        /// <param name="barPeriod">The explicitly declared length of a single bar, when the stored data period
+        /// differs from the nominal period implied by <paramref name="resolution"/></param>
         /// <returns>Index Option Contract</returns>
         /// <exception cref="ArgumentException">The provided Symbol is not an <see cref="IndexOption"/></exception>
         [DocumentationAttribute(AddingData)]
-        public IndexOption AddIndexOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true)
+        public IndexOption AddIndexOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true,
+            TimeSpan? barPeriod = null)
         {
             if (symbol.SecurityType != SecurityType.IndexOption || symbol.IsCanonical())
             {
                 throw new ArgumentException("Symbol provided must be non-canonical and of type SecurityType.IndexOption");
             }
 
-            return (IndexOption)AddOptionContract(symbol, resolution, fillForward);
+            return (IndexOption)AddOptionContract(symbol, resolution, fillForward, barPeriod: barPeriod);
         }
 
         /// <summary>
@@ -2420,16 +2425,20 @@ namespace QuantConnect.Algorithm
         /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this option. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
+        /// <param name="barPeriod">The explicitly declared length of a single bar, when the stored data period
+        /// differs from the nominal period implied by <paramref name="resolution"/></param>
         /// <returns>The new <see cref="Option"/> security</returns>
         [DocumentationAttribute(AddingData)]
         public Option AddOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true,
-            decimal leverage = Security.NullLeverage, bool extendedMarketHours = false)
+            decimal leverage = Security.NullLeverage, bool extendedMarketHours = false, TimeSpan? barPeriod = null)
         {
             if (symbol == null || !symbol.SecurityType.IsOption() || symbol.Underlying == null)
             {
                 throw new ArgumentException($"Unexpected option symbol {symbol}. " +
                     $"Please provide a valid option contract with it's underlying symbol set.");
             }
+
+            var securityBarPeriod = barPeriod ?? UniverseSettings.BarPeriod;
 
             // add underlying if not present
             var underlying = symbol.Underlying;
@@ -2439,7 +2448,8 @@ namespace QuantConnect.Algorithm
                 // The underlying might have been removed, let's see if there's already a subscription for it
                 (!underlyingSecurity.IsTradable && SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(underlying).Count == 0))
             {
-                underlyingSecurity = AddSecurity(underlying, resolution, fillForward, leverage, extendedMarketHours);
+                underlyingSecurity = AddSecurity(underlying, resolution, fillForward, leverage, extendedMarketHours,
+                    barPeriod: securityBarPeriod);
                 underlyingConfigs = SubscriptionManager.SubscriptionDataConfigService
                     .GetSubscriptionDataConfigs(underlying);
             }
@@ -2469,7 +2479,7 @@ namespace QuantConnect.Algorithm
             }
 
             var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillForward, extendedMarketHours,
-                dataNormalizationMode: DataNormalizationMode.Raw);
+                dataNormalizationMode: DataNormalizationMode.Raw, barPeriod: securityBarPeriod);
             var option = (Option)Securities.CreateSecurity(symbol, configs, leverage, underlying: underlyingSecurity);
 
             underlyingConfigs.SetDataNormalizationMode(DataNormalizationMode.Raw);
@@ -2487,7 +2497,8 @@ namespace QuantConnect.Algorithm
                 {
                     DataNormalizationMode = DataNormalizationMode.Raw,
                     Resolution = underlyingConfigs.GetHighestResolution(),
-                    ExtendedMarketHours = extendedMarketHours
+                    ExtendedMarketHours = extendedMarketHours,
+                    BarPeriod = securityBarPeriod
                 };
                 universe = AddUniverse(new OptionContractUniverse(new SubscriptionDataConfig(configs.First(),
                     // We can use any data type here, since we are not going to use the data.

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -1991,7 +1991,7 @@ namespace QuantConnect.Algorithm
         /// <returns>The new Security that was added to the algorithm</returns>
         [DocumentationAttribute(AddingData)]
         public Security AddSecurity(Symbol symbol, Resolution? resolution = null, bool? fillForward = null, decimal leverage = Security.NullLeverage, bool? extendedMarketHours = null,
-            DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0)
+            DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0, TimeSpan? barPeriod = null)
         {
             // allow users to specify negative numbers, we get the abs of it
             var contractOffset = (uint)Math.Abs(contractDepthOffset);
@@ -2020,6 +2020,12 @@ namespace QuantConnect.Algorithm
             }
 
             var isFilteredSubscription = !isCanonical;
+            var securityBarPeriod = barPeriod ?? UniverseSettings.BarPeriod;
+            if (isCanonical)
+            {
+                // canonical subscriptions are forced to daily, so a declared bar period no longer applies
+                securityBarPeriod = null;
+            }
             List<SubscriptionDataConfig> configs;
             // we pass dataNormalizationMode to SubscriptionManager.SubscriptionDataConfigService.Add conditionally,
             // so the default value for its argument is used when the it is null here.
@@ -2031,7 +2037,8 @@ namespace QuantConnect.Algorithm
                     extendedMarketHours.Value,
                     isFilteredSubscription,
                     dataNormalizationMode: dataNormalizationMode.Value,
-                    contractDepthOffset: (uint)contractDepthOffset);
+                    contractDepthOffset: (uint)contractDepthOffset,
+                    barPeriod: securityBarPeriod);
             }
             else
             {
@@ -2040,7 +2047,8 @@ namespace QuantConnect.Algorithm
                    securityFillForward,
                    extendedMarketHours.Value,
                    isFilteredSubscription,
-                   contractDepthOffset: (uint)contractDepthOffset);
+                   contractDepthOffset: (uint)contractDepthOffset,
+                   barPeriod: securityBarPeriod);
             }
 
             var security = Securities.CreateSecurity(symbol, configs, leverage);
@@ -2058,7 +2066,8 @@ namespace QuantConnect.Algorithm
                     var universeSettingsResolution = resolution ?? UniverseSettings.Resolution;
                     var settings = new UniverseSettings(universeSettingsResolution, leverage, fillForward.Value, extendedMarketHours.Value, UniverseSettings.MinimumTimeInUniverse)
                     {
-                        Asynchronous = UniverseSettings.Asynchronous
+                        Asynchronous = UniverseSettings.Asynchronous,
+                        BarPeriod = barPeriod ?? UniverseSettings.BarPeriod
                     };
 
                     if (symbol.SecurityType.IsOption())
@@ -2115,12 +2124,15 @@ namespace QuantConnect.Algorithm
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">True to send data during pre and post market sessions. Default is <value>false</value></param>
         /// <param name="dataNormalizationMode">The price scaling mode to use for the equity</param>
+        /// <param name="barPeriod">The explicitly declared length of a single bar, when the stored data period
+        /// differs from the nominal period implied by <paramref name="resolution"/></param>
         /// <returns>The new <see cref="Equity"/> security</returns>
         [DocumentationAttribute(AddingData)]
         public Equity AddEquity(string ticker, Resolution? resolution = null, string market = null, bool fillForward = true,
-            decimal leverage = Security.NullLeverage, bool extendedMarketHours = false, DataNormalizationMode? dataNormalizationMode = null)
+            decimal leverage = Security.NullLeverage, bool extendedMarketHours = false, DataNormalizationMode? dataNormalizationMode = null,
+            TimeSpan? barPeriod = null)
         {
-            return AddSecurity<Equity>(SecurityType.Equity, ticker, resolution, market, fillForward, leverage, extendedMarketHours, normalizationMode: dataNormalizationMode);
+            return AddSecurity<Equity>(SecurityType.Equity, ticker, resolution, market, fillForward, leverage, extendedMarketHours, normalizationMode: dataNormalizationMode, barPeriod: barPeriod);
         }
 
         /// <summary>
@@ -2133,12 +2145,13 @@ namespace QuantConnect.Algorithm
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <returns>The new <see cref="Option"/> security</returns>
         [DocumentationAttribute(AddingData)]
-        public Option AddOption(string underlying, Resolution? resolution = null, string market = null, bool? fillForward = null, decimal leverage = Security.NullLeverage)
+        public Option AddOption(string underlying, Resolution? resolution = null, string market = null, bool? fillForward = null, decimal leverage = Security.NullLeverage,
+            TimeSpan? barPeriod = null)
         {
             market = GetMarket(market, underlying, SecurityType.Option);
 
             var underlyingSymbol = QuantConnect.Symbol.Create(underlying, SecurityType.Equity, market);
-            return AddOption(underlyingSymbol, resolution, market, fillForward, leverage);
+            return AddOption(underlyingSymbol, resolution, market, fillForward, leverage, barPeriod);
         }
 
         /// <summary>
@@ -2154,9 +2167,10 @@ namespace QuantConnect.Algorithm
         /// <returns>The new option security instance</returns>
         /// <exception cref="KeyNotFoundException"></exception>
         [DocumentationAttribute(AddingData)]
-        public Option AddOption(Symbol underlying, Resolution? resolution = null, string market = null, bool? fillForward = null, decimal leverage = Security.NullLeverage)
+        public Option AddOption(Symbol underlying, Resolution? resolution = null, string market = null, bool? fillForward = null, decimal leverage = Security.NullLeverage,
+            TimeSpan? barPeriod = null)
         {
-            return AddOption(underlying, null, resolution, market, fillForward, leverage);
+            return AddOption(underlying, null, resolution, market, fillForward, leverage, barPeriod);
         }
 
         /// <summary>
@@ -2174,7 +2188,7 @@ namespace QuantConnect.Algorithm
         /// <exception cref="KeyNotFoundException"></exception>
         [DocumentationAttribute(AddingData)]
         public Option AddOption(Symbol underlying, string targetOption, Resolution? resolution = null,
-            string market = null, bool? fillForward = null, decimal leverage = Security.NullLeverage)
+            string market = null, bool? fillForward = null, decimal leverage = Security.NullLeverage, TimeSpan? barPeriod = null)
         {
             var optionType = QuantConnect.Symbol.GetOptionTypeFromUnderlying(underlying);
 
@@ -2198,7 +2212,7 @@ namespace QuantConnect.Algorithm
                 canonicalSymbol = QuantConnect.Symbol.CreateCanonicalOption(underlying, targetOption, market, alias);
             }
 
-            return (Option)AddSecurity(canonicalSymbol, resolution, fillForward, leverage);
+            return (Option)AddSecurity(canonicalSymbol, resolution, fillForward, leverage, barPeriod: barPeriod);
         }
 
         /// <summary>
@@ -2308,7 +2322,7 @@ namespace QuantConnect.Algorithm
         /// <returns>Canonical Option security</returns>
         [DocumentationAttribute(AddingData)]
 
-        public IndexOption AddIndexOption(string underlying, Resolution? resolution = null, string market = null, bool fillForward = true)
+        public IndexOption AddIndexOption(string underlying, Resolution? resolution = null, string market = null, bool fillForward = true, TimeSpan? barPeriod = null)
         {
             string targetOption = null;
             // Some non-standard index options, like the weekly SPXW, are options on an index (SPX) but have their own ticker.
@@ -2327,7 +2341,7 @@ namespace QuantConnect.Algorithm
                 underlying = underlyingTicker;
             }
 
-            return AddIndexOption(underlying, targetOption, resolution, market, fillForward);
+            return AddIndexOption(underlying, targetOption, resolution, market, fillForward, barPeriod);
         }
 
         /// <summary>
@@ -2338,9 +2352,9 @@ namespace QuantConnect.Algorithm
         /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
         /// <returns>Canonical Option security</returns>
         [DocumentationAttribute(AddingData)]
-        public IndexOption AddIndexOption(Symbol symbol, Resolution? resolution = null, bool fillForward = true)
+        public IndexOption AddIndexOption(Symbol symbol, Resolution? resolution = null, bool fillForward = true, TimeSpan? barPeriod = null)
         {
-            return AddIndexOption(symbol, null, resolution, fillForward);
+            return AddIndexOption(symbol, null, resolution, fillForward, barPeriod);
         }
 
         /// <summary>
@@ -2352,14 +2366,14 @@ namespace QuantConnect.Algorithm
         /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
         /// <returns>Canonical Option security</returns>
         [DocumentationAttribute(AddingData)]
-        public IndexOption AddIndexOption(Symbol symbol, string targetOption, Resolution? resolution = null, bool fillForward = true)
+        public IndexOption AddIndexOption(Symbol symbol, string targetOption, Resolution? resolution = null, bool fillForward = true, TimeSpan? barPeriod = null)
         {
             if (symbol.SecurityType != SecurityType.Index)
             {
                 throw new ArgumentException("Symbol provided must be of type SecurityType.Index");
             }
 
-            return (IndexOption)AddOption(symbol, targetOption, resolution, symbol.ID.Market, fillForward);
+            return (IndexOption)AddOption(symbol, targetOption, resolution, symbol.ID.Market, fillForward, barPeriod: barPeriod);
         }
 
         /// <summary>
@@ -2372,11 +2386,11 @@ namespace QuantConnect.Algorithm
         /// <param name="fillForward">If true, this will fill in missing data points with the previous data point</param>
         /// <returns>Canonical Option security</returns>
         [DocumentationAttribute(AddingData)]
-        public IndexOption AddIndexOption(string underlying, string targetOption, Resolution? resolution = null, string market = null, bool fillForward = true)
+        public IndexOption AddIndexOption(string underlying, string targetOption, Resolution? resolution = null, string market = null, bool fillForward = true, TimeSpan? barPeriod = null)
         {
             return AddIndexOption(
                 QuantConnect.Symbol.Create(underlying, SecurityType.Index, GetMarket(market, underlying, SecurityType.Index)),
-                targetOption, resolution, fillForward);
+                targetOption, resolution, fillForward, barPeriod);
         }
 
         /// <summary>
@@ -2532,11 +2546,13 @@ namespace QuantConnect.Algorithm
         /// <param name="resolution">The <see cref="Resolution"/> of market data, Tick, Second, Minute, Hour, or Daily. Default is <see cref="Resolution.Minute"/></param>
         /// <param name="market">The index trading market, <seealso cref="Market"/>. Default value is null and looked up using <see cref="IBrokerageModel.DefaultMarkets"> in <see cref="AddSecurity{T}"/></param>
         /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
+        /// <param name="barPeriod">The explicitly declared length of a single bar, when the stored data period
+        /// differs from the nominal period implied by <paramref name="resolution"/></param>
         /// <returns>The new <see cref="Index"/> security</returns>
         [DocumentationAttribute(AddingData)]
-        public Index AddIndex(string ticker, Resolution? resolution = null, string market = null, bool fillForward = true)
+        public Index AddIndex(string ticker, Resolution? resolution = null, string market = null, bool fillForward = true, TimeSpan? barPeriod = null)
         {
-            var index = AddSecurity<Index>(SecurityType.Index, ticker, resolution, market, fillForward, 1, false);
+            var index = AddSecurity<Index>(SecurityType.Index, ticker, resolution, market, fillForward, 1, false, barPeriod: barPeriod);
             return index;
         }
 
@@ -3014,7 +3030,7 @@ namespace QuantConnect.Algorithm
         /// </summary>
         [DocumentationAttribute(AddingData)]
         private T AddSecurity<T>(SecurityType securityType, string ticker, Resolution? resolution, string market, bool fillForward, decimal leverage, bool extendedMarketHours,
-            DataMappingMode? mappingMode = null, DataNormalizationMode? normalizationMode = null)
+            DataMappingMode? mappingMode = null, DataNormalizationMode? normalizationMode = null, TimeSpan? barPeriod = null)
             where T : Security
         {
             market = GetMarket(market, ticker, securityType);
@@ -3029,7 +3045,8 @@ namespace QuantConnect.Algorithm
 
             var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillForward, extendedMarketHours,
                 dataNormalizationMode: normalizationMode ?? UniverseSettings.DataNormalizationMode,
-                dataMappingMode: mappingMode ?? UniverseSettings.DataMappingMode);
+                dataMappingMode: mappingMode ?? UniverseSettings.DataMappingMode,
+                barPeriod: barPeriod ?? UniverseSettings.BarPeriod);
             var security = Securities.CreateSecurity(symbol, configs, leverage);
 
             return (T)AddToUserDefinedUniverse(security, configs);

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -612,8 +612,8 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
         /// <returns>The new Security that was added to the algorithm</returns>
         public Security AddSecurity(Symbol symbol, Resolution? resolution = null, bool? fillForward = null, decimal leverage = Security.NullLeverage, bool? extendedMarketHours = null,
-            DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0)
-            => _baseAlgorithm.AddSecurity(symbol, resolution, fillForward, leverage, extendedMarketHours, dataMappingMode, dataNormalizationMode, contractDepthOffset);
+            DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0, TimeSpan? barPeriod = null)
+            => _baseAlgorithm.AddSecurity(symbol, resolution, fillForward, leverage, extendedMarketHours, dataMappingMode, dataNormalizationMode, contractDepthOffset, barPeriod);
 
         /// <summary>
         /// Creates and adds a new single <see cref="Future"/> contract to the algorithm

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -623,6 +623,8 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
+        /// <param name="barPeriod">The explicitly declared length of a single bar, when the stored data period
+        /// differs from the nominal period implied by <paramref name="resolution"/></param>
         /// <returns>The new <see cref="Future"/> security</returns>
         public Future AddFutureContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true, decimal leverage = 0m,
             bool extendedMarketHours = false)
@@ -637,8 +639,9 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">Use extended market hours data</param>
         /// <returns>The new <see cref="Option"/> security</returns>
-        public Option AddOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true, decimal leverage = 0m, bool extendedMarketHours = false)
-            => _baseAlgorithm.AddOptionContract(symbol, resolution, fillForward, leverage, extendedMarketHours);
+        public Option AddOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true, decimal leverage = 0m,
+            bool extendedMarketHours = false, TimeSpan? barPeriod = null)
+            => _baseAlgorithm.AddOptionContract(symbol, resolution, fillForward, leverage, extendedMarketHours, barPeriod);
 
         /// <summary>
         /// Invoked at the end of every time step. This allows the algorithm

--- a/Common/Data/HistoryRequest.cs
+++ b/Common/Data/HistoryRequest.cs
@@ -41,6 +41,17 @@ namespace QuantConnect.Data
         public Resolution Resolution { get; set; }
 
         /// <summary>
+        /// The explicitly declared length of a single bar, when the stored data period differs from the
+        /// nominal period implied by <see cref="Resolution"/>. Null derives it from the resolution
+        /// </summary>
+        public TimeSpan? BarPeriod { get; set; }
+
+        /// <summary>
+        /// The length of a single bar for this request
+        /// </summary>
+        public TimeSpan BarSpan => BarPeriod ?? Resolution.ToTimeSpan();
+
+        /// <summary>
         /// Gets the requested fill forward resolution, set to null for no fill forward behavior.
         /// Will always return null when Resolution is set to Tick.
         /// </summary>
@@ -163,6 +174,7 @@ namespace QuantConnect.Data
                 hours, config.DataTimeZone, config.FillDataForward ? config.Resolution : (Resolution?)null,
                 config.ExtendedMarketHours, config.IsCustomData, config.DataNormalizationMode, config.TickType, config.DataMappingMode, config.ContractDepthOffset)
         {
+            BarPeriod = config.BarPeriod;
         }
 
         /// <summary>
@@ -174,6 +186,8 @@ namespace QuantConnect.Data
         public HistoryRequest(HistoryRequest request, Symbol newSymbol, DateTime newStartTimeUtc, DateTime newEndTimeUtc)
             : this (newStartTimeUtc, newEndTimeUtc, request.DataType, newSymbol, request.Resolution, request.ExchangeHours, request.DataTimeZone, request.FillForwardResolution,
                   request.IncludeExtendedMarketHours, request.IsCustomData, request.DataNormalizationMode, request.TickType, request.DataMappingMode, request.ContractDepthOffset)
-        { }
+        {
+            BarPeriod = request.BarPeriod;
+        }
     }
 }

--- a/Common/Data/HistoryRequestFactory.cs
+++ b/Common/Data/HistoryRequestFactory.cs
@@ -89,7 +89,9 @@ namespace QuantConnect.Data
                 DataType = dataType,
                 Resolution = resolution.Value,
                 FillForwardResolution = fillForwardResolution,
-                TickType = subscription.TickType
+                TickType = subscription.TickType,
+                // a declared bar period describes the data of a specific resolution, drop it if the resolution changes
+                BarPeriod = resolution.Value == subscription.Resolution ? subscription.BarPeriod : null
             };
 
             if (extendedMarketHours != null)
@@ -136,9 +138,10 @@ namespace QuantConnect.Data
             SecurityExchangeHours exchange,
             DateTimeZone dataTimeZone,
             Type dataType,
-            bool? extendedMarketHours = null)
+            bool? extendedMarketHours = null,
+            TimeSpan? barPeriod = null)
         {
-            return GetStartTimeAlgoTz(_algorithm.UtcTime, symbol, periods, resolution, exchange, dataTimeZone, dataType, extendedMarketHours);
+            return GetStartTimeAlgoTz(_algorithm.UtcTime, symbol, periods, resolution, exchange, dataTimeZone, dataType, extendedMarketHours, barPeriod);
         }
 
         /// <summary>
@@ -164,7 +167,8 @@ namespace QuantConnect.Data
             SecurityExchangeHours exchange,
             DateTimeZone dataTimeZone,
             Type dataType,
-            bool? extendedMarketHours = null)
+            bool? extendedMarketHours = null,
+            TimeSpan? barPeriod = null)
         {
             var isExtendedMarketHours = false;
             // hour and daily resolution does no have extended market hours data. Same for chain universes
@@ -183,7 +187,7 @@ namespace QuantConnect.Data
                 }
             }
 
-            var timeSpan = resolution.ToTimeSpan();
+            var timeSpan = barPeriod ?? resolution.ToTimeSpan();
             // make this a minimum of one second
             timeSpan = timeSpan < Time.OneSecond ? Time.OneSecond : timeSpan;
 

--- a/Common/Data/SubscriptionDataConfig.cs
+++ b/Common/Data/SubscriptionDataConfig.cs
@@ -67,6 +67,16 @@ namespace QuantConnect.Data
         public TimeSpan Increment { get; }
 
         /// <summary>
+        /// The explicitly declared length of a single bar for this subscription, when the stored data
+        /// period differs from the nominal period implied by <see cref="Resolution"/>.
+        /// </summary>
+        /// <remarks>Null means the period is derived from <see cref="Resolution"/>, which is the default
+        /// behavior. This allows data whose true bar period is not one of the <see cref="Resolution"/>
+        /// values to be described accurately, so that bar end times, fill forward and consolidation all
+        /// operate on the real period instead of an assumed one.</remarks>
+        public TimeSpan? BarPeriod { get; }
+
+        /// <summary>
         /// True if wish to send old data when time gaps in data feed.
         /// </summary>
         public bool FillDataForward { get; }
@@ -197,6 +207,8 @@ namespace QuantConnect.Data
         /// <param name="dataMappingMode">The contract mapping mode to use for the security</param>
         /// <param name="contractDepthOffset">The continuous contract desired offset from the current front month.
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
+        /// <param name="barPeriod">The explicitly declared length of a single bar, when the stored data period
+        /// differs from the nominal period implied by <paramref name="resolution"/>. Null derives it from the resolution</param>
         public SubscriptionDataConfig(Type objectType,
             Symbol symbol,
             Resolution resolution,
@@ -211,12 +223,21 @@ namespace QuantConnect.Data
             DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted,
             DataMappingMode dataMappingMode = DataMappingMode.OpenInterest,
             uint contractDepthOffset = 0,
-            bool mappedConfig = false)
+            bool mappedConfig = false,
+            TimeSpan? barPeriod = null)
         {
             if (objectType == null) throw new ArgumentNullException(nameof(objectType));
             if (symbol == null) throw new ArgumentNullException(nameof(symbol));
             if (dataTimeZone == null) throw new ArgumentNullException(nameof(dataTimeZone));
             if (exchangeTimeZone == null) throw new ArgumentNullException(nameof(exchangeTimeZone));
+            if (barPeriod.HasValue && barPeriod.Value <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(barPeriod), barPeriod, "Bar period must be positive");
+            }
+            if (barPeriod.HasValue && resolution == Resolution.Tick)
+            {
+                throw new ArgumentException("Bar period is not supported for tick resolution", nameof(barPeriod));
+            }
 
             Type = objectType;
             Resolution = resolution;
@@ -237,7 +258,8 @@ namespace QuantConnect.Data
 
             TickType = tickType ?? LeanData.GetCommonTickTypeForCommonDataTypes(objectType, SecurityType);
 
-            Increment = resolution.ToTimeSpan();
+            Increment = barPeriod ?? resolution.ToTimeSpan();
+            BarPeriod = barPeriod;
             //Ticks are individual sales and fillforward doesn't apply.
             FillDataForward = resolution == Resolution.Tick ? false : fillForward;
         }
@@ -265,6 +287,9 @@ namespace QuantConnect.Data
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
         /// <param name="mappedConfig">True if this is created as a mapped config. This is useful for continuous contract at live trading
         /// where we subscribe to the mapped symbol but want to preserve uniqueness</param>
+        /// <param name="barPeriod">The explicitly declared length of a single bar. When not provided, the source config's
+        /// value is inherited, unless <paramref name="resolution"/> changes the resolution, in which case the declared
+        /// period no longer describes the requested data and is dropped</param>
         public SubscriptionDataConfig(SubscriptionDataConfig config,
             Type objectType = null,
             Symbol symbol = null,
@@ -280,7 +305,8 @@ namespace QuantConnect.Data
             DataNormalizationMode? dataNormalizationMode = null,
             DataMappingMode? dataMappingMode = null,
             uint? contractDepthOffset = null,
-            bool? mappedConfig = null)
+            bool? mappedConfig = null,
+            TimeSpan? barPeriod = null)
             : this(
             objectType ?? config.Type,
             symbol ?? config.Symbol,
@@ -296,12 +322,26 @@ namespace QuantConnect.Data
             dataNormalizationMode ?? config.DataNormalizationMode,
             dataMappingMode ?? config.DataMappingMode,
             contractDepthOffset ?? config.ContractDepthOffset,
-            mappedConfig ?? false
+            mappedConfig ?? false,
+            barPeriod ?? GetInheritedBarPeriod(config, resolution)
             )
         {
             PriceScaleFactor = config.PriceScaleFactor;
             SumOfDividends = config.SumOfDividends;
             Consolidators = config.Consolidators;
+        }
+
+        /// <summary>
+        /// Helper for the copy constructor. A declared bar period describes the data of a specific resolution,
+        /// so it is only inherited when the copy keeps the source resolution.
+        /// </summary>
+        private static TimeSpan? GetInheritedBarPeriod(SubscriptionDataConfig config, Resolution? resolution)
+        {
+            if (resolution.HasValue && resolution.Value != config.Resolution)
+            {
+                return null;
+            }
+            return config.BarPeriod;
         }
 
         /// <summary>
@@ -327,6 +367,7 @@ namespace QuantConnect.Data
                 && ExchangeTimeZone.Equals(other.ExchangeTimeZone)
                 && ContractDepthOffset == other.ContractDepthOffset
                 && IsFilteredSubscription == other.IsFilteredSubscription
+                && BarPeriod == other.BarPeriod
                 && _mappedConfig == other._mappedConfig;
         }
 
@@ -368,6 +409,7 @@ namespace QuantConnect.Data
                 hashCode = (hashCode*397) ^ ExchangeTimeZone.Id.GetHashCode();// timezone hash is expensive, use id instead
                 hashCode = (hashCode*397) ^ ContractDepthOffset.GetHashCode();
                 hashCode = (hashCode*397) ^ IsFilteredSubscription.GetHashCode();
+                hashCode = (hashCode*397) ^ BarPeriod.GetHashCode();
                 hashCode = (hashCode*397) ^ _mappedConfig.GetHashCode();
                 return hashCode;
             }

--- a/Common/Data/SubscriptionDataConfigExtensions.cs
+++ b/Common/Data/SubscriptionDataConfigExtensions.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Util;
@@ -38,6 +39,26 @@ namespace QuantConnect.Data
             return subscriptionDataConfigs
                 .Select(x => x.Resolution)
                 .DefaultIfEmpty(Resolution.Daily)
+                .Min();
+        }
+
+        /// <summary>
+        /// Extension method used to obtain the shortest bar period for a given set of
+        /// <see cref="SubscriptionDataConfig"/>, honoring any explicitly declared
+        /// <see cref="SubscriptionDataConfig.BarPeriod"/>
+        /// </summary>
+        /// <param name="subscriptionDataConfigs"></param>
+        /// <returns>The shortest bar period, <see cref="Resolution.Daily"/>'s period if there
+        /// are no subscriptions</returns>
+        /// <remarks>Equivalent to <see cref="GetHighestResolution"/> followed by
+        /// <see cref="Extensions.ToTimeSpan"/> for any subscription that does not declare a bar period,
+        /// since <see cref="Extensions.ToTimeSpan"/> is monotonic in the <see cref="Resolution"/> order</remarks>
+        public static TimeSpan GetHighestResolutionSpan(
+            this IEnumerable<SubscriptionDataConfig> subscriptionDataConfigs)
+        {
+            return subscriptionDataConfigs
+                .Select(x => x.Increment)
+                .DefaultIfEmpty(Resolution.Daily.ToTimeSpan())
                 .Min();
         }
 

--- a/Common/Data/UniverseSelection/Universe.cs
+++ b/Common/Data/UniverseSelection/Universe.cs
@@ -294,7 +294,8 @@ namespace QuantConnect.Data.UniverseSelection
                 dataNormalizationMode: UniverseSettings.DataNormalizationMode,
                 subscriptionDataTypes: UniverseSettings.SubscriptionDataTypes,
                 dataMappingMode: UniverseSettings.DataMappingMode,
-                contractDepthOffset: (uint)Math.Abs(UniverseSettings.ContractDepthOffset));
+                contractDepthOffset: (uint)Math.Abs(UniverseSettings.ContractDepthOffset),
+                barPeriod: UniverseSettings.BarPeriod);
             return result.Select(config => new SubscriptionRequest(isUniverseSubscription: false,
                 universe: this,
                 security: security,

--- a/Common/Data/UniverseSelection/UniverseSettings.cs
+++ b/Common/Data/UniverseSelection/UniverseSettings.cs
@@ -40,6 +40,12 @@ namespace QuantConnect.Data.UniverseSelection
         public bool FillForward { get; set; }
 
         /// <summary>
+        /// The explicitly declared length of a single bar, when the stored data period differs from the
+        /// nominal period implied by <see cref="Resolution"/>. Null derives it from the resolution
+        /// </summary>
+        public TimeSpan? BarPeriod { get; set; }
+
+        /// <summary>
         /// If configured, will be used to determine universe selection schedule and filter or skip selection data
         /// that does not fit the schedule
         /// </summary>
@@ -127,6 +133,7 @@ namespace QuantConnect.Data.UniverseSelection
             Resolution = universeSettings.Resolution;
             Leverage = universeSettings.Leverage;
             FillForward = universeSettings.FillForward;
+            BarPeriod = universeSettings.BarPeriod;
             DataMappingMode = universeSettings.DataMappingMode;
             ContractDepthOffset = universeSettings.ContractDepthOffset;
             ExtendedMarketHours = universeSettings.ExtendedMarketHours;

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -739,6 +739,8 @@ namespace QuantConnect.Interfaces
         /// <param name="fillForward">If true, returns the last available data even if none in that timeslice. Default is <value>true</value></param>
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">Show the after market data as well</param>
+        /// <param name="barPeriod">The explicitly declared length of a single bar, when the stored data period
+        /// differs from the nominal period implied by <paramref name="resolution"/></param>
         /// <returns>The new <see cref="Future"/> security</returns>
         Future AddFutureContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true, decimal leverage = 0m, bool extendedMarketHours = false);
 
@@ -751,7 +753,8 @@ namespace QuantConnect.Interfaces
         /// <param name="leverage">The requested leverage for this equity. Default is set by <see cref="SecurityInitializer"/></param>
         /// <param name="extendedMarketHours">Show the after market data as well</param>
         /// <returns>The new <see cref="Option"/> security</returns>
-        Option AddOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true, decimal leverage = 0m, bool extendedMarketHours = false);
+        Option AddOptionContract(Symbol symbol, Resolution? resolution = null, bool fillForward = true, decimal leverage = 0m,
+            bool extendedMarketHours = false, TimeSpan? barPeriod = null);
 
         /// <summary>
         /// Removes the security with the specified symbol. This will cancel all

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -725,9 +725,11 @@ namespace QuantConnect.Interfaces
         /// <param name="dataNormalizationMode">The price scaling mode to use for the security</param>
         /// <param name="contractDepthOffset">The continuous contract desired offset from the current front month.
         /// For example, 0 (default) will use the front month, 1 will use the back month contract</param>
+        /// <param name="barPeriod">The explicitly declared length of a single bar, when the stored data period
+        /// differs from the nominal period implied by <paramref name="resolution"/></param>
         /// <returns>The new Security that was added to the algorithm</returns>
         Security AddSecurity(Symbol symbol, Resolution? resolution = null, bool? fillForward = null, decimal leverage = Security.NullLeverage, bool? extendedMarketHours = null,
-            DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0);
+            DataMappingMode? dataMappingMode = null, DataNormalizationMode? dataNormalizationMode = null, int contractDepthOffset = 0, TimeSpan? barPeriod = null);
 
         /// <summary>
         /// Creates and adds a new single <see cref="Future"/> contract to the algorithm

--- a/Common/Interfaces/ISubscriptionDataConfigService.cs
+++ b/Common/Interfaces/ISubscriptionDataConfigService.cs
@@ -42,7 +42,8 @@ namespace QuantConnect.Interfaces
             bool isCustomData = false,
             DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted,
             DataMappingMode dataMappingMode = DataMappingMode.OpenInterest,
-            uint contractDepthOffset = 0
+            uint contractDepthOffset = 0,
+            TimeSpan? barPeriod = null
             );
 
         /// <summary>
@@ -61,7 +62,8 @@ namespace QuantConnect.Interfaces
             List<Tuple<Type, TickType>> subscriptionDataTypes = null,
             DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted,
             DataMappingMode dataMappingMode = DataMappingMode.OpenInterest,
-            uint contractDepthOffset = 0
+            uint contractDepthOffset = 0,
+            TimeSpan? barPeriod = null
             );
 
         /// <summary>

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -1015,7 +1015,10 @@ namespace QuantConnect.Orders.Fills
                     continue;
                 }
 
-                if (config.Resolution != Resolution.Hour && config.Resolution != Resolution.Daily)
+                // A bar long enough that filling at its close would be unrealistic: the order predates the bar,
+                // so it fills at the open. Expressed as a duration so that subscriptions declaring an explicit
+                // bar period are handled correctly. Equivalent to Resolution.Hour/Daily when none is declared.
+                if (config.Increment <= Time.OneMinute)
                 {
                     return false;
                 }
@@ -1051,10 +1054,9 @@ namespace QuantConnect.Orders.Fills
                 return true;
             }
 
-            // Use the lowest (finest) subscribed resolution to size a single bar.
+            // Use the lowest (finest) subscribed bar period to size a single bar.
             var resolutionSpan = subscriptionConfigs
-                .GetHighestResolution()
-                .ToTimeSpan();
+                .GetHighestResolutionSpan();
 
             // Tick data has no bar to wait for (zero span)
             if (resolutionSpan == TimeSpan.Zero)

--- a/Engine/DataFeeds/DataManager.cs
+++ b/Engine/DataFeeds/DataManager.cs
@@ -585,12 +585,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             bool isCustomData = false,
             DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted,
             DataMappingMode dataMappingMode = DataMappingMode.OpenInterest,
-            uint contractDepthOffset = 0
+            uint contractDepthOffset = 0,
+            TimeSpan? barPeriod = null
             )
         {
             return Add(symbol, resolution, fillForward, extendedMarketHours, isFilteredSubscription, isInternalFeed, isCustomData,
                 new List<Tuple<Type, TickType>> { new Tuple<Type, TickType>(dataType, LeanData.GetCommonTickTypeForCommonDataTypes(dataType, symbol.SecurityType)) },
-                dataNormalizationMode, dataMappingMode, contractDepthOffset)
+                dataNormalizationMode, dataMappingMode, contractDepthOffset, barPeriod)
                 .First();
         }
 
@@ -610,7 +611,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             List<Tuple<Type, TickType>> subscriptionDataTypes = null,
             DataNormalizationMode dataNormalizationMode = DataNormalizationMode.Adjusted,
             DataMappingMode dataMappingMode = DataMappingMode.OpenInterest,
-            uint contractDepthOffset = 0
+            uint contractDepthOffset = 0,
+            TimeSpan? barPeriod = null
             )
         {
             var dataTypes = subscriptionDataTypes;
@@ -724,7 +726,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                               tickType: tickType,
                               dataNormalizationMode: dataNormalizationMode,
                               dataMappingMode: dataMappingMode,
-                              contractDepthOffset: contractDepthOffset)).ToList();
+                              contractDepthOffset: contractDepthOffset,
+                              barPeriod: barPeriod)).ToList();
 
             for (int i = 0; i < result.Count; i++)
             {

--- a/Engine/DataFeeds/SubscriptionCollection.cs
+++ b/Engine/DataFeeds/SubscriptionCollection.cs
@@ -185,7 +185,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     (operation == FillForwardResolutionOperation.AfterRemove // We are removing
                     && configuration.Increment == _fillForwardResolution.Value // True: We are removing the resolution we were using
                     // False: there is at least another one equal, no need to update, but we only look at those valid configuration which are the ones which set the FF resolution
-                    && _subscriptions.Keys.All(x => !ValidateFillForwardResolution(x) || x.Resolution != configuration.Resolution)))
+                    && _subscriptions.Keys.All(x => !ValidateFillForwardResolution(x) || x.Increment != configuration.Increment)))
                 )
             {
                 var configurations = (operation == FillForwardResolutionOperation.BeforeAdd)
@@ -193,10 +193,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
                 var eventArgs = new FillForwardResolutionChangedEvent { Old = _fillForwardResolution.Value };
                 _fillForwardResolution.Value = configurations.Where(ValidateFillForwardResolution)
-                                                             .Select(x => x.Resolution)
+                                                             .Select(x => x.Increment)
                                                              .Distinct()
-                                                             .DefaultIfEmpty(Resolution.Minute)
-                                                             .Min().ToTimeSpan();
+                                                             .DefaultIfEmpty(Resolution.Minute.ToTimeSpan())
+                                                             .Min();
                 if (_fillForwardResolution.Value != eventArgs.Old)
                 {
                     eventArgs.New = _fillForwardResolution.Value;

--- a/Engine/DataFeeds/SubscriptionData.cs
+++ b/Engine/DataFeeds/SubscriptionData.cs
@@ -84,6 +84,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // note we do this after fetching the 'emitTimeUtc' which should use the end time set by the fill forward enumerator
                 if (barSpan != TimeSpan.Zero)
                 {
+                    var hasDeclaredBarAlignment = configuration.BarPeriod.HasValue
+                        && barSpan == configuration.Increment;
                     if (barSpan != configuration.Increment)
                     {
                         // when we detect a difference let's refetch the span in utc using noda time 'ConvertToUtc' that will not take into account day light savings difference
@@ -92,7 +94,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         // Note: we don't use 'configuration.Increment' because during warmup, if the warmup resolution is set, we will emit data respecting it instead of the 'configuration'
                         barSpan = data.EndTime.ConvertToUtc(configuration.ExchangeTimeZone) - data.Time.ConvertToUtc(configuration.ExchangeTimeZone);
                     }
-                    data.Time = data.Time.ExchangeRoundDownInTimeZone(barSpan, exchangeHours, configuration.DataTimeZone, configuration.ExtendedMarketHours);
+                    if (!hasDeclaredBarAlignment)
+                    {
+                        data.Time = data.Time.ExchangeRoundDownInTimeZone(barSpan, exchangeHours, configuration.DataTimeZone, configuration.ExtendedMarketHours);
+                    }
                 }
             }
             else if (data.IsFillForward)

--- a/Tests/Algorithm/AlgorithmAddSecurityTests.cs
+++ b/Tests/Algorithm/AlgorithmAddSecurityTests.cs
@@ -258,6 +258,70 @@ namespace QuantConnect.Tests.Algorithm
             Assert.AreEqual(1, _algo.SubscriptionManager.Subscriptions.Count(x => x.Symbol == spx.Symbol));
         }
 
+        [Test]
+        public void OptionUniversePropagatesDeclaredBarPeriod()
+        {
+            var barPeriod = TimeSpan.FromMinutes(30);
+            var spx = _algo.AddIndex("SPX", Resolution.Minute, fillForward: true, barPeriod: barPeriod);
+            var canonical = _algo.AddIndexOption(spx.Symbol, Resolution.Minute, fillForward: true, barPeriod: barPeriod);
+            var universe = _algo.UniverseManager[canonical.Symbol];
+            var start = new DateTime(2024, 9, 2);
+            var end = start.AddDays(1);
+
+            var requests = universe.GetSubscriptionRequests(spx, start, end,
+                _algo.SubscriptionManager.SubscriptionDataConfigService).ToList();
+
+            Assert.That(requests.Select(x => x.Configuration.BarPeriod), Has.All.EqualTo(barPeriod));
+            var underlyingConfigs = _algo.SubscriptionManager.Subscriptions
+                .Where(x => x.Symbol == spx.Symbol).ToList();
+            Assert.AreEqual(1, underlyingConfigs.Count);
+            Assert.AreEqual(barPeriod, underlyingConfigs.Single().Increment);
+
+            var optionSymbol = Symbol.CreateOption(
+                spx.Symbol,
+                Market.USA,
+                OptionStyle.European,
+                OptionRight.Call,
+                3200m,
+                new DateTime(2024, 9, 20));
+            var option = _algo.AddIndexOptionContract(optionSymbol, Resolution.Minute,
+                fillForward: true, barPeriod: barPeriod);
+            requests = universe.GetSubscriptionRequests(option, start, end,
+                _algo.SubscriptionManager.SubscriptionDataConfigService).ToList();
+
+            Assert.That(requests.Select(x => x.Configuration.BarPeriod), Has.All.EqualTo(barPeriod));
+            Assert.That(requests.Select(x => x.Configuration.Increment), Has.All.EqualTo(barPeriod));
+        }
+
+        [Test]
+        public void AddOptionContractPropagatesDeclaredBarPeriodToUnderlying()
+        {
+            var barPeriod = TimeSpan.FromMinutes(30);
+            var underlying = Symbol.Create("SPX", SecurityType.Index, Market.USA);
+            var optionSymbol = Symbol.CreateOption(
+                underlying,
+                Market.USA,
+                OptionStyle.European,
+                OptionRight.Call,
+                3200m,
+                new DateTime(2024, 9, 20));
+
+            _algo.AddIndexOptionContract(optionSymbol, Resolution.Minute,
+                fillForward: true, barPeriod: barPeriod);
+
+            var underlyingConfigs = _algo.SubscriptionManager.Subscriptions
+                .Where(x => x.Symbol == underlying).ToList();
+            Assert.IsNotEmpty(underlyingConfigs);
+            Assert.That(underlyingConfigs.Select(x => x.BarPeriod), Has.All.EqualTo(barPeriod));
+            Assert.That(underlyingConfigs.Select(x => x.Increment), Has.All.EqualTo(barPeriod));
+
+            var optionConfigs = _algo.SubscriptionManager.Subscriptions
+                .Where(x => x.Symbol == optionSymbol).ToList();
+            Assert.IsNotEmpty(optionConfigs);
+            Assert.That(optionConfigs.Select(x => x.BarPeriod), Has.All.EqualTo(barPeriod));
+            Assert.That(optionConfigs.Select(x => x.Increment), Has.All.EqualTo(barPeriod));
+        }
+
         [TestCase("SPXW", "SPX")]
         [TestCase("RUTW", "RUT")]
         [TestCase("VIXW", "VIX")]

--- a/Tests/Common/Data/SubscriptionDataConfigBarPeriodTests.cs
+++ b/Tests/Common/Data/SubscriptionDataConfigBarPeriodTests.cs
@@ -1,0 +1,201 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+
+namespace QuantConnect.Tests.Common.Data
+{
+    [TestFixture]
+    public class SubscriptionDataConfigBarPeriodTests
+    {
+        private static readonly Resolution[] AllResolutions =
+            (Resolution[])Enum.GetValues(typeof(Resolution));
+
+        private static SubscriptionDataConfig CreateConfig(Resolution resolution = Resolution.Minute,
+            TimeSpan? barPeriod = null, Symbol symbol = null)
+        {
+            return new SubscriptionDataConfig(typeof(TradeBar), symbol ?? Symbols.SPY, resolution,
+                TimeZones.NewYork, TimeZones.NewYork, false, false, false, false, TickType.Trade, false,
+                barPeriod: barPeriod);
+        }
+
+        [Test]
+        public void IncrementIsDerivedFromResolutionByDefault([Values] Resolution resolution)
+        {
+            var config = CreateConfig(resolution);
+
+            Assert.IsNull(config.BarPeriod);
+            Assert.AreEqual(resolution.ToTimeSpan(), config.Increment);
+        }
+
+        [Test]
+        public void DeclaredBarPeriodDrivesIncrement()
+        {
+            var barPeriod = TimeSpan.FromMinutes(30);
+            var config = CreateConfig(Resolution.Minute, barPeriod);
+
+            Assert.AreEqual(barPeriod, config.BarPeriod);
+            Assert.AreEqual(barPeriod, config.Increment);
+            // the resolution is untouched, so data continues to be resolved from the same files
+            Assert.AreEqual(Resolution.Minute, config.Resolution);
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void RejectsNonPositiveBarPeriod(int minutes)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                CreateConfig(Resolution.Minute, TimeSpan.FromMinutes(minutes)));
+        }
+
+        [Test]
+        public void RejectsBarPeriodForTickResolution()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                CreateConfig(Resolution.Tick, TimeSpan.FromMinutes(30)));
+        }
+
+        [Test]
+        public void CopyConstructorInheritsBarPeriod()
+        {
+            var barPeriod = TimeSpan.FromMinutes(30);
+            var config = CreateConfig(Resolution.Minute, barPeriod);
+
+            var copy = new SubscriptionDataConfig(config, symbol: Symbols.AAPL);
+
+            Assert.AreEqual(barPeriod, copy.BarPeriod);
+            Assert.AreEqual(barPeriod, copy.Increment);
+        }
+
+        [Test]
+        public void CopyConstructorDropsBarPeriodWhenResolutionChanges()
+        {
+            var config = CreateConfig(Resolution.Minute, TimeSpan.FromMinutes(30));
+
+            var copy = new SubscriptionDataConfig(config, resolution: Resolution.Daily);
+
+            Assert.IsNull(copy.BarPeriod);
+            Assert.AreEqual(Resolution.Daily.ToTimeSpan(), copy.Increment);
+        }
+
+        [Test]
+        public void CopyConstructorHonorsExplicitBarPeriodOverride()
+        {
+            var config = CreateConfig(Resolution.Minute, TimeSpan.FromMinutes(30));
+
+            var copy = new SubscriptionDataConfig(config, barPeriod: TimeSpan.FromMinutes(15));
+
+            Assert.AreEqual(TimeSpan.FromMinutes(15), copy.Increment);
+        }
+
+        [Test]
+        public void ConfigsDifferingOnlyByBarPeriodAreNotEqual()
+        {
+            var thirtyMinutes = CreateConfig(Resolution.Minute, TimeSpan.FromMinutes(30));
+            var fifteenMinutes = CreateConfig(Resolution.Minute, TimeSpan.FromMinutes(15));
+
+            Assert.AreNotEqual(thirtyMinutes, fifteenMinutes);
+            Assert.AreNotEqual(thirtyMinutes.GetHashCode(), fifteenMinutes.GetHashCode());
+
+            var set = new HashSet<SubscriptionDataConfig> { thirtyMinutes };
+            Assert.IsTrue(set.Add(fifteenMinutes), "Configs with different bar periods must not be deduplicated");
+        }
+
+        [Test]
+        public void EqualityIsUnchangedWhenNoBarPeriodIsDeclared()
+        {
+            var first = CreateConfig();
+            var second = CreateConfig();
+
+            Assert.AreEqual(first, second);
+            Assert.AreEqual(first.GetHashCode(), second.GetHashCode());
+        }
+
+        /// <summary>
+        /// GetHighestResolutionSpan must be a drop in replacement for GetHighestResolution().ToTimeSpan()
+        /// for any set of configurations that does not declare a bar period.
+        /// </summary>
+        [Test]
+        public void HighestResolutionSpanMatchesHighestResolutionWhenNoBarPeriodDeclared()
+        {
+            foreach (var first in AllResolutions)
+            {
+                foreach (var second in AllResolutions)
+                {
+                    var configs = new List<SubscriptionDataConfig>
+                    {
+                        CreateConfig(first),
+                        CreateConfig(second, symbol: Symbols.AAPL)
+                    };
+
+                    Assert.AreEqual(configs.GetHighestResolution().ToTimeSpan(), configs.GetHighestResolutionSpan(),
+                        $"Mismatch for {first} and {second}");
+                }
+            }
+        }
+
+        [Test]
+        public void HighestResolutionSpanFallsBackToDailyWhenEmpty()
+        {
+            var configs = new List<SubscriptionDataConfig>();
+
+            Assert.AreEqual(configs.GetHighestResolution().ToTimeSpan(), configs.GetHighestResolutionSpan());
+            Assert.AreEqual(Resolution.Daily.ToTimeSpan(), configs.GetHighestResolutionSpan());
+        }
+
+        [Test]
+        public void HighestResolutionSpanHonorsDeclaredBarPeriod()
+        {
+            var configs = new List<SubscriptionDataConfig>
+            {
+                CreateConfig(Resolution.Minute, TimeSpan.FromMinutes(30)),
+                CreateConfig(Resolution.Hour, symbol: Symbols.AAPL)
+            };
+
+            Assert.AreEqual(TimeSpan.FromMinutes(30), configs.GetHighestResolutionSpan());
+            // the enum based helper cannot see the declared period and reports the finer nominal resolution
+            Assert.AreEqual(Resolution.Minute, configs.GetHighestResolution());
+        }
+
+        /// <summary>
+        /// The fill model treats a bar as coarse, and therefore fills a resting order at the bar open, when
+        /// its period exceeds one minute. That must select exactly the same resolutions as the previous
+        /// Resolution.Hour/Resolution.Daily test.
+        /// </summary>
+        [Test]
+        public void CoarseBarPredicateMatchesHourAndDailyOnly([Values] Resolution resolution)
+        {
+            var config = CreateConfig(resolution);
+
+            var isCoarseByPeriod = config.Increment > Time.OneMinute;
+            var isCoarseByResolution = resolution == Resolution.Hour || resolution == Resolution.Daily;
+
+            Assert.AreEqual(isCoarseByResolution, isCoarseByPeriod, $"Mismatch for {resolution}");
+        }
+
+        [Test]
+        public void DeclaredThirtyMinuteBarIsCoarse()
+        {
+            var config = CreateConfig(Resolution.Minute, TimeSpan.FromMinutes(30));
+
+            Assert.Greater(config.Increment, Time.OneMinute);
+        }
+    }
+}

--- a/Tests/Engine/DataFeeds/Enumerators/FillForwardEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/FillForwardEnumeratorTests.cs
@@ -68,6 +68,95 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
         }
 
         [Test]
+        public void DeclaredBarPeriodSuppressesSyntheticBars()
+        {
+            var time = new DateTime(2024, 9, 2, 9, 15, 0);
+            var thirtyMinutes = TimeSpan.FromMinutes(30);
+            var exchange = new EquityExchange(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork));
+
+            List<BaseData> CreateSource(TimeSpan period) => new List<BaseData>
+            {
+                new TradeBar { Time = time, Value = 1, Period = period, Volume = 100 },
+                new TradeBar { Time = time.AddMinutes(30), Value = 2, Period = period, Volume = 100 },
+                new TradeBar { Time = time.AddMinutes(60), Value = 3, Period = period, Volume = 100 }
+            };
+
+            (int actual, int filled, List<DateTime> endTimes) Enumerate(TimeSpan period)
+            {
+                var source = CreateSource(period).GetEnumerator();
+                using var fillForwardEnumerator = new FillForwardEnumerator(source, exchange, Ref.Create(period),
+                    false, time, time.AddMinutes(60).Add(period), period, exchange.TimeZone, false);
+
+                var actual = 0;
+                var filled = 0;
+                var endTimes = new List<DateTime>();
+                while (fillForwardEnumerator.MoveNext())
+                {
+                    if (fillForwardEnumerator.Current.IsFillForward)
+                    {
+                        filled++;
+                    }
+                    else
+                    {
+                        actual++;
+                        endTimes.Add(fillForwardEnumerator.Current.EndTime);
+                    }
+                }
+                return (actual, filled, endTimes);
+            }
+
+            // 30 minute data described as one minute: every gap is filled with synthetic bars
+            var asMinute = Enumerate(Time.OneMinute);
+            Assert.AreEqual(3, asMinute.actual);
+            Assert.Greater(asMinute.filled, 0, "Data described as one minute should be filled forward");
+            Assert.AreEqual(time.AddMinutes(1), asMinute.endTimes[0]);
+
+            // the same data described by its real period: nothing synthetic, and correct end times
+            var asThirtyMinutes = Enumerate(thirtyMinutes);
+            Assert.AreEqual(3, asThirtyMinutes.actual);
+            Assert.AreEqual(0, asThirtyMinutes.filled, "Complete data must not be filled forward");
+            CollectionAssert.AreEqual(
+                new[] { time.AddMinutes(30), time.AddMinutes(60), time.AddMinutes(90) },
+                asThirtyMinutes.endTimes);
+        }
+
+        [Test]
+        public void FillsForwardGenuineGapsWhenBarPeriodIsDeclared()
+        {
+            var time = new DateTime(2024, 9, 2, 9, 15, 0);
+            var thirtyMinutes = TimeSpan.FromMinutes(30);
+            var exchange = new EquityExchange(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork));
+
+            // an illiquid contract that does not trade between 09:45 and 10:45
+            var source = new List<BaseData>
+            {
+                new TradeBar { Time = time, Value = 1, Period = thirtyMinutes, Volume = 100 },
+                new TradeBar { Time = time.AddMinutes(90), Value = 2, Period = thirtyMinutes, Volume = 100 }
+            }.GetEnumerator();
+
+            using var fillForwardEnumerator = new FillForwardEnumerator(source, exchange, Ref.Create(thirtyMinutes),
+                false, time, time.AddMinutes(120), thirtyMinutes, exchange.TimeZone, false);
+
+            var filled = 0;
+            var actual = 0;
+            while (fillForwardEnumerator.MoveNext())
+            {
+                if (fillForwardEnumerator.Current.IsFillForward)
+                {
+                    filled++;
+                    Assert.AreEqual(0, ((TradeBar)fillForwardEnumerator.Current).Volume);
+                }
+                else
+                {
+                    actual++;
+                }
+            }
+
+            Assert.AreEqual(2, actual);
+            Assert.AreEqual(2, filled, "The two missing 30 minute bars should be filled forward");
+        }
+
+        [Test]
         public void DelistingEvents()
         {
             var dataResolution = Time.OneMinute;

--- a/Tests/Engine/DataFeeds/SubscriptionDataTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionDataTests.cs
@@ -57,6 +57,38 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         }
 
         [Test]
+        public void CreatedSubscriptionPreservesDeclaredBarAlignment()
+        {
+            var barPeriod = TimeSpan.FromMinutes(30);
+            var time = new DateTime(2020, 5, 21, 9, 15, 0);
+            var tradeBar = new TradeBar
+            {
+                Time = time,
+                Period = barPeriod,
+                Symbol = Symbols.SPY
+            };
+            var config = new SubscriptionDataConfig(
+                typeof(TradeBar),
+                Symbols.SPY,
+                Resolution.Minute,
+                TimeZones.Utc,
+                TimeZones.Utc,
+                false,
+                false,
+                false,
+                barPeriod: barPeriod
+            );
+            var exchangeHours = SecurityExchangeHours.AlwaysOpen(TimeZones.Utc);
+            var offsetProvider = new TimeZoneOffsetProvider(TimeZones.Utc, time.Date, time.Date.AddDays(1));
+
+            var subscription = SubscriptionData.Create(false, config, exchangeHours, offsetProvider,
+                tradeBar, config.DataNormalizationMode);
+
+            Assert.AreEqual(time, subscription.Data.Time);
+            Assert.AreEqual(time.Add(barPeriod), subscription.Data.EndTime);
+        }
+
+        [Test]
         public void CreatedSubscriptionDoesNotRoundDownForPeriodLessData()
         {
             var data = new MyCustomData


### PR DESCRIPTION
## Description

LEAN derives a bar's length from the *name* of its resolution, so data whose stored period differs from the nominal one is misdescribed. Concretely, 30-minute bars kept in the `minute` folders are treated as 1-minute bars: `FillForwardEnumerator` manufactures ~29 synthetic bars per real bar, and every bar is stamped with an end time 29 minutes too early.

This adds an optional `barPeriod` to `SubscriptionDataConfig`, surfaced on `AddEquity`, `AddIndex`, `AddOption`, `AddIndexOption`, `AddSecurity` and `UniverseSettings`:

```csharp
AddEquity("SPY", Resolution.Minute, barPeriod: TimeSpan.FromMinutes(30));
```

It defaults to `null`, so the period continues to be derived from the resolution and **no existing algorithm changes behaviour**. `Resolution` is deliberately untouched, so data still resolves from the same files and **no data needs regenerating**.

With the period declared, `ShouldFillForward` sees a gap equal to the period rather than 30x it, so no synthetic bars are emitted when the data is complete, and genuine gaps are still filled with exactly one bar.

## Four latent `Resolution`-as-duration reads

Four places read `Resolution` where they mean a duration. They agree today because `Increment` is a pure function of `Resolution`, so **each change is provably equivalent for any subscription that does not declare a period**, and the PR includes tests asserting that equivalence across all five resolutions.

| Location | Issue |
|---|---|
| `SubscriptionCollection` | Derived the fill-forward cadence from the resolution enum, which would reinstate the synthetic bars |
| `FillModel.ShouldWaitForFreshData` | Tested `Resolution.Hour/Daily` to decide whether a resting order fills at the bar **open** rather than its close. Now `Increment > Time.OneMinute`, which selects exactly `Hour` and `Daily`. Without this, a declared 30-minute bar would fill at the close of the *following* bar |
| `FillModel` stale threshold | Sized via `GetHighestResolution().ToTimeSpan()`. Added `GetHighestResolutionSpan()`, taking the minimum `Increment` |
| `CreateConsolidator` | Compared a `TimeSpan` against `Increment` and a `Resolution` against `Resolution` in one expression. Both now compare durations |

The consolidator change also fixes a pre-existing bug: against coarser-than-nominal data, `SMA(symbol, 20, Resolution.Minute)` evaluated `Minute < Minute` as false, skipped the guard, matched the identity branch and silently returned the coarser bars labelled as minute bars. It now throws.

`Equals`/`GetHashCode` include the declared period so configs differing only by it are not deduplicated, and the copy constructor drops it when the resolution changes, since it described the previous resolution.

## Testing

New fixture `Tests/Common/Data/SubscriptionDataConfigBarPeriodTests.cs` (23 tests) covers the equivalence proofs, config identity, copy-constructor inheritance, and validation. Two new `FillForwardEnumeratorTests` assert that a declared period emits zero synthetic bars with correct end times, while a genuine gap is still filled.

Suites run green in `quantconnect/lean:foundation`:

| Filter | Result |
|---|---|
| `SubscriptionDataConfigBarPeriodTests` | 23 passed |
| `FillForwardEnumeratorTests`, `SubscriptionCollectionTests`, `SubscriptionDataConfigTests` | 315 passed |
| `Fills`, `FillModel` | 544 passed, 2 skipped |
| `Consolidator`, `HistoryRequest`, `UniverseSettings` | 669 passed |

Full solution builds clean on net10.0.
