### PR TITLE
Add results analyses detecting the isolator time limit runtime errors

### DIFF
--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -104,12 +104,14 @@ namespace QuantConnect.Lean.Engine
                 //-> Initialize messaging system
                 SystemHandlers.Notify.SetAuthentication(job);
 
+                var performanceTrackingTool = new PerformanceTrackingTool();
+
                 //-> Set the result handler type for this algorithm job, and launch the associated result thread.
-                AlgorithmHandlers.Results.Initialize(new(job, SystemHandlers.Notify, SystemHandlers.Api, AlgorithmHandlers.Transactions, AlgorithmHandlers.MapFileProvider));
+                AlgorithmHandlers.Results.Initialize(
+                    new(job, SystemHandlers.Notify, SystemHandlers.Api, AlgorithmHandlers.Transactions, AlgorithmHandlers.MapFileProvider, performanceTrackingTool));
 
                 IBrokerage brokerage = null;
                 DataManager dataManager = null;
-                var performanceTrackingTool = new PerformanceTrackingTool();
                 var synchronizer = _liveMode ? new LiveSynchronizer() : new Synchronizer();
                 try
                 {

--- a/Engine/Results/Analysis/AlgorithmSpeedSample.cs
+++ b/Engine/Results/Analysis/AlgorithmSpeedSample.cs
@@ -1,0 +1,68 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+using System;
+
+namespace QuantConnect.Lean.Engine.Results.Analysis
+{
+    /// <summary>
+    /// A point-in-time sample of the engine's cumulative speed counters, fed by the result handler
+    /// into the <see cref="AlgorithmSpeedTracker"/> on each in-run analysis run.
+    /// </summary>
+    public readonly struct AlgorithmSpeedSample
+    {
+        /// <summary>
+        /// The wall-clock time elapsed since the backtest started.
+        /// </summary>
+        public TimeSpan Elapsed { get; }
+
+        /// <summary>
+        /// The cumulative data points processed by the main algorithm loop.
+        /// </summary>
+        public long DataPoints { get; }
+
+        /// <summary>
+        /// The cumulative data points served by the history provider.
+        /// </summary>
+        public long HistoryDataPoints { get; }
+
+        /// <summary>
+        /// The calendar days the backtest has processed so far.
+        /// </summary>
+        public int ProcessedDays { get; }
+
+        /// <summary>
+        /// The total calendar days the backtest will run.
+        /// </summary>
+        public int TotalDays { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AlgorithmSpeedSample"/> struct.
+        /// </summary>
+        /// <param name="elapsed">Wall-clock time elapsed since the backtest started.</param>
+        /// <param name="dataPoints">Cumulative data points processed by the main algorithm loop.</param>
+        /// <param name="historyDataPoints">Cumulative data points served by the history provider.</param>
+        /// <param name="processedDays">Calendar days the backtest has processed so far.</param>
+        /// <param name="totalDays">Total calendar days the backtest will run.</param>
+        public AlgorithmSpeedSample(TimeSpan elapsed, long dataPoints, long historyDataPoints, int processedDays, int totalDays)
+        {
+            Elapsed = elapsed;
+            DataPoints = dataPoints;
+            HistoryDataPoints = historyDataPoints;
+            ProcessedDays = processedDays;
+            TotalDays = totalDays;
+        }
+    }
+}

--- a/Engine/Results/Analysis/AlgorithmSpeedTracker.cs
+++ b/Engine/Results/Analysis/AlgorithmSpeedTracker.cs
@@ -1,0 +1,204 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Lean.Engine.Results.Analysis
+{
+    /// <summary>
+    /// Accumulates periodic samples of the engine's speed counters (data points processed, history data points,
+    /// backtest days processed) while a backtest runs, and computes the throughput and progress metrics consumed
+    /// by the in-run <see cref="Analyses.AlgorithmSpeedAnalysis"/>.
+    /// All rates are computed between samples, so setup time before the first sample is excluded.
+    /// </summary>
+    public class AlgorithmSpeedTracker
+    {
+        /// <summary>
+        /// The number of trailing samples that make up the "recent" window used by the windowed rates.
+        /// At the ~30 second in-run analysis cadence this spans roughly the last two minutes.
+        /// </summary>
+        public const int RecentWindowSamples = 5;
+
+        private readonly List<AlgorithmSpeedSample> _samples = new();
+
+        /// <summary>
+        /// The number of samples recorded so far.
+        /// </summary>
+        public int SampleCount => _samples.Count;
+
+        /// <summary>
+        /// The total number of calendar days the backtest will run.
+        /// </summary>
+        public int TotalDays => _samples.Count > 0 ? _samples[^1].TotalDays : 0;
+
+        /// <summary>
+        /// The number of calendar days the backtest has processed as of the latest sample.
+        /// </summary>
+        public int ProcessedDays => _samples.Count > 0 ? _samples[^1].ProcessedDays : 0;
+
+        /// <summary>
+        /// The backtest progress as of the latest sample, in the [0, 1] range.
+        /// </summary>
+        public decimal Progress => TotalDays > 0 ? Math.Min((decimal)ProcessedDays / TotalDays, 1m) : 0m;
+
+        /// <summary>
+        /// The wall-clock time elapsed since the backtest started, as of the latest sample.
+        /// </summary>
+        public TimeSpan Elapsed => _samples.Count > 0 ? _samples[^1].Elapsed : TimeSpan.Zero;
+
+        /// <summary>
+        /// The wall-clock time between the first and the latest sample, that is,
+        /// the period the rates are measured over.
+        /// </summary>
+        public TimeSpan SampledSpan => _samples.Count > 1 ? _samples[^1].Elapsed - _samples[0].Elapsed : TimeSpan.Zero;
+
+        /// <summary>
+        /// Whether the main loop data point counter is being fed. When the counter is not wired in
+        /// (it reads zero), data-point-based rates are not meaningful and should not be used.
+        /// </summary>
+        public bool HasDataPointCounts => _samples.Count > 0 && _samples[^1].DataPoints > 0;
+
+        /// <summary>
+        /// Records a sample of the cumulative speed counters. Samples with a non-increasing
+        /// elapsed time are ignored so rates are always computed over positive time deltas.
+        /// </summary>
+        /// <param name="sample">The sample of the cumulative speed counters.</param>
+        public void AddSample(AlgorithmSpeedSample sample)
+        {
+            if (_samples.Count > 0 && sample.Elapsed <= _samples[^1].Elapsed)
+            {
+                return;
+            }
+            _samples.Add(sample);
+        }
+
+        /// <summary>
+        /// The average data points processed per second over the whole sampled span, including
+        /// history data points to match the speed the engine reports on completion.
+        /// Null when there are not enough samples to measure.
+        /// </summary>
+        public double? DataPointsPerSecond => RateBetween(0, _samples.Count - 1, TotalDataPoints);
+
+        /// <summary>
+        /// The average data points processed per second over the first <see cref="RecentWindowSamples"/> samples,
+        /// used as the early-run baseline for degradation detection. Null when there are not enough samples to measure.
+        /// </summary>
+        public double? InitialDataPointsPerSecond => RateBetween(0, Math.Min(RecentWindowSamples, _samples.Count) - 1, TotalDataPoints);
+
+        /// <summary>
+        /// The average data points processed per second over the recent window, including history data points.
+        /// </summary>
+        /// <param name="skipLast">Number of trailing samples to skip, to evaluate the window as of a previous run.</param>
+        /// <returns>The windowed rate, or null when there are not enough samples to measure.</returns>
+        public double? RecentDataPointsPerSecond(int skipLast = 0)
+        {
+            var (start, end) = RecentWindow(skipLast);
+            return RateBetween(start, end, TotalDataPoints);
+        }
+
+        /// <summary>
+        /// The average backtest calendar days processed per wall-clock second over the recent window.
+        /// </summary>
+        /// <param name="skipLast">Number of trailing samples to skip, to evaluate the window as of a previous run.</param>
+        /// <returns>The windowed rate, or null when there are not enough samples to measure.</returns>
+        public double? RecentDaysPerSecond(int skipLast = 0)
+        {
+            var (start, end) = RecentWindow(skipLast);
+            return RateBetween(start, end, sample => sample.ProcessedDays);
+        }
+
+        /// <summary>
+        /// The number of history data points served over the recent window.
+        /// </summary>
+        /// <param name="skipLast">Number of trailing samples to skip, to evaluate the window as of a previous run.</param>
+        public long RecentHistoryDataPoints(int skipLast = 0)
+        {
+            var (start, end) = RecentWindow(skipLast);
+            return end > start ? _samples[end].HistoryDataPoints - _samples[start].HistoryDataPoints : 0;
+        }
+
+        /// <summary>
+        /// The share of the data points processed over the recent window that were served by the history
+        /// provider, in the [0, 1] range.
+        /// </summary>
+        /// <param name="skipLast">Number of trailing samples to skip, to evaluate the window as of a previous run.</param>
+        /// <returns>The share, or null when there are not enough samples or no data points were processed in the window.</returns>
+        public double? RecentHistoryDataPointsShare(int skipLast = 0)
+        {
+            var (start, end) = RecentWindow(skipLast);
+            if (end <= start)
+            {
+                return null;
+            }
+            var totalDelta = TotalDataPoints(_samples[end]) - TotalDataPoints(_samples[start]);
+            if (totalDelta <= 0)
+            {
+                return null;
+            }
+            return (_samples[end].HistoryDataPoints - _samples[start].HistoryDataPoints) / totalDelta;
+        }
+
+        /// <summary>
+        /// The estimated wall-clock time left for the backtest to complete, projecting the recent
+        /// calendar-days-per-second pace over the remaining backtest days.
+        /// </summary>
+        /// <param name="skipLast">Number of trailing samples to skip, to evaluate the projection as of a previous run.</param>
+        /// <returns>The estimate, zero when the backtest already reached its end date, or null when the recent pace
+        /// is zero or there are not enough samples to measure.</returns>
+        public TimeSpan? EstimatedRemainingTime(int skipLast = 0)
+        {
+            var end = _samples.Count - 1 - skipLast;
+            if (end < 0 || TotalDays <= 0)
+            {
+                return null;
+            }
+            var remainingDays = TotalDays - _samples[end].ProcessedDays;
+            if (remainingDays <= 0)
+            {
+                return TimeSpan.Zero;
+            }
+            var daysPerSecond = RecentDaysPerSecond(skipLast);
+            if (daysPerSecond is null or <= 0)
+            {
+                return null;
+            }
+            return TimeSpan.FromSeconds(remainingDays / daysPerSecond.Value);
+        }
+
+        private (int Start, int End) RecentWindow(int skipLast)
+        {
+            var end = _samples.Count - 1 - skipLast;
+            var start = Math.Max(0, end - RecentWindowSamples + 1);
+            return (start, end);
+        }
+
+        private double? RateBetween(int startIndex, int endIndex, Func<AlgorithmSpeedSample, double> selector)
+        {
+            if (startIndex < 0 || endIndex <= startIndex || endIndex >= _samples.Count)
+            {
+                return null;
+            }
+            var seconds = (_samples[endIndex].Elapsed - _samples[startIndex].Elapsed).TotalSeconds;
+            if (seconds <= 0)
+            {
+                return null;
+            }
+            return (selector(_samples[endIndex]) - selector(_samples[startIndex])) / seconds;
+        }
+
+        private static double TotalDataPoints(AlgorithmSpeedSample sample) => sample.DataPoints + sample.HistoryDataPoints;
+    }
+}

--- a/Engine/Results/Analysis/AlgorithmSpeedTracker.cs
+++ b/Engine/Results/Analysis/AlgorithmSpeedTracker.cs
@@ -72,6 +72,19 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         public bool HasDataPointCounts => _samples.Count > 0 && _samples[^1].DataPoints > 0;
 
         /// <summary>
+        /// The average data points processed per second over the whole sampled span, including
+        /// history data points to match the speed the engine reports on completion.
+        /// Null when there are not enough samples to measure.
+        /// </summary>
+        public double? DataPointsPerSecond => RateBetween(0, _samples.Count - 1, TotalDataPoints);
+
+        /// <summary>
+        /// The average data points processed per second over the first <see cref="RecentWindowSamples"/> samples,
+        /// used as the early-run baseline for degradation detection. Null when there are not enough samples to measure.
+        /// </summary>
+        public double? InitialDataPointsPerSecond => RateBetween(0, Math.Min(RecentWindowSamples, _samples.Count) - 1, TotalDataPoints);
+
+        /// <summary>
         /// Records a sample of the cumulative speed counters. Samples with a non-increasing
         /// elapsed time are ignored so rates are always computed over positive time deltas.
         /// </summary>
@@ -84,19 +97,6 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
             }
             _samples.Add(sample);
         }
-
-        /// <summary>
-        /// The average data points processed per second over the whole sampled span, including
-        /// history data points to match the speed the engine reports on completion.
-        /// Null when there are not enough samples to measure.
-        /// </summary>
-        public double? DataPointsPerSecond => RateBetween(0, _samples.Count - 1, TotalDataPoints);
-
-        /// <summary>
-        /// The average data points processed per second over the first <see cref="RecentWindowSamples"/> samples,
-        /// used as the early-run baseline for degradation detection. Null when there are not enough samples to measure.
-        /// </summary>
-        public double? InitialDataPointsPerSecond => RateBetween(0, Math.Min(RecentWindowSamples, _samples.Count) - 1, TotalDataPoints);
 
         /// <summary>
         /// The average data points processed per second over the recent window, including history data points.

--- a/Engine/Results/Analysis/Analyses/AlgorithmSpeedAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/AlgorithmSpeedAnalysis.cs
@@ -88,9 +88,12 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
         public override string Issue { get; } = "The algorithm is running slowly.";
 
         /// <summary>
-        /// Gets the severity weight for the algorithm speed analysis.
+        /// Gets the severity weight for the algorithm speed analysis. High enough to run before the
+        /// order-response error analyses in the in-run chain: this analysis drives the user's decision
+        /// to stop a slow backtest, and it is one of the cheapest in the set, so it should not be the
+        /// one skipped when the time limit or the failed-analyses cap truncates a run.
         /// </summary>
-        public override int Weight { get; } = 77;
+        public override int Weight { get; } = 96;
 
         /// <summary>
         /// Runs the algorithm speed analysis against the speed metrics tracked for the running backtest.

--- a/Engine/Results/Analysis/Analyses/AlgorithmSpeedAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/AlgorithmSpeedAnalysis.cs
@@ -142,8 +142,8 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
             var projection = remaining.HasValue
                 ? Invariant($"about {FormatDuration(remaining.Value)} remaining at the recent pace")
                 : "the remaining time cannot be estimated yet";
-            var sample = Invariant($"Processing {recent.Value / 1000:F1}k data points per second recently ") +
-                Invariant($"({average / 1000:F1}k average); {speed.Progress * 100:F0}% complete after ") +
+            var sample = Invariant($"Processing {FormatRate(recent.Value)} data points per second recently ") +
+                Invariant($"({FormatRate(average)} average); {speed.Progress * 100:F0}% complete after ") +
                 Invariant($"{FormatDuration(speed.Elapsed)}, {projection}.");
 
             findings.Add(new(SlowExecutionName,
@@ -238,8 +238,8 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
 
             findings.Add(new(ThroughputDegradationName,
                 "The algorithm's processing speed is degrading as the backtest progresses.",
-                Invariant($"Throughput dropped from {initial.Value / 1000:F1}k data points per second early in the run ") +
-                    Invariant($"to {recent.Value / 1000:F1}k recently."),
+                Invariant($"Throughput dropped from {FormatRate(initial.Value)} data points per second early in the run ") +
+                    Invariant($"to {FormatRate(recent.Value)} recently."),
                 null,
                 [
                     "Check for collections that grow unboundedly as the backtest progresses, like lists of past data points; use rolling windows with a fixed size instead.",
@@ -277,6 +277,17 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
 
                     "Reduce the period or resolution of the history requests.",
                 ]));
+        }
+
+        /// <summary>
+        /// Formats a data points per second rate compactly: in thousands like "12.5k" when at least
+        /// one thousand, as a raw count like "340" below that, so very slow rates don't read as "0.0k".
+        /// </summary>
+        private static string FormatRate(double dataPointsPerSecond)
+        {
+            return dataPointsPerSecond >= 1000
+                ? Invariant($"{dataPointsPerSecond / 1000:F1}k")
+                : Invariant($"{dataPointsPerSecond:F0}");
         }
 
         /// <summary>

--- a/Engine/Results/Analysis/Analyses/AlgorithmSpeedAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/AlgorithmSpeedAnalysis.cs
@@ -1,0 +1,298 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+using System;
+using System.Collections.Generic;
+using static QuantConnect.StringExtensions;
+
+namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
+{
+    /// <summary>
+    /// In-run analysis that tracks the algorithm's execution speed so the user can decide to stop
+    /// a slow backtest early. It reads the throughput and progress metrics accumulated by
+    /// <see cref="AlgorithmSpeedTracker"/> and reports slow processing speed, a long projected
+    /// remaining runtime, degrading throughput, and history-request-dominated data loads.
+    /// Benchmark speeds: https://www.quantconnect.com/performance
+    /// </summary>
+    public class AlgorithmSpeedAnalysis : BaseResultsAnalysis
+    {
+        /// <summary>
+        /// The data points per second under which execution is reported as slow,
+        /// matching the threshold used by <see cref="ExecutionSpeedAnalysis"/> on completed backtests.
+        /// </summary>
+        public const int SlowDataPointsPerSecond = 40_000;
+
+        /// <summary>
+        /// The recent-to-initial throughput ratio under which throughput is reported as degrading.
+        /// </summary>
+        public const double DegradationRatio = 0.5;
+
+        /// <summary>
+        /// The share of recently processed data points served by the history provider
+        /// over which the data load is reported as history-request dominated.
+        /// </summary>
+        public const double HighHistoryDataPointsShare = 0.5;
+
+        /// <summary>
+        /// The minimum number of history data points in the recent window for the
+        /// history-request load to be worth reporting.
+        /// </summary>
+        public const long MinimumRecentHistoryDataPoints = 10_000;
+
+        /// <summary>
+        /// The minimum wall-clock span the metrics must cover before any finding is reported,
+        /// so early warm-up noise doesn't produce false positives.
+        /// </summary>
+        public static readonly TimeSpan MinimumSampledSpan = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// The projected remaining runtime over which the backtest is reported as long-running.
+        /// </summary>
+        public static readonly TimeSpan LongProjectedRemainingTime = TimeSpan.FromHours(1);
+
+        /// <summary>
+        /// The name of the slow execution sub-finding.
+        /// </summary>
+        public const string SlowExecutionName = "SlowExecution";
+
+        /// <summary>
+        /// The name of the long projected runtime sub-finding.
+        /// </summary>
+        public const string LongProjectedRuntimeName = "LongProjectedRuntime";
+
+        /// <summary>
+        /// The name of the degrading throughput sub-finding.
+        /// </summary>
+        public const string ThroughputDegradationName = "ThroughputDegradation";
+
+        /// <summary>
+        /// The name of the history-request load sub-finding.
+        /// </summary>
+        public const string HistoryRequestLoadName = "HistoryRequestLoad";
+
+        /// <summary>
+        /// Gets the description of the slow algorithm issue.
+        /// </summary>
+        public override string Issue { get; } = "The algorithm is running slowly.";
+
+        /// <summary>
+        /// Gets the severity weight for the algorithm speed analysis.
+        /// </summary>
+        public override int Weight { get; } = 77;
+
+        /// <summary>
+        /// Runs the algorithm speed analysis against the speed metrics tracked for the running backtest.
+        /// </summary>
+        public override IReadOnlyList<QuantConnect.Analysis> Run(ResultsAnalysisRunParameters parameters) => Run(parameters.Speed);
+
+        /// <summary>
+        /// Runs the algorithm speed analysis against the given speed metrics.
+        /// Each detected condition is reported as its own sub-finding. Every condition must hold for
+        /// both the current recent window and the window as of the previous run, so a single noisy
+        /// sample doesn't flag or clear a finding.
+        /// </summary>
+        /// <param name="speed">The speed metrics tracked for the running backtest, or null when not tracked.</param>
+        /// <returns>The failed sub-findings, or empty when speed is not tracked or still within the warm-up span.</returns>
+        public IReadOnlyList<QuantConnect.Analysis> Run(AlgorithmSpeedTracker speed)
+        {
+            if (speed == null || speed.SampledSpan < MinimumSampledSpan)
+            {
+                return [];
+            }
+
+            var findings = new List<QuantConnect.Analysis>();
+            AddSlowExecution(speed, findings);
+            AddLongProjectedRuntime(speed, findings);
+            AddThroughputDegradation(speed, findings);
+            AddHistoryRequestLoad(speed, findings);
+            return CreateAggregatedResponse(findings);
+        }
+
+        /// <summary>
+        /// Reports slow execution when the recent data points per second are below the platform benchmark.
+        /// </summary>
+        private static void AddSlowExecution(AlgorithmSpeedTracker speed, List<QuantConnect.Analysis> findings)
+        {
+            if (!speed.HasDataPointCounts)
+            {
+                return;
+            }
+
+            var recent = speed.RecentDataPointsPerSecond();
+            var previous = speed.RecentDataPointsPerSecond(skipLast: 1);
+            if (recent is null or >= SlowDataPointsPerSecond || previous is null or >= SlowDataPointsPerSecond)
+            {
+                return;
+            }
+
+            var average = speed.DataPointsPerSecond ?? 0;
+            var remaining = speed.EstimatedRemainingTime();
+            var projection = remaining.HasValue
+                ? Invariant($"about {FormatDuration(remaining.Value)} remaining at the recent pace")
+                : "the remaining time cannot be estimated yet";
+            var sample = Invariant($"Processing {recent.Value / 1000:F1}k data points per second recently ") +
+                Invariant($"({average / 1000:F1}k average); {speed.Progress * 100:F0}% complete after ") +
+                Invariant($"{FormatDuration(speed.Elapsed)}, {projection}.");
+
+            findings.Add(new(SlowExecutionName,
+                Invariant($"The algorithm is running below {SlowDataPointsPerSecond / 1000}k data points per second."),
+                sample,
+                null,
+                [
+                    "Review the algorithm code for inefficiencies.",
+
+                    "If there is a universe, reduce its size.",
+
+                    "Reduce the data resolution.",
+
+                    "If the algorithm is training a model, reduce the amount of training data or reduce the number of epochs in the training process.",
+
+                    "If the projected runtime is not acceptable, stop the backtest, apply the changes above, and run it again.",
+                ]));
+        }
+
+        /// <summary>
+        /// Reports a long projected runtime when, at the recent pace, the backtest needs more than
+        /// <see cref="LongProjectedRemainingTime"/> to complete, or when it has stopped making
+        /// backtest-time progress altogether.
+        /// </summary>
+        private static void AddLongProjectedRuntime(AlgorithmSpeedTracker speed, List<QuantConnect.Analysis> findings)
+        {
+            if (speed.TotalDays <= 0 || speed.ProcessedDays >= speed.TotalDays)
+            {
+                return;
+            }
+
+            var daysPerSecond = speed.RecentDaysPerSecond();
+            var previousDaysPerSecond = speed.RecentDaysPerSecond(skipLast: 1);
+
+            string sample = null;
+            if (daysPerSecond is 0 && previousDaysPerSecond is 0)
+            {
+                sample = Invariant($"The backtest has made no backtest-time progress recently: ") +
+                    Invariant($"still {speed.Progress * 100:F0}% complete after {FormatDuration(speed.Elapsed)}.");
+            }
+            else
+            {
+                var remaining = speed.EstimatedRemainingTime();
+                var previousRemaining = speed.EstimatedRemainingTime(skipLast: 1);
+                if (remaining > LongProjectedRemainingTime && previousRemaining > LongProjectedRemainingTime)
+                {
+                    sample = Invariant($"About {FormatDuration(remaining.Value)} of backtest remain at the recent pace ") +
+                        Invariant($"({speed.Progress * 100:F0}% complete after {FormatDuration(speed.Elapsed)}).");
+                }
+            }
+
+            if (sample == null)
+            {
+                return;
+            }
+
+            findings.Add(new(LongProjectedRuntimeName,
+                "The backtest is projected to take a long time to complete.",
+                sample,
+                null,
+                [
+                    "Reduce the backtest period.",
+
+                    "Reduce the data resolution or the universe size.",
+
+                    "Review the algorithm code for inefficiencies.",
+
+                    "If the projected runtime is not acceptable, stop the backtest, apply the changes above, and run it again.",
+                ]));
+        }
+
+        /// <summary>
+        /// Reports degrading throughput when the recent data points per second dropped below
+        /// <see cref="DegradationRatio"/> of the early-run baseline. Requires enough samples for the
+        /// baseline and recent windows to not overlap.
+        /// </summary>
+        private static void AddThroughputDegradation(AlgorithmSpeedTracker speed, List<QuantConnect.Analysis> findings)
+        {
+            if (!speed.HasDataPointCounts || speed.SampleCount < 2 * AlgorithmSpeedTracker.RecentWindowSamples + 1)
+            {
+                return;
+            }
+
+            var initial = speed.InitialDataPointsPerSecond;
+            var recent = speed.RecentDataPointsPerSecond();
+            var previous = speed.RecentDataPointsPerSecond(skipLast: 1);
+            if (initial is null or <= 0 || recent == null || previous == null ||
+                recent >= DegradationRatio * initial || previous >= DegradationRatio * initial)
+            {
+                return;
+            }
+
+            findings.Add(new(ThroughputDegradationName,
+                "The algorithm's processing speed is degrading as the backtest progresses.",
+                Invariant($"Throughput dropped from {initial.Value / 1000:F1}k data points per second early in the run ") +
+                    Invariant($"to {recent.Value / 1000:F1}k recently."),
+                null,
+                [
+                    "Check for collections that grow unboundedly as the backtest progresses, like lists of past data points; use rolling windows with a fixed size instead.",
+
+                    "Check for history requests whose range grows as the backtest progresses, like requests from the algorithm start date to the current time.",
+
+                    "If there is a universe, check whether the number of selected securities keeps growing; remove securities that are no longer used.",
+
+                    "Check the algorithm's memory usage: sustained growth causes garbage collection pressure that slows the whole run down.",
+                ]));
+        }
+
+        /// <summary>
+        /// Reports a history-request-dominated data load when most of the recently processed data
+        /// points were served by the history provider.
+        /// </summary>
+        private static void AddHistoryRequestLoad(AlgorithmSpeedTracker speed, List<QuantConnect.Analysis> findings)
+        {
+            var share = speed.RecentHistoryDataPointsShare();
+            var previousShare = speed.RecentHistoryDataPointsShare(skipLast: 1);
+            if (share is null or <= HighHistoryDataPointsShare || previousShare is null or <= HighHistoryDataPointsShare ||
+                speed.RecentHistoryDataPoints() < MinimumRecentHistoryDataPoints)
+            {
+                return;
+            }
+
+            findings.Add(new(HistoryRequestLoadName,
+                "Most of the data being processed comes from history requests.",
+                Invariant($"{share.Value * 100:F0}% of the data points processed recently were served by history requests."),
+                null,
+                [
+                    "Avoid issuing history requests on every data update; maintain the data incrementally with rolling windows or consolidators instead.",
+
+                    "Warm up indicators with the automatic indicator warm-up or the algorithm warm-up period instead of history requests.",
+
+                    "Reduce the period or resolution of the history requests.",
+                ]));
+        }
+
+        /// <summary>
+        /// Formats a duration as a compact human-readable string, like "2h 5m", "12m" or "45s".
+        /// </summary>
+        private static string FormatDuration(TimeSpan duration)
+        {
+            if (duration.TotalHours >= 1)
+            {
+                return Invariant($"{(int)duration.TotalHours}h {duration.Minutes}m");
+            }
+            if (duration.TotalMinutes >= 1)
+            {
+                return Invariant($"{(int)duration.TotalMinutes}m");
+            }
+            return Invariant($"{(int)duration.TotalSeconds}s");
+        }
+    }
+}

--- a/Engine/Results/Analysis/Analyses/PortfolioValueIsNotPositiveAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/PortfolioValueIsNotPositiveAnalysis.cs
@@ -44,6 +44,13 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
         /// <returns>Analysis results flagging the issue when ending equity is zero or negative.</returns>
         public IReadOnlyList<QuantConnect.Analysis> Run(Result result)
         {
+            if (result.TotalPerformance == null)
+            {
+                // The statistics are withheld when they are not meaningful yet,
+                // like while the algorithm warms up
+                return [];
+            }
+
             var hasEquity = result.TotalPerformance.PortfolioStatistics.EndEquity > 0;
             var potentialSolutions = hasEquity ? [] : Solutions();
             return SingleResponse(!hasEquity, potentialSolutions);

--- a/Engine/Results/Analysis/Analyses/RuntimeErrorAnalyses/MaximumRuntimeExceededRuntimeErrorAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/RuntimeErrorAnalyses/MaximumRuntimeExceededRuntimeErrorAnalysis.cs
@@ -1,0 +1,63 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+using System.Collections.Generic;
+
+namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
+{
+    /// <summary>
+    /// Detects algorithms terminated because the whole run outlived the maximum allowed wall-clock
+    /// time, emitted by the <see cref="Isolator"/> ("Execution Security Error: Operation timed out -
+    /// N minutes max") or by the engine when the isolator reports an incomplete run ("Failed to
+    /// complete algorithm within N seconds").
+    /// </summary>
+    public class MaximumRuntimeExceededRuntimeErrorAnalysis : RuntimeErrorAnalysis
+    {
+        /// <summary>
+        /// Gets the description of the maximum runtime exceeded issue.
+        /// </summary>
+        public override string Issue { get; } = "The algorithm exceeded the maximum allowed total runtime and was terminated.";
+
+        /// <summary>
+        /// Gets the severity weight for this analysis. The timeout is a fatal error that terminated
+        /// the run, so it ranks above every non-fatal finding.
+        /// </summary>
+        public override int Weight { get; } = 100;
+
+        /// <summary>
+        /// Gets the patterns identifying the maximum runtime exceeded error message.
+        /// </summary>
+        protected override string[][] ErrorMessagePatterns { get; } =
+        [
+            ["Operation timed out", "minutes max"],
+            ["Failed to complete algorithm within"],
+        ];
+
+        /// <summary>
+        /// Gets the suggested solutions to complete the run within the maximum allowed runtime.
+        /// </summary>
+        protected override List<string> Solutions(Language language) =>
+        [
+            "Reduce the backtest period so the run completes within the allowed runtime.",
+
+            "Reduce the universe size and the data resolution to lower the total amount of data processed.",
+
+            "Review the algorithm code for inefficiencies: avoid recomputing values from scratch on every data update, " +
+                "and avoid history requests whose range grows as the backtest progresses.",
+
+            "Check for infinite or recursive loops that keep the algorithm running without making progress.",
+        ];
+    }
+}

--- a/Engine/Results/Analysis/Analyses/RuntimeErrorAnalyses/OperationCanceledRuntimeErrorAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/RuntimeErrorAnalyses/OperationCanceledRuntimeErrorAnalysis.cs
@@ -1,0 +1,60 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+using System.Collections.Generic;
+
+namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
+{
+    /// <summary>
+    /// Detects algorithms that were forcefully canceled, emitted by the <see cref="Isolator"/> when
+    /// the algorithm is asked to stop but its code is still running once the shutdown grace period
+    /// expires ("Operation was canceled").
+    /// </summary>
+    public class OperationCanceledRuntimeErrorAnalysis : RuntimeErrorAnalysis
+    {
+        /// <summary>
+        /// Gets the description of the forced cancellation issue.
+        /// </summary>
+        public override string Issue { get; } = "The algorithm did not shut down within the grace period after a stop request and was forcefully canceled.";
+
+        /// <summary>
+        /// Gets the severity weight for this analysis. The cancellation is a fatal error that
+        /// terminated the run, so it ranks above every non-fatal finding.
+        /// </summary>
+        public override int Weight { get; } = 100;
+
+        /// <summary>
+        /// Gets the patterns identifying the forced cancellation error message.
+        /// </summary>
+        protected override string[][] ErrorMessagePatterns { get; } =
+        [
+            ["Operation was canceled"],
+        ];
+
+        /// <summary>
+        /// Gets the suggested solutions to let the algorithm respond to stop requests promptly.
+        /// </summary>
+        protected override List<string> Solutions(Language language) =>
+        [
+            "This error is raised when the algorithm is asked to stop, typically because the user stopped or deleted it, " +
+                "but its code keeps running past the shutdown grace period. If you stopped it on purpose, the error is expected and can be ignored.",
+
+            "If you did not stop the algorithm, reduce the work done per event handler so it can respond to stop requests promptly: " +
+                "break up big loops, avoid long blocking operations, and avoid large history requests or model training on every data update.",
+
+            "Reduce the universe size and the data resolution so each time loop processes less data and control returns to the engine sooner.",
+        ];
+    }
+}

--- a/Engine/Results/Analysis/Analyses/RuntimeErrorAnalyses/RuntimeErrorAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/RuntimeErrorAnalyses/RuntimeErrorAnalysis.cs
@@ -1,0 +1,91 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
+{
+    /// <summary>
+    /// Abstract base class for analyses that detect a specific runtime error that terminated the
+    /// algorithm by inspecting the error message for known text fragments. The runtime error is
+    /// read from the result state, falling back to the "Runtime Error:" log line for results
+    /// that carry no state.
+    /// </summary>
+    public abstract class RuntimeErrorAnalysis : BaseResultsAnalysis
+    {
+        /// <summary>
+        /// Gets the patterns identifying the runtime error. Each pattern is a set of text fragments
+        /// that must all be present in the error message (case-insensitive); the error matches
+        /// when any pattern does.
+        /// </summary>
+        protected abstract string[][] ErrorMessagePatterns { get; }
+
+        /// <summary>
+        /// Gets the suggested solutions for the detected runtime error.
+        /// </summary>
+        protected abstract List<string> Solutions(Language language);
+
+        /// <summary>
+        /// Runs the runtime error analysis against the provided backtest parameters.
+        /// </summary>
+        public override IReadOnlyList<QuantConnect.Analysis> Run(ResultsAnalysisRunParameters parameters)
+            => Run(parameters.Result?.State, parameters.Logs, parameters.Language);
+
+        /// <summary>
+        /// Runs the runtime error analysis against the algorithm state and logs.
+        /// </summary>
+        /// <param name="state">The algorithm state of the result, holding the runtime error message if any.</param>
+        /// <param name="logs">The full list of log lines produced by the backtest.</param>
+        /// <param name="language">The programming language the algorithm is written in.</param>
+        /// <returns>A single response with the matched error message and solutions, or without them when the error is not found.</returns>
+        public IReadOnlyList<QuantConnect.Analysis> Run(IDictionary<string, string> state, IReadOnlyList<string> logs, Language language)
+        {
+            var sample = GetRuntimeErrorMessages(state, logs).FirstOrDefault(Matches);
+            return SingleResponse(sample, sample != null ? Solutions(language) : []);
+        }
+
+        /// <summary>
+        /// Determines whether the given runtime error message matches any of the
+        /// <see cref="ErrorMessagePatterns"/>.
+        /// </summary>
+        private bool Matches(string message)
+        {
+            return ErrorMessagePatterns.Any(
+                fragments => fragments.All(fragment => message.Contains(fragment, StringComparison.InvariantCultureIgnoreCase)));
+        }
+
+        /// <summary>
+        /// Gets the candidate runtime error messages: the result state's runtime error entry when
+        /// present, plus any "Runtime Error:" lines from the logs.
+        /// </summary>
+        private static IEnumerable<string> GetRuntimeErrorMessages(IDictionary<string, string> state, IReadOnlyList<string> logs)
+        {
+            if (state != null && state.TryGetValue("RuntimeError", out var error) && !string.IsNullOrEmpty(error))
+            {
+                yield return error;
+            }
+
+            foreach (var log in logs ?? [])
+            {
+                if (log.Contains("Runtime Error", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    yield return log;
+                }
+            }
+        }
+    }
+}

--- a/Engine/Results/Analysis/Analyses/RuntimeErrorAnalyses/SingleTimeLoopTimeoutRuntimeErrorAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/RuntimeErrorAnalyses/SingleTimeLoopTimeoutRuntimeErrorAnalysis.cs
@@ -1,0 +1,78 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+using QuantConnect.Algorithm;
+using System.Collections.Generic;
+
+namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
+{
+    /// <summary>
+    /// Detects algorithms terminated because a single time loop exceeded the per-loop time limit,
+    /// emitted by the <see cref="Isolator"/> when the algorithm manager's time loop tracker trips
+    /// ("Algorithm took longer than N minutes on a single time loop").
+    /// </summary>
+    public class SingleTimeLoopTimeoutRuntimeErrorAnalysis : RuntimeErrorAnalysis
+    {
+        /// <summary>
+        /// Gets the description of the single time loop timeout issue.
+        /// </summary>
+        public override string Issue { get; } = "A single time loop took longer than the maximum allowed, so the algorithm was terminated.";
+
+        /// <summary>
+        /// Gets the severity weight for this analysis. A timeout is a fatal error that terminated
+        /// the run, so it ranks above every non-fatal finding.
+        /// </summary>
+        public override int Weight { get; } = 100;
+
+        /// <summary>
+        /// Gets the patterns identifying the single time loop timeout error message.
+        /// </summary>
+        protected override string[][] ErrorMessagePatterns { get; } =
+        [
+            ["took longer than", "single time loop"],
+        ];
+
+        /// <summary>
+        /// Gets the suggested solutions to keep each time loop within the time limit.
+        /// </summary>
+        protected override List<string> Solutions(Language language)
+        {
+            var solutions = new List<string>
+            {
+                $"Look for heavy work inside a single event handler (`{FormatCode(nameof(QCAlgorithm.OnData), language)}`, scheduled events, universe selection functions): " +
+                    "large or nested loops over all securities, or values recomputed from scratch on every data update. " +
+                    "Cache the values and update them incrementally with rolling windows, consolidators or indicators instead.",
+
+                "If there is a universe, reduce its size and filter it: return from the selection functions only the securities the strategy actually trades, " +
+                    $"and narrow option and future chain universes with the `{FormatCode("SetFilter", language)}` contract filters (strikes and expirations).",
+
+                "Reduce the number of subscribed securities or the data resolution to lower the amount of data processed on each time loop.",
+
+                "Avoid issuing large history requests inside event handlers; request only the period the strategy needs, " +
+                    "or maintain the data incrementally instead of re-requesting it on every data update.",
+
+                $"If the algorithm trains a machine learning model, run the training through the `{FormatCode(nameof(QCAlgorithm.Train), language)}` method, " +
+                    "which allocates additional time for it to complete.",
+
+                "Check for loops whose exit condition may never be met: an infinite loop in an event handler surfaces as this error.",
+            };
+            if (language == Language.Python)
+            {
+                solutions.Add("Vectorize heavy numeric Python loops with numpy or pandas operations, which run orders of magnitude faster.");
+            }
+            return solutions;
+        }
+    }
+}

--- a/Engine/Results/Analysis/InRunResultsAnalyzer.cs
+++ b/Engine/Results/Analysis/InRunResultsAnalyzer.cs
@@ -1,0 +1,82 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+using QuantConnect.Algorithm;
+using QuantConnect.Lean.Engine.Results.Analysis.Analyses;
+using System.Collections.Generic;
+
+namespace QuantConnect.Lean.Engine.Results.Analysis
+{
+    /// <summary>
+    /// Runs a reduced suite of backtest diagnostic tests periodically while the backtest is still running,
+    /// against a snapshot of the current intermediate results.
+    /// </summary>
+    public class InRunResultsAnalyzer : ResultsAnalyzer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InRunResultsAnalyzer"/> class.
+        /// </summary>
+        /// <param name="result">A snapshot of the current intermediate backtest result to analyze.</param>
+        /// <param name="algorithm">The algorithm instance used for history requests and settings.</param>
+        /// <param name="language">The programming language the algorithm is written in.</param>
+        /// <param name="logs">The list of log lines produced by the backtest so far.</param>
+        public InRunResultsAnalyzer(Result result, QCAlgorithm algorithm, Language language, IReadOnlyList<string> logs)
+            : base(result, algorithm, language, logs)
+        {
+        }
+
+        /// <summary>
+        /// The equity and benchmark curves are not built for in-run analysis:
+        /// none of the in-run analyses read them, and building them would issue
+        /// a benchmark history request on every run.
+        /// </summary>
+        protected override bool RequiresEquityCurves => false;
+
+        /// <summary>
+        /// Creates the set of diagnostic analyses to run while the backtest is in progress.
+        /// Only analyses that read the result snapshot (logs, orders, order events, charts) are
+        /// included: they are cheap, thread-safe, and detect error conditions whose findings
+        /// don't depend on the backtest being complete. Curve and statistics based analyses are
+        /// left to the final analysis, since partial-period statistics are noisy and require
+        /// history requests.
+        /// </summary>
+        protected override IReadOnlyCollection<BaseResultsAnalysis> GetAnalyses() => new BaseResultsAnalysis[]
+        {
+            new PortfolioValueIsNotPositiveAnalysis(),
+            new InsufficientBuyingPowerOrderResponseErrorAnalysis(),
+            new MarginCallsAnalysis(),
+            new ExceedsShortableQuantityOrderResponseErrorAnalysis(),
+            new SecurityPriceZeroOrderResponseErrorAnalysis(),
+            new OrderQuantityZeroOrderResponseErrorAnalysis(),
+            new NonTradableSecurityOrderResponseErrorAnalysis(),
+            new BrokerageModelRefusedToSubmitOrderOrderResponseErrorAnalysis(),
+            new BrokerageModelRefusedToUpdateOrderOrderResponseErrorAnalysis(),
+            new TakeProfitAndStopLossOrdersAnalysis(),
+            new StaleOrderFillsAnalysis(),
+            new AlgorithmWarmingUpOrderResponseErrorAnalysis(),
+            new ExchangeNotOpenOrderResponseErrorAnalysis(),
+            new ForexConversionRateZeroOrderResponseErrorAnalysis(),
+            new ExceededMaximumOrdersOrderResponseErrorAnalysis(),
+            new UnsupportedOptionShortPositionExerciseAnalysis(),
+            new UnsupportedOptionExerciseQuantityAnalysis(),
+            new EuropeanOptionNotExpiredOnExerciseOrderResponseErrorAnalysis(),
+            new OptionOrderOnStockSplitOrderResponseErrorAnalysis(),
+            new MarketOnOpenNotAllowedDuringRegularHoursOrderResponseErrorAnalysis(),
+            new OrderQuantityLessThanLotSizeOrderResponseErrorAnalysis(),
+            new InsightsEmittedForDelistedSecuritiesAnalysis(),
+            new PortfolioMarginUsageAnalysis(),
+        };
+    }
+}

--- a/Engine/Results/Analysis/InRunResultsAnalyzer.cs
+++ b/Engine/Results/Analysis/InRunResultsAnalyzer.cs
@@ -37,9 +37,14 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
             nameof(PortfolioValueIsNotPositiveAnalysis),
             nameof(TakeProfitAndStopLossOrdersAnalysis),
             nameof(PortfolioMarginUsageAnalysis),
+            nameof(AlgorithmSpeedAnalysis),
         };
 
         private readonly Dictionary<string, QuantConnect.Analysis> _findings = new();
+
+        private readonly AlgorithmSpeedTracker _speed = new();
+
+        private readonly QCAlgorithm _algorithm;
 
         /// <summary>
         /// The number of order events already consumed by previous runs. The order events
@@ -56,6 +61,19 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         public int LogsPosition { get; private set; }
 
         /// <summary>
+        /// The equity and benchmark curves are not built for in-run analysis:
+        /// none of the in-run analyses read them, and building them would issue
+        /// a benchmark history request on every run.
+        /// </summary>
+        protected override bool RequiresEquityCurves => false;
+
+        /// <summary>
+        /// The in-run analyses read the algorithm speed metrics accumulated from the
+        /// samples received on each run.
+        /// </summary>
+        protected override AlgorithmSpeedTracker SpeedTracker => _speed;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="InRunResultsAnalyzer"/> class.
         /// The instance is expected to be kept alive for the duration of the backtest,
         /// receiving fresh data on each <see cref="Run(Result, IReadOnlyList{string}, int, int)"/> call.
@@ -65,6 +83,7 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         public InRunResultsAnalyzer(QCAlgorithm algorithm, Language language)
             : base(null, algorithm, language, null)
         {
+            _algorithm = algorithm;
         }
 
         /// <summary>
@@ -75,15 +94,30 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         /// Findings from analyses scanning the order event and log streams are accumulated
         /// (first sample kept, counts totaled), while findings from state-based analyses are
         /// replaced on every run.
+        /// While the algorithm is warming up, nothing is analyzed or consumed and no findings are reported.
         /// </summary>
         /// <param name="result">A snapshot of the current intermediate backtest result, holding only new order events.</param>
         /// <param name="logs">The log lines produced since the previous run.</param>
+        /// <param name="speedSample">A sample of the engine speed counters for the algorithm speed analysis, when available.</param>
         /// <param name="timeLimitSeconds">Wall-clock seconds allowed for the full chain before early exit.</param>
         /// <param name="maxFailedAnalyses">Maximum number of failing analyses to return.</param>
         /// <returns>The accumulated findings, ranked by analysis weight.</returns>
-        public IReadOnlyList<QuantConnect.Analysis> Run(Result result, IReadOnlyList<string> logs, int timeLimitSeconds = 1, int maxFailedAnalyses = 10)
+        public IReadOnlyList<QuantConnect.Analysis> Run(Result result, IReadOnlyList<string> logs, AlgorithmSpeedSample? speedSample = null,
+            int timeLimitSeconds = 1, int maxFailedAnalyses = 10)
         {
+            // Nothing is analyzed during the algorithm warm-up period: trading hasn't started, and
+            // sampling the warm-up pace would skew the speed metrics. The positions don't advance,
+            // so the order events and logs produced during warm-up are analyzed by the first run after it ends.
+            if (_algorithm?.IsWarmingUp == true)
+            {
+                return [];
+            }
+
             SetAnalysisData(result, logs);
+            if (speedSample.HasValue)
+            {
+                _speed.AddSample(speedSample.Value);
+            }
             var newFindings = Run(timeLimitSeconds, maxFailedAnalyses);
 
             // The positions are advanced even when the time limit truncates a run, so the analyses that
@@ -112,6 +146,14 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
                 _findings[finding.Name] = finding;
             }
 
+            return RankFindings(maxFailedAnalyses);
+        }
+
+        /// <summary>
+        /// Ranks the accumulated findings by their analysis weight, capped to the given maximum.
+        /// </summary>
+        private IReadOnlyList<QuantConnect.Analysis> RankFindings(int maxFailedAnalyses)
+        {
             var weights = GetAnalyses().ToDictionary(analysis => analysis.GetType().Name, analysis => analysis.Weight);
             return _findings.Values
                 .OrderByDescending(finding => weights.GetValueOrDefault(BaseAnalysisName(finding.Name)))
@@ -135,13 +177,6 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         }
 
         /// <summary>
-        /// The equity and benchmark curves are not built for in-run analysis:
-        /// none of the in-run analyses read them, and building them would issue
-        /// a benchmark history request on every run.
-        /// </summary>
-        protected override bool RequiresEquityCurves => false;
-
-        /// <summary>
         /// Creates the set of diagnostic analyses to run while the backtest is in progress.
         /// Only analyses that read the result snapshot (logs, orders, order events, charts) are
         /// included: they are cheap, thread-safe, and detect error conditions whose findings
@@ -149,8 +184,8 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         /// left to the final analysis, since partial-period statistics are noisy and require
         /// history requests.
         /// </summary>
-        protected override IReadOnlyCollection<BaseResultsAnalysis> GetAnalyses() => new BaseResultsAnalysis[]
-        {
+        protected override IReadOnlyCollection<BaseResultsAnalysis> GetAnalyses() =>
+        [
             new PortfolioValueIsNotPositiveAnalysis(),
             new InsufficientBuyingPowerOrderResponseErrorAnalysis(),
             new MarginCallsAnalysis(),
@@ -174,6 +209,7 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
             new OrderQuantityLessThanLotSizeOrderResponseErrorAnalysis(),
             new InsightsEmittedForDelistedSecuritiesAnalysis(),
             new PortfolioMarginUsageAnalysis(),
-        };
+            new AlgorithmSpeedAnalysis(),
+        ];
     }
 }

--- a/Engine/Results/Analysis/InRunResultsAnalyzer.cs
+++ b/Engine/Results/Analysis/InRunResultsAnalyzer.cs
@@ -86,6 +86,10 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
             SetAnalysisData(result, logs);
             var newFindings = Run(timeLimitSeconds, maxFailedAnalyses);
 
+            // The positions are advanced even when the time limit truncates a run, so the analyses that
+            // didn't get to run miss this delta until the final analysis re-scans the complete streams.
+            // Stress tests show runs complete in a fraction of the time limit, but if its trace message
+            // starts showing up in logs, revisit this (e.g. track per-analysis positions).
             OrderEventsPosition += result.OrderEvents?.Count ?? 0;
             LogsPosition += logs?.Count ?? 0;
 

--- a/Engine/Results/Analysis/InRunResultsAnalyzer.cs
+++ b/Engine/Results/Analysis/InRunResultsAnalyzer.cs
@@ -44,18 +44,16 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
 
         private readonly AlgorithmSpeedTracker _speed = new();
 
-        private readonly QCAlgorithm _algorithm;
-
         /// <summary>
         /// The number of order events already consumed by previous runs. The order events
-        /// in the result passed to <see cref="Run(Result, IReadOnlyList{string}, int, int)"/>
+        /// in the result passed to <see cref="Run(Result, IReadOnlyList{string}, System.Nullable{AlgorithmSpeedSample}, int, int)"/>
         /// are expected to start at this position.
         /// </summary>
         public int OrderEventsPosition { get; private set; }
 
         /// <summary>
         /// The number of log entries already consumed by previous runs. The logs passed to
-        /// <see cref="Run(Result, IReadOnlyList{string}, int, int)"/> are expected to start
+        /// <see cref="Run(Result, IReadOnlyList{string}, System.Nullable{AlgorithmSpeedSample}, int, int)"/> are expected to start
         /// at this position.
         /// </summary>
         public int LogsPosition { get; private set; }
@@ -76,14 +74,13 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         /// <summary>
         /// Initializes a new instance of the <see cref="InRunResultsAnalyzer"/> class.
         /// The instance is expected to be kept alive for the duration of the backtest,
-        /// receiving fresh data on each <see cref="Run(Result, IReadOnlyList{string}, int, int)"/> call.
+        /// receiving fresh data on each <see cref="Run(Result, IReadOnlyList{string}, System.Nullable{AlgorithmSpeedSample}, int, int)"/> call.
         /// </summary>
         /// <param name="algorithm">The algorithm instance used for history requests and settings.</param>
         /// <param name="language">The programming language the algorithm is written in.</param>
         public InRunResultsAnalyzer(QCAlgorithm algorithm, Language language)
             : base(null, algorithm, language, null)
         {
-            _algorithm = algorithm;
         }
 
         /// <summary>
@@ -94,25 +91,17 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         /// Findings from analyses scanning the order event and log streams are accumulated
         /// (first sample kept, counts totaled), while findings from state-based analyses are
         /// replaced on every run.
-        /// While the algorithm is warming up, nothing is analyzed or consumed and no findings are reported.
         /// </summary>
         /// <param name="result">A snapshot of the current intermediate backtest result, holding only new order events.</param>
         /// <param name="logs">The log lines produced since the previous run.</param>
-        /// <param name="speedSample">A sample of the engine speed counters for the algorithm speed analysis, when available.</param>
+        /// <param name="speedSample">A sample of the engine speed counters for the algorithm speed analysis.
+        /// Null when the counters should not be sampled, like while the algorithm warms up.</param>
         /// <param name="timeLimitSeconds">Wall-clock seconds allowed for the full chain before early exit.</param>
         /// <param name="maxFailedAnalyses">Maximum number of failing analyses to return.</param>
         /// <returns>The accumulated findings, ranked by analysis weight.</returns>
         public IReadOnlyList<QuantConnect.Analysis> Run(Result result, IReadOnlyList<string> logs, AlgorithmSpeedSample? speedSample = null,
             int timeLimitSeconds = 1, int maxFailedAnalyses = 10)
         {
-            // Nothing is analyzed during the algorithm warm-up period: trading hasn't started, and
-            // sampling the warm-up pace would skew the speed metrics. The positions don't advance,
-            // so the order events and logs produced during warm-up are analyzed by the first run after it ends.
-            if (_algorithm?.IsWarmingUp == true)
-            {
-                return [];
-            }
-
             SetAnalysisData(result, logs);
             if (speedSample.HasValue)
             {

--- a/Engine/Results/Analysis/InRunResultsAnalyzer.cs
+++ b/Engine/Results/Analysis/InRunResultsAnalyzer.cs
@@ -45,6 +45,26 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         private readonly AlgorithmSpeedTracker _speed = new();
 
         /// <summary>
+        /// The equity and benchmark curves are not built for in-run analysis:
+        /// none of the in-run analyses read them, and building them would issue
+        /// a benchmark history request on every run.
+        /// </summary>
+        protected override bool RequiresEquityCurves => false;
+
+        /// <summary>
+        /// The in-run analyses read the algorithm speed metrics accumulated from the
+        /// samples received on each run.
+        /// </summary>
+        protected override AlgorithmSpeedTracker SpeedTracker => _speed;
+
+        /// <summary>
+        /// The names of the charts the in-run analyses read. Only these need to be
+        /// cloned into the result snapshot passed to
+        /// <see cref="Run(Result, IReadOnlyList{string}, System.Nullable{AlgorithmSpeedSample}, int, int)"/>.
+        /// </summary>
+        public static IReadOnlyList<string> RequiredCharts { get; } = [BaseResultsHandler.PortfolioMarginKey];
+
+        /// <summary>
         /// The number of order events already consumed by previous runs. The order events
         /// in the result passed to <see cref="Run(Result, IReadOnlyList{string}, System.Nullable{AlgorithmSpeedSample}, int, int)"/>
         /// are expected to start at this position.
@@ -57,19 +77,6 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         /// at this position.
         /// </summary>
         public int LogsPosition { get; private set; }
-
-        /// <summary>
-        /// The equity and benchmark curves are not built for in-run analysis:
-        /// none of the in-run analyses read them, and building them would issue
-        /// a benchmark history request on every run.
-        /// </summary>
-        protected override bool RequiresEquityCurves => false;
-
-        /// <summary>
-        /// The in-run analyses read the algorithm speed metrics accumulated from the
-        /// samples received on each run.
-        /// </summary>
-        protected override AlgorithmSpeedTracker SpeedTracker => _speed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InRunResultsAnalyzer"/> class.
@@ -117,7 +124,9 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
             LogsPosition += logs?.Count ?? 0;
 
             // State-based analyses are recomputed from scratch each run: remove their previous
-            // findings so they are replaced, or dropped if they no longer fail
+            // findings so they are replaced, or dropped if they no longer fail. If a time-limit
+            // truncated run skipped one of them, its finding drops until a run reaches it again —
+            // same trade-off as the positions advancement above
             foreach (var name in _findings.Keys.Where(IsStateBased).ToList())
             {
                 _findings.Remove(name);
@@ -143,7 +152,7 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         /// </summary>
         private IReadOnlyList<QuantConnect.Analysis> RankFindings(int maxFailedAnalyses)
         {
-            var weights = GetAnalyses().ToDictionary(analysis => analysis.GetType().Name, analysis => analysis.Weight);
+            var weights = Analyses.ToDictionary(analysis => analysis.GetType().Name, analysis => analysis.Weight);
             return _findings.Values
                 .OrderByDescending(finding => weights.GetValueOrDefault(BaseAnalysisName(finding.Name)))
                 .Take(maxFailedAnalyses)

--- a/Engine/Results/Analysis/InRunResultsAnalyzer.cs
+++ b/Engine/Results/Analysis/InRunResultsAnalyzer.cs
@@ -15,7 +15,9 @@
 */
 using QuantConnect.Algorithm;
 using QuantConnect.Lean.Engine.Results.Analysis.Analyses;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace QuantConnect.Lean.Engine.Results.Analysis
 {
@@ -26,15 +28,106 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
     public class InRunResultsAnalyzer : ResultsAnalyzer
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="InRunResultsAnalyzer"/> class.
+        /// Analyses that read the current backtest state (statistics, orders, charts) instead of scanning
+        /// the append-only order event and log streams. They must run against the full current state on
+        /// every run, and their previous findings are replaced instead of accumulated.
         /// </summary>
-        /// <param name="result">A snapshot of the current intermediate backtest result to analyze.</param>
+        private static readonly HashSet<string> StateBasedAnalyses = new()
+        {
+            nameof(PortfolioValueIsNotPositiveAnalysis),
+            nameof(TakeProfitAndStopLossOrdersAnalysis),
+            nameof(PortfolioMarginUsageAnalysis),
+        };
+
+        private readonly Dictionary<string, QuantConnect.Analysis> _findings = new();
+
+        /// <summary>
+        /// The number of order events already consumed by previous runs. The order events
+        /// in the result passed to <see cref="Run(Result, IReadOnlyList{string}, int, int)"/>
+        /// are expected to start at this position.
+        /// </summary>
+        public int OrderEventsPosition { get; private set; }
+
+        /// <summary>
+        /// The number of log entries already consumed by previous runs. The logs passed to
+        /// <see cref="Run(Result, IReadOnlyList{string}, int, int)"/> are expected to start
+        /// at this position.
+        /// </summary>
+        public int LogsPosition { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InRunResultsAnalyzer"/> class.
+        /// The instance is expected to be kept alive for the duration of the backtest,
+        /// receiving fresh data on each <see cref="Run(Result, IReadOnlyList{string}, int, int)"/> call.
+        /// </summary>
         /// <param name="algorithm">The algorithm instance used for history requests and settings.</param>
         /// <param name="language">The programming language the algorithm is written in.</param>
-        /// <param name="logs">The list of log lines produced by the backtest so far.</param>
-        public InRunResultsAnalyzer(Result result, QCAlgorithm algorithm, Language language, IReadOnlyList<string> logs)
-            : base(result, algorithm, language, logs)
+        public InRunResultsAnalyzer(QCAlgorithm algorithm, Language language)
+            : base(null, algorithm, language, null)
         {
+        }
+
+        /// <summary>
+        /// Runs the analyses incrementally: <paramref name="result"/> and <paramref name="logs"/> are
+        /// expected to contain only the order events and log lines produced since the previous run
+        /// (per <see cref="OrderEventsPosition"/> and <see cref="LogsPosition"/>), and the returned
+        /// findings are the merge of this run's findings into the ones accumulated by previous runs.
+        /// Findings from analyses scanning the order event and log streams are accumulated
+        /// (first sample kept, counts totaled), while findings from state-based analyses are
+        /// replaced on every run.
+        /// </summary>
+        /// <param name="result">A snapshot of the current intermediate backtest result, holding only new order events.</param>
+        /// <param name="logs">The log lines produced since the previous run.</param>
+        /// <param name="timeLimitSeconds">Wall-clock seconds allowed for the full chain before early exit.</param>
+        /// <param name="maxFailedAnalyses">Maximum number of failing analyses to return.</param>
+        /// <returns>The accumulated findings, ranked by analysis weight.</returns>
+        public IReadOnlyList<QuantConnect.Analysis> Run(Result result, IReadOnlyList<string> logs, int timeLimitSeconds = 1, int maxFailedAnalyses = 10)
+        {
+            SetAnalysisData(result, logs);
+            var newFindings = Run(timeLimitSeconds, maxFailedAnalyses);
+
+            OrderEventsPosition += result.OrderEvents?.Count ?? 0;
+            LogsPosition += logs?.Count ?? 0;
+
+            // State-based analyses are recomputed from scratch each run: remove their previous
+            // findings so they are replaced, or dropped if they no longer fail
+            foreach (var name in _findings.Keys.Where(IsStateBased).ToList())
+            {
+                _findings.Remove(name);
+            }
+
+            foreach (var finding in newFindings)
+            {
+                if (!IsStateBased(finding.Name) && _findings.TryGetValue(finding.Name, out var previous))
+                {
+                    // This run only saw new order events and logs: keep the first sample and total the counts.
+                    // A null count means a single occurrence
+                    finding.Sample = previous.Sample;
+                    finding.Count = (previous.Count ?? 1) + (finding.Count ?? 1);
+                }
+                _findings[finding.Name] = finding;
+            }
+
+            var weights = GetAnalyses().ToDictionary(analysis => analysis.GetType().Name, analysis => analysis.Weight);
+            return _findings.Values
+                .OrderByDescending(finding => weights.GetValueOrDefault(BaseAnalysisName(finding.Name)))
+                .Take(maxFailedAnalyses)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Determines whether the given finding was produced by a state-based analysis.
+        /// </summary>
+        private static bool IsStateBased(string findingName) => StateBasedAnalyses.Contains(BaseAnalysisName(findingName));
+
+        /// <summary>
+        /// Gets the analysis class name from a finding name, which aggregated
+        /// analyses suffix with the sub-analysis name.
+        /// </summary>
+        private static string BaseAnalysisName(string findingName)
+        {
+            var separatorIndex = findingName.IndexOf(" / ", StringComparison.Ordinal);
+            return separatorIndex < 0 ? findingName : findingName[..separatorIndex];
         }
 
         /// <summary>

--- a/Engine/Results/Analysis/ResultsAnalysisRunParameters.cs
+++ b/Engine/Results/Analysis/ResultsAnalysisRunParameters.cs
@@ -56,6 +56,12 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         public SortedList<DateTime, decimal> BenchmarkEquityCurve { get; }
 
         /// <summary>
+        /// The speed metrics tracked for the running backtest.
+        /// Only available for in-run analysis; null on the final analysis.
+        /// </summary>
+        public AlgorithmSpeedTracker Speed { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ResultsAnalysisRunParameters"/> class with the specified dependencies.
         /// </summary>
         public ResultsAnalysisRunParameters(
@@ -64,7 +70,8 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
             Language language,
             IReadOnlyList<string> logs,
             SortedList<DateTime, decimal> equityCurve,
-            SortedList<DateTime, decimal> benchmarkEquityCurve)
+            SortedList<DateTime, decimal> benchmarkEquityCurve,
+            AlgorithmSpeedTracker speed = null)
         {
             Result = result;
             Algorithm = algorithm;
@@ -72,6 +79,7 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
             Logs = logs;
             EquityCurve = equityCurve;
             BenchmarkEquityCurve = benchmarkEquityCurve;
+            Speed = speed;
         }
     }
 }

--- a/Engine/Results/Analysis/ResultsAnalyzer.cs
+++ b/Engine/Results/Analysis/ResultsAnalyzer.cs
@@ -62,51 +62,27 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         /// <returns>Up to <paramref name="maxFailedAnalyses"/> <see cref="QuantConnect.Analysis"/> entries with solutions, ranked by weight.</returns>
         public IReadOnlyList<QuantConnect.Analysis> Run(int timeLimitSeconds = 5, int maxFailedAnalyses = 10)
         {
-            (_equityCurve, _benchmarkEquityCurve) = ReadEquityCurve(_result, _algorithm);
+            var analyses = GetAnalyses();
+            if (analyses.Count == 0)
+            {
+                return [];
+            }
+
+            _equityCurve = new();
+            _benchmarkEquityCurve = new();
+            if (RequiresEquityCurves)
+            {
+                (_equityCurve, _benchmarkEquityCurve) = ReadEquityCurve(_result, _algorithm);
+            }
 
             var parameters = new ResultsAnalysisRunParameters(_result, _algorithm, _language, _logs, _equityCurve, _benchmarkEquityCurve);
-
-            // Instances are sorted by their own Weight — changing a weight automatically reorders execution.
-            var analyses = new BaseResultsAnalysis[]
-            {
-                new PortfolioValueIsNotPositiveAnalysis(),
-                new FlatEquityCurveAnalysis(),
-                new InsufficientBuyingPowerOrderResponseErrorAnalysis(),
-                new MarginCallsAnalysis(),
-                new ExceedsShortableQuantityOrderResponseErrorAnalysis(),
-                new SecurityPriceZeroOrderResponseErrorAnalysis(),
-                new OrderQuantityZeroOrderResponseErrorAnalysis(),
-                new NonTradableSecurityOrderResponseErrorAnalysis(),
-                new BrokerageModelRefusedToSubmitOrderOrderResponseErrorAnalysis(),
-                new BrokerageModelRefusedToUpdateOrderOrderResponseErrorAnalysis(),
-                new TakeProfitAndStopLossOrdersAnalysis(),
-                new StaleOrderFillsAnalysis(),
-                new AlgorithmWarmingUpOrderResponseErrorAnalysis(),
-                new ExchangeNotOpenOrderResponseErrorAnalysis(),
-                new ForexConversionRateZeroOrderResponseErrorAnalysis(),
-                new OrderFillsDuringExtendedMarketHoursAnalysis(),
-                new ExceededMaximumOrdersOrderResponseErrorAnalysis(),
-                new UnsupportedOptionShortPositionExerciseAnalysis(),
-                new UnsupportedOptionExerciseQuantityAnalysis(),
-                new EuropeanOptionNotExpiredOnExerciseOrderResponseErrorAnalysis(),
-                new OptionOrderOnStockSplitOrderResponseErrorAnalysis(),
-                new MarketOnOpenNotAllowedDuringRegularHoursOrderResponseErrorAnalysis(),
-                new OrderQuantityLessThanLotSizeOrderResponseErrorAnalysis(),
-                new InsightsEmittedForDelistedSecuritiesAnalysis(),
-                new StatisticalSignificanceOfDailyReturnsAnalysis(),
-                new PerformanceRelativeToBenchmarkAnalysis(),
-                new CrisisEventsAnalysis(),
-                new ExecutionSpeedAnalysis(),
-                new PortfolioMarginUsageAnalysis(),
-                new ParameterCountAnalysis(),
-                new MonteCarloPercentileAnalysis(),
-            }.OrderByDescending(a => a.Weight);
 
             var responses = new List<QuantConnect.Analysis>();
             var timer = Stopwatch.StartNew();
             var timeLimit = TimeSpan.FromSeconds(timeLimitSeconds);
 
-            foreach (var analysis in analyses)
+            // Instances are sorted by their own Weight — changing a weight automatically reorders execution.
+            foreach (var analysis in analyses.OrderByDescending(a => a.Weight))
             {
                 if (responses.Count >= maxFailedAnalyses)
                 {
@@ -130,6 +106,51 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
 
             return responses;
         }
+
+        /// <summary>
+        /// Whether the equity and benchmark curves should be built before running the analyses.
+        /// Building them requires a benchmark history request, so analyzers whose analyses
+        /// don't read the curves can skip it.
+        /// </summary>
+        protected virtual bool RequiresEquityCurves => true;
+
+        /// <summary>
+        /// Creates the set of diagnostic analyses to run against the backtest.
+        /// </summary>
+        protected virtual IReadOnlyCollection<BaseResultsAnalysis> GetAnalyses() => new BaseResultsAnalysis[]
+        {
+            new PortfolioValueIsNotPositiveAnalysis(),
+            new FlatEquityCurveAnalysis(),
+            new InsufficientBuyingPowerOrderResponseErrorAnalysis(),
+            new MarginCallsAnalysis(),
+            new ExceedsShortableQuantityOrderResponseErrorAnalysis(),
+            new SecurityPriceZeroOrderResponseErrorAnalysis(),
+            new OrderQuantityZeroOrderResponseErrorAnalysis(),
+            new NonTradableSecurityOrderResponseErrorAnalysis(),
+            new BrokerageModelRefusedToSubmitOrderOrderResponseErrorAnalysis(),
+            new BrokerageModelRefusedToUpdateOrderOrderResponseErrorAnalysis(),
+            new TakeProfitAndStopLossOrdersAnalysis(),
+            new StaleOrderFillsAnalysis(),
+            new AlgorithmWarmingUpOrderResponseErrorAnalysis(),
+            new ExchangeNotOpenOrderResponseErrorAnalysis(),
+            new ForexConversionRateZeroOrderResponseErrorAnalysis(),
+            new OrderFillsDuringExtendedMarketHoursAnalysis(),
+            new ExceededMaximumOrdersOrderResponseErrorAnalysis(),
+            new UnsupportedOptionShortPositionExerciseAnalysis(),
+            new UnsupportedOptionExerciseQuantityAnalysis(),
+            new EuropeanOptionNotExpiredOnExerciseOrderResponseErrorAnalysis(),
+            new OptionOrderOnStockSplitOrderResponseErrorAnalysis(),
+            new MarketOnOpenNotAllowedDuringRegularHoursOrderResponseErrorAnalysis(),
+            new OrderQuantityLessThanLotSizeOrderResponseErrorAnalysis(),
+            new InsightsEmittedForDelistedSecuritiesAnalysis(),
+            new StatisticalSignificanceOfDailyReturnsAnalysis(),
+            new PerformanceRelativeToBenchmarkAnalysis(),
+            new CrisisEventsAnalysis(),
+            new ExecutionSpeedAnalysis(),
+            new PortfolioMarginUsageAnalysis(),
+            new ParameterCountAnalysis(),
+            new MonteCarloPercentileAnalysis(),
+        };
 
         /// <summary>
         /// Reads the backtest's "Strategy Equity" chart and fetches SPY daily history to build
@@ -164,10 +185,21 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
             var benchmarkSeries = new SortedList<DateTime, decimal>();
             var historyStart = algorithm.StartDate - TimeSpan.FromDays(3);
             var historyEnd = algorithm.EndDate + TimeSpan.FromDays(1);
+            if (historyEnd > algorithm.Time)
+            {
+                // When running mid-backtest, requesting past the current algorithm time would get the request
+                // trimmed by the engine anyway, while also emitting a debug message to the user
+                historyEnd = algorithm.Time;
+            }
             foreach (var bar in algorithm.History(spy, historyStart, historyEnd, Resolution.Daily))
             {
                 var time = algorithm.Settings.DailyPreciseEndTime ? bar.EndTime.AddDays(1).Date : bar.EndTime;
                 benchmarkSeries.Add(time.Date.ConvertToUtc(exchangeTimeZone), bar.Close);
+            }
+
+            if (benchmarkSeries.Count == 0)
+            {
+                return (new(), new());
             }
 
             // ── 3. Resample both to daily data points ────────────────────────────

--- a/Engine/Results/Analysis/ResultsAnalyzer.cs
+++ b/Engine/Results/Analysis/ResultsAnalyzer.cs
@@ -37,6 +37,20 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         private Result _result;
 
         /// <summary>
+        /// Whether the equity and benchmark curves should be built before running the analyses.
+        /// Building them requires a benchmark history request, so analyzers whose analyses
+        /// don't read the curves can skip it.
+        /// </summary>
+        protected virtual bool RequiresEquityCurves => true;
+
+        /// <summary>
+        /// The speed metrics tracked for the running backtest, made available to the analyses
+        /// through <see cref="ResultsAnalysisRunParameters.Speed"/>. Null unless the analyzer
+        /// tracks the algorithm speed, like the in-run analyzer does.
+        /// </summary>
+        protected virtual AlgorithmSpeedTracker SpeedTracker => null;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ResultsAnalyzer"/> class.
         /// </summary>
         /// <param name="result">The backtest result to analyze.</param>
@@ -118,20 +132,6 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
             _result = result;
             _logs = logs;
         }
-
-        /// <summary>
-        /// Whether the equity and benchmark curves should be built before running the analyses.
-        /// Building them requires a benchmark history request, so analyzers whose analyses
-        /// don't read the curves can skip it.
-        /// </summary>
-        protected virtual bool RequiresEquityCurves => true;
-
-        /// <summary>
-        /// The speed metrics tracked for the running backtest, made available to the analyses
-        /// through <see cref="ResultsAnalysisRunParameters.Speed"/>. Null unless the analyzer
-        /// tracks the algorithm speed, like the in-run analyzer does.
-        /// </summary>
-        protected virtual AlgorithmSpeedTracker SpeedTracker => null;
 
         /// <summary>
         /// Creates the set of diagnostic analyses to run against the backtest.

--- a/Engine/Results/Analysis/ResultsAnalyzer.cs
+++ b/Engine/Results/Analysis/ResultsAnalyzer.cs
@@ -75,7 +75,7 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
                 (_equityCurve, _benchmarkEquityCurve) = ReadEquityCurve(_result, _algorithm);
             }
 
-            var parameters = new ResultsAnalysisRunParameters(_result, _algorithm, _language, _logs, _equityCurve, _benchmarkEquityCurve);
+            var parameters = new ResultsAnalysisRunParameters(_result, _algorithm, _language, _logs, _equityCurve, _benchmarkEquityCurve, SpeedTracker);
 
             var responses = new List<QuantConnect.Analysis>();
             var timer = Stopwatch.StartNew();
@@ -125,6 +125,13 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         /// don't read the curves can skip it.
         /// </summary>
         protected virtual bool RequiresEquityCurves => true;
+
+        /// <summary>
+        /// The speed metrics tracked for the running backtest, made available to the analyses
+        /// through <see cref="ResultsAnalysisRunParameters.Speed"/>. Null unless the analyzer
+        /// tracks the algorithm speed, like the in-run analyzer does.
+        /// </summary>
+        protected virtual AlgorithmSpeedTracker SpeedTracker => null;
 
         /// <summary>
         /// Creates the set of diagnostic analyses to run against the backtest.

--- a/Engine/Results/Analysis/ResultsAnalyzer.cs
+++ b/Engine/Results/Analysis/ResultsAnalyzer.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
     {
         private readonly QCAlgorithm _algorithm;
         private readonly Language _language;
-        private readonly IReadOnlyList<string> _logs;
+        private IReadOnlyList<string> _logs;
         private SortedList<DateTime, decimal> _equityCurve;
         private SortedList<DateTime, decimal> _benchmarkEquityCurve;
         private Result _result;
@@ -105,6 +105,18 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
             }
 
             return responses;
+        }
+
+        /// <summary>
+        /// Sets the backtest data to analyze. Used by analyzers that are kept alive
+        /// and run multiple times against fresh data.
+        /// </summary>
+        /// <param name="result">The backtest result to analyze.</param>
+        /// <param name="logs">The list of log lines to analyze.</param>
+        protected void SetAnalysisData(Result result, IReadOnlyList<string> logs)
+        {
+            _result = result;
+            _logs = logs;
         }
 
         /// <summary>

--- a/Engine/Results/Analysis/ResultsAnalyzer.cs
+++ b/Engine/Results/Analysis/ResultsAnalyzer.cs
@@ -35,6 +35,13 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         private SortedList<DateTime, decimal> _equityCurve;
         private SortedList<DateTime, decimal> _benchmarkEquityCurve;
         private Result _result;
+        private IReadOnlyCollection<BaseResultsAnalysis> _analyses;
+
+        /// <summary>
+        /// The diagnostic analyses to run. Created once and reused across runs,
+        /// since the analyses are stateless.
+        /// </summary>
+        protected IReadOnlyCollection<BaseResultsAnalysis> Analyses => _analyses ??= GetAnalyses();
 
         /// <summary>
         /// Whether the equity and benchmark curves should be built before running the analyses.
@@ -76,7 +83,7 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         /// <returns>Up to <paramref name="maxFailedAnalyses"/> <see cref="QuantConnect.Analysis"/> entries with solutions, ranked by weight.</returns>
         public IReadOnlyList<QuantConnect.Analysis> Run(int timeLimitSeconds = 5, int maxFailedAnalyses = 10)
         {
-            var analyses = GetAnalyses();
+            var analyses = Analyses;
             if (analyses.Count == 0)
             {
                 return [];
@@ -136,8 +143,8 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         /// <summary>
         /// Creates the set of diagnostic analyses to run against the backtest.
         /// </summary>
-        protected virtual IReadOnlyCollection<BaseResultsAnalysis> GetAnalyses() => new BaseResultsAnalysis[]
-        {
+        protected virtual IReadOnlyCollection<BaseResultsAnalysis> GetAnalyses() =>
+        [
             new PortfolioValueIsNotPositiveAnalysis(),
             new FlatEquityCurveAnalysis(),
             new InsufficientBuyingPowerOrderResponseErrorAnalysis(),
@@ -169,7 +176,7 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
             new PortfolioMarginUsageAnalysis(),
             new ParameterCountAnalysis(),
             new MonteCarloPercentileAnalysis(),
-        };
+        ];
 
         /// <summary>
         /// Reads the backtest's "Strategy Equity" chart and fetches SPY daily history to build
@@ -204,12 +211,6 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
             var benchmarkSeries = new SortedList<DateTime, decimal>();
             var historyStart = algorithm.StartDate - TimeSpan.FromDays(3);
             var historyEnd = algorithm.EndDate + TimeSpan.FromDays(1);
-            if (historyEnd > algorithm.Time)
-            {
-                // When running mid-backtest, requesting past the current algorithm time would get the request
-                // trimmed by the engine anyway, while also emitting a debug message to the user
-                historyEnd = algorithm.Time;
-            }
             foreach (var bar in algorithm.History(spy, historyStart, historyEnd, Resolution.Daily))
             {
                 var time = algorithm.Settings.DailyPreciseEndTime ? bar.EndTime.AddDays(1).Date : bar.EndTime;

--- a/Engine/Results/Analysis/ResultsAnalyzer.cs
+++ b/Engine/Results/Analysis/ResultsAnalyzer.cs
@@ -145,6 +145,9 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
         /// </summary>
         protected virtual IReadOnlyCollection<BaseResultsAnalysis> GetAnalyses() =>
         [
+            new SingleTimeLoopTimeoutRuntimeErrorAnalysis(),
+            new OperationCanceledRuntimeErrorAnalysis(),
+            new MaximumRuntimeExceededRuntimeErrorAnalysis(),
             new PortfolioValueIsNotPositiveAnalysis(),
             new FlatEquityCurveAnalysis(),
             new InsufficientBuyingPowerOrderResponseErrorAnalysis(),

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -469,11 +469,31 @@ namespace QuantConnect.Lean.Engine.Results
                     return null;
                 }
 
-                // The analyses read the charts without holding ChartLock, so hand them clones
-                Dictionary<string, Chart> charts;
+                // The analyses read the charts without holding ChartLock, so hand them clones,
+                // but only of the charts they read
+                var charts = new Dictionary<string, Chart>();
+                bool hasEquitySamples;
                 lock (ChartLock)
                 {
-                    charts = Charts.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone());
+                    foreach (var chartName in InRunResultsAnalyzer.RequiredCharts)
+                    {
+                        if (Charts.TryGetValue(chartName, out var chart))
+                        {
+                            charts[chartName] = chart.Clone();
+                        }
+                    }
+
+                    hasEquitySamples = Charts.TryGetValue(StrategyEquityKey, out var equityChart) &&
+                        equityChart.Series.TryGetValue(EquityKey, out var equitySeries) &&
+                        equitySeries.Values.Count > 0;
+                }
+
+                // Equity is not sampled while the algorithm warms up, so until the first sample exists
+                // the generated statistics are all-zero defaults that would flag a false non-positive
+                // portfolio value finding. Withhold them so the analyses reading them skip instead
+                if (Algorithm.IsWarmingUp || !hasEquitySamples)
+                {
+                    totalPerformance = null;
                 }
 
                 _inRunResultsAnalyzer ??= new InRunResultsAnalyzer(AlgorithmInstance, _job.Language);

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -464,13 +464,6 @@ namespace QuantConnect.Lean.Engine.Results
         {
             try
             {
-                // Nothing to analyze until trading starts: skip building the snapshot altogether.
-                // The analyzer catches up on the warm-up order events and logs on the first run after warm-up ends.
-                if (Algorithm.IsWarmingUp)
-                {
-                    return null;
-                }
-
                 if (AlgorithmInstance == null)
                 {
                     return null;
@@ -485,13 +478,18 @@ namespace QuantConnect.Lean.Engine.Results
 
                 _inRunResultsAnalyzer ??= new InRunResultsAnalyzer(AlgorithmInstance, _job.Language);
 
-                // Sample the engine speed counters for the algorithm speed analysis
-                var speedSample = new AlgorithmSpeedSample(
-                    DateTime.UtcNow - StartTime,
-                    PerformanceTrackingTool?.DataPoints ?? 0,
-                    PerformanceTrackingTool?.HistoryDataPoints ?? 0,
-                    _progressMonitor?.ProcessedDays ?? 0,
-                    _progressMonitor?.TotalDays ?? 0);
+                // Sample the engine speed counters for the algorithm speed analysis, but not while the
+                // algorithm is warming up: the warm-up pace would skew the speed metrics. The analyses
+                // themselves do run during warm-up, so conditions like orders submitted while warming up
+                // surface without waiting for warm-up to end
+                AlgorithmSpeedSample? speedSample = Algorithm.IsWarmingUp
+                    ? null
+                    : new AlgorithmSpeedSample(
+                        DateTime.UtcNow - StartTime,
+                        PerformanceTrackingTool?.DataPoints ?? 0,
+                        PerformanceTrackingTool?.HistoryDataPoints ?? 0,
+                        _progressMonitor?.ProcessedDays ?? 0,
+                        _progressMonitor?.TotalDays ?? 0);
 
                 // Only the order events and logs produced since the previous run are analyzed,
                 // the analyzer accumulates findings across runs

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -228,6 +228,11 @@ namespace QuantConnect.Lean.Engine.Results
                         // we store the last 100 order events, the final packet will contain the full list
                         TransactionHandler.OrderEvents.Reverse().Take(100).ToList(), state: GetAlgorithmState()));
 
+                    if (RunResultsAnalysis)
+                    {
+                        completeResult.Analysis = RunInRunResultsAnalysis(statisticsResult.TotalPerformance);
+                    }
+
                     StoreResult(new BacktestResultPacket(_job, completeResult, Algorithm.EndDate, Algorithm.StartDate, progress));
 
                     _nextS3Update = DateTime.UtcNow.AddSeconds(30);
@@ -437,6 +442,58 @@ namespace QuantConnect.Lean.Engine.Results
             catch (Exception err)
             {
                 Log.Error(err);
+            }
+        }
+
+        /// <summary>
+        /// Runs the in-run results analyzer against a snapshot of the current intermediate backtest state.
+        /// Invoked periodically while the backtest is still running, unlike the full analysis performed
+        /// by <see cref="SendFinalResult"/> when the backtest ends.
+        /// </summary>
+        /// <param name="totalPerformance">The current total algorithm performance, for analyses that read portfolio statistics</param>
+        /// <returns>The failed analyses with solutions, or null if the analysis could not run</returns>
+        protected virtual IReadOnlyList<QuantConnect.Analysis> RunInRunResultsAnalysis(AlgorithmPerformance totalPerformance)
+        {
+            try
+            {
+                var algorithm = _job.Language == Language.Python ? (Algorithm as AlgorithmPythonWrapper)?.BaseAlgorithm : Algorithm as QCAlgorithm;
+                if (algorithm == null)
+                {
+                    return null;
+                }
+
+                // The analyses read the charts without holding ChartLock, so hand them clones
+                Dictionary<string, Chart> charts;
+                lock (ChartLock)
+                {
+                    charts = Charts.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone());
+                }
+
+                // Unlike the intermediate result stored to disk, the analyses get the full order
+                // and order event collections, not just the latest 100
+                var snapshot = new BacktestResult(new BacktestResultParameters(
+                    charts,
+                    TransactionHandler.Orders.ToDictionary(),
+                    Algorithm.Transactions.TransactionRecord,
+                    new Dictionary<string, string>(),
+                    new Dictionary<string, string>(),
+                    new Dictionary<string, AlgorithmPerformance>(),
+                    TransactionHandler.OrderEvents.ToList(),
+                    totalPerformance));
+
+                List<string> logs;
+                lock (LogStore)
+                {
+                    logs = LogStore.Select(x => x.Message).ToList();
+                }
+
+                // Keep the time budget small: this runs on the result handler thread and delays message processing
+                return new InRunResultsAnalyzer(snapshot, algorithm, _job.Language, logs).Run(timeLimitSeconds: 1);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error running in-run backtest analysis");
+                return null;
             }
         }
 

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -52,6 +52,8 @@ namespace QuantConnect.Lean.Engine.Results
 
         private BacktestProgressMonitor _progressMonitor;
 
+        private InRunResultsAnalyzer _inRunResultsAnalyzer;
+
         /// <summary>
         /// Calculates the capacity of a strategy per Symbol in real-time
         /// </summary>
@@ -469,8 +471,18 @@ namespace QuantConnect.Lean.Engine.Results
                     charts = Charts.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone());
                 }
 
-                // Unlike the intermediate result stored to disk, the analyses get the full order
-                // and order event collections, not just the latest 100
+                _inRunResultsAnalyzer ??= new InRunResultsAnalyzer(algorithm, _job.Language);
+
+                // Only the order events and logs produced since the previous run are analyzed,
+                // the analyzer accumulates findings across runs
+                var orderEvents = TransactionHandler.OrderEvents.Skip(_inRunResultsAnalyzer.OrderEventsPosition).ToList();
+
+                List<string> logs;
+                lock (LogStore)
+                {
+                    logs = LogStore.Skip(_inRunResultsAnalyzer.LogsPosition).Select(x => x.Message).ToList();
+                }
+
                 var snapshot = new BacktestResult(new BacktestResultParameters(
                     charts,
                     TransactionHandler.Orders.ToDictionary(),
@@ -478,17 +490,11 @@ namespace QuantConnect.Lean.Engine.Results
                     new Dictionary<string, string>(),
                     new Dictionary<string, string>(),
                     new Dictionary<string, AlgorithmPerformance>(),
-                    TransactionHandler.OrderEvents.ToList(),
+                    orderEvents,
                     totalPerformance));
 
-                List<string> logs;
-                lock (LogStore)
-                {
-                    logs = LogStore.Select(x => x.Message).ToList();
-                }
-
                 // Keep the time budget small: this runs on the result handler thread and delays message processing
-                return new InRunResultsAnalyzer(snapshot, algorithm, _job.Language, logs).Run(timeLimitSeconds: 1);
+                return _inRunResultsAnalyzer.Run(snapshot, logs, timeLimitSeconds: 1);
             }
             catch (Exception ex)
             {

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -461,6 +461,13 @@ namespace QuantConnect.Lean.Engine.Results
         {
             try
             {
+                // Nothing to analyze until trading starts: skip building the snapshot altogether.
+                // The analyzer catches up on the warm-up order events and logs on the first run after warm-up ends.
+                if (Algorithm.IsWarmingUp)
+                {
+                    return null;
+                }
+
                 var algorithm = _job.Language == Language.Python ? (Algorithm as AlgorithmPythonWrapper)?.BaseAlgorithm : Algorithm as QCAlgorithm;
                 if (algorithm == null)
                 {
@@ -475,6 +482,14 @@ namespace QuantConnect.Lean.Engine.Results
                 }
 
                 _inRunResultsAnalyzer ??= new InRunResultsAnalyzer(algorithm, _job.Language);
+
+                // Sample the engine speed counters for the algorithm speed analysis
+                var speedSample = new AlgorithmSpeedSample(
+                    DateTime.UtcNow - StartTime,
+                    PerformanceTrackingTool?.DataPoints ?? 0,
+                    Algorithm.HistoryProvider?.DataPointCount ?? 0,
+                    _progressMonitor?.ProcessedDays ?? 0,
+                    _progressMonitor?.TotalDays ?? 0);
 
                 // Only the order events and logs produced since the previous run are analyzed,
                 // the analyzer accumulates findings across runs
@@ -497,7 +512,7 @@ namespace QuantConnect.Lean.Engine.Results
                     totalPerformance));
 
                 // Keep the time budget small: this runs on the result handler thread and delays message processing
-                return _inRunResultsAnalyzer.Run(snapshot, logs, timeLimitSeconds: 1);
+                return _inRunResultsAnalyzer.Run(snapshot, logs, speedSample, timeLimitSeconds: 1);
             }
             catch (Exception ex)
             {

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -66,6 +66,10 @@ namespace QuantConnect.Lean.Engine.Results
         private string _algorithmId;
         private int _projectId;
 
+        private QCAlgorithm _algorithmInstance;
+
+        private QCAlgorithm AlgorithmInstance => _algorithmInstance ??= _job.Language == Language.Python ? (Algorithm as AlgorithmPythonWrapper)?.BaseAlgorithm : Algorithm as QCAlgorithm;
+
         /// <summary>
         /// Whether or not to run the results analysis at the end of the backtest.
         /// </summary>
@@ -418,13 +422,12 @@ namespace QuantConnect.Lean.Engine.Results
                 // Run backtest analyzer
                 if (RunResultsAnalysis)
                 {
-                    var algorithm = _job.Language == Language.Python ? (Algorithm as AlgorithmPythonWrapper)?.BaseAlgorithm : Algorithm as QCAlgorithm;
                     List<string> logs;
                     lock (LogStore)
                     {
                         logs = LogStore.Select(x => x.Message).ToList();
                     }
-                    var analyzer = new ResultsAnalyzer(result.Results, algorithm, _job.Language, logs);
+                    var analyzer = new ResultsAnalyzer(result.Results, AlgorithmInstance, _job.Language, logs);
                     try
                     {
                         result.Results.Analysis = analyzer.Run();
@@ -468,8 +471,7 @@ namespace QuantConnect.Lean.Engine.Results
                     return null;
                 }
 
-                var algorithm = _job.Language == Language.Python ? (Algorithm as AlgorithmPythonWrapper)?.BaseAlgorithm : Algorithm as QCAlgorithm;
-                if (algorithm == null)
+                if (AlgorithmInstance == null)
                 {
                     return null;
                 }
@@ -481,13 +483,13 @@ namespace QuantConnect.Lean.Engine.Results
                     charts = Charts.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone());
                 }
 
-                _inRunResultsAnalyzer ??= new InRunResultsAnalyzer(algorithm, _job.Language);
+                _inRunResultsAnalyzer ??= new InRunResultsAnalyzer(AlgorithmInstance, _job.Language);
 
                 // Sample the engine speed counters for the algorithm speed analysis
                 var speedSample = new AlgorithmSpeedSample(
                     DateTime.UtcNow - StartTime,
                     PerformanceTrackingTool?.DataPoints ?? 0,
-                    Algorithm.HistoryProvider?.DataPointCount ?? 0,
+                    PerformanceTrackingTool?.HistoryDataPoints ?? 0,
                     _progressMonitor?.ProcessedDays ?? 0,
                     _progressMonitor?.TotalDays ?? 0);
 

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -14,6 +14,7 @@
  *
 */
 
+using Newtonsoft.Json;
 using QuantConnect.Algorithm;
 using QuantConnect.AlgorithmFactory.Python.Wrappers;
 using QuantConnect.Brokerages;
@@ -53,6 +54,7 @@ namespace QuantConnect.Lean.Engine.Results
         private BacktestProgressMonitor _progressMonitor;
 
         private InRunResultsAnalyzer _inRunResultsAnalyzer;
+        private string _lastInRunAnalysisSignature = "[]";
 
         /// <summary>
         /// Calculates the capacity of a strategy per Symbol in real-time
@@ -233,6 +235,7 @@ namespace QuantConnect.Lean.Engine.Results
                     if (RunResultsAnalysis)
                     {
                         completeResult.Analysis = RunInRunResultsAnalysis(statisticsResult.TotalPerformance);
+                        SendInRunAnalysis(completeResult.Analysis, progress);
                     }
 
                     StoreResult(new BacktestResultPacket(_job, completeResult, Algorithm.EndDate, Algorithm.StartDate, progress));
@@ -501,6 +504,30 @@ namespace QuantConnect.Lean.Engine.Results
                 Log.Error(ex, "Error running in-run backtest analysis");
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Sends the in-run analysis findings to the browser in their own packet,
+        /// only when they changed since they were last sent.
+        /// </summary>
+        /// <param name="findings">The accumulated in-run analysis findings, or null if the analysis could not run</param>
+        /// <param name="progress">The current backtest progress</param>
+        private void SendInRunAnalysis(IReadOnlyList<QuantConnect.Analysis> findings, decimal progress)
+        {
+            if (findings == null)
+            {
+                return;
+            }
+
+            var signature = JsonConvert.SerializeObject(findings);
+            if (signature == _lastInRunAnalysisSignature)
+            {
+                return;
+            }
+            _lastInRunAnalysisSignature = signature;
+
+            MessagingHandler.Send(new BacktestResultPacket(_job, new BacktestResult { Analysis = findings },
+                Algorithm.EndDate, Algorithm.StartDate, progress));
         }
 
         /// <summary>

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -307,6 +307,12 @@ namespace QuantConnect.Lean.Engine.Results
         protected IMapFileProvider MapFileProvider { get; set; }
 
         /// <summary>
+        /// The tool tracking the engine's performance counters, used by the in-run
+        /// algorithm speed analysis. May be null when the host doesn't track performance.
+        /// </summary>
+        protected PerformanceTrackingTool PerformanceTrackingTool { get; set; }
+
+        /// <summary>
         /// Creates a new instance
         /// </summary>
         protected BaseResultsHandler()
@@ -498,6 +504,7 @@ namespace QuantConnect.Lean.Engine.Results
             _updateRunner.Start();
             State["Hostname"] = _hostName;
             MapFileProvider = parameters.MapFileProvider;
+            PerformanceTrackingTool = parameters.PerformanceTrackingTool;
 
             SerializerSettings = new()
             {

--- a/Engine/Results/ResultHandlerInitializeParameters.cs
+++ b/Engine/Results/ResultHandlerInitializeParameters.cs
@@ -17,6 +17,7 @@
 using QuantConnect.Packets;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.TransactionHandlers;
+using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.Results
 {
@@ -51,15 +52,23 @@ namespace QuantConnect.Lean.Engine.Results
         public IMapFileProvider MapFileProvider { get; set; }
 
         /// <summary>
+        /// The tool tracking the engine's performance counters, used by the in-run
+        /// algorithm speed analysis. Optional: may be null when the host doesn't track performance.
+        /// </summary>
+        public PerformanceTrackingTool PerformanceTrackingTool { get; set; }
+
+        /// <summary>
         /// Creates a new instance
         /// </summary>
-        public ResultHandlerInitializeParameters(AlgorithmNodePacket job, IMessagingHandler messagingHandler, IApi api, ITransactionHandler transactionHandler, IMapFileProvider mapFileProvider)
+        public ResultHandlerInitializeParameters(AlgorithmNodePacket job, IMessagingHandler messagingHandler, IApi api, ITransactionHandler transactionHandler,
+            IMapFileProvider mapFileProvider, PerformanceTrackingTool performanceTrackingTool = null)
         {
             Job = job;
             Api = api;
             MapFileProvider = mapFileProvider;
             MessagingHandler = messagingHandler;
             TransactionHandler = transactionHandler;
+            PerformanceTrackingTool = performanceTrackingTool;
         }
     }
 }

--- a/Tests/Engine/Results/AlgorithmSpeedAnalysisTests.cs
+++ b/Tests/Engine/Results/AlgorithmSpeedAnalysisTests.cs
@@ -1,0 +1,208 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Lean.Engine.Results.Analysis;
+using QuantConnect.Lean.Engine.Results.Analysis.Analyses;
+
+namespace QuantConnect.Tests.Engine.Results
+{
+    [TestFixture]
+    public class AlgorithmSpeedAnalysisTests
+    {
+        [Test]
+        public void NoFindingsWithoutSpeedMetrics()
+        {
+            Assert.IsEmpty(new AlgorithmSpeedAnalysis().Run((AlgorithmSpeedTracker)null));
+
+            var parameters = new ResultsAnalysisRunParameters(null, null, Language.CSharp, null, null, null);
+            Assert.IsEmpty(new AlgorithmSpeedAnalysis().Run(parameters));
+        }
+
+        [Test]
+        public void NoFindingsBeforeTheMinimumSampledSpan()
+        {
+            // Very slow, but only 30s of samples: still within the warm-up grace period
+            var tracker = AlgorithmSpeedTrackerTests.BuildUniformTracker(samples: 2, stepSeconds: 30,
+                dataPointsPerStep: 100, historyDataPointsPerStep: 0, daysPerStep: 0, totalDays: 0);
+
+            Assert.IsEmpty(new AlgorithmSpeedAnalysis().Run(tracker));
+        }
+
+        [Test]
+        public void FlagsSlowExecutionWithProgressAndProjection()
+        {
+            // 10k data points per second, 1 backtest day every 30s with only 4 days left: slow, but not long-running
+            var tracker = AlgorithmSpeedTrackerTests.BuildUniformTracker(samples: 7, stepSeconds: 30,
+                dataPointsPerStep: 300_000, historyDataPointsPerStep: 0, daysPerStep: 1, totalDays: 10);
+
+            var findings = new AlgorithmSpeedAnalysis().Run(tracker);
+
+            var finding = findings.Single();
+            Assert.AreEqual($"{nameof(AlgorithmSpeedAnalysis)} / {AlgorithmSpeedAnalysis.SlowExecutionName}", finding.Name);
+            var sample = (string)finding.Sample;
+            StringAssert.Contains("10.0k data points per second", sample);
+            StringAssert.Contains("60% complete", sample);
+            StringAssert.Contains("remaining at the recent pace", sample);
+            Assert.IsNotEmpty(finding.Solutions);
+        }
+
+        [Test]
+        public void DoesNotFlagFastExecution()
+        {
+            // 100k data points per second and a short remaining runtime
+            var tracker = AlgorithmSpeedTrackerTests.BuildUniformTracker(samples: 7, stepSeconds: 30,
+                dataPointsPerStep: 3_000_000, historyDataPointsPerStep: 0, daysPerStep: 1, totalDays: 10);
+
+            Assert.IsEmpty(new AlgorithmSpeedAnalysis().Run(tracker));
+        }
+
+        [Test]
+        public void SlowExecutionRequiresTwoConsecutiveSlowWindows()
+        {
+            // A fast run whose very last window stalls: the previous window is still fast, so no flag yet
+            var tracker = new AlgorithmSpeedTracker();
+            for (var i = 0; i < 6; i++)
+            {
+                tracker.AddSample(new(TimeSpan.FromSeconds(30 * i), 3_000_000L * i, 0, 0, 0));
+            }
+            tracker.AddSample(new(TimeSpan.FromSeconds(750), 15_000_000, 0, 0, 0));
+
+            Assert.IsEmpty(new AlgorithmSpeedAnalysis().Run(tracker));
+
+            // One more stalled window and both recent windows are slow: now it flags
+            tracker.AddSample(new(TimeSpan.FromSeconds(1350), 15_000_000, 0, 0, 0));
+
+            var findings = new AlgorithmSpeedAnalysis().Run(tracker);
+            Assert.IsTrue(findings.Any(finding => finding.Name.EndsWith(AlgorithmSpeedAnalysis.SlowExecutionName, StringComparison.Ordinal)));
+        }
+
+        [Test]
+        public void MissingDataPointCountsSuppressDataPointBasedFindings()
+        {
+            // The data point counters are not wired in (always zero), but calendar progress is glacial:
+            // only the projected runtime finding should be reported
+            var tracker = AlgorithmSpeedTrackerTests.BuildUniformTracker(samples: 12, stepSeconds: 30,
+                dataPointsPerStep: 0, historyDataPointsPerStep: 0, daysPerStep: 1, totalDays: 100_000);
+
+            var findings = new AlgorithmSpeedAnalysis().Run(tracker);
+
+            var finding = findings.Single();
+            Assert.AreEqual($"{nameof(AlgorithmSpeedAnalysis)} / {AlgorithmSpeedAnalysis.LongProjectedRuntimeName}", finding.Name);
+        }
+
+        [Test]
+        public void FlagsLongProjectedRuntime()
+        {
+            // Fast processing, but ~35 wall-clock days of backtest left at one backtest day per 30s
+            var tracker = AlgorithmSpeedTrackerTests.BuildUniformTracker(samples: 7, stepSeconds: 30,
+                dataPointsPerStep: 3_000_000, historyDataPointsPerStep: 0, daysPerStep: 1, totalDays: 100_000);
+
+            var findings = new AlgorithmSpeedAnalysis().Run(tracker);
+
+            var finding = findings.Single();
+            Assert.AreEqual($"{nameof(AlgorithmSpeedAnalysis)} / {AlgorithmSpeedAnalysis.LongProjectedRuntimeName}", finding.Name);
+            StringAssert.Contains("remain at the recent pace", (string)finding.Sample);
+            Assert.IsNotEmpty(finding.Solutions);
+        }
+
+        [Test]
+        public void FlagsStalledCalendarProgressAsLongProjectedRuntime()
+        {
+            // Fast processing but the backtest time is not advancing at all
+            var tracker = new AlgorithmSpeedTracker();
+            for (var i = 0; i < 7; i++)
+            {
+                tracker.AddSample(new(TimeSpan.FromSeconds(30 * i), 3_000_000L * i, 0, 3, 10));
+            }
+
+            var findings = new AlgorithmSpeedAnalysis().Run(tracker);
+
+            var finding = findings.Single();
+            Assert.AreEqual($"{nameof(AlgorithmSpeedAnalysis)} / {AlgorithmSpeedAnalysis.LongProjectedRuntimeName}", finding.Name);
+            StringAssert.Contains("no backtest-time progress", (string)finding.Sample);
+        }
+
+        [Test]
+        public void FlagsThroughputDegradation()
+        {
+            // 100k data points per second for the first 6 intervals, 10k for the last 5
+            var tracker = new AlgorithmSpeedTracker();
+            var dataPoints = 0L;
+            for (var i = 0; i < 12; i++)
+            {
+                tracker.AddSample(new(TimeSpan.FromSeconds(30 * i), dataPoints, 0, 0, 0));
+                dataPoints += i < 6 ? 3_000_000 : 300_000;
+            }
+
+            var findings = new AlgorithmSpeedAnalysis().Run(tracker);
+
+            var degradation = findings.Single(finding =>
+                finding.Name.EndsWith(AlgorithmSpeedAnalysis.ThroughputDegradationName, StringComparison.Ordinal));
+            StringAssert.Contains("100.0k data points per second early in the run", (string)degradation.Sample);
+            StringAssert.Contains("10.0k recently", (string)degradation.Sample);
+            // The recent pace is also below the absolute threshold, so slow execution is reported too
+            Assert.IsTrue(findings.Any(finding => finding.Name.EndsWith(AlgorithmSpeedAnalysis.SlowExecutionName, StringComparison.Ordinal)));
+        }
+
+        [Test]
+        public void NoDegradationFindingBeforeTheBaselineAndRecentWindowsAreDisjoint()
+        {
+            var tracker = new AlgorithmSpeedTracker();
+            var dataPoints = 0L;
+            for (var i = 0; i < 9; i++)
+            {
+                tracker.AddSample(new(TimeSpan.FromSeconds(30 * i), dataPoints, 0, 0, 0));
+                dataPoints += i < 3 ? 3_000_000 : 300_000;
+            }
+
+            var findings = new AlgorithmSpeedAnalysis().Run(tracker);
+
+            Assert.IsFalse(findings.Any(finding =>
+                finding.Name.EndsWith(AlgorithmSpeedAnalysis.ThroughputDegradationName, StringComparison.Ordinal)));
+        }
+
+        [Test]
+        public void FlagsHistoryRequestDominatedLoad()
+        {
+            // Fast overall, but 75% of the data points come from history requests
+            var tracker = AlgorithmSpeedTrackerTests.BuildUniformTracker(samples: 7, stepSeconds: 30,
+                dataPointsPerStep: 1_000_000, historyDataPointsPerStep: 3_000_000, daysPerStep: 1, totalDays: 10);
+
+            var findings = new AlgorithmSpeedAnalysis().Run(tracker);
+
+            var finding = findings.Single();
+            Assert.AreEqual($"{nameof(AlgorithmSpeedAnalysis)} / {AlgorithmSpeedAnalysis.HistoryRequestLoadName}", finding.Name);
+            StringAssert.Contains("75% of the data points", (string)finding.Sample);
+        }
+
+        [Test]
+        public void NoHistoryLoadFindingBelowTheMinimumHistoryDataPointCount()
+        {
+            // 60% history share, but only a few hundred history data points in the window
+            var tracker = AlgorithmSpeedTrackerTests.BuildUniformTracker(samples: 7, stepSeconds: 30,
+                dataPointsPerStep: 40, historyDataPointsPerStep: 60, daysPerStep: 1, totalDays: 10);
+
+            var findings = new AlgorithmSpeedAnalysis().Run(tracker);
+
+            Assert.IsFalse(findings.Any(finding =>
+                finding.Name.EndsWith(AlgorithmSpeedAnalysis.HistoryRequestLoadName, StringComparison.Ordinal)));
+        }
+    }
+}

--- a/Tests/Engine/Results/AlgorithmSpeedAnalysisTests.cs
+++ b/Tests/Engine/Results/AlgorithmSpeedAnalysisTests.cs
@@ -64,6 +64,19 @@ namespace QuantConnect.Tests.Engine.Results
         }
 
         [Test]
+        public void FormatsRatesBelowOneThousandAsRawCounts()
+        {
+            // 100 data points per second: formatted as a raw count instead of "0.1k"
+            var tracker = AlgorithmSpeedTrackerTests.BuildUniformTracker(samples: 7, stepSeconds: 30,
+                dataPointsPerStep: 3_000, historyDataPointsPerStep: 0, daysPerStep: 1, totalDays: 10);
+
+            var findings = new AlgorithmSpeedAnalysis().Run(tracker);
+
+            var finding = findings.Single(x => x.Name.EndsWith(AlgorithmSpeedAnalysis.SlowExecutionName, StringComparison.Ordinal));
+            StringAssert.Contains("Processing 100 data points per second recently (100 average)", (string)finding.Sample);
+        }
+
+        [Test]
         public void DoesNotFlagFastExecution()
         {
             // 100k data points per second and a short remaining runtime

--- a/Tests/Engine/Results/AlgorithmSpeedTrackerTests.cs
+++ b/Tests/Engine/Results/AlgorithmSpeedTrackerTests.cs
@@ -1,0 +1,144 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Lean.Engine.Results.Analysis;
+
+namespace QuantConnect.Tests.Engine.Results
+{
+    [TestFixture]
+    public class AlgorithmSpeedTrackerTests
+    {
+        [Test]
+        public void RatesAreNotMeasurableWithASingleSample()
+        {
+            var tracker = new AlgorithmSpeedTracker();
+            tracker.AddSample(new(TimeSpan.FromSeconds(30), 1000, 0, 1, 100));
+
+            Assert.IsNull(tracker.DataPointsPerSecond);
+            Assert.IsNull(tracker.RecentDataPointsPerSecond());
+            Assert.IsNull(tracker.RecentDaysPerSecond());
+            Assert.IsNull(tracker.RecentHistoryDataPointsShare());
+            Assert.IsNull(tracker.EstimatedRemainingTime());
+            Assert.AreEqual(TimeSpan.Zero, tracker.SampledSpan);
+        }
+
+        [Test]
+        public void ComputesCumulativeInitialAndRecentRates()
+        {
+            // 7 samples 30s apart: 3 fast intervals at 100k dp/s followed by 3 slow ones at 10k dp/s
+            var tracker = new AlgorithmSpeedTracker();
+            var dataPoints = 0L;
+            for (var i = 0; i < 7; i++)
+            {
+                tracker.AddSample(new(TimeSpan.FromSeconds(30 * i), dataPoints, 0, i, 100));
+                dataPoints += i < 3 ? 3_000_000 : 300_000;
+            }
+
+            // (3 * 3M + 3 * 300k) / 180s
+            Assert.AreEqual(55_000, tracker.DataPointsPerSecond.Value, 1);
+            // First 5 samples: (3 * 3M + 1 * 300k) / 120s
+            Assert.AreEqual(77_500, tracker.InitialDataPointsPerSecond.Value, 1);
+            // Last 5 samples: (1 * 3M + 3 * 300k) / 120s
+            Assert.AreEqual(32_500, tracker.RecentDataPointsPerSecond().Value, 1);
+            // Skipping the last sample: (2 * 3M + 2 * 300k) / 120s
+            Assert.AreEqual(55_000, tracker.RecentDataPointsPerSecond(skipLast: 1).Value, 1);
+        }
+
+        [Test]
+        public void IncludesHistoryDataPointsInRatesAndShare()
+        {
+            // 100k loop + 200k history data points every 30s
+            var tracker = BuildUniformTracker(samples: 6, stepSeconds: 30, dataPointsPerStep: 100_000,
+                historyDataPointsPerStep: 200_000, daysPerStep: 1, totalDays: 100);
+
+            Assert.AreEqual(10_000, tracker.DataPointsPerSecond.Value, 1);
+            Assert.AreEqual(10_000, tracker.RecentDataPointsPerSecond().Value, 1);
+            Assert.AreEqual(2.0 / 3.0, tracker.RecentHistoryDataPointsShare().Value, 0.001);
+            Assert.AreEqual(4 * 200_000, tracker.RecentHistoryDataPoints());
+        }
+
+        [Test]
+        public void EstimatesRemainingTimeFromTheRecentPace()
+        {
+            // One backtest day every 30s, 95 days to go after the last sample
+            var tracker = BuildUniformTracker(samples: 6, stepSeconds: 30, dataPointsPerStep: 100_000,
+                historyDataPointsPerStep: 0, daysPerStep: 1, totalDays: 100);
+
+            Assert.AreEqual(1.0 / 30, tracker.RecentDaysPerSecond().Value, 0.0001);
+            Assert.AreEqual(95 * 30, tracker.EstimatedRemainingTime().Value.TotalSeconds, 0.1);
+        }
+
+        [Test]
+        public void RemainingTimeIsZeroWhenTheEndDateIsReached()
+        {
+            var tracker = BuildUniformTracker(samples: 6, stepSeconds: 30, dataPointsPerStep: 100_000,
+                historyDataPointsPerStep: 0, daysPerStep: 1, totalDays: 5);
+
+            Assert.AreEqual(TimeSpan.Zero, tracker.EstimatedRemainingTime());
+        }
+
+        [Test]
+        public void RemainingTimeIsNotMeasurableWithoutCalendarProgress()
+        {
+            var tracker = BuildUniformTracker(samples: 6, stepSeconds: 30, dataPointsPerStep: 100_000,
+                historyDataPointsPerStep: 0, daysPerStep: 0, totalDays: 100);
+
+            Assert.AreEqual(0, tracker.RecentDaysPerSecond());
+            Assert.IsNull(tracker.EstimatedRemainingTime());
+        }
+
+        [Test]
+        public void IgnoresSamplesWithNonIncreasingElapsedTime()
+        {
+            var tracker = new AlgorithmSpeedTracker();
+            tracker.AddSample(new(TimeSpan.FromSeconds(30), 1000, 0, 1, 100));
+            tracker.AddSample(new(TimeSpan.FromSeconds(30), 2000, 0, 1, 100));
+            tracker.AddSample(new(TimeSpan.FromSeconds(20), 3000, 0, 1, 100));
+
+            Assert.AreEqual(1, tracker.SampleCount);
+        }
+
+        [Test]
+        public void TracksProgressAndDataPointCountsAvailability()
+        {
+            var tracker = new AlgorithmSpeedTracker();
+            Assert.AreEqual(0, tracker.Progress);
+            Assert.IsFalse(tracker.HasDataPointCounts);
+
+            tracker.AddSample(new(TimeSpan.FromSeconds(30), 0, 1000, 25, 100));
+            Assert.AreEqual(0.25m, tracker.Progress);
+            Assert.IsFalse(tracker.HasDataPointCounts);
+
+            tracker.AddSample(new(TimeSpan.FromSeconds(60), 500, 2000, 50, 100));
+            Assert.AreEqual(0.5m, tracker.Progress);
+            Assert.IsTrue(tracker.HasDataPointCounts);
+        }
+
+        public static AlgorithmSpeedTracker BuildUniformTracker(int samples, int stepSeconds, long dataPointsPerStep,
+            long historyDataPointsPerStep, int daysPerStep, int totalDays)
+        {
+            var tracker = new AlgorithmSpeedTracker();
+            for (var i = 0; i < samples; i++)
+            {
+                tracker.AddSample(new(TimeSpan.FromSeconds(stepSeconds * i), dataPointsPerStep * i,
+                    historyDataPointsPerStep * i, daysPerStep * i, totalDays));
+            }
+            return tracker;
+        }
+    }
+}

--- a/Tests/Engine/Results/InRunResultsAnalyzerTests.cs
+++ b/Tests/Engine/Results/InRunResultsAnalyzerTests.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using NUnit.Framework;
+using QuantConnect.Algorithm;
 using QuantConnect.Lean.Engine.Results.Analysis;
 using QuantConnect.Lean.Engine.Results.Analysis.Analyses;
 using QuantConnect.Orders;
@@ -178,6 +179,36 @@ namespace QuantConnect.Tests.Engine.Results
         }
 
         [Test]
+        public void NothingIsAnalyzedOrConsumedDuringAlgorithmWarmUp()
+        {
+            // A fresh algorithm is warming up until the engine flips it
+            var algorithm = new QCAlgorithm();
+            var ran = false;
+            var fake = new FakeAnalysisA(10)
+            {
+                Findings = () => MakeFindings(nameof(FakeAnalysisA), "sample", 1),
+                OnRun = () => ran = true
+            };
+            var analyzer = new TestInRunResultsAnalyzer(algorithm, fake);
+
+            var findings = analyzer.Run(MakeResult(2), new[] { "log" });
+
+            Assert.IsFalse(ran);
+            Assert.IsEmpty(findings);
+            Assert.AreEqual(0, analyzer.OrderEventsPosition);
+            Assert.AreEqual(0, analyzer.LogsPosition);
+
+            // Once warm-up finishes, the analysis catches up on the unconsumed order events and logs
+            algorithm.SetFinishedWarmingUp();
+            findings = analyzer.Run(MakeResult(2), new[] { "log" });
+
+            Assert.IsTrue(ran);
+            Assert.AreEqual("sample", findings.Single().Sample);
+            Assert.AreEqual(2, analyzer.OrderEventsPosition);
+            Assert.AreEqual(1, analyzer.LogsPosition);
+        }
+
+        [Test]
         public void FindingsAreRankedByAnalysisWeightAndCapped()
         {
             var lowWeight = new FakeAnalysisA(10)
@@ -226,7 +257,12 @@ namespace QuantConnect.Tests.Engine.Results
             private readonly IReadOnlyCollection<BaseResultsAnalysis> _analyses;
 
             public TestInRunResultsAnalyzer(params BaseResultsAnalysis[] analyses)
-                : base(null, Language.CSharp)
+                : this(null, analyses)
+            {
+            }
+
+            public TestInRunResultsAnalyzer(QCAlgorithm algorithm, params BaseResultsAnalysis[] analyses)
+                : base(algorithm, Language.CSharp)
             {
                 _analyses = analyses;
             }

--- a/Tests/Engine/Results/InRunResultsAnalyzerTests.cs
+++ b/Tests/Engine/Results/InRunResultsAnalyzerTests.cs
@@ -1,0 +1,276 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using QuantConnect.Lean.Engine.Results.Analysis;
+using QuantConnect.Lean.Engine.Results.Analysis.Analyses;
+using QuantConnect.Orders;
+using QuantConnect.Packets;
+
+namespace QuantConnect.Tests.Engine.Results
+{
+    [TestFixture]
+    public class InRunResultsAnalyzerTests
+    {
+        private static readonly IReadOnlyList<string> SomeSolutions = new[] { "A solution" };
+
+        [Test]
+        public void PositionsAdvanceByTheConsumedOrderEventsAndLogs()
+        {
+            var analyzer = new TestInRunResultsAnalyzer(new FakeAnalysisA(10));
+
+            analyzer.Run(MakeResult(3), new[] { "log 1", "log 2" });
+            Assert.AreEqual(3, analyzer.OrderEventsPosition);
+            Assert.AreEqual(2, analyzer.LogsPosition);
+
+            analyzer.Run(MakeResult(5), new[] { "log 3" });
+            Assert.AreEqual(8, analyzer.OrderEventsPosition);
+            Assert.AreEqual(3, analyzer.LogsPosition);
+
+            // Null order events and logs don't move the positions
+            analyzer.Run(new BacktestResult(), null);
+            Assert.AreEqual(8, analyzer.OrderEventsPosition);
+            Assert.AreEqual(3, analyzer.LogsPosition);
+        }
+
+        [Test]
+        public void PositionsAdvanceEvenWhenTheTimeLimitTruncatesTheRun()
+        {
+            var truncatedRan = false;
+            // The slow analysis has the higher weight so it runs first and exhausts the time limit
+            var slow = new FakeAnalysisA(20) { OnRun = () => Thread.Sleep(1100) };
+            var truncated = new FakeAnalysisB(10) { OnRun = () => truncatedRan = true };
+            var analyzer = new TestInRunResultsAnalyzer(slow, truncated);
+
+            analyzer.Run(MakeResult(4), new[] { "log 1" }, timeLimitSeconds: 1);
+
+            Assert.IsFalse(truncatedRan);
+            Assert.AreEqual(4, analyzer.OrderEventsPosition);
+            Assert.AreEqual(1, analyzer.LogsPosition);
+        }
+
+        [Test]
+        public void StreamBasedFindingsAccumulateAcrossRuns()
+        {
+            var fake = new FakeAnalysisA(10);
+            var analyzer = new TestInRunResultsAnalyzer(fake);
+
+            fake.Findings = () => MakeFindings(nameof(FakeAnalysisA), "first sample", 3);
+            analyzer.Run(MakeResult(1), new[] { "log" });
+
+            fake.Findings = () => MakeFindings(nameof(FakeAnalysisA), "second sample", 2);
+            var findings = analyzer.Run(MakeResult(1), new[] { "log" });
+
+            var finding = findings.Single();
+            Assert.AreEqual("first sample", finding.Sample);
+            Assert.AreEqual(5, finding.Count);
+        }
+
+        [Test]
+        public void StreamBasedFindingsWithNullCountsCountSingleOccurrences()
+        {
+            var fake = new FakeAnalysisA(10)
+            {
+                Findings = () => MakeFindings(nameof(FakeAnalysisA), "sample", null)
+            };
+            var analyzer = new TestInRunResultsAnalyzer(fake);
+
+            analyzer.Run(MakeResult(1), new[] { "log" });
+            var findings = analyzer.Run(MakeResult(1), new[] { "log" });
+
+            Assert.AreEqual(2, findings.Single().Count);
+        }
+
+        [Test]
+        public void StreamBasedFindingsPersistWhenNotReemitted()
+        {
+            var fake = new FakeAnalysisA(10)
+            {
+                Findings = () => MakeFindings(nameof(FakeAnalysisA), "sample", 4)
+            };
+            var analyzer = new TestInRunResultsAnalyzer(fake);
+            analyzer.Run(MakeResult(1), new[] { "log" });
+
+            // The next delta produces no new occurrences: the accumulated finding is still reported
+            fake.Findings = () => new List<QuantConnect.Analysis>();
+            var findings = analyzer.Run(MakeResult(1), new[] { "log" });
+
+            var finding = findings.Single();
+            Assert.AreEqual("sample", finding.Sample);
+            Assert.AreEqual(4, finding.Count);
+        }
+
+        [Test]
+        public void StateBasedFindingsAreReplacedOnEveryRun()
+        {
+            var fake = new FakeAnalysisA(10)
+            {
+                Findings = () => MakeFindings(nameof(PortfolioValueIsNotPositiveAnalysis), "old sample", 2)
+            };
+            var analyzer = new TestInRunResultsAnalyzer(fake);
+            analyzer.Run(MakeResult(1), new[] { "log" });
+
+            fake.Findings = () => MakeFindings(nameof(PortfolioValueIsNotPositiveAnalysis), "new sample", 3);
+            var findings = analyzer.Run(MakeResult(1), new[] { "log" });
+
+            // Replaced, not accumulated: latest sample and count win
+            var finding = findings.Single();
+            Assert.AreEqual("new sample", finding.Sample);
+            Assert.AreEqual(3, finding.Count);
+        }
+
+        [Test]
+        public void StateBasedFindingsAreDroppedWhenTheyNoLongerFail()
+        {
+            var fake = new FakeAnalysisA(10)
+            {
+                Findings = () => MakeFindings(nameof(PortfolioValueIsNotPositiveAnalysis), "sample", 2)
+            };
+            var analyzer = new TestInRunResultsAnalyzer(fake);
+            Assert.IsNotEmpty(analyzer.Run(MakeResult(1), new[] { "log" }));
+
+            fake.Findings = () => new List<QuantConnect.Analysis>();
+            var findings = analyzer.Run(MakeResult(1), new[] { "log" });
+
+            Assert.IsEmpty(findings);
+        }
+
+        [Test]
+        public void AggregatedStateBasedFindingsAreReplacedByFullName()
+        {
+            // Aggregated analyses emit "AnalysisClass / SubAnalysis" finding names: state-based
+            // behavior is determined by the base analysis name, replacement is keyed by the full name
+            var stateBasedName = nameof(PortfolioValueIsNotPositiveAnalysis);
+            var fake = new FakeAnalysisA(10)
+            {
+                Findings = () => MakeFindings($"{stateBasedName} / SubA", "sample a", 1)
+                    .Concat(MakeFindings($"{stateBasedName} / SubB", "sample b", 1))
+                    .ToList()
+            };
+            var analyzer = new TestInRunResultsAnalyzer(fake);
+            Assert.AreEqual(2, analyzer.Run(MakeResult(1), new[] { "log" }).Count);
+
+            fake.Findings = () => MakeFindings($"{stateBasedName} / SubA", "new sample a", 2);
+            var findings = analyzer.Run(MakeResult(1), new[] { "log" });
+
+            // SubB no longer fails and is dropped; SubA is replaced with the fresh finding
+            var finding = findings.Single();
+            Assert.AreEqual($"{stateBasedName} / SubA", finding.Name);
+            Assert.AreEqual("new sample a", finding.Sample);
+            Assert.AreEqual(2, finding.Count);
+        }
+
+        [Test]
+        public void FindingsAreRankedByAnalysisWeightAndCapped()
+        {
+            var lowWeight = new FakeAnalysisA(10)
+            {
+                Findings = () => MakeFindings(nameof(FakeAnalysisA), "sample a", 1)
+            };
+            // Aggregated finding names rank by their base analysis' weight
+            var midWeight = new FakeAnalysisB(20)
+            {
+                Findings = () => MakeFindings($"{nameof(FakeAnalysisB)} / Sub", "sample b", 1)
+            };
+            var highWeight = new FakeAnalysisC(30)
+            {
+                Findings = () => MakeFindings(nameof(FakeAnalysisC), "sample c", 1)
+            };
+            var analyzer = new TestInRunResultsAnalyzer(lowWeight, midWeight, highWeight);
+
+            var findings = analyzer.Run(MakeResult(1), new[] { "log" });
+            CollectionAssert.AreEqual(
+                new[] { nameof(FakeAnalysisC), $"{nameof(FakeAnalysisB)} / Sub", nameof(FakeAnalysisA) },
+                findings.Select(finding => finding.Name));
+
+            // The accumulated findings are capped to the top weighted ones
+            lowWeight.Findings = midWeight.Findings = highWeight.Findings = () => new List<QuantConnect.Analysis>();
+            findings = analyzer.Run(MakeResult(1), new[] { "log" }, maxFailedAnalyses: 2);
+            CollectionAssert.AreEqual(
+                new[] { nameof(FakeAnalysisC), $"{nameof(FakeAnalysisB)} / Sub" },
+                findings.Select(finding => finding.Name));
+        }
+
+        private static BacktestResult MakeResult(int orderEventsCount)
+        {
+            return new BacktestResult
+            {
+                OrderEvents = Enumerable.Range(0, orderEventsCount).Select(_ => new OrderEvent()).ToList()
+            };
+        }
+
+        private static List<QuantConnect.Analysis> MakeFindings(string name, string sample, int? count)
+        {
+            return new List<QuantConnect.Analysis> { new(name, "An issue", sample, count, SomeSolutions) };
+        }
+
+        private class TestInRunResultsAnalyzer : InRunResultsAnalyzer
+        {
+            private readonly IReadOnlyCollection<BaseResultsAnalysis> _analyses;
+
+            public TestInRunResultsAnalyzer(params BaseResultsAnalysis[] analyses)
+                : base(null, Language.CSharp)
+            {
+                _analyses = analyses;
+            }
+
+            protected override IReadOnlyCollection<BaseResultsAnalysis> GetAnalyses() => _analyses;
+        }
+
+        private class FakeAnalysis : BaseResultsAnalysis
+        {
+            private readonly int _weight;
+
+            public override string Issue => "A fake issue";
+
+            public override int Weight => _weight;
+
+            public Func<IReadOnlyList<QuantConnect.Analysis>> Findings { get; set; } = () => new List<QuantConnect.Analysis>();
+
+            public Action OnRun { get; set; }
+
+            protected FakeAnalysis(int weight)
+            {
+                _weight = weight;
+            }
+
+            public override IReadOnlyList<QuantConnect.Analysis> Run(ResultsAnalysisRunParameters parameters)
+            {
+                OnRun?.Invoke();
+                return Findings();
+            }
+        }
+
+        private sealed class FakeAnalysisA : FakeAnalysis
+        {
+            public FakeAnalysisA(int weight) : base(weight) { }
+        }
+
+        private sealed class FakeAnalysisB : FakeAnalysis
+        {
+            public FakeAnalysisB(int weight) : base(weight) { }
+        }
+
+        private sealed class FakeAnalysisC : FakeAnalysis
+        {
+            public FakeAnalysisC(int weight) : base(weight) { }
+        }
+    }
+}

--- a/Tests/Engine/Results/InRunResultsAnalyzerTests.cs
+++ b/Tests/Engine/Results/InRunResultsAnalyzerTests.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using NUnit.Framework;
-using QuantConnect.Algorithm;
 using QuantConnect.Lean.Engine.Results.Analysis;
 using QuantConnect.Lean.Engine.Results.Analysis.Analyses;
 using QuantConnect.Orders;
@@ -179,33 +178,22 @@ namespace QuantConnect.Tests.Engine.Results
         }
 
         [Test]
-        public void NothingIsAnalyzedOrConsumedDuringAlgorithmWarmUp()
+        public void SpeedSamplesAreTrackedOnlyWhenProvided()
         {
-            // A fresh algorithm is warming up until the engine flips it
-            var algorithm = new QCAlgorithm();
-            var ran = false;
-            var fake = new FakeAnalysisA(10)
-            {
-                Findings = () => MakeFindings(nameof(FakeAnalysisA), "sample", 1),
-                OnRun = () => ran = true
-            };
-            var analyzer = new TestInRunResultsAnalyzer(algorithm, fake);
+            AlgorithmSpeedTracker speed = null;
+            var fake = new FakeAnalysisA(10) { OnParameters = parameters => speed = parameters.Speed };
+            var analyzer = new TestInRunResultsAnalyzer(fake);
 
-            var findings = analyzer.Run(MakeResult(2), new[] { "log" });
+            analyzer.Run(MakeResult(1), new[] { "log" });
+            Assert.IsNotNull(speed);
+            Assert.AreEqual(0, speed.SampleCount);
 
-            Assert.IsFalse(ran);
-            Assert.IsEmpty(findings);
-            Assert.AreEqual(0, analyzer.OrderEventsPosition);
-            Assert.AreEqual(0, analyzer.LogsPosition);
+            analyzer.Run(MakeResult(1), new[] { "log" }, new AlgorithmSpeedSample(TimeSpan.FromSeconds(30), 100, 0, 1, 10));
+            Assert.AreEqual(1, speed.SampleCount);
 
-            // Once warm-up finishes, the analysis catches up on the unconsumed order events and logs
-            algorithm.SetFinishedWarmingUp();
-            findings = analyzer.Run(MakeResult(2), new[] { "log" });
-
-            Assert.IsTrue(ran);
-            Assert.AreEqual("sample", findings.Single().Sample);
-            Assert.AreEqual(2, analyzer.OrderEventsPosition);
-            Assert.AreEqual(1, analyzer.LogsPosition);
+            // No sample provided (e.g. while the algorithm warms up): the tracker is left untouched
+            analyzer.Run(MakeResult(1), new[] { "log" });
+            Assert.AreEqual(1, speed.SampleCount);
         }
 
         [Test]
@@ -257,12 +245,7 @@ namespace QuantConnect.Tests.Engine.Results
             private readonly IReadOnlyCollection<BaseResultsAnalysis> _analyses;
 
             public TestInRunResultsAnalyzer(params BaseResultsAnalysis[] analyses)
-                : this(null, analyses)
-            {
-            }
-
-            public TestInRunResultsAnalyzer(QCAlgorithm algorithm, params BaseResultsAnalysis[] analyses)
-                : base(algorithm, Language.CSharp)
+                : base(null, Language.CSharp)
             {
                 _analyses = analyses;
             }
@@ -282,6 +265,8 @@ namespace QuantConnect.Tests.Engine.Results
 
             public Action OnRun { get; set; }
 
+            public Action<ResultsAnalysisRunParameters> OnParameters { get; set; }
+
             protected FakeAnalysis(int weight)
             {
                 _weight = weight;
@@ -290,6 +275,7 @@ namespace QuantConnect.Tests.Engine.Results
             public override IReadOnlyList<QuantConnect.Analysis> Run(ResultsAnalysisRunParameters parameters)
             {
                 OnRun?.Invoke();
+                OnParameters?.Invoke(parameters);
                 return Findings();
             }
         }

--- a/Tests/Engine/Results/InRunResultsAnalyzerTests.cs
+++ b/Tests/Engine/Results/InRunResultsAnalyzerTests.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using NUnit.Framework;
+using QuantConnect.Lean.Engine.Results;
 using QuantConnect.Lean.Engine.Results.Analysis;
 using QuantConnect.Lean.Engine.Results.Analysis.Analyses;
 using QuantConnect.Orders;
@@ -227,6 +228,28 @@ namespace QuantConnect.Tests.Engine.Results
                 findings.Select(finding => finding.Name));
         }
 
+        [Test]
+        public void RequiredChartsAreTheChartsReadByTheInRunAnalyses()
+        {
+            // The result handler only clones these charts into the analyzed snapshot,
+            // so this must stay in sync with the charts the in-run analyses read
+            CollectionAssert.AreEquivalent(
+                new[] { BaseResultsHandler.PortfolioMarginKey },
+                InRunResultsAnalyzer.RequiredCharts);
+        }
+
+        [Test]
+        public void AnalysesAreCreatedOnceAndReusedAcrossRuns()
+        {
+            var analyzer = new TestInRunResultsAnalyzer(new FakeAnalysisA(10));
+
+            analyzer.Run(MakeResult(1), new[] { "log" });
+            analyzer.Run(MakeResult(1), new[] { "log" });
+
+            // Both the analysis chain and the findings ranking read the cached set
+            Assert.AreEqual(1, analyzer.GetAnalysesCallCount);
+        }
+
         private static BacktestResult MakeResult(int orderEventsCount)
         {
             return new BacktestResult
@@ -250,7 +273,13 @@ namespace QuantConnect.Tests.Engine.Results
                 _analyses = analyses;
             }
 
-            protected override IReadOnlyCollection<BaseResultsAnalysis> GetAnalyses() => _analyses;
+            public int GetAnalysesCallCount { get; private set; }
+
+            protected override IReadOnlyCollection<BaseResultsAnalysis> GetAnalyses()
+            {
+                GetAnalysesCallCount++;
+                return _analyses;
+            }
         }
 
         private class FakeAnalysis : BaseResultsAnalysis

--- a/Tests/Engine/Results/PortfolioValueIsNotPositiveAnalysisTests.cs
+++ b/Tests/Engine/Results/PortfolioValueIsNotPositiveAnalysisTests.cs
@@ -1,0 +1,68 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Lean.Engine.Results.Analysis.Analyses;
+using QuantConnect.Packets;
+using QuantConnect.Statistics;
+
+namespace QuantConnect.Tests.Engine.Results
+{
+    [TestFixture]
+    public class PortfolioValueIsNotPositiveAnalysisTests
+    {
+        [Test]
+        public void ReturnsNoFindingsWhenStatisticsAreWithheld()
+        {
+            // The result handler withholds the statistics when they are not meaningful yet,
+            // like while the algorithm warms up and no equity has been sampled
+            var findings = new PortfolioValueIsNotPositiveAnalysis().Run(new BacktestResult());
+
+            Assert.IsEmpty(findings);
+        }
+
+        [TestCase(0)]
+        [TestCase(-100000)]
+        public void FlagsNonPositiveEndingEquity(int endEquity)
+        {
+            var findings = new PortfolioValueIsNotPositiveAnalysis().Run(MakeResult(endEquity));
+
+            var finding = findings.Single();
+            Assert.AreEqual(nameof(PortfolioValueIsNotPositiveAnalysis), finding.Name);
+            Assert.IsNotEmpty(finding.Solutions);
+        }
+
+        [Test]
+        public void ReturnsNoActionableFindingWhenEndingEquityIsPositive()
+        {
+            var findings = new PortfolioValueIsNotPositiveAnalysis().Run(MakeResult(100000));
+
+            Assert.IsEmpty(findings.Single().Solutions);
+        }
+
+        private static BacktestResult MakeResult(decimal endEquity)
+        {
+            return new BacktestResult
+            {
+                TotalPerformance = new AlgorithmPerformance
+                {
+                    PortfolioStatistics = new PortfolioStatistics { EndEquity = endEquity }
+                }
+            };
+        }
+    }
+}

--- a/Tests/Engine/Results/ResultsAnalyzerTests.cs
+++ b/Tests/Engine/Results/ResultsAnalyzerTests.cs
@@ -129,6 +129,17 @@ namespace QuantConnect.Tests.Engine.Results
             Assert.AreEqual(1, findings.Count);
         }
 
+        [Test]
+        public void AnalysesAreCreatedOnceAndReusedAcrossRuns()
+        {
+            var analyzer = new TestResultsAnalyzer(false, new FakeAnalysisA(10));
+
+            analyzer.Run();
+            analyzer.Run();
+
+            Assert.AreEqual(1, analyzer.GetAnalysesCallCount);
+        }
+
         private class TestResultsAnalyzer : ResultsAnalyzer
         {
             private readonly bool _requiresEquityCurves;
@@ -143,7 +154,13 @@ namespace QuantConnect.Tests.Engine.Results
 
             protected override bool RequiresEquityCurves => _requiresEquityCurves;
 
-            protected override IReadOnlyCollection<BaseResultsAnalysis> GetAnalyses() => _analyses;
+            public int GetAnalysesCallCount { get; private set; }
+
+            protected override IReadOnlyCollection<BaseResultsAnalysis> GetAnalyses()
+            {
+                GetAnalysesCallCount++;
+                return _analyses;
+            }
         }
 
         private class FakeAnalysis : BaseResultsAnalysis

--- a/Tests/Engine/Results/ResultsAnalyzerTests.cs
+++ b/Tests/Engine/Results/ResultsAnalyzerTests.cs
@@ -1,0 +1,188 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using QuantConnect.Lean.Engine.Results.Analysis;
+using QuantConnect.Lean.Engine.Results.Analysis.Analyses;
+
+namespace QuantConnect.Tests.Engine.Results
+{
+    [TestFixture]
+    public class ResultsAnalyzerTests
+    {
+        private static readonly IReadOnlyList<string> SomeSolutions = new[] { "A solution" };
+
+        [Test]
+        public void RunsTheOverriddenAnalysisSetAndKeepsFindingsWithSolutions()
+        {
+            var withSolutions = new FakeAnalysisA(10)
+            {
+                Findings = () => new List<QuantConnect.Analysis>
+                {
+                    new(nameof(FakeAnalysisA), "An issue", "sample", null, SomeSolutions)
+                }
+            };
+            var withoutSolutions = new FakeAnalysisB(20)
+            {
+                Findings = () => new List<QuantConnect.Analysis>
+                {
+                    new(nameof(FakeAnalysisB), "An issue", "sample", null, new List<string>())
+                }
+            };
+            var analyzer = new TestResultsAnalyzer(false, withSolutions, withoutSolutions);
+
+            var findings = analyzer.Run();
+
+            // Findings without solutions are not reported
+            Assert.AreEqual(nameof(FakeAnalysisA), findings.Single().Name);
+        }
+
+        [Test]
+        public void EmptyAnalysisSetProducesNoFindings()
+        {
+            var analyzer = new TestResultsAnalyzer(false);
+            Assert.IsEmpty(analyzer.Run());
+        }
+
+        [Test]
+        public void SkipsEquityCurveConstructionWhenNotRequired()
+        {
+            ResultsAnalysisRunParameters seenParameters = null;
+            var fake = new FakeAnalysisA(10) { OnRun = parameters => seenParameters = parameters };
+            // Null result and algorithm: building the curves would throw, so a successful
+            // run proves the equity curves were skipped
+            var analyzer = new TestResultsAnalyzer(false, fake);
+
+            Assert.DoesNotThrow(() => analyzer.Run());
+
+            Assert.IsNotNull(seenParameters);
+            Assert.IsNotNull(seenParameters.EquityCurve);
+            Assert.IsEmpty(seenParameters.EquityCurve);
+            Assert.IsNotNull(seenParameters.BenchmarkEquityCurve);
+            Assert.IsEmpty(seenParameters.BenchmarkEquityCurve);
+        }
+
+        [Test]
+        public void AnalysesRunInDescendingWeightOrder()
+        {
+            var runOrder = new List<string>();
+            var analyzer = new TestResultsAnalyzer(false,
+                new FakeAnalysisA(10) { OnRun = _ => runOrder.Add(nameof(FakeAnalysisA)) },
+                new FakeAnalysisB(30) { OnRun = _ => runOrder.Add(nameof(FakeAnalysisB)) },
+                new FakeAnalysisC(20) { OnRun = _ => runOrder.Add(nameof(FakeAnalysisC)) });
+
+            analyzer.Run();
+
+            CollectionAssert.AreEqual(
+                new[] { nameof(FakeAnalysisB), nameof(FakeAnalysisC), nameof(FakeAnalysisA) },
+                runOrder);
+        }
+
+        [Test]
+        public void TimeLimitStopsTheAnalysisChain()
+        {
+            var truncatedRan = false;
+            // The slow analysis has the higher weight so it runs first and exhausts the time limit
+            var slow = new FakeAnalysisA(20) { OnRun = _ => Thread.Sleep(1100) };
+            var truncated = new FakeAnalysisB(10) { OnRun = _ => truncatedRan = true };
+            var analyzer = new TestResultsAnalyzer(false, slow, truncated);
+
+            analyzer.Run(timeLimitSeconds: 1);
+
+            Assert.IsFalse(truncatedRan);
+        }
+
+        [Test]
+        public void MaxFailedAnalysesStopsTheAnalysisChain()
+        {
+            var skippedRan = false;
+            var failing = new FakeAnalysisA(20)
+            {
+                Findings = () => new List<QuantConnect.Analysis>
+                {
+                    new(nameof(FakeAnalysisA), "An issue", "sample", null, SomeSolutions)
+                }
+            };
+            var skipped = new FakeAnalysisB(10) { OnRun = _ => skippedRan = true };
+            var analyzer = new TestResultsAnalyzer(false, failing, skipped);
+
+            var findings = analyzer.Run(maxFailedAnalyses: 1);
+
+            Assert.IsFalse(skippedRan);
+            Assert.AreEqual(1, findings.Count);
+        }
+
+        private class TestResultsAnalyzer : ResultsAnalyzer
+        {
+            private readonly bool _requiresEquityCurves;
+            private readonly IReadOnlyCollection<BaseResultsAnalysis> _analyses;
+
+            public TestResultsAnalyzer(bool requiresEquityCurves, params BaseResultsAnalysis[] analyses)
+                : base(null, null, Language.CSharp, null)
+            {
+                _requiresEquityCurves = requiresEquityCurves;
+                _analyses = analyses;
+            }
+
+            protected override bool RequiresEquityCurves => _requiresEquityCurves;
+
+            protected override IReadOnlyCollection<BaseResultsAnalysis> GetAnalyses() => _analyses;
+        }
+
+        private class FakeAnalysis : BaseResultsAnalysis
+        {
+            private readonly int _weight;
+
+            public override string Issue => "A fake issue";
+
+            public override int Weight => _weight;
+
+            public Func<IReadOnlyList<QuantConnect.Analysis>> Findings { get; set; } = () => new List<QuantConnect.Analysis>();
+
+            public Action<ResultsAnalysisRunParameters> OnRun { get; set; }
+
+            protected FakeAnalysis(int weight)
+            {
+                _weight = weight;
+            }
+
+            public override IReadOnlyList<QuantConnect.Analysis> Run(ResultsAnalysisRunParameters parameters)
+            {
+                OnRun?.Invoke(parameters);
+                return Findings();
+            }
+        }
+
+        private sealed class FakeAnalysisA : FakeAnalysis
+        {
+            public FakeAnalysisA(int weight) : base(weight) { }
+        }
+
+        private sealed class FakeAnalysisB : FakeAnalysis
+        {
+            public FakeAnalysisB(int weight) : base(weight) { }
+        }
+
+        private sealed class FakeAnalysisC : FakeAnalysis
+        {
+            public FakeAnalysisC(int weight) : base(weight) { }
+        }
+    }
+}

--- a/Tests/Engine/Results/RuntimeErrorAnalysesTests.cs
+++ b/Tests/Engine/Results/RuntimeErrorAnalysesTests.cs
@@ -1,0 +1,150 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Lean.Engine.Results.Analysis.Analyses;
+
+namespace QuantConnect.Tests.Engine.Results
+{
+    [TestFixture]
+    public class RuntimeErrorAnalysesTests
+    {
+        private const string SingleTimeLoopError =
+            "20240101 15:30:00.000 Runtime Error: Algorithm took longer than 10 minutes on a single time loop. CurrentTimeStepElapsed: 10.0 minutes";
+
+        private const string SingleTimeLoopWithAdditionalTimeError =
+            "Runtime Error: Algorithm took longer than 10 minutes on a single time loop. " +
+            "An additional 30 minutes were also allocated and consumed. CurrentTimeStepElapsed: 40.1 minutes";
+
+        private const string OperationCanceledError = "20240101 15:30:00.000 Runtime Error: Operation was canceled";
+
+        private const string MaximumRuntimeError =
+            "Runtime Error: Execution Security Error: Operation timed out - 1440 minutes max. Check for recursive loops.";
+
+        private const string MaximumRuntimeEngineError =
+            "Runtime Error: Failed to complete algorithm within 86400 seconds. Please make it run faster.";
+
+        private static RuntimeErrorAnalysis[] CreateAnalyses() =>
+        [
+            new SingleTimeLoopTimeoutRuntimeErrorAnalysis(),
+            new OperationCanceledRuntimeErrorAnalysis(),
+            new MaximumRuntimeExceededRuntimeErrorAnalysis(),
+        ];
+
+        [TestCase(SingleTimeLoopError, typeof(SingleTimeLoopTimeoutRuntimeErrorAnalysis))]
+        [TestCase(SingleTimeLoopWithAdditionalTimeError, typeof(SingleTimeLoopTimeoutRuntimeErrorAnalysis))]
+        [TestCase(OperationCanceledError, typeof(OperationCanceledRuntimeErrorAnalysis))]
+        [TestCase(MaximumRuntimeError, typeof(MaximumRuntimeExceededRuntimeErrorAnalysis))]
+        [TestCase(MaximumRuntimeEngineError, typeof(MaximumRuntimeExceededRuntimeErrorAnalysis))]
+        public void DetectsItsOwnRuntimeErrorFromState(string runtimeError, Type expectedAnalysisType)
+        {
+            var state = new Dictionary<string, string> { ["RuntimeError"] = runtimeError };
+
+            foreach (var analysis in CreateAnalyses())
+            {
+                var finding = analysis.Run(state, [], Language.CSharp).Single();
+
+                if (analysis.GetType() == expectedAnalysisType)
+                {
+                    Assert.AreEqual(expectedAnalysisType.Name, finding.Name);
+                    Assert.AreEqual(runtimeError, finding.Sample);
+                    Assert.IsNotEmpty(finding.Solutions);
+                }
+                else
+                {
+                    Assert.IsNull(finding.Sample, $"{analysis.GetType().Name} should not flag \"{runtimeError}\"");
+                    Assert.IsEmpty(finding.Solutions);
+                }
+            }
+        }
+
+        [Test]
+        public void DetectsRuntimeErrorFromLogsWhenStateIsMissing()
+        {
+            var logs = new List<string>
+            {
+                "20240101 15:29:00.000 Launching analysis for the algorithm",
+                SingleTimeLoopError,
+            };
+
+            var finding = new SingleTimeLoopTimeoutRuntimeErrorAnalysis().Run(null, logs, Language.CSharp).Single();
+
+            Assert.AreEqual(SingleTimeLoopError, finding.Sample);
+            Assert.IsNotEmpty(finding.Solutions);
+        }
+
+        [Test]
+        public void IgnoresLogLinesThatAreNotRuntimeErrors()
+        {
+            // These mention cancellation and timeouts but are not the algorithm's runtime error
+            var logs = new List<string>
+            {
+                "20240101 15:29:00.000 Isolator.ExecuteWithTimeLimit(): Operation was canceled",
+                "20240101 15:29:00.000 The download operation timed out after 5 minutes max wait",
+            };
+
+            foreach (var analysis in CreateAnalyses())
+            {
+                var finding = analysis.Run(new Dictionary<string, string>(), logs, Language.CSharp).Single();
+
+                Assert.IsNull(finding.Sample);
+                Assert.IsEmpty(finding.Solutions);
+            }
+        }
+
+        [TestCase("Runtime Error: System.DivideByZeroException: Attempted to divide by zero.")]
+        [TestCase("")]
+        public void DoesNotFlagOtherRuntimeErrorsOrCleanRuns(string runtimeError)
+        {
+            var state = new Dictionary<string, string> { ["RuntimeError"] = runtimeError };
+
+            foreach (var analysis in CreateAnalyses())
+            {
+                var finding = analysis.Run(state, [], Language.CSharp).Single();
+
+                Assert.IsNull(finding.Sample);
+                Assert.IsEmpty(finding.Solutions);
+            }
+        }
+
+        [TestCase(Language.CSharp, "Train", "OnData")]
+        [TestCase(Language.Python, "train", "on_data")]
+        public void FormatsCodeReferencesForTheAlgorithmLanguage(Language language, string trainMethod, string onDataMethod)
+        {
+            var state = new Dictionary<string, string> { ["RuntimeError"] = SingleTimeLoopError };
+
+            var solutions = new SingleTimeLoopTimeoutRuntimeErrorAnalysis().Run(state, [], language).Single().Solutions;
+
+            Assert.IsTrue(solutions.Any(solution => solution.Contains($"`{trainMethod}`")));
+            Assert.IsTrue(solutions.Any(solution => solution.Contains($"`{onDataMethod}`")));
+        }
+
+        [Test]
+        public void PythonSolutionsIncludeVectorizationAdvice()
+        {
+            var state = new Dictionary<string, string> { ["RuntimeError"] = SingleTimeLoopError };
+
+            var csharpSolutions = new SingleTimeLoopTimeoutRuntimeErrorAnalysis().Run(state, [], Language.CSharp).Single().Solutions;
+            var pythonSolutions = new SingleTimeLoopTimeoutRuntimeErrorAnalysis().Run(state, [], Language.Python).Single().Solutions;
+
+            Assert.IsFalse(csharpSolutions.Any(solution => solution.Contains("numpy")));
+            Assert.IsTrue(pythonSolutions.Any(solution => solution.Contains("numpy")));
+        }
+    }
+}


### PR DESCRIPTION
#### Description

Adds a new `RuntimeErrorAnalysis` family of backtest results analyses that detect algorithms terminated by the execution time limits enforced by the `Isolator`, and give the user actionable recommendations to avoid the error. The runtime error message is read from the result state (`State["RuntimeError"]`), falling back to the "Runtime Error:" log line for results that carry no state.

Three analyses, each detecting one termination reason (at most one can fire per run, all ranked as fatal with weight 100):

- `SingleTimeLoopTimeoutRuntimeErrorAnalysis` — "Algorithm took longer than N minutes on a single time loop", emitted by `AlgorithmTimeLimitManager`/`Isolator` when a single time loop exceeds the per-loop limit. Recommends: moving heavy per-event work to incremental computation (rolling windows, consolidators, indicators), reducing and filtering universes (including option/future chain `SetFilter` filters), lowering subscription counts and resolution, avoiding large history requests inside event handlers, running ML training through `Train()` (which allocates additional time), checking for infinite loops, and vectorizing with numpy/pandas for Python algorithms.
- `OperationCanceledRuntimeErrorAnalysis` — "Operation was canceled", emitted by the `Isolator` when the algorithm is asked to stop (user stop/delete) but its code keeps running past the shutdown grace period. Explains that the error is expected if the run was stopped on purpose, and otherwise recommends reducing per-event work so control returns to the engine promptly.
- `MaximumRuntimeExceededRuntimeErrorAnalysis` — the overall maximum runtime timeout, matching both the "Execution Security Error: Operation timed out - N minutes max" and "Failed to complete algorithm within N seconds" message shapes. Recommends shortening the backtest period, reducing universe size/resolution, and reviewing code inefficiencies.

The abstract `RuntimeErrorAnalysis` base owns the shared plumbing (runtime error extraction and fragment-set message matching), so future runtime-error analyses (e.g. out-of-memory) only declare their patterns, issue and solutions. The three analyses are registered in the final `ResultsAnalyzer` chain only: these errors terminate the run, so there is nothing for the in-run analyzer to catch while the backtest is alive.

Note: this PR is stacked on #9632 (`feature-in-run-backtest-analysis`); the diff includes its commits until it is merged. The new analysis work is contained in the last commit.

#### Related Issue

N/A

#### Motivation and Context

When a backtest dies with "Operation was canceled" or "Algorithm took longer than 10 minutes on a single time loop", the message alone doesn't tell the user (or an LLM reading the results) what caused it or how to fix it. These analyses surface the common causes — big loops in event handlers, oversized or unfiltered universes, too many securities, large history requests, untimed model training — as concrete recommendations in the results analysis findings.

#### Requires Documentation Change

N/A

#### How Has This Been Tested?

- New `RuntimeErrorAnalysesTests` unit tests covering: each error message shape being flagged by exactly its own analysis and ignored by the other two, detection from the state and from the logs fallback, no false positives on non-runtime-error log lines (e.g. the Isolator's own trace messages) or unrelated runtime errors, clean runs, and Python snake_case formatting of code references in the solutions.
- Full analysis test suite (`*AnalysisTests`, `ResultsAnalyzer*`) passing locally.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
