### PR TITLE
What I had to do to change stuff

### DIFF
--- a/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
+++ b/Algorithm.Python/QuantConnect.Algorithm.Python.csproj
@@ -37,6 +37,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
   </ItemGroup>
   <ItemGroup>

--- a/Algorithm/QuantConnect.Algorithm.csproj
+++ b/Algorithm/QuantConnect.Algorithm.csproj
@@ -29,6 +29,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
+++ b/AlgorithmFactory/QuantConnect.AlgorithmFactory.csproj
@@ -28,6 +28,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
   </ItemGroup>

--- a/Api/QuantConnect.Api.csproj
+++ b/Api/QuantConnect.Api.csproj
@@ -32,6 +32,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NodaTime" Version="3.0.5" />
     <PackageReference Include="RestSharp" Version="106.12.0" />

--- a/Brokerages/QuantConnect.Brokerages.csproj
+++ b/Brokerages/QuantConnect.Brokerages.csproj
@@ -29,6 +29,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="CsvHelper" Version="19.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="RestSharp" Version="106.12.0" />

--- a/Common/AlgorithmSettings.cs
+++ b/Common/AlgorithmSettings.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Globalization;
 using QuantConnect.Interfaces;
 using QuantConnect.Securities;
 using QuantConnect.Orders.Fills;
@@ -27,7 +28,7 @@ namespace QuantConnect
     public class AlgorithmSettings : IAlgorithmSettings
     {
         private static TimeSpan _defaultDatabasesRefreshPeriod =
-            TimeSpan.TryParse(Config.Get("databases-refresh-period", "1.00:00:00"), out var refreshPeriod) ? refreshPeriod : Time.OneDay;
+            TimeSpan.TryParse(Config.Get("databases-refresh-period", "1.00:00:00"), CultureInfo.InvariantCulture, out var refreshPeriod) ? refreshPeriod : Time.OneDay;
 
         // We default this to true so that we don't terminate live algorithms when the
         // brokerage account has existing holdings for an asset that is not supported by Lean.
@@ -77,7 +78,7 @@ namespace QuantConnect
         /// </summary>
         /// <remarks>
         /// All securities added with <see cref="IAlgorithm.AddSecurity"/> are counted as one,
-        /// with the exception of options and futures where every single contract in a chain counts as one.
+        /// with the exception of options and futures where
         /// </remarks>
         [Obsolete("This property is deprecated. Please observe data subscription limits set by your brokerage to avoid runtime errors.")]
         public int DataSubscriptionLimit { get; set; } = int.MaxValue;
@@ -121,24 +122,7 @@ namespace QuantConnect
         public Resolution? WarmupResolution { get; set; }
 
         /// <summary>
-        /// The warmup resolution to use if any
-        /// </summary>
-        /// <remarks>This allows improving the warmup speed by setting it to a lower resolution than the one added in the algorithm.
-        /// Pass through version to be user friendly</remarks>
-        public Resolution? WarmUpResolution
-        {
-            get
-            {
-                return WarmupResolution;
-            }
-            set
-            {
-                WarmupResolution = value;
-            }
-        }
-
-        /// <summary>
-        /// Number of trading days per year for this Algorithm's portfolio statistics.
+        /// Gets or sets the number of trading days per year for this Algorithm's portfolio statistics.
         /// </summary>
         /// <remarks>Effect on
         /// <see cref="Statistics.PortfolioStatistics.AnnualVariance"/>,

--- a/Common/Chart.cs
+++ b/Common/Chart.cs
@@ -101,7 +101,7 @@ namespace QuantConnect
             //If we dont already have this series, add to the chrt:
             if (!Series.TryAdd(series.Name, series))
             {
-                throw new DuplicateNameException($"Chart.AddSeries(): ${Messages.Chart.ChartSeriesAlreadyExists}");
+                throw new DuplicateNameException("A series with the same name already exists in this chart.");
             }
         }
 

--- a/Common/Data/Auxiliary/LocalDiskMapFileProvider.cs
+++ b/Common/Data/Auxiliary/LocalDiskMapFileProvider.cs
@@ -50,17 +50,17 @@ namespace QuantConnect.Data.Auxiliary
         }
 
         /// <summary>
-        /// Gets a <see cref="MapFileResolver"/> representing all the map
+        /// Returns a <see cref="MapFileResolver"/> representing all the map
         /// files for the specified market
         /// </summary>
         /// <param name="auxiliaryDataKey">Key used to fetch a map file resolver. Specifying market and security type</param>
-        /// <returns>A <see cref="MapFileRow"/> containing all map files for the specified market</returns>
-        public MapFileResolver Get(AuxiliaryDataKey auxiliaryDataKey)
+        /// <returns>A <see cref="MapFileResolver"/> containing all map files for the specified market</returns>
+        public MapFileResolver GetMapFileResolver(AuxiliaryDataKey auxiliaryDataKey)
         {
-            return _cache.GetOrAdd(auxiliaryDataKey, GetMapFileResolver);
+            return _cache.GetOrAdd(auxiliaryDataKey, CreateMapFileResolver);
         }
 
-        private MapFileResolver GetMapFileResolver(AuxiliaryDataKey key)
+        private MapFileResolver CreateMapFileResolver(AuxiliaryDataKey key)
         {
             var securityType = key.SecurityType;
             var market = key.Market;
@@ -71,7 +71,7 @@ namespace QuantConnect.Data.Auxiliary
                 // only write this message once per application instance
                 if (Interlocked.CompareExchange(ref _wroteTraceStatement, 1, 0) == 0)
                 {
-                    Log.Error($"LocalDiskMapFileProvider.GetMapFileResolver({market}): " +
+                    Log.Error($"LocalDiskMapFileProvider.CreateMapFileResolver({market}): " +
                         $"The specified directory does not exist: {mapFileDirectory}"
                     );
                 }

--- a/Common/ExtendedDictionary.cs
+++ b/Common/ExtendedDictionary.cs
@@ -52,13 +52,23 @@ namespace QuantConnect
         /// <summary>
         /// Gets the value associated with the specified key.
         /// </summary>
-        /// <returns>
-        /// true if the object that implements <see cref="T:System.Collections.Generic.IDictionary`2"/> contains an element with the specified key; otherwise, false.
-        /// </returns>
         /// <param name="key">The key whose value to get.</param>
-        /// <param name="value">When this method returns, the value associated with the specified key, if the key is found; otherwise, the default value for the type of the <paramref name="value"/> parameter. This parameter is passed uninitialized.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is null.</exception>
-        public abstract bool TryGetValue(TKey key, out TValue value);
+        /// <returns>The value associated with the specified key if found; otherwise, the default value for TValue.</returns>
+        public TValue GetValue(TKey key)
+        {
+            return get(key);
+        }
+
+        /// <summary>
+        /// Gets the value associated with the specified key, or the provided default value if not found.
+        /// </summary>
+        /// <param name="key">The key whose value to get.</param>
+        /// <param name="value">The value to return if the key is not found.</param>
+        /// <returns>The value associated with the specified key if found; otherwise, the provided default value.</returns>
+        public TValue GetValue(TKey key, TValue value)
+        {
+            return get(key, value);
+        }
 
         /// <summary>
         /// Checks if the dictionary contains the specified key.
@@ -67,7 +77,19 @@ namespace QuantConnect
         /// <returns>true if the dictionary contains an element with the specified key; otherwise, false.</returns>
         public virtual bool ContainsKey(TKey key)
         {
-            return key != null && TryGetValue(key, out _);
+            if (key == null)
+            {
+                return false;
+            }
+
+            foreach (var item in GetItems())
+            {
+                if (EqualityComparer<TKey>.Default.Equals(item.Key, key))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         /// <summary>
@@ -91,6 +113,31 @@ namespace QuantConnect
         /// An <see cref="T:System.Collections.Generic.ICollection`1"/> containing the values in the object that implements <see cref="T:System.Collections.Generic.IDictionary`2"/>.
         /// </returns>
         protected abstract IEnumerable<TValue> GetValues { get; }
+
+        /// <summary>
+        /// Tries to get the value associated with the specified key.
+        /// Default implementation enumerates GetItems(); derived types can override for efficiency.
+        /// </summary>
+        public virtual bool TryGetValue(TKey key, out TValue value)
+        {
+            if (key == null)
+            {
+                value = default;
+                return false;
+            }
+
+            foreach (var kvp in GetItems())
+            {
+                if (EqualityComparer<TKey>.Default.Equals(kvp.Key, key))
+                {
+                    value = kvp.Value;
+                    return true;
+                }
+            }
+
+            value = default;
+            return false;
+        }
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="IDictionary"/> object is read-only.
@@ -270,11 +317,14 @@ namespace QuantConnect
             {
                 throw new KeyNotFoundException(Messages.ExtendedDictionary.KeyNotFoundDueToNone);
             }
+
             if (TryGetValue(key, out TValue data))
             {
                 Remove(key);
+                return data;
             }
-            return data;
+
+            throw new KeyNotFoundException(Messages.ExtendedDictionary.KeyNotFoundDueToNoData(this, key));
         }
 
         /// <summary>

--- a/Common/Interfaces/IExtendedDictionary.cs
+++ b/Common/Interfaces/IExtendedDictionary.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -55,7 +55,7 @@ namespace QuantConnect.Interfaces
         /// <param name="key">Key to be searched in the dictionary</param>
         /// <returns>The value for the specified key if key is in dictionary.
         /// None if the key is not found and value is not specified.</returns>
-        TValue get(TKey key);
+        TValue GetValue(TKey key);
 
         /// <summary>
         /// Returns the value for the specified key if key is in dictionary.
@@ -64,7 +64,7 @@ namespace QuantConnect.Interfaces
         /// <param name="value">Value to be returned if the key is not found. The default value is null.</param>
         /// <returns>The value for the specified key if key is in dictionary.
         /// value if the key is not found and value is specified.</returns>
-        TValue get(TKey key, TValue value);
+        TValue GetValue(TKey key, TValue value);
 
         /// <summary>
         /// Returns a view object that displays a list of dictionary's (key, value) tuple pairs.

--- a/Common/Interfaces/IMapFileProvider.cs
+++ b/Common/Interfaces/IMapFileProvider.cs
@@ -32,11 +32,11 @@ namespace QuantConnect.Interfaces
         void Initialize(IDataProvider dataProvider);
 
         /// <summary>
-        /// Gets a <see cref="MapFileResolver"/> representing all the map
+        /// Returns a <see cref="MapFileResolver"/> representing all the map
         /// files for the specified market
         /// </summary>
         /// <param name="auxiliaryDataKey">Key used to fetch a map file resolver. Specifying market and security type</param>
         /// <returns>A <see cref="MapFileResolver"/> containing all map files for the specified market</returns>
-        MapFileResolver Get(AuxiliaryDataKey auxiliaryDataKey);
+        MapFileResolver GetMapFileResolver(AuxiliaryDataKey auxiliaryDataKey);
     }
 }

--- a/Common/Messages/Messages.QuantConnect.cs
+++ b/Common/Messages/Messages.QuantConnect.cs
@@ -80,42 +80,42 @@ namespace QuantConnect
             /// <summary>
             /// Returns a string message saying: Return Over Maximum Drawdown
             /// </summary>
-            public static string ReturnOverMaximumDrawdownKey = "Return Over Maximum Drawdown";
+            public static readonly string ReturnOverMaximumDrawdownKey = "Return Over Maximum Drawdown";
 
             /// <summary>
             /// Returns a string message saying: Portfolio Turnover
             /// </summary>
-            public static string PortfolioTurnoverKey = "Portfolio Turnover";
+            public static readonly string PortfolioTurnoverKey = "Portfolio Turnover";
 
             /// <summary>
             /// Returns a string message saying: Total Insights Generated
             /// </summary>
-            public static string TotalInsightsGeneratedKey = "Total Insights Generated";
+            public static readonly string TotalInsightsGeneratedKey = "Total Insights Generated";
 
             /// <summary>
             /// Returns a string message saying: Total Insights Closed
             /// </summary>
-            public static string TotalInsightsClosedKey = "Total Insights Closed";
+            public static readonly string TotalInsightsClosedKey = "Total Insights Closed";
 
             /// <summary>
             /// Returns a string message saying: Total Insights Analysis Completed
             /// </summary>
-            public static string TotalInsightsAnalysisCompletedKey = "Total Insights Analysis Completed";
+            public static readonly string TotalInsightsAnalysisCompletedKey = "Total Insights Analysis Completed";
 
             /// <summary>
             /// Returns a string message saying: Long Insight Count
             /// </summary>
-            public static string LongInsightCountKey = "Long Insight Count";
+            public static readonly string LongInsightCountKey = "Long Insight Count";
 
             /// <summary>
             /// Returns a string message saying: Short Insight Count
             /// </summary>
-            public static string ShortInsightCountKey = "Short Insight Count";
+            public static readonly string ShortInsightCountKey = "Short Insight Count";
 
             /// <summary>
             /// Returns a string message saying: Long/Short Ratio
             /// </summary>
-            public static string LongShortRatioKey = "Long/Short Ratio";
+            public static readonly string LongShortRatioKey = "Long/Short Ratio";
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace QuantConnect
             /// <summary>
             /// Returns a string message saying Chart series name already exists
             /// </summary>
-            public static string ChartSeriesAlreadyExists = "Chart series name already exists";
+            public const string ChartSeriesAlreadyExists = "Chart series name already exists";
         }
 
         /// <summary>
@@ -175,31 +175,31 @@ namespace QuantConnect
         }
 
         /// <summary>
-        /// Provides user-facing messages for the <see cref="QuantConnect.ExtendedDictionary{T}"/> class and its consumers or related classes
+        /// Provides user-facing messages for the <see cref="QuantConnect.ExtendedDictionary{TKey,TValue}"/> class and its consumers or related classes
         /// </summary>
         public static class ExtendedDictionary
         {
             /// <summary>
             /// Returns a string message saying the types deriving from ExtendedDictionary must implement the void Clear() method
             /// </summary>
-            public static string ClearMethodNotImplemented = "Types deriving from 'ExtendedDictionary' must implement the 'void Clear() method.";
+            public static readonly string ClearMethodNotImplemented = "Types deriving from 'ExtendedDictionary' must implement the 'void Clear() method.";
 
             /// <summary>
             /// Returns a string message saying the types deriving from ExtendedDictionary must implement the void Remove(Symbol) method
             /// </summary>
-            public static string RemoveMethodNotImplemented =
+            public static readonly string RemoveMethodNotImplemented =
                 "Types deriving from 'ExtendedDictionary' must implement the 'void Remove(Symbol) method.";
 
             /// <summary>
             /// Returns a string message saying the types deriving from ExtendedDictionary must implement the T this[Symbol] method
             /// </summary>
-            public static string IndexerBySymbolNotImplemented =
+            public static readonly string IndexerBySymbolNotImplemented =
                 "Types deriving from 'ExtendedDictionary' must implement the 'T this[Symbol] method.";
 
             /// <summary>
             /// Returns a string with the error message we receive from Python when we try to pop a key with a null value in the ExtendedDictionary. It also shows a recommendation for solving this problem
             /// </summary>
-            public static string KeyNotFoundDueToNone = $"KeyError: None. Please check if the key is None before trying to access it or use data.pop(key, default) to return a default value instead of raising an exception.";
+            public static readonly string KeyNotFoundDueToNone = "KeyError: None. Please check if the key is None before trying to access it or use data.pop(key, default) to return a default value instead of raising an exception.";
 
             /// <summary>
             /// Returns a string message saying Clear/clear method call is an invalid operation. It also says that the given instance

--- a/Common/QuantConnect.csproj
+++ b/Common/QuantConnect.csproj
@@ -35,6 +35,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
     <PackageReference Include="CloneExtensions" Version="1.3.0" />
     <PackageReference Include="fasterflect" Version="3.0.0" />

--- a/Common/Securities/Positions/PortfolioState.cs
+++ b/Common/Securities/Positions/PortfolioState.cs
@@ -20,6 +20,7 @@ using Newtonsoft.Json;
 using QuantConnect.Logging;
 using QuantConnect.Securities;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace QuantConnect.Securities.Positions
 {
@@ -47,19 +48,19 @@ namespace QuantConnect.Securities.Positions
         /// The different positions groups
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public List<PositionGroupState> PositionGroups { get; set; }
+        public Collection<PositionGroupState> PositionGroups { get; } = new Collection<PositionGroupState>();
 
         /// <summary>
         /// Gets the cash book that keeps track of all currency holdings (only settled cash)
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public Dictionary<string, Cash> CashBook { get; set; }
+        public Dictionary<string, Cash> CashBook { get; } = new Dictionary<string, Cash>();
 
         /// <summary>
         /// Gets the cash book that keeps track of all currency holdings (only unsettled cash)
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public Dictionary<string, Cash> UnsettledCashBook { get; set; }
+        public Dictionary<string, Cash> UnsettledCashBook { get; } = new Dictionary<string, Cash>();
 
         /// <summary>
         /// Helper method to create the portfolio state snapshot
@@ -69,50 +70,55 @@ namespace QuantConnect.Securities.Positions
             try
             {
                 var totalMarginUsed = 0m;
-                var positionGroups = new List<PositionGroupState>(portfolioManager.Positions.Groups.Count);
+                var result = new PortfolioState
+                {
+                    Time = utcNow,
+                    TotalPortfolioValue = currentPortfolioValue,
+                    TotalMarginUsed = 0m
+                };
+
                 foreach (var group in portfolioManager.Positions.Groups)
                 {
                     var buyingPowerForPositionGroup = group.BuyingPowerModel.GetReservedBuyingPowerForPositionGroup(portfolioManager, group);
 
                     var positionGroupState = new PositionGroupState
                     {
-                        MarginUsed = buyingPowerForPositionGroup,
-                        Positions = group.Positions.ToList()
+                        MarginUsed = buyingPowerForPositionGroup
                     };
+
+                    foreach (var pos in group.Positions)
+                    {
+                        positionGroupState.Positions.Add(pos);
+                    }
+
                     if (currentPortfolioValue != 0)
                     {
                         positionGroupState.PortfolioValuePercentage = (buyingPowerForPositionGroup / currentPortfolioValue).RoundToSignificantDigits(4);
                     }
 
-                    positionGroups.Add(positionGroupState);
+                    result.PositionGroups.Add(positionGroupState);
                     totalMarginUsed += buyingPowerForPositionGroup;
                 }
 
-                var result = new PortfolioState
-                {
-                    Time = utcNow,
-                    TotalPortfolioValue = currentPortfolioValue,
-                    TotalMarginUsed = totalMarginUsed,
-                    CashBook = portfolioManager.CashBook.Where(pair => pair.Value.Amount != 0).ToDictionary(pair => pair.Key, pair => pair.Value)
-                };
+                result.TotalMarginUsed = totalMarginUsed;
 
-                var unsettledCashBook = portfolioManager.UnsettledCashBook
-                    .Where(pair => pair.Value.Amount != 0)
-                    .ToDictionary(pair => pair.Key, pair => pair.Value);
-                if (positionGroups.Count > 0)
+                foreach (var pair in portfolioManager.CashBook.Where(pair => pair.Value.Amount != 0))
                 {
-                    result.PositionGroups = positionGroups;
+                    result.CashBook[pair.Key] = pair.Value;
                 }
-                if (unsettledCashBook.Count > 0)
+
+                foreach (var pair in portfolioManager.UnsettledCashBook.Where(pair => pair.Value.Amount != 0))
                 {
-                    result.UnsettledCashBook = unsettledCashBook;
+                    result.UnsettledCashBook[pair.Key] = pair.Value;
                 }
+
+                // If no items were added, JSON DefaultValueHandling.Ignore will omit them.
                 return result;
             }
             catch (Exception e)
             {
                 Log.Error(e);
-                return null;
+                throw;
             }
         }
     }
@@ -141,6 +147,6 @@ namespace QuantConnect.Securities.Positions
         /// <summary>
         /// The positions which compose this group
         /// </summary>
-        public List<IPosition> Positions { get; set; }
+        public Collection<IPosition> Positions { get; } = new Collection<IPosition>();
     }
 }

--- a/Compression/QuantConnect.Compression.csproj
+++ b/Compression/QuantConnect.Compression.csproj
@@ -29,6 +29,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="DotNetZip" Version="1.16.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
   </ItemGroup>

--- a/Configuration/ApplicationParser.cs
+++ b/Configuration/ApplicationParser.cs
@@ -79,7 +79,7 @@ namespace QuantConnect.Configuration
                             optionsObject[optionKey] = subDictionary;
                             break;
                         default:
-                            throw new ArgumentOutOfRangeException();
+                            throw new InvalidOperationException($"Unsupported option type: {matchingOption?.Type}");
                     }
                 }
 

--- a/Configuration/QuantConnect.Configuration.csproj
+++ b/Configuration/QuantConnect.Configuration.csproj
@@ -30,6 +30,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>

--- a/DownloaderDataProvider/QuantConnect.DownloaderDataProvider.Launcher.csproj
+++ b/DownloaderDataProvider/QuantConnect.DownloaderDataProvider.Launcher.csproj
@@ -41,6 +41,9 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Common\QuantConnect.csproj" />
     <ProjectReference Include="..\Configuration\QuantConnect.Configuration.csproj" />
     <ProjectReference Include="..\Engine\QuantConnect.Lean.Engine.csproj" />

--- a/Engine/QuantConnect.Lean.Engine.csproj
+++ b/Engine/QuantConnect.Lean.Engine.csproj
@@ -41,6 +41,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
     <PackageReference Include="fasterflect" Version="3.0.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />

--- a/Indicators/QuantConnect.Indicators.csproj
+++ b/Indicators/QuantConnect.Indicators.csproj
@@ -31,6 +31,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
   </ItemGroup>

--- a/Launcher/QuantConnect.Lean.Launcher.csproj
+++ b/Launcher/QuantConnect.Lean.Launcher.csproj
@@ -36,6 +36,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="DynamicInterop" Version="0.9.1" />
   </ItemGroup>
   <ItemGroup>

--- a/Logging/QuantConnect.Logging.csproj
+++ b/Logging/QuantConnect.Logging.csproj
@@ -34,6 +34,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Messaging/QuantConnect.Messaging.csproj
+++ b/Messaging/QuantConnect.Messaging.csproj
@@ -29,6 +29,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="NetMQ" Version="4.0.1.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>

--- a/Optimizer.Launcher/QuantConnect.Optimizer.Launcher.csproj
+++ b/Optimizer.Launcher/QuantConnect.Optimizer.Launcher.csproj
@@ -31,6 +31,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
   <ItemGroup>

--- a/Optimizer/QuantConnect.Optimizer.csproj
+++ b/Optimizer/QuantConnect.Optimizer.csproj
@@ -31,6 +31,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
   <ItemGroup>

--- a/Queues/QuantConnect.Queues.csproj
+++ b/Queues/QuantConnect.Queues.csproj
@@ -29,6 +29,7 @@
     <Message Text="SelectedOptimization $(SelectedOptimization)" Importance="high" />
   </Target>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
   <ItemGroup>

--- a/Report/QuantConnect.Report.csproj
+++ b/Report/QuantConnect.Report.csproj
@@ -39,6 +39,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="QuantConnect.pythonnet" Version="2.0.64" />
     <PackageReference Include="Deedle" Version="2.1.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />

--- a/Research/QuantConnect.Research.csproj
+++ b/Research/QuantConnect.Research.csproj
@@ -31,6 +31,7 @@
     <Compile Include="..\Common\Properties\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
     <PackageReference Include="Plotly.NET" Version="5.1.0" />
     <PackageReference Include="Plotly.NET.CSharp" Version="0.13.0" />
     <PackageReference Include="Plotly.NET.Interactive" Version="5.0.0" />

--- a/ToolBox/QuantConnect.ToolBox.csproj
+++ b/ToolBox/QuantConnect.ToolBox.csproj
@@ -51,6 +51,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Accord" Version="3.6.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Engine\QuantConnect.Lean.Engine.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Messages.QuantConnect: had to change it for one of summaries. had to change one of codes into private const... I had convert the public static string message fields to public static readonly string so they are not mutable at runtime (satisfies S2223) and remove the unused private const field (the Chart field body left empty) to avoid the unused-field warning.

AlghorithmSettings:

1.
Replaced the ambiguous cref with <see cref="IAlgorithm.AddSecurity"/>. Removed the duplicate WarmUpResolution alias and kept the interface-matching WarmupResolution. Passed CultureInfo.InvariantCulture to TimeSpan.TryParse. Replaced the parameterless ArgumentOutOfRangeException with InvalidOperationException($"Unsupported option type: {matchingOption?.Type}") to clarify the failure and satisfy analyzers.

this changed ApplicationParser as well.

Chart:
I replaced the inaccessible reference with a direct string literal for the exception message. This ensures the exception can be thrown without access issues and preserves the intended error message. It didn't sadly work for one of examples due to its protection level forbidding me from accesing it.

PortfolioState: I added the static modifier to the Error method declaration, which resolves the CA1822 warning and makes it clear that the method does not depend on instance state. the class HasSufficientPositionGroupBuyingPowerForOrderParameters is defined more than once in the namespace QuantConnect.Securities.Positions. I removed the duplicate class definition from PortfolioState.cs to make sure only one definition of HasSufficientPositionGroupBuyingPowerForOrderParameters exists in my fork to resolve the CS0101 error.

IExtendedDictionary: I renamed the get methods to GetValue to avoid the reserved keyword conflict, following .NET naming conventions and resolving the CA1716 diagnostic. I might also update any implementations and usages of this interface accordingly.

IMapFileProvider: I renamed the Get method to GetMapFileResolver, making the method name more descriptive and avoiding the reserved keyword conflict. This change resolves the CA1716 warning and improves code clarity. I will also need to update all implementations and usages of this interface method accordingly.

And then I did both stuff:
IMapFileProvider, LocalDiskMapFileProvider, MapFilePrimaryExchangeProvider and MapFileResolverTests: I renamed the interface method to GetMapFileResolver, updated LocalDiskMapFileProvider to implement GetMapFileResolver (renamed its private factory to CreateMapFileResolver), and updated all call sites found (e.g., MapFilePrimaryExchangeProvider and tests). I might have to update any additional implementations/usages in my codebase similarly (search for .Get( with AuxiliaryDataKey) and replace with .GetMapFileResolver(...)).

I returned to PortfolioState and then replaced List<T> with Collection<T> for PositionGroups and Positions, made collection properties getter-only and initialized them, changed CashBook/UnsettledCashBook to getter-only dictionaries initialized empty, updated Create to populate those collections instead of replacing them, and adjusted the catch to log then rethrow (to avoid swallowing general exceptions). I must apply similar patterns to other types as needed.

ExtendedDictionary needed an error to be fixed: I added public implementations for both GetValue(TKey) and GetValue(TKey, TValue) in ExtendedDictionary<TKey, TValue>, delegating to the existing get methods. This satisfies the interface contract and resolves the CS0535 error. I replaced the call to TryGetValue with a manual search through the dictionary items using GetItems(), which is an abstract method guaranteed to be implemented by derived classes. This approach checks each key for equality and returns true if a match is found, otherwise false. This ensures the method works regardless of the underlying implementation. I added a default, virtual TryGetValue implementation that enumerates GetItems() (derived types can override for efficiency) and I updated pop(TKey) to return the found value or throw when missing, eliminating the unassigned data use.

Despite having the: "Targeting .NET 10.0 or higher in Visual Studio 2022 17.14 is not supported." warning, I am not using newer Visual Studio for now.

I could not find metadata files...