### PR TITLE
Handle null keys gracefully in dictionary lookup methods

### DIFF
--- a/Algorithm.Python/PythonDictionaryFeatureRegressionAlgorithm.py
+++ b/Algorithm.Python/PythonDictionaryFeatureRegressionAlgorithm.py
@@ -52,6 +52,15 @@ class PythonDictionaryFeatureRegressionAlgorithm(QCAlgorithm):
         if spy is None:
             raise AssertionError('SPY is not in Slice')
 
+        if slice.contains_key(None):
+            raise AssertionError('Slice.contains_key(None) should return False instead of throwing')
+
+        if slice.get(None) is not None:
+            raise AssertionError('Slice.get(None) should return None instead of throwing')
+
+        if slice.bars.contains_key(None):
+            raise AssertionError('TradeBars.contains_key(None) should return False instead of throwing')
+
         for symbol, bar in slice.bars.items():
             self.plot(symbol, 'Price', bar.close)
 
@@ -74,6 +83,16 @@ class PythonDictionaryFeatureRegressionAlgorithm(QCAlgorithm):
         if aapl is not None:
             raise AssertionError('aapl is not None')
 
+        # A None key should behave like a missing key instead of throwing,
+        # e.g. when a symbol field is only assigned later in the algorithm
+        none_symbol = None
+        price = self.securities[none_symbol].price if self.securities.contains_key(none_symbol) else None
+        if price is not None:
+            raise AssertionError('Securities.contains_key(None) should return False instead of throwing')
+
+        if self.securities.get(none_symbol) is not None:
+            raise AssertionError('Securities.get(None) should return None instead of throwing')
+
         for symbol, security in self.securities.items():
             self.plot(symbol, 'Price', security.price)
 
@@ -94,6 +113,12 @@ class PythonDictionaryFeatureRegressionAlgorithm(QCAlgorithm):
         aapl = self.portfolio.get(self.aapl_symbol)
         if aapl is not None:
             raise AssertionError('aapl is not None')
+
+        if self.portfolio.contains_key(None):
+            raise AssertionError('Portfolio.contains_key(None) should return False instead of throwing')
+
+        if self.portfolio.get(None) is not None:
+            raise AssertionError('Portfolio.get(None) should return None instead of throwing')
 
         for symbol, holdings in self.portfolio.items():
             msg = f'{symbol}: {holdings.leverage}'

--- a/Common/Data/Market/OptionChains.cs
+++ b/Common/Data/Market/OptionChains.cs
@@ -113,6 +113,11 @@ namespace QuantConnect.Data.Market
 
         private static Symbol GetCanonicalOptionSymbol(Symbol symbol)
         {
+            if (symbol == null)
+            {
+                return null;
+            }
+
             if (symbol.SecurityType.HasOptions())
             {
                 return Symbol.CreateCanonicalOption(symbol);

--- a/Common/Data/Market/OptionChains.cs
+++ b/Common/Data/Market/OptionChains.cs
@@ -113,7 +113,7 @@ namespace QuantConnect.Data.Market
 
         private static Symbol GetCanonicalOptionSymbol(Symbol symbol)
         {
-            if (symbol == null)
+            if (ReferenceEquals(symbol, null))
             {
                 return null;
             }

--- a/Common/Data/Slice.cs
+++ b/Common/Data/Slice.cs
@@ -527,7 +527,7 @@ namespace QuantConnect.Data
         /// <returns>True if this instance contains data for the symbol, false otherwise</returns>
         public override bool ContainsKey(Symbol symbol)
         {
-            return _data.Value.ContainsKey(symbol);
+            return symbol != null && _data.Value.ContainsKey(symbol);
         }
 
         /// <summary>
@@ -540,7 +540,7 @@ namespace QuantConnect.Data
         {
             data = null;
             SymbolData symbolData;
-            if (_data.Value.TryGetValue(symbol, out symbolData))
+            if (symbol != null && _data.Value.TryGetValue(symbol, out symbolData))
             {
                 data = symbolData.GetData();
                 return data != null;

--- a/Common/Data/Slice.cs
+++ b/Common/Data/Slice.cs
@@ -527,7 +527,7 @@ namespace QuantConnect.Data
         /// <returns>True if this instance contains data for the symbol, false otherwise</returns>
         public override bool ContainsKey(Symbol symbol)
         {
-            return symbol != null && _data.Value.ContainsKey(symbol);
+            return !ReferenceEquals(symbol, null) && _data.Value.ContainsKey(symbol);
         }
 
         /// <summary>
@@ -540,7 +540,7 @@ namespace QuantConnect.Data
         {
             data = null;
             SymbolData symbolData;
-            if (symbol != null && _data.Value.TryGetValue(symbol, out symbolData))
+            if (!ReferenceEquals(symbol, null) && _data.Value.TryGetValue(symbol, out symbolData))
             {
                 data = symbolData.GetData();
                 return data != null;

--- a/Common/Securities/CashBook.cs
+++ b/Common/Securities/CashBook.cs
@@ -279,7 +279,7 @@ namespace QuantConnect.Securities
         /// <param name="symbol">Key.</param>
         public override bool ContainsKey(string symbol)
         {
-            return symbol != null && _currencies.ContainsKey(symbol);
+            return !ReferenceEquals(symbol, null) && _currencies.ContainsKey(symbol);
         }
 
         /// <summary>
@@ -291,7 +291,7 @@ namespace QuantConnect.Securities
         /// <param name="value">Value.</param>
         public override bool TryGetValue(string symbol, out Cash value)
         {
-            if (symbol == null)
+            if (ReferenceEquals(symbol, null))
             {
                 value = null;
                 return false;

--- a/Common/Securities/CashBook.cs
+++ b/Common/Securities/CashBook.cs
@@ -279,7 +279,7 @@ namespace QuantConnect.Securities
         /// <param name="symbol">Key.</param>
         public override bool ContainsKey(string symbol)
         {
-            return _currencies.ContainsKey(symbol);
+            return symbol != null && _currencies.ContainsKey(symbol);
         }
 
         /// <summary>
@@ -291,6 +291,11 @@ namespace QuantConnect.Securities
         /// <param name="value">Value.</param>
         public override bool TryGetValue(string symbol, out Cash value)
         {
+            if (symbol == null)
+            {
+                value = null;
+                return false;
+            }
             return _currencies.TryGetValue(symbol, out value);
         }
 

--- a/Common/Securities/Positions/SecurityPositionGroupModel.cs
+++ b/Common/Securities/Positions/SecurityPositionGroupModel.cs
@@ -246,6 +246,11 @@ namespace QuantConnect.Securities.Positions
         /// <returns>True if a group with the specified key was found, false otherwise</returns>
         public override bool TryGetValue(PositionGroupKey key, out IPositionGroup value)
         {
+            if (key == null)
+            {
+                value = null;
+                return false;
+            }
             return Groups.TryGetGroup(key, out value);
         }
     }

--- a/Common/Securities/Positions/SecurityPositionGroupModel.cs
+++ b/Common/Securities/Positions/SecurityPositionGroupModel.cs
@@ -246,7 +246,7 @@ namespace QuantConnect.Securities.Positions
         /// <returns>True if a group with the specified key was found, false otherwise</returns>
         public override bool TryGetValue(PositionGroupKey key, out IPositionGroup value)
         {
-            if (key == null)
+            if (ReferenceEquals(key, null))
             {
                 value = null;
                 return false;

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -147,6 +147,10 @@ namespace QuantConnect.Securities
         /// <returns>Bool true if contains this symbol pair</returns>
         public override bool ContainsKey(Symbol symbol)
         {
+            if (symbol == null)
+            {
+                return false;
+            }
             lock (_securityManager)
             {
                 return _completeSecuritiesCollection.ContainsKey(symbol);
@@ -252,6 +256,11 @@ namespace QuantConnect.Securities
         /// <returns>True on successfully locating the security object</returns>
         public override bool TryGetValue(Symbol symbol, out Security security)
         {
+            if (symbol == null)
+            {
+                security = null;
+                return false;
+            }
             lock (_securityManager)
             {
                 return _completeSecuritiesCollection.TryGetValue(symbol, out security);

--- a/Common/Securities/SecurityManager.cs
+++ b/Common/Securities/SecurityManager.cs
@@ -147,7 +147,7 @@ namespace QuantConnect.Securities
         /// <returns>Bool true if contains this symbol pair</returns>
         public override bool ContainsKey(Symbol symbol)
         {
-            if (symbol == null)
+            if (ReferenceEquals(symbol, null))
             {
                 return false;
             }
@@ -256,7 +256,7 @@ namespace QuantConnect.Securities
         /// <returns>True on successfully locating the security object</returns>
         public override bool TryGetValue(Symbol symbol, out Security security)
         {
-            if (symbol == null)
+            if (ReferenceEquals(symbol, null))
             {
                 security = null;
                 return false;

--- a/Common/Util/BaseExtendedDictionary.cs
+++ b/Common/Util/BaseExtendedDictionary.cs
@@ -83,7 +83,7 @@ namespace Common.Util
         /// <returns>true if the key was found; otherwise, false</returns>
         public override bool TryGetValue(TKey key, out TValue value)
         {
-            if (key == null)
+            if (ReferenceEquals(key, null))
             {
                 value = default;
                 return false;
@@ -175,7 +175,7 @@ namespace Common.Util
         /// <returns>true if the dictionary contains an element with the specified key; otherwise, false</returns>
         public override bool ContainsKey(TKey key)
         {
-            return key != null && Dictionary.ContainsKey(key);
+            return !ReferenceEquals(key, null) && Dictionary.ContainsKey(key);
         }
 
         /// <summary>

--- a/Common/Util/BaseExtendedDictionary.cs
+++ b/Common/Util/BaseExtendedDictionary.cs
@@ -83,6 +83,11 @@ namespace Common.Util
         /// <returns>true if the key was found; otherwise, false</returns>
         public override bool TryGetValue(TKey key, out TValue value)
         {
+            if (key == null)
+            {
+                value = default;
+                return false;
+            }
             return Dictionary.TryGetValue(key, out value);
         }
 
@@ -170,7 +175,7 @@ namespace Common.Util
         /// <returns>true if the dictionary contains an element with the specified key; otherwise, false</returns>
         public override bool ContainsKey(TKey key)
         {
-            return Dictionary.ContainsKey(key);
+            return key != null && Dictionary.ContainsKey(key);
         }
 
         /// <summary>

--- a/Tests/Common/ExtendedDictionaryTests.cs
+++ b/Tests/Common/ExtendedDictionaryTests.cs
@@ -16,9 +16,13 @@
 using NUnit.Framework;
 using Python.Runtime;
 using QuantConnect.Statistics;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using QuantConnect.Data;
 using QuantConnect.Data.Market;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Positions;
 
 namespace QuantConnect.Tests.Common
 {
@@ -227,6 +231,57 @@ def set(dictionary, key, value):
 
             exception = Assert.Throws<ClrBubbledException>(() => module.InvokeMethod("get", pyDict, pyStringNonExistingSymbol));
             Assert.IsInstanceOf<KeyNotFoundException>(exception.InnerException);
+        }
+
+        [Test]
+        public void ConcreteDictionariesHandleNullKeysGracefully()
+        {
+            var time = new DateTime(2025, 1, 1);
+
+            var securities = new SecurityManager(new TimeKeeper(time, TimeZones.NewYork));
+            Assert.IsFalse(securities.ContainsKey(null));
+            Assert.IsFalse(securities.TryGetValue(null, out _));
+            Assert.IsNull(securities.get(null));
+
+            var portfolio = new SecurityPortfolioManager(securities, new SecurityTransactionManager(null, securities), new AlgorithmSettings());
+            Assert.IsFalse(portfolio.ContainsKey(null));
+            Assert.IsFalse(portfolio.TryGetValue(null, out _));
+            Assert.IsNull(portfolio.get(null));
+
+            var cashBook = new CashBook();
+            Assert.IsFalse(cashBook.ContainsKey(null));
+            Assert.IsFalse(cashBook.TryGetValue(null, out _));
+            Assert.IsNull(cashBook.get(null));
+
+            var slice = new Slice(time, new List<BaseData>(), time);
+            Assert.IsFalse(slice.ContainsKey(null));
+            Assert.IsFalse(slice.TryGetValue(null, out _));
+            Assert.IsNull(slice.get(null));
+
+            var tradeBars = new TradeBars();
+            Assert.IsFalse(tradeBars.ContainsKey(null));
+            Assert.IsFalse(tradeBars.TryGetValue(null, out _));
+            Assert.IsNull(tradeBars.get(null));
+
+            var optionChains = new OptionChains();
+            Assert.IsFalse(optionChains.ContainsKey(null));
+            Assert.IsFalse(optionChains.TryGetValue(null, out _));
+            Assert.IsNull(optionChains.get(null));
+
+            var futuresChains = new FuturesChains();
+            Assert.IsFalse(futuresChains.ContainsKey(null));
+            Assert.IsFalse(futuresChains.TryGetValue(null, out _));
+            Assert.IsNull(futuresChains.get(null));
+
+            var universeManager = new UniverseManager();
+            Assert.IsFalse(universeManager.ContainsKey(null));
+            Assert.IsFalse(universeManager.TryGetValue(null, out _));
+            Assert.IsNull(universeManager.get(null));
+
+            var positionGroups = new SecurityPositionGroupModel();
+            Assert.IsFalse(positionGroups.ContainsKey(null));
+            Assert.IsFalse(positionGroups.TryGetValue(null, out _));
+            Assert.IsNull(positionGroups.get(null));
         }
 
         private class TestDictionary<TKey, TValue> : ExtendedDictionary<TKey, TValue>

--- a/Tests/Common/ExtendedDictionaryTests.cs
+++ b/Tests/Common/ExtendedDictionaryTests.cs
@@ -233,55 +233,36 @@ def set(dictionary, key, value):
             Assert.IsInstanceOf<KeyNotFoundException>(exception.InnerException);
         }
 
-        [Test]
-        public void ConcreteDictionariesHandleNullKeysGracefully()
+        private static IEnumerable<TestCaseData> NullKeyTestCases()
         {
             var time = new DateTime(2025, 1, 1);
-
             var securities = new SecurityManager(new TimeKeeper(time, TimeZones.NewYork));
-            Assert.IsFalse(securities.ContainsKey(null));
-            Assert.IsFalse(securities.TryGetValue(null, out _));
-            Assert.IsNull(securities.get(null));
 
-            var portfolio = new SecurityPortfolioManager(securities, new SecurityTransactionManager(null, securities), new AlgorithmSettings());
-            Assert.IsFalse(portfolio.ContainsKey(null));
-            Assert.IsFalse(portfolio.TryGetValue(null, out _));
-            Assert.IsNull(portfolio.get(null));
+            yield return new TestCaseData(securities).SetArgDisplayNames(nameof(SecurityManager));
+            yield return new TestCaseData(new SecurityPortfolioManager(securities, new SecurityTransactionManager(null, securities), new AlgorithmSettings()))
+                .SetArgDisplayNames(nameof(SecurityPortfolioManager));
+            yield return new TestCaseData(new CashBook()).SetArgDisplayNames(nameof(CashBook));
+            yield return new TestCaseData(new Slice(time, new List<BaseData>(), time)).SetArgDisplayNames(nameof(Slice));
+            yield return new TestCaseData(new TradeBars()).SetArgDisplayNames(nameof(TradeBars));
+            yield return new TestCaseData(new OptionChains()).SetArgDisplayNames(nameof(OptionChains));
+            yield return new TestCaseData(new FuturesChains()).SetArgDisplayNames(nameof(FuturesChains));
+            yield return new TestCaseData(new UniverseManager()).SetArgDisplayNames(nameof(UniverseManager));
+            yield return new TestCaseData(new SecurityPositionGroupModel()).SetArgDisplayNames(nameof(SecurityPositionGroupModel));
+        }
 
-            var cashBook = new CashBook();
-            Assert.IsFalse(cashBook.ContainsKey(null));
-            Assert.IsFalse(cashBook.TryGetValue(null, out _));
-            Assert.IsNull(cashBook.get(null));
+        [TestCaseSource(nameof(NullKeyTestCases))]
+        public void DictionariesHandleNullKeysGracefully(object dictionary)
+        {
+            AssertNullKeyIsHandledGracefully((dynamic)dictionary);
+        }
 
-            var slice = new Slice(time, new List<BaseData>(), time);
-            Assert.IsFalse(slice.ContainsKey(null));
-            Assert.IsFalse(slice.TryGetValue(null, out _));
-            Assert.IsNull(slice.get(null));
-
-            var tradeBars = new TradeBars();
-            Assert.IsFalse(tradeBars.ContainsKey(null));
-            Assert.IsFalse(tradeBars.TryGetValue(null, out _));
-            Assert.IsNull(tradeBars.get(null));
-
-            var optionChains = new OptionChains();
-            Assert.IsFalse(optionChains.ContainsKey(null));
-            Assert.IsFalse(optionChains.TryGetValue(null, out _));
-            Assert.IsNull(optionChains.get(null));
-
-            var futuresChains = new FuturesChains();
-            Assert.IsFalse(futuresChains.ContainsKey(null));
-            Assert.IsFalse(futuresChains.TryGetValue(null, out _));
-            Assert.IsNull(futuresChains.get(null));
-
-            var universeManager = new UniverseManager();
-            Assert.IsFalse(universeManager.ContainsKey(null));
-            Assert.IsFalse(universeManager.TryGetValue(null, out _));
-            Assert.IsNull(universeManager.get(null));
-
-            var positionGroups = new SecurityPositionGroupModel();
-            Assert.IsFalse(positionGroups.ContainsKey(null));
-            Assert.IsFalse(positionGroups.TryGetValue(null, out _));
-            Assert.IsNull(positionGroups.get(null));
+        private static void AssertNullKeyIsHandledGracefully<TKey, TValue>(ExtendedDictionary<TKey, TValue> dictionary)
+            where TKey : class
+            where TValue : class
+        {
+            Assert.IsFalse(dictionary.ContainsKey(null));
+            Assert.IsFalse(dictionary.TryGetValue(null, out _));
+            Assert.IsNull(dictionary.get(null));
         }
 
         private class TestDictionary<TKey, TValue> : ExtendedDictionary<TKey, TValue>

--- a/Tests/Common/ExtendedDictionaryTests.cs
+++ b/Tests/Common/ExtendedDictionaryTests.cs
@@ -243,6 +243,7 @@ def set(dictionary, key, value):
                 .SetArgDisplayNames(nameof(SecurityPortfolioManager));
             yield return new TestCaseData(new CashBook()).SetArgDisplayNames(nameof(CashBook));
             yield return new TestCaseData(new Slice(time, new List<BaseData>(), time)).SetArgDisplayNames(nameof(Slice));
+            yield return new TestCaseData(new DataDictionary<TradeBar>()).SetArgDisplayNames("DataDictionary");
             yield return new TestCaseData(new TradeBars()).SetArgDisplayNames(nameof(TradeBars));
             yield return new TestCaseData(new OptionChains()).SetArgDisplayNames(nameof(OptionChains));
             yield return new TestCaseData(new FuturesChains()).SetArgDisplayNames(nameof(FuturesChains));


### PR DESCRIPTION

#### Description

A Python algorithm guarding a securities lookup with `contains_key` crashes when the key is `None`:

```
RuntimeError at 01/03/2023 15:00:00 UTC. Context: Scheduled event: 'SPX: EveryDay: 10' at 1/3/2023 3:00:00 PM ArgumentNullException: Value cannot be null. (Parameter 'key')
    spx_price = self.securities[self._spx_underlying].price if self.securities.contains_key(self._spx_underlying) else None
                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This is easy to hit when a symbol field is initialized to `None` and only assigned later (e.g. when the first option chain arrives), while a scheduled event fires before that assignment.

Cause: the `ContainsKey`/`TryGetValue` overrides in the `ExtendedDictionary<TKey, TValue>` family pass the key straight into the backing .NET dictionary, which throws `ArgumentNullException` for a null key — while the `ExtendedDictionary` base and its `get`/`pop` helpers already treat a null/`None` key as a missing key.

The fix — a null key now behaves like a missing key (`false`/default) in the lookup methods:
- `SecurityManager.ContainsKey`/`TryGetValue` return `false` for a null symbol (this also covers `SecurityPortfolioManager`, which delegates to `Securities`).
- `BaseExtendedDictionary.ContainsKey`/`TryGetValue` return `false` for a null key, covering `DataDictionary` collections (`TradeBars`, chains, etc.), `UniverseManager` and `ReadOnlyExtendedDictionary`.
- `Slice.ContainsKey`/`TryGetValue` return `false` for a null symbol.
- `CashBook.ContainsKey`/`TryGetValue` return `false` for a null symbol.
- `OptionChains.GetCanonicalOptionSymbol` passes a null symbol through instead of throwing `NullReferenceException`, so its `ContainsKey`/`TryGetValue` fall back to the now-guarded base implementations.
- `SecurityPositionGroupModel.TryGetValue` returns `false` for a null key.

#### Related Issue

N/A — user-reported runtime error, reproduction included in the description.

#### Motivation and Context

`self.securities.contains_key(symbol)` is the natural Python idiom for defensively guarding a lookup; in a Python dictionary `None in d` / `d.get(None)` returns `False`/`None`, so the guard itself throwing is surprising and defeats its purpose.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

- `ExtendedDictionaryTests.DictionariesHandleNullKeysGracefully` (new): parameterized with one test case per dictionary type — `SecurityManager`, `SecurityPortfolioManager`, `CashBook`, `Slice`, `DataDictionary`, `TradeBars`, `OptionChains`, `FuturesChains`, `UniverseManager` and `SecurityPositionGroupModel` — asserting `ContainsKey(null)` is `false`, `TryGetValue(null)` is `false` and `get(null)` is null.
- `PythonDictionaryFeatureRegressionAlgorithm` (extended): exercises the exact reported pattern from Python — `contains_key(None)`/`get(None)` on `Securities`, `Portfolio`, the `Slice` and `slice.bars` — and fails if any of them throws or returns a non-missing result. Expected statistics unchanged.
- Reproduced the reported error with a scratch algorithm (scheduled event calling `contains_key(None)` on `Securities`) before the fix; after the fix the same algorithm completes and the guard returns `None`.
- Test suites for all touched classes (`ExtendedDictionaryTests`, `SliceTests`, `CashBookTests`, `SecurityManagerTests`, `SecurityPortfolioManagerTests`, `OptionChainsTests`, `DataDictionaryTests`, `UniverseManagerTests`, position group tests): 3,381 passed, 0 failed.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
