### PR TITLE
Add big-request guardrails and honest resource diagnostics

### DIFF
--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -38,6 +38,20 @@ namespace QuantConnect.Algorithm
 
         private bool _dataDictionaryTickWarningSent;
 
+        // Large history request diagnostics: huge or repeatedly re-fetched requests are a recurring cause of
+        // multi-hour stalls and out of memory kills, warn upfront instead of failing with an opaque error later.
+        // A single request over the cells threshold triggers the size warning; requests over threshold divided by
+        // 'OverlappingRequestSizeDivisor' are tracked for the "re-fetch an overlapping window every day/selection"
+        // pattern, warning after 'OverlappingRequestsWarningCount' consecutive overlapping calls
+        private const int OverlappingRequestsWarningCount = 30;
+        private const int OverlappingRequestSizeDivisor = 50;
+        private readonly long _historyRequestCellsWarningThreshold = Config.GetInt("history-request-cells-warning-threshold", 5000000);
+        private bool _largeHistoryRequestWarningSent;
+        private bool _overlappingHistoryRequestsWarningSent;
+        private int _consecutiveOverlappingHistoryRequests;
+        private DateTime _previousLargeHistoryRequestStartUtc;
+        private DateTime _previousLargeHistoryRequestEndUtc;
+
         /// <summary>
         /// Gets or sets the history provider for the algorithm
         /// </summary>
@@ -1019,7 +1033,9 @@ namespace QuantConnect.Algorithm
         private IEnumerable<Slice> History(IEnumerable<HistoryRequest> requests, DateTimeZone timeZone)
         {
             // filter out any universe securities that may have made it this far
-            var filteredRequests = GetFilterestRequests(requests);
+            var filteredRequests = GetFilterestRequests(requests).ToList();
+
+            WarnOnLargeHistoryRequests(filteredRequests);
 
             // filter out future data to prevent look ahead bias
             var history = HistoryProvider.GetHistory(filteredRequests, timeZone);
@@ -1033,6 +1049,93 @@ namespace QuantConnect.Algorithm
             }
 
             return history;
+        }
+
+        /// <summary>
+        /// Emits one-time warnings for history requests that are likely to stall the algorithm or run it out of memory:
+        /// a single call estimated over <see cref="_historyRequestCellsWarningThreshold"/> data cells (bars x columns),
+        /// and repeated calls with time windows overlapping the previous call, e.g. re-fetching a long lookback on
+        /// every day or universe selection instead of updating incrementally
+        /// </summary>
+        private void WarnOnLargeHistoryRequests(List<HistoryRequest> requests)
+        {
+            if (_largeHistoryRequestWarningSent && _overlappingHistoryRequestsWarningSent || requests.Count == 0)
+            {
+                return;
+            }
+
+            long estimatedCells = 0;
+            var startUtc = DateTime.MaxValue;
+            var endUtc = DateTime.MinValue;
+            foreach (var request in requests)
+            {
+                estimatedCells += EstimateDataCells(request);
+                if (request.StartTimeUtc < startUtc)
+                {
+                    startUtc = request.StartTimeUtc;
+                }
+                if (request.EndTimeUtc > endUtc)
+                {
+                    endUtc = request.EndTimeUtc;
+                }
+            }
+
+            if (!_largeHistoryRequestWarningSent && estimatedCells >= _historyRequestCellsWarningThreshold)
+            {
+                _largeHistoryRequestWarningSent = true;
+                Debug($"Warning: large history request, estimated at ~{estimatedCells.ToStringInvariant("N0")} data cells" +
+                    $" across {requests.Count} request(s). Large history calls are slow and can run the algorithm out of memory:" +
+                    " consider requesting fewer symbols, a shorter period or a coarser resolution.");
+            }
+
+            if (!_overlappingHistoryRequestsWarningSent && estimatedCells >= _historyRequestCellsWarningThreshold / OverlappingRequestSizeDivisor)
+            {
+                var overlaps = startUtc < _previousLargeHistoryRequestEndUtc && endUtc > _previousLargeHistoryRequestStartUtc;
+                _consecutiveOverlappingHistoryRequests = overlaps ? _consecutiveOverlappingHistoryRequests + 1 : 0;
+                _previousLargeHistoryRequestStartUtc = startUtc;
+                _previousLargeHistoryRequestEndUtc = endUtc;
+
+                if (_consecutiveOverlappingHistoryRequests >= OverlappingRequestsWarningCount)
+                {
+                    _overlappingHistoryRequestsWarningSent = true;
+                    Debug($"Warning: history() has been called {OverlappingRequestsWarningCount}+ times with time windows overlapping" +
+                        " the previous call. Re-fetching a long lookback repeatedly is slow: consider fetching history once and keeping" +
+                        " it updated with a rolling window, consolidators or indicator warm up, or shortening the lookback.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Rough order-of-magnitude estimate of the data cells (bars x columns) a history request will produce
+        /// </summary>
+        private static long EstimateDataCells(HistoryRequest request)
+        {
+            var span = request.EndTimeUtc - request.StartTimeUtc;
+            if (span <= TimeSpan.Zero)
+            {
+                return 0;
+            }
+
+            // ~5 tradable days a week; sub-daily resolutions only have data during regular market hours
+            var tradableDays = Math.Max(1, span.TotalDays * 5 / 7);
+            double bars;
+            switch (request.Resolution)
+            {
+                case Resolution.Daily:
+                    bars = tradableDays;
+                    break;
+                case Resolution.Tick:
+                    // unknowable upfront, use a conservative 1 data point per second of market time
+                    bars = tradableDays * request.ExchangeHours.RegularMarketDuration.TotalSeconds;
+                    break;
+                default:
+                    bars = tradableDays * (request.ExchangeHours.RegularMarketDuration / request.Resolution.ToTimeSpan());
+                    break;
+            }
+
+            // approximate data frame column counts per data point
+            var columns = request.TickType == TickType.Quote ? 10 : request.TickType == TickType.OpenInterest ? 1 : 5;
+            return (long)(bars * columns);
         }
 
         private IEnumerable<HistoryRequest> GetFilterestRequests(IEnumerable<HistoryRequest> requests)

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -38,19 +38,7 @@ namespace QuantConnect.Algorithm
 
         private bool _dataDictionaryTickWarningSent;
 
-        // Large history request diagnostics: huge or repeatedly re-fetched requests are a recurring cause of
-        // multi-hour stalls and out of memory kills, warn upfront instead of failing with an opaque error later.
-        // A single request over the cells threshold triggers the size warning; requests over threshold divided by
-        // 'OverlappingRequestSizeDivisor' are tracked for the "re-fetch an overlapping window every day/selection"
-        // pattern, warning after 'OverlappingRequestsWarningCount' consecutive overlapping calls
-        private const int OverlappingRequestsWarningCount = 30;
-        private const int OverlappingRequestSizeDivisor = 50;
-        private readonly long _historyRequestCellsWarningThreshold = Config.GetInt("history-request-cells-warning-threshold", 5000000);
-        private bool _largeHistoryRequestWarningSent;
-        private bool _overlappingHistoryRequestsWarningSent;
-        private int _consecutiveOverlappingHistoryRequests;
-        private DateTime _previousLargeHistoryRequestStartUtc;
-        private DateTime _previousLargeHistoryRequestEndUtc;
+        private readonly LargeHistoryRequestDiagnostics _largeHistoryRequestDiagnostics = new();
 
         /// <summary>
         /// Gets or sets the history provider for the algorithm
@@ -1035,7 +1023,7 @@ namespace QuantConnect.Algorithm
             // filter out any universe securities that may have made it this far
             var filteredRequests = GetFilterestRequests(requests).ToList();
 
-            WarnOnLargeHistoryRequests(filteredRequests);
+            _largeHistoryRequestDiagnostics.WarnOnLargeHistoryRequests(filteredRequests, Debug);
 
             // filter out future data to prevent look ahead bias
             var history = HistoryProvider.GetHistory(filteredRequests, timeZone);
@@ -1049,93 +1037,6 @@ namespace QuantConnect.Algorithm
             }
 
             return history;
-        }
-
-        /// <summary>
-        /// Emits one-time warnings for history requests that are likely to stall the algorithm or run it out of memory:
-        /// a single call estimated over <see cref="_historyRequestCellsWarningThreshold"/> data cells (bars x columns),
-        /// and repeated calls with time windows overlapping the previous call, e.g. re-fetching a long lookback on
-        /// every day or universe selection instead of updating incrementally
-        /// </summary>
-        private void WarnOnLargeHistoryRequests(List<HistoryRequest> requests)
-        {
-            if (_largeHistoryRequestWarningSent && _overlappingHistoryRequestsWarningSent || requests.Count == 0)
-            {
-                return;
-            }
-
-            long estimatedCells = 0;
-            var startUtc = DateTime.MaxValue;
-            var endUtc = DateTime.MinValue;
-            foreach (var request in requests)
-            {
-                estimatedCells += EstimateDataCells(request);
-                if (request.StartTimeUtc < startUtc)
-                {
-                    startUtc = request.StartTimeUtc;
-                }
-                if (request.EndTimeUtc > endUtc)
-                {
-                    endUtc = request.EndTimeUtc;
-                }
-            }
-
-            if (!_largeHistoryRequestWarningSent && estimatedCells >= _historyRequestCellsWarningThreshold)
-            {
-                _largeHistoryRequestWarningSent = true;
-                Debug($"Warning: large history request, estimated at ~{estimatedCells.ToStringInvariant("N0")} data cells" +
-                    $" across {requests.Count} request(s). Large history calls are slow and can run the algorithm out of memory:" +
-                    " consider requesting fewer symbols, a shorter period or a coarser resolution.");
-            }
-
-            if (!_overlappingHistoryRequestsWarningSent && estimatedCells >= _historyRequestCellsWarningThreshold / OverlappingRequestSizeDivisor)
-            {
-                var overlaps = startUtc < _previousLargeHistoryRequestEndUtc && endUtc > _previousLargeHistoryRequestStartUtc;
-                _consecutiveOverlappingHistoryRequests = overlaps ? _consecutiveOverlappingHistoryRequests + 1 : 0;
-                _previousLargeHistoryRequestStartUtc = startUtc;
-                _previousLargeHistoryRequestEndUtc = endUtc;
-
-                if (_consecutiveOverlappingHistoryRequests >= OverlappingRequestsWarningCount)
-                {
-                    _overlappingHistoryRequestsWarningSent = true;
-                    Debug($"Warning: history() has been called {OverlappingRequestsWarningCount}+ times with time windows overlapping" +
-                        " the previous call. Re-fetching a long lookback repeatedly is slow: consider fetching history once and keeping" +
-                        " it updated with a rolling window, consolidators or indicator warm up, or shortening the lookback.");
-                }
-            }
-        }
-
-        /// <summary>
-        /// Rough order-of-magnitude estimate of the data cells (bars x columns) a history request will produce
-        /// </summary>
-        private static long EstimateDataCells(HistoryRequest request)
-        {
-            var span = request.EndTimeUtc - request.StartTimeUtc;
-            if (span <= TimeSpan.Zero)
-            {
-                return 0;
-            }
-
-            // ~5 tradable days a week; sub-daily resolutions only have data during regular market hours
-            var tradableDays = Math.Max(1, span.TotalDays * 5 / 7);
-            double bars;
-            switch (request.Resolution)
-            {
-                case Resolution.Daily:
-                    bars = tradableDays;
-                    break;
-                case Resolution.Tick:
-                    // unknowable upfront, use a conservative 1 data point per second of market time
-                    bars = tradableDays * request.ExchangeHours.RegularMarketDuration.TotalSeconds;
-                    break;
-                default:
-                    bars = tradableDays * (request.ExchangeHours.RegularMarketDuration / request.Resolution.ToTimeSpan());
-                    break;
-            }
-
-            // approximate data frame column counts per data point
-            var columns = request.TickType == TickType.Quote ? 10 : request.TickType == TickType.OpenInterest ? 1 : 5;
-            return (long)(bars * columns);
         }
 
         private IEnumerable<HistoryRequest> GetFilterestRequests(IEnumerable<HistoryRequest> requests)
@@ -1656,6 +1557,113 @@ namespace QuantConnect.Algorithm
                 {
                     yield return enumerator.Current;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Large history request diagnostics: huge or repeatedly re-fetched requests are a recurring cause of
+        /// multi-hour stalls and out of memory kills, warn upfront instead of failing with an opaque error later.
+        /// A single call over the cells threshold triggers the size warning; calls over threshold divided by
+        /// <see cref="OverlappingRequestSizeDivisor"/> are tracked for the "re-fetch an overlapping window every
+        /// day/selection" pattern, warning after <see cref="OverlappingRequestsWarningCount"/> consecutive overlapping calls
+        /// </summary>
+        private sealed class LargeHistoryRequestDiagnostics
+        {
+            private const int OverlappingRequestsWarningCount = 30;
+            private const int OverlappingRequestSizeDivisor = 50;
+
+            private readonly long _cellsWarningThreshold = Config.GetInt("history-request-cells-warning-threshold", 5000000);
+            private bool _largeRequestWarningSent;
+            private bool _overlappingRequestsWarningSent;
+            private int _consecutiveOverlappingRequests;
+            private DateTime _previousRequestStartUtc;
+            private DateTime _previousRequestEndUtc;
+
+            /// <summary>
+            /// Emits one-time warnings for history requests that are likely to stall the algorithm or run it out of memory:
+            /// a single call estimated over <see cref="_cellsWarningThreshold"/> data cells (bars x columns),
+            /// and repeated calls with time windows overlapping the previous call, e.g. re-fetching a long lookback on
+            /// every day or universe selection instead of updating incrementally
+            /// </summary>
+            public void WarnOnLargeHistoryRequests(List<HistoryRequest> requests, Action<string> debug)
+            {
+                if (_largeRequestWarningSent && _overlappingRequestsWarningSent || requests.Count == 0)
+                {
+                    return;
+                }
+
+                long estimatedCells = 0;
+                var startUtc = DateTime.MaxValue;
+                var endUtc = DateTime.MinValue;
+                foreach (var request in requests)
+                {
+                    estimatedCells += EstimateDataCells(request);
+                    if (request.StartTimeUtc < startUtc)
+                    {
+                        startUtc = request.StartTimeUtc;
+                    }
+                    if (request.EndTimeUtc > endUtc)
+                    {
+                        endUtc = request.EndTimeUtc;
+                    }
+                }
+
+                if (!_largeRequestWarningSent && estimatedCells >= _cellsWarningThreshold)
+                {
+                    _largeRequestWarningSent = true;
+                    debug($"Warning: large history request, estimated at ~{estimatedCells.ToStringInvariant("N0")} data cells" +
+                        $" across {requests.Count} request(s). Large history calls are slow and can run the algorithm out of memory:" +
+                        " consider requesting fewer symbols, a shorter period or a coarser resolution.");
+                }
+
+                if (!_overlappingRequestsWarningSent && estimatedCells >= _cellsWarningThreshold / OverlappingRequestSizeDivisor)
+                {
+                    var overlaps = startUtc < _previousRequestEndUtc && endUtc > _previousRequestStartUtc;
+                    _consecutiveOverlappingRequests = overlaps ? _consecutiveOverlappingRequests + 1 : 0;
+                    _previousRequestStartUtc = startUtc;
+                    _previousRequestEndUtc = endUtc;
+
+                    if (_consecutiveOverlappingRequests >= OverlappingRequestsWarningCount)
+                    {
+                        _overlappingRequestsWarningSent = true;
+                        debug($"Warning: history() has been called {OverlappingRequestsWarningCount}+ times with time windows overlapping" +
+                            " the previous call. Re-fetching a long lookback repeatedly is slow: consider fetching history once and keeping" +
+                            " it updated with a rolling window, consolidators or indicator warm up, or shortening the lookback.");
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Rough order-of-magnitude estimate of the data cells (bars x columns) a history request will produce
+            /// </summary>
+            private static long EstimateDataCells(HistoryRequest request)
+            {
+                var span = request.EndTimeUtc - request.StartTimeUtc;
+                if (span <= TimeSpan.Zero)
+                {
+                    return 0;
+                }
+
+                // ~5 tradable days a week; sub-daily resolutions only have data during regular market hours
+                var tradableDays = Math.Max(1, span.TotalDays * 5 / 7);
+                double bars;
+                switch (request.Resolution)
+                {
+                    case Resolution.Daily:
+                        bars = tradableDays;
+                        break;
+                    case Resolution.Tick:
+                        // unknowable upfront, use a conservative 1 data point per second of market time
+                        bars = tradableDays * request.ExchangeHours.RegularMarketDuration.TotalSeconds;
+                        break;
+                    default:
+                        bars = tradableDays * (request.ExchangeHours.RegularMarketDuration / request.Resolution.ToTimeSpan());
+                        break;
+                }
+
+                // approximate data frame column counts per data point
+                var columns = request.TickType == TickType.Quote ? 10 : request.TickType == TickType.OpenInterest ? 1 : 5;
+                return (long)(bars * columns);
             }
         }
     }

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -1569,6 +1569,7 @@ namespace QuantConnect.Algorithm
         {
             private const int OverlappingRequestsWarningCount = 30;
             private const int OverlappingRequestSizeDivisor = 50;
+            private const int AssumedTicksPerSecond = 10;
 
             private readonly long _cellsWarningThreshold = Config.GetInt("history-request-cells-warning-threshold", 5000000);
             private bool _largeRequestWarningSent;
@@ -1582,49 +1583,59 @@ namespace QuantConnect.Algorithm
             /// </summary>
             public void WarnOnLargeHistoryRequests(List<HistoryRequest> requests, Action<string> debug)
             {
-                if (_largeRequestWarningSent && _overlappingRequestsWarningSent || requests.Count == 0)
+                try
                 {
-                    return;
-                }
-
-                long estimatedCells = 0;
-                var startUtc = DateTime.MaxValue;
-                var endUtc = DateTime.MinValue;
-                foreach (var request in requests)
-                {
-                    estimatedCells += EstimateDataCells(request);
-                    if (request.StartTimeUtc < startUtc)
+                    if (_largeRequestWarningSent && _overlappingRequestsWarningSent || requests.Count == 0)
                     {
-                        startUtc = request.StartTimeUtc;
+                        return;
                     }
-                    if (request.EndTimeUtc > endUtc)
+
+                    long estimatedCells = 0;
+                    var startUtc = DateTime.MaxValue;
+                    var endUtc = DateTime.MinValue;
+                    foreach (var request in requests)
                     {
-                        endUtc = request.EndTimeUtc;
+                        estimatedCells += EstimateDataCells(request);
+                        if (request.StartTimeUtc < startUtc)
+                        {
+                            startUtc = request.StartTimeUtc;
+                        }
+                        if (request.EndTimeUtc > endUtc)
+                        {
+                            endUtc = request.EndTimeUtc;
+                        }
+                    }
+
+                    if (!_largeRequestWarningSent && estimatedCells >= _cellsWarningThreshold)
+                    {
+                        _largeRequestWarningSent = true;
+                        debug($"Warning: large history request, estimated at ~{estimatedCells.ToStringInvariant("N0")} data cells" +
+                            $" across {requests.Count} request(s). This can be slow and memory intensive: request fewer symbols," +
+                            " a shorter period or a coarser resolution.");
+                    }
+
+                    if (!_overlappingRequestsWarningSent && estimatedCells >= _cellsWarningThreshold / OverlappingRequestSizeDivisor)
+                    {
+                        var overlaps = startUtc < _previousRequestEndUtc && endUtc > _previousRequestStartUtc;
+                        _consecutiveOverlappingRequests = overlaps ? _consecutiveOverlappingRequests + 1 : 0;
+                        _previousRequestStartUtc = startUtc;
+                        _previousRequestEndUtc = endUtc;
+
+                        if (_consecutiveOverlappingRequests >= OverlappingRequestsWarningCount)
+                        {
+                            _overlappingRequestsWarningSent = true;
+                            debug($"Warning: history() has been called {OverlappingRequestsWarningCount}+ consecutive times with" +
+                                " overlapping time windows. Instead of re-fetching a long lookback, fetch it once and keep it updated" +
+                                " with a rolling window, consolidators or indicator warm up.");
+                        }
                     }
                 }
-
-                if (!_largeRequestWarningSent && estimatedCells >= _cellsWarningThreshold)
+                catch (Exception exception)
                 {
+                    // diagnostics must never interfere with the algorithm: log, disable and move on
                     _largeRequestWarningSent = true;
-                    debug($"Warning: large history request, estimated at ~{estimatedCells.ToStringInvariant("N0")} data cells" +
-                        $" across {requests.Count} request(s). This can be slow and memory intensive: request fewer symbols," +
-                        " a shorter period or a coarser resolution.");
-                }
-
-                if (!_overlappingRequestsWarningSent && estimatedCells >= _cellsWarningThreshold / OverlappingRequestSizeDivisor)
-                {
-                    var overlaps = startUtc < _previousRequestEndUtc && endUtc > _previousRequestStartUtc;
-                    _consecutiveOverlappingRequests = overlaps ? _consecutiveOverlappingRequests + 1 : 0;
-                    _previousRequestStartUtc = startUtc;
-                    _previousRequestEndUtc = endUtc;
-
-                    if (_consecutiveOverlappingRequests >= OverlappingRequestsWarningCount)
-                    {
-                        _overlappingRequestsWarningSent = true;
-                        debug($"Warning: history() has been called {OverlappingRequestsWarningCount}+ consecutive times with" +
-                            " overlapping time windows. Instead of re-fetching a long lookback, fetch it once and keep it updated" +
-                            " with a rolling window, consolidators or indicator warm up.");
-                    }
+                    _overlappingRequestsWarningSent = true;
+                    QuantConnect.Logging.Log.Error(exception);
                 }
             }
 
@@ -1648,8 +1659,9 @@ namespace QuantConnect.Algorithm
                         bars = tradableDays;
                         break;
                     case Resolution.Tick:
-                        // unknowable upfront, use a conservative 1 data point per second of market time
-                        bars = tradableDays * request.ExchangeHours.RegularMarketDuration.TotalSeconds;
+                        // unknowable upfront: liquid symbols see ~10 trades and 100+ quotes per second,
+                        // so 10 data points per second of market time is still on the low side
+                        bars = tradableDays * request.ExchangeHours.RegularMarketDuration.TotalSeconds * AssumedTicksPerSecond;
                         break;
                     default:
                         bars = tradableDays * (request.ExchangeHours.RegularMarketDuration / request.Resolution.ToTimeSpan());

--- a/Algorithm/QCAlgorithm.History.cs
+++ b/Algorithm/QCAlgorithm.History.cs
@@ -1561,11 +1561,9 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
-        /// Large history request diagnostics: huge or repeatedly re-fetched requests are a recurring cause of
-        /// multi-hour stalls and out of memory kills, warn upfront instead of failing with an opaque error later.
-        /// A single call over the cells threshold triggers the size warning; calls over threshold divided by
-        /// <see cref="OverlappingRequestSizeDivisor"/> are tracked for the "re-fetch an overlapping window every
-        /// day/selection" pattern, warning after <see cref="OverlappingRequestsWarningCount"/> consecutive overlapping calls
+        /// One-time warnings for history requests likely to stall the algorithm or run it out of memory:
+        /// a single call over the cells threshold, or repeated large calls with overlapping time windows,
+        /// e.g. re-fetching a long lookback every day instead of updating incrementally
         /// </summary>
         private sealed class LargeHistoryRequestDiagnostics
         {
@@ -1580,10 +1578,7 @@ namespace QuantConnect.Algorithm
             private DateTime _previousRequestEndUtc;
 
             /// <summary>
-            /// Emits one-time warnings for history requests that are likely to stall the algorithm or run it out of memory:
-            /// a single call estimated over <see cref="_cellsWarningThreshold"/> data cells (bars x columns),
-            /// and repeated calls with time windows overlapping the previous call, e.g. re-fetching a long lookback on
-            /// every day or universe selection instead of updating incrementally
+            /// Checks the given requests and emits the applicable warnings through the given debug callback
             /// </summary>
             public void WarnOnLargeHistoryRequests(List<HistoryRequest> requests, Action<string> debug)
             {
@@ -1612,8 +1607,8 @@ namespace QuantConnect.Algorithm
                 {
                     _largeRequestWarningSent = true;
                     debug($"Warning: large history request, estimated at ~{estimatedCells.ToStringInvariant("N0")} data cells" +
-                        $" across {requests.Count} request(s). Large history calls are slow and can run the algorithm out of memory:" +
-                        " consider requesting fewer symbols, a shorter period or a coarser resolution.");
+                        $" across {requests.Count} request(s). This can be slow and memory intensive: request fewer symbols," +
+                        " a shorter period or a coarser resolution.");
                 }
 
                 if (!_overlappingRequestsWarningSent && estimatedCells >= _cellsWarningThreshold / OverlappingRequestSizeDivisor)
@@ -1626,9 +1621,9 @@ namespace QuantConnect.Algorithm
                     if (_consecutiveOverlappingRequests >= OverlappingRequestsWarningCount)
                     {
                         _overlappingRequestsWarningSent = true;
-                        debug($"Warning: history() has been called {OverlappingRequestsWarningCount}+ times with time windows overlapping" +
-                            " the previous call. Re-fetching a long lookback repeatedly is slow: consider fetching history once and keeping" +
-                            " it updated with a rolling window, consolidators or indicator warm up, or shortening the lookback.");
+                        debug($"Warning: history() has been called {OverlappingRequestsWarningCount}+ consecutive times with" +
+                            " overlapping time windows. Instead of re-fetching a long lookback, fetch it once and keep it updated" +
+                            " with a rolling window, consolidators or indicator warm up.");
                     }
                 }
             }

--- a/Common/IsolatorLimitResultProvider.cs
+++ b/Common/IsolatorLimitResultProvider.cs
@@ -45,7 +45,7 @@ namespace QuantConnect
             }
 
             var timeProvider = RealTimeProvider.Instance;
-            isolatorLimitProvider.Consume(timeProvider, () => scheduledEvent.Scan(scanTimeUtc), timeMonitor);
+            isolatorLimitProvider.Consume(timeProvider, () => scheduledEvent.Scan(scanTimeUtc), timeMonitor, scheduledEvent.Name);
         }
 
         /// <summary>
@@ -63,13 +63,15 @@ namespace QuantConnect
             this IIsolatorLimitResultProvider isolatorLimitProvider,
             ITimeProvider timeProvider,
             Action code,
-            TimeMonitor timeMonitor
+            TimeMonitor timeMonitor,
+            string name = null
             )
         {
             var consumer = new TimeConsumer
             {
                 IsolatorLimitProvider = isolatorLimitProvider,
-                TimeProvider = timeProvider
+                TimeProvider = timeProvider,
+                Name = name
             };
             timeMonitor.Add(consumer);
             code();

--- a/Common/Scheduling/TimeConsumer.cs
+++ b/Common/Scheduling/TimeConsumer.cs
@@ -42,5 +42,16 @@ namespace QuantConnect.Scheduling
         /// to be <see cref="IsolatorLimitProvider"/>
         /// </summary>
         public DateTime? NextTimeRequest { get; set; }
+
+        /// <summary>
+        /// Name of the work being executed, if any, e.g. the scheduled event's name. Used to name the
+        /// long-running work in logs when additional time is requested
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The number of additional minutes that have been requested for this consumer so far
+        /// </summary>
+        public int AdditionalMinutesRequested { get; set; }
     }
 }

--- a/Common/Scheduling/TimeMonitor.cs
+++ b/Common/Scheduling/TimeMonitor.cs
@@ -37,6 +37,12 @@ namespace QuantConnect.Scheduling
         protected List<TimeConsumer> TimeConsumers { get; init; }
 
         /// <summary>
+        /// Optional handler used to also surface long-running work warnings to the user,
+        /// e.g. through the result handler's debug messages. Engine logs alone don't reach the user's logs
+        /// </summary>
+        public Action<string> UserWarningHandler { get; set; }
+
+        /// <summary>
         /// Returns the number of time consumers currently being monitored
         /// </summary>
         public int Count
@@ -113,14 +119,15 @@ namespace QuantConnect.Scheduling
                 if (consumer.Name != null)
                 {
                     // name the long-running work: the first minute crossing is the actionable heads-up, later ones are informational
-                    var message = $"TimeMonitor.ProcessConsumer(): '{consumer.Name}' has been executing for over {consumer.AdditionalMinutesRequested} minute(s)";
+                    var message = $"'{consumer.Name}' has been executing for over {consumer.AdditionalMinutesRequested} minute(s)";
                     if (consumer.AdditionalMinutesRequested == 1)
                     {
-                        Log.Error($"{message}. It will be stopped once the algorithm time loop limit is exhausted");
+                        Log.Error($"TimeMonitor.ProcessConsumer(): {message}. It will be stopped once the algorithm time loop limit is exhausted");
+                        UserWarningHandler?.Invoke($"Warning: {message}. It will be stopped once the algorithm time loop limit is exhausted");
                     }
                     else
                     {
-                        Log.Trace(message);
+                        Log.Trace($"TimeMonitor.ProcessConsumer(): {message}");
                     }
                 }
             }

--- a/Common/Scheduling/TimeMonitor.cs
+++ b/Common/Scheduling/TimeMonitor.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Threading;
 using QuantConnect.Util;
+using QuantConnect.Logging;
 using System.Collections.Generic;
 
 namespace QuantConnect.Scheduling
@@ -106,6 +107,22 @@ namespace QuantConnect.Scheduling
                 catch
                 {
                     // pass
+                }
+
+                consumer.AdditionalMinutesRequested++;
+                if (consumer.Name != null)
+                {
+                    // name the long-running work upfront: an opaque isolator kill minutes later is much harder to act on.
+                    // The first crossing of the one minute mark is the actionable heads-up, following ones are informational
+                    var message = $"TimeMonitor.ProcessConsumer(): '{consumer.Name}' has been executing for over {consumer.AdditionalMinutesRequested} minute(s)";
+                    if (consumer.AdditionalMinutesRequested == 1)
+                    {
+                        Log.Error($"{message}. It will be stopped once the algorithm time loop limit is exhausted");
+                    }
+                    else
+                    {
+                        Log.Trace(message);
+                    }
                 }
             }
         }

--- a/Common/Scheduling/TimeMonitor.cs
+++ b/Common/Scheduling/TimeMonitor.cs
@@ -112,8 +112,7 @@ namespace QuantConnect.Scheduling
                 consumer.AdditionalMinutesRequested++;
                 if (consumer.Name != null)
                 {
-                    // name the long-running work upfront: an opaque isolator kill minutes later is much harder to act on.
-                    // The first crossing of the one minute mark is the actionable heads-up, following ones are informational
+                    // name the long-running work: the first minute crossing is the actionable heads-up, later ones are informational
                     var message = $"TimeMonitor.ProcessConsumer(): '{consumer.Name}' has been executing for over {consumer.AdditionalMinutesRequested} minute(s)";
                     if (consumer.AdditionalMinutesRequested == 1)
                     {

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -101,7 +101,8 @@ namespace QuantConnect.Lean.Engine
             // initialize the time limit manager
             TimeLimit = new AlgorithmTimeLimitManager(
                 CreateTokenBucket(job?.Controls?.TrainingLimits),
-                TimeSpan.FromMinutes(Config.GetDouble("algorithm-manager-time-loop-maximum", 20))
+                TimeSpan.FromMinutes(Config.GetDouble("algorithm-manager-time-loop-maximum", 20)),
+                TimeSpan.FromMinutes(Config.GetDouble("algorithm-manager-time-loop-warning", 1))
             );
         }
 

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -102,7 +102,7 @@ namespace QuantConnect.Lean.Engine
             TimeLimit = new AlgorithmTimeLimitManager(
                 CreateTokenBucket(job?.Controls?.TrainingLimits),
                 TimeSpan.FromMinutes(Config.GetDouble("algorithm-manager-time-loop-maximum", 20)),
-                TimeSpan.FromMinutes(Config.GetDouble("algorithm-manager-time-loop-warning", 1))
+                TimeSpan.FromMinutes(Config.GetDouble("algorithm-manager-time-loop-warning", 3))
             );
         }
 

--- a/Engine/AlgorithmManager.cs
+++ b/Engine/AlgorithmManager.cs
@@ -124,6 +124,8 @@ namespace QuantConnect.Lean.Engine
             //Initialize:
             _algorithm = algorithm;
             _performanceTrackingTool = performanceTrackingTool;
+            // surface time limit warnings in the user's logs, not just the engine log
+            TimeLimit.UserWarningHandler = results.DebugMessage;
 
             var token = cancellationTokenSource.Token;
             _cancellationTokenSource = cancellationTokenSource;

--- a/Engine/AlgorithmTimeLimitManager.cs
+++ b/Engine/AlgorithmTimeLimitManager.cs
@@ -55,11 +55,11 @@ namespace QuantConnect.Lean.Engine
         /// spend in a single time loop. This value can be overriden if certain actions are taken by the
         /// algorithm, such as invoking the training methods.</param>
         /// <param name="timeLoopWarningThreshold">Elapsed time of a single time loop after which a warning is logged,
-        /// once per time step. Defaults to one minute; a non positive value disables the warning</param>
+        /// once per time step. Defaults to three minutes; a non positive value disables the warning</param>
         public AlgorithmTimeLimitManager(ITokenBucket additionalTimeBucket, TimeSpan timeLoopMaximum, TimeSpan? timeLoopWarningThreshold = null)
         {
             _timeLoopMaximum = timeLoopMaximum;
-            _timeLoopWarningThreshold = timeLoopWarningThreshold ?? TimeSpan.FromMinutes(1);
+            _timeLoopWarningThreshold = timeLoopWarningThreshold ?? TimeSpan.FromMinutes(3);
             AdditionalTimeBucket = additionalTimeBucket;
             _currentTimeStepTime = new ReferenceWrapper<DateTime>(DateTime.MinValue);
         }

--- a/Engine/AlgorithmTimeLimitManager.cs
+++ b/Engine/AlgorithmTimeLimitManager.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -54,9 +54,8 @@ namespace QuantConnect.Lean.Engine
         /// <param name="timeLoopMaximum">Specifies the maximum amount of time the algorithm is permitted to
         /// spend in a single time loop. This value can be overriden if certain actions are taken by the
         /// algorithm, such as invoking the training methods.</param>
-        /// <param name="timeLoopWarningThreshold">Elapsed time of a single time loop after which a warning is
-        /// logged, once per time step, so a slow handler is flagged well before the time loop maximum stops the
-        /// algorithm. Defaults to one minute; a non positive value disables the warning</param>
+        /// <param name="timeLoopWarningThreshold">Elapsed time of a single time loop after which a warning is logged,
+        /// once per time step. Defaults to one minute; a non positive value disables the warning</param>
         public AlgorithmTimeLimitManager(ITokenBucket additionalTimeBucket, TimeSpan timeLoopMaximum, TimeSpan? timeLoopWarningThreshold = null)
         {
             _timeLoopMaximum = timeLoopMaximum;
@@ -107,19 +106,18 @@ namespace QuantConnect.Lean.Engine
             TimeSpan currentTimeStepElapsed;
             var message = IsOutOfTime(out currentTimeStepElapsed) ? GetErrorMessage(currentTimeStepElapsed) : string.Empty;
 
-            // warn early about an abnormally long time step: waiting for the time loop maximum to stop the algorithm
-            // costs many opaque minutes, while a warning naming the elapsed time is immediately actionable
+            // warn early about an abnormally long time step: an isolator kill minutes later is opaque,
+            // the elapsed-time warning is actionable now
             if (message.Length == 0 && !_stopped && !_timeStepWarningSent
                 && _timeLoopWarningThreshold > TimeSpan.Zero && currentTimeStepElapsed > _timeLoopWarningThreshold)
             {
                 _timeStepWarningSent = true;
-                // override message flood protection: the message text repeats for every slow time step (at most one
-                // line per warning threshold of wall-clock time) and each occurrence is relevant
+                // override flood protection: the same text repeats for each slow time step and each occurrence matters
                 Log.Error("AlgorithmTimeLimitManager.IsWithinLimit(): " +
-                    $"the current algorithm time step has been executing for {currentTimeStepElapsed.TotalMinutes.ToStringInvariant("0.0")} minutes; " +
-                    $"the algorithm will be stopped if a single time step exceeds {_timeLoopMaximum.TotalMinutes.ToStringInvariant()} minutes. " +
-                    "If a scheduled event is running it is named in a 'TimeMonitor' log entry; other common causes are large" +
-                    " history() requests, heavy work in data event handlers (e.g. on_data) or an infinite loop.",
+                    $"the current time step has been executing for {currentTimeStepElapsed.TotalMinutes.ToStringInvariant("0.0")} minutes" +
+                    $" and the algorithm will be stopped if it exceeds {_timeLoopMaximum.TotalMinutes.ToStringInvariant()} minutes." +
+                    " Common causes: a slow scheduled event (named in 'TimeMonitor' logs), large history() requests," +
+                    " heavy on_data work or an infinite loop.",
                     overrideMessageFloodProtection: true);
             }
 

--- a/Engine/AlgorithmTimeLimitManager.cs
+++ b/Engine/AlgorithmTimeLimitManager.cs
@@ -35,6 +35,8 @@ namespace QuantConnect.Lean.Engine
 
         private volatile ReferenceWrapper<DateTime> _currentTimeStepTime;
         private readonly TimeSpan _timeLoopMaximum;
+        private readonly TimeSpan _timeLoopWarningThreshold;
+        private volatile bool _timeStepWarningSent;
 
         /// <summary>
         /// Gets the additional time bucket which is responsible for tracking additional time requested
@@ -52,9 +54,13 @@ namespace QuantConnect.Lean.Engine
         /// <param name="timeLoopMaximum">Specifies the maximum amount of time the algorithm is permitted to
         /// spend in a single time loop. This value can be overriden if certain actions are taken by the
         /// algorithm, such as invoking the training methods.</param>
-        public AlgorithmTimeLimitManager(ITokenBucket additionalTimeBucket, TimeSpan timeLoopMaximum)
+        /// <param name="timeLoopWarningThreshold">Elapsed time of a single time loop after which a warning is
+        /// logged, once per time step, so a slow handler is flagged well before the time loop maximum stops the
+        /// algorithm. Defaults to one minute; a non positive value disables the warning</param>
+        public AlgorithmTimeLimitManager(ITokenBucket additionalTimeBucket, TimeSpan timeLoopMaximum, TimeSpan? timeLoopWarningThreshold = null)
         {
             _timeLoopMaximum = timeLoopMaximum;
+            _timeLoopWarningThreshold = timeLoopWarningThreshold ?? TimeSpan.FromMinutes(1);
             AdditionalTimeBucket = additionalTimeBucket;
             _currentTimeStepTime = new ReferenceWrapper<DateTime>(DateTime.MinValue);
         }
@@ -80,6 +86,7 @@ namespace QuantConnect.Lean.Engine
             // accessing DateTime.UtcNow from the algorithm manager thread to the isolator thread
             _currentTimeStepTime = new ReferenceWrapper<DateTime>(DateTime.MinValue);
             Interlocked.Exchange(ref _additionalMinutes, 0L);
+            _timeStepWarningSent = false;
         }
 
         /// <summary>
@@ -99,6 +106,23 @@ namespace QuantConnect.Lean.Engine
         {
             TimeSpan currentTimeStepElapsed;
             var message = IsOutOfTime(out currentTimeStepElapsed) ? GetErrorMessage(currentTimeStepElapsed) : string.Empty;
+
+            // warn early about an abnormally long time step: waiting for the time loop maximum to stop the algorithm
+            // costs many opaque minutes, while a warning naming the elapsed time is immediately actionable
+            if (message.Length == 0 && !_stopped && !_timeStepWarningSent
+                && _timeLoopWarningThreshold > TimeSpan.Zero && currentTimeStepElapsed > _timeLoopWarningThreshold)
+            {
+                _timeStepWarningSent = true;
+                // override message flood protection: the message text repeats for every slow time step (at most one
+                // line per warning threshold of wall-clock time) and each occurrence is relevant
+                Log.Error("AlgorithmTimeLimitManager.IsWithinLimit(): " +
+                    $"the current algorithm time step has been executing for {currentTimeStepElapsed.TotalMinutes.ToStringInvariant("0.0")} minutes; " +
+                    $"the algorithm will be stopped if a single time step exceeds {_timeLoopMaximum.TotalMinutes.ToStringInvariant()} minutes. " +
+                    "If a scheduled event is running it is named in a 'TimeMonitor' log entry; other common causes are large" +
+                    " history() requests, heavy work in data event handlers (e.g. on_data) or an infinite loop.",
+                    overrideMessageFloodProtection: true);
+            }
+
             return new IsolatorLimitResult(currentTimeStepElapsed, message);
         }
 

--- a/Engine/AlgorithmTimeLimitManager.cs
+++ b/Engine/AlgorithmTimeLimitManager.cs
@@ -45,6 +45,12 @@ namespace QuantConnect.Lean.Engine
         public ITokenBucket AdditionalTimeBucket { get; }
 
         /// <summary>
+        /// Optional handler used to also surface the slow time step warning to the user,
+        /// e.g. through the result handler's debug messages. Engine logs alone don't reach the user's logs
+        /// </summary>
+        public Action<string> UserWarningHandler { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of <see cref="AlgorithmTimeLimitManager"/> to manage the
         /// creation of <see cref="IsolatorLimitResult"/> instances as it pertains to the
         /// algorithm manager's time loop
@@ -112,13 +118,13 @@ namespace QuantConnect.Lean.Engine
                 && _timeLoopWarningThreshold > TimeSpan.Zero && currentTimeStepElapsed > _timeLoopWarningThreshold)
             {
                 _timeStepWarningSent = true;
-                // override flood protection: the same text repeats for each slow time step and each occurrence matters
-                Log.Error("AlgorithmTimeLimitManager.IsWithinLimit(): " +
-                    $"the current time step has been executing for {currentTimeStepElapsed.TotalMinutes.ToStringInvariant("0.0")} minutes" +
+                var warning = $"the current time step has been executing for {currentTimeStepElapsed.TotalMinutes.ToStringInvariant("0.0")} minutes" +
                     $" and the algorithm will be stopped if it exceeds {_timeLoopMaximum.TotalMinutes.ToStringInvariant()} minutes." +
                     " Common causes: a slow scheduled event (named in 'TimeMonitor' logs), large history() requests," +
-                    " heavy on_data work or an infinite loop.",
-                    overrideMessageFloodProtection: true);
+                    " heavy on_data work or an infinite loop.";
+                // override flood protection: the same text repeats for each slow time step and each occurrence matters
+                Log.Error($"AlgorithmTimeLimitManager.IsWithinLimit(): {warning}", overrideMessageFloodProtection: true);
+                UserWarningHandler?.Invoke($"Warning: {warning}");
             }
 
             return new IsolatorLimitResult(currentTimeStepElapsed, message);

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -54,10 +54,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             new Dictionary<Resolution, int>
             {
                 { Resolution.Tick, 100 },
-                { Resolution.Second, 250 },
-                { Resolution.Minute, 500 },
-                { Resolution.Hour, 1000 },
-                { Resolution.Daily, 2000 },
+                { Resolution.Second, 500 },
+                { Resolution.Minute, 1000 },
+                { Resolution.Hour, 2000 },
+                { Resolution.Daily, 4000 },
             });
 
         /// <summary>
@@ -512,7 +512,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // skip small selections: only a selection that is itself a meaningful share of its
                 // threshold can tip the shared budget, so don't aggregate across all universes for every one
                 if (!TryGetSizeWarningThreshold(universe, out _, out var universeThreshold)
-                    || GetSelectionSize(universe) * MinimumSignificantSelectionRatio < universeThreshold)
+                    || universe.Selected.Count * MinimumSignificantSelectionRatio < universeThreshold)
                 {
                     return;
                 }
@@ -550,7 +550,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     ? "Narrow the filter (SetFilter/set_filter) or add specific contracts (AddOptionContract/add_option_contract)."
                     : "Select fewer symbols or use a coarser universe resolution (UniverseSettings.Resolution/universe_settings.resolution).";
                 _algorithm.Debug($"Warning: universe selections have reached {string.Join(" and ", counts)} across {universeCount} universe(s)," +
-                    $" latest: {GetSelectionSize(universe)} from {GetUniverseName(universe)}. Each selected symbol adds data" +
+                    $" latest: {universe.Selected.Count} from {universe.Configuration.Symbol.Value}. Each selected symbol adds data" +
                     $" subscriptions, increasing time and memory usage. {suggestion}");
             }
             catch (Exception exception)
@@ -570,7 +570,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             {
                 return;
             }
-            var selectionSize = GetSelectionSize(universe);
+            var selectionSize = universe.Selected.Count;
             load += selectionSize / (double)threshold;
             universeCount++;
             selectedByResolution[(int)resolution] += selectionSize;
@@ -578,40 +578,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
 
         /// <summary>
         /// Gets the selection size warning threshold for the resolution the universe's members subscribe at.
-        /// False when the resolution is unavailable or warnings are disabled for it
+        /// False when warnings are disabled for it
         /// </summary>
         private bool TryGetSizeWarningThreshold(Universe universe, out Resolution resolution, out int threshold)
         {
-            threshold = 0;
-            resolution = default;
-            var settings = universe.UniverseSettings;
-            if (settings == null)
-            {
-                return false;
-            }
-            resolution = settings.Resolution;
+            resolution = universe.UniverseSettings.Resolution;
             return _universeSelectionSizeWarningThresholds.TryGetValue(resolution, out threshold) && threshold > 0;
-        }
-
-        /// <summary>
-        /// Number of symbols a universe selected. Option universe selections have the underlying
-        /// symbol prepended, which is not a contract
-        /// </summary>
-        private static int GetSelectionSize(Universe universe)
-        {
-            return universe is OptionChainUniverse
-                ? Math.Max(0, universe.Selected.Count - 1)
-                : universe.Selected.Count;
-        }
-
-        /// <summary>
-        /// User-recognizable name for the universe emitting the warning
-        /// </summary>
-        private static string GetUniverseName(Universe universe)
-        {
-            return universe is OptionChainUniverse optionUniverse
-                ? optionUniverse.Option.Symbol.Underlying.Value
-                : universe.Configuration.Symbol.Value;
         }
 
         private void RemoveSecurityFromUniverse(

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -526,11 +526,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 {
                     Accumulate(kvp.Value, ref load, ref universeCount, selectedByResolution);
                 }
-                if (universeCount == 0)
-                {
-                    // not registered in the universe manager, count the given universe only
-                    Accumulate(universe, ref load, ref universeCount, selectedByResolution);
-                }
 
                 if (load < 1)
                 {

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using QuantConnect.Benchmarks;
+using QuantConnect.Configuration;
 using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
@@ -42,6 +43,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private bool _initializedSecurityBenchmark;
         private bool _anyDoesNotHaveFundamentalDataWarningLogged;
         private readonly SecurityChangesConstructor _securityChangesConstructor;
+        private bool _optionUniverseSelectionSizeWarningSent;
+        private readonly int _optionUniverseContractsWarningThreshold = Config.GetInt("option-universe-contracts-warning-threshold", 500);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UniverseSelection"/> class
@@ -183,6 +186,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             {
                 // materialize the enumerable into a set for processing
                 universe.Selected = selectSymbolsResult.ToHashSet();
+
+                if (universe is OptionChainUniverse optionChainUniverse)
+                {
+                    WarnOnLargeOptionUniverseSelection(optionChainUniverse);
+                }
             }
 
             // first check for no pending removals, even if the universe selection
@@ -471,6 +479,52 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
 
             return SecurityChanges.None;
+        }
+
+        /// <summary>
+        /// Warns, once per algorithm, when option universe selections accumulate contracts beyond
+        /// 'option-universe-contracts-warning-threshold'. Every selected contract materializes into data subscriptions,
+        /// and wide filters, or many chained per-underlying option universes, are a recurring cause of out of memory
+        /// kills and multi-hour stalls. Warn only, never fail: the run may still succeed
+        /// </summary>
+        internal void WarnOnLargeOptionUniverseSelection(OptionChainUniverse universe)
+        {
+            if (_optionUniverseSelectionSizeWarningSent || _optionUniverseContractsWarningThreshold <= 0)
+            {
+                return;
+            }
+
+            // aggregate over all option universes: many chained per-underlying chains are as heavy as a single wide one.
+            // Note that 'Selected' includes the prepended underlying symbol, which is not a contract
+            var totalContracts = 0;
+            var universeCount = 0;
+            foreach (var kvp in _algorithm.UniverseManager)
+            {
+                if (kvp.Value is OptionChainUniverse optionUniverse && optionUniverse.Selected != null)
+                {
+                    totalContracts += Math.Max(0, optionUniverse.Selected.Count - 1);
+                    universeCount++;
+                }
+            }
+            if (universeCount == 0)
+            {
+                // not registered in the universe manager, count the given universe only
+                universeCount = 1;
+                totalContracts = Math.Max(0, universe.Selected.Count - 1);
+            }
+
+            if (totalContracts < _optionUniverseContractsWarningThreshold)
+            {
+                return;
+            }
+
+            _optionUniverseSelectionSizeWarningSent = true;
+            var latestCount = Math.Max(0, universe.Selected.Count - 1);
+            _algorithm.Debug($"Warning: option universe selections have reached ~{totalContracts} contracts across {universeCount}" +
+                $" option universe(s), latest: {latestCount} contracts for {universe.Option.Symbol.Underlying.Value}. Each selected" +
+                " contract adds data subscriptions, which can slow down the algorithm and run it out of memory. Consider narrowing" +
+                " the universe filter (SetFilter/set_filter strikes and expiration ranges) or trading specific contracts found via" +
+                " OptionChain()/option_chain() and added with AddOptionContract/add_option_contract.");
         }
 
         private void RemoveSecurityFromUniverse(

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -43,8 +43,19 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private bool _initializedSecurityBenchmark;
         private bool _anyDoesNotHaveFundamentalDataWarningLogged;
         private readonly SecurityChangesConstructor _securityChangesConstructor;
-        private bool _optionUniverseSelectionSizeWarningSent;
-        private readonly int _optionUniverseContractsWarningThreshold = Config.GetInt("option-universe-contracts-warning-threshold", 500);
+        private bool _universeSelectionSizeWarningSent;
+        // the cost of a selected symbol grows with the resolution its subscriptions are added at,
+        // so the warning threshold is defined per resolution instead of as a single flat count
+        private readonly Dictionary<Resolution, int> _universeSelectionSizeWarningThresholds = Config.GetValue(
+            "universe-selection-size-warning-thresholds",
+            new Dictionary<Resolution, int>
+            {
+                { Resolution.Tick, 100 },
+                { Resolution.Second, 250 },
+                { Resolution.Minute, 500 },
+                { Resolution.Hour, 1000 },
+                { Resolution.Daily, 2000 },
+            });
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UniverseSelection"/> class
@@ -187,10 +198,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 // materialize the enumerable into a set for processing
                 universe.Selected = selectSymbolsResult.ToHashSet();
 
-                if (universe is OptionChainUniverse optionChainUniverse)
-                {
-                    WarnOnLargeOptionUniverseSelection(optionChainUniverse);
-                }
+                WarnOnLargeUniverseSelection(universe);
             }
 
             // first check for no pending removals, even if the universe selection
@@ -482,47 +490,107 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         }
 
         /// <summary>
-        /// Warns once per algorithm when option universes select more contracts than
-        /// 'option-universe-contracts-warning-threshold', a recurring cause of out of memory kills and stalls.
+        /// Warns once per algorithm when universe selections grow past the per-resolution symbol thresholds in
+        /// 'universe-selection-size-warning-thresholds', a recurring cause of out of memory kills and stalls.
+        /// All universes consume a single shared subscription budget: each resolution's threshold defines the
+        /// full budget for symbols subscribed at that resolution, and each universe consumes a fraction of it,
+        /// so load still accumulates across universes of different resolutions.
         /// Warn only, never fail: the run may still succeed
         /// </summary>
-        internal void WarnOnLargeOptionUniverseSelection(OptionChainUniverse universe)
+        internal void WarnOnLargeUniverseSelection(Universe universe)
         {
-            if (_optionUniverseSelectionSizeWarningSent || _optionUniverseContractsWarningThreshold <= 0)
+            try
             {
-                return;
-            }
-
-            // aggregate over all option universes: many small chains are as heavy as a single wide one.
-            // 'Selected' includes the prepended underlying symbol, which is not a contract
-            var totalContracts = 0;
-            var universeCount = 0;
-            foreach (var kvp in _algorithm.UniverseManager)
-            {
-                if (kvp.Value is OptionChainUniverse optionUniverse && optionUniverse.Selected != null)
+                if (_universeSelectionSizeWarningSent)
                 {
-                    totalContracts += Math.Max(0, optionUniverse.Selected.Count - 1);
-                    universeCount++;
+                    return;
                 }
-            }
-            if (universeCount == 0)
-            {
-                // not registered in the universe manager, count the given universe only
-                universeCount = 1;
-                totalContracts = Math.Max(0, universe.Selected.Count - 1);
-            }
 
-            if (totalContracts < _optionUniverseContractsWarningThreshold)
-            {
-                return;
-            }
+                var load = 0d;
+                var universeCount = 0;
+                var selectedByResolution = new SortedDictionary<Resolution, int>();
 
-            _optionUniverseSelectionSizeWarningSent = true;
-            var latestCount = Math.Max(0, universe.Selected.Count - 1);
-            _algorithm.Debug($"Warning: option universe selections have reached ~{totalContracts} contracts across {universeCount}" +
-                $" universe(s), latest: {latestCount} for {universe.Option.Symbol.Underlying.Value}. Each contract adds data" +
-                " subscriptions, increasing time and memory usage. Narrow the filter (SetFilter/set_filter) or add specific" +
-                " contracts (AddOptionContract/add_option_contract).");
+                void Accumulate(Universe target)
+                {
+                    if (target.Selected == null || !TryGetSizeWarningThreshold(target, out var resolution, out var threshold))
+                    {
+                        return;
+                    }
+                    var selectionSize = GetSelectionSize(target);
+                    load += selectionSize / (double)threshold;
+                    universeCount++;
+                    selectedByResolution.TryGetValue(resolution, out var resolutionCount);
+                    selectedByResolution[resolution] = resolutionCount + selectionSize;
+                }
+
+                foreach (var kvp in _algorithm.UniverseManager)
+                {
+                    Accumulate(kvp.Value);
+                }
+                if (universeCount == 0)
+                {
+                    // not registered in the universe manager, count the given universe only
+                    Accumulate(universe);
+                }
+
+                if (load < 1)
+                {
+                    return;
+                }
+
+                _universeSelectionSizeWarningSent = true;
+                var counts = string.Join(" and ", selectedByResolution.Select(pair => $"~{pair.Value} symbols at {pair.Key} resolution"));
+                var suggestion = universe is OptionChainUniverse
+                    ? "Narrow the filter (SetFilter/set_filter) or add specific contracts (AddOptionContract/add_option_contract)."
+                    : "Select fewer symbols or use a coarser universe resolution (UniverseSettings.Resolution/universe_settings.resolution).";
+                _algorithm.Debug($"Warning: universe selections have reached {counts} across {universeCount} universe(s)," +
+                    $" latest: {GetSelectionSize(universe)} from {GetUniverseName(universe)}. Each selected symbol adds data" +
+                    $" subscriptions, increasing time and memory usage. {suggestion}");
+            }
+            catch (Exception exception)
+            {
+                // diagnostics must never interfere with the algorithm: log, disable and move on
+                _universeSelectionSizeWarningSent = true;
+                Log.Error(exception);
+            }
+        }
+
+        /// <summary>
+        /// Gets the selection size warning threshold for the resolution the universe's members subscribe at.
+        /// False when the resolution is unavailable or warnings are disabled for it
+        /// </summary>
+        private bool TryGetSizeWarningThreshold(Universe universe, out Resolution resolution, out int threshold)
+        {
+            threshold = 0;
+            resolution = default;
+            var settings = universe.UniverseSettings;
+            if (settings == null)
+            {
+                return false;
+            }
+            resolution = settings.Resolution;
+            return _universeSelectionSizeWarningThresholds.TryGetValue(resolution, out threshold) && threshold > 0;
+        }
+
+        /// <summary>
+        /// Number of symbols a universe selected. Option universe selections have the underlying
+        /// symbol prepended, which is not a contract
+        /// </summary>
+        private static int GetSelectionSize(Universe universe)
+        {
+            return universe is OptionChainUniverse
+                ? Math.Max(0, universe.Selected.Count - 1)
+                : universe.Selected.Count;
+        }
+
+        /// <summary>
+        /// User-recognizable name for the universe emitting the warning
+        /// </summary>
+        private static string GetUniverseName(Universe universe)
+        {
+            return universe is OptionChainUniverse optionUniverse
+                ? optionUniverse.Option.Symbol.Underlying.Value
+                : universe.Configuration.Symbol.Value;
         }
 
         private void RemoveSecurityFromUniverse(

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -482,10 +482,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         }
 
         /// <summary>
-        /// Warns, once per algorithm, when option universe selections accumulate contracts beyond
-        /// 'option-universe-contracts-warning-threshold'. Every selected contract materializes into data subscriptions,
-        /// and wide filters, or many chained per-underlying option universes, are a recurring cause of out of memory
-        /// kills and multi-hour stalls. Warn only, never fail: the run may still succeed
+        /// Warns once per algorithm when option universes select more contracts than
+        /// 'option-universe-contracts-warning-threshold', a recurring cause of out of memory kills and stalls.
+        /// Warn only, never fail: the run may still succeed
         /// </summary>
         internal void WarnOnLargeOptionUniverseSelection(OptionChainUniverse universe)
         {
@@ -494,8 +493,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 return;
             }
 
-            // aggregate over all option universes: many chained per-underlying chains are as heavy as a single wide one.
-            // Note that 'Selected' includes the prepended underlying symbol, which is not a contract
+            // aggregate over all option universes: many small chains are as heavy as a single wide one.
+            // 'Selected' includes the prepended underlying symbol, which is not a contract
             var totalContracts = 0;
             var universeCount = 0;
             foreach (var kvp in _algorithm.UniverseManager)
@@ -521,10 +520,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             _optionUniverseSelectionSizeWarningSent = true;
             var latestCount = Math.Max(0, universe.Selected.Count - 1);
             _algorithm.Debug($"Warning: option universe selections have reached ~{totalContracts} contracts across {universeCount}" +
-                $" option universe(s), latest: {latestCount} contracts for {universe.Option.Symbol.Underlying.Value}. Each selected" +
-                " contract adds data subscriptions, which can slow down the algorithm and run it out of memory. Consider narrowing" +
-                " the universe filter (SetFilter/set_filter strikes and expiration ranges) or trading specific contracts found via" +
-                " OptionChain()/option_chain() and added with AddOptionContract/add_option_contract.");
+                $" universe(s), latest: {latestCount} for {universe.Option.Symbol.Underlying.Value}. Each contract adds data" +
+                " subscriptions, increasing time and memory usage. Narrow the filter (SetFilter/set_filter) or add specific" +
+                " contracts (AddOptionContract/add_option_contract).");
         }
 
         private void RemoveSecurityFromUniverse(

--- a/Engine/DataFeeds/UniverseSelection.cs
+++ b/Engine/DataFeeds/UniverseSelection.cs
@@ -44,6 +44,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private bool _anyDoesNotHaveFundamentalDataWarningLogged;
         private readonly SecurityChangesConstructor _securityChangesConstructor;
         private bool _universeSelectionSizeWarningSent;
+        // a selection must be at least 1/N of its resolution threshold before the large selection check runs
+        private const int MinimumSignificantSelectionRatio = 10;
+        private static readonly int SelectionSizeWarningResolutionCount = Enum.GetValues<Resolution>().Length;
         // the cost of a selected symbol grows with the resolution its subscriptions are added at,
         // so the warning threshold is defined per resolution instead of as a single flat count
         private readonly Dictionary<Resolution, int> _universeSelectionSizeWarningThresholds = Config.GetValue(
@@ -501,36 +504,32 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         {
             try
             {
-                if (_universeSelectionSizeWarningSent)
+                if (_universeSelectionSizeWarningSent || universe.Selected == null)
+                {
+                    return;
+                }
+
+                // skip small selections: only a selection that is itself a meaningful share of its
+                // threshold can tip the shared budget, so don't aggregate across all universes for every one
+                if (!TryGetSizeWarningThreshold(universe, out _, out var universeThreshold)
+                    || GetSelectionSize(universe) * MinimumSignificantSelectionRatio < universeThreshold)
                 {
                     return;
                 }
 
                 var load = 0d;
                 var universeCount = 0;
-                var selectedByResolution = new SortedDictionary<Resolution, int>();
-
-                void Accumulate(Universe target)
-                {
-                    if (target.Selected == null || !TryGetSizeWarningThreshold(target, out var resolution, out var threshold))
-                    {
-                        return;
-                    }
-                    var selectionSize = GetSelectionSize(target);
-                    load += selectionSize / (double)threshold;
-                    universeCount++;
-                    selectedByResolution.TryGetValue(resolution, out var resolutionCount);
-                    selectedByResolution[resolution] = resolutionCount + selectionSize;
-                }
+                // per resolution symbol counts, indexed by the resolution enum value
+                Span<int> selectedByResolution = stackalloc int[SelectionSizeWarningResolutionCount];
 
                 foreach (var kvp in _algorithm.UniverseManager)
                 {
-                    Accumulate(kvp.Value);
+                    Accumulate(kvp.Value, ref load, ref universeCount, selectedByResolution);
                 }
                 if (universeCount == 0)
                 {
                     // not registered in the universe manager, count the given universe only
-                    Accumulate(universe);
+                    Accumulate(universe, ref load, ref universeCount, selectedByResolution);
                 }
 
                 if (load < 1)
@@ -539,11 +538,18 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
 
                 _universeSelectionSizeWarningSent = true;
-                var counts = string.Join(" and ", selectedByResolution.Select(pair => $"~{pair.Value} symbols at {pair.Key} resolution"));
+                var counts = new List<string>();
+                for (var i = 0; i < selectedByResolution.Length; i++)
+                {
+                    if (selectedByResolution[i] > 0)
+                    {
+                        counts.Add($"~{selectedByResolution[i]} symbols at {(Resolution)i} resolution");
+                    }
+                }
                 var suggestion = universe is OptionChainUniverse
                     ? "Narrow the filter (SetFilter/set_filter) or add specific contracts (AddOptionContract/add_option_contract)."
                     : "Select fewer symbols or use a coarser universe resolution (UniverseSettings.Resolution/universe_settings.resolution).";
-                _algorithm.Debug($"Warning: universe selections have reached {counts} across {universeCount} universe(s)," +
+                _algorithm.Debug($"Warning: universe selections have reached {string.Join(" and ", counts)} across {universeCount} universe(s)," +
                     $" latest: {GetSelectionSize(universe)} from {GetUniverseName(universe)}. Each selected symbol adds data" +
                     $" subscriptions, increasing time and memory usage. {suggestion}");
             }
@@ -553,6 +559,21 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 _universeSelectionSizeWarningSent = true;
                 Log.Error(exception);
             }
+        }
+
+        /// <summary>
+        /// Adds a universe's selection to the shared budget load and per resolution symbol counts
+        /// </summary>
+        private void Accumulate(Universe universe, ref double load, ref int universeCount, Span<int> selectedByResolution)
+        {
+            if (universe.Selected == null || !TryGetSizeWarningThreshold(universe, out var resolution, out var threshold))
+            {
+                return;
+            }
+            var selectionSize = GetSelectionSize(universe);
+            load += selectionSize / (double)threshold;
+            universeCount++;
+            selectedByResolution[(int)resolution] += selectionSize;
         }
 
         /// <summary>

--- a/Engine/DataFeeds/ZipDataCacheProvider.cs
+++ b/Engine/DataFeeds/ZipDataCacheProvider.cs
@@ -97,6 +97,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         }
                         catch (Exception exception)
                         {
+                            RethrowIfOutOfMemory(exception, filename, entryName);
                             if (exception is ZipException || exception is ZlibException)
                             {
                                 Log.Error("ZipDataCacheProvider.Fetch(): Corrupt zip file/entry: " + filename + "#" + entryName + " Error: " + exception);
@@ -109,8 +110,14 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
                 catch (Exception err)
                 {
-                    Log.Error(err, "Inner try/catch");
                     stream?.DisposeSafely();
+                    if (err is OutOfMemoryException)
+                    {
+                        // let the memory diagnostic bubble up: returning a null stream here would just resurface
+                        // as a confusing downstream failure while the process is dying anyway
+                        throw;
+                    }
+                    Log.Error(err, "Inner try/catch");
                     return null;
                 }
             }
@@ -290,6 +297,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 {
                     // don't leak the file stream!
                     dataStream.DisposeSafely();
+                    RethrowIfOutOfMemory(exception, filename, entryName);
                     if (exception is ZipException || exception is ZlibException)
                     {
                         Log.Error("ZipDataCacheProvider.Fetch(): Corrupt zip file/entry: " + filename + "#" + entryName + " Error: " + exception);
@@ -412,6 +420,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
                 catch (Exception exception)
                 {
+                    RethrowIfOutOfMemory(exception, filename, entryName: null);
                     if (exception is ZipException || exception is ZlibException)
                     {
                         Log.Error("ZipDataCacheProvider.Fetch(): Corrupt zip file/entry: " + filename + " Error: " + exception);
@@ -423,6 +432,26 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Rethrows the given exception as an honest memory diagnostic if it is, or wraps, an <see cref="OutOfMemoryException"/>.
+        /// Ionic wraps allocation failures while reading a zip into 'ZipException: Cannot read that as a ZipFile', which we would
+        /// otherwise log as a corrupt zip file and swallow, sending users down a data-integrity path when the process is actually
+        /// out of memory, usually due to too many subscriptions or too much data being requested
+        /// </summary>
+        private static void RethrowIfOutOfMemory(Exception exception, string filename, string entryName)
+        {
+            for (var inner = exception; inner != null; inner = inner.InnerException)
+            {
+                if (inner is OutOfMemoryException)
+                {
+                    var entry = entryName != null ? "#" + entryName : string.Empty;
+                    throw new OutOfMemoryException("ZipDataCacheProvider.Fetch(): ran out of memory reading " + filename + entry +
+                        ". This indicates memory exhaustion, not a corrupt data file: reduce the number of subscriptions" +
+                        " (e.g. narrow option universe filters) or the amount of data requested.", exception);
+                }
+            }
         }
 
 

--- a/Engine/DataFeeds/ZipDataCacheProvider.cs
+++ b/Engine/DataFeeds/ZipDataCacheProvider.cs
@@ -113,8 +113,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     stream?.DisposeSafely();
                     if (err is OutOfMemoryException)
                     {
-                        // let the memory diagnostic bubble up: returning a null stream here would just resurface
-                        // as a confusing downstream failure while the process is dying anyway
+                        // let the memory diagnostic bubble up instead of resurfacing as a confusing downstream failure
                         throw;
                     }
                     Log.Error(err, "Inner try/catch");
@@ -435,10 +434,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         }
 
         /// <summary>
-        /// Rethrows the given exception as an honest memory diagnostic if it is, or wraps, an <see cref="OutOfMemoryException"/>.
-        /// Ionic wraps allocation failures while reading a zip into 'ZipException: Cannot read that as a ZipFile', which we would
-        /// otherwise log as a corrupt zip file and swallow, sending users down a data-integrity path when the process is actually
-        /// out of memory, usually due to too many subscriptions or too much data being requested
+        /// Rethrows as a memory diagnostic if the exception is, or wraps, an <see cref="OutOfMemoryException"/>.
+        /// Ionic wraps allocation failures into 'ZipException: Cannot read that as a ZipFile', which would otherwise
+        /// be logged as a corrupt zip file and swallowed
         /// </summary>
         private static void RethrowIfOutOfMemory(Exception exception, string filename, string entryName)
         {
@@ -448,7 +446,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 {
                     var entry = entryName != null ? "#" + entryName : string.Empty;
                     throw new OutOfMemoryException("ZipDataCacheProvider.Fetch(): ran out of memory reading " + filename + entry +
-                        ". This indicates memory exhaustion, not a corrupt data file: reduce the number of subscriptions" +
+                        ". This is memory exhaustion, not a corrupt data file: reduce the number of subscriptions" +
                         " (e.g. narrow option universe filters) or the amount of data requested.", exception);
                 }
             }

--- a/Engine/RealTime/BaseRealTimeHandler.cs
+++ b/Engine/RealTime/BaseRealTimeHandler.cs
@@ -119,7 +119,8 @@ namespace QuantConnect.Lean.Engine.RealTime
         {
             Algorithm = algorithm;
             ResultHandler = resultHandler;
-            TimeMonitor = new TimeMonitor(GetTimeMonitorTimeout());
+            // surface long-running scheduled event warnings in the user's logs, not just the engine log
+            TimeMonitor = new TimeMonitor(GetTimeMonitorTimeout()) { UserWarningHandler = message => ResultHandler?.DebugMessage(message) };
             IsolatorLimitProvider = isolatorLimitProvider;
 
             if (job.Language == Language.CSharp)

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -38,6 +38,7 @@ using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Tests.Common.Data.Fundamental;
 using QuantConnect.Logging;
+using QuantConnect.Configuration;
 
 namespace QuantConnect.Tests.Algorithm
 {
@@ -4285,6 +4286,79 @@ def get_history(algorithm, symbol):
                     new TestCaseData(language, Symbols.ES_Future_Chain, Resolution.Minute, futureStart, futureStart.AddDays(2), 900),
                 };
             }).ToArray();
+        }
+
+        [Test]
+        public void WarnsOnLargeHistoryRequest()
+        {
+            Config.Set("history-request-cells-warning-threshold", "1000");
+            try
+            {
+                var algorithm = CreateAlgorithmForHistoryWarningTests();
+                var symbol = algorithm.AddEquity("SPY", Resolution.Daily).Symbol;
+
+                // ~365 daily bars x 5 columns > 1000 cells
+                algorithm.History(new[] { symbol }, 365, Resolution.Daily);
+
+                Assert.AreEqual(1, algorithm.DebugMessages.Count(x => x.Contains("large history request")));
+
+                // the warning is only sent once per algorithm
+                algorithm.History(new[] { symbol }, 365, Resolution.Daily);
+                Assert.AreEqual(1, algorithm.DebugMessages.Count(x => x.Contains("large history request")));
+            }
+            finally
+            {
+                Config.Reset();
+            }
+        }
+
+        [Test]
+        public void DoesNotWarnOnSmallHistoryRequest()
+        {
+            // default threshold
+            var algorithm = CreateAlgorithmForHistoryWarningTests();
+            var symbol = algorithm.AddEquity("SPY", Resolution.Daily).Symbol;
+
+            algorithm.History(new[] { symbol }, 30, Resolution.Daily);
+
+            Assert.AreEqual(0, algorithm.DebugMessages.Count(x => x.Contains("large history request")));
+        }
+
+        [Test]
+        public void WarnsOnRepeatedOverlappingHistoryRequests()
+        {
+            // the "large call" floor tracked for overlap detection is threshold / 50 = 2000 cells
+            Config.Set("history-request-cells-warning-threshold", "100000");
+            try
+            {
+                var algorithm = CreateAlgorithmForHistoryWarningTests();
+                var symbol = algorithm.AddEquity("SPY", Resolution.Daily).Symbol;
+
+                for (var i = 0; i < 40; i++)
+                {
+                    // ~800 daily bars x 5 columns = ~4000 cells: over the large-call floor, under the size warning threshold
+                    algorithm.History(new[] { symbol }, 800, Resolution.Daily);
+                }
+
+                Assert.AreEqual(0, algorithm.DebugMessages.Count(x => x.Contains("large history request")));
+                Assert.AreEqual(1, algorithm.DebugMessages.Count(x => x.Contains("overlapping")));
+            }
+            finally
+            {
+                Config.Reset();
+            }
+        }
+
+        private static QCAlgorithm CreateAlgorithmForHistoryWarningTests()
+        {
+            // the warning thresholds are read from the config when the algorithm is created,
+            // so we create a dedicated instance instead of using the fixture's algorithm
+            var algorithm = new QCAlgorithm();
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
+            algorithm.HistoryProvider = new TestHistoryProvider();
+            algorithm.SetStartDate(2013, 10, 07);
+            algorithm.Settings.SeedInitialPrices = false;
+            return algorithm;
         }
 
         private QCAlgorithm GetAlgorithm(DateTime dateTime)

--- a/Tests/Algorithm/AlgorithmHistoryTests.cs
+++ b/Tests/Algorithm/AlgorithmHistoryTests.cs
@@ -4313,6 +4313,27 @@ def get_history(algorithm, symbol):
         }
 
         [Test]
+        public void WarnsOnLargeTickHistoryRequest()
+        {
+            Config.Set("history-request-cells-warning-threshold", "1000000");
+            try
+            {
+                var algorithm = CreateAlgorithmForHistoryWarningTests();
+                var symbol = algorithm.AddEquity("SPY", Resolution.Tick).Symbol;
+
+                // one market day estimated at 10 ticks per second: 234,000 bars x 5 columns > 1,000,000 cells.
+                // At 1 tick per second the estimate would stay under the threshold and miss the warning
+                algorithm.History(new[] { symbol }, TimeSpan.FromDays(1), Resolution.Tick);
+
+                Assert.AreEqual(1, algorithm.DebugMessages.Count(x => x.Contains("large history request")));
+            }
+            finally
+            {
+                Config.Reset();
+            }
+        }
+
+        [Test]
         public void DoesNotWarnOnSmallHistoryRequest()
         {
             // default threshold

--- a/Tests/Common/IsolatorLimitResultProviderTests.cs
+++ b/Tests/Common/IsolatorLimitResultProviderTests.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Logging;
 using QuantConnect.Scheduling;
 using QuantConnect.Util;
 
@@ -142,6 +143,43 @@ namespace QuantConnect.Tests.Common
             // give time to the monitor to register the time consumer ended
             _timeMonitorEvent.WaitOne();
             Assert.AreEqual(0, _timeMonitor.Count);
+        }
+
+        [Test]
+        public void ConsumeNamesTheWorkWhenRequestingAdditionalTime()
+        {
+            var previousLogHandler = Log.LogHandler;
+            try
+            {
+                var logHandler = new QueueLogHandler();
+                Log.LogHandler = logHandler;
+
+                var timeProvider = new ManualTimeProvider(new DateTime(2000, 01, 01));
+                var provider = new FakeIsolatorLimitResultProvider();
+
+                Action code = () =>
+                {
+                    // lets give the monitor time to register the initial time
+                    _timeMonitorEvent.WaitOne();
+                    timeProvider.Advance(TimeSpan.FromSeconds(65));
+                    // give the monitoring task time to request more time
+                    _timeMonitorEvent.WaitOne();
+                };
+
+                provider.Consume(timeProvider, code, _timeMonitor, "My Slow Scheduled Event");
+
+                Assert.AreEqual(1, provider.Invocations.Count);
+                Assert.AreEqual(1, logHandler.Logs.Count(
+                    entry => entry.Message.Contains("'My Slow Scheduled Event' has been executing for over 1 minute")));
+
+                // give time to the monitor to register the time consumer ended
+                _timeMonitorEvent.WaitOne();
+                Assert.AreEqual(0, _timeMonitor.Count);
+            }
+            finally
+            {
+                Log.LogHandler = previousLogHandler;
+            }
         }
 
         private class FakeIsolatorLimitResultProvider : IIsolatorLimitResultProvider

--- a/Tests/Common/IsolatorLimitResultProviderTests.cs
+++ b/Tests/Common/IsolatorLimitResultProviderTests.cs
@@ -153,6 +153,8 @@ namespace QuantConnect.Tests.Common
             {
                 var logHandler = new QueueLogHandler();
                 Log.LogHandler = logHandler;
+                var userWarnings = new List<string>();
+                _timeMonitor.UserWarningHandler = userWarnings.Add;
 
                 var timeProvider = new ManualTimeProvider(new DateTime(2000, 01, 01));
                 var provider = new FakeIsolatorLimitResultProvider();
@@ -171,6 +173,9 @@ namespace QuantConnect.Tests.Common
                 Assert.AreEqual(1, provider.Invocations.Count);
                 Assert.AreEqual(1, logHandler.Logs.Count(
                     entry => entry.Message.Contains("'My Slow Scheduled Event' has been executing for over 1 minute")));
+                // the warning also reaches the user
+                Assert.AreEqual(1, userWarnings.Count(
+                    message => message.Contains("'My Slow Scheduled Event' has been executing for over 1 minute")));
 
                 // give time to the monitor to register the time consumer ended
                 _timeMonitorEvent.WaitOne();
@@ -179,6 +184,7 @@ namespace QuantConnect.Tests.Common
             finally
             {
                 Log.LogHandler = previousLogHandler;
+                _timeMonitor.UserWarningHandler = null;
             }
         }
 

--- a/Tests/Engine/AlgorithmTimeLimitManagerTests.cs
+++ b/Tests/Engine/AlgorithmTimeLimitManagerTests.cs
@@ -69,8 +69,10 @@ namespace QuantConnect.Tests.Engine
                 var logHandler = new QueueLogHandler();
                 Log.LogHandler = logHandler;
 
+                var userWarnings = new List<string>();
                 var timeManager = new AlgorithmTimeLimitManager(TokenBucket.Null, TimeSpan.FromMinutes(20),
                     timeLoopWarningThreshold: TimeSpan.FromMilliseconds(5));
+                timeManager.UserWarningHandler = userWarnings.Add;
                 timeManager.StartNewTimeStep();
                 // the first call initializes the current time step start time
                 Assert.IsTrue(timeManager.IsWithinLimit().IsWithinCustomLimits);
@@ -80,11 +82,13 @@ namespace QuantConnect.Tests.Engine
                 var result = timeManager.IsWithinLimit();
                 Assert.IsTrue(result.IsWithinCustomLimits, result.ErrorMessage);
                 Assert.AreEqual(1, WarningCount(logHandler));
+                Assert.AreEqual(1, userWarnings.Count(x => x.Contains("time step has been executing")));
 
                 // only warns once per time step
                 Thread.Sleep(20);
                 Assert.IsTrue(timeManager.IsWithinLimit().IsWithinCustomLimits);
                 Assert.AreEqual(1, WarningCount(logHandler));
+                Assert.AreEqual(1, userWarnings.Count);
 
                 // a new slow time step warns again
                 timeManager.StartNewTimeStep();
@@ -92,6 +96,7 @@ namespace QuantConnect.Tests.Engine
                 Thread.Sleep(50);
                 Assert.IsTrue(timeManager.IsWithinLimit().IsWithinCustomLimits);
                 Assert.AreEqual(2, WarningCount(logHandler));
+                Assert.AreEqual(2, userWarnings.Count);
             }
             finally
             {
@@ -108,14 +113,17 @@ namespace QuantConnect.Tests.Engine
                 var logHandler = new QueueLogHandler();
                 Log.LogHandler = logHandler;
 
-                // default one minute warning threshold
+                // default three minute warning threshold
+                var userWarnings = new List<string>();
                 var timeManager = new AlgorithmTimeLimitManager(TokenBucket.Null, TimeSpan.FromMinutes(20));
+                timeManager.UserWarningHandler = userWarnings.Add;
                 timeManager.StartNewTimeStep();
                 Assert.IsTrue(timeManager.IsWithinLimit().IsWithinCustomLimits);
                 Thread.Sleep(20);
                 Assert.IsTrue(timeManager.IsWithinLimit().IsWithinCustomLimits);
 
                 Assert.AreEqual(0, WarningCount(logHandler));
+                Assert.AreEqual(0, userWarnings.Count);
             }
             finally
             {

--- a/Tests/Engine/AlgorithmTimeLimitManagerTests.cs
+++ b/Tests/Engine/AlgorithmTimeLimitManagerTests.cs
@@ -16,11 +16,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using QuantConnect.Algorithm.CSharp;
 using QuantConnect.Configuration;
 using QuantConnect.Lean.Engine;
+using QuantConnect.Logging;
 using QuantConnect.Util.RateLimit;
 
 namespace QuantConnect.Tests.Engine
@@ -55,6 +58,74 @@ namespace QuantConnect.Tests.Engine
                 parameter.Statistics,
                 parameter.Language,
                 parameter.ExpectedFinalStatus);
+        }
+
+        [Test]
+        public void WarnsOnceOnLongTimeStepWithoutFailing()
+        {
+            var previousLogHandler = Log.LogHandler;
+            try
+            {
+                var logHandler = new QueueLogHandler();
+                Log.LogHandler = logHandler;
+
+                var timeManager = new AlgorithmTimeLimitManager(TokenBucket.Null, TimeSpan.FromMinutes(20),
+                    timeLoopWarningThreshold: TimeSpan.FromMilliseconds(5));
+                timeManager.StartNewTimeStep();
+                // the first call initializes the current time step start time
+                Assert.IsTrue(timeManager.IsWithinLimit().IsWithinCustomLimits);
+                Thread.Sleep(50);
+
+                // the time step is over the warning threshold: it warns but does not fail
+                var result = timeManager.IsWithinLimit();
+                Assert.IsTrue(result.IsWithinCustomLimits, result.ErrorMessage);
+                Assert.AreEqual(1, WarningCount(logHandler));
+
+                // only warns once per time step
+                Thread.Sleep(20);
+                Assert.IsTrue(timeManager.IsWithinLimit().IsWithinCustomLimits);
+                Assert.AreEqual(1, WarningCount(logHandler));
+
+                // a new slow time step warns again
+                timeManager.StartNewTimeStep();
+                Assert.IsTrue(timeManager.IsWithinLimit().IsWithinCustomLimits);
+                Thread.Sleep(50);
+                Assert.IsTrue(timeManager.IsWithinLimit().IsWithinCustomLimits);
+                Assert.AreEqual(2, WarningCount(logHandler));
+            }
+            finally
+            {
+                Log.LogHandler = previousLogHandler;
+            }
+        }
+
+        [Test]
+        public void DoesNotWarnOnFastTimeStep()
+        {
+            var previousLogHandler = Log.LogHandler;
+            try
+            {
+                var logHandler = new QueueLogHandler();
+                Log.LogHandler = logHandler;
+
+                // default one minute warning threshold
+                var timeManager = new AlgorithmTimeLimitManager(TokenBucket.Null, TimeSpan.FromMinutes(20));
+                timeManager.StartNewTimeStep();
+                Assert.IsTrue(timeManager.IsWithinLimit().IsWithinCustomLimits);
+                Thread.Sleep(20);
+                Assert.IsTrue(timeManager.IsWithinLimit().IsWithinCustomLimits);
+
+                Assert.AreEqual(0, WarningCount(logHandler));
+            }
+            finally
+            {
+                Log.LogHandler = previousLogHandler;
+            }
+        }
+
+        private static int WarningCount(QueueLogHandler logHandler)
+        {
+            return logHandler.Logs.Count(entry => entry.Message.Contains("time step has been executing"));
         }
 
         [Test]

--- a/Tests/Engine/DataCacheProviders/ZipDataCacheProviderTests.cs
+++ b/Tests/Engine/DataCacheProviders/ZipDataCacheProviderTests.cs
@@ -52,6 +52,35 @@ namespace QuantConnect.Tests.Engine.DataCacheProviders
         }
 
         [Test]
+        public void FetchRethrowsOutOfMemoryAsMemoryDiagnostic()
+        {
+            // Ionic wraps the allocation failure into ZipException("Cannot read that as a ZipFile"), which used to be
+            // logged as a corrupt zip file and swallowed, see A-abb25be1. We want an honest memory diagnostic instead.
+            using var dataCacheProvider = new ZipDataCacheProvider(new OutOfMemoryDataProvider());
+
+            var exception = Assert.Throws<OutOfMemoryException>(
+                () => dataCacheProvider.Fetch("/data/option/usa/daily/pep_2026_trade_american.zip#entry.csv"));
+
+            StringAssert.Contains("ran out of memory", exception.Message);
+            StringAssert.DoesNotContain("Corrupt zip", exception.Message);
+            Assert.IsNotNull(exception.InnerException);
+        }
+
+        [Test]
+        public void FetchDoesNotThrowOnCorruptZipFile()
+        {
+            // a truly corrupt file must keep the previous behavior: log and return null instead of throwing
+            using var dataCacheProvider = new ZipDataCacheProvider(TestGlobals.DataProvider, cacheTimer: 0.1);
+
+            var tempZipFile = Path.GetTempFileName().Replace(".tmp", ".zip", StringComparison.InvariantCulture);
+            File.WriteAllText(tempZipFile, "corrupted zip");
+
+            Stream result = null;
+            Assert.DoesNotThrow(() => result = dataCacheProvider.Fetch(tempZipFile + "#testEntry.csv"));
+            Assert.IsNull(result);
+        }
+
+        [Test]
         public void StoreFailsCorruptedFile()
         {
             var dataCacheProvider = new ZipDataCacheProvider(TestGlobals.DataProvider, cacheTimer: 0.1);
@@ -71,6 +100,35 @@ namespace QuantConnect.Tests.Engine.DataCacheProviders
         {
             dataCacheProvider.Fetch(_tempZipFileEntry);
             dataCacheProvider.Store(_tempZipFileEntry, data);
+        }
+
+        /// <summary>
+        /// Provider whose streams fail allocation-style, simulating reading a zip while the process is out of memory
+        /// </summary>
+        private class OutOfMemoryDataProvider : IDataProvider
+        {
+            public event EventHandler<DataProviderNewDataRequestEventArgs> NewDataRequest;
+
+            public Stream Fetch(string key)
+            {
+                NewDataRequest?.Invoke(this, null);
+                return new OutOfMemoryStream();
+            }
+
+            private class OutOfMemoryStream : Stream
+            {
+                public override bool CanRead => true;
+                public override bool CanSeek => true;
+                public override bool CanWrite => false;
+                public override long Length => 1024;
+                public override long Position { get; set; }
+
+                public override void Flush() { }
+                public override int Read(byte[] buffer, int offset, int count) => throw new OutOfMemoryException();
+                public override long Seek(long offset, SeekOrigin origin) => Position;
+                public override void SetLength(long value) => throw new NotSupportedException();
+                public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            }
         }
     }
 }

--- a/Tests/Engine/DataCacheProviders/ZipDataCacheProviderTests.cs
+++ b/Tests/Engine/DataCacheProviders/ZipDataCacheProviderTests.cs
@@ -55,7 +55,7 @@ namespace QuantConnect.Tests.Engine.DataCacheProviders
         public void FetchRethrowsOutOfMemoryAsMemoryDiagnostic()
         {
             // Ionic wraps the allocation failure into ZipException("Cannot read that as a ZipFile"), which used to be
-            // logged as a corrupt zip file and swallowed, see A-abb25be1. We want an honest memory diagnostic instead.
+            // logged as a corrupt zip file and swallowed. We want an honest memory diagnostic instead.
             using var dataCacheProvider = new ZipDataCacheProvider(new OutOfMemoryDataProvider());
 
             var exception = Assert.Throws<OutOfMemoryException>(

--- a/Tests/Engine/DataFeeds/UniverseSelectionTests.cs
+++ b/Tests/Engine/DataFeeds/UniverseSelectionTests.cs
@@ -128,7 +128,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
                 equityUniverse.Selected = CreateEquitySelection(30);
                 algorithm.DataManager.UniverseSelection.WarnOnLargeUniverseSelection(equityUniverse);
                 Assert.AreEqual(1, UniverseSizeWarningCount(algorithm));
-                Assert.AreEqual(1, algorithm.DebugMessages.Count(x => x.Contains("~8 symbols at Minute resolution") &&
+                Assert.AreEqual(1, algorithm.DebugMessages.Count(x => x.Contains("~9 symbols at Minute resolution") &&
                     x.Contains("~30 symbols at Daily resolution")));
             }
             finally

--- a/Tests/Engine/DataFeeds/UniverseSelectionTests.cs
+++ b/Tests/Engine/DataFeeds/UniverseSelectionTests.cs
@@ -37,7 +37,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         [Test]
         public void WarnsOnLargeOptionUniverseSelection()
         {
-            Config.Set("option-universe-contracts-warning-threshold", "10");
+            // option universe subscriptions are added at minute resolution
+            Config.Set("universe-selection-size-warning-thresholds", "{\"Minute\": 10}");
             try
             {
                 var algorithm = new AlgorithmStub(new MockDataFeed());
@@ -49,17 +50,18 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
                 // below the threshold: no warning
                 universe.Selected = CreateOptionSelection(option.Symbol.Underlying, 5);
-                algorithm.DataManager.UniverseSelection.WarnOnLargeOptionUniverseSelection(universe);
-                Assert.AreEqual(0, OptionUniverseWarningCount(algorithm));
+                algorithm.DataManager.UniverseSelection.WarnOnLargeUniverseSelection(universe);
+                Assert.AreEqual(0, UniverseSizeWarningCount(algorithm));
 
                 // above the threshold: warns
                 universe.Selected = CreateOptionSelection(option.Symbol.Underlying, 15);
-                algorithm.DataManager.UniverseSelection.WarnOnLargeOptionUniverseSelection(universe);
-                Assert.AreEqual(1, OptionUniverseWarningCount(algorithm));
+                algorithm.DataManager.UniverseSelection.WarnOnLargeUniverseSelection(universe);
+                Assert.AreEqual(1, UniverseSizeWarningCount(algorithm));
+                Assert.AreEqual(1, algorithm.DebugMessages.Count(x => x.Contains("SetFilter")));
 
                 // only warns once per algorithm
-                algorithm.DataManager.UniverseSelection.WarnOnLargeOptionUniverseSelection(universe);
-                Assert.AreEqual(1, OptionUniverseWarningCount(algorithm));
+                algorithm.DataManager.UniverseSelection.WarnOnLargeUniverseSelection(universe);
+                Assert.AreEqual(1, UniverseSizeWarningCount(algorithm));
             }
             finally
             {
@@ -67,9 +69,84 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             }
         }
 
-        private static int OptionUniverseWarningCount(AlgorithmStub algorithm)
+        [Test]
+        public void LargeUniverseSelectionWarningIsResolutionAware()
         {
-            return algorithm.DebugMessages.Count(x => x.Contains("option universe selections"));
+            Config.Set("universe-selection-size-warning-thresholds", "{\"Minute\": 10, \"Daily\": 50}");
+            try
+            {
+                var algorithm = new AlgorithmStub(new MockDataFeed());
+                algorithm.SetEndDate(new DateTime(2024, 12, 13));
+                algorithm.SetStartDate(algorithm.EndDate.Subtract(TimeSpan.FromDays(10)));
+                algorithm.UniverseSettings.Resolution = Resolution.Daily;
+                algorithm.AddUniverse(coarse => Enumerable.Empty<Symbol>());
+                // OnEndOfTimeStep will add all pending universe additions
+                algorithm.OnEndOfTimeStep();
+                var universe = algorithm.UniverseManager.Values.First();
+
+                // over the minute threshold but under this universe's daily threshold: no warning
+                universe.Selected = CreateEquitySelection(20);
+                algorithm.DataManager.UniverseSelection.WarnOnLargeUniverseSelection(universe);
+                Assert.AreEqual(0, UniverseSizeWarningCount(algorithm));
+
+                // over the daily threshold: warns with the generic suggestion
+                universe.Selected = CreateEquitySelection(60);
+                algorithm.DataManager.UniverseSelection.WarnOnLargeUniverseSelection(universe);
+                Assert.AreEqual(1, UniverseSizeWarningCount(algorithm));
+                Assert.AreEqual(1, algorithm.DebugMessages.Count(x => x.Contains("Daily") && x.Contains("UniverseSettings.Resolution")));
+            }
+            finally
+            {
+                Config.Reset();
+            }
+        }
+
+        [Test]
+        public void LargeUniverseSelectionWarningAggregatesAcrossResolutions()
+        {
+            Config.Set("universe-selection-size-warning-thresholds", "{\"Minute\": 10, \"Daily\": 50}");
+            try
+            {
+                var algorithm = new AlgorithmStub(new MockDataFeed());
+                algorithm.SetStartDate(2014, 6, 6);
+                var option = algorithm.AddOption("AAPL");
+                algorithm.AddUniverse(fundamentals => Enumerable.Empty<Symbol>());
+                // OnEndOfTimeStep will add all pending universe additions
+                algorithm.OnEndOfTimeStep();
+                var optionUniverse = algorithm.UniverseManager.Values.OfType<OptionChainUniverse>().Single();
+                var equityUniverse = algorithm.UniverseManager.Values.Single(x => x is FundamentalUniverseFactory);
+                optionUniverse.UniverseSettings = new UniverseSettings(optionUniverse.UniverseSettings) { Resolution = Resolution.Minute };
+                equityUniverse.UniverseSettings = new UniverseSettings(equityUniverse.UniverseSettings) { Resolution = Resolution.Daily };
+
+                // 8/10 minute contracts: under budget
+                optionUniverse.Selected = CreateOptionSelection(option.Symbol.Underlying, 8);
+                algorithm.DataManager.UniverseSelection.WarnOnLargeUniverseSelection(optionUniverse);
+                Assert.AreEqual(0, UniverseSizeWarningCount(algorithm));
+
+                // 8/10 minute contracts + 30/50 daily symbols = 1.4 of the shared budget: warns,
+                // even though each universe is under its own resolution threshold
+                equityUniverse.Selected = CreateEquitySelection(30);
+                algorithm.DataManager.UniverseSelection.WarnOnLargeUniverseSelection(equityUniverse);
+                Assert.AreEqual(1, UniverseSizeWarningCount(algorithm));
+                Assert.AreEqual(1, algorithm.DebugMessages.Count(x => x.Contains("~8 symbols at Minute resolution") &&
+                    x.Contains("~30 symbols at Daily resolution")));
+            }
+            finally
+            {
+                Config.Reset();
+            }
+        }
+
+        private static int UniverseSizeWarningCount(AlgorithmStub algorithm)
+        {
+            return algorithm.DebugMessages.Count(x => x.Contains("universe selections"));
+        }
+
+        private static HashSet<Symbol> CreateEquitySelection(int count)
+        {
+            return Enumerable.Range(0, count)
+                .Select(i => Symbol.Create($"SYM{i}", SecurityType.Equity, Market.USA))
+                .ToHashSet();
         }
 
         private static HashSet<Symbol> CreateOptionSelection(Symbol underlying, int contractCount)

--- a/Tests/Engine/DataFeeds/UniverseSelectionTests.cs
+++ b/Tests/Engine/DataFeeds/UniverseSelectionTests.cs
@@ -137,6 +137,41 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             }
         }
 
+        [Test]
+        public void LargeUniverseSelectionWarningSkipsSmallSelections()
+        {
+            Config.Set("universe-selection-size-warning-thresholds", "{\"Minute\": 10, \"Daily\": 100}");
+            try
+            {
+                var algorithm = new AlgorithmStub(new MockDataFeed());
+                algorithm.SetStartDate(2014, 6, 6);
+                var option = algorithm.AddOption("AAPL");
+                algorithm.AddUniverse(fundamentals => Enumerable.Empty<Symbol>());
+                // OnEndOfTimeStep will add all pending universe additions
+                algorithm.OnEndOfTimeStep();
+                var optionUniverse = algorithm.UniverseManager.Values.OfType<OptionChainUniverse>().Single();
+                var equityUniverse = algorithm.UniverseManager.Values.Single(x => x is FundamentalUniverseFactory);
+                optionUniverse.UniverseSettings = new UniverseSettings(optionUniverse.UniverseSettings) { Resolution = Resolution.Minute };
+                equityUniverse.UniverseSettings = new UniverseSettings(equityUniverse.UniverseSettings) { Resolution = Resolution.Daily };
+
+                // the option universe alone exceeds the shared budget, but the selection being checked
+                // is too small (under a tenth of its threshold) to run the check
+                optionUniverse.Selected = CreateOptionSelection(option.Symbol.Underlying, 20);
+                equityUniverse.Selected = CreateEquitySelection(5);
+                algorithm.DataManager.UniverseSelection.WarnOnLargeUniverseSelection(equityUniverse);
+                Assert.AreEqual(0, UniverseSizeWarningCount(algorithm));
+
+                // a significant selection runs the check and warns
+                equityUniverse.Selected = CreateEquitySelection(10);
+                algorithm.DataManager.UniverseSelection.WarnOnLargeUniverseSelection(equityUniverse);
+                Assert.AreEqual(1, UniverseSizeWarningCount(algorithm));
+            }
+            finally
+            {
+                Config.Reset();
+            }
+        }
+
         private static int UniverseSizeWarningCount(AlgorithmStub algorithm)
         {
             return algorithm.DebugMessages.Count(x => x.Contains("universe selections"));

--- a/Tests/Engine/DataFeeds/UniverseSelectionTests.cs
+++ b/Tests/Engine/DataFeeds/UniverseSelectionTests.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Moq;
 using NUnit.Framework;
+using QuantConnect.Configuration;
 using QuantConnect.Data;
 using QuantConnect.Data.Fundamental;
 using QuantConnect.Data.UniverseSelection;
@@ -33,6 +34,56 @@ namespace QuantConnect.Tests.Engine.DataFeeds
     [TestFixture]
     public class UniverseSelectionTests
     {
+        [Test]
+        public void WarnsOnLargeOptionUniverseSelection()
+        {
+            Config.Set("option-universe-contracts-warning-threshold", "10");
+            try
+            {
+                var algorithm = new AlgorithmStub(new MockDataFeed());
+                algorithm.SetStartDate(2014, 6, 6);
+                var option = algorithm.AddOption("AAPL");
+                // OnEndOfTimeStep will add all pending universe additions
+                algorithm.OnEndOfTimeStep();
+                var universe = algorithm.UniverseManager.Values.OfType<OptionChainUniverse>().Single();
+
+                // below the threshold: no warning
+                universe.Selected = CreateOptionSelection(option.Symbol.Underlying, 5);
+                algorithm.DataManager.UniverseSelection.WarnOnLargeOptionUniverseSelection(universe);
+                Assert.AreEqual(0, OptionUniverseWarningCount(algorithm));
+
+                // above the threshold: warns
+                universe.Selected = CreateOptionSelection(option.Symbol.Underlying, 15);
+                algorithm.DataManager.UniverseSelection.WarnOnLargeOptionUniverseSelection(universe);
+                Assert.AreEqual(1, OptionUniverseWarningCount(algorithm));
+
+                // only warns once per algorithm
+                algorithm.DataManager.UniverseSelection.WarnOnLargeOptionUniverseSelection(universe);
+                Assert.AreEqual(1, OptionUniverseWarningCount(algorithm));
+            }
+            finally
+            {
+                Config.Reset();
+            }
+        }
+
+        private static int OptionUniverseWarningCount(AlgorithmStub algorithm)
+        {
+            return algorithm.DebugMessages.Count(x => x.Contains("option universe selections"));
+        }
+
+        private static HashSet<Symbol> CreateOptionSelection(Symbol underlying, int contractCount)
+        {
+            // option universe selections have the underlying symbol prepended
+            var selected = new HashSet<Symbol> { underlying };
+            var expiry = new DateTime(2014, 7, 19);
+            for (var i = 0; i < contractCount; i++)
+            {
+                selected.Add(Symbol.CreateOption(underlying, Market.USA, OptionStyle.American, OptionRight.Call, 100 + i, expiry));
+            }
+            return selected;
+        }
+
         [Test]
         public void CreatedEquityIsNotAddedToSymbolCache()
         {


### PR DESCRIPTION
#### Description

Adds four independent warn-don't-fail diagnostics for big-request failure modes that today surface as opaque or misleading fatal errors. Runs that would have succeeded are unaffected; all thresholds are config overridable, and the diagnostics never throw: a failure while checking or emitting a warning is logged and disables the check instead of interfering with the algorithm.

- **Honest OOM diagnostic in `ZipDataCacheProvider.Fetch`**: allocation failures wrapped by Ionic were logged as `Corrupt zip file/entry` and swallowed. An `OutOfMemoryException` anywhere in the chain is now rethrown as a memory diagnostic. Truly corrupt zips keep the old behavior.
- **Large history request warning** (in the `QCAlgorithm.History` funnel, so all overloads): warns once over an estimated data-cell threshold (default 5M), and warns once when 30 consecutive large calls have overlapping time windows (the re-fetch-a-long-lookback-every-day pattern). Tick history is estimated at 10 data points per second of market time, grounded on the repo's SPY sample data (~10.7 trade and ~115 quote ticks per second).
- **Early slow time step warning**: `AlgorithmTimeLimitManager` logs a warning once per time step over a threshold (default 3 minutes) instead of staying silent until the isolator kill, and `TimeMonitor` now names the running scheduled event when it crosses the one-minute mark. Both warnings also reach the user's log file through the result handler's debug messages, not just the engine log.
- **Large universe selection warning**: warns once when universe selections grow past a per-resolution symbol threshold table (`universe-selection-size-warning-thresholds`, a JSON object with defaults Tick 100, Second 500, Minute 1000, Hour 2000, Daily 4000; a resolution set to a non positive value is disabled). All universe types are covered. Option chain universes get the narrow-the-filter suggestion (`SetFilter`/`AddOptionContract`); other universes are pointed at selecting fewer symbols or a coarser universe resolution.

  How the load is calculated: every universe contributes `selected symbols / threshold for its resolution`, and the warning fires when the sum across all universes reaches 1. For example, 500 symbols at Minute (500/1000 = 0.5) plus 2000 symbols at Daily (2000/4000 = 0.5) adds up to 1.0 and warns, even though neither universe crosses its own threshold. The check is cheap by design: it only runs when the universe that just selected is itself at least a tenth of its threshold (so small selections never trigger the cross-universe scan), it allocates nothing on the way to a no-warning result, and it stops running entirely once the warning has been emitted.

#### Related Issue

N/A

#### Motivation and Context

These failure modes cost hours: a wide option universe dying as "corrupt zip" (actually OOM), billion-cell history re-fetches stalling backtests, and 10-minute isolator kills that never name the slow handler. Upfront, named warnings make them self-correcting.

#### Requires Documentation Change

No. The new config keys only tune warnings and have safe defaults.

#### How Has This Been Tested?

- New unit tests per diagnostic, each proven red on pre-change code: OOM rethrow + corrupt-zip regression guard, history size/overlap/tick warnings, time-step warning (once per step, re-arms on new step, also reaches the user handler), named scheduled event log (engine and user channels), universe selection warning (under/over threshold, resolution aware, cross-resolution aggregation, once per algorithm).
- Touched fixtures all green: zip cache, time-limit manager, isolator, universe selection, real-time handler, plus the full `AlgorithmHistoryTests` fixture.
- `BasicTemplateOptionsAlgorithm` (C# + Python) statistics unchanged.
- End-to-end Launcher runs verified each warning fires with the expected text and the runs complete normally.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`


