### PR TITLE
Restore the LogEntry based SaveLogs signature

### DIFF
--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -737,7 +737,11 @@ namespace QuantConnect.Lean.Engine.Results
             if (!ExitTriggered)
             {
                 Log.Trace("BacktestingResultHandler.Exit(): starting...");
-                var copy = CloneLogs();
+                List<LogEntry> copy;
+                lock (LogStore)
+                {
+                    copy = LogStore.ToList();
+                }
                 ProcessSynchronousEvents(true);
                 Log.Trace("BacktestingResultHandler.Exit(): Saving logs...");
                 var logLocation = SaveLogs(_algorithmId, copy);

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -603,19 +603,9 @@ namespace QuantConnect.Lean.Engine.Results
         /// <returns>The path to the logs</returns>
         public virtual string SaveLogs(string id, List<LogEntry> logs)
         {
-            return SaveLogs(id, logs.Select(x => x.Message));
-        }
-
-        /// <summary>
-        /// Returns the location of the logs
-        /// </summary>
-        /// <param name="id">Id that will be incorporated into the algorithm log name</param>
-        /// <param name="logLines">The log lines to save</param>
-        /// <returns>The path to the logs</returns>
-        public virtual string SaveLogs(string id, IEnumerable<string> logLines)
-        {
             var filename = $"{id}-log.txt";
             var path = GetResultsPath(filename);
+            var logLines = logs.Select(x => x.Message);
             File.WriteAllLines(path, logLines);
             return path;
         }


### PR DESCRIPTION
#### Description

PR #9632 split `BaseResultsHandler.SaveLogs` into two overloads (`List<LogEntry>` and `IEnumerable<string>`) so `BacktestingResultHandler.Exit()` could reuse the message-list clone. This restores the original public API:

- `BaseResultsHandler.SaveLogs(string id, List<LogEntry> logs)` is again the single overload, writing the entry messages itself.
- `BacktestingResultHandler.Exit()` clones the `LogEntry` list under the log store lock and passes it to `SaveLogs`, as it did before #9632.
- `CloneLogs()` stays for the final-result and in-run analysis paths, which need the message strings.

#### Related Issue

N/A

#### Motivation and Context

`SaveLogs` is a public virtual member that result handler implementations override; its signature should not have changed as a side effect of #9632.

#### Requires Documentation Change

N/A

#### How Has This Been Tested?

- `BaseResultsHandlerTests`, `BacktestingResultHandlerTests` and `LiveTradingResultHandlerTests`: 31 passed.
- Manual Launcher run of an algorithm logging on every bar: `BacktestingResultHandler.Exit()` saved the complete log file (launch line, 390 bar lines, end-of-algorithm line, completion line) at the end of the backtest.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes (no new tests: restores the pre-#9632 signature, already covered by the existing result handler fixtures).
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
