### PR TITLE
Add contract days_to_expiry/dte and interpret Python date/datetime type errors

### DIFF
--- a/Algorithm.CSharp/ContractDaysToExpiryRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/ContractDaysToExpiryRegressionAlgorithm.cs
@@ -1,0 +1,140 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Regression algorithm asserting the behavior of <see cref="BaseContract.DaysToExpiry()"/> and <see cref="BaseContract.DTE"/>,
+    /// the supported alternative to manual expiry math mixing datetime and date values.
+    /// The Python version also asserts that the reference argument accepts both datetime and date instances.
+    /// </summary>
+    public class ContractDaysToExpiryRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _optionSymbol;
+        private int _contractsValidated;
+
+        public override void Initialize()
+        {
+            SetStartDate(2015, 12, 24);
+            SetEndDate(2015, 12, 24);
+            SetCash(100000);
+
+            var option = AddOption("GOOG");
+            option.SetFilter(u => u.Strikes(-2, +2).Expiration(0, 180));
+            _optionSymbol = option.Symbol;
+        }
+
+        public override void OnData(Slice slice)
+        {
+            OptionChain chain;
+            if (!slice.OptionChains.TryGetValue(_optionSymbol, out chain))
+            {
+                return;
+            }
+
+            foreach (var contract in chain)
+            {
+                var expected = (contract.Expiry.Date - Time.Date).Days;
+                if (contract.DaysToExpiry() != expected)
+                {
+                    throw new RegressionTestException($"Expected DaysToExpiry() to be {expected} but was {contract.DaysToExpiry()}");
+                }
+                if (contract.DTE != expected)
+                {
+                    throw new RegressionTestException($"Expected DTE to be {expected} but was {contract.DTE}");
+                }
+                if (contract.DaysToExpiry(Time.AddDays(-10)) != expected + 10)
+                {
+                    throw new RegressionTestException($"Expected DaysToExpiry(reference) to be {expected + 10} but was {contract.DaysToExpiry(Time.AddDays(-10))}");
+                }
+                _contractsValidated++;
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_contractsValidated == 0)
+            {
+                throw new RegressionTestException("No contracts were validated");
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 37131;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 0;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "0"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "100000"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$0.00"},
+            {"Estimated Strategy Capacity", "$0"},
+            {"Lowest Capacity Asset", ""},
+            {"Portfolio Turnover", "0%"},
+            {"Drawdown Recovery", "0"},
+            {"OrderListHash", "d41d8cd98f00b204e9800998ecf8427e"}
+        };
+    }
+}

--- a/Algorithm.Python/ContractDaysToExpiryRegressionAlgorithm.py
+++ b/Algorithm.Python/ContractDaysToExpiryRegressionAlgorithm.py
@@ -1,0 +1,55 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Regression algorithm asserting the behavior of 'days_to_expiry' and 'dte' on option/future contracts,
+### the supported alternative to manual expiry math mixing datetime and date values.
+### It also asserts that the reference argument accepts both datetime and date instances.
+### </summary>
+class ContractDaysToExpiryRegressionAlgorithm(QCAlgorithm):
+    def initialize(self):
+        self.set_start_date(2015, 12, 24)
+        self.set_end_date(2015, 12, 24)
+        self.set_cash(100000)
+
+        option = self.add_option("GOOG")
+        option.set_filter(lambda u: u.strikes(-2, +2).expiration(0, 180))
+        self._option_symbol = option.symbol
+        self._contracts_validated = 0
+
+    def on_data(self, slice):
+        chain = slice.option_chains.get(self._option_symbol)
+        if not chain:
+            return
+
+        for contract in chain:
+            # The manual shape, with the operand types correctly aligned
+            expected = (contract.expiry.date() - self.time.date()).days
+            if contract.days_to_expiry() != expected:
+                raise AssertionError(f"Expected days_to_expiry() to be {expected} but was {contract.days_to_expiry()}")
+            if contract.dte != expected:
+                raise AssertionError(f"Expected dte to be {expected} but was {contract.dte}")
+            # The reference argument accepts both datetime and date instances
+            if contract.days_to_expiry(self.time) != expected:
+                raise AssertionError(f"Expected days_to_expiry(datetime) to be {expected} but was {contract.days_to_expiry(self.time)}")
+            if contract.days_to_expiry(self.time.date()) != expected:
+                raise AssertionError(f"Expected days_to_expiry(date) to be {expected} but was {contract.days_to_expiry(self.time.date())}")
+            if contract.days_to_expiry(reference=self.time.date() - timedelta(days=10)) != expected + 10:
+                raise AssertionError(f"Expected days_to_expiry(reference=date) to be {expected + 10}")
+            self._contracts_validated += 1
+
+    def on_end_of_algorithm(self):
+        if self._contracts_validated == 0:
+            raise AssertionError("No contracts were validated")

--- a/Common/AlgorithmImports.py
+++ b/Common/AlgorithmImports.py
@@ -95,6 +95,7 @@ except:
     pass
 
 from datetime import date, time, datetime, timedelta
+from zoneinfo import ZoneInfo
 from typing import *
 import math
 import json

--- a/Common/Data/Market/BaseContract.cs
+++ b/Common/Data/Market/BaseContract.cs
@@ -49,6 +49,34 @@ namespace QuantConnect.Data.Market
         public DateTime Expiry => Symbol.ID.Date;
 
         /// <summary>
+        /// Gets the number of whole days until the contract expires, based on the contract's current time.
+        /// Shorthand alias of <see cref="DaysToExpiry()"/>
+        /// </summary>
+        [PandasIgnore]
+        public int DTE => DaysToExpiry();
+
+        /// <summary>
+        /// Gets the number of whole days between the contract's current time (<see cref="Time"/>) and <see cref="Expiry"/>
+        /// </summary>
+        /// <returns>The number of whole days until the contract expires</returns>
+        public int DaysToExpiry()
+        {
+            return DaysToExpiry(Time);
+        }
+
+        /// <summary>
+        /// Gets the number of whole days between the given reference and <see cref="Expiry"/>.
+        /// From Python, the reference accepts both <c>datetime</c> and <c>date</c> instances, avoiding the
+        /// TypeError users hit when manually mixing them, e.g. <c>(contract.expiry - self.time.date()).days</c>
+        /// </summary>
+        /// <param name="reference">The date to measure from. Only the date part is used</param>
+        /// <returns>The number of whole days from the given reference until the contract expires</returns>
+        public int DaysToExpiry(DateTime reference)
+        {
+            return (Expiry.Date - reference.Date).Days;
+        }
+
+        /// <summary>
         /// Gets the local date time this contract's data was last updated
         /// </summary>
         [PandasIgnore]

--- a/Common/Exceptions/GenericTypeParameterPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/GenericTypeParameterPythonExceptionInterpreter.cs
@@ -1,0 +1,62 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using Python.Runtime;
+using QuantConnect.Util;
+
+namespace QuantConnect.Exceptions
+{
+    /// <summary>
+    /// Interprets the TypeError exceptions pythonnet raises when a .NET generic type or Array is indexed with
+    /// something that is not a .NET type, e.g. 'RollingWindow[datetime](10)' with Python's datetime type
+    /// </summary>
+    public class GenericTypeParameterPythonExceptionInterpreter : PythonExceptionInterpreter
+    {
+        /// <summary>
+        /// Determines the order that an instance of this class should be called
+        /// </summary>
+        public override int Order => 0;
+
+        /// <summary>
+        /// Determines if this interpreter should be applied to the specified exception.
+        /// </summary>
+        /// <param name="exception">The exception to check</param>
+        /// <returns>True if the exception can be interpreted, false otherwise</returns>
+        public override bool CanInterpret(Exception exception)
+        {
+            // "type(s) expected" is raised for generic types, "type expected" for Array
+            return base.CanInterpret(exception) &&
+                (exception.Message.Contains(Messages.GenericTypeParameterPythonExceptionInterpreter.TypesExpectedSubstring) ||
+                    exception.Message.Contains(Messages.GenericTypeParameterPythonExceptionInterpreter.TypeExpectedSubstring));
+        }
+
+        /// <summary>
+        /// Interprets the specified exception into a new exception
+        /// </summary>
+        /// <param name="exception">The exception to be interpreted</param>
+        /// <param name="innerInterpreter">An interpreter that should be applied to the inner exception.</param>
+        /// <returns>The interpreted exception</returns>
+        public override Exception Interpret(Exception exception, IExceptionInterpreter innerInterpreter)
+        {
+            var pe = (PythonException)exception;
+
+            var message = Messages.GenericTypeParameterPythonExceptionInterpreter.InvalidGenericTypeParameter;
+            message += PythonUtil.PythonExceptionStackParser(pe.StackTrace);
+
+            return new Exception(message, pe);
+        }
+    }
+}

--- a/Common/Exceptions/TzInfoPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/TzInfoPythonExceptionInterpreter.cs
@@ -1,0 +1,63 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using Python.Runtime;
+using QuantConnect.Util;
+
+namespace QuantConnect.Exceptions
+{
+    /// <summary>
+    /// Interprets TypeError exceptions caused by passing a Lean time zone (a NodaTime DateTimeZone, like the
+    /// <see cref="TimeZones"/> values) where Python expects a tzinfo instance, e.g. 'datetime.now(TimeZones.NEW_YORK)'
+    /// </summary>
+    public class TzInfoPythonExceptionInterpreter : PythonExceptionInterpreter
+    {
+        /// <summary>
+        /// Determines the order that an instance of this class should be called
+        /// </summary>
+        public override int Order => 0;
+
+        /// <summary>
+        /// Determines if this interpreter should be applied to the specified exception.
+        /// </summary>
+        /// <param name="exception">The exception to check</param>
+        /// <returns>True if the exception can be interpreted, false otherwise</returns>
+        public override bool CanInterpret(Exception exception)
+        {
+            // CPython raises "tzinfo argument must be None or of a tzinfo subclass, not type 'CachedDateTimeZone'".
+            // Only interpret it when the offending type is a NodaTime time zone, so the hint below is accurate
+            return base.CanInterpret(exception) &&
+                exception.Message.Contains(Messages.TzInfoPythonExceptionInterpreter.TzInfoSubclassExpectedSubstring) &&
+                exception.Message.Contains(Messages.TzInfoPythonExceptionInterpreter.DateTimeZoneTypeSubstring);
+        }
+
+        /// <summary>
+        /// Interprets the specified exception into a new exception
+        /// </summary>
+        /// <param name="exception">The exception to be interpreted</param>
+        /// <param name="innerInterpreter">An interpreter that should be applied to the inner exception.</param>
+        /// <returns>The interpreted exception</returns>
+        public override Exception Interpret(Exception exception, IExceptionInterpreter innerInterpreter)
+        {
+            var pe = (PythonException)exception;
+
+            var message = Messages.TzInfoPythonExceptionInterpreter.LeanTimeZoneUsedAsTzInfo;
+            message += PythonUtil.PythonExceptionStackParser(pe.StackTrace);
+
+            return new Exception(message, pe);
+        }
+    }
+}

--- a/Common/Exceptions/UnsupportedOperandPythonExceptionInterpreter.cs
+++ b/Common/Exceptions/UnsupportedOperandPythonExceptionInterpreter.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Text.RegularExpressions;
 using Python.Runtime;
 using QuantConnect.Util;
 
@@ -36,8 +37,15 @@ namespace QuantConnect.Exceptions
         /// <returns>True if the exception can be interpreted, false otherwise</returns>
         public override bool CanInterpret(Exception exception)
         {
-            return base.CanInterpret(exception) &&
-                exception.Message.Contains(Messages.UnsupportedOperandPythonExceptionInterpreter.UnsupportedOperandTypeExpectedSubstring);
+            if (!base.CanInterpret(exception))
+            {
+                return false;
+            }
+            return exception.Message.Contains(Messages.UnsupportedOperandPythonExceptionInterpreter.UnsupportedOperandTypeExpectedSubstring) ||
+                // "can't compare datetime.datetime to datetime.date", the ordering flavor of mixing datetimes and dates,
+                // e.g. 'self.time.date() <= some_stored_datetime'
+                (exception.Message.Contains(Messages.UnsupportedOperandPythonExceptionInterpreter.CannotCompareTypesSubstring) &&
+                    HasDatetimeAndDateOperands(exception.Message));
         }
 
         /// <summary>
@@ -50,11 +58,37 @@ namespace QuantConnect.Exceptions
         {
             var pe = (PythonException)exception;
 
-            var types = pe.Message.Split(':')[1].Trim();
-            var message = Messages.UnsupportedOperandPythonExceptionInterpreter.InvalidObjectTypesForOperation(types);
+            string message;
+            if (pe.Message.Contains(Messages.UnsupportedOperandPythonExceptionInterpreter.UnsupportedOperandTypeExpectedSubstring))
+            {
+                var types = pe.Message.Split(':')[1].Trim();
+                message = Messages.UnsupportedOperandPythonExceptionInterpreter.InvalidObjectTypesForOperation(types);
+            }
+            else
+            {
+                // "can't compare {left} to {right}"
+                var match = Regex.Match(pe.Message, @"can't compare (?<left>\S+) to (?<right>\S+)");
+                var types = match.Success
+                    ? $"'{match.Groups["left"].Value}' and '{match.Groups["right"].Value}'"
+                    : "'datetime.datetime' and 'datetime.date'";
+                message = Messages.UnsupportedOperandPythonExceptionInterpreter.InvalidObjectTypesForComparison(types);
+            }
+
+            if (HasDatetimeAndDateOperands(pe.Message))
+            {
+                // The single most common shape of this error is expiry math like '(contract.id.date - self.time.date()).days',
+                // so point users at the supported alternatives
+                message += Messages.UnsupportedOperandPythonExceptionInterpreter.DatetimeAndDateOperandsHint;
+            }
             message += PythonUtil.PythonExceptionStackParser(pe.StackTrace);
 
             return new Exception(message, pe);
+        }
+
+        private static bool HasDatetimeAndDateOperands(string message)
+        {
+            // "datetime.date" is a prefix of "datetime.datetime", so require a word boundary after ".date"
+            return Regex.IsMatch(message, @"datetime\.datetime\b") && Regex.IsMatch(message, @"datetime\.date\b");
         }
     }
 }

--- a/Common/Messages/Messages.Exceptions.cs
+++ b/Common/Messages/Messages.Exceptions.cs
@@ -195,6 +195,19 @@ namespace QuantConnect
             public static string UnsupportedOperandTypeExpectedSubstring = "unsupported operand type";
 
             /// <summary>
+            /// Substring of the TypeError CPython raises when ordering datetime.datetime against datetime.date,
+            /// e.g. "can't compare datetime.datetime to datetime.date"
+            /// </summary>
+            public static string CannotCompareTypesSubstring = "can't compare";
+
+            /// <summary>
+            /// Additional guidance appended when the offending operands are datetime.datetime and datetime.date
+            /// </summary>
+            public static string DatetimeAndDateOperandsHint =
+                " When mixing datetime and date values, align the types first, e.g. 'self.time.date()'." +
+                " For expiry math, option and future contracts provide 'contract.days_to_expiry(reference)', which accepts both types, and 'contract.dte'.";
+
+            /// <summary>
             /// Returns a message for invalid object types for operation
             /// </summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -203,6 +216,65 @@ namespace QuantConnect
                 return $@"Trying to perform a summation, subtraction, multiplication or division between {
                     types} objects throws a TypeError exception. To prevent the exception, ensure that both values share the same type.";
             }
+
+            /// <summary>
+            /// Returns a message for an invalid comparison between two object types
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string InvalidObjectTypesForComparison(string types)
+            {
+                return $"Trying to compare {types} objects throws a TypeError exception. To prevent the exception, ensure that both values share the same type.";
+            }
+        }
+
+        /// <summary>
+        /// Provides user-facing messages for the <see cref="Exceptions.TzInfoPythonExceptionInterpreter"/> class and its consumers or related classes
+        /// </summary>
+        public static class TzInfoPythonExceptionInterpreter
+        {
+            /// <summary>
+            /// Substring of the TypeError CPython raises when a non-tzinfo object is passed as a tzinfo argument
+            /// </summary>
+            public static string TzInfoSubclassExpectedSubstring = "of a tzinfo subclass";
+
+            /// <summary>
+            /// Substring identifying NodaTime time zone types, e.g. 'CachedDateTimeZone', the type of the TimeZones values
+            /// </summary>
+            public static string DateTimeZoneTypeSubstring = "DateTimeZone";
+
+            /// <summary>
+            /// Message explaining that Lean time zones are not Python tzinfo instances and pointing at zoneinfo
+            /// </summary>
+            public static string LeanTimeZoneUsedAsTzInfo =
+                "Trying to use a Lean time zone like 'TimeZones.NEW_YORK' where Python expects a tzinfo instance throws a TypeError exception," +
+                " because Lean time zones are NodaTime DateTimeZone objects intended for Lean APIs." +
+                " Use Python's zoneinfo module instead, e.g. 'datetime.now(ZoneInfo(\"America/New_York\"))'." +
+                " 'ZoneInfo' is imported by AlgorithmImports, and 'ZoneInfo(str(TimeZones.NEW_YORK))' converts any Lean time zone.";
+        }
+
+        /// <summary>
+        /// Provides user-facing messages for the <see cref="Exceptions.GenericTypeParameterPythonExceptionInterpreter"/> class and its consumers or related classes
+        /// </summary>
+        public static class GenericTypeParameterPythonExceptionInterpreter
+        {
+            /// <summary>
+            /// The TypeError message pythonnet raises when a generic type is indexed with something that is not a .NET type
+            /// </summary>
+            public static string TypesExpectedSubstring = "type(s) expected";
+
+            /// <summary>
+            /// The TypeError message pythonnet raises when the Array type is indexed with something that is not a .NET type
+            /// </summary>
+            public static string TypeExpectedSubstring = "type expected";
+
+            /// <summary>
+            /// Message explaining that Python types cannot parameterize .NET generic types and pointing at the alternatives
+            /// </summary>
+            public static string InvalidGenericTypeParameter =
+                "Trying to parameterize a .NET generic type with a Python type throws a TypeError exception." +
+                " Python types like 'datetime' cannot be used as generic type parameters: use a .NET type, e.g. 'from System import DateTime'" +
+                " then 'RollingWindow[DateTime](10)', or one of the supported aliases int, float, bool and str." +
+                " The untyped 'RollingWindow(10)' also accepts values of any type.";
         }
     }
 }

--- a/Tests/Common/Data/Market/FuturesContractTests.cs
+++ b/Tests/Common/Data/Market/FuturesContractTests.cs
@@ -112,6 +112,19 @@ namespace QuantConnect.Tests.Common.Data.Market
         }
 
         [Test]
+        public void DaysToExpiryFromContractTimeAndExplicitReference()
+        {
+            // Future_CLF19_Jan2019 expires on 2018-12-19
+            var futureContract = new FuturesContract(Symbols.Future_CLF19_Jan2019) { Time = new DateTime(2018, 12, 10, 17, 0, 0) };
+
+            Assert.AreEqual(9, futureContract.DaysToExpiry());
+            Assert.AreEqual(futureContract.DaysToExpiry(), futureContract.DTE);
+
+            Assert.AreEqual(1, futureContract.DaysToExpiry(new DateTime(2018, 12, 18)));
+            Assert.AreEqual(-1, futureContract.DaysToExpiry(new DateTime(2018, 12, 20, 23, 59, 59)));
+        }
+
+        [Test]
         public void OpenInterest()
         {
             var futureContract = new FuturesContract(Symbols.Future_CLF19_Jan2019);

--- a/Tests/Common/Data/Market/OptionContractTests.cs
+++ b/Tests/Common/Data/Market/OptionContractTests.cs
@@ -15,6 +15,7 @@
 
 using System;
 using NUnit.Framework;
+using Python.Runtime;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
 using QuantConnect.Securities;
@@ -68,6 +69,47 @@ namespace QuantConnect.Tests.Common.Data.Market
             Assert.AreEqual(contract.LastPrice, contract.Price);
             Assert.AreEqual(contract.LastPrice, contract.Value);
             Assert.AreEqual(contract.LastPrice, contract.Close);
+        }
+
+        [Test]
+        public void DaysToExpiryFromContractTimeAndExplicitReference()
+        {
+            // SPY_C_192_Feb19_2016 expires on 2016-02-19
+            var symbol = Symbols.SPY_C_192_Feb19_2016;
+            var contract = new OptionContract(CreateOption(symbol)) { Time = new DateTime(2016, 02, 16, 9, 30, 0) };
+
+            // Default reference is the contract's current time, only the date parts matter
+            Assert.AreEqual(3, contract.DaysToExpiry());
+            Assert.AreEqual(contract.DaysToExpiry(), contract.DTE);
+
+            Assert.AreEqual(30, contract.DaysToExpiry(new DateTime(2016, 01, 20)));
+            Assert.AreEqual(0, contract.DaysToExpiry(new DateTime(2016, 02, 19, 23, 59, 59)));
+            Assert.AreEqual(-2, contract.DaysToExpiry(new DateTime(2016, 02, 21)));
+        }
+
+        [Test]
+        public void DaysToExpiryAcceptsPythonDateAndDatetimeReferences()
+        {
+            var symbol = Symbols.SPY_C_192_Feb19_2016;
+            var contract = new OptionContract(CreateOption(symbol)) { Time = new DateTime(2016, 02, 16, 9, 30, 0) };
+
+            using (Py.GIL())
+            {
+                dynamic getDte = PyModule.FromString("OptionContractTests_DaysToExpiry", @"
+from datetime import date, datetime
+
+def get_dte(contract):
+    return (contract.days_to_expiry(), contract.dte, contract.days_to_expiry(date(2016, 1, 20)),
+        contract.days_to_expiry(datetime(2016, 2, 19, 23, 59)), contract.days_to_expiry(reference=date(2016, 2, 21)))
+").GetAttr("get_dte");
+
+                var result = getDte(contract);
+                Assert.AreEqual(3, (int)result[0]);
+                Assert.AreEqual(3, (int)result[1]);
+                Assert.AreEqual(30, (int)result[2]);
+                Assert.AreEqual(0, (int)result[3]);
+                Assert.AreEqual(-2, (int)result[4]);
+            }
         }
     }
 }

--- a/Tests/Common/Exceptions/GenericTypeParameterPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/GenericTypeParameterPythonExceptionInterpreterTests.cs
@@ -1,0 +1,60 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Exceptions;
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Tests.Common.Exceptions
+{
+    [TestFixture]
+    public class GenericTypeParameterPythonExceptionInterpreterTests
+    {
+        private PythonException _pythonException;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            // x = RollingWindow[datetime](10)
+            _pythonException = UnsupportedOperandPythonExceptionInterpreterTests.CreatePythonException("python_type_as_generic_type_parameter");
+        }
+
+        [Test]
+        [TestCase(typeof(Exception), ExpectedResult = false)]
+        [TestCase(typeof(KeyNotFoundException), ExpectedResult = false)]
+        [TestCase(typeof(DivideByZeroException), ExpectedResult = false)]
+        [TestCase(typeof(InvalidOperationException), ExpectedResult = false)]
+        [TestCase(typeof(PythonException), ExpectedResult = true)]
+        public bool CanInterpretReturnsTrueForOnlyGenericTypeParameterPythonExceptionType(Type exceptionType)
+        {
+            var exception = CreateExceptionFromType(exceptionType);
+            return new GenericTypeParameterPythonExceptionInterpreter().CanInterpret(exception);
+        }
+
+        [Test]
+        public void InterpretedMessagePointsAtNetTypesAndUntypedRollingWindow()
+        {
+            var interpreted = new GenericTypeParameterPythonExceptionInterpreter().Interpret(_pythonException, NullExceptionInterpreter.Instance);
+            Assert.True(interpreted.Message.Contains("RollingWindow[DateTime](10)"), interpreted.Message);
+            Assert.True(interpreted.Message.Contains("RollingWindow(10)"), interpreted.Message);
+            // The stack trace should point at the offending line
+            Assert.True(interpreted.Message.Contains("RollingWindow[datetime](10)"), interpreted.Message);
+        }
+
+        private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _pythonException : (Exception)Activator.CreateInstance(type);
+    }
+}

--- a/Tests/Common/Exceptions/TzInfoPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/TzInfoPythonExceptionInterpreterTests.cs
@@ -1,0 +1,81 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using Python.Runtime;
+using QuantConnect.Exceptions;
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Tests.Common.Exceptions
+{
+    [TestFixture]
+    public class TzInfoPythonExceptionInterpreterTests
+    {
+        private PythonException _pythonException;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            // x = datetime.now(TimeZones.NEW_YORK)
+            _pythonException = UnsupportedOperandPythonExceptionInterpreterTests.CreatePythonException("lean_time_zone_as_tzinfo");
+        }
+
+        [Test]
+        [TestCase(typeof(Exception), ExpectedResult = false)]
+        [TestCase(typeof(KeyNotFoundException), ExpectedResult = false)]
+        [TestCase(typeof(DivideByZeroException), ExpectedResult = false)]
+        [TestCase(typeof(InvalidOperationException), ExpectedResult = false)]
+        [TestCase(typeof(PythonException), ExpectedResult = true)]
+        public bool CanInterpretReturnsTrueForOnlyTzInfoPythonExceptionType(Type exceptionType)
+        {
+            var exception = CreateExceptionFromType(exceptionType);
+            return new TzInfoPythonExceptionInterpreter().CanInterpret(exception);
+        }
+
+        [Test]
+        public void InterpretedMessagePointsAtZoneInfo()
+        {
+            var interpreted = new TzInfoPythonExceptionInterpreter().Interpret(_pythonException, NullExceptionInterpreter.Instance);
+            Assert.True(interpreted.Message.Contains("zoneinfo"), interpreted.Message);
+            Assert.True(interpreted.Message.Contains("ZoneInfo(\"America/New_York\")"), interpreted.Message);
+            // The stack trace should point at the offending line
+            Assert.True(interpreted.Message.Contains("datetime.now(TimeZones.NEW_YORK)"), interpreted.Message);
+        }
+
+        [Test]
+        public void DoesNotInterpretOtherTzInfoTypeErrors()
+        {
+            // A non-Lean type as tzinfo should not get the Lean-specific hint
+            PythonException exception = null;
+            using (Py.GIL())
+            {
+                try
+                {
+                    PythonEngine.Exec("from datetime import datetime\ndatetime.now('America/New_York')");
+                }
+                catch (PythonException pythonException)
+                {
+                    exception = pythonException;
+                }
+            }
+
+            Assert.IsNotNull(exception);
+            Assert.False(new TzInfoPythonExceptionInterpreter().CanInterpret(exception));
+        }
+
+        private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _pythonException : (Exception)Activator.CreateInstance(type);
+    }
+}

--- a/Tests/Common/Exceptions/UnsupportedOperandPythonExceptionInterpreterTests.cs
+++ b/Tests/Common/Exceptions/UnsupportedOperandPythonExceptionInterpreterTests.cs
@@ -83,6 +83,84 @@ namespace QuantConnect.Tests.Common.Exceptions
             Assert.True(exception.Message.Contains("x = None + \"Pepe Grillo\""));
         }
 
+        [Test]
+        public void NonDatetimeOperandsDoNotGetTheDatetimeHint()
+        {
+            var interpreted = new UnsupportedOperandPythonExceptionInterpreter()
+                .Interpret(_pythonException, NullExceptionInterpreter.Instance);
+            Assert.False(interpreted.Message.Contains("days_to_expiry"));
+        }
+
+        [Test]
+        public void DatetimeAndDateSubtractionGetsTheDatetimeHint()
+        {
+            // (contract.id.date - self.time.date()).days, the most common fleet shape of this error
+            var exception = CreatePythonException("datetime_and_date_subtraction");
+            var interpreter = new UnsupportedOperandPythonExceptionInterpreter();
+            Assert.True(interpreter.CanInterpret(exception));
+
+            var interpreted = interpreter.Interpret(exception, NullExceptionInterpreter.Instance);
+            Assert.True(interpreted.Message.Contains("'datetime.datetime' and 'datetime.date'"), interpreted.Message);
+            Assert.True(interpreted.Message.Contains("days_to_expiry"), interpreted.Message);
+            Assert.True(interpreted.Message.Contains(".date()"), interpreted.Message);
+        }
+
+        [Test]
+        public void DatetimeAndDateComparisonIsInterpretedWithTheDatetimeHint()
+        {
+            // "can't compare datetime.datetime to datetime.date", e.g. self.time.date() <= some_stored_datetime
+            var exception = CreatePythonException("datetime_and_date_comparison");
+            var interpreter = new UnsupportedOperandPythonExceptionInterpreter();
+            Assert.True(interpreter.CanInterpret(exception));
+
+            var interpreted = interpreter.Interpret(exception, NullExceptionInterpreter.Instance);
+            Assert.True(interpreted.Message.Contains("Trying to compare"), interpreted.Message);
+            Assert.True(interpreted.Message.Contains("'datetime.datetime'"), interpreted.Message);
+            Assert.True(interpreted.Message.Contains("'datetime.date'"), interpreted.Message);
+            Assert.True(interpreted.Message.Contains("days_to_expiry"), interpreted.Message);
+        }
+
+        [Test]
+        public void OtherComparisonTypeErrorsAreNotInterpreted()
+        {
+            // "can't compare offset-naive and offset-aware datetimes" is not the datetime-vs-date shape
+            PythonException exception = null;
+            using (Py.GIL())
+            {
+                try
+                {
+                    PythonEngine.Exec("from datetime import datetime, timezone\ndatetime.now() < datetime.now(timezone.utc)");
+                }
+                catch (PythonException pythonException)
+                {
+                    exception = pythonException;
+                }
+            }
+
+            Assert.IsNotNull(exception);
+            Assert.False(new UnsupportedOperandPythonExceptionInterpreter().CanInterpret(exception));
+        }
+
+        internal static PythonException CreatePythonException(string methodName)
+        {
+            using (Py.GIL())
+            {
+                var module = Py.Import("Test_PythonExceptionInterpreter");
+                dynamic algorithm = module.GetAttr("Test_PythonExceptionInterpreter").Invoke();
+
+                try
+                {
+                    algorithm.InvokeMethod(methodName);
+                }
+                catch (PythonException pythonException)
+                {
+                    return pythonException;
+                }
+            }
+
+            throw new InvalidOperationException($"Expected '{methodName}' to throw a PythonException");
+        }
+
         private Exception CreateExceptionFromType(Type type) => type == typeof(PythonException) ? _pythonException : (Exception)Activator.CreateInstance(type);
     }
 }

--- a/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
+++ b/Tests/RegressionAlgorithms/Test_PythonExceptionInterpreter.py
@@ -32,6 +32,18 @@ class Test_PythonExceptionInterpreter(QCAlgorithm):
     def unsupported_operand(self):
         x = None + "Pepe Grillo"
 
+    def datetime_and_date_subtraction(self):
+        x = datetime.now() - datetime.now().date()
+
+    def datetime_and_date_comparison(self):
+        x = datetime.now() <= datetime.now().date()
+
+    def lean_time_zone_as_tzinfo(self):
+        x = datetime.now(TimeZones.NEW_YORK)
+
+    def python_type_as_generic_type_parameter(self):
+        x = RollingWindow[datetime](10)
+
     def module_not_found(self):
         from MissingClrNamespace.Distributions import Normal
 


### PR DESCRIPTION
#### Description

Python algorithms mix .NET-converted `datetime` values (`self.time`, expiries) with pure Python `date` objects and die on DTE math:

```
can't compare datetime.datetime to datetime.date
tzinfo argument must be None or of a tzinfo subclass, not type 'CachedDateTimeZone'
type(s) expected
```

The changes:

- New `contract.days_to_expiry(reference)` / `contract.dte` on option and future contracts: whole days to expiry, date parts only. The reference accepts `datetime` or `date` from Python and defaults to the contract's current time.
- The datetime-vs-date TypeErrors now get a hint pointing at `.date()` alignment and `days_to_expiry`/`dte`.
- New tzinfo interpreter: `datetime.now(TimeZones.NEW_YORK)` now explains Lean time zones are not `tzinfo` and points at `ZoneInfo("America/New_York")`.
- `AlgorithmImports` now imports `ZoneInfo`, so the hinted fix works without an extra import.
- New generic-parameter interpreter: the bare `type(s) expected` error (e.g. `RollingWindow[datetime](30)`) now explains that Python types cannot parameterize .NET generics and names the alternatives.

Related work: QuantConnect/pythonnet#143 adds datetime/date coercion at the interop layer; the hints here still cover pure-Python mixes.

Deferred (needs interop-layer changes): making `RollingWindow[datetime]` work, and making Lean time zones directly usable as `tzinfo`.

#### Related Issue

N/A

#### Motivation and Context

DTE filtering is line one of nearly every options/futures selector, and these exact errors are easy to hit and hard to decode.

#### Requires Documentation Change

Yes: document `days_to_expiry`/`dte` and the `ZoneInfo` availability.

#### How Has This Been Tested?

- `ContractDaysToExpiryRegressionAlgorithm` (C# + Python): validates `days_to_expiry`/`dte` against manual expiry math; the Python twin passes `datetime`, `date` and keyword references.
- `OptionContractTests` / `FuturesContractTests`: default and explicit references, plus Python binding tests.
- New/extended interpreter tests using real Python exceptions; negative cases assert unrelated errors are not interpreted.
- Full `Tests.Common.Exceptions` + `Tests.Common.Data.Market` namespaces: 211 passed, 0 failed.
- End-to-end Launcher runs: the three failure shapes reproduced verbatim on master, new messages verified after.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
