### PR TITLE
Re-capture starting portfolio value after warm-up and fire OnWarmupFinished before post-warm-up data

### DIFF
--- a/Algorithm.CSharp/OnWarmupFinishedOrderingRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OnWarmupFinishedOrderingRegressionAlgorithm.cs
@@ -1,0 +1,147 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting <see cref="OnWarmupFinished"/> is called before any data with
+    /// <see cref="QCAlgorithm.IsWarmingUp"/> already false is sent to <see cref="OnData(Slice)"/>.
+    /// The warm-up period ends at midnight in the middle of the forex trading week, so there is data
+    /// ending exactly at the warm-up boundary
+    /// </summary>
+    public class OnWarmupFinishedOrderingRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private int _warmupOnDataCalls;
+        private bool _warmupFinishedCalled;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2014, 5, 7);
+            SetEndDate(2014, 5, 7);
+            SetCash(100000);
+
+            AddForex("EURUSD", Resolution.Minute, Market.Oanda);
+            SetWarmUp(TimeSpan.FromDays(1));
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
+        {
+            if (IsWarmingUp)
+            {
+                _warmupOnDataCalls++;
+            }
+            else if (!_warmupFinishedCalled)
+            {
+                throw new RegressionTestException(
+                    $"OnData was called with {nameof(IsWarmingUp)} false at {Time:yyyy-MM-dd HH:mm:ss} before {nameof(OnWarmupFinished)}!");
+            }
+        }
+
+        public override void OnWarmupFinished()
+        {
+            _warmupFinishedCalled = true;
+
+            if (Time != StartDate)
+            {
+                throw new RegressionTestException(
+                    $"Expected {nameof(OnWarmupFinished)} to fire at StartDate ({StartDate:yyyy-MM-dd HH:mm:ss}), but fired at {Time:yyyy-MM-dd HH:mm:ss}");
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_warmupFinishedCalled)
+            {
+                throw new RegressionTestException($"{nameof(OnWarmupFinished)} was never called!");
+            }
+            if (_warmupOnDataCalls == 0)
+            {
+                throw new RegressionTestException("Expected some warm-up data!");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 2893;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 5;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000.00"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"Drawdown Recovery", "0"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.CSharp/WarmupStartingPortfolioValueRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/WarmupStartingPortfolioValueRegressionAlgorithm.cs
@@ -1,0 +1,128 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm reproducing GH issue #9647: the algorithm holds cash in a currency other than
+    /// the account currency and warms up, so the currency conversion rates are seeded at the warm-up start
+    /// and drift during the warm-up replay. The starting portfolio value must be captured once warm-up
+    /// brings the conversion rates up to date, which the "Start Equity" expected statistic asserts:
+    /// it must match the portfolio value at the warm-up end (EURUSD ~1.20 at the start date) instead of
+    /// the stale snapshot valued with the warm-up start rate (EURUSD ~1.05 a year earlier), and the
+    /// algorithm must not report any net profit from the rate drift during warm-up since it never trades
+    /// </summary>
+    public class WarmupStartingPortfolioValueRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private bool _warmupFinishedCalled;
+
+        /// <summary>
+        /// Initialise the data and resolution required, as well as the cash and start-end dates for your algorithm. All algorithms must initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            SetStartDate(2018, 1, 1);
+            SetEndDate(2018, 1, 8);
+            SetCash(100000);
+            SetCash("EUR", 100000);
+
+            AddForex("EURUSD", Resolution.Daily, Market.Oanda);
+            SetBenchmark(time => 0m);
+            SetWarmUp(TimeSpan.FromDays(365));
+        }
+
+        public override void OnWarmupFinished()
+        {
+            _warmupFinishedCalled = true;
+
+            if (Portfolio.CashBook["EUR"].ConversionRate == 0)
+            {
+                throw new RegressionTestException("EUR conversion rate was not set once warm-up finished");
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (!_warmupFinishedCalled)
+            {
+                throw new RegressionTestException($"{nameof(OnWarmupFinished)} was never called!");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 321;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 5;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "-13.102%"},
+            {"Drawdown", "0.600%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "220025.00"},
+            {"End Equity", "219282"},
+            {"Net Profit", "-0.338%"},
+            {"Sharpe Ratio", "-3.477"},
+            {"Sortino Ratio", "-12.68"},
+            {"Probabilistic Sharpe Ratio", "22.877%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0.035"},
+            {"Annual Variance", "0.001"},
+            {"Information Ratio", "-2.9"},
+            {"Tracking Error", "0.035"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"Drawdown Recovery", "1"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -243,6 +243,8 @@ namespace QuantConnect.Lean.Engine
                 // the time pulse are just to advance algorithm time, lets shortcut the loop here
                 if (timeSlice.IsTimePulse)
                 {
+                    // a time pulse might have been emitted just to align the algorithm time with the end of
+                    // the warm-up period, in which case OnWarmupFinished must fire here, at that aligned time
                     CheckWarmupFinished();
                     continue;
                 }
@@ -309,6 +311,8 @@ namespace QuantConnect.Lean.Engine
                 // security prices got updated
                 algorithm.Portfolio.InvalidateTotalPortfolioValue();
 
+                // if this time slice ended the warm-up period, notify now: after the data updates above,
+                // so OnWarmupFinished sees current prices, and before any user code runs post warm-up
                 CheckWarmupFinished();
 
                 if (timeSlice.Slice.SymbolChangedEvents.Count != 0)

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -168,6 +168,23 @@ namespace QuantConnect.Lean.Engine
 
             //Loop over the queues: get a data collection, then pass them all into relevent methods in the algorithm.
             Log.Trace($"AlgorithmManager.Run(): Begin DataStream - Start: {algorithm.StartDate} Stop: {algorithm.EndDate} Time: {algorithm.Time} Warmup: {algorithm.IsWarmingUp}");
+            var wasWarmingUp = algorithm.IsWarmingUp;
+            void CheckWarmupFinished()
+            {
+                if (wasWarmingUp && !algorithm.IsWarmingUp)
+                {
+                    // warmup finished: notify the result handler first so it can re-capture the starting
+                    // portfolio value before any user code gets a chance to trade
+                    wasWarmingUp = false;
+                    results.OnWarmupFinished();
+                    // we trigger this callback here and not internally in the algorithm so that we can go through python if required
+                    algorithm.OnWarmupFinished();
+                    algorithm.Debug("Algorithm finished warming up.");
+                    Log.Trace($"AlgorithmManager.Run(): Subscriptions count after warm up: {algorithm.SubscriptionManager.Count}");
+                    results.SendStatusUpdate(AlgorithmStatus.Running, "100");
+                }
+            }
+
             foreach (var timeSlice in Stream(algorithm, synchronizer, results, token))
             {
                 // reset our timer on each loop
@@ -226,6 +243,7 @@ namespace QuantConnect.Lean.Engine
                 // the time pulse are just to advance algorithm time, lets shortcut the loop here
                 if (timeSlice.IsTimePulse)
                 {
+                    CheckWarmupFinished();
                     continue;
                 }
 
@@ -290,6 +308,8 @@ namespace QuantConnect.Lean.Engine
 
                 // security prices got updated
                 algorithm.Portfolio.InvalidateTotalPortfolioValue();
+
+                CheckWarmupFinished();
 
                 if (timeSlice.Slice.SymbolChangedEvents.Count != 0)
                 {
@@ -722,16 +742,6 @@ namespace QuantConnect.Lean.Engine
                         Log.Trace($"AlgorithmManager.Stream(): Subscriptions count before warm up: {algorithm.SubscriptionManager.Count}");
                         logSubscriptionCountFlag = true;
                     }
-                }
-                else if (warmingUp)
-                {
-                    // warmup finished, send an update
-                    warmingUp = false;
-                    // we trigger this callback here and not internally in the algorithm so that we can go through python if required
-                    algorithm.OnWarmupFinished();
-                    algorithm.Debug("Algorithm finished warming up.");
-                    Log.Trace($"AlgorithmManager.Stream(): Subscriptions count after warm up: {algorithm.SubscriptionManager.Count}");
-                    results.SendStatusUpdate(AlgorithmStatus.Running, "100");
                 }
                 yield return timeSlice;
             }

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -60,8 +60,6 @@ namespace QuantConnect.Lean.Engine.Results
 
         private Bar _currentAlgorithmEquity;
 
-        private bool _recaptureStartingPortfolioValue;
-
         private List<ISeriesPoint> _temporaryPerformanceValues;
         private List<ISeriesPoint> _temporaryBenchmarkValues;
         private DateTime _temporaryChartsLastSampleTime;
@@ -527,11 +525,6 @@ namespace QuantConnect.Lean.Engine.Results
             AlgorithmCurrencySymbol = Currencies.GetCurrencySymbol(Algorithm.AccountCurrency);
             CumulativeMaxPortfolioValue = DailyPortfolioValue = StartingPortfolioValue = startingPortfolioValue;
 
-            // If the algorithm will warm up, the given starting portfolio value was captured with currency
-            // conversion rates seeded at the warm-up start, so it will be re-captured once warm-up
-            // brings the conversion rates up to date
-            _recaptureStartingPortfolioValue = algorithm.IsWarmingUp;
-
             _unrealizedProfit = new ReferenceWrapper<decimal>(0);
             _benchmarkValue = new ReferenceWrapper<decimal>(0);
             _portfolioValue = new ReferenceWrapper<decimal>(startingPortfolioValue);
@@ -663,45 +656,38 @@ namespace QuantConnect.Lean.Engine.Results
 
         /// <summary>
         /// Event fired when the algorithm's warm-up period finishes, right before the algorithm's
-        /// <see cref="IAlgorithm.OnWarmupFinished"/> callback is triggered
+        /// <see cref="IAlgorithm.OnWarmupFinished"/> callback is triggered.
+        /// Re-captures the starting portfolio value and dependent baselines, since the value captured
+        /// at setup time used currency conversion rates seeded at the warm-up start
         /// </summary>
         public virtual void OnWarmupFinished()
         {
-            RecaptureStartingPortfolioValueIfWarmupFinished(Algorithm.UtcTime);
-        }
-
-        /// <summary>
-        /// Re-captures the starting portfolio value and dependent baselines once warm-up completes,
-        /// since the value captured at setup time used currency conversion rates seeded at the warm-up start
-        /// </summary>
-        /// <param name="time">Current UTC time</param>
-        protected void RecaptureStartingPortfolioValueIfWarmupFinished(DateTime time)
-        {
-            if (_recaptureStartingPortfolioValue && !Algorithm.IsWarmingUp)
+            if (Algorithm.IsWarmingUp)
             {
-                _recaptureStartingPortfolioValue = false;
-                // warm-up has brought the currency conversion rates up to date, so now both holdings prices
-                // and conversion rates are current and we can capture the real starting portfolio value
-                UpdatePortfolioValues(time, force: true);
-                var currentPortfolioValue = GetPortfolioValue();
-                // only reassign values that actually changed, so unchanged ones keep their original decimal
-                // scale and their statistics string representation
-                if (CumulativeMaxPortfolioValue != currentPortfolioValue)
-                {
-                    CumulativeMaxPortfolioValue = currentPortfolioValue;
-                }
-                if (DailyPortfolioValue != currentPortfolioValue)
-                {
-                    DailyPortfolioValue = currentPortfolioValue;
-                }
-                if (StartingPortfolioValue != currentPortfolioValue)
-                {
-                    StartingPortfolioValue = currentPortfolioValue;
-                    // discard any equity bar built during warm-up so the first sample opens at the re-captured value
-                    CurrentAlgorithmEquity = null;
-                    Log.Trace($"{GetType().Name}.RecaptureStartingPortfolioValueIfWarmupFinished(): " +
-                        $"Re-captured starting portfolio value after warm-up: {StartingPortfolioValue.ToStringInvariant()}");
-                }
+                return;
+            }
+
+            // warm-up has brought the currency conversion rates up to date, so now both holdings prices
+            // and conversion rates are current and we can capture the real starting portfolio value
+            UpdatePortfolioValues(Algorithm.UtcTime, force: true);
+            var currentPortfolioValue = GetPortfolioValue();
+            // only reassign values that actually changed, so unchanged ones keep their original decimal
+            // scale and their statistics string representation
+            if (CumulativeMaxPortfolioValue != currentPortfolioValue)
+            {
+                CumulativeMaxPortfolioValue = currentPortfolioValue;
+            }
+            if (DailyPortfolioValue != currentPortfolioValue)
+            {
+                DailyPortfolioValue = currentPortfolioValue;
+            }
+            if (StartingPortfolioValue != currentPortfolioValue)
+            {
+                StartingPortfolioValue = currentPortfolioValue;
+                // discard any equity bar built during warm-up so the first sample opens at the re-captured value
+                CurrentAlgorithmEquity = null;
+                Log.Trace($"{GetType().Name}.OnWarmupFinished(): " +
+                    $"Re-captured starting portfolio value after warm-up: {StartingPortfolioValue.ToStringInvariant()}");
             }
         }
 
@@ -719,11 +705,6 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="time">Current UTC time in the AlgorithmManager loop</param>
         public virtual void Sample(DateTime time)
         {
-            // The daily sample scheduled at the warm-up end can fire from the scheduled events scan, which flips
-            // the warm-up flag before the algorithm manager reaches its warm-up finished notification,
-            // so check for the re-capture here too before using the baselines
-            RecaptureStartingPortfolioValueIfWarmupFinished(time);
-
             // Force an update for our values before doing our daily sample
             UpdatePortfolioValues(time);
             UpdateBenchmarkValue(time);

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -662,11 +662,6 @@ namespace QuantConnect.Lean.Engine.Results
         /// </summary>
         public virtual void OnWarmupFinished()
         {
-            if (Algorithm.IsWarmingUp)
-            {
-                return;
-            }
-
             // warm-up has brought the currency conversion rates up to date, so now both holdings prices
             // and conversion rates are current and we can capture the real starting portfolio value
             UpdatePortfolioValues(Algorithm.UtcTime, force: true);

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -60,6 +60,8 @@ namespace QuantConnect.Lean.Engine.Results
 
         private Bar _currentAlgorithmEquity;
 
+        private bool _recaptureStartingPortfolioValue;
+
         private List<ISeriesPoint> _temporaryPerformanceValues;
         private List<ISeriesPoint> _temporaryBenchmarkValues;
         private DateTime _temporaryChartsLastSampleTime;
@@ -525,6 +527,11 @@ namespace QuantConnect.Lean.Engine.Results
             AlgorithmCurrencySymbol = Currencies.GetCurrencySymbol(Algorithm.AccountCurrency);
             CumulativeMaxPortfolioValue = DailyPortfolioValue = StartingPortfolioValue = startingPortfolioValue;
 
+            // If the algorithm will warm up, the given starting portfolio value was captured with currency
+            // conversion rates seeded at the warm-up start, so it will be re-captured once warm-up
+            // brings the conversion rates up to date
+            _recaptureStartingPortfolioValue = algorithm.IsWarmingUp;
+
             _unrealizedProfit = new ReferenceWrapper<decimal>(0);
             _benchmarkValue = new ReferenceWrapper<decimal>(0);
             _portfolioValue = new ReferenceWrapper<decimal>(startingPortfolioValue);
@@ -655,6 +662,50 @@ namespace QuantConnect.Lean.Engine.Results
         protected decimal GetPortfolioValue() => _portfolioValue.Value;
 
         /// <summary>
+        /// Event fired when the algorithm's warm-up period finishes, right before the algorithm's
+        /// <see cref="IAlgorithm.OnWarmupFinished"/> callback is triggered
+        /// </summary>
+        public virtual void OnWarmupFinished()
+        {
+            RecaptureStartingPortfolioValueIfWarmupFinished(Algorithm.UtcTime);
+        }
+
+        /// <summary>
+        /// Re-captures the starting portfolio value and dependent baselines once warm-up completes,
+        /// since the value captured at setup time used currency conversion rates seeded at the warm-up start
+        /// </summary>
+        /// <param name="time">Current UTC time</param>
+        protected void RecaptureStartingPortfolioValueIfWarmupFinished(DateTime time)
+        {
+            if (_recaptureStartingPortfolioValue && !Algorithm.IsWarmingUp)
+            {
+                _recaptureStartingPortfolioValue = false;
+                // warm-up has brought the currency conversion rates up to date, so now both holdings prices
+                // and conversion rates are current and we can capture the real starting portfolio value
+                UpdatePortfolioValues(time, force: true);
+                var currentPortfolioValue = GetPortfolioValue();
+                // only reassign values that actually changed, so unchanged ones keep their original decimal
+                // scale and their statistics string representation
+                if (CumulativeMaxPortfolioValue != currentPortfolioValue)
+                {
+                    CumulativeMaxPortfolioValue = currentPortfolioValue;
+                }
+                if (DailyPortfolioValue != currentPortfolioValue)
+                {
+                    DailyPortfolioValue = currentPortfolioValue;
+                }
+                if (StartingPortfolioValue != currentPortfolioValue)
+                {
+                    StartingPortfolioValue = currentPortfolioValue;
+                    // discard any equity bar built during warm-up so the first sample opens at the re-captured value
+                    CurrentAlgorithmEquity = null;
+                    Log.Trace($"{GetType().Name}.RecaptureStartingPortfolioValueIfWarmupFinished(): " +
+                        $"Re-captured starting portfolio value after warm-up: {StartingPortfolioValue.ToStringInvariant()}");
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets the current benchmark value
         /// </summary>
         /// <remarks>Useful so that live trading implementation can freeze the returned value if there is no user exchange open
@@ -668,6 +719,11 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="time">Current UTC time in the AlgorithmManager loop</param>
         public virtual void Sample(DateTime time)
         {
+            // The daily sample scheduled at the warm-up end can fire from the scheduled events scan, which flips
+            // the warm-up flag before the algorithm manager reaches its warm-up finished notification,
+            // so check for the re-capture here too before using the baselines
+            RecaptureStartingPortfolioValueIfWarmupFinished(time);
+
             // Force an update for our values before doing our daily sample
             UpdatePortfolioValues(time);
             UpdateBenchmarkValue(time);

--- a/Engine/Results/IResultHandler.cs
+++ b/Engine/Results/IResultHandler.cs
@@ -58,6 +58,12 @@ namespace QuantConnect.Lean.Engine.Results
         void OnSecuritiesChanged(SecurityChanges changes);
 
         /// <summary>
+        /// Event fired when the algorithm's warm-up period finishes, right before the algorithm's
+        /// <see cref="IAlgorithm.OnWarmupFinished"/> callback is triggered
+        /// </summary>
+        void OnWarmupFinished();
+
+        /// <summary>
         /// Initialize the result handler with this result packet.
         /// </summary>
         /// <param name="parameters">DTO parameters class to initialize a result handler</param>

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -79,7 +79,6 @@ namespace QuantConnect.Lean.Engine.Results
 
         private bool _sampleChartAlways;
         private bool _userExchangeIsOpen;
-        private bool _recaptureStartingPortfolioValue;
         private DateTime _lastChartSampleLogicCheck;
         private readonly Dictionary<string, SecurityExchangeHours> _exchangeHours;
 
@@ -778,11 +777,6 @@ namespace QuantConnect.Lean.Engine.Results
             base.SetAlgorithm(algorithm, startingPortfolioValue);
             Algorithm.SetStatisticsService(this);
 
-            // If the algorithm will warm up, the given starting portfolio value was captured with currency
-            // conversion rates seeded at the warm-up start, mixed with deploy-time holdings prices,
-            // so it will be re-captured once warm-up brings the conversion rates up to date
-            _recaptureStartingPortfolioValue = algorithm.IsWarmingUp;
-
             // we need to forward Console.Write messages to the algorithm's Debug function
             var debug = new FuncTextWriter(algorithm.Debug);
             var error = new FuncTextWriter(algorithm.Error);
@@ -1123,19 +1117,6 @@ namespace QuantConnect.Lean.Engine.Results
         public virtual void ProcessSynchronousEvents(bool forceProcess = false)
         {
             var time = DateTime.UtcNow;
-
-            if (_recaptureStartingPortfolioValue && !Algorithm.IsWarmingUp)
-            {
-                _recaptureStartingPortfolioValue = false;
-                // warm-up has brought the currency conversion rates up to date, so now both holdings prices
-                // and conversion rates are current and we can capture the real deploy-time portfolio value
-                UpdatePortfolioValues(time, force: true);
-                CumulativeMaxPortfolioValue = DailyPortfolioValue = StartingPortfolioValue = GetPortfolioValue();
-                // discard any equity bar built during warm-up so the first sample opens at the re-captured value
-                CurrentAlgorithmEquity = null;
-                Log.Trace("LiveTradingResultHandler.ProcessSynchronousEvents(): " +
-                    $"Re-captured starting portfolio value after warm-up: {StartingPortfolioValue.ToStringInvariant()}");
-            }
 
             // Check to see if we should update stored portfolio values
             UpdatePortfolioValues(time, forceProcess);

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -79,6 +79,7 @@ namespace QuantConnect.Lean.Engine.Results
 
         private bool _sampleChartAlways;
         private bool _userExchangeIsOpen;
+        private bool _recaptureStartingPortfolioValue;
         private DateTime _lastChartSampleLogicCheck;
         private readonly Dictionary<string, SecurityExchangeHours> _exchangeHours;
 
@@ -777,6 +778,11 @@ namespace QuantConnect.Lean.Engine.Results
             base.SetAlgorithm(algorithm, startingPortfolioValue);
             Algorithm.SetStatisticsService(this);
 
+            // If the algorithm will warm up, the given starting portfolio value was captured with currency
+            // conversion rates seeded at the warm-up start, mixed with deploy-time holdings prices,
+            // so it will be re-captured once warm-up brings the conversion rates up to date
+            _recaptureStartingPortfolioValue = algorithm.IsWarmingUp;
+
             // we need to forward Console.Write messages to the algorithm's Debug function
             var debug = new FuncTextWriter(algorithm.Debug);
             var error = new FuncTextWriter(algorithm.Error);
@@ -1117,6 +1123,19 @@ namespace QuantConnect.Lean.Engine.Results
         public virtual void ProcessSynchronousEvents(bool forceProcess = false)
         {
             var time = DateTime.UtcNow;
+
+            if (_recaptureStartingPortfolioValue && !Algorithm.IsWarmingUp)
+            {
+                _recaptureStartingPortfolioValue = false;
+                // warm-up has brought the currency conversion rates up to date, so now both holdings prices
+                // and conversion rates are current and we can capture the real deploy-time portfolio value
+                UpdatePortfolioValues(time, force: true);
+                CumulativeMaxPortfolioValue = DailyPortfolioValue = StartingPortfolioValue = GetPortfolioValue();
+                // discard any equity bar built during warm-up so the first sample opens at the re-captured value
+                CurrentAlgorithmEquity = null;
+                Log.Trace("LiveTradingResultHandler.ProcessSynchronousEvents(): " +
+                    $"Re-captured starting portfolio value after warm-up: {StartingPortfolioValue.ToStringInvariant()}");
+            }
 
             // Check to see if we should update stored portfolio values
             UpdatePortfolioValues(time, forceProcess);

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -191,6 +191,10 @@ namespace QuantConnect.Tests.Engine
             {
             }
 
+            public void OnWarmupFinished()
+            {
+            }
+
             public void DebugMessage(string message)
             {
             }

--- a/Tests/Engine/Results/BacktestingResultHandlerTests.cs
+++ b/Tests/Engine/Results/BacktestingResultHandlerTests.cs
@@ -568,10 +568,6 @@ namespace QuantConnect.Tests.Engine.Results
                 resultHandler.SetAlgorithm(algorithm, 90000);
                 Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
 
-                // not re-captured while still warming up
-                resultHandler.OnWarmupFinished();
-                Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
-
                 algorithm.SetFinishedWarmingUp();
                 resultHandler.OnWarmupFinished();
 

--- a/Tests/Engine/Results/BacktestingResultHandlerTests.cs
+++ b/Tests/Engine/Results/BacktestingResultHandlerTests.cs
@@ -18,8 +18,11 @@ using NUnit.Framework;
 using QuantConnect.Algorithm.CSharp;
 using QuantConnect.Configuration;
 using QuantConnect.Lean.Engine.Results;
+using QuantConnect.Lean.Engine.TransactionHandlers;
 using QuantConnect.Logging;
+using QuantConnect.Packets;
 using QuantConnect.Report;
+using QuantConnect.Tests.Engine.DataFeeds;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -545,6 +548,101 @@ namespace QuantConnect.Tests.Engine.Results
 
                 return new KeyValuePair<DateTime, double>(x.Time, value);
             }));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void RecapturesStartingPortfolioValueAfterWarmup(bool warmingUp)
+        {
+            using var api = new Api.Api();
+            using var messaging = new QuantConnect.Messaging.Messaging();
+            var resultHandler = new TestableBacktestingResultHandler();
+            resultHandler.Initialize(new(new BacktestNodePacket(), messaging, api, new BacktestingTransactionHandler(), null));
+
+            try
+            {
+                var algorithm = new AlgorithmStub();
+                algorithm.SetCash(120000);
+                if (!warmingUp)
+                {
+                    algorithm.SetFinishedWarmingUp();
+                }
+
+                // The setup-time snapshot: when the algorithm has a warm-up period, it is captured
+                // with currency conversion rates seeded at the warm-up start
+                resultHandler.SetAlgorithm(algorithm, 90000);
+                Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
+
+                if (warmingUp)
+                {
+                    // not re-captured while still warming up
+                    resultHandler.OnWarmupFinished();
+                    Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
+
+                    algorithm.SetFinishedWarmingUp();
+                    resultHandler.OnWarmupFinished();
+
+                    // re-captured once warm-up finished, when the conversion rates are up to date
+                    Assert.AreEqual(120000, resultHandler.ExposedStartingPortfolioValue);
+                    Assert.AreEqual(120000, resultHandler.ExposedDailyPortfolioValue);
+                    Assert.AreEqual(120000, resultHandler.ExposedCumulativeMaxPortfolioValue);
+
+                    // re-captured only once: it must not move with subsequent portfolio value changes
+                    algorithm.Portfolio.CashBook[Currencies.USD].AddAmount(5000);
+                    algorithm.Portfolio.InvalidateTotalPortfolioValue();
+                    resultHandler.OnWarmupFinished();
+                    Assert.AreEqual(120000, resultHandler.ExposedStartingPortfolioValue);
+                }
+                else
+                {
+                    // without warm-up the setup-time value is already consistent and is kept
+                    resultHandler.OnWarmupFinished();
+                    Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
+                    Assert.AreEqual(90000, resultHandler.ExposedDailyPortfolioValue);
+                    Assert.AreEqual(90000, resultHandler.ExposedCumulativeMaxPortfolioValue);
+                }
+            }
+            finally
+            {
+                resultHandler.Exit();
+            }
+        }
+
+        [Test]
+        public void RecapturesStartingPortfolioValueOnFirstSampleAfterWarmup()
+        {
+            using var api = new Api.Api();
+            using var messaging = new QuantConnect.Messaging.Messaging();
+            var resultHandler = new TestableBacktestingResultHandler();
+            resultHandler.Initialize(new(new BacktestNodePacket(), messaging, api, new BacktestingTransactionHandler(), null));
+
+            try
+            {
+                var algorithm = new AlgorithmStub();
+                algorithm.SetCash(120000);
+                resultHandler.SetAlgorithm(algorithm, 90000);
+                Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
+
+                // The daily sample scheduled at the warm-up end can fire before the algorithm manager
+                // notifies the warm-up finished, so sampling must re-capture before using the baselines
+                algorithm.SetFinishedWarmingUp();
+                resultHandler.Sample(algorithm.UtcTime);
+
+                Assert.AreEqual(120000, resultHandler.ExposedStartingPortfolioValue);
+                Assert.AreEqual(120000, resultHandler.ExposedDailyPortfolioValue);
+                Assert.AreEqual(120000, resultHandler.ExposedCumulativeMaxPortfolioValue);
+            }
+            finally
+            {
+                resultHandler.Exit();
+            }
+        }
+
+        private class TestableBacktestingResultHandler : BacktestingResultHandler
+        {
+            public decimal ExposedStartingPortfolioValue => StartingPortfolioValue;
+            public decimal ExposedDailyPortfolioValue => DailyPortfolioValue;
+            public decimal ExposedCumulativeMaxPortfolioValue => CumulativeMaxPortfolioValue;
         }
     }
 }

--- a/Tests/Engine/Results/BacktestingResultHandlerTests.cs
+++ b/Tests/Engine/Results/BacktestingResultHandlerTests.cs
@@ -550,9 +550,8 @@ namespace QuantConnect.Tests.Engine.Results
             }));
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public void RecapturesStartingPortfolioValueAfterWarmup(bool warmingUp)
+        [Test]
+        public void RecapturesStartingPortfolioValueAfterWarmup()
         {
             using var api = new Api.Api();
             using var messaging = new QuantConnect.Messaging.Messaging();
@@ -563,71 +562,20 @@ namespace QuantConnect.Tests.Engine.Results
             {
                 var algorithm = new AlgorithmStub();
                 algorithm.SetCash(120000);
-                if (!warmingUp)
-                {
-                    algorithm.SetFinishedWarmingUp();
-                }
 
                 // The setup-time snapshot: when the algorithm has a warm-up period, it is captured
                 // with currency conversion rates seeded at the warm-up start
                 resultHandler.SetAlgorithm(algorithm, 90000);
                 Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
 
-                if (warmingUp)
-                {
-                    // not re-captured while still warming up
-                    resultHandler.OnWarmupFinished();
-                    Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
-
-                    algorithm.SetFinishedWarmingUp();
-                    resultHandler.OnWarmupFinished();
-
-                    // re-captured once warm-up finished, when the conversion rates are up to date
-                    Assert.AreEqual(120000, resultHandler.ExposedStartingPortfolioValue);
-                    Assert.AreEqual(120000, resultHandler.ExposedDailyPortfolioValue);
-                    Assert.AreEqual(120000, resultHandler.ExposedCumulativeMaxPortfolioValue);
-
-                    // re-captured only once: it must not move with subsequent portfolio value changes
-                    algorithm.Portfolio.CashBook[Currencies.USD].AddAmount(5000);
-                    algorithm.Portfolio.InvalidateTotalPortfolioValue();
-                    resultHandler.OnWarmupFinished();
-                    Assert.AreEqual(120000, resultHandler.ExposedStartingPortfolioValue);
-                }
-                else
-                {
-                    // without warm-up the setup-time value is already consistent and is kept
-                    resultHandler.OnWarmupFinished();
-                    Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
-                    Assert.AreEqual(90000, resultHandler.ExposedDailyPortfolioValue);
-                    Assert.AreEqual(90000, resultHandler.ExposedCumulativeMaxPortfolioValue);
-                }
-            }
-            finally
-            {
-                resultHandler.Exit();
-            }
-        }
-
-        [Test]
-        public void RecapturesStartingPortfolioValueOnFirstSampleAfterWarmup()
-        {
-            using var api = new Api.Api();
-            using var messaging = new QuantConnect.Messaging.Messaging();
-            var resultHandler = new TestableBacktestingResultHandler();
-            resultHandler.Initialize(new(new BacktestNodePacket(), messaging, api, new BacktestingTransactionHandler(), null));
-
-            try
-            {
-                var algorithm = new AlgorithmStub();
-                algorithm.SetCash(120000);
-                resultHandler.SetAlgorithm(algorithm, 90000);
+                // not re-captured while still warming up
+                resultHandler.OnWarmupFinished();
                 Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
 
-                // The daily sample scheduled at the warm-up end can fire before the algorithm manager
-                // notifies the warm-up finished, so sampling must re-capture before using the baselines
                 algorithm.SetFinishedWarmingUp();
-                resultHandler.Sample(algorithm.UtcTime);
+                resultHandler.OnWarmupFinished();
 
+                // re-captured once warm-up finished, when the conversion rates are up to date
                 Assert.AreEqual(120000, resultHandler.ExposedStartingPortfolioValue);
                 Assert.AreEqual(120000, resultHandler.ExposedDailyPortfolioValue);
                 Assert.AreEqual(120000, resultHandler.ExposedCumulativeMaxPortfolioValue);

--- a/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
+++ b/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
@@ -217,10 +217,6 @@ namespace QuantConnect.Tests.Engine.Results
                 resultHandler.SetAlgorithm(algorithm, 90000);
                 Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
 
-                // not re-captured while still warming up
-                resultHandler.OnWarmupFinished();
-                Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
-
                 algorithm.SetFinishedWarmingUp();
                 resultHandler.OnWarmupFinished();
 

--- a/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
+++ b/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
@@ -199,6 +199,64 @@ namespace QuantConnect.Tests.Engine.Results
             }
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void RecapturesStartingPortfolioValueAfterWarmup(bool warmingUp)
+        {
+            using var api = new Api.Api();
+            using var messaging = new QuantConnect.Messaging.Messaging();
+            var resultHandler = new TestableLiveTradingResultHandler();
+            resultHandler.Initialize(new(new LiveNodePacket(), messaging, api, new BacktestingTransactionHandler(), null));
+
+            try
+            {
+                var algorithm = new AlgorithmStub();
+                algorithm.SetCash(120000);
+                if (!warmingUp)
+                {
+                    algorithm.SetFinishedWarmingUp();
+                }
+
+                // The setup-time snapshot: when the algorithm has a warm-up period, it mixes deploy-time
+                // holdings prices with currency conversion rates seeded at the warm-up start
+                resultHandler.SetAlgorithm(algorithm, 90000);
+                Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
+
+                resultHandler.ProcessSynchronousEvents();
+
+                if (warmingUp)
+                {
+                    // not re-captured while still warming up
+                    Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
+
+                    algorithm.SetFinishedWarmingUp();
+                    resultHandler.ProcessSynchronousEvents();
+
+                    // re-captured once warm-up finished, when the conversion rates are up to date
+                    Assert.AreEqual(120000, resultHandler.ExposedStartingPortfolioValue);
+                    Assert.AreEqual(120000, resultHandler.ExposedDailyPortfolioValue);
+                    Assert.AreEqual(120000, resultHandler.ExposedCumulativeMaxPortfolioValue);
+
+                    // re-captured only once: it must not move with subsequent portfolio value changes
+                    algorithm.Portfolio.CashBook[Currencies.USD].AddAmount(5000);
+                    algorithm.Portfolio.InvalidateTotalPortfolioValue();
+                    resultHandler.ProcessSynchronousEvents();
+                    Assert.AreEqual(120000, resultHandler.ExposedStartingPortfolioValue);
+                }
+                else
+                {
+                    // without warm-up the setup-time value is already consistent and is kept
+                    Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
+                    Assert.AreEqual(90000, resultHandler.ExposedDailyPortfolioValue);
+                    Assert.AreEqual(90000, resultHandler.ExposedCumulativeMaxPortfolioValue);
+                }
+            }
+            finally
+            {
+                resultHandler.Exit();
+            }
+        }
+
         [Test]
         public void MessagesArePrefixedWithAlgorithmTime()
         {
@@ -415,6 +473,12 @@ namespace QuantConnect.Tests.Engine.Results
 
         private class TestableLiveTradingResultHandler : LiveTradingResultHandler
         {
+            public decimal ExposedStartingPortfolioValue => StartingPortfolioValue;
+
+            public decimal ExposedDailyPortfolioValue => DailyPortfolioValue;
+
+            public decimal ExposedCumulativeMaxPortfolioValue => CumulativeMaxPortfolioValue;
+
             public void PublicTrimCharts(DateTime utcNow) => TrimCharts(utcNow);
         }
 

--- a/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
+++ b/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
@@ -199,9 +199,8 @@ namespace QuantConnect.Tests.Engine.Results
             }
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public void RecapturesStartingPortfolioValueAfterWarmup(bool warmingUp)
+        [Test]
+        public void RecapturesStartingPortfolioValueAfterWarmup()
         {
             using var api = new Api.Api();
             using var messaging = new QuantConnect.Messaging.Messaging();
@@ -212,44 +211,23 @@ namespace QuantConnect.Tests.Engine.Results
             {
                 var algorithm = new AlgorithmStub();
                 algorithm.SetCash(120000);
-                if (!warmingUp)
-                {
-                    algorithm.SetFinishedWarmingUp();
-                }
 
                 // The setup-time snapshot: when the algorithm has a warm-up period, it mixes deploy-time
                 // holdings prices with currency conversion rates seeded at the warm-up start
                 resultHandler.SetAlgorithm(algorithm, 90000);
                 Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
 
-                if (warmingUp)
-                {
-                    // not re-captured while still warming up
-                    resultHandler.OnWarmupFinished();
-                    Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
+                // not re-captured while still warming up
+                resultHandler.OnWarmupFinished();
+                Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
 
-                    algorithm.SetFinishedWarmingUp();
-                    resultHandler.OnWarmupFinished();
+                algorithm.SetFinishedWarmingUp();
+                resultHandler.OnWarmupFinished();
 
-                    // re-captured once warm-up finished, when the conversion rates are up to date
-                    Assert.AreEqual(120000, resultHandler.ExposedStartingPortfolioValue);
-                    Assert.AreEqual(120000, resultHandler.ExposedDailyPortfolioValue);
-                    Assert.AreEqual(120000, resultHandler.ExposedCumulativeMaxPortfolioValue);
-
-                    // re-captured only once: it must not move with subsequent portfolio value changes
-                    algorithm.Portfolio.CashBook[Currencies.USD].AddAmount(5000);
-                    algorithm.Portfolio.InvalidateTotalPortfolioValue();
-                    resultHandler.OnWarmupFinished();
-                    Assert.AreEqual(120000, resultHandler.ExposedStartingPortfolioValue);
-                }
-                else
-                {
-                    // without warm-up the setup-time value is already consistent and is kept
-                    resultHandler.OnWarmupFinished();
-                    Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
-                    Assert.AreEqual(90000, resultHandler.ExposedDailyPortfolioValue);
-                    Assert.AreEqual(90000, resultHandler.ExposedCumulativeMaxPortfolioValue);
-                }
+                // re-captured once warm-up finished, when the conversion rates are up to date
+                Assert.AreEqual(120000, resultHandler.ExposedStartingPortfolioValue);
+                Assert.AreEqual(120000, resultHandler.ExposedDailyPortfolioValue);
+                Assert.AreEqual(120000, resultHandler.ExposedCumulativeMaxPortfolioValue);
             }
             finally
             {

--- a/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
+++ b/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
@@ -222,15 +222,14 @@ namespace QuantConnect.Tests.Engine.Results
                 resultHandler.SetAlgorithm(algorithm, 90000);
                 Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
 
-                resultHandler.ProcessSynchronousEvents();
-
                 if (warmingUp)
                 {
                     // not re-captured while still warming up
+                    resultHandler.OnWarmupFinished();
                     Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
 
                     algorithm.SetFinishedWarmingUp();
-                    resultHandler.ProcessSynchronousEvents();
+                    resultHandler.OnWarmupFinished();
 
                     // re-captured once warm-up finished, when the conversion rates are up to date
                     Assert.AreEqual(120000, resultHandler.ExposedStartingPortfolioValue);
@@ -240,12 +239,13 @@ namespace QuantConnect.Tests.Engine.Results
                     // re-captured only once: it must not move with subsequent portfolio value changes
                     algorithm.Portfolio.CashBook[Currencies.USD].AddAmount(5000);
                     algorithm.Portfolio.InvalidateTotalPortfolioValue();
-                    resultHandler.ProcessSynchronousEvents();
+                    resultHandler.OnWarmupFinished();
                     Assert.AreEqual(120000, resultHandler.ExposedStartingPortfolioValue);
                 }
                 else
                 {
                     // without warm-up the setup-time value is already consistent and is kept
+                    resultHandler.OnWarmupFinished();
                     Assert.AreEqual(90000, resultHandler.ExposedStartingPortfolioValue);
                     Assert.AreEqual(90000, resultHandler.ExposedDailyPortfolioValue);
                     Assert.AreEqual(90000, resultHandler.ExposedCumulativeMaxPortfolioValue);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description

Two related warm-up fixes:

**1. Starting portfolio value captured with stale currency conversion rates (#9647).**
In deployments with a warm-up period, `StartingPortfolioValue` is captured at setup time with the cash book conversion rates seeded point-in-time at the warm-up start (in live mode additionally mixed with deploy-time holdings prices). For portfolios holding cash or positions in a currency other than the account currency, the further back warm-up reaches, the staler the FX component of the snapshot — producing a permanent phantom net return, contaminated drawdown statistics and an incorrect initial reported equity. It recurs on every live restart. Backtesting is affected by the same mechanism in a milder form: `BacktestingSetupHandler` captures `Portfolio.Cash` right after the conversion rates are seeded at the warm-up start, so the reported net return absorbs the FX drift that occurs during the warm-up window, before the algorithm can trade.

**2. `OnWarmupFinished` fired after the first non-warm-up data reached `OnData`.**
`AlgorithmManager.Stream` could only detect the warm-up transition when pulling the next time slice — one slice after `IsWarmingUp` flipped inside the engine loop. When data ends exactly at the warm-up boundary (the normal case for intraday subscriptions on markets trading through it), one `OnData` call with `IsWarmingUp` already false executed before `OnWarmupFinished`, and orders placed there (the common "trade as soon as warm-up is done" pattern) could fill before the callback ran.

The fix:

- The warm-up finished transition moves from `AlgorithmManager.Stream` into the `Run` loop, where it is handled in the same time slice that flips `IsWarmingUp`: after the slice's securities and cash book updates — so `OnWarmupFinished` sees the same market data as before — and before any user code runs for that slice. The transition is also checked at the time-pulse shortcut, since the boundary slice can be a dataless pulse; this keeps `OnWarmupFinished` firing with the algorithm time at the warm-up end.
- The transition first notifies the result handler through a new `IResultHandler.OnWarmupFinished`, then triggers the algorithm's `OnWarmupFinished` callback (still invoked through the Python wrapper) and the running status update.
- `BaseResultsHandler.OnWarmupFinished` re-captures `StartingPortfolioValue`, `CumulativeMaxPortfolioValue` and `DailyPortfolioValue` from the current portfolio value — generically, for both backtesting and live trading — before any post-warm-up user code can trade. The algorithm manager notifies it exactly once, right when warm-up finishes; the re-capture only reassigns values that actually changed (so unaffected algorithms keep byte-identical statistics) and discards the equity bar accumulated during warm-up so the first equity sample opens at the re-captured value.

Seeding the conversion rates point-in-time at the warm-up start is kept as is: it is correct for epoch-consistent warm-up replay, and chart sampling during warm-up was already skipped by the result handlers. Only the capture timing changes. Algorithms without warm-up are unaffected, and algorithms with warm-up but no foreign-currency balances re-capture a value identical to the setup-time one, keeping their statistics unchanged.

#### Related Issue

Closes #9647

#### Motivation and Context

Live algorithms with a long warm-up and multi-currency holdings report a permanent, incorrect net return (observed: -4.55% on an account that had not traded) and skewed drawdown statistics from the moment of deployment. Backtests combining warm-up with foreign-currency cash report returns contaminated by FX drift from a period when the algorithm could not trade. Additionally, algorithms could receive tradable post-warm-up data before `OnWarmupFinished`, breaking the expectation that the callback marks the start of live data.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

- New `WarmupStartingPortfolioValueRegressionAlgorithm`: reproduces the issue in backtesting — foreign-currency cash with a one-year warm-up, so the conversion rate seeded at the warm-up start (EURUSD ~1.05) drifts ~14% during replay. The expected "Start Equity" statistic (220025.00) pins the re-captured warm-up-end value instead of the stale snapshot (~205290), and "Net Profit" reflects only the trading window. Fails on master, passes with the fix.
- New `OnWarmupFinishedOrderingRegressionAlgorithm`: minute forex data with the warm-up boundary at mid-week midnight, so there is data ending exactly at the boundary; asserts `OnWarmupFinished` fires at the warm-up end time and before any `OnData` call with `IsWarmingUp` false. Fails on master, passes with the fix.
- New `LiveTradingResultHandlerTests.RecapturesStartingPortfolioValueAfterWarmup` and `BacktestingResultHandlerTests.RecapturesStartingPortfolioValueAfterWarmup`: verify `StartingPortfolioValue`, `CumulativeMaxPortfolioValue` and `DailyPortfolioValue` are re-captured from the current portfolio value on the warm-up finished notification.
- Full warm-up regression battery (42 tests, including `OnWarmupFinished*`, `WarmupConversionRates` and the option/future/universe warm-up variants): all pass with unchanged expected statistics.
- `LimitOrdersAreFilledAfterHoursForFuturesRegressionAlgorithm`, which places orders inside `OnWarmupFinished`: unchanged statistics, confirming the callback still sees the same market data as before.
- `Engine.Results`, `AlgorithmManager`, `PaperBrokerage` and `AlgorithmLiveTrading` unit test fixtures: 50 passed, 0 failed.
- End-to-end reproductions in local paper trading and backtesting, before and after the fix (see below).

<details>
<summary>End-to-end reproduction in local paper trading and backtesting</summary>

Live mode anchors to the real clock while the repo's EURUSD daily sample data covers 2007-2018, so a warm-up long enough to reach back into that data reproduces the mixed-epoch snapshot: setup seeds the EURUSD rate at the warm-up start (2013 => ~1.35) and warm-up replay carries it to the end of the sample data (2018-12-31 => ~1.147).

Scratch algorithm (EUR cash in a USD account, warm-up back to ~2013-09):

```csharp
public class Issue9647ReproductionAlgorithm : QCAlgorithm
{
    public override void Initialize()
    {
        SetCash(100000);
        SetCash("EUR", 100000);
        AddForex("EURUSD", Resolution.Daily, Market.Oanda);
        SetBenchmark(time => 0m);
        SetWarmUp(TimeSpan.FromDays(4700));
    }

    public override void OnWarmupFinished()
    {
        Log($"OnWarmupFinished at utc {UtcTime:O}: " +
            $"TotalPortfolioValue={Portfolio.TotalPortfolioValue.ToStringInvariant()}, " +
            $"EUR ConversionRate={Portfolio.CashBook["EUR"].ConversionRate.ToStringInvariant()}");
    }
}
```

`Launcher/config.json`: `"environment": "live-paper"`, with the environment's `data-queue-handler` switched to `[ "QuantConnect.Lean.Engine.DataFeeds.Queues.FakeDataQueue" ]` (the default `LiveDataQueue` is a stub that throws on subscribe).

**Without the fix** — the stale snapshot is captured and never corrected, a permanent ~-8.75% phantom return on an account that never traded:

```
BaseSetupHandler.SetupCurrencyConversions():
EUR: €      100000.00 @     1.3525 = $135251.00
CashBook Total Value:                $235251.00     <- captured as StartingPortfolioValue

OnWarmupFinished: TotalPortfolioValue=214657.00000, EUR ConversionRate=1.14657
```

**With the fix** — same setup snapshot (warm-up replay still gets its epoch-consistent seed), but the starting value is re-captured right when warm-up completes, landing exactly on the algorithm's own portfolio value:

```
EUR: €      100000.00 @     1.3525 = $135251.00
LiveTradingResultHandler.RecaptureStartingPortfolioValueIfWarmupFinished(): Re-captured starting portfolio value after warm-up: 214657.00000
OnWarmupFinished: TotalPortfolioValue=214657.00000, EUR ConversionRate=1.14657
```

The same effect reproduces in a backtest with the algorithm above modified with `SetStartDate(2018, 1, 1)`, `SetEndDate(2018, 1, 15)` and `SetWarmUp(TimeSpan.FromDays(1461))` (warm-up back to ~2014-01, EURUSD ~1.38 there vs ~1.20 at the start date), run in the `backtesting` environment. The algorithm never trades, and EUR actually appreciated during the two test weeks:

**Without the fix** — a phantom -6.378% net profit from the FX drift during the warm-up window:

```
EUR: €      100000.00 @     1.3788 = $137879.00
CashBook Total Value:                $237879.00     <- captured as StartingPortfolioValue
OnWarmupFinished at 2018-01-01: TotalPortfolioValue=220025.00000, EUR ConversionRate=1.20025
STATISTICS:: Net Profit -6.378%
```

**With the fix** — the reported return reflects only the actual FX movement during the trading window:

```
EUR: €      100000.00 @     1.3788 = $137879.00
BacktestingResultHandler.RecaptureStartingPortfolioValueIfWarmupFinished(): Re-captured starting portfolio value after warm-up: 220025.00000
OnWarmupFinished at 2018-01-01: TotalPortfolioValue=220025.00000, EUR ConversionRate=1.20025
STATISTICS:: Net Profit 1.219%
```

</details>

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
