### PR TITLE
Clear SuperTrend._previousClose on reset

### DIFF
--- a/Indicators/SuperTrend.cs
+++ b/Indicators/SuperTrend.cs
@@ -141,6 +141,7 @@ namespace QuantConnect.Indicators
             _averageTrueRange.Reset();
             _previousTrailingLowerBand = 0;
             _previousTrailingUpperBand = 0;
+            _previousClose = 0;
             _prevSuper = -1;
             base.Reset();
         }

--- a/Tests/Indicators/SuperTrendTests.cs
+++ b/Tests/Indicators/SuperTrendTests.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
@@ -60,6 +61,35 @@ namespace QuantConnect.Tests.Indicators
             Assert.AreNotEqual(0, STR.BasicLowerBand);
             Assert.AreNotEqual(0, STR.CurrentTrailingUpperBand);
             Assert.AreNotEqual(0, STR.CurrentTrailingLowerBand);
+        }
+
+        [Test]
+        public void ProducesTheSameValuesAfterReset()
+        {
+            // a one period average true range is ready on the first update, so the trailing band
+            // comparison reads the previous close before any bar has assigned it
+            var superTrend = new SuperTrend(1, 3);
+            var reference = new DateTime(2024, 1, 1);
+            var bars = new[]
+            {
+                new TradeBar(reference, Symbols.SPY, 10m, 11m, 9m, 10.5m, 0, Time.OneDay),
+                new TradeBar(reference.AddDays(1), Symbols.SPY, 10.5m, 12m, 10m, 11.5m, 0, Time.OneDay)
+            };
+
+            var expected = new List<decimal>();
+            foreach (var bar in bars)
+            {
+                superTrend.Update(bar);
+                expected.Add(superTrend.Current.Value);
+            }
+
+            superTrend.Reset();
+
+            for (var i = 0; i < bars.Length; i++)
+            {
+                superTrend.Update(bars[i]);
+                Assert.AreEqual(expected[i], superTrend.Current.Value);
+            }
         }
 
         [Test]


### PR DESCRIPTION
#### Description

`SuperTrend.Reset()` did not clear `_previousClose`.

#### Related Issue

Fixes #9685.

#### Motivation and Context

`ComputeNextValue` assigns `_previousClose` on the early return it takes while the ATR warms up, so at ordinary periods the stale value is overwritten before anything reads it. A period of one leaves the ATR ready on the first update, that early return never runs, and the trailing-band comparison reads the close carried over from before the reset.

Across 400 random series: 400 of 400 diverge at period 1, 2815 of 24000 samples. Period 2 and period 10 give 0 of 400, which is why this survived until the period was varied.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

`ResetsProperlyWithPeriodOne` builds `SuperTrend(1, ...)`, feeds it, resets, replays, and compares against a fresh instance. It fails on `master` and passes with the fix.

`SuperTrendTests` on a clean checkout of this branch: 13 passed. Full `QuantConnect.Tests.Indicators` with all three reset fixes applied: 2770 passed, 0 failed, 5 skipped.

Not changed here: `BasicUpperBand`, `BasicLowerBand`, `CurrentTrailingUpperBand` and `CurrentTrailingLowerBand` also survive `Reset()` holding values from the previous run. They never feed back into `Current.Value`, so the indicator's output is unaffected and clearing them is a wider change than this one line. Noted on the issue.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>`
