### PR TITLE
Automatic warm-up for registered indicators, scalar Update error and not-ready Current warning

### DIFF
--- a/Algorithm.CSharp/AutomaticIndicatorWarmupConsolidatorRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AutomaticIndicatorWarmupConsolidatorRegressionAlgorithm.cs
@@ -1,0 +1,147 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using QuantConnect.Data;
+using QuantConnect.Data.Consolidators;
+using QuantConnect.Indicators;
+using QuantConnect.Interfaces;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    /// <summary>
+    /// Asserts that indicators registered with a consolidator are automatically warmed up when
+    /// 'Settings.AutomaticIndicatorWarmUp' is enabled, without requiring a manual history replay
+    /// </summary>
+    public class AutomaticIndicatorWarmupConsolidatorRegressionAlgorithm : QCAlgorithm, IRegressionAlgorithmDefinition
+    {
+        private Symbol _spy;
+        private AverageTrueRange _atr;
+        private RelativeStrengthIndex _rsi;
+
+        public override void Initialize()
+        {
+            SetStartDate(2013, 10, 08);
+            SetEndDate(2013, 10, 09);
+
+            Settings.AutomaticIndicatorWarmUp = true;
+            _spy = AddEquity("SPY", Resolution.Minute).Symbol;
+
+            // Test case 1: bar indicator registered with a consolidator, previously required a manual history replay
+            _atr = new AverageTrueRange(10);
+            RegisterIndicator(_spy, _atr, new TradeBarConsolidator(TimeSpan.FromMinutes(30)));
+            AssertIsReady(_atr, expected: true);
+
+            // Test case 2: data point indicator registered with a consolidator and a selector
+            _rsi = new RelativeStrengthIndex(14);
+            RegisterIndicator(_spy, _rsi, new TradeBarConsolidator(TimeSpan.FromMinutes(30)), Field.Close);
+            AssertIsReady(_rsi, expected: true);
+
+            // Test case 3: non time based consolidators cannot be automatically warmed up, the indicator is
+            // registered but left cold
+            var renkoRsi = new RelativeStrengthIndex(14);
+            RegisterIndicator(_spy, renkoRsi, new RenkoConsolidator(1m), Field.Close);
+            AssertIsReady(renkoRsi, expected: false);
+
+            // Test case 4: with the setting disabled nothing is warmed up
+            Settings.AutomaticIndicatorWarmUp = false;
+            var notWarmed = new AverageTrueRange(10);
+            RegisterIndicator(_spy, notWarmed, new TradeBarConsolidator(TimeSpan.FromMinutes(30)));
+            AssertIsReady(notWarmed, expected: false);
+            Settings.AutomaticIndicatorWarmUp = true;
+        }
+
+        private static void AssertIsReady(IIndicator indicator, bool expected)
+        {
+            if (indicator.IsReady != expected)
+            {
+                throw new RegressionTestException($"Expected {indicator.Name} IsReady to be {expected} but was {indicator.IsReady}");
+            }
+        }
+
+        /// <summary>
+        /// OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.
+        /// </summary>
+        /// <param name="slice">Slice object keyed by symbol containing the stock data</param>
+        public override void OnData(Slice slice)
+        {
+            if (!Portfolio.Invested)
+            {
+                SetHoldings(_spy, 1);
+            }
+        }
+
+        /// <summary>
+        /// This is used by the regression test system to indicate if the open source Lean repository has the required data to run this algorithm.
+        /// </summary>
+        public bool CanRunLocally { get; } = true;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate which languages this algorithm is written in.
+        /// </summary>
+        public List<Language> Languages { get; } = new() { Language.CSharp, Language.Python };
+
+        /// <summary>
+        /// Data Points count of all timeslices of algorithm
+        /// </summary>
+        public long DataPoints => 1582;
+
+        /// <summary>
+        /// Data Points count of the algorithm history
+        /// </summary>
+        public int AlgorithmHistoryDataPoints => 1500;
+
+        /// <summary>
+        /// Final status of the algorithm
+        /// </summary>
+        public AlgorithmStatus AlgorithmStatus => AlgorithmStatus.Completed;
+
+        /// <summary>
+        /// This is used by the regression test system to indicate what the expected statistics are from running the algorithm
+        /// </summary>
+        public Dictionary<string, string> ExpectedStatistics => new Dictionary<string, string>
+        {
+            {"Total Orders", "1"},
+            {"Average Win", "0%"},
+            {"Average Loss", "0%"},
+            {"Compounding Annual Return", "0%"},
+            {"Drawdown", "0%"},
+            {"Expectancy", "0"},
+            {"Start Equity", "100000"},
+            {"End Equity", "98848.47"},
+            {"Net Profit", "0%"},
+            {"Sharpe Ratio", "0"},
+            {"Sortino Ratio", "0"},
+            {"Probabilistic Sharpe Ratio", "0%"},
+            {"Loss Rate", "0%"},
+            {"Win Rate", "0%"},
+            {"Profit-Loss Ratio", "0"},
+            {"Alpha", "0"},
+            {"Beta", "0"},
+            {"Annual Standard Deviation", "0"},
+            {"Annual Variance", "0"},
+            {"Information Ratio", "0"},
+            {"Tracking Error", "0"},
+            {"Treynor Ratio", "0"},
+            {"Total Fees", "$3.44"},
+            {"Estimated Strategy Capacity", "$31000000.00"},
+            {"Lowest Capacity Asset", "SPY R735QTJ8XC9X"},
+            {"Portfolio Turnover", "50.43%"},
+            {"Drawdown Recovery", "0"},
+            {"OrderListHash", "00636a25aed88acd2171c6221c747716"}
+        };
+    }
+}

--- a/Algorithm.CSharp/AutomaticIndicatorWarmupDataTypeRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AutomaticIndicatorWarmupDataTypeRegressionAlgorithm.cs
@@ -65,13 +65,12 @@ namespace QuantConnect.Algorithm.CSharp
             // force spy for use Raw data mode so that it matches the used when unsubscribed which uses the universe settings
             SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(spy).SetDataNormalizationMode(DataNormalizationMode.Raw);
 
-            // Test case: custom IndicatorBase<QuoteBar> indicator using Future subscribed symbol
+            // Test case: custom IndicatorBase<QuoteBar> indicator using Future subscribed symbol.
+            // Since 'Settings.AutomaticIndicatorWarmUp' is enabled, registering with a consolidator warms the indicator up
             var indicator = new CustomIndicator();
             var consolidator = CreateConsolidator(TimeSpan.FromMinutes(2), typeof(QuoteBar));
             RegisterIndicator(_symbol, indicator, consolidator);
 
-            AssertIndicatorState(indicator, isReady: false);
-            WarmUpIndicator(_symbol, indicator);
             AssertIndicatorState(indicator, isReady: true);
 
             // Test case: SimpleMovingAverage<IndicatorDataPoint> using Future Subscribed symbol (should use TradeBar)
@@ -151,7 +150,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 85;
+        public int AlgorithmHistoryDataPoints => 87;
 
         /// <summary>
         /// Final status of the algorithm

--- a/Algorithm.CSharp/AutomaticIndicatorWarmupRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/AutomaticIndicatorWarmupRegressionAlgorithm.cs
@@ -44,19 +44,30 @@ namespace QuantConnect.Algorithm.CSharp
                 throw new RegressionTestException("Expected SMA to be warmed up");
             }
 
-            // Test case 2
+            // Test case 2: 'RegisterIndicator' respects the automatic indicator warm-up setting
             var indicator = new CustomIndicator(10);
             RegisterIndicator(_spy, indicator, Resolution.Minute, (Func<IBaseData, decimal>) null);
 
-            if (indicator.IsReady)
+            if (!indicator.IsReady)
+            {
+                throw new RegressionTestException("Expected CustomIndicator to be automatically warmed up when registered");
+            }
+
+            // Test case 3: with the setting disabled 'RegisterIndicator' does not warm up, 'WarmUpIndicator' does
+            Settings.AutomaticIndicatorWarmUp = false;
+            var notWarmedIndicator = new CustomIndicator(10);
+            RegisterIndicator(_spy, notWarmedIndicator, Resolution.Minute, (Func<IBaseData, decimal>) null);
+
+            if (notWarmedIndicator.IsReady)
             {
                 throw new RegressionTestException("Expected CustomIndicator Not to be warmed up");
             }
-            WarmUpIndicator(_spy, indicator);
-            if (!indicator.IsReady)
+            WarmUpIndicator(_spy, notWarmedIndicator);
+            if (!notWarmedIndicator.IsReady)
             {
                 throw new RegressionTestException("Expected CustomIndicator to be warmed up");
             }
+            Settings.AutomaticIndicatorWarmUp = true;
         }
 
         /// <summary>
@@ -70,7 +81,7 @@ namespace QuantConnect.Algorithm.CSharp
                 var subscription = SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(_spy).First(config => config.TickType == TickType.Trade);
 
                 // we expect 1 consolidator per indicator
-                if (subscription.Consolidators.Count != 2)
+                if (subscription.Consolidators.Count != 3)
                 {
                     throw new RegressionTestException($"Unexpected consolidator count for subscription: {subscription.Consolidators.Count}");
                 }
@@ -113,7 +124,7 @@ namespace QuantConnect.Algorithm.CSharp
         /// <summary>
         /// Data Points count of the algorithm history
         /// </summary>
-        public int AlgorithmHistoryDataPoints => 40;
+        public int AlgorithmHistoryDataPoints => 60;
 
         /// <summary>
         /// Final status of the algorithm

--- a/Algorithm.Python/AutomaticIndicatorWarmupConsolidatorRegressionAlgorithm.py
+++ b/Algorithm.Python/AutomaticIndicatorWarmupConsolidatorRegressionAlgorithm.py
@@ -1,0 +1,57 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from AlgorithmImports import *
+
+### <summary>
+### Asserts that indicators registered with a consolidator are automatically warmed up when
+### 'settings.automatic_indicator_warm_up' is enabled, without requiring a manual history replay
+### </summary>
+class AutomaticIndicatorWarmupConsolidatorRegressionAlgorithm(QCAlgorithm):
+    def initialize(self):
+        self.set_start_date(2013, 10, 8)
+        self.set_end_date(2013, 10, 9)
+
+        self.settings.automatic_indicator_warm_up = True
+        self._spy = self.add_equity("SPY", Resolution.MINUTE).symbol
+
+        # Test case 1: bar indicator registered with a consolidator, previously required a manual history replay
+        self._atr = AverageTrueRange(10)
+        self.register_indicator(self._spy, self._atr, TradeBarConsolidator(timedelta(minutes=30)))
+        self.assert_is_ready(self._atr, True)
+
+        # Test case 2: data point indicator registered with a consolidator and a selector
+        self._rsi = RelativeStrengthIndex(14)
+        self.register_indicator(self._spy, self._rsi, TradeBarConsolidator(timedelta(minutes=30)), lambda bar: bar.close)
+        self.assert_is_ready(self._rsi, True)
+
+        # Test case 3: non time based consolidators cannot be automatically warmed up, the indicator is
+        # registered but left cold
+        renko_rsi = RelativeStrengthIndex(14)
+        self.register_indicator(self._spy, renko_rsi, RenkoConsolidator(1), lambda bar: bar.close)
+        self.assert_is_ready(renko_rsi, False)
+
+        # Test case 4: with the setting disabled nothing is warmed up
+        self.settings.automatic_indicator_warm_up = False
+        not_warmed = AverageTrueRange(10)
+        self.register_indicator(self._spy, not_warmed, TradeBarConsolidator(timedelta(minutes=30)))
+        self.assert_is_ready(not_warmed, False)
+        self.settings.automatic_indicator_warm_up = True
+
+    def assert_is_ready(self, indicator, expected):
+        if indicator.is_ready != expected:
+            raise Exception(f"Expected {indicator.name} is_ready to be {expected} but was {indicator.is_ready}")
+
+    def on_data(self, data):
+        if not self.portfolio.invested:
+            self.set_holdings(self._spy, 1)

--- a/Algorithm/QCAlgorithm.Indicators.cs
+++ b/Algorithm/QCAlgorithm.Indicators.cs
@@ -57,6 +57,11 @@ namespace QuantConnect.Algorithm
         };
 
         /// <summary>
+        /// True once the warning about registered indicators that cannot be automatically warmed up has been sent
+        /// </summary>
+        private bool _registeredIndicatorNoWarmUpWarningSent;
+
+        /// <summary>
         /// Gets whether or not WarmUpIndicator is allowed to warm up indicators
         /// </summary>
         [Obsolete("Please use Settings.AutomaticIndicatorWarmUp")]
@@ -1178,7 +1183,7 @@ namespace QuantConnect.Algorithm
         {
             var name = Invariant($"{symbol}({fieldName ?? "close"},{resolution})");
             var identity = new Identity(name);
-            RegisterIndicator(symbol, identity, ResolveConsolidator(symbol, resolution), selector);
+            RegisterIndicatorCore(symbol, identity, ResolveConsolidator(symbol, resolution), selector);
             return identity;
         }
 
@@ -1998,7 +2003,7 @@ namespace QuantConnect.Algorithm
         {
             var name = CreateIndicatorName(symbol, $"RDV({period})", resolution);
             var relativeDailyVolume = new RelativeDailyVolume(name, period);
-            RegisterIndicator(symbol, relativeDailyVolume, resolution, selector);
+            RegisterIndicatorCore(symbol, relativeDailyVolume, ResolveConsolidator(symbol, resolution, typeof(TradeBar)), selector);
 
             return relativeDailyVolume;
         }
@@ -3243,6 +3248,35 @@ namespace QuantConnect.Algorithm
         [DocumentationAttribute(Indicators)]
         public void RegisterIndicator(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, IDataConsolidator consolidator, Func<IBaseData, decimal> selector = null)
         {
+            RegisterIndicatorCore(symbol, indicator, consolidator, selector);
+
+            if (TryGetRegisteredIndicatorWarmUpPeriod(indicator, consolidator, out var barSpan))
+            {
+                if (barSpan.HasValue)
+                {
+                    // wrap the decimal selector the same way the live consolidator handler does
+                    Func<IBaseData, IndicatorDataPoint> warmUpSelector = null;
+                    if (selector != null)
+                    {
+                        warmUpSelector = x => new IndicatorDataPoint(x.Symbol, x.EndTime, selector(x));
+                    }
+                    WarmUpConsolidatorRegisteredIndicator(symbol, indicator, consolidator, barSpan.Value, warmUpSelector);
+                }
+                else
+                {
+                    // identity consolidator: warm up directly at the subscription resolution
+                    WarmUpIndicator(symbol, indicator, (Resolution?)null, selector);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Registers the consolidator to receive automatic updates as well as configures the indicator to receive updates
+        /// from the consolidator, without triggering the automatic indicator warm-up. Used by the indicator creation
+        /// helpers, which handle warm-up themselves
+        /// </summary>
+        private void RegisterIndicatorCore(Symbol symbol, IndicatorBase<IndicatorDataPoint> indicator, IDataConsolidator consolidator, Func<IBaseData, decimal> selector = null)
+        {
             // default our selector to the Value property on BaseData
             selector = selector ?? (x => x.Value);
 
@@ -3316,6 +3350,31 @@ namespace QuantConnect.Algorithm
         public void RegisterIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, IDataConsolidator consolidator, Func<IBaseData, T> selector = null)
             where T : IBaseData
         {
+            RegisterIndicatorCore(symbol, indicator, consolidator, selector);
+
+            if (TryGetRegisteredIndicatorWarmUpPeriod(indicator, consolidator, out var barSpan))
+            {
+                if (barSpan.HasValue)
+                {
+                    WarmUpConsolidatorRegisteredIndicator(symbol, indicator, consolidator, barSpan.Value, selector);
+                }
+                else
+                {
+                    // identity consolidator: warm up directly at the subscription resolution.
+                    // Same as 'WarmUpIndicator(symbol, indicator, resolution)' but without its 'class' generic constraint
+                    IndicatorHistory(indicator, new[] { symbol }, 0, (Resolution?)null, selector);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Registers the consolidator to receive automatic updates as well as configures the indicator to receive updates
+        /// from the consolidator, without triggering the automatic indicator warm-up. Used by the indicator creation
+        /// helpers, which handle warm-up themselves
+        /// </summary>
+        private void RegisterIndicatorCore<T>(Symbol symbol, IndicatorBase<T> indicator, IDataConsolidator consolidator, Func<IBaseData, T> selector = null)
+            where T : IBaseData
+        {
             // assign default using cast
             var selectorToUse = selector ?? (x => (T)x);
 
@@ -3345,6 +3404,83 @@ namespace QuantConnect.Algorithm
                 var value = selectorToUse(consolidated);
                 indicator.Update(value);
             };
+        }
+
+        /// <summary>
+        /// Determines whether an indicator explicitly registered with a consolidator should be automatically warmed up,
+        /// see <see cref="IAlgorithmSettings.AutomaticIndicatorWarmUp"/>, and gets the consolidator's bar span to warm up with.
+        /// A null <paramref name="barSpan"/> with a true return value means the consolidator is an identity pass-through,
+        /// so the subscription resolution should be used
+        /// </summary>
+        private bool TryGetRegisteredIndicatorWarmUpPeriod(IndicatorBase indicator, IDataConsolidator consolidator, out TimeSpan? barSpan)
+        {
+            barSpan = null;
+            if (!Settings.AutomaticIndicatorWarmUp
+                || indicator is not IIndicatorWarmUpPeriodProvider warmUpPeriodProvider
+                || warmUpPeriodProvider.WarmUpPeriod <= 0)
+            {
+                // indicators which don't define a warm up period are silently skipped, unlike 'WarmUpIndicator',
+                // since the user did not explicitly request this specific indicator to be warmed up
+                return false;
+            }
+
+            var period = (consolidator as ConsolidatorBase)?.Period;
+            if (!period.HasValue)
+            {
+                // non time based consolidators, Renko for instance, don't have a period we can warm up from
+                if (!_registeredIndicatorNoWarmUpWarningSent)
+                {
+                    _registeredIndicatorNoWarmUpWarningSent = true;
+                    Debug($"Warning: automatic indicator warm-up is not supported for consolidators of type" +
+                        $" '{consolidator.GetType().Name}' because their consolidation period is unknown." +
+                        $" '{indicator.Name}' was registered but not warmed up, please warm it up manually if needed.");
+                }
+                return false;
+            }
+
+            if (period.Value != TimeSpan.Zero)
+            {
+                barSpan = period;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Warms up an indicator that was registered with a consolidator by replaying historical data through
+        /// a temporary consolidator mirroring the registered one, so the indicator is fed the same bar type and
+        /// span it will receive live. This is what enables 'Settings.AutomaticIndicatorWarmUp' to cover
+        /// consolidator-registered indicators, which otherwise force a manual history replay
+        /// </summary>
+        private void WarmUpConsolidatorRegisteredIndicator<T>(Symbol symbol, IndicatorBase<T> indicator, IDataConsolidator consolidator, TimeSpan barSpan,
+            Func<IBaseData, T> selector)
+            where T : IBaseData
+        {
+            var history = GetIndicatorWarmUpHistory(new[] { symbol }, indicator, barSpan, out _);
+            if (history == Enumerable.Empty<Slice>())
+            {
+                return;
+            }
+
+            // assign default selector
+            selector ??= GetDefaultSelector<T>();
+
+            // mirror the registered consolidator's input type instead of using it directly:
+            // pumping history through the live instance would replay stale bars into other attached handlers
+            var tickType = LeanData.GetCommonTickTypeForCommonDataTypes(consolidator.InputType, symbol.SecurityType);
+            var warmUpConsolidator = CreateConsolidator(barSpan, consolidator.InputType, tickType);
+            warmUpConsolidator.DataConsolidated += (_, consolidated) => indicator.Update(selector(consolidated));
+
+            foreach (var slice in history)
+            {
+                if (slice.TryGet(warmUpConsolidator.InputType, symbol, out var data))
+                {
+                    warmUpConsolidator.Update(data);
+                }
+            }
+
+            // scan to flush the last consolidated bar. The security exists at this point, registering created it if missing
+            warmUpConsolidator.Scan(Securities[symbol].LocalTime);
+            warmUpConsolidator.Dispose();
         }
 
         /// <summary>
@@ -4381,7 +4517,7 @@ namespace QuantConnect.Algorithm
             var dataType = GetDataTypeFromSelector(selector);
             foreach (var symbol in symbols)
             {
-                RegisterIndicator(symbol, indicator, ResolveConsolidator(symbol, resolution, dataType), selector);
+                RegisterIndicatorCore(symbol, indicator, ResolveConsolidator(symbol, resolution, dataType), selector);
             }
 
             if (Settings.AutomaticIndicatorWarmUp)
@@ -4396,7 +4532,7 @@ namespace QuantConnect.Algorithm
         {
             foreach (var symbol in symbols)
             {
-                RegisterIndicator(symbol, indicator, resolution, selector);
+                RegisterIndicatorCore(symbol, indicator, ResolveConsolidator(symbol, resolution, typeof(T)), selector);
             }
 
             if (Settings.AutomaticIndicatorWarmUp)
@@ -4407,12 +4543,12 @@ namespace QuantConnect.Algorithm
 
         private void InitializeOptionIndicator(IndicatorBase<IBaseData> indicator, Resolution? resolution, Symbol symbol, Symbol mirrorOption)
         {
-            RegisterIndicator(symbol, indicator, ResolveConsolidator(symbol, resolution, typeof(QuoteBar)));
-            RegisterIndicator(symbol.Underlying, indicator, ResolveConsolidator(symbol.Underlying, resolution));
+            RegisterIndicatorCore(symbol, indicator, ResolveConsolidator(symbol, resolution, typeof(QuoteBar)));
+            RegisterIndicatorCore(symbol.Underlying, indicator, ResolveConsolidator(symbol.Underlying, resolution));
             var symbols = new List<Symbol> { symbol, symbol.Underlying };
             if (mirrorOption != null)
             {
-                RegisterIndicator(mirrorOption, indicator, ResolveConsolidator(mirrorOption, resolution, typeof(QuoteBar)));
+                RegisterIndicatorCore(mirrorOption, indicator, ResolveConsolidator(mirrorOption, resolution, typeof(QuoteBar)));
                 symbols.Add(mirrorOption);
             }
 

--- a/Common/AlgorithmSettings.cs
+++ b/Common/AlgorithmSettings.cs
@@ -36,7 +36,8 @@ namespace QuantConnect
         private static bool _defaultIgnoreUnknownAssetHoldings = Config.GetBool("ignore-unknown-asset-holdings", true);
 
         /// <summary>
-        /// Gets whether or not WarmUpIndicator is allowed to warm up indicators
+        /// Gets whether or not indicators are automatically warmed up with historical data when created
+        /// through the indicator helper methods or registered through 'RegisterIndicator'
         /// </summary>
         public bool AutomaticIndicatorWarmUp { get; set; }
 

--- a/Common/Data/Consolidators/ConsolidatorBase.cs
+++ b/Common/Data/Consolidators/ConsolidatorBase.cs
@@ -48,6 +48,12 @@ namespace QuantConnect.Data.Consolidators
         public abstract IBaseData WorkingData { get; }
 
         /// <summary>
+        /// Gets the period of time each consolidated bar spans, if this consolidator is time based, null otherwise.
+        /// A zero period means the consolidator emits each input as is, see <see cref="IdentityDataConsolidator{T}"/>
+        /// </summary>
+        public virtual TimeSpan? Period => null;
+
+        /// <summary>
         /// Gets the type consumed by this consolidator
         /// </summary>
         public abstract Type InputType { get; }

--- a/Common/Data/Consolidators/IdentityDataConsolidator.cs
+++ b/Common/Data/Consolidators/IdentityDataConsolidator.cs
@@ -52,6 +52,12 @@ namespace QuantConnect.Data.Consolidators
         }
 
         /// <summary>
+        /// Gets the period of time each consolidated bar spans. This consolidator emits each input as is,
+        /// which is expressed as a zero period
+        /// </summary>
+        public override TimeSpan? Period => TimeSpan.Zero;
+
+        /// <summary>
         /// Updates this consolidator with the specified data
         /// </summary>
         /// <param name="data">The new data for the consolidator</param>

--- a/Common/Data/Consolidators/MarketHourAwareConsolidator.cs
+++ b/Common/Data/Consolidators/MarketHourAwareConsolidator.cs
@@ -28,12 +28,13 @@ namespace QuantConnect.Data.Consolidators
     {
         private readonly bool _dailyStrictEndTimeEnabled;
         private readonly bool _extendedMarketHours;
+        private readonly TimeSpan _period;
         private bool _useStrictEndTime;
 
         /// <summary>
         /// The consolidation period requested
         /// </summary>
-        protected TimeSpan Period { get; }
+        public override TimeSpan? Period => _period;
 
         /// <summary>
         /// The consolidator instance
@@ -75,7 +76,7 @@ namespace QuantConnect.Data.Consolidators
         public MarketHourAwareConsolidator(bool dailyStrictEndTimeEnabled, Resolution resolution, Type dataType, TickType tickType, bool extendedMarketHours)
         {
             _dailyStrictEndTimeEnabled = dailyStrictEndTimeEnabled;
-            Period = resolution.ToTimeSpan();
+            _period = resolution.ToTimeSpan();
             _extendedMarketHours = extendedMarketHours;
 
             Consolidator = CreateConsolidator(resolution, dataType, tickType);
@@ -94,7 +95,7 @@ namespace QuantConnect.Data.Consolidators
         public MarketHourAwareConsolidator(bool dailyStrictEndTimeEnabled, TimeSpan period, Type dataType, TickType tickType, bool extendedMarketHours)
         {
             _dailyStrictEndTimeEnabled = dailyStrictEndTimeEnabled;
-            Period = period;
+            _period = period;
             _extendedMarketHours = extendedMarketHours;
 
             // when the period exactly matches a standard resolution, reuse the resolution based consolidation so its
@@ -123,23 +124,23 @@ namespace QuantConnect.Data.Consolidators
                 {
                     return resolution == Resolution.Daily
                         ? new TickConsolidator(DailyStrictEndTime)
-                        : new TickConsolidator(Period);
+                        : new TickConsolidator(_period);
                 }
                 return resolution == Resolution.Daily
                     ? new TickQuoteBarConsolidator(DailyStrictEndTime)
-                    : new TickQuoteBarConsolidator(Period);
+                    : new TickQuoteBarConsolidator(_period);
             }
             if (dataType == typeof(TradeBar))
             {
                 return resolution == Resolution.Daily
                     ? new TradeBarConsolidator(DailyStrictEndTime)
-                    : new TradeBarConsolidator(Period);
+                    : new TradeBarConsolidator(_period);
             }
             if (dataType == typeof(QuoteBar))
             {
                 return resolution == Resolution.Daily
                     ? new QuoteBarConsolidator(DailyStrictEndTime)
-                    : new QuoteBarConsolidator(Period);
+                    : new QuoteBarConsolidator(_period);
             }
             throw new ArgumentNullException(nameof(dataType), $"{dataType.Name} not supported");
         }
@@ -179,7 +180,7 @@ namespace QuantConnect.Data.Consolidators
             // the data resolution is hour and the exchange opens at any point in time over the data.Time to data.EndTime interval
             if (_extendedMarketHours ||
                 ExchangeHours.IsOpen(data.Time, false) ||
-                (Period == Time.OneDay && (data.EndTime - data.Time >= Time.OneHour) && ExchangeHours.IsOpen(data.Time, data.EndTime, false)))
+                (_period == Time.OneDay && (data.EndTime - data.Time >= Time.OneHour) && ExchangeHours.IsOpen(data.Time, data.EndTime, false)))
             {
                 Consolidator.Update(data);
             }
@@ -238,9 +239,9 @@ namespace QuantConnect.Data.Consolidators
         protected virtual CalendarInfo DailyStrictEndTime(DateTime dateTime)
         {
             // strict end times describe a single daily bar, so periods larger than a day fall back to standard period consolidation
-            if (!_useStrictEndTime || Period > Time.OneDay)
+            if (!_useStrictEndTime || _period > Time.OneDay)
             {
-                return new(Period > Time.OneDay ? dateTime : dateTime.RoundDown(Period), Period);
+                return new(_period > Time.OneDay ? dateTime : dateTime.RoundDown(_period), _period);
             }
             return LeanData.GetDailyCalendar(dateTime, ExchangeHours, _extendedMarketHours);
         }
@@ -253,9 +254,9 @@ namespace QuantConnect.Data.Consolidators
         {
             if (ExchangeHours == null || ExchangeHours.IsMarketAlwaysOpen)
             {
-                return new(dateTime.RoundDown(Period), Period);
+                return new(dateTime.RoundDown(_period), _period);
             }
-            return LeanData.GetIntradayCalendar(dateTime, Period, ExchangeHours, _extendedMarketHours);
+            return LeanData.GetIntradayCalendar(dateTime, _period, ExchangeHours, _extendedMarketHours);
         }
 
         /// <summary>
@@ -263,7 +264,7 @@ namespace QuantConnect.Data.Consolidators
         /// </summary>
         protected virtual bool UseStrictEndTime(Symbol symbol)
         {
-            return LeanData.UseStrictEndTime(_dailyStrictEndTimeEnabled, symbol, Period, ExchangeHours);
+            return LeanData.UseStrictEndTime(_dailyStrictEndTimeEnabled, symbol, _period, ExchangeHours);
         }
 
         /// <summary>

--- a/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
+++ b/Common/Data/Consolidators/PeriodCountConsolidatorBase.cs
@@ -289,9 +289,9 @@ namespace QuantConnect.Data.Consolidators
         protected bool IsTimeBased => !_maxCount.HasValue;
 
         /// <summary>
-        /// Gets the time period for this consolidator
+        /// Gets the time period for this consolidator, null when in pure count mode
         /// </summary>
-        protected TimeSpan? Period => _period;
+        public override TimeSpan? Period => _period;
 
         /// <summary>
         /// Determines whether or not the specified data should be processed

--- a/Common/Interfaces/IAlgorithmSettings.cs
+++ b/Common/Interfaces/IAlgorithmSettings.cs
@@ -24,7 +24,8 @@ namespace QuantConnect.Interfaces
     public interface IAlgorithmSettings
     {
         /// <summary>
-        /// Gets whether or not WarmUpIndicator is allowed to warm up indicators
+        /// Gets whether or not indicators are automatically warmed up with historical data when created
+        /// through the indicator helper methods or registered through 'RegisterIndicator'
         /// </summary>
         bool AutomaticIndicatorWarmUp { get; set; }
 

--- a/Indicators/IndicatorBase.cs
+++ b/Indicators/IndicatorBase.cs
@@ -28,11 +28,48 @@ namespace QuantConnect.Indicators
     public abstract partial class IndicatorBase : WindowBase<IndicatorDataPoint>, IIndicator
     {
         /// <summary>
+        /// Tracks whether any indicator on the current thread is being updated. Indicators routinely read
+        /// each other's 'Current' while computing, e.g. MACD reads its EMAs before they are ready, so the
+        /// not-ready read warning only applies to reads happening outside of any indicator update
+        /// </summary>
+        [ThreadStatic]
+        private static int _updateScopeDepth;
+
+        /// <summary>
+        /// True once the not-ready 'Current' read warning is no longer applicable for this indicator,
+        /// either because it was already logged or because the indicator got ready. Keeps the hot path
+        /// to a single boolean check
+        /// </summary>
+        private bool _notReadyCurrentWarningDisabled;
+
+        /// <summary>
         /// The data consolidators associated with this indicator if any
         /// </summary>
         /// <remarks>These references allow us to unregister an indicator from getting future data updates through it's consolidators.
         /// We need multiple consolitadors because some indicators consume data from multiple different symbols</remarks>
         public ISet<IDataConsolidator> Consolidators { get; } = new HashSet<IDataConsolidator>();
+
+        /// <summary>
+        /// Gets the current state of this indicator. If the state has not been updated
+        /// then the time on the value will equal DateTime.MinValue.
+        /// </summary>
+        /// <remarks>Reading 'Current' while the indicator is not ready yields a meaningless value, a common
+        /// silent logic bug, so the first such user read logs a warning naming the samples needed vs received</remarks>
+        public override IndicatorDataPoint Current
+        {
+            get
+            {
+                if (!_notReadyCurrentWarningDisabled)
+                {
+                    ValidateCurrentAccess();
+                }
+                return base.Current;
+            }
+            protected set
+            {
+                base.Current = value;
+            }
+        }
 
         /// <summary>
         /// Gets the previous state of this indicator. If the state has not been updated
@@ -99,6 +136,82 @@ namespace QuantConnect.Indicators
         /// <param name="input">The value to use to update this indicator</param>
         /// <returns>True if this indicator is ready, false otherwise</returns>
         public abstract bool Update(IBaseData input);
+
+        /// <summary>
+        /// Updating an indicator with a raw value is not supported: an update always requires a time.
+        /// This overload exists to turn a common misuse, e.g. 'indicator.update(bar.close)' in Python, which
+        /// otherwise surfaces as a hard to understand runtime binding error, into a prescriptive error naming
+        /// the valid update forms. Python numeric values bind to it through their double conversion.
+        /// It takes a double on purpose: a decimal overload would make existing 'Update(IndicatorDataPoint)'
+        /// C# call sites ambiguous through the data point's implicit decimal conversion
+        /// </summary>
+        /// <param name="value">The value the indicator was incorrectly updated with</param>
+        public bool Update(double value)
+        {
+            if (this is IndicatorBase<IndicatorDataPoint>)
+            {
+                throw new NotSupportedException($"{GetType().Name}.Update() requires a time for each new value." +
+                    " Use one of the following methods instead: Update(DateTime, decimal), e.g. 'indicator.Update(bar.EndTime, bar.Close)', or Update(IndicatorDataPoint)");
+            }
+
+            var suggestions = new List<string>
+            {
+                "Update(TradeBar)",
+                "Update(QuoteBar)"
+            };
+
+            if (this is IndicatorBase<IBaseData>)
+            {
+                suggestions.Add("Update(Tick)");
+            }
+
+            throw new NotSupportedException($"{GetType().Name} does not support being updated with just a value: it requires a full data bar." +
+                $" Use one of the following methods instead: {string.Join(", ", suggestions)}");
+        }
+
+        /// <summary>
+        /// Flags the current thread as updating an indicator, see <see cref="_updateScopeDepth"/>
+        /// </summary>
+        protected static void EnterUpdateScope()
+        {
+            _updateScopeDepth++;
+        }
+
+        /// <summary>
+        /// Removes the indicator updating flag from the current thread, see <see cref="_updateScopeDepth"/>
+        /// </summary>
+        protected static void ExitUpdateScope()
+        {
+            _updateScopeDepth--;
+        }
+
+        /// <summary>
+        /// Logs a warning, once per indicator, when 'Current' is read outside of any indicator update
+        /// while this indicator is not ready yet
+        /// </summary>
+        private void ValidateCurrentAccess()
+        {
+            if (IsReady)
+            {
+                // once ready the warning no longer applies, disable the check so reads only cost a boolean check
+                _notReadyCurrentWarningDisabled = true;
+                return;
+            }
+
+            if (_updateScopeDepth != 0)
+            {
+                // internal read from another indicator's update, not a user read
+                return;
+            }
+
+            _notReadyCurrentWarningDisabled = true;
+            var samplesNeeded = (this as IIndicatorWarmUpPeriodProvider)?.WarmUpPeriod;
+            var samplesReceived = $"received {Samples} sample{(Samples == 1 ? string.Empty : "s")}";
+            var requirement = samplesNeeded > 0 ? $"{samplesReceived} but requires {samplesNeeded}" : samplesReceived;
+            Log.Error($"IndicatorBase.Current: The indicator '{Name}' is not ready yet, it has {requirement}." +
+                " Its value is not meaningful until 'IsReady' is true. Either check 'IsReady' before reading 'Current', or warm the indicator up," +
+                " e.g. with 'Settings.AutomaticIndicatorWarmUp = true' or 'algorithm.WarmUpIndicator()'. This message is only logged once per indicator.");
+        }
 
         /// <summary>
         /// ToString Overload for Indicator Base
@@ -185,45 +298,53 @@ namespace QuantConnect.Indicators
         /// <returns>True if this indicator is ready, false otherwise</returns>
         public override bool Update(IBaseData input)
         {
-            T _previousSymbolInput = default(T);
-            if (_previousInput.TryGetValue(input.Symbol.ID, out _previousSymbolInput) && input.EndTime < _previousSymbolInput.EndTime)
+            EnterUpdateScope();
+            try
             {
-                if (!_loggedForwardOnlyIndicatorError)
+                T _previousSymbolInput = default(T);
+                if (_previousInput.TryGetValue(input.Symbol.ID, out _previousSymbolInput) && input.EndTime < _previousSymbolInput.EndTime)
                 {
-                    _loggedForwardOnlyIndicatorError = true;
-                    // if we receive a time in the past, log once and return
-                    Log.Error($"IndicatorBase.Update(): This is a forward only indicator: {Name} Input: {input.EndTime:u} Previous: {_previousSymbolInput.EndTime:u}. It will not be updated with this input.");
+                    if (!_loggedForwardOnlyIndicatorError)
+                    {
+                        _loggedForwardOnlyIndicatorError = true;
+                        // if we receive a time in the past, log once and return
+                        Log.Error($"IndicatorBase.Update(): This is a forward only indicator: {Name} Input: {input.EndTime:u} Previous: {_previousSymbolInput.EndTime:u}. It will not be updated with this input.");
+                    }
+                    return IsReady;
+                }
+                if (!ReferenceEquals(input, _previousSymbolInput))
+                {
+                    // compute a new value and update our previous time
+                    Samples++;
+
+                    if (!(input is T))
+                    {
+                        if (typeof(T) == typeof(IndicatorDataPoint))
+                        {
+                            input = new IndicatorDataPoint(input.Symbol, input.EndTime, input.Value);
+                        }
+                        else
+                        {
+                            throw new ArgumentException($"IndicatorBase.Update() 'input' expected to be of type {typeof(T)} but is of type {input.GetType()}");
+                        }
+                    }
+                    _previousInput[input.Symbol.ID] = (T)input;
+
+                    var nextResult = ValidateAndComputeNextValue((T)input);
+                    if (nextResult.Status == IndicatorStatus.Success)
+                    {
+                        Current = new IndicatorDataPoint(input.Symbol, input.EndTime, nextResult.Value);
+
+                        // let others know we've produced a new data point
+                        OnUpdated(Current);
+                    }
                 }
                 return IsReady;
             }
-            if (!ReferenceEquals(input, _previousSymbolInput))
+            finally
             {
-                // compute a new value and update our previous time
-                Samples++;
-
-                if (!(input is T))
-                {
-                    if (typeof(T) == typeof(IndicatorDataPoint))
-                    {
-                        input = new IndicatorDataPoint(input.Symbol, input.EndTime, input.Value);
-                    }
-                    else
-                    {
-                        throw new ArgumentException($"IndicatorBase.Update() 'input' expected to be of type {typeof(T)} but is of type {input.GetType()}");
-                    }
-                }
-                _previousInput[input.Symbol.ID] = (T)input;
-
-                var nextResult = ValidateAndComputeNextValue((T)input);
-                if (nextResult.Status == IndicatorStatus.Success)
-                {
-                    Current = new IndicatorDataPoint(input.Symbol, input.EndTime, nextResult.Value);
-
-                    // let others know we've produced a new data point
-                    OnUpdated(Current);
-                }
+                ExitUpdateScope();
             }
-            return IsReady;
         }
 
         /// <summary>

--- a/Tests/Algorithm/AlgorithmIndicatorsTests.cs
+++ b/Tests/Algorithm/AlgorithmIndicatorsTests.cs
@@ -21,6 +21,7 @@ using NUnit.Framework;
 using Python.Runtime;
 using QuantConnect.Algorithm;
 using QuantConnect.Data;
+using QuantConnect.Data.Consolidators;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
 using QuantConnect.Lean.Engine.DataFeeds;
@@ -800,6 +801,85 @@ def get_indicator(algo, symbol):
             // The indicator should have been updated during the warm-up period
             var lastInput = testModule.GetAttr("LastInputTracker").GetAttr("last_input").GetAndDispose<TradeBar>();
             Assert.IsNotNull(lastInput);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void RegisterIndicatorWithConsolidatorRespectsAutomaticIndicatorWarmUp(bool automaticIndicatorWarmUp)
+        {
+            _algorithm.Settings.AutomaticIndicatorWarmUp = automaticIndicatorWarmUp;
+
+            var indicator = new AverageTrueRange(10);
+            var consolidator = new TradeBarConsolidator(TimeSpan.FromMinutes(30));
+            _algorithm.RegisterIndicator(_equity, indicator, consolidator);
+
+            Assert.AreEqual(automaticIndicatorWarmUp, indicator.IsReady);
+            if (automaticIndicatorWarmUp)
+            {
+                Assert.GreaterOrEqual(indicator.Samples, indicator.WarmUpPeriod);
+            }
+            else
+            {
+                Assert.AreEqual(0, indicator.Samples);
+            }
+        }
+
+        [Test]
+        public void RegisterIndicatorWithConsolidatorAndSelectorAutomaticallyWarmsUpDataPointIndicator()
+        {
+            var indicator = new RelativeStrengthIndex(14);
+            var consolidator = new TradeBarConsolidator(TimeSpan.FromMinutes(30));
+            _algorithm.RegisterIndicator(_equity, indicator, consolidator, Field.Close);
+
+            Assert.IsTrue(indicator.IsReady);
+            Assert.GreaterOrEqual(indicator.Samples, indicator.WarmUpPeriod);
+        }
+
+        [Test]
+        public void RegisterIndicatorWithResolutionAutomaticallyWarmsUpIndicator()
+        {
+            var indicator = new SimpleMovingAverage(10);
+            _algorithm.RegisterIndicator(_equity, indicator, Resolution.Minute, (Func<IBaseData, decimal>)null);
+
+            Assert.IsTrue(indicator.IsReady);
+        }
+
+        [Test]
+        public void RegisterIndicatorWithNonTimeBasedConsolidatorSkipsAutomaticWarmUp()
+        {
+            var indicator = new RelativeStrengthIndex(14);
+            var consolidator = new RenkoConsolidator(10m);
+            Assert.DoesNotThrow(() => _algorithm.RegisterIndicator(_equity, indicator, consolidator, Field.Close));
+
+            // the consolidation period cannot be inferred, so the indicator is registered but not warmed up
+            Assert.IsFalse(indicator.IsReady);
+            Assert.AreEqual(0, indicator.Samples);
+        }
+
+        [Test]
+        public void RegisterIndicatorWithConsolidatorWarmsUpForexIndicatorWithQuoteData()
+        {
+            // forex is quote only: warming up must not request trade data, see GH Agents issue #305 (improvement #8)
+            _algorithm.SetDateTime(new DateTime(2014, 5, 9));
+            var eurusd = _algorithm.AddForex("EURUSD", Resolution.Minute, Market.Oanda).Symbol;
+
+            var indicator = new AverageTrueRange(10);
+            var consolidator = new QuoteBarConsolidator(TimeSpan.FromMinutes(30));
+            _algorithm.RegisterIndicator(eurusd, indicator, consolidator);
+
+            Assert.IsTrue(indicator.IsReady);
+        }
+
+        [Test]
+        public void IndicatorHelpersWarmUpForexIndicatorsWithQuoteData()
+        {
+            // forex is quote only: the ATR helper must warm up from quote bars without any manual history replay
+            _algorithm.SetDateTime(new DateTime(2014, 5, 9));
+            var eurusd = _algorithm.AddForex("EURUSD", Resolution.Minute, Market.Oanda).Symbol;
+
+            var indicator = _algorithm.ATR(eurusd, 10, resolution: Resolution.Minute);
+
+            Assert.IsTrue(indicator.IsReady);
         }
 
         // Some specific indicator helper methods tests

--- a/Tests/Algorithm/AlgorithmIndicatorsTests.cs
+++ b/Tests/Algorithm/AlgorithmIndicatorsTests.cs
@@ -859,7 +859,7 @@ def get_indicator(algo, symbol):
         [Test]
         public void RegisterIndicatorWithConsolidatorWarmsUpForexIndicatorWithQuoteData()
         {
-            // forex is quote only: warming up must not request trade data, see GH Agents issue #305 (improvement #8)
+            // forex is quote only: warming up must not request trade data
             _algorithm.SetDateTime(new DateTime(2014, 5, 9));
             var eurusd = _algorithm.AddForex("EURUSD", Resolution.Minute, Market.Oanda).Symbol;
 

--- a/Tests/Indicators/IndicatorTests.cs
+++ b/Tests/Indicators/IndicatorTests.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using NUnit.Framework;
+using Python.Runtime;
 using QuantConnect.Algorithm;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
@@ -339,6 +340,131 @@ namespace QuantConnect.Tests.Indicators
             var date = new DateTime(2020, 1, 1);
             target.Update(new Tick(date, Symbols.SPY, 1, 1));
             Assert.AreEqual(Symbols.SPY, target.Current.Symbol);
+        }
+
+        [Test]
+        public void ScalarUpdateThrowsPrescriptiveErrorForDataPointIndicators()
+        {
+            // common misuse: 'sma.update(bar.close)', the update requires a time
+            var indicator = new SimpleMovingAverage(3);
+            var exception = Assert.Throws<NotSupportedException>(() => indicator.Update(1.23));
+            StringAssert.Contains("Update(DateTime, decimal)", exception.Message);
+            StringAssert.Contains("Update(IndicatorDataPoint)", exception.Message);
+        }
+
+        [Test]
+        public void ScalarUpdateThrowsPrescriptiveErrorForBarIndicators()
+        {
+            // common misuse: 'atr.update(bar.close)', bar indicators require the full bar
+            var indicator = new AverageTrueRange(10);
+            var exception = Assert.Throws<NotSupportedException>(() => indicator.Update(1.23));
+            StringAssert.Contains("Update(TradeBar)", exception.Message);
+            StringAssert.Contains("Update(QuoteBar)", exception.Message);
+        }
+
+        [TestCase("RelativeStrengthIndex(14)", "Update(DateTime, decimal)")]
+        [TestCase("AverageTrueRange(10)", "Update(TradeBar)")]
+        public void ScalarUpdateThrowsPrescriptiveErrorFromPython(string indicator, string expectedSuggestion)
+        {
+            // reproduces the fleet crash 'sd.rsi.update(bar.close)': the raw value must bind to the
+            // Update(double) overload instead of failing with a cryptic runtime binding error
+            using (Py.GIL())
+            {
+                var testModule = PyModule.FromString("ScalarUpdateThrowsPrescriptiveErrorFromPython",
+                    @$"
+from AlgorithmImports import *
+
+def run():
+    indicator = {indicator}
+    try:
+        indicator.update(70.5)
+    except Exception as e:
+        return str(e)
+    return None
+");
+                var errorMessage = testModule.GetAttr("run").Invoke().As<string>();
+                Assert.IsNotNull(errorMessage);
+                StringAssert.Contains(expectedSuggestion, errorMessage);
+            }
+        }
+
+        [Test]
+        public void ReadingCurrentBeforeIndicatorIsReadyLogsOncePerIndicator()
+        {
+            var previousHandler = Log.LogHandler;
+            var testHandler = new QueueLogHandler();
+            Log.LogHandler = testHandler;
+            try
+            {
+                var indicator = new SimpleMovingAverage("SMA", 3);
+                indicator.Update(new IndicatorDataPoint(new DateTime(2023, 6, 12, 9, 30, 0), 1m));
+
+                var value = indicator.Current.Value;
+
+                var warnings = testHandler.Logs.Where(entry => entry.Message.Contains("is not ready")).ToList();
+                Assert.AreEqual(1, warnings.Count);
+                StringAssert.Contains("received 1 sample", warnings[0].Message);
+                StringAssert.Contains("requires 3", warnings[0].Message);
+                StringAssert.Contains("SMA", warnings[0].Message);
+
+                // reading again does not log again
+                value = indicator.Current.Value;
+                Assert.AreEqual(1, testHandler.Logs.Count(entry => entry.Message.Contains("is not ready")));
+            }
+            finally
+            {
+                Log.LogHandler = previousHandler;
+            }
+        }
+
+        [Test]
+        public void ReadingCurrentWhenReadyDoesNotLog()
+        {
+            var previousHandler = Log.LogHandler;
+            var testHandler = new QueueLogHandler();
+            Log.LogHandler = testHandler;
+            try
+            {
+                var indicator = new SimpleMovingAverage("SMA", 2);
+                var referenceDate = new DateTime(2023, 6, 12, 9, 30, 0);
+                indicator.Update(new IndicatorDataPoint(referenceDate, 1m));
+                indicator.Update(new IndicatorDataPoint(referenceDate.AddMinutes(1), 2m));
+                Assert.IsTrue(indicator.IsReady);
+
+                var value = indicator.Current.Value;
+
+                Assert.IsFalse(testHandler.Logs.Any(entry => entry.Message.Contains("is not ready")));
+            }
+            finally
+            {
+                Log.LogHandler = previousHandler;
+            }
+        }
+
+        [Test]
+        public void InternalCurrentReadsWhileUpdatingDoNotLog()
+        {
+            var previousHandler = Log.LogHandler;
+            var testHandler = new QueueLogHandler();
+            Log.LogHandler = testHandler;
+            try
+            {
+                // MACD reads its internal EMAs 'Current' values on every update, while they are not ready yet.
+                // Those internal reads must not trigger the not-ready warning
+                var indicator = new MovingAverageConvergenceDivergence(2, 3, 2);
+                var referenceDate = new DateTime(2023, 6, 12, 9, 30, 0);
+                for (var i = 0; i < 2; i++)
+                {
+                    indicator.Update(new IndicatorDataPoint(referenceDate.AddMinutes(i), i));
+                }
+                Assert.IsFalse(indicator.IsReady);
+
+                Assert.IsFalse(testHandler.Logs.Any(entry => entry.Message.Contains("is not ready")));
+            }
+            finally
+            {
+                Log.LogHandler = previousHandler;
+            }
         }
 
         private static void TestComparisonOperators<TValue>()

--- a/Tests/Indicators/IndicatorTests.cs
+++ b/Tests/Indicators/IndicatorTests.cs
@@ -366,7 +366,7 @@ namespace QuantConnect.Tests.Indicators
         [TestCase("AverageTrueRange(10)", "Update(TradeBar)")]
         public void ScalarUpdateThrowsPrescriptiveErrorFromPython(string indicator, string expectedSuggestion)
         {
-            // reproduces the fleet crash 'sd.rsi.update(bar.close)': the raw value must bind to the
+            // reproduces the common misuse 'rsi.update(bar.close)': the raw value must bind to the
             // Update(double) overload instead of failing with a cryptic runtime binding error
             using (Py.GIL())
             {


### PR DESCRIPTION
#### Description

Indicator warm-up automation improvements, closing the gaps that force algorithms into manual history-replay ceremony:

- `Settings.AutomaticIndicatorWarmUp` now also covers `RegisterIndicator`, including consolidator registrations:
  - History is replayed through a temporary consolidator mirroring the registered one (same input type and period), so the indicator gets the same bars it will receive live. The live consolidator is untouched.
  - The consolidator's span comes from a new `ConsolidatorBase.Period` virtual, implemented by the time-based consolidators.
  - Non time-based consolidators (Renko, range, count) are skipped with a one-time debug message; indicators without a `WarmUpPeriod` are skipped silently.
  - Internal helper registrations go through a private `RegisterIndicatorCore`, so their warm-up behavior is unchanged.
- `indicator.update(bar.close)` — the common scalar-update misuse from Python — now throws a prescriptive `NotSupportedException` naming the valid update forms, instead of a cryptic binding error. (A `decimal` overload is not viable: it makes existing `Update(IndicatorDataPoint)` call sites ambiguous.)
- Reading `indicator.Current` while `!IsReady` logs a one-time warning naming samples received vs needed. Internal reads by composite indicators (e.g. MACD reading its EMAs) are suppressed, and the check self-disables once ready.
- Verified the automatic warm-up path already picks the correct bar type per asset class (quote bars for forex/CFD) — pinned with tests, no code change.

Behavioral notes:

- The `AutomaticIndicatorWarmUp` default stays `false`; flipping it is a separate policy decision.
- Candlestick pattern helpers now warm up under the setting too, consistent with other helpers.
- `MarketHourAwareConsolidator.Period` changed from `protected TimeSpan` to `public override TimeSpan?`.

Deferred: a per-call `register_indicator(..., warm_up=True)` flag and a generalized warm-up helper (existing `WarmUpIndicator` overloads already cover the indicator case).

#### Related Issue

N/A

#### Motivation and Context

Manual warm-up ceremony is a large source of boilerplate (~10–35 lines per algorithm), and manual replay is a recurring crash class (`self.history[TradeBar](forex_pair, ...)` on quote-only forex; `rsi.update(bar.close)` binding errors). Making `register_indicator` respect the existing setting deletes the idiom instead of documenting it.

#### Requires Documentation Change

Yes: `Settings.AutomaticIndicatorWarmUp` now also covers `RegisterIndicator`-registered indicators; the indicator `Update` docs can mention the scalar-update error.

#### How Has This Been Tested?

- New `AlgorithmIndicatorsTests` cases (red before, green after): consolidator registration warms iff the setting is on; selector and resolution overloads; Renko skipped without throwing; forex indicators warm from quote data.
- New `IndicatorTests` cases: prescriptive scalar-update error for data-point and bar indicators, including through the real Python binding; not-ready `Current` warning fires once, not when ready, and not for internal composite reads.
- New `AutomaticIndicatorWarmupConsolidatorRegressionAlgorithm` (C# + Python): green with identical statistics. Existing warm-up regression algorithms updated and green.
- Suites: full `Tests.Algorithm` (12,715), `Tests.Indicators` (1,493), `Tests.Python` (1,323), all consolidator fixtures (234) — 0 failures.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
