### PR TITLE
Fix live currency conversion seeding after warm-up clock rewind

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -756,13 +756,24 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(HistoricalData)]
         public DataDictionary<IEnumerable<BaseData>> GetLastKnownPrices(IEnumerable<Symbol> symbols)
         {
+            return GetLastKnownPrices(symbols, UtcTime);
+        }
+
+        /// <summary>
+        /// Yields data to warm up multiple securities for all their subscribed data types using the specified reference time
+        /// </summary>
+        /// <param name="symbols">The symbols we want to get seed data for</param>
+        /// <param name="referenceUtcTime">The UTC time to use as the reference for the history requests</param>
+        /// <returns>Securities historical data</returns>
+        public DataDictionary<IEnumerable<BaseData>> GetLastKnownPrices(IEnumerable<Symbol> symbols, DateTime referenceUtcTime)
+        {
             if (HistoryProvider == null)
             {
                 return new DataDictionary<IEnumerable<BaseData>>();
             }
 
             var data = new Dictionary<(Symbol, Type, TickType), BaseData>();
-            GetLastKnownPricesImpl(symbols, data);
+            GetLastKnownPricesImpl(symbols, data, referenceUtcTime);
 
             return data
                 .GroupBy(kvp => kvp.Key.Item1)
@@ -808,7 +819,7 @@ namespace QuantConnect.Algorithm
         }
 
         private void GetLastKnownPricesImpl(IEnumerable<Symbol> symbols, Dictionary<(Symbol, Type, TickType), BaseData> result,
-            int attempts = 0, IEnumerable<HistoryRequest> failedRequests = null)
+            DateTime referenceUtcTime, int attempts = 0, IEnumerable<HistoryRequest> failedRequests = null)
         {
             IEnumerable<HistoryRequest> historyRequests;
             var isRetry = failedRequests != null;
@@ -818,14 +829,14 @@ namespace QuantConnect.Algorithm
             if (attempts == 0)
             {
                 historyRequests = CreateBarCountHistoryRequests(symbols, SeedLookbackPeriod,
-                    fillForward: false, useAllSubscriptions: true)
+                    fillForward: false, useAllSubscriptions: true, referenceUtcTime: referenceUtcTime)
                     .SelectMany(request =>
                     {
                         // Make open interest request daily, higher resolutions will need greater periods to return data
                         if (request.DataType == typeof(OpenInterest) && request.Resolution < Resolution.Daily)
                         {
                             return CreateBarCountHistoryRequests([request.Symbol], typeof(OpenInterest), SeedLookbackPeriod,
-                                Resolution.Daily, fillForward: false, useAllSubscriptions: true);
+                                Resolution.Daily, fillForward: false, useAllSubscriptions: true, referenceUtcTime: referenceUtcTime);
                         }
 
                         if (request.Resolution < Resolution.Minute)
@@ -837,7 +848,7 @@ namespace QuantConnect.Algorithm
                             }
 
                             return CreateBarCountHistoryRequests([request.Symbol], dataType, SeedLookbackPeriod,
-                                Resolution.Minute, fillForward: false, useAllSubscriptions: true);
+                                Resolution.Minute, fillForward: false, useAllSubscriptions: true, referenceUtcTime: referenceUtcTime);
                         }
 
                         return [request];
@@ -856,7 +867,8 @@ namespace QuantConnect.Algorithm
                         var periods = resolution == Resolution.Daily
                             ? SeedRetryDailyLookbackPeriod
                             : resolution == Resolution.Hour ? SeedRetryHourLookbackPeriod : SeedRetryMinuteLookbackPeriod;
-                        return CreateBarCountHistoryRequests([group.Key], periods, resolution, fillForward: false, useAllSubscriptions: true)
+                        return CreateBarCountHistoryRequests([group.Key], periods, resolution, fillForward: false, useAllSubscriptions: true,
+                            referenceUtcTime: referenceUtcTime)
                             .Where(request => symbolRequests.Any(x => x.DataType == request.DataType));
                     })
                     .SelectMany(x => x);
@@ -865,7 +877,8 @@ namespace QuantConnect.Algorithm
             {
                 // Fall back to bigger daily requests as a last resort
                 historyRequests = CreateBarCountHistoryRequests(failedRequests.Select(x => x.Symbol).Distinct(),
-                    Math.Min(60, 5 * SeedRetryDailyLookbackPeriod), Resolution.Daily, fillForward: false, useAllSubscriptions: true);
+                    Math.Min(60, 5 * SeedRetryDailyLookbackPeriod), Resolution.Daily, fillForward: false, useAllSubscriptions: true,
+                    referenceUtcTime: referenceUtcTime);
             }
 
             var requests = historyRequests.ToArray();
@@ -874,7 +887,7 @@ namespace QuantConnect.Algorithm
                 return;
             }
 
-            foreach (var slice in History(requests))
+            foreach (var slice in History(requests, TimeZone, referenceUtcTime))
             {
                 for (var i = 0; i < requests.Length; i++)
                 {
@@ -924,7 +937,7 @@ namespace QuantConnect.Algorithm
             if (attempts < 2)
             {
                 // Give it another try to get data for all symbols and all data types
-                GetLastKnownPricesImpl(null, result, attempts + 1,
+                GetLastKnownPricesImpl(null, result, referenceUtcTime, attempts + 1,
                     requests.Where((request, i) => !result.ContainsKey((request.Symbol, request.DataType, request.TickType))));
             }
         }
@@ -1016,10 +1029,10 @@ namespace QuantConnect.Algorithm
             return result.Memoize();
         }
 
-        private IEnumerable<Slice> History(IEnumerable<HistoryRequest> requests, DateTimeZone timeZone)
+        private IEnumerable<Slice> History(IEnumerable<HistoryRequest> requests, DateTimeZone timeZone, DateTime? referenceUtcTime = null)
         {
             // filter out any universe securities that may have made it this far
-            var filteredRequests = GetFilterestRequests(requests);
+            var filteredRequests = GetFilterestRequests(requests, referenceUtcTime);
 
             // filter out future data to prevent look ahead bias
             var history = HistoryProvider.GetHistory(filteredRequests, timeZone);
@@ -1035,15 +1048,16 @@ namespace QuantConnect.Algorithm
             return history;
         }
 
-        private IEnumerable<HistoryRequest> GetFilterestRequests(IEnumerable<HistoryRequest> requests)
+        private IEnumerable<HistoryRequest> GetFilterestRequests(IEnumerable<HistoryRequest> requests, DateTime? referenceUtcTime = null)
         {
             var sentMessage = false;
+            var maximumEndTimeUtc = referenceUtcTime ?? UtcTime;
             foreach (var request in requests.Where(hr => HistoryRequestValid(hr.Symbol)))
             {
                 // prevent future requests
-                if (request.EndTimeUtc > UtcTime)
+                if (request.EndTimeUtc > maximumEndTimeUtc)
                 {
-                    var endTimeUtc = UtcTime;
+                    var endTimeUtc = maximumEndTimeUtc;
                     var startTimeUtc = request.StartTimeUtc;
                     if (request.StartTimeUtc > request.EndTimeUtc)
                     {
@@ -1118,7 +1132,8 @@ namespace QuantConnect.Algorithm
         /// </summary>
         private IEnumerable<HistoryRequest> CreateBarCountHistoryRequests(IEnumerable<Symbol> symbols, int periods, Resolution? resolution = null,
             bool? fillForward = null, bool? extendedMarketHours = null, DataMappingMode? dataMappingMode = null,
-            DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null, bool useAllSubscriptions = false)
+            DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null, bool useAllSubscriptions = false,
+            DateTime? referenceUtcTime = null)
         {
             // Materialize the symbols to avoid multiple enumeration
             var symbolsArray = symbols.ToArray();
@@ -1132,7 +1147,8 @@ namespace QuantConnect.Algorithm
                 dataMappingMode,
                 dataNormalizationMode,
                 contractDepthOffset,
-                useAllSubscriptions);
+                useAllSubscriptions,
+                referenceUtcTime);
         }
 
         /// <summary>
@@ -1140,7 +1156,8 @@ namespace QuantConnect.Algorithm
         /// </summary>
         private IEnumerable<HistoryRequest> CreateBarCountHistoryRequests(IEnumerable<Symbol> symbols, Type requestedType, int periods,
             Resolution? resolution = null, bool? fillForward = null, bool? extendedMarketHours = null, DataMappingMode? dataMappingMode = null,
-            DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null, bool useAllSubscriptions = false)
+            DataNormalizationMode? dataNormalizationMode = null, int? contractDepthOffset = null, bool useAllSubscriptions = false,
+            DateTime? referenceUtcTime = null)
         {
             return symbols.Where(HistoryRequestValid).SelectMany(symbol =>
             {
@@ -1157,9 +1174,12 @@ namespace QuantConnect.Algorithm
                     var type = requestedType ?? config.Type;
                     var res = resolution ?? config.Resolution;
                     var exchange = GetExchangeHours(symbol, type);
-                    var start = _historyRequestFactory.GetStartTimeAlgoTz(symbol, periods, res, exchange, config.DataTimeZone,
-                        config.Type, extendedMarketHours);
-                    var end = Time;
+                    var start = referenceUtcTime.HasValue
+                        ? _historyRequestFactory.GetStartTimeAlgoTz(referenceUtcTime.Value, symbol, periods, res, exchange,
+                            config.DataTimeZone, config.Type, extendedMarketHours)
+                        : _historyRequestFactory.GetStartTimeAlgoTz(symbol, periods, res, exchange, config.DataTimeZone,
+                            config.Type, extendedMarketHours);
+                    var end = referenceUtcTime?.ConvertFromUtc(TimeZone) ?? Time;
 
                     return _historyRequestFactory.CreateHistoryRequest(config, start, end, exchange, res, fillForward,
                         extendedMarketHours, dataMappingMode, dataNormalizationMode, contractDepthOffset);

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -1107,6 +1107,14 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         public DataDictionary<IEnumerable<BaseData>> GetLastKnownPrices(IEnumerable<Symbol> symbols) => _baseAlgorithm.GetLastKnownPrices(symbols);
 
         /// <summary>
+        /// Yields data to warm up multiple securities for all their subscribed data types using the specified reference time
+        /// </summary>
+        /// <param name="symbols">The symbols we want to get seed data for</param>
+        /// <param name="referenceUtcTime">The UTC time to use as the reference for the history requests</param>
+        /// <returns>Securities historical data</returns>
+        public DataDictionary<IEnumerable<BaseData>> GetLastKnownPrices(IEnumerable<Symbol> symbols, DateTime referenceUtcTime) => _baseAlgorithm.GetLastKnownPrices(symbols, referenceUtcTime);
+
+        /// <summary>
         /// Set the runtime error
         /// </summary>
         /// <param name="exception">Represents error that occur during execution</param>

--- a/Common/AlgorithmUtils.cs
+++ b/Common/AlgorithmUtils.cs
@@ -33,8 +33,27 @@ namespace QuantConnect
         /// <param name="algorithm">The algorithm instance</param>
         public static void SeedSecurities(IReadOnlyCollection<Security> securities, IAlgorithm algorithm)
         {
+            SeedSecurities(securities, algorithm, null);
+        }
+
+        /// <summary>
+        /// Seeds the provided securities with their last known prices from the algorithm using the specified reference time
+        /// </summary>
+        /// <param name="securities">The securities to seed</param>
+        /// <param name="algorithm">The algorithm instance</param>
+        /// <param name="referenceUtcTime">The UTC time to use as the reference for the history requests</param>
+        public static void SeedSecurities(IReadOnlyCollection<Security> securities, IAlgorithm algorithm, DateTime referenceUtcTime)
+        {
+            SeedSecurities(securities, algorithm, (DateTime?)referenceUtcTime);
+        }
+
+        private static void SeedSecurities(IReadOnlyCollection<Security> securities, IAlgorithm algorithm, DateTime? referenceUtcTime)
+        {
             var securitiesToSeed = securities.Where(x => x.Price == 0);
-            var data = algorithm.GetLastKnownPrices(securitiesToSeed.Select(x => x.Symbol));
+            var symbols = securitiesToSeed.Select(x => x.Symbol);
+            var data = referenceUtcTime.HasValue
+                ? algorithm.GetLastKnownPrices(symbols, referenceUtcTime.Value)
+                : algorithm.GetLastKnownPrices(symbols);
 
             foreach (var security in securitiesToSeed)
             {
@@ -59,6 +78,27 @@ namespace QuantConnect
         /// </param>
         public static void SeedCurrencyConversionRates(IAlgorithm algorithm, IReadOnlyCollection<string> currenciesToUpdateWhiteList = null)
         {
+            SeedCurrencyConversionRates(algorithm, null, currenciesToUpdateWhiteList);
+        }
+
+        /// <summary>
+        /// Seeds an initial conversion rate for the cashbook currencies that don't have one yet using the specified reference time
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
+        /// <param name="referenceUtcTime">The UTC time to use as the reference for the history requests</param>
+        /// <param name="currenciesToUpdateWhiteList">
+        /// If passed, only the currencies in the CashBook contained in this list will be updated.
+        /// By default, if not passed (null), all currencies in the cashbook without a properly set up currency conversion will be updated.
+        /// </param>
+        public static void SeedCurrencyConversionRates(IAlgorithm algorithm, DateTime referenceUtcTime,
+            IReadOnlyCollection<string> currenciesToUpdateWhiteList = null)
+        {
+            SeedCurrencyConversionRates(algorithm, (DateTime?)referenceUtcTime, currenciesToUpdateWhiteList);
+        }
+
+        private static void SeedCurrencyConversionRates(IAlgorithm algorithm, DateTime? referenceUtcTime,
+            IReadOnlyCollection<string> currenciesToUpdateWhiteList = null)
+        {
             Func<Cash, bool> cashToUpdateFilter = currenciesToUpdateWhiteList == null
                 ? (x) => x.CurrencyConversion != null && x.ConversionRate == 0
                 : (x) => currenciesToUpdateWhiteList.Contains(x.Symbol);
@@ -74,7 +114,7 @@ namespace QuantConnect
                 .Distinct()
                 .ToList();
 
-            SeedSecurities(securitiesToUpdate, algorithm);
+            SeedSecurities(securitiesToUpdate, algorithm, referenceUtcTime);
 
             foreach (var cash in cashToUpdate)
             {

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -859,6 +859,17 @@ namespace QuantConnect.Interfaces
         DataDictionary<IEnumerable<BaseData>> GetLastKnownPrices(IEnumerable<Symbol> symbols);
 
         /// <summary>
+        /// Yields data to warm up multiple securities for all their subscribed data types using the specified reference time
+        /// </summary>
+        /// <param name="symbols">The symbols we want to get seed data for</param>
+        /// <param name="referenceUtcTime">The UTC time to use as the reference for the history requests</param>
+        /// <returns>Securities historical data</returns>
+        DataDictionary<IEnumerable<BaseData>> GetLastKnownPrices(IEnumerable<Symbol> symbols, DateTime referenceUtcTime)
+        {
+            return GetLastKnownPrices(symbols);
+        }
+
+        /// <summary>
         /// Set the runtime error
         /// </summary>
         /// <param name="exception">Represents error that occur during execution</param>

--- a/Engine/Setup/BaseSetupHandler.cs
+++ b/Engine/Setup/BaseSetupHandler.cs
@@ -83,6 +83,35 @@ namespace QuantConnect.Lean.Engine.Setup
             UniverseSelection universeSelection,
             IReadOnlyCollection<string> currenciesToUpdateWhiteList = null)
         {
+            SetupCurrencyConversions(algorithm, universeSelection, null, currenciesToUpdateWhiteList);
+        }
+
+        /// <summary>
+        /// Will first check and add all the required conversion rate securities
+        /// and later will seed an initial value to them using the specified reference time.
+        /// </summary>
+        /// <param name="algorithm">The algorithm instance</param>
+        /// <param name="universeSelection">The universe selection instance</param>
+        /// <param name="referenceUtcTime">The UTC time to use as the reference for the history requests</param>
+        /// <param name="currenciesToUpdateWhiteList">
+        /// If passed, the currencies in the CashBook that are contained in this list will be updated.
+        /// By default, if not passed (null), all currencies in the cashbook without a properly set up currency conversion will be updated.
+        /// </param>
+        public static void SetupCurrencyConversions(
+            IAlgorithm algorithm,
+            UniverseSelection universeSelection,
+            DateTime referenceUtcTime,
+            IReadOnlyCollection<string> currenciesToUpdateWhiteList = null)
+        {
+            SetupCurrencyConversions(algorithm, universeSelection, (DateTime?)referenceUtcTime, currenciesToUpdateWhiteList);
+        }
+
+        private static void SetupCurrencyConversions(
+            IAlgorithm algorithm,
+            UniverseSelection universeSelection,
+            DateTime? referenceUtcTime,
+            IReadOnlyCollection<string> currenciesToUpdateWhiteList = null)
+        {
             // this is needed to have non-zero currency conversion rates during warmup
             // will also set the Cash.ConversionRateSecurity.
             // We don't let it seed the conversion rates here because we do that right below,
@@ -90,7 +119,14 @@ namespace QuantConnect.Lean.Engine.Setup
             universeSelection.EnsureCurrencyDataFeeds(SecurityChanges.None, seedNewCurrencies: false);
 
             // now set conversion rates
-            AlgorithmUtils.SeedCurrencyConversionRates(algorithm, currenciesToUpdateWhiteList);
+            if (referenceUtcTime.HasValue)
+            {
+                AlgorithmUtils.SeedCurrencyConversionRates(algorithm, referenceUtcTime.Value, currenciesToUpdateWhiteList);
+            }
+            else
+            {
+                AlgorithmUtils.SeedCurrencyConversionRates(algorithm, currenciesToUpdateWhiteList);
+            }
 
             Log.Trace($"BaseSetupHandler.SetupCurrencyConversions():{Environment.NewLine}" +
                 $"Account Type: {algorithm.BrokerageModel.AccountType}{Environment.NewLine}{Environment.NewLine}{algorithm.Portfolio.CashBook}");

--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -324,9 +324,10 @@ namespace QuantConnect.Lean.Engine.Setup
                 dataAggregator?.Initialize(new() { AlgorithmSettings = algorithm.Settings });
 
                 //Finalize Initialization
+                var deploymentTimeUtc = algorithm.UtcTime;
                 algorithm.PostInitialize();
 
-                BaseSetupHandler.SetupCurrencyConversions(algorithm, parameters.UniverseSelection);
+                BaseSetupHandler.SetupCurrencyConversions(algorithm, parameters.UniverseSelection, deploymentTimeUtc);
 
                 if (algorithm.Portfolio.TotalPortfolioValue == 0)
                 {

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -540,6 +540,46 @@ namespace QuantConnect.Tests.Engine.Setup
             Assert.Greater(algorithm.UtcTime, time);
         }
 
+        [Test]
+        public void CurrencyConversionSeedingUsesDeploymentTimeAfterWarmupClockIsRewound()
+        {
+            var algorithm = new WarmupTestAlgorithm();
+            var historyProvider = new RecordingHistoryProvider();
+            algorithm.SetHistoryProvider(historyProvider);
+
+            var job = GetJob();
+            var resultHandler = new Mock<IResultHandler>();
+            var transactionHandler = new Mock<ITransactionHandler>();
+            var realTimeHandler = new Mock<IRealTimeHandler>();
+            var brokerage = new Mock<IBrokerage>();
+
+            brokerage.Setup(x => x.IsConnected).Returns(true);
+            brokerage.Setup(x => x.AccountBaseCurrency).Returns(Currencies.USD);
+            brokerage.Setup(x => x.GetCashBalance()).Returns(new List<CashAmount>
+            {
+                new CashAmount(100, Currencies.EUR)
+            });
+            brokerage.Setup(x => x.GetAccountHoldings()).Returns(new List<Holding>());
+            brokerage.Setup(x => x.GetOpenOrders()).Returns(new List<Order>());
+
+            using var setupHandler = new BrokerageSetupHandler();
+            setupHandler.CreateBrokerage(job, algorithm, out var factory);
+            factory.Dispose();
+
+            Assert.IsTrue(setupHandler.Setup(new SetupHandlerParameters(algorithm.DataManager.UniverseSelection, algorithm, brokerage.Object, job,
+                resultHandler.Object, transactionHandler.Object, realTimeHandler.Object, TestGlobals.DataCacheProvider, TestGlobals.MapFileProvider)));
+
+            Assert.AreEqual(algorithm.DeploymentUtcTime - TimeSpan.FromDays(30), algorithm.WarmupStartUtcTime);
+            Assert.AreEqual(algorithm.WarmupStartUtcTime, algorithm.UtcTime);
+
+            var fxRequest = historyProvider.Requests.Single(request => request.Symbol.Value == "EURUSD");
+            Assert.AreEqual(algorithm.DeploymentUtcTime, fxRequest.EndTimeUtc,
+                $"Expected FX seeding request to end at deployment time {algorithm.DeploymentUtcTime:O}, but it ended at {fxRequest.EndTimeUtc:O}.");
+            Assert.AreNotEqual(algorithm.WarmupStartUtcTime, fxRequest.EndTimeUtc);
+            Assert.AreEqual(1.25m, algorithm.Portfolio.CashBook[Currencies.EUR].ConversionRate);
+            Assert.AreEqual(125m, setupHandler.StartingPortfolioValue);
+        }
+
         [TestCase(true, true)]
         [TestCase(true, false)]
         [TestCase(false, true)]
@@ -855,6 +895,24 @@ namespace QuantConnect.Tests.Engine.Setup
             }
         }
 
+        private class WarmupTestAlgorithm : TestAlgorithm
+        {
+            public DateTime DeploymentUtcTime { get; private set; }
+            public DateTime WarmupStartUtcTime { get; private set; }
+
+            public override void Initialize()
+            {
+                SetWarmup(TimeSpan.FromDays(30));
+            }
+
+            public override void PostInitialize()
+            {
+                DeploymentUtcTime = UtcTime;
+                base.PostInitialize();
+                WarmupStartUtcTime = UtcTime;
+            }
+        }
+
         internal static LiveNodePacket GetJob()
         {
             var job = new LiveNodePacket
@@ -913,6 +971,32 @@ namespace QuantConnect.Tests.Engine.Setup
                 var request = requestsList[0];
                 return new List<Slice>{ new Slice(DateTime.UtcNow,
                     new List<BaseData> {new QuoteBar(DateTime.MinValue, request.Symbol, new Bar(1, 2, 3, 4), 5, new Bar(1, 2, 3, 4), 5) }, DateTime.UtcNow)};
+            }
+        }
+
+        private class RecordingHistoryProvider : HistoryProviderBase
+        {
+            public List<Data.HistoryRequest> Requests { get; } = new List<Data.HistoryRequest>();
+
+            public override int DataPointCount { get; }
+
+            public override void Initialize(HistoryProviderInitializeParameters parameters)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override IEnumerable<Slice> GetHistory(IEnumerable<Data.HistoryRequest> requests, DateTimeZone sliceTimeZone)
+            {
+                var requestsList = requests.ToList();
+                Requests.AddRange(requestsList);
+
+                return requestsList.Select(request => new Slice(request.EndTimeUtc,
+                    new List<BaseData>
+                    {
+                        new QuoteBar(request.EndTimeUtc, request.Symbol,
+                            new Bar(1.25m, 1.25m, 1.25m, 1.25m), 0,
+                            new Bar(1.25m, 1.25m, 1.25m, 1.25m), 0)
+                    }, request.EndTimeUtc));
             }
         }
     }


### PR DESCRIPTION
#### Description

Fixes live currency conversion seeding when `PostInitialize()` rewinds the algorithm clock to the warm-up start time.

The change captures the deployment UTC time immediately before `PostInitialize()` and propagates that explicit reference through the initial live currency conversion seeding pipeline:

* `BrokerageSetupHandler`
* `BaseSetupHandler.SetupCurrencyConversions`
* `AlgorithmUtils.SeedCurrencyConversionRates`
* `AlgorithmUtils.SeedSecurities`
* `IAlgorithm.GetLastKnownPrices`

A backward-compatible `IAlgorithm.GetLastKnownPrices` overload accepts the explicit reference time. `QCAlgorithm` uses it for history request start and end times, retries, and endpoint filtering. The existing overload continues to use the algorithm clock, preserving normal history and backtesting behavior.

`AlgorithmPythonWrapper` explicitly forwards the reference time to its underlying `QCAlgorithm`.

A regression test covers the warm-up clock rewind, FX request endpoint, seeded conversion rate, and `StartingPortfolioValue`.

#### Related Issue

Fixes #9647

#### Motivation and Context

During live setup, `PostInitialize()` can rewind `algorithm.UtcTime` to the beginning of the configured warm-up period before currency conversion rates are seeded.

The previous flow therefore requested an FX quote at the warm-up start instead of deployment time. This could value foreign-currency balances using a stale rate and permanently distort `TotalPortfolioValue`, `StartingPortfolioValue`, net return, equity-curve statistics, and drawdown calculations.

The explicit deployment timestamp is limited to the initial live currency conversion seeding path. Normal history requests and backtesting continue to use the algorithm clock.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Successfully built:

```text
dotnet build QuantConnect.Lean.sln -c Release --no-restore /p:RunAnalyzers=false
dotnet build Tests\QuantConnect.Tests.csproj -c Release --no-restore /p:RunAnalyzers=false
```

Both builds completed with zero errors.

The targeted regression test was discovered and entered its test body locally, but `BrokerageSetupHandler.Setup()` returned `false` before the timestamp and portfolio-value assertions were reached.

The local LEAN environment does not contain the complete map-file/data prerequisites required by the setup pipeline, including `Data/equity/sgx/map_files`. No fabricated data, placeholder map files, global test-initialization changes, or test bypasses were introduced.

The regression test therefore compiles but could not be completed locally. The full execution is left to CI or an environment with the complete LEAN test data.

#### Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Refactor (non-breaking change which improves implementation)
* [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

* [x] My code follows the code style of this project.
* [x] I have read the **CONTRIBUTING** document.
* [x] I have added tests to cover my changes.
* [ ] All new and existing tests passed. The solution and test project build successfully, but the targeted test could not complete locally because the required LEAN map-file/data assets are unavailable.
* [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
