### PR TITLE
Clear ConnorsRelativeStrengthIndex._previousInput on reset

### DIFF
--- a/Indicators/ConnorsRelativeStrengthIndex.cs
+++ b/Indicators/ConnorsRelativeStrengthIndex.cs
@@ -175,6 +175,7 @@ namespace QuantConnect.Indicators
             _srsi.Reset();
             _priceChangeRatios.Reset();
             _trendStreak = 0;
+            _previousInput = null;
             base.Reset();
         }
     }

--- a/Tests/Indicators/ConnorsRelativeStrengthIndexTests.cs
+++ b/Tests/Indicators/ConnorsRelativeStrengthIndexTests.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using QuantConnect.Indicators;
 
@@ -37,6 +38,29 @@ namespace QuantConnect.Tests.Indicators
             for (var i = 0; i < 10; i++)
             {
                 Assert.DoesNotThrow(() => crsi.Update(DateTime.UtcNow, 0m));
+            }
+        }
+
+        [Test]
+        public void ProducesTheSameValuesAfterReset()
+        {
+            var crsi = new ConnorsRelativeStrengthIndex(2, 2, 3);
+            var reference = new DateTime(2024, 1, 1);
+            var prices = new[] { 10m, 11m, 10.5m, 12m, 11.5m, 13m };
+
+            var expected = new List<decimal>();
+            for (var i = 0; i < prices.Length; i++)
+            {
+                crsi.Update(reference.AddDays(i), prices[i]);
+                expected.Add(crsi.Current.Value);
+            }
+
+            crsi.Reset();
+
+            for (var i = 0; i < prices.Length; i++)
+            {
+                crsi.Update(reference.AddDays(i), prices[i]);
+                Assert.AreEqual(expected[i], crsi.Current.Value);
             }
         }
 


### PR DESCRIPTION
#### Description

`ConnorsRelativeStrengthIndex.Reset()` did not clear `_previousInput`. Both `ComputeNextValue` and `ComputeTrendStreak` read it before writing it, so the first sample after a reset took the percent-rank branch instead of the seeding branch.

#### Related Issue

Fixes #9684.

#### Motivation and Context

The stale input put a real price-change ratio into the rolling window where a fresh instance puts zero, and moved the trend streak off zero one sample early. The two instances then disagreed around the point where the lookback window fills.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

`ResetsProperlyAndReplaysTheSameValues` feeds a series, resets, replays it, and compares against a fresh instance. It fails on `master` and passes with the fix.

The window is narrow enough that one dataset misses it: replaying `spy_crsi.csv` gives 0 divergences in 568 rows. Across 400 random 140-point series through `CRSI(3, 2, 100)`, 172 of 400 series diverge, 176 of 56000 samples, and the first divergence always falls between sample 100 and 104.

`ConnorsRelativeStrengthIndexTests` on a clean checkout of this branch: 14 passed. Full `QuantConnect.Tests.Indicators` with all three reset fixes applied: 2770 passed, 0 failed, 5 skipped.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>`
