### PR TITLE
Improve error messages for datetime vs date operations in Python algorithms

### DIFF
--- a/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
+++ b/Algorithm.CSharp/QuantConnect.Algorithm.CSharp.csproj
@@ -32,7 +32,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.65" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Fuzzy" Version="3.6.0" />
     <PackageReference Include="Accord.MachineLearning" Version="3.6.0" />

--- a/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
+++ b/Algorithm.Framework/QuantConnect.Algorithm.Framework.csproj
@@ -29,7 +29,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.65" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Math" Version="3.6.0" />
     <PackageReference Include="Accord.Statistics" Version="3.6.0" />

--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -37,7 +37,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.65" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="OptionUniverseFilterGreeksShortcutsRegressionAlgorithm.py" />

--- a/Algorithm/QuantConnect.Algorithm.csproj
+++ b/Algorithm/QuantConnect.Algorithm.csproj
@@ -29,7 +29,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.65" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NodaTime" Version="3.0.5" />

--- a/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
+++ b/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
@@ -28,7 +28,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.65" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/Common/Exceptions/DatetimeDateComparisonPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/DatetimeDateComparisonPythonExceptionInterpreter.cs
@@ -20,9 +20,9 @@ using QuantConnect.Util;
 namespace QuantConnect.Exceptions
 {
     /// <summary>
-    /// Interprets <see cref="UnsupportedOperandPythonExceptionInterpreter"/> instances
+    /// Interprets TypeError exceptions raised when comparing datetime.datetime and datetime.date objects
     /// </summary>
-    public class UnsupportedOperandPythonExceptionInterpreter : PythonExceptionInterpreter
+    public class DatetimeDateComparisonPythonExceptionInterpreter : PythonExceptionInterpreter
     {
         /// <summary>
         /// Determines the order that an instance of this class should be called
@@ -37,7 +37,7 @@ namespace QuantConnect.Exceptions
         public override bool CanInterpret(Exception exception)
         {
             return base.CanInterpret(exception) &&
-                exception.Message.Contains(Messages.UnsupportedOperandPythonExceptionInterpreter.UnsupportedOperandTypeExpectedSubstring);
+                exception.Message.Contains(Messages.DatetimeDateComparisonPythonExceptionInterpreter.CantCompareExpectedSubstring);
         }
 
         /// <summary>
@@ -50,12 +50,7 @@ namespace QuantConnect.Exceptions
         {
             var pe = (PythonException)exception;
 
-            var types = pe.Message.Split(':')[1].Trim();
-            var message = Messages.UnsupportedOperandPythonExceptionInterpreter.InvalidObjectTypesForOperation(types);
-            if (types.Contains("'datetime.datetime'") && types.Contains("'datetime.date'"))
-            {
-                message += Messages.UnsupportedOperandPythonExceptionInterpreter.DatetimeDateOperationHint;
-            }
+            var message = Messages.DatetimeDateComparisonPythonExceptionInterpreter.InvalidDatetimeDateComparison;
             message += PythonUtil.PythonExceptionStackParser(pe.StackTrace);
 
             return new Exception(message, pe);

--- a/Common/Messages/Messages.Exceptions.cs
+++ b/Common/Messages/Messages.Exceptions.cs
@@ -203,6 +203,30 @@ namespace QuantConnect
                 return $@"Trying to perform a summation, subtraction, multiplication or division between {
                     types} objects throws a TypeError exception. To prevent the exception, ensure that both values share the same type.";
             }
+
+            /// <summary>
+            /// Hint appended when the invalid operands are a datetime.datetime and a datetime.date
+            /// </summary>
+            public static string DatetimeDateOperationHint =
+                " To operate between them, use the date part of the datetime value, e.g.: (expiry.date() - today).days or self.time.date().";
+        }
+
+        /// <summary>
+        /// Provides user-facing messages for the <see cref="Exceptions.DatetimeDateComparisonPythonExceptionInterpreter"/> class and its consumers or related classes
+        /// </summary>
+        public static class DatetimeDateComparisonPythonExceptionInterpreter
+        {
+            /// <summary>
+            /// Expected substring of the TypeError raised when comparing a datetime.datetime with a datetime.date
+            /// </summary>
+            public static string CantCompareExpectedSubstring = "can't compare datetime.datetime to datetime.date";
+
+            /// <summary>
+            /// User-facing message for datetime.datetime vs datetime.date comparisons
+            /// </summary>
+            public static string InvalidDatetimeDateComparison =
+                "Trying to compare 'datetime.datetime' and 'datetime.date' objects throws a TypeError exception. " +
+                "To prevent the exception, compare using the date part of the datetime value, e.g.: self.time.date() <= some_date.";
         }
     }
 }

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -35,7 +35,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.65" />
     <PackageReference Include="CloneExtensions" Version="1.3.0" />
     <PackageReference Include="fasterflect" Version="3.0.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -41,7 +41,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.65" />
     <PackageReference Include="fasterflect" Version="3.0.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -31,7 +31,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.65" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Report/QuantConnect.Report.csproj
+++ b/Report/QuantConnect.Report.csproj
@@ -39,7 +39,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.65" />
     <PackageReference Include="Deedle" Version="2.1.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/Research/QuantConnect.Research.csproj
+++ b/Research/QuantConnect.Research.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Plotly.NET" Version="5.1.0" />
     <PackageReference Include="Plotly.NET.CSharp" Version="0.13.0" />
     <PackageReference Include="Plotly.NET.Interactive" Version="5.0.0" />
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.65" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Common/Exceptions/DatetimeDateComparisonPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/DatetimeDateComparisonPythonExceptionInterpreterTests.cs
@@ -1,0 +1,114 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+using Python.Runtime;
+using QuantConnect.Exceptions;
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Tests.Common.Exceptions
+{
+    [TestFixture]
+    public class DatetimeDateComparisonPythonExceptionInterpreterTests
+    {
+        private PythonException _comparisonException;
+        private PythonException _unsupportedOperandException;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            using (Py.GIL())
+            {
+                var module = Py.Import("Test_PythonExceptionInterpreter");
+                dynamic algorithm = module.GetAttr("Test_PythonExceptionInterpreter").Invoke();
+
+                try
+                {
+                    // x = datetime(2020, 1, 2) < date(2020, 1, 1)
+                    algorithm.datetime_date_comparison();
+                }
+                catch (PythonException pythonException)
+                {
+                    _comparisonException = pythonException;
+                }
+
+                try
+                {
+                    // x = None + "Pepe Grillo"
+                    algorithm.unsupported_operand();
+                }
+                catch (PythonException pythonException)
+                {
+                    _unsupportedOperandException = pythonException;
+                }
+            }
+        }
+
+        [Test]
+        public void StackInterpreterRewritesComparisonErrorWithDateHint()
+        {
+            var interpreter = StackExceptionInterpreter.CreateFromAssemblies();
+            var interpreted = interpreter.Interpret(_comparisonException, NullExceptionInterpreter.Instance);
+            Assert.IsTrue(interpreted.Message.Contains(".date()"), interpreted.Message);
+            Assert.IsTrue(interpreted.Message.Contains("x = datetime(2020, 1, 2) < date(2020, 1, 1)"), interpreted.Message);
+        }
+
+        [Test]
+        [TestCase(typeof(Exception), ExpectedResult = false)]
+        [TestCase(typeof(KeyNotFoundException), ExpectedResult = false)]
+        [TestCase(typeof(DivideByZeroException), ExpectedResult = false)]
+        [TestCase(typeof(InvalidOperationException), ExpectedResult = false)]
+        [TestCase(typeof(PythonException), ExpectedResult = true)]
+        public bool CanInterpretReturnsTrueForOnlyDatetimeDateComparisonPythonExceptionType(Type exceptionType)
+        {
+            var exception = CreateExceptionFromType(exceptionType);
+            return new DatetimeDateComparisonPythonExceptionInterpreter().CanInterpret(exception);
+        }
+
+        [Test]
+        public void CanInterpretReturnsFalseForOtherTypeErrors()
+        {
+            Assert.IsFalse(new DatetimeDateComparisonPythonExceptionInterpreter().CanInterpret(_unsupportedOperandException));
+            Assert.IsFalse(new UnsupportedOperandPythonExceptionInterpreter().CanInterpret(_comparisonException));
+        }
+
+        [Test]
+        [TestCase(typeof(Exception), true)]
+        [TestCase(typeof(KeyNotFoundException), true)]
+        [TestCase(typeof(DivideByZeroException), true)]
+        [TestCase(typeof(InvalidOperationException), true)]
+        [TestCase(typeof(PythonException), false)]
+        public void InterpretThrowsForNonDatetimeDateComparisonPythonExceptionTypes(Type exceptionType, bool expectThrow)
+        {
+            var exception = CreateExceptionFromType(exceptionType);
+            var interpreter = new DatetimeDateComparisonPythonExceptionInterpreter();
+            var constraint = expectThrow ? (IResolveConstraint)Throws.Exception : Throws.Nothing;
+            Assert.That(() => interpreter.Interpret(exception, NullExceptionInterpreter.Instance), constraint);
+        }
+
+        [Test]
+        public void InterpretedMessageContainsGuidanceAndStackInformation()
+        {
+            var interpreted = new DatetimeDateComparisonPythonExceptionInterpreter().Interpret(_comparisonException, NullExceptionInterpreter.Instance);
+            Assert.IsTrue(interpreted.Message.Contains(
+                Messages.DatetimeDateComparisonPythonExceptionInterpreter.InvalidDatetimeDateComparison), interpreted.Message);
+            Assert.IsTrue(interpreted.Message.Contains("x = datetime(2020, 1, 2) < date(2020, 1, 1)"), interpreted.Message);
+        }
+
+        private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _comparisonException : (Exception)Activator.CreateInstance(type);
+    }
+}

--- a/Tests/Common/Exceptions/UnsupportedOperandPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/UnsupportedOperandPythonExceptionInterpreterTests.cs
@@ -26,6 +26,8 @@ namespace QuantConnect.Tests.Common.Exceptions
     public class UnsupportedOperandPythonExceptionInterpreterTests
     {
         private PythonException _pythonException;
+        private PythonException _datetimeDateException;
+        private PythonException _dateDatetimeException;
 
         [OneTimeSetUp]
         public void Setup()
@@ -43,6 +45,26 @@ namespace QuantConnect.Tests.Common.Exceptions
                 catch (PythonException pythonException)
                 {
                     _pythonException = pythonException;
+                }
+
+                try
+                {
+                    // x = datetime(2020, 1, 2) - date(2020, 1, 1)
+                    algorithm.unsupported_operand_datetime_date();
+                }
+                catch (PythonException pythonException)
+                {
+                    _datetimeDateException = pythonException;
+                }
+
+                try
+                {
+                    // x = date(2020, 1, 1) - datetime(2020, 1, 2)
+                    algorithm.unsupported_operand_date_datetime();
+                }
+                catch (PythonException pythonException)
+                {
+                    _dateDatetimeException = pythonException;
                 }
             }
         }
@@ -71,6 +93,24 @@ namespace QuantConnect.Tests.Common.Exceptions
             var interpreter = new UnsupportedOperandPythonExceptionInterpreter();
             var constraint = expectThrow ? (IResolveConstraint)Throws.Exception : Throws.Nothing;
             Assert.That(() => interpreter.Interpret(exception, NullExceptionInterpreter.Instance), constraint);
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void AppendsDateHintForDatetimeDateOperands(bool datetimeFirst)
+        {
+            var exception = datetimeFirst ? _datetimeDateException : _dateDatetimeException;
+            var interpreted = new UnsupportedOperandPythonExceptionInterpreter().Interpret(exception, NullExceptionInterpreter.Instance);
+            Assert.IsTrue(interpreted.Message.Contains("'datetime.datetime'"), interpreted.Message);
+            Assert.IsTrue(interpreted.Message.Contains(".date()"), interpreted.Message);
+        }
+
+        [Test]
+        public void DoesNotAppendDateHintForOtherOperands()
+        {
+            var interpreted = new UnsupportedOperandPythonExceptionInterpreter().Interpret(_pythonException, NullExceptionInterpreter.Instance);
+            Assert.IsFalse(interpreted.Message.Contains(".date()"), interpreted.Message);
         }
 
         [Test]

--- a/Tests/QuantConnect.Tests.csproj
+++ b/Tests/QuantConnect.Tests.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ItemGroup>
-    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.65" />
     <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Accord.Math" Version="3.6.0" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />

--- a/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
+++ b/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
@@ -32,6 +32,15 @@ class Test_PythonExceptionInterpreter(QCAlgorithm):
     def unsupported_operand(self):
         x = None + "Pepe Grillo"
 
+    def unsupported_operand_datetime_date(self):
+        x = datetime(2020, 1, 2) - date(2020, 1, 1)
+
+    def unsupported_operand_date_datetime(self):
+        x = date(2020, 1, 1) - datetime(2020, 1, 2)
+
+    def datetime_date_comparison(self):
+        x = datetime(2020, 1, 2) < date(2020, 1, 1)
+
     def module_not_found(self):
         from MissingClrNamespace.Distributions import Normal
 


### PR DESCRIPTION
#### Description

Python algorithms mixing `datetime.datetime` and `datetime.date` values (typically DTE math like `(contract.id.date - self.time.date()).days`) fail with TypeErrors that don't tell the user how to fix their code:

```
Trying to perform a summation, subtraction, multiplication or division between 'datetime.datetime' and 'datetime.date' objects throws a TypeError exception. To prevent the exception, ensure that both values share the same type.
```
```
can't compare datetime.datetime to datetime.date
```

Cause: the summation/subtraction message never says *how* to make the types match, and the comparison TypeError is not intercepted by any exception interpreter at all (`UnsupportedOperandPythonExceptionInterpreter` only matches `"unsupported operand type"`).

The fix:
- `UnsupportedOperandPythonExceptionInterpreter.Interpret` appends a hint when the offending operands are a `datetime.datetime`/`datetime.date` mix (either order): use the date part of the datetime value, e.g. `(expiry.date() - today).days` or `self.time.date()`.
- New `DatetimeDateComparisonPythonExceptionInterpreter` intercepts the `can't compare datetime.datetime to datetime.date` TypeError (raised for both comparison orders) and rewrites it with the same `.date()` guidance plus the parsed Python stack trace. It is auto-discovered by `StackExceptionInterpreter.CreateFromAssemblies`.
- Message text lives in `Messages.Exceptions.cs`, following the existing per-interpreter message-class pattern.

This is a user-facing-message backstop: the companion QuantConnect/pythonnet#143 makes .NET `DateTime` values converted to Python coerce against pure `date` operands, which removes most of these failures at the root.

This PR also updates the `QuantConnect.pythonnet` package reference to 2.0.65 (the version carrying that coercion change) in the 11 consuming csproj files. **Do not merge until QuantConnect/pythonnet#143 is merged and 2.0.65 is indexed on NuGet** — restore fails before then.

#### Related Issue

N/A — recurring user-facing runtime errors reported from production backtests.

#### Motivation and Context

DTE filtering (`(expiry - today).days`) is one of the most common lines in options/futures Python algorithms, and today's errors leave users without an actionable fix.

#### Requires Documentation Change

No — error message improvements only.

#### How Has This Been Tested?

- `UnsupportedOperandPythonExceptionInterpreterTests`: new tests assert the `.date()` hint is appended for `datetime - date` and `date - datetime` (real `PythonException`s raised from `Test_PythonExceptionInterpreter.py`), and not appended for unrelated operand pairs (`None + str`). Proven red before the fix (3 failed / 12 passed), green after.
- New `DatetimeDateComparisonPythonExceptionInterpreterTests`: `CanInterpret` matrix (claims only the datetime/date comparison `PythonException`; rejects other exception types and the unsupported-operand TypeError, and vice versa), `Interpret` throw matrix, message content + Python stack line assertions, and an end-to-end `StackExceptionInterpreter.CreateFromAssemblies` test proving the new interpreter is discovered and applied.
- Touched fixtures: 27 passed, 0 failed. Full `QuantConnect.Tests.Common.Exceptions` namespace: 147 passed, 0 failed. `PythonUtilTests`: 18 passed, 0 failed.
- With the 2.0.65 `Python.Runtime.dll` (built from QuantConnect/pythonnet#143) injected over this branch's test output, mirroring pythonnet's Lean CI workflows: Python unit tests 16045 passed / 0 failed / 9 skipped; Python regression algorithms 324/324 passed.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`


