### PR TITLE
Add Interactive Brokers KRX future fees

### DIFF
--- a/Common/Currencies.cs
+++ b/Common/Currencies.cs
@@ -72,6 +72,11 @@ namespace QuantConnect
         public const string JPY = "JPY";
 
         /// <summary>
+        /// KRW (South Korean won) currency string
+        /// </summary>
+        public const string KRW = "KRW";
+
+        /// <summary>
         /// Null currency used when a real one is not required
         /// </summary>
         public const string NullCurrency = "QCC";
@@ -87,6 +92,7 @@ namespace QuantConnect
             {USD, "$"},
             {GBP, "₤"},
             {JPY, "¥"},
+            {KRW, "₩"},
             {EUR, "€"},
             {"NZD", "$"},
             {"AUD", "$"},

--- a/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
+++ b/Common/Orders/Fees/InteractiveBrokersFeeModel.cs
@@ -43,8 +43,15 @@ namespace QuantConnect.Orders.Fees
             {
                 { Market.USA, UnitedStatesFutureFees },
                 { Market.HKFE, HongKongFutureFees },
-                { Market.EUREX, EUREXFutureFees }
+                { Market.EUREX, EUREXFutureFees },
+                { Market.KRX, KoreaFutureFees }
             };
+
+        /// <summary>
+        /// Korea Exchange futures are charged a flat rate of the trade value, which already includes
+        /// the exchange, regulatory, clearing and carrying fees.
+        /// </summary>
+        private const decimal _koreaFutureFeeRate = 0.00004m;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmediateFillModel"/>
@@ -376,6 +383,16 @@ namespace QuantConnect.Orders.Fees
 
             // let's add a 50% extra charge for exchange fees
             return new CashAmount(ibFeePerContract * 1.5m, security.QuoteCurrency.Symbol);
+        }
+
+        /// <summary>
+        /// Gets the fee for a single Korea Exchange future contract, a percentage of its trade value
+        /// in the contract quote currency
+        /// </summary>
+        private static CashAmount KoreaFutureFees(Security security)
+        {
+            var tradeValuePerContract = security.Price * security.SymbolProperties.ContractMultiplier;
+            return new CashAmount(_koreaFutureFeeRate * tradeValuePerContract, security.QuoteCurrency.Symbol);
         }
 
         private static CashAmount EUREXFutureFees(Security security)

--- a/Tests/Common/Orders/Fees/InteractiveBrokersFeeModelTests.cs
+++ b/Tests/Common/Orders/Fees/InteractiveBrokersFeeModelTests.cs
@@ -161,6 +161,40 @@ namespace QuantConnect.Tests.Common.Orders.Fees
             Assert.AreEqual(1000 * 40m, fee.Value.Amount);
         }
 
+        [TestCase(false)]
+        [TestCase(true)]
+        public void KoreaFutureFee(bool canonical)
+        {
+            var symbol = Symbols.CreateFutureSymbol(Futures.Indices.Kospi200, SecurityIdentifier.DefaultDate);
+            if (!canonical)
+            {
+                symbol = Symbols.CreateFutureSymbol(Futures.Indices.Kospi200,
+                    FuturesExpiryFunctions.FuturesExpiryFunction(symbol)(new DateTime(2026, 9, 1)));
+            }
+            var entry = MarketHoursDatabase.FromDataFolder().GetEntry(symbol.ID.Market, symbol, symbol.SecurityType);
+            var properties = SymbolPropertiesDatabase.FromDataFolder()
+                .GetSymbolProperties(symbol.ID.Market, symbol, symbol.SecurityType, null);
+            var security = new Future(symbol, entry.ExchangeHours,
+                new Cash(properties.QuoteCurrency, 0, 0),
+                properties,
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+            security.SetMarketPrice(new Tick(new DateTime(2026, 8, 5), security.Symbol, 1046, 1046));
+
+            var fee = _feeModel.GetOrderFee(
+                new OrderFeeParameters(
+                    security,
+                    new MarketOrder(security.Symbol, 1, new DateTime(2026, 8, 5))
+                )
+            );
+
+            Assert.AreEqual(Currencies.KRW, fee.Value.Currency);
+            // 0.004% of the trade value: 1046 * 250,000 contract multiplier
+            Assert.AreEqual(10460m, fee.Value.Amount);
+        }
+
         [TestCase(OrderType.ComboMarket, 0.01, 250)]
         [TestCase(OrderType.ComboLimit, 0.01, 250)]
         [TestCase(OrderType.ComboLegLimit, 0.01, 250)]


### PR DESCRIPTION
#### Description

Adds a `Market.KRX` entry to `InteractiveBrokersFeeModel`'s future fee map, so KOSPI 200 (KM)
futures can be traded through the Interactive Brokers brokerage.

Unlike the per contract fees of the currently supported markets, IB charges Korea Exchange
futures a flat percentage of the trade value (0.004%) that already includes the exchange,
regulatory, clearing and carrying fees, so the fee is computed from the security price and its
contract multiplier, and returned in the contract quote currency (KRW).

Also adds the `KRW` currency string and its `₩` display symbol to `Currencies`.

#### Related Issue

Follow up of #9585, which added the KOSPI 200 (KM) futures, and of
QuantConnect/Lean.Brokerages.InteractiveBrokers#239, its brokerage counterpart. Neither updated
the fee model.

#### Motivation and Context

`InteractiveBrokersFeeModel` only knew about `Market.USA`, `Market.HKFE` and `Market.EUREX`, so
the future fee lookup threw `KeyNotFoundException: InteractiveBrokersFeeModel(): unexpected
future Market krx` for every KM order. The transaction handler catches it and invalidates the
order with `Error executing margin models`, so the order never reaches the brokerage:

```
Order Error: id: 1, Error executing margin models:
  InteractiveBrokersFeeModel(): unexpected future Market krx
```

This affects every KRX future order regardless of the account permissions or the market state:
the data side of the KOSPI 200 support works, but the security cannot be traded at all.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Unit tests: `KoreaFutureFee` in `InteractiveBrokersFeeModelTests`, for both the canonical and the
contract symbol, asserting the fee amount and its KRW currency. The whole
`InteractiveBrokersFeeModelTests` fixture passes (128 tests).

The fee rate was measured live against IB, trading the front KM contract on a paper account with
the fee model bypassed. Both legs of the round trip match 0.004% of the trade value exactly, as
reported by IB's own commission report:

| Fill | Price | Trade value (KRW) | IB commission (KRW) | Rate |
|---|---|---|---|---|
| Buy 1 | 1046 | 1046 x 250,000 = 261,500,000 | 10,460 | 0.004% |
| Sell 1 | 1049 | 1049 x 250,000 = 262,250,000 | 10,490 | 0.004% |

With this change, the same order placed through the standard fee model reaches IB and fills,
instead of being invalidated locally.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
