### PR TITLE
Prefer pythonnet's structured bind-failure data over message parsing

### DIFF
--- a/Common/Exceptions/NoMethodMatchPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/NoMethodMatchPythonExceptionInterpreter.cs
@@ -25,9 +25,8 @@ namespace QuantConnect.Exceptions
     public class NoMethodMatchPythonExceptionInterpreter : PythonExceptionInterpreter
     {
         /// <summary>
-        /// Attribute names pythonnet attaches to the bind-failure TypeError, carrying the
-        /// data its message is built from: the snake_case method name and the rendered
-        /// overloads hint block exactly as it appears at the end of the message.
+        /// Attributes pythonnet attaches to the bind-failure TypeError with the data its
+        /// message is built from: the method name and the overloads hint block.
         /// </summary>
         private const string MethodNameAttribute = "_clr_method_name";
         private const string OverloadsHintAttribute = "_clr_overloads_hint";
@@ -58,8 +57,6 @@ namespace QuantConnect.Exceptions
         {
             var pe = (PythonException)exception;
 
-            // Prefer the structured data pythonnet attaches to the bind-failure TypeError,
-            // falling back to parsing the message for versions that do not attach it.
             TryGetStructuredBindFailureData(pe, out var methodName, out var overloadsHint);
 
             methodName ??= GetMethodName(pe.Message);
@@ -77,10 +74,9 @@ namespace QuantConnect.Exceptions
         }
 
         /// <summary>
-        /// Reads the structured bind-failure data pythonnet attaches to the TypeError so
-        /// the method name and overloads hint do not have to be parsed out of the message.
-        /// Both outputs are null when the attributes are absent (raised by a pythonnet
-        /// version that does not attach them) or cannot be read.
+        /// Reads the structured bind-failure data pythonnet attaches to the TypeError.
+        /// Outputs are null when the attributes are absent (older pythonnet) or unreadable,
+        /// so the caller falls back to parsing the message.
         /// </summary>
         private static void TryGetStructuredBindFailureData(PythonException exception, out string methodName,
             out string overloadsHint)
@@ -110,7 +106,7 @@ namespace QuantConnect.Exceptions
                     }
                 }
 
-                // Normalize so the caller's null-coalescing fallback kicks in
+                // Empty means absent so the caller's null-coalescing fallback kicks in
                 if (string.IsNullOrEmpty(methodName))
                 {
                     methodName = null;
@@ -122,7 +118,6 @@ namespace QuantConnect.Exceptions
             }
             catch
             {
-                // Fall back to message parsing on any failure reading the attributes
                 methodName = null;
                 overloadsHint = null;
             }

--- a/Common/Exceptions/NoMethodMatchPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/NoMethodMatchPythonExceptionInterpreter.cs
@@ -25,6 +25,14 @@ namespace QuantConnect.Exceptions
     public class NoMethodMatchPythonExceptionInterpreter : PythonExceptionInterpreter
     {
         /// <summary>
+        /// Attribute names pythonnet attaches to the bind-failure TypeError, carrying the
+        /// data its message is built from: the snake_case method name and the rendered
+        /// overloads hint block exactly as it appears at the end of the message.
+        /// </summary>
+        private const string MethodNameAttribute = "_clr_method_name";
+        private const string OverloadsHintAttribute = "_clr_overloads_hint";
+
+        /// <summary>
         /// Determines the order that an instance of this class should be called
         /// </summary>
         public override int Order => 0;
@@ -50,10 +58,14 @@ namespace QuantConnect.Exceptions
         {
             var pe = (PythonException)exception;
 
-            var methodName = GetMethodName(pe.Message);
+            // Prefer the structured data pythonnet attaches to the bind-failure TypeError,
+            // falling back to parsing the message for versions that do not attach it.
+            TryGetStructuredBindFailureData(pe, out var methodName, out var overloadsHint);
+
+            methodName ??= GetMethodName(pe.Message);
             var message = Messages.NoMethodMatchPythonExceptionInterpreter.AttemptedToAccessMethodThatDoesNotExist(methodName);
 
-            var overloadsHint = GetOverloadsHint(pe.Message);
+            overloadsHint ??= GetOverloadsHint(pe.Message);
             if (!string.IsNullOrEmpty(overloadsHint))
             {
                 message += $" {overloadsHint}";
@@ -62,6 +74,58 @@ namespace QuantConnect.Exceptions
             message += PythonUtil.PythonExceptionStackParser(pe.StackTrace);
 
             return new MissingMethodException(message, pe);
+        }
+
+        /// <summary>
+        /// Reads the structured bind-failure data pythonnet attaches to the TypeError so
+        /// the method name and overloads hint do not have to be parsed out of the message.
+        /// Both outputs are null when the attributes are absent (raised by a pythonnet
+        /// version that does not attach them) or cannot be read.
+        /// </summary>
+        private static void TryGetStructuredBindFailureData(PythonException exception, out string methodName,
+            out string overloadsHint)
+        {
+            methodName = null;
+            overloadsHint = null;
+
+            try
+            {
+                var value = exception.Value;
+                if (value == null)
+                {
+                    return;
+                }
+
+                using (Py.GIL())
+                {
+                    if (value.HasAttr(MethodNameAttribute))
+                    {
+                        using var nameAttribute = value.GetAttr(MethodNameAttribute);
+                        methodName = nameAttribute.As<string>();
+                    }
+                    if (value.HasAttr(OverloadsHintAttribute))
+                    {
+                        using var hintAttribute = value.GetAttr(OverloadsHintAttribute);
+                        overloadsHint = hintAttribute.As<string>();
+                    }
+                }
+
+                // Normalize so the caller's null-coalescing fallback kicks in
+                if (string.IsNullOrEmpty(methodName))
+                {
+                    methodName = null;
+                }
+                if (string.IsNullOrEmpty(overloadsHint))
+                {
+                    overloadsHint = null;
+                }
+            }
+            catch
+            {
+                // Fall back to message parsing on any failure reading the attributes
+                methodName = null;
+                overloadsHint = null;
+            }
         }
 
         /// <summary>

--- a/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
@@ -162,8 +162,7 @@ namespace QuantConnect.Tests.Common.Exceptions
         [Test]
         public void InterpretPrefersStructuredAttributesOverMessageParsing()
         {
-            // The fixture raises a TypeError whose message names 'parsed_name' but whose
-            // structured attributes name 'structured_name'; the attributes must win.
+            // The fixture's message names 'parsed_name' but its attributes name 'structured_name'
             var pythonException = ThrowFixtureMethod("no_method_match_with_structured_attributes");
 
             var interpreter = new NoMethodMatchPythonExceptionInterpreter();
@@ -178,8 +177,7 @@ namespace QuantConnect.Tests.Common.Exceptions
         [Test]
         public void InterpretFallsBackToMessageParsingWithoutStructuredAttributes()
         {
-            // Same message shape but no structured attributes (older pythonnet versions):
-            // the interpreter must extract the method name and hint from the message.
+            // Same message shape but no attributes, as raised by older pythonnet versions
             var pythonException = ThrowFixtureMethod("no_method_match_without_structured_attributes");
 
             var interpreter = new NoMethodMatchPythonExceptionInterpreter();

--- a/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/NoMethodMatchPythonExceptionInterpreterTests.cs
@@ -159,6 +159,47 @@ namespace QuantConnect.Tests.Common.Exceptions
             Assert.That(exception.Message, Does.Contain("rsi("));
         }
 
+        [Test]
+        public void InterpretPrefersStructuredAttributesOverMessageParsing()
+        {
+            // The fixture raises a TypeError whose message names 'parsed_name' but whose
+            // structured attributes name 'structured_name'; the attributes must win.
+            var pythonException = ThrowFixtureMethod("no_method_match_with_structured_attributes");
+
+            var interpreter = new NoMethodMatchPythonExceptionInterpreter();
+            var exception = interpreter.Interpret(pythonException, NullExceptionInterpreter.Instance);
+
+            Assert.That(exception.Message, Does.Contain("required by the structured_name method"));
+            Assert.That(exception.Message, Does.Contain("The expected signature is:"));
+            Assert.That(exception.Message, Does.Contain("structured_name(x: int)"));
+            Assert.That(exception.Message, Does.Not.Contain("parsed_name"));
+        }
+
+        [Test]
+        public void InterpretFallsBackToMessageParsingWithoutStructuredAttributes()
+        {
+            // Same message shape but no structured attributes (older pythonnet versions):
+            // the interpreter must extract the method name and hint from the message.
+            var pythonException = ThrowFixtureMethod("no_method_match_without_structured_attributes");
+
+            var interpreter = new NoMethodMatchPythonExceptionInterpreter();
+            var exception = interpreter.Interpret(pythonException, NullExceptionInterpreter.Instance);
+
+            Assert.That(exception.Message, Does.Contain("required by the parsed_name method"));
+            Assert.That(exception.Message, Does.Contain("The following overloads are available:"));
+            Assert.That(exception.Message, Does.Contain("parsed_name(x: str)"));
+        }
+
+        private static PythonException ThrowFixtureMethod(string methodName)
+        {
+            using (Py.GIL())
+            {
+                var module = Py.Import("Test_PythonExceptionInterpreter");
+                var algorithm = module.GetAttr("Test_PythonExceptionInterpreter").Invoke();
+                return Assert.Throws<PythonException>(() => algorithm.GetAttr(methodName).Invoke());
+            }
+        }
+
         private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _pythonException : (Exception)Activator.CreateInstance(type);
     }
 }

--- a/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
+++ b/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
@@ -30,9 +30,7 @@ class Test_PythonExceptionInterpreter(QCAlgorithm):
         self._indicator = self.rsi(symbol, 15, Resolution.DAILY)
 
     def no_method_match_with_structured_attributes(self):
-        # Synthesizes the TypeError pythonnet raises on a bind failure, carrying the
-        # structured attributes but a different method name in the message, so tests
-        # can verify the attributes take precedence over message parsing.
+        # A bind-failure TypeError whose attributes name a different method than its message
         error = TypeError("No method matches given arguments for parsed_name: (<class 'str'>). "
                           "The following overloads are available:\n  parsed_name(x: str)")
         error._clr_method_name = 'structured_name'
@@ -40,8 +38,7 @@ class Test_PythonExceptionInterpreter(QCAlgorithm):
         raise error
 
     def no_method_match_without_structured_attributes(self):
-        # The bind-failure message shape from pythonnet versions that do not attach
-        # the structured attributes; the interpreter must fall back to parsing it.
+        # The message-only shape raised by pythonnet versions without the attributes
         raise TypeError("No method matches given arguments for parsed_name: (<class 'str'>). "
                         "The following overloads are available:\n  parsed_name(x: str)")
 

--- a/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
+++ b/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
@@ -29,6 +29,22 @@ class Test_PythonExceptionInterpreter(QCAlgorithm):
         # so no RSI overload matches the given arguments.
         self._indicator = self.rsi(symbol, 15, Resolution.DAILY)
 
+    def no_method_match_with_structured_attributes(self):
+        # Synthesizes the TypeError pythonnet raises on a bind failure, carrying the
+        # structured attributes but a different method name in the message, so tests
+        # can verify the attributes take precedence over message parsing.
+        error = TypeError("No method matches given arguments for parsed_name: (<class 'str'>). "
+                          "The following overloads are available:\n  parsed_name(x: str)")
+        error._clr_method_name = 'structured_name'
+        error._clr_overloads_hint = 'The expected signature is:\n  structured_name(x: int)'
+        raise error
+
+    def no_method_match_without_structured_attributes(self):
+        # The bind-failure message shape from pythonnet versions that do not attach
+        # the structured attributes; the interpreter must fall back to parsing it.
+        raise TypeError("No method matches given arguments for parsed_name: (<class 'str'>). "
+                        "The following overloads are available:\n  parsed_name(x: str)")
+
     def unsupported_operand(self):
         x = None + "Pepe Grillo"
 


### PR DESCRIPTION
#### Description

`NoMethodMatchPythonExceptionInterpreter` now prefers the structured data pythonnet attaches to the bind-failure TypeError — `_clr_method_name` and `_clr_overloads_hint` attributes on the exception instance — over parsing them out of the exception message. When the attributes are absent (any pythonnet version released so far) or cannot be read, the interpreter silently falls back to the existing message parsing, which is left intact. The rendered user-facing message is unchanged in both paths.

Pairs with QuantConnect/pythonnet#148, which attaches the attributes; this PR degrades gracefully without it, so it can be merged independently and does not require a pythonnet version bump.

#### Related Issue

Part of the error-surface improvements from the fleet-evidence study (QuantConnect/Agents#305, improvement 1): the interpreter's string parsing of pythonnet's message has garbled user-facing errors before (#9573, #9594); reading structured fields removes that coupling going forward.

#### Motivation and Context

Lean currently reconstructs the failed method name and the overloads hint by string-parsing pythonnet's TypeError message, a contract that has silently drifted before and produced garbled messages like `required by the 'int'>) method`. With pythonnet attaching the underlying data as exception attributes, the interpreter reads fields instead of parsing prose, and only falls back to parsing for older pythonnet versions.

#### Requires Documentation Change

None.

#### How Has This Been Tested?

- New tests in `NoMethodMatchPythonExceptionInterpreterTests`: one verifying the structured attributes take precedence over the message contents when present, one verifying the fallback to message parsing when they are absent. Both use synthesized TypeErrors from the `Test_PythonExceptionInterpreter` fixture, so they run against the currently referenced pythonnet package.
- Existing `NoMethodMatchPythonExceptionInterpreterTests` (real bind failures through the referenced pythonnet) still pass, covering the fallback path end-to-end.
- The structured path was also verified end-to-end against a locally built pythonnet from QuantConnect/pythonnet#148 copied into the test output.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
