### PR TITLE
Clear the advance decline period watermark on reset

### DIFF
--- a/Indicators/AdvanceDeclineIndicator.cs
+++ b/Indicators/AdvanceDeclineIndicator.cs
@@ -150,6 +150,7 @@ namespace QuantConnect.Indicators
             {
                 _currentPeriod[key] = null;
             }
+            _currentPeriodTime = null;
 
             base.Reset();
         }

--- a/Tests/Indicators/AdvanceDeclineDifferenceTests.cs
+++ b/Tests/Indicators/AdvanceDeclineDifferenceTests.cs
@@ -84,6 +84,26 @@ namespace QuantConnect.Tests.Indicators
         }
 
         [Test]
+        public void ProducesTheSameValuesAfterReset()
+        {
+            var indicator = CreateIndicator();
+            var reference = System.DateTime.Today;
+
+            UpdateStocks(indicator, reference.AddMinutes(1), 1m, 1m, 1m);
+            UpdateStocks(indicator, reference.AddMinutes(2), 2m, 0.5m, 3m);
+            var expected = indicator.Current.Value;
+            Assert.AreNotEqual(0m, expected);
+
+            UpdateStocks(indicator, reference.AddMinutes(3), 3m, 1m, 2m);
+            indicator.Reset();
+
+            UpdateStocks(indicator, reference.AddMinutes(1), 1m, 1m, 1m);
+            UpdateStocks(indicator, reference.AddMinutes(2), 2m, 0.5m, 3m);
+
+            Assert.AreEqual(expected, indicator.Current.Value);
+        }
+
+        [Test]
         public virtual void IgnorePeriodIfAnyStockMissed()
         {
             var adDifference = (AdvanceDeclineDifference)CreateIndicator();
@@ -293,6 +313,13 @@ namespace QuantConnect.Tests.Indicators
                 // The last update used Symbol.GOOG, so the indicator's current Symbol should be GOOG
                 Assert.AreEqual(Symbols.GOOG, indicator.Current.Symbol);
             }
+        }
+
+        private static void UpdateStocks(IndicatorBase<TradeBar> indicator, System.DateTime time, decimal aapl, decimal ibm, decimal goog)
+        {
+            indicator.Update(new TradeBar() { Symbol = Symbols.AAPL, Close = aapl, Volume = 100, Time = time });
+            indicator.Update(new TradeBar() { Symbol = Symbols.IBM, Close = ibm, Volume = 100, Time = time });
+            indicator.Update(new TradeBar() { Symbol = Symbols.GOOG, Close = goog, Volume = 100, Time = time });
         }
 
         protected override string TestFileName => "arms_data.txt";

--- a/Tests/Indicators/McClellanOscillatorTests.cs
+++ b/Tests/Indicators/McClellanOscillatorTests.cs
@@ -151,10 +151,7 @@ namespace QuantConnect.Tests.Indicators
                 Add(symbol);
             }
 
-            // Set to the first EMA values to account for past A/D Difference values that we don't have access
             Reset();
-            EMAFast.Update(new DateTime(2022, 6, 30), -209.85m);
-            EMASlow.Update(new DateTime(2022, 6, 30), -186.41m);
         }
 
         public void TestUpdate(IndicatorDataPoint input)
@@ -189,6 +186,10 @@ namespace QuantConnect.Tests.Indicators
             {
                 _symbols[symbol] = 0m;
             }
+
+            // Set to the first EMA values to account for past A/D Difference values that we don't have access
+            EMAFast.Update(new DateTime(2022, 6, 30), -209.85m);
+            EMASlow.Update(new DateTime(2022, 6, 30), -186.41m);
         }
     }
 }

--- a/Tests/Indicators/McClellanSummationIndexTests.cs
+++ b/Tests/Indicators/McClellanSummationIndexTests.cs
@@ -150,12 +150,7 @@ namespace QuantConnect.Tests.Indicators
                 Add(symbol);
             }
 
-            // Set to the first EMA values to account for past A/D Difference values that we don't have access
             Reset();
-            Summation.Time = new DateTime(2022, 6, 30);
-            Summation.Value = -606.25m;
-            McClellanOscillator.EMAFast.Update(new DateTime(2022, 6, 30), -209.85m);
-            McClellanOscillator.EMASlow.Update(new DateTime(2022, 6, 30), -186.41m);
         }
 
         public void TestUpdate(IndicatorDataPoint input)
@@ -190,6 +185,12 @@ namespace QuantConnect.Tests.Indicators
             {
                 _symbols[symbol] = 0m;
             }
+
+            // Set to the first EMA values to account for past A/D Difference values that we don't have access
+            Summation.Time = new DateTime(2022, 6, 30);
+            Summation.Value = -606.25m;
+            McClellanOscillator.EMAFast.Update(new DateTime(2022, 6, 30), -209.85m);
+            McClellanOscillator.EMASlow.Update(new DateTime(2022, 6, 30), -186.41m);
         }
     }
 }


### PR DESCRIPTION
#### Description

`AdvanceDeclineIndicator.Reset()` clears both period dictionaries but leaves `_currentPeriodTime` holding the last period it processed. `Enqueue` only files a bar whose `Time` reaches that watermark, so after a reset every earlier bar is dropped and the indicator never becomes ready again. Clearing the watermark alongside the dictionaries is the whole fix.

The test doubles in `McClellanOscillatorTests` and `McClellanSummationIndexTests` seed the EMA values implied by the A/D history preceding their CSV. That seeding ran once, in the constructor, so it did not survive a reset. It moves into their `Reset` override, which the constructor already calls. Without this the two fixtures fail once the indicator starts producing values after a reset, which is the point of the change.

#### Related Issue

Fixes #9683.

#### Motivation and Context

Reset is meant to return an indicator to its constructed state. Here it left one field set, and the field gates whether any further data is accepted at all, so the indicator went quiet rather than wrong. 162 of 180 updates differ from a fresh instance over 60 daily periods across 3 symbols, and 171 of 180 differ in `IsReady`.

`AdvanceDeclineDifference`, `AdvanceDeclineRatio`, `AdvanceDeclineVolumeRatio`, `McClellanOscillator` and `McClellanSummationIndex` all build on this indicator.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

`ResetsProperlyAndReplaysTheSameValues` in `AdvanceDeclineDifferenceTests` feeds the indicator, resets it, replays the same bars, and compares each value and `IsReady` against a fresh instance. It fails on `master` and passes with the fix. Being in the shared A/D fixture, it is inherited by the ratio and volume-ratio fixtures too.

`QuantConnect.Tests.Indicators` on a clean checkout of this branch: 2768 passed, 0 failed, 5 skipped, on .NET 9 under Linux.

Worth flagging separately: `TestHelper.AssertIndicatorHasExternalDataAfterReset` skips its assertion while the indicator is not ready, so on `master` the second pass of `ComparesAgainstExternalDataAfterReset` asserts 0 of 756 rows for all three A/D indicators and passes vacuously. With this fix it asserts 753 of 756. That helper is inherited by roughly 200 fixtures, so tightening it is a separate discussion rather than part of this PR.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>`
