### PR TITLE
Add exception interpreters for Python ModuleNotFoundError and multiple inheritance TypeError

### DIFF
--- a/Common/Exceptions/ModuleNotFoundPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/ModuleNotFoundPythonExceptionInterpreter.cs
@@ -1,0 +1,69 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using Python.Runtime;
+using QuantConnect.Util;
+
+namespace QuantConnect.Exceptions
+{
+    /// <summary>
+    /// Interprets Python ModuleNotFoundError exceptions
+    /// </summary>
+    public class ModuleNotFoundPythonExceptionInterpreter : PythonExceptionInterpreter
+    {
+        /// <summary>
+        /// Determines the order that an instance of this class should be called
+        /// </summary>
+        public override int Order => 0;
+
+        /// <summary>
+        /// Determines if this interpreter should be applied to the specified exception.
+        /// </summary>
+        /// <param name="exception">The exception to check</param>
+        /// <returns>True if the exception can be interpreted, false otherwise</returns>
+        public override bool CanInterpret(Exception exception)
+        {
+            var pythonException = exception as PythonException;
+            if (pythonException == null)
+            {
+                return false;
+            }
+
+            using (Py.GIL())
+            {
+                return base.CanInterpret(exception) &&
+                    pythonException.Type.Name.Equals("ModuleNotFoundError", StringComparison.InvariantCultureIgnoreCase);
+            }
+        }
+
+        /// <summary>
+        /// Interprets the specified exception into a new exception
+        /// </summary>
+        /// <param name="exception">The exception to be interpreted</param>
+        /// <param name="innerInterpreter">An interpreter that should be applied to the inner exception.</param>
+        /// <returns>The interpreted exception</returns>
+        public override Exception Interpret(Exception exception, IExceptionInterpreter innerInterpreter)
+        {
+            var pe = (PythonException)exception;
+
+            var moduleName = pe.Message.GetStringBetweenChars('\'', '\'');
+            var message = Messages.ModuleNotFoundPythonExceptionInterpreter.ModuleNotFound(moduleName);
+            message += PythonUtil.PythonExceptionStackParser(pe.StackTrace);
+
+            return new Exception(message, pe);
+        }
+    }
+}

--- a/Common/Exceptions/ModuleNotFoundPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/ModuleNotFoundPythonExceptionInterpreter.cs
@@ -14,6 +14,8 @@
 */
 
 using System;
+using System.Linq;
+using System.Text.RegularExpressions;
 using Python.Runtime;
 using QuantConnect.Util;
 
@@ -24,6 +26,8 @@ namespace QuantConnect.Exceptions
     /// </summary>
     public class ModuleNotFoundPythonExceptionInterpreter : PythonExceptionInterpreter
     {
+        private static readonly Regex _camelCasedNameRegex = new Regex(@"^[A-Z][a-zA-Z0-9]*(\.[A-Z][a-zA-Z0-9]*)*$", RegexOptions.Compiled);
+
         /// <summary>
         /// Determines the order that an instance of this class should be called
         /// </summary>
@@ -60,10 +64,20 @@ namespace QuantConnect.Exceptions
             var pe = (PythonException)exception;
 
             var moduleName = pe.Message.GetStringBetweenChars('\'', '\'');
-            var message = Messages.ModuleNotFoundPythonExceptionInterpreter.ModuleNotFound(moduleName);
+            var message = Messages.ModuleNotFoundPythonExceptionInterpreter.ModuleNotFound(moduleName, IsCamelCased(moduleName));
             message += PythonUtil.PythonExceptionStackParser(pe.StackTrace);
 
             return new Exception(message, pe);
+        }
+
+        /// <summary>
+        /// Determines whether the module name follows .NET namespace casing (e.g. "QuantConnect.Indicators"):
+        /// every dot-separated segment starts with an uppercase letter and the name contains at least one
+        /// lowercase letter, so all-uppercase Python packages like "PIL" are not treated as assemblies.
+        /// </summary>
+        private static bool IsCamelCased(string moduleName)
+        {
+            return _camelCasedNameRegex.IsMatch(moduleName) && moduleName.Any(char.IsLower);
         }
     }
 }

--- a/Common/Exceptions/MultipleInheritancePythonExceptionInterpreter.cs
+++ b/Common/Exceptions/MultipleInheritancePythonExceptionInterpreter.cs
@@ -1,0 +1,60 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using Python.Runtime;
+using QuantConnect.Util;
+
+namespace QuantConnect.Exceptions
+{
+    /// <summary>
+    /// Interprets Python TypeError exceptions caused by inheriting from multiple classes
+    /// when one of them is a managed (C#) class
+    /// </summary>
+    public class MultipleInheritancePythonExceptionInterpreter : PythonExceptionInterpreter
+    {
+        /// <summary>
+        /// Determines the order that an instance of this class should be called
+        /// </summary>
+        public override int Order => 0;
+
+        /// <summary>
+        /// Determines if this interpreter should be applied to the specified exception.
+        /// </summary>
+        /// <param name="exception">The exception to check</param>
+        /// <returns>True if the exception can be interpreted, false otherwise</returns>
+        public override bool CanInterpret(Exception exception)
+        {
+            return base.CanInterpret(exception) &&
+                exception.Message.Contains(Messages.MultipleInheritancePythonExceptionInterpreter.MultipleInheritanceExpectedSubstring);
+        }
+
+        /// <summary>
+        /// Interprets the specified exception into a new exception
+        /// </summary>
+        /// <param name="exception">The exception to be interpreted</param>
+        /// <param name="innerInterpreter">An interpreter that should be applied to the inner exception.</param>
+        /// <returns>The interpreted exception</returns>
+        public override Exception Interpret(Exception exception, IExceptionInterpreter innerInterpreter)
+        {
+            var pe = (PythonException)exception;
+
+            var message = Messages.MultipleInheritancePythonExceptionInterpreter.InvalidMultipleInheritance;
+            message += PythonUtil.PythonExceptionStackParser(pe.StackTrace);
+
+            return new Exception(message, pe);
+        }
+    }
+}

--- a/Common/Messages/Messages.Exceptions.cs
+++ b/Common/Messages/Messages.Exceptions.cs
@@ -96,14 +96,18 @@ namespace QuantConnect
         public static class ModuleNotFoundPythonExceptionInterpreter
         {
             /// <summary>
-            /// Returns a string message saying the given module could not be found. It also contains an advice on how to fix it,
-            /// both for C# namespaces and Python packages
+            /// Returns a string message saying the given module could not be found, with advice on how to fix it.
+            /// The .NET assembly advice is only included when the module name looks like a .NET namespace
             /// </summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static string ModuleNotFound(string moduleName)
+            public static string ModuleNotFound(string moduleName, bool isModuleNameCamelCased)
             {
-                return $"No module named '{moduleName}'. If it is a Python package, ensure it is installed in the environment. " +
-                    "If it is a .NET assembly, importing it is not supported, use an equivalent Python package instead.";
+                var message = $"No module named '{moduleName}'. If it is a Python package, ensure it is installed in the environment.";
+                if (isModuleNameCamelCased)
+                {
+                    message += " If it is a .NET assembly, importing it is not supported, use an equivalent Python package instead.";
+                }
+                return message;
             }
         }
 

--- a/Common/Messages/Messages.Exceptions.cs
+++ b/Common/Messages/Messages.Exceptions.cs
@@ -102,8 +102,9 @@ namespace QuantConnect
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string ModuleNotFound(string moduleName)
             {
-                return $"No module named '{moduleName}'. If it is a C# namespace, call clr.AddReference(\"<AssemblyName>\") " +
-                    "before importing it. If it is a Python package, ensure it is installed in the environment.";
+                return $"No module named '{moduleName}'. If it is a Python package, ensure it is installed in the environment. " +
+                    "If it is a C# namespace, ensure the algorithm starts with 'from AlgorithmImports import *'. " +
+                    "Only custom C# libraries in local runs require clr.AddReference(\"<AssemblyName>\") before importing.";
             }
         }
 

--- a/Common/Messages/Messages.Exceptions.cs
+++ b/Common/Messages/Messages.Exceptions.cs
@@ -103,8 +103,7 @@ namespace QuantConnect
             public static string ModuleNotFound(string moduleName)
             {
                 return $"No module named '{moduleName}'. If it is a Python package, ensure it is installed in the environment. " +
-                    "If it is a C# namespace, ensure the algorithm starts with 'from AlgorithmImports import *'. " +
-                    "Only custom C# libraries in local runs require clr.AddReference(\"<AssemblyName>\") before importing.";
+                    "If it is a .NET assembly, importing it is not supported, use an equivalent Python package instead.";
             }
         }
 

--- a/Common/Messages/Messages.Exceptions.cs
+++ b/Common/Messages/Messages.Exceptions.cs
@@ -91,6 +91,43 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Provides user-facing messages for the <see cref="Exceptions.ModuleNotFoundPythonExceptionInterpreter"/> class and its consumers or related classes
+        /// </summary>
+        public static class ModuleNotFoundPythonExceptionInterpreter
+        {
+            /// <summary>
+            /// Returns a string message saying the given module could not be found. It also contains an advice on how to fix it,
+            /// both for C# namespaces and Python packages
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string ModuleNotFound(string moduleName)
+            {
+                return $"No module named '{moduleName}'. If it is a C# namespace, call clr.AddReference(\"<AssemblyName>\") " +
+                    "before importing it. If it is a Python package, ensure it is installed in the environment.";
+            }
+        }
+
+        /// <summary>
+        /// Provides user-facing messages for the <see cref="Exceptions.MultipleInheritancePythonExceptionInterpreter"/> class and its consumers or related classes
+        /// </summary>
+        public static class MultipleInheritancePythonExceptionInterpreter
+        {
+            /// <summary>
+            /// String message saying: cannot use multiple inheritance with managed classes
+            /// </summary>
+            public static string MultipleInheritanceExpectedSubstring = "cannot use multiple inheritance with managed classes";
+
+            /// <summary>
+            /// String message saying a Python class cannot inherit from multiple classes when one of them is a C# class.
+            /// It also contains an advice on how to fix it
+            /// </summary>
+            public static string InvalidMultipleInheritance =
+                "A Python class cannot inherit from multiple classes when one of them is a C# class, like QCAlgorithm. " +
+                "Keep the C# class as the only base and move the other bases' members into helper classes used via " +
+                "composition (e.g. self._helper = MyHelper()).";
+        }
+
+        /// <summary>
         /// Provides user-facing messages for the <see cref="Exceptions.NoMethodMatchPythonExceptionInterpreter"/> class and its consumers or related classes
         /// </summary>
         public static class NoMethodMatchPythonExceptionInterpreter

--- a/Tests/Common/Exceptions/ModuleNotFoundPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/ModuleNotFoundPythonExceptionInterpreterTests.cs
@@ -83,6 +83,39 @@ namespace QuantConnect.Tests.Common.Exceptions
             Assert.True(exception.Message.Contains("use an equivalent Python package instead"));
         }
 
+        [Test]
+        [TestCase("FakeMissingAssembly", true)]
+        [TestCase("FakeMissingAssembly99", true)]
+        [TestCase("fake_missing_module", false)]
+        [TestCase("fakemissingmodule", false)]
+        [TestCase("FAKEMISSINGMODULE", false)]
+        [TestCase("Fake_Missing_Module", false)]
+        public void AddsDotNetAssemblyAdviceOnlyForCamelCasedModuleNames(string moduleName, bool expectDotNetAdvice)
+        {
+            PythonException pythonException = null;
+            using (Py.GIL())
+            {
+                try
+                {
+                    Py.Import(moduleName);
+                }
+                catch (PythonException exception)
+                {
+                    pythonException = exception;
+                }
+            }
+
+            Assert.IsNotNull(pythonException);
+
+            var interpreter = new ModuleNotFoundPythonExceptionInterpreter();
+            Assert.IsTrue(interpreter.CanInterpret(pythonException));
+
+            var interpretedException = interpreter.Interpret(pythonException, NullExceptionInterpreter.Instance);
+            StringAssert.Contains($"No module named '{moduleName}'", interpretedException.Message);
+            StringAssert.Contains("ensure it is installed in the environment", interpretedException.Message);
+            Assert.AreEqual(expectDotNetAdvice, interpretedException.Message.Contains(".NET assembly", StringComparison.Ordinal));
+        }
+
         private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _pythonException : (Exception)Activator.CreateInstance(type);
     }
 }

--- a/Tests/Common/Exceptions/ModuleNotFoundPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/ModuleNotFoundPythonExceptionInterpreterTests.cs
@@ -80,7 +80,7 @@ namespace QuantConnect.Tests.Common.Exceptions
             var interpreter = StackExceptionInterpreter.CreateFromAssemblies();
             exception = interpreter.Interpret(exception, NullExceptionInterpreter.Instance);
             Assert.True(exception.Message.Contains("No module named 'MissingClrNamespace'"));
-            Assert.True(exception.Message.Contains("AlgorithmImports"));
+            Assert.True(exception.Message.Contains("use an equivalent Python package instead"));
         }
 
         private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _pythonException : (Exception)Activator.CreateInstance(type);

--- a/Tests/Common/Exceptions/ModuleNotFoundPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/ModuleNotFoundPythonExceptionInterpreterTests.cs
@@ -80,7 +80,7 @@ namespace QuantConnect.Tests.Common.Exceptions
             var interpreter = StackExceptionInterpreter.CreateFromAssemblies();
             exception = interpreter.Interpret(exception, NullExceptionInterpreter.Instance);
             Assert.True(exception.Message.Contains("No module named 'MissingClrNamespace'"));
-            Assert.True(exception.Message.Contains("clr.AddReference"));
+            Assert.True(exception.Message.Contains("AlgorithmImports"));
         }
 
         private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _pythonException : (Exception)Activator.CreateInstance(type);

--- a/Tests/Common/Exceptions/ModuleNotFoundPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/ModuleNotFoundPythonExceptionInterpreterTests.cs
@@ -1,0 +1,88 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+using Python.Runtime;
+using QuantConnect.Exceptions;
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Tests.Common.Exceptions
+{
+    [TestFixture]
+    public class ModuleNotFoundPythonExceptionInterpreterTests
+    {
+        private PythonException _pythonException;
+
+        [SetUp]
+        public void Setup()
+        {
+            using (Py.GIL())
+            {
+                var module = Py.Import("Test_PythonExceptionInterpreter");
+                dynamic algorithm = module.GetAttr("Test_PythonExceptionInterpreter").Invoke();
+
+                try
+                {
+                    // from MissingClrNamespace.Distributions import Normal
+                    algorithm.module_not_found();
+                }
+                catch (PythonException pythonException)
+                {
+                    _pythonException = pythonException;
+                }
+            }
+        }
+
+        [Test]
+        [TestCase(typeof(Exception), ExpectedResult = false)]
+        [TestCase(typeof(KeyNotFoundException), ExpectedResult = false)]
+        [TestCase(typeof(DivideByZeroException), ExpectedResult = false)]
+        [TestCase(typeof(InvalidOperationException), ExpectedResult = false)]
+        [TestCase(typeof(PythonException), ExpectedResult = true)]
+        public bool CanInterpretReturnsTrueForOnlyModuleNotFoundPythonExceptionType(Type exceptionType)
+        {
+            var exception = CreateExceptionFromType(exceptionType);
+            return new ModuleNotFoundPythonExceptionInterpreter().CanInterpret(exception);
+        }
+
+        [Test]
+        [TestCase(typeof(Exception), true)]
+        [TestCase(typeof(KeyNotFoundException), true)]
+        [TestCase(typeof(DivideByZeroException), true)]
+        [TestCase(typeof(InvalidOperationException), true)]
+        [TestCase(typeof(PythonException), false)]
+        public void InterpretThrowsForNonModuleNotFoundPythonExceptionTypes(Type exceptionType, bool expectThrow)
+        {
+            var exception = CreateExceptionFromType(exceptionType);
+            var interpreter = new ModuleNotFoundPythonExceptionInterpreter();
+            var constraint = expectThrow ? (IResolveConstraint)Throws.Exception : Throws.Nothing;
+            Assert.That(() => interpreter.Interpret(exception, NullExceptionInterpreter.Instance), constraint);
+        }
+
+        [Test]
+        public void VerifyMessageContainsModuleNameAndAdvice()
+        {
+            var exception = CreateExceptionFromType(typeof(PythonException));
+            var interpreter = StackExceptionInterpreter.CreateFromAssemblies();
+            exception = interpreter.Interpret(exception, NullExceptionInterpreter.Instance);
+            Assert.True(exception.Message.Contains("No module named 'MissingClrNamespace'"));
+            Assert.True(exception.Message.Contains("clr.AddReference"));
+        }
+
+        private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _pythonException : (Exception)Activator.CreateInstance(type);
+    }
+}

--- a/Tests/Common/Exceptions/MultipleInheritancePythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/MultipleInheritancePythonExceptionInterpreterTests.cs
@@ -1,0 +1,88 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+using Python.Runtime;
+using QuantConnect.Exceptions;
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Tests.Common.Exceptions
+{
+    [TestFixture]
+    public class MultipleInheritancePythonExceptionInterpreterTests
+    {
+        private PythonException _pythonException;
+
+        [SetUp]
+        public void Setup()
+        {
+            using (Py.GIL())
+            {
+                var module = Py.Import("Test_PythonExceptionInterpreter");
+                dynamic algorithm = module.GetAttr("Test_PythonExceptionInterpreter").Invoke();
+
+                try
+                {
+                    // class MultipleInheritanceAlgorithm(QCAlgorithm, MultipleInheritanceMixin)
+                    algorithm.multiple_inheritance();
+                }
+                catch (PythonException pythonException)
+                {
+                    _pythonException = pythonException;
+                }
+            }
+        }
+
+        [Test]
+        [TestCase(typeof(Exception), ExpectedResult = false)]
+        [TestCase(typeof(KeyNotFoundException), ExpectedResult = false)]
+        [TestCase(typeof(DivideByZeroException), ExpectedResult = false)]
+        [TestCase(typeof(InvalidOperationException), ExpectedResult = false)]
+        [TestCase(typeof(PythonException), ExpectedResult = true)]
+        public bool CanInterpretReturnsTrueForOnlyMultipleInheritancePythonExceptionType(Type exceptionType)
+        {
+            var exception = CreateExceptionFromType(exceptionType);
+            return new MultipleInheritancePythonExceptionInterpreter().CanInterpret(exception);
+        }
+
+        [Test]
+        [TestCase(typeof(Exception), true)]
+        [TestCase(typeof(KeyNotFoundException), true)]
+        [TestCase(typeof(DivideByZeroException), true)]
+        [TestCase(typeof(InvalidOperationException), true)]
+        [TestCase(typeof(PythonException), false)]
+        public void InterpretThrowsForNonMultipleInheritancePythonExceptionTypes(Type exceptionType, bool expectThrow)
+        {
+            var exception = CreateExceptionFromType(exceptionType);
+            var interpreter = new MultipleInheritancePythonExceptionInterpreter();
+            var constraint = expectThrow ? (IResolveConstraint)Throws.Exception : Throws.Nothing;
+            Assert.That(() => interpreter.Interpret(exception, NullExceptionInterpreter.Instance), constraint);
+        }
+
+        [Test]
+        public void VerifyMessageContainsAdviceAndStackTraceInformation()
+        {
+            var exception = CreateExceptionFromType(typeof(PythonException));
+            var interpreter = StackExceptionInterpreter.CreateFromAssemblies();
+            exception = interpreter.Interpret(exception, NullExceptionInterpreter.Instance);
+            Assert.True(exception.Message.Contains("composition"));
+            Assert.True(exception.Message.Contains("MultipleInheritanceAlgorithm(QCAlgorithm, MultipleInheritanceMixin)"));
+        }
+
+        private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _pythonException : (Exception)Activator.CreateInstance(type);
+    }
+}

--- a/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
+++ b/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
@@ -32,6 +32,15 @@ class Test_PythonExceptionInterpreter(QCAlgorithm):
     def unsupported_operand(self):
         x = None + "Pepe Grillo"
 
+    def module_not_found(self):
+        from MissingClrNamespace.Distributions import Normal
+
+    def multiple_inheritance(self):
+        class MultipleInheritanceMixin:
+            pass
+        class MultipleInheritanceAlgorithm(QCAlgorithm, MultipleInheritanceMixin):
+            pass
+
     def zero_division_error(self):
         x = 1 / 0
 


### PR DESCRIPTION
#### Description

Two common Python algorithm initialization failures currently surface through the generic `PythonExceptionInterpreter` with no guidance on how to fix them:

```
AlgorithmPythonWrapper(): No module named 'MathNet'
```

```
AlgorithmPythonWrapper(): cannot use multiple inheritance with managed classes
  at <module>
    class QuarterDailyMomentum(QCAlgorithm, LogMixin):
```

Cause: importing a C# namespace whose assembly has not been loaded into the CLR raises `ModuleNotFoundError`, and defining a Python class with a managed class plus another base raises `TypeError` — neither had a specialized interpreter.

The fix:
- `ModuleNotFoundPythonExceptionInterpreter` matches `PythonException`s whose Python type is `ModuleNotFoundError` and appends a short hint: install the package if it is a Python one; importing .NET assemblies is not supported, so use an equivalent Python package instead.
- `MultipleInheritancePythonExceptionInterpreter` matches the `cannot use multiple inheritance with managed classes` `TypeError` and recommends keeping the C# class as the only base, moving the other bases' members into helpers used via composition.
- Both run at `Order = 0`, taking precedence over the generic `PythonExceptionInterpreter`, and keep the parsed Python stack trace so the failing line is still shown.
- Messages are intentionally one sentence of advice each to keep runtime error output short.

#### Related Issue

N/A

#### Motivation and Context

Actionable one-line hints let users (and LLM assistants reading the error) fix these failures without external help, while keeping the error message short.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

- New `ModuleNotFoundPythonExceptionInterpreterTests` and `MultipleInheritancePythonExceptionInterpreterTests`: `CanInterpret` type matrix, `Interpret` mismatch behavior, and interpreted-message content through `StackExceptionInterpreter.CreateFromAssemblies`.
- New `module_not_found` / `multiple_inheritance` trigger methods in `Test_PythonExceptionInterpreter.py`.
- Full `QuantConnect.Tests.Common.Exceptions` suite: 125 passed, 0 failed.
- Verified the final messages end-to-end through `AlgorithmPythonWrapper` construction and full Launcher backtest runs of reproduction algorithms for both failure modes.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
