### PR TITLE
Fix the warm-up order analysis for Python algorithms and register the MarketOnClose too-late analysis

### DIFF
--- a/Engine/Results/Analysis/Analyses/Messages/MessageAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/Messages/MessageAnalysis.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses.Messages
 {
@@ -25,7 +26,18 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses.Messages
     /// </summary>
     public abstract class MessageAnalysis : BaseResultsAnalysis
     {
-        protected abstract string[] ExpectedMessageText { get; }
+        /// <summary>
+        /// The text fragments a message must all contain (case-insensitive) to identify the issue.
+        /// Ignored when <see cref="ExpectedMessagePattern"/> is set.
+        /// </summary>
+        protected virtual string[] ExpectedMessageText { get; }
+
+        /// <summary>
+        /// Optional regex that identifies the issue message, taking precedence over
+        /// <see cref="ExpectedMessageText"/>. Use it for messages with variable parts fragments
+        /// cannot pin down, like method names formatted by algorithm language.
+        /// </summary>
+        protected virtual Regex ExpectedMessagePattern { get; }
 
         /// <summary>
         /// Returns messages from <paramref name="messages"/> that contain all strings in <paramref name="expectedMessages"/>
@@ -42,12 +54,14 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses.Messages
             => Run(parameters.Logs, parameters.Language);
 
         /// <summary>
-        /// Runs the analysis by scanning <paramref name="messages"/> for the expected text fragments
-        /// and returns results with solutions when matches are found.
+        /// Runs the analysis by scanning <paramref name="messages"/> for the expected pattern or
+        /// text fragments and returns results with solutions when matches are found.
         /// </summary>
         public virtual IReadOnlyList<QuantConnect.Analysis> Run(IReadOnlyList<string> messages, Language language)
         {
-            var foundMessages = Match(messages, ExpectedMessageText).ToList();
+            var foundMessages = (ExpectedMessagePattern != null
+                ? messages.Where(message => ExpectedMessagePattern.IsMatch(message))
+                : Match(messages, ExpectedMessageText)).ToList();
             var solutions = foundMessages.Count > 0 ? Solutions(language) : [];
             return SingleResponse(foundMessages.Count > 0 ? foundMessages[0] : null, foundMessages.Count > 1 ? foundMessages.Count : null, solutions);
         }

--- a/Engine/Results/Analysis/Analyses/OrderResponseErrorsAnalyses/AlgorithmWarmingUpOrderResponseErrorAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/OrderResponseErrorsAnalyses/AlgorithmWarmingUpOrderResponseErrorAnalysis.cs
@@ -39,11 +39,14 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
 
         /// <summary>
         /// Gets the message fragments that identify a warm-up period order error.
+        /// The method name is language-formatted in the message (OnWarmupFinished for C#,
+        /// on_warmup_finished for Python), so the fragments must not include it.
         /// </summary>
         protected override string[] ExpectedMessageText { get; } =
         [
             "This operation is not allowed in Initialize or during warm up: OrderRequest.",
-            ". Please move this code to the OnWarmupFinished() method.",
+            ". Please move this code to the ",
+            "() method.",
         ];
 
         /// <summary>

--- a/Engine/Results/Analysis/Analyses/OrderResponseErrorsAnalyses/AlgorithmWarmingUpOrderResponseErrorAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/OrderResponseErrorsAnalyses/AlgorithmWarmingUpOrderResponseErrorAnalysis.cs
@@ -14,6 +14,7 @@
  *
 */
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using QuantConnect.Interfaces;
 using QuantConnect.Lean.Engine.Results.Analysis.Analyses.Messages;
 
@@ -38,16 +39,14 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
         public override int Weight { get; } = 96;
 
         /// <summary>
-        /// Gets the message fragments that identify a warm-up period order error.
-        /// The method name is language-formatted in the message (OnWarmupFinished for C#,
-        /// on_warmup_finished for Python), so the fragments must not include it.
+        /// Gets the pattern that identifies a warm-up period order error. The method names are
+        /// language-formatted in the message (OnWarmupFinished for C#, on_warmup_finished for
+        /// Python), so a pattern is used instead of text fragments to match both.
         /// </summary>
-        protected override string[] ExpectedMessageText { get; } =
-        [
-            "This operation is not allowed in Initialize or during warm up: OrderRequest.",
-            ". Please move this code to the ",
-            "() method.",
-        ];
+        protected override Regex ExpectedMessagePattern { get; } = new(
+            @"This operation is not allowed in Initialize or during warm up: OrderRequest\.\w+\. " +
+            @"Please move this code to the (OnWarmupFinished|on_warmup_finished)\(\) method\.",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Gets solutions suggesting moving orders out of the warm-up period.

--- a/Engine/Results/Analysis/ResultsAnalyzer.cs
+++ b/Engine/Results/Analysis/ResultsAnalyzer.cs
@@ -428,6 +428,7 @@ namespace QuantConnect.Lean.Engine.Results.Analysis
             new EuropeanOptionNotExpiredOnExerciseOrderResponseErrorAnalysis(),
             new OptionOrderOnStockSplitOrderResponseErrorAnalysis(),
             new MarketOnOpenNotAllowedDuringRegularHoursOrderResponseErrorAnalysis(),
+            new MarketOnCloseOrderTooLateOrderResponseErrorAnalysis(),
             new OrderQuantityLessThanLotSizeOrderResponseErrorAnalysis(),
             new InsightsEmittedForDelistedSecuritiesAnalysis(),
             new StatisticalSignificanceOfDailyReturnsAnalysis(),

--- a/Tests/Engine/Results/AlgorithmWarmingUpOrderResponseErrorAnalysisTests.cs
+++ b/Tests/Engine/Results/AlgorithmWarmingUpOrderResponseErrorAnalysisTests.cs
@@ -1,0 +1,57 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Lean.Engine.Results.Analysis.Analyses;
+
+namespace QuantConnect.Tests.Engine.Results
+{
+    [TestFixture]
+    public class AlgorithmWarmingUpOrderResponseErrorAnalysisTests
+    {
+        // The engine formats the method names by algorithm language, so the same rejection
+        // produces a different message for C# and Python algorithms
+        private const string CSharpMessage = "This operation is not allowed in Initialize or during warm up: " +
+            "OrderRequest.Submit. Please move this code to the OnWarmupFinished() method.";
+
+        private const string PythonMessage = "This operation is not allowed in initialize or during warm up: " +
+            "OrderRequest.submit. Please move this code to the on_warmup_finished() method.";
+
+        [TestCase(CSharpMessage, Language.CSharp)]
+        [TestCase(PythonMessage, Language.Python)]
+        public void MatchesTheLanguageFormattedWarmUpRejectionMessage(string message, Language language)
+        {
+            var analysis = new AlgorithmWarmingUpOrderResponseErrorAnalysis();
+
+            var finding = analysis.Run(new[] { "Some other log line", message }, language).Single();
+
+            Assert.AreEqual(message, finding.Sample);
+            Assert.IsNotEmpty(finding.Solutions);
+        }
+
+        [Test]
+        public void DoesNotMatchUnrelatedMessages()
+        {
+            var analysis = new AlgorithmWarmingUpOrderResponseErrorAnalysis();
+
+            var finding = analysis.Run(new[] { "Some other log line" }, Language.CSharp).Single();
+
+            Assert.IsNull(finding.Sample);
+            Assert.IsEmpty(finding.Solutions);
+        }
+    }
+}

--- a/Tests/Engine/Results/MarketOnCloseOrderTooLateOrderResponseErrorAnalysisTests.cs
+++ b/Tests/Engine/Results/MarketOnCloseOrderTooLateOrderResponseErrorAnalysisTests.cs
@@ -1,0 +1,51 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Lean.Engine.Results.Analysis.Analyses;
+
+namespace QuantConnect.Tests.Engine.Results
+{
+    [TestFixture]
+    public class MarketOnCloseOrderTooLateOrderResponseErrorAnalysisTests
+    {
+        private const string RejectionMessage = "MarketOnClose orders must be placed within 00:15:30 before market close." +
+            " Override this TimeSpan buffer by setting Orders.MarketOnCloseOrder.SubmissionTimeBuffer in QCAlgorithm.Initialize().";
+
+        [Test]
+        public void MatchesTheTooLateRejectionMessage()
+        {
+            var analysis = new MarketOnCloseOrderTooLateOrderResponseErrorAnalysis();
+
+            var finding = analysis.Run(new[] { "Some other log line", RejectionMessage }, Language.CSharp).Single();
+
+            Assert.AreEqual(RejectionMessage, finding.Sample);
+            Assert.IsNotEmpty(finding.Solutions);
+        }
+
+        [Test]
+        public void DoesNotMatchUnrelatedMessages()
+        {
+            var analysis = new MarketOnCloseOrderTooLateOrderResponseErrorAnalysis();
+
+            var finding = analysis.Run(new[] { "Some other log line" }, Language.CSharp).Single();
+
+            Assert.IsNull(finding.Sample);
+            Assert.IsEmpty(finding.Solutions);
+        }
+    }
+}

--- a/Tests/Engine/Results/ResultsAnalyzerTests.cs
+++ b/Tests/Engine/Results/ResultsAnalyzerTests.cs
@@ -163,6 +163,14 @@ namespace QuantConnect.Tests.Engine.Results
         }
 
         [Test]
+        public void DefaultAnalysisSetIncludesTheMarketOnCloseOrderTooLateAnalysis()
+        {
+            var analyses = new DefaultSetResultsAnalyzer().DefaultAnalyses;
+
+            Assert.IsTrue(analyses.Any(analysis => analysis is MarketOnCloseOrderTooLateOrderResponseErrorAnalysis));
+        }
+
+        [Test]
         public void DefaultAnalysisSetDeclaresTheFinalOnlyAnalyses()
         {
             var finalOnly = new DefaultSetResultsAnalyzer().DefaultAnalyses


### PR DESCRIPTION
#### Description

Two of the backtest results analyses never produce their findings, found while manually testing the in-run analysis stream (#9632) with a Python algorithm:

**`AlgorithmWarmingUpOrderResponseErrorAnalysis` never matches Python algorithms.** The engine formats the method names in the rejection message by algorithm language, so a Python algorithm produces:

```
This operation is not allowed in initialize or during warm up: OrderRequest.submit. Please move this code to the on_warmup_finished() method.
```

while the analysis expected the C# shape (`... Please move this code to the OnWarmupFinished() method.`). The case-insensitive match absorbs `initialize`, but the snake-cased `on_warmup_finished` can never contain `OnWarmupFinished`.

- Cause: the expected message fragments include the language-formatted method name.
- Fix: `MessageAnalysis` now supports an optional `ExpectedMessagePattern` regex that takes precedence over the text fragments, for messages with variable parts fragments cannot pin down. The warm-up analysis uses it to match the full message with both method-name spellings: `(OnWarmupFinished|on_warmup_finished)\(\) method\.`

**`MarketOnCloseOrderTooLateOrderResponseErrorAnalysis` never fires for any algorithm.** The rejection is logged with the exact expected text, but the analysis was never registered.

- Cause: the class was not included in `ResultsAnalyzer.GetAnalyses()`.
- Fix: registered it with the other order-response error analyses.

#### Related Issue

N/A

#### Motivation and Context

These findings exist to surface order errors to the user (and LLM consumers) during and after a backtest; both were silently dead — one for every Python algorithm, the other for everyone.

#### Requires Documentation Change

N/A

#### How Has This Been Tested?

- New `AlgorithmWarmingUpOrderResponseErrorAnalysisTests`: the analysis matches both the C#- and the Python-formatted rejection message, and ignores unrelated messages.
- New `MarketOnCloseOrderTooLateOrderResponseErrorAnalysisTests`: the analysis matches the too-late rejection message, and ignores unrelated messages.
- `ResultsAnalyzerTests.DefaultAnalysisSetIncludesTheMarketOnCloseOrderTooLateAnalysis`: pins the registration in the default analysis set.
- All analyzer fixtures pass: 37 tests (`ResultsAnalyzerTests`, `ResultsAnalyzerInRunTests`, the two new fixtures).
- Manual verification through the Launcher with a packet-capturing messaging handler and a Python algorithm that submits an order during warm-up and a MarketOnClose order after the submission cut-off: before the fix neither finding ever appeared; after the fix the warm-up finding streams from the first in-run cycle (and mutes after the reporting cap like any other finding), and the MarketOnClose finding appears on the cycle following the rejection.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
