### PR TITLE
fix: keep the log handler set by the brokerage test project

### DIFF
--- a/Tests/Brokerages/BrokerageTests.cs
+++ b/Tests/Brokerages/BrokerageTests.cs
@@ -50,8 +50,6 @@ namespace QuantConnect.Tests.Brokerages
         [SetUp]
         public void Setup()
         {
-            Log.LogHandler = new NUnitLogHandler();
-
             Log.Trace("");
             Log.Trace("");
             Log.Trace("--- SETUP ---");


### PR DESCRIPTION
#### Description

`BrokerageTests.Setup` replaced `Log.LogHandler` with a new `NUnitLogHandler` before every test. That line is removed, so the log handler chosen by the test project is kept.

#### Related Issue

N/A

#### Motivation and Context

No fixture in Lean derives from `BrokerageTests`. Its consumers are the brokerage plugin repositories (`Lean.Brokerages.Tastytrade`, `Lean.Brokerages.CharlesSchwab`, `Lean.Brokerages.Alpaca` and others), which use it as the base class for their live brokerage tests. Each of them sets a log handler in its own `TestSetup`:

```csharp
Log.LogHandler = new CompositeLogHandler(); // ConsoleLogHandler + FileLogHandler
```

That line runs once, from a `TestCaseSource` while NUnit builds the test tree, and never runs again. The first brokerage test replaced it, so for the rest of the run there was no `log.txt` and no console output. The only place left was `TestContext.Progress`, which the default `dotnet test` console logger does not print. A failing brokerage test in CI showed no log at all.

**Why `ConsoleLogHandler` is the better default here**

Both handlers write the same text. They differ in where the text goes and who can read it there.

| | ConsoleLogHandler | NUnitLogHandler |
|---|---|---|
| Visible in Visual Studio | yes, while the test runs | yes, while the test runs |
| Visible in CI (`dotnet test`) | yes, when the test fails | no, never |
| Usable outside tests (Launcher, live trading) | yes | no, it lives in the test project and needs NUnit |
| Line order | `Error` goes to stderr, the rest to stdout, so error lines can move | one stream for all levels, order is kept |
| Save only errors to a file | yes, `2> errors.txt` | no, everything is mixed |

The order difference is real but small. Three logged lines:

```
TRACE:: sending order
ERROR:: order rejected
TRACE:: closing socket
```

With `ConsoleLogHandler` the error line travels on a different stream, so it can arrive last and look like the socket broke first. `NUnitLogHandler` keeps the order.

The CI difference is the one that costs something. With `NUnitLogHandler` only, a failing test in GitHub Actions produces an empty log. `NUnitLogHandler` is tidier, `ConsoleLogHandler` reaches more places, and the test project is the right place to make that choice.

Consumers that set no handler keep Lean's default `ConsoleLogHandler` instead of getting an `NUnitLogHandler`. Their output is still shown in Visual Studio while the test runs, and now it is also shown in CI when a test fails.

#### Requires Documentation Change

No

#### How Has This Been Tested?

- Measured with a small NUnit project that the default `dotnet test` console logger prints `Console.Out` for a failing test, but never prints `TestContext.Progress`. This is why the handler from `TestSetup` has to survive.
- Confirmed that `TestSetup` in the brokerage plugin repositories sets the log handler once, before any `[SetUp]` runs.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- test infrastructure change, there is no new behaviour to unit test -->
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
